### PR TITLE
upgrade msbuild and fix omnisharp-roslyn

### DIFF
--- a/pkgs/development/tools/build-managers/msbuild/default.nix
+++ b/pkgs/development/tools/build-managers/msbuild/default.nix
@@ -3,8 +3,8 @@
 let
 
   xplat = fetchurl {
-    url = "https://github.com/mono/msbuild/releases/download/0.08/mono_msbuild_6.4.0.208.zip";
-    sha256 = "05k7qmnhfvrdgyjn6vp81jb97y21m261jnwdyqpjqpcmzz18j93g";
+    url = "https://github.com/mono/msbuild/releases/download/v16.9.0/mono_msbuild_6.12.0.137.zip";
+    sha256 = "1wnzbdpk4s9bmawlh359ak2b8zi0sgx1qvcjnvfncr1wsck53v7q";
   };
 
   deps = map (package: package.src)
@@ -23,11 +23,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "msbuild";
-  version = "16.8+xamarinxplat.2020.07.30.15.02";
+  version = "16.10.1+xamarinxplat.2021.05.26.14.00";
 
   src = fetchurl {
     url = "https://download.mono-project.com/sources/msbuild/msbuild-${version}.tar.xz";
-    sha256 = "10amyca78b6pjfsy54b1rgwz2c1bx0sfky9zhldvzy4divckp25g";
+    sha256 = "05ghqqkdj4s3d0xkp7mkdzjig5zj3k6ajx71j0g2wv6rdbvg6899";
   };
 
   nativeBuildInputs = [
@@ -47,16 +47,17 @@ stdenv.mkDerivation rec {
   LOCALE_ARCHIVE = lib.optionalString stdenv.isLinux
       "${glibcLocales}/lib/locale/locale-archive";
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/mono/msbuild/commit/cad85cefabdaa001fb4bdbea2f5bf1d1cdb83c9b.patch";
-      sha256 = "1s8agc7nxxs69b3fl1v1air0c4dpig3hy4sk11l1560jrlx06dhh";
-    })
-  ];
-
   postPatch = ''
+    # not patchShebangs, there is /bin/bash in the body of the script as well
+    substituteInPlace ./eng/cibuild_bootstrapped_msbuild.sh --replace /bin/bash ${stdenv.shell}
+
+    patchShebangs eng/*.sh mono/build/*.sh
+
     sed -i -e "/<\/projectImportSearchPaths>/a <property name=\"MSBuildExtensionsPath\" value=\"$out/lib/mono/xbuild\"/>" \
       src/MSBuild/app.config
+
+    # license check is case sensitive
+    mv LICENSE license.bak && mv license.bak license
   '';
 
   buildPhase = ''
@@ -70,9 +71,6 @@ stdenv.mkDerivation rec {
       nuget add $package -Source nixos
     done
 
-    # license check is case sensitive
-    mv LICENSE license.bak && mv license.bak license
-
     mkdir -p artifacts
     unzip ${xplat} -d artifacts
     mv artifacts/msbuild artifacts/mono-msbuild
@@ -82,9 +80,10 @@ stdenv.mkDerivation rec {
 
     # overwrite the file
     echo "#!${stdenv.shell}" > eng/common/dotnet-install.sh
+    echo "#!${stdenv.shell}" > mono/build/get_sdk_files.sh
 
-    # not patchShebangs, there is /bin/bash in the body of the script as well
-    substituteInPlace ./eng/cibuild_bootstrapped_msbuild.sh --replace /bin/bash ${stdenv.shell}
+    mkdir -p mono/dotnet-overlay/msbuild-bin
+    cp ${dotnet-sdk}/sdk/*/{Microsoft.NETCoreSdk.BundledVersions.props,RuntimeIdentifierGraph.json} mono/dotnet-overlay/msbuild-bin
 
     # DisableNerdbankVersioning https://gitter.im/Microsoft/msbuild/archives/2018/06/27?at=5b33dbc4ce3b0f268d489bfa
     # TODO there are some (many?) failing tests

--- a/pkgs/development/tools/build-managers/msbuild/deps.nix
+++ b/pkgs/development/tools/build-managers/msbuild/deps.nix
@@ -1,41 +1,81 @@
 { fetchurl }: [
   {
+    name = "benchmarkdotnet";
+    version = "0.12.1";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/benchmarkdotnet/0.12.1/benchmarkdotnet.0.12.1.nupkg";
+      sha256 = "0whk81a0v70lkhcd9yffls6vnqnc63hw6jfx8mr7iqp02jbrb15w";
+    };
+  }
+  {
+    name = "benchmarkdotnet.annotations";
+    version = "0.12.1";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/benchmarkdotnet.annotations/0.12.1/benchmarkdotnet.annotations.0.12.1.nupkg";
+      sha256 = "061v8zdp69a80vb9gf5n8di2qqz6bwj2215shgsw40i0s8j3flw3";
+    };
+  }
+  {
+    name = "commandlineparser";
+    version = "2.4.3";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/commandlineparser/2.4.3/commandlineparser.2.4.3.nupkg";
+      sha256 = "1aca3q25n3dg55v4j3kzlzfzd5k2jpy6zhp8x7g74pdfdqzrhg55";
+    };
+  }
+  {
     name = "fsharp.net.sdk";
     version = "1.0.4-bundled-0100";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/fsharp.net.sdk/1.0.4-bundled-0100/fsharp.net.sdk.1.0.4-bundled-0100.nupkg";
-      sha256 = "0zy4n2an2jh3xrdy1m5fjvynpd0b66i0hkpqdhy2q6d7dj0ks351";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/fsharp.net.sdk/1.0.4-bundled-0100/fsharp.net.sdk.1.0.4-bundled-0100.nupkg";
+      sha256 = "06hydwby6pzqzzcxmz4z8v5hiiylhzldl7ggfvr4c5xhpb6bcl78";
+    };
+  }
+  {
+    name = "iced";
+    version = "1.4.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/iced/1.4.0/iced.1.4.0.nupkg";
+      sha256 = "1l8l20clb56vfsjcpspz0z4f3gy3mr2nwilbb8wjlr5fhx6g23n9";
     };
   }
   {
     name = "illink.tasks";
-    version = "0.1.6-prerelease.19380.1";
+    version = "0.1.6-prerelease.20175.2";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/illink.tasks/0.1.6-prerelease.19380.1/illink.tasks.0.1.6-prerelease.19380.1.nupkg";
-      sha256 = "1ihgzhizgiijg2kj38fn6hsinvxi7bvl0dpk7mbgc08rpgfdsvja";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/7d9f5c21-0d79-403f-bfe3-9a4506529760/nuget/v3/flat2/illink.tasks/0.1.6-prerelease.20175.2/illink.tasks.0.1.6-prerelease.20175.2.nupkg";
+      sha256 = "0s4fk48m255n3figh0nnw8cp40qk33khq56sjqnippbk8n6w487z";
+    };
+  }
+  {
+    name = "jnm2.referenceassemblies.net35";
+    version = "1.0.1";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/jnm2.referenceassemblies.net35/1.0.1/jnm2.referenceassemblies.net35.1.0.1.nupkg";
+      sha256 = "10dplszwicqnjyxbxkyc3cs0kzqvcrf73pmbxxd0rmqnakz23a7c";
     };
   }
   {
     name = "largeaddressaware";
-    version = "1.0.3";
+    version = "1.0.5";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/largeaddressaware/1.0.3/largeaddressaware.1.0.3.nupkg";
-      sha256 = "1ppss9bgj0hf5s8307bnm2a4qm10mrymp0v12m28a5q81zjz0fr5";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/largeaddressaware/1.0.5/largeaddressaware.1.0.5.nupkg";
+      sha256 = "0hsjh3m3wr5bfy82bzn606iin35ps03lzfrn3hvjgcn1w68d6291";
     };
   }
   {
     name = "microbuild.core";
     version = "0.2.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microbuild.core/0.2.0/microbuild.core.0.2.0.nupkg";
-      sha256 = "1ya040l8fhi0hhira8kwdmv7cc88ar7kiixkpxirgcn9gmpn7ggv";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microbuild.core/0.2.0/microbuild.core.0.2.0.nupkg";
+      sha256 = "0q4s45jskbyxfx4ay6znnvv94zma2wd85b8rwmwszd2nb0xl3194";
     };
   }
   {
     name = "microbuild.core.sentinel";
     version = "1.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microbuild.core.sentinel/1.0.0/microbuild.core.sentinel.1.0.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microbuild.core.sentinel/1.0.0/microbuild.core.sentinel.1.0.0.nupkg";
       sha256 = "035kqx5fkapql108n222lz8psvxk04mv3dy1qg3h08i4b8j3dy8i";
     };
   }
@@ -43,7 +83,7 @@
     name = "microsoft.bcl.asyncinterfaces";
     version = "1.1.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/1.1.0/microsoft.bcl.asyncinterfaces.1.1.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.bcl.asyncinterfaces/1.1.0/microsoft.bcl.asyncinterfaces.1.1.0.nupkg";
       sha256 = "1dq5yw7cy6s42193yl4iqscfw5vzkjkgv0zyy32scr4jza6ni1a1";
     };
   }
@@ -51,15 +91,15 @@
     name = "microsoft.build";
     version = "14.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.build/14.3.0/microsoft.build.14.3.0.nupkg";
-      sha256 = "16jzspb0qj9szjfhhmb836vgqdq4m1gk3y816qg2mdjmv52r91dh";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.build/14.3.0/microsoft.build.14.3.0.nupkg";
+      sha256 = "1zamn3p8xxi0wsjlpln0y71ncb977f3fp08mvaz4wmbmi76nr0rz";
     };
   }
   {
     name = "microsoft.build.centralpackageversions";
     version = "2.0.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.build.centralpackageversions/2.0.1/microsoft.build.centralpackageversions.2.0.1.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.build.centralpackageversions/2.0.1/microsoft.build.centralpackageversions.2.0.1.nupkg";
       sha256 = "17cjiaj2b98q8s89168g42jb8rhwm6062jcbv57rbkdiiwdsn55k";
     };
   }
@@ -67,31 +107,31 @@
     name = "microsoft.build.framework";
     version = "14.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.build.framework/14.3.0/microsoft.build.framework.14.3.0.nupkg";
-      sha256 = "19p1w27d3qi09fxag0byvjrv6x54nd5fkiszqzqr7676r90aswxh";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.build.framework/14.3.0/microsoft.build.framework.14.3.0.nupkg";
+      sha256 = "0r7y1i7dbr3pb53fdrh268hyi627w85nzv2iblwyg8dzkfxraafd";
     };
   }
   {
     name = "microsoft.build.framework";
     version = "15.5.180";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.build.framework/15.5.180/microsoft.build.framework.15.5.180.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.build.framework/15.5.180/microsoft.build.framework.15.5.180.nupkg";
       sha256 = "064y3a711ikx9pm9d2wyms4i3k4f9hfvn3vymhwygg7yv7gcj92z";
     };
   }
   {
     name = "microsoft.build.nugetsdkresolver";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/microsoft.build.nugetsdkresolver/5.7.0-rtm.6710/microsoft.build.nugetsdkresolver.5.7.0-rtm.6710.nupkg";
-      sha256 = "07zi6akd5iqq6q3cwc273vvfx70dn2lzx1ham4pzlq7dh7gq3vha";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.build.nugetsdkresolver/5.9.1-rc.8/microsoft.build.nugetsdkresolver.5.9.1-rc.8.nupkg";
+      sha256 = "1dgxkal27rqlnz0ppbmbg4v7yla5wb9s2djk5cb6bpsqy2ngd88d";
     };
   }
   {
     name = "microsoft.build.tasks.git";
     version = "1.1.0-beta-20206-02";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.build.tasks.git/1.1.0-beta-20206-02/microsoft.build.tasks.git.1.1.0-beta-20206-02.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.build.tasks.git/1.1.0-beta-20206-02/microsoft.build.tasks.git.1.1.0-beta-20206-02.nupkg";
       sha256 = "1gwlhvqlkvs5c7qjky726alf71xflbh3x970g3dypfczi0y6gccx";
     };
   }
@@ -99,87 +139,135 @@
     name = "microsoft.build.utilities.core";
     version = "14.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.build.utilities.core/14.3.0/microsoft.build.utilities.core.14.3.0.nupkg";
-      sha256 = "0xk5n4i40w53amrd7bxlhikdvmh8z2anrk99pvz2rf50v946g6li";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.build.utilities.core/14.3.0/microsoft.build.utilities.core.14.3.0.nupkg";
+      sha256 = "0351nsnx12nzkss6vaqwwh7d7car7hrgyh0vyd4bl83c4x3ls1kb";
     };
   }
   {
     name = "microsoft.build.utilities.core";
     version = "15.5.180";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.build.utilities.core/15.5.180/microsoft.build.utilities.core.15.5.180.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.build.utilities.core/15.5.180/microsoft.build.utilities.core.15.5.180.nupkg";
       sha256 = "0c4bjhaqgc98bchln8p5d2p1vyn8qrha2b8gpn2l7bnznbcrd630";
     };
   }
   {
-    name = "microsoft.codeanalysis.build.tasks";
-    version = "3.0.0-beta3-19064-03";
+    name = "microsoft.codeanalysis.analyzers";
+    version = "2.6.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.codeanalysis.build.tasks/3.0.0-beta3-19064-03/microsoft.codeanalysis.build.tasks.3.0.0-beta3-19064-03.nupkg";
-      sha256 = "1l01l0jyqgs8ix5v6b6n0q4yv1y1khr14dh7pw0qivkc5gsys19v";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.codeanalysis.analyzers/2.6.1/microsoft.codeanalysis.analyzers.2.6.1.nupkg";
+      sha256 = "1plk343h9fyxg08b9bcnlqyaq00cbnc1v73pj9nbcyphmgf5bqfp";
+    };
+  }
+  {
+    name = "microsoft.codeanalysis.build.tasks";
+    version = "3.9.0-5.21112.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.build.tasks/3.9.0-5.21112.8/microsoft.codeanalysis.build.tasks.3.9.0-5.21112.8.nupkg";
+      sha256 = "18wvmkpvp1yq288xryap3v07clhs36xiw6vyk4j59i2aqnjjnmc7";
+    };
+  }
+  {
+    name = "microsoft.codeanalysis.common";
+    version = "2.10.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.codeanalysis.common/2.10.0/microsoft.codeanalysis.common.2.10.0.nupkg";
+      sha256 = "1l690xqrhmkasns5ghz0vqj8n2xyl5yrwan5gs52hwfxdwahqaaj";
+    };
+  }
+  {
+    name = "microsoft.codeanalysis.csharp";
+    version = "2.10.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.codeanalysis.csharp/2.10.0/microsoft.codeanalysis.csharp.2.10.0.nupkg";
+      sha256 = "0saabsr81crawdzs2cnzyjp5cgg2hk5k6q7n0i0pxghswb0m4dxk";
     };
   }
   {
     name = "microsoft.codecoverage";
-    version = "16.1.1";
+    version = "16.6.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.codecoverage/16.1.1/microsoft.codecoverage.16.1.1.nupkg";
-      sha256 = "0xca3sys0a5ilz16ic7g4gds2b974nvmf89qwr1i6v8f7illhda5";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.codecoverage/16.6.1/microsoft.codecoverage.16.6.1.nupkg";
+      sha256 = "01ffm4nflqdb93vq4xl0j3377x360fgx6c6h12mpkcy85ixbv3rl";
     };
   }
   {
-    name = "microsoft.diasymreader.pdb2pdb";
-    version = "1.1.0-beta2-19521-03";
+    name = "microsoft.diagnostics.netcore.client";
+    version = "0.2.61701";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.diasymreader.pdb2pdb/1.1.0-beta2-19521-03/microsoft.diasymreader.pdb2pdb.1.1.0-beta2-19521-03.nupkg";
-      sha256 = "1r82h0qiah2xx9rg8lvfvfdzxz60zd6vfs8kvck0csha5psmn56w";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.diagnostics.netcore.client/0.2.61701/microsoft.diagnostics.netcore.client.0.2.61701.nupkg";
+      sha256 = "1ic1607jj4ln8dbibf1fz5v9svk9x2kqlgvhndc6ijaqnbc4wcr1";
+    };
+  }
+  {
+    name = "microsoft.diagnostics.runtime";
+    version = "1.1.57604";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.diagnostics.runtime/1.1.57604/microsoft.diagnostics.runtime.1.1.57604.nupkg";
+      sha256 = "1gm9gsg3h9ipcvwzp7jfns030c4b6l4cpkpyx9ccphlax9mvmfsi";
+    };
+  }
+  {
+    name = "microsoft.diagnostics.tracing.traceevent";
+    version = "2.0.49";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.diagnostics.tracing.traceevent/2.0.49/microsoft.diagnostics.tracing.traceevent.2.0.49.nupkg";
+      sha256 = "08ww98l9a4cx52h3y8w1x5vzl4jf02a66wf9z1j2py406wjifja9";
     };
   }
   {
     name = "microsoft.dotnet.arcade.sdk";
-    version = "1.0.0-beta.20365.6";
+    version = "5.0.0-beta.21226.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.dotnet.arcade.sdk/1.0.0-beta.20365.6/microsoft.dotnet.arcade.sdk.1.0.0-beta.20365.6.nupkg";
-      sha256 = "1ypsxq3ljdfwvrqyg6b8ii8mbqnjcb2vdr17jc4h0mdmkj0rlcdl";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.dotnet.arcade.sdk/5.0.0-beta.21226.1/microsoft.dotnet.arcade.sdk.5.0.0-beta.21226.1.nupkg";
+      sha256 = "1d7pczd99cladgmblq8g1dqw88n3aqg7rf8bpsabqrjjrz0pfi43";
     };
   }
   {
     name = "microsoft.dotnet.msbuildsdkresolver";
-    version = "3.1.400-preview.20365.4";
+    version = "5.0.300-servicing.21267.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.dotnet.msbuildsdkresolver/3.1.400-preview.20365.4/microsoft.dotnet.msbuildsdkresolver.3.1.400-preview.20365.4.nupkg";
-      sha256 = "0ifhk0whgbq0yw075al8sb14ajcnvyp883srx1j62vil9gfz0fp9";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/a8a526e9-91b3-4569-ba2d-ff08dbb7c110/nuget/v3/flat2/microsoft.dotnet.msbuildsdkresolver/5.0.300-servicing.21267.11/microsoft.dotnet.msbuildsdkresolver.5.0.300-servicing.21267.11.nupkg";
+      sha256 = "1jgg2akhpgfndqfdcyvm7b83nxva9h86nivc7p6dw8rcvazffbp5";
+    };
+  }
+  {
+    name = "microsoft.dotnet.platformabstractions";
+    version = "2.1.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.dotnet.platformabstractions/2.1.0/microsoft.dotnet.platformabstractions.2.1.0.nupkg";
+      sha256 = "1qydvyyinj3b5mraazjal3n2k7jqhn05b6n1a2f3qjkqkxi63dmy";
     };
   }
   {
     name = "microsoft.dotnet.signtool";
-    version = "1.0.0-beta.20365.6";
+    version = "5.0.0-beta.21226.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.dotnet.signtool/1.0.0-beta.20365.6/microsoft.dotnet.signtool.1.0.0-beta.20365.6.nupkg";
-      sha256 = "0zaw9hc19ldms3jy6n27x4p9clzz3nvpddyacwhgqiahjw2wqasz";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.dotnet.signtool/5.0.0-beta.21226.1/microsoft.dotnet.signtool.5.0.0-beta.21226.1.nupkg";
+      sha256 = "1jd3648n3i9i1njx8wb9g8i29s3n5srx3whdhvrkwjm9g5n11gbj";
     };
   }
   {
     name = "microsoft.net.build.extensions";
     version = "3.1.400-preview.20365.20";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.net.build.extensions/3.1.400-preview.20365.20/microsoft.net.build.extensions.3.1.400-preview.20365.20.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d5f6139d-6136-4228-8b2d-9676e9e4eb3d/nuget/v3/flat2/microsoft.net.build.extensions/3.1.400-preview.20365.20/microsoft.net.build.extensions.3.1.400-preview.20365.20.nupkg";
       sha256 = "1vmcj7p7jsr1lbkbxqqjsixkaxdazr5nwhhp1q402dgky9cayhd5";
     };
   }
   {
     name = "microsoft.net.compilers.toolset";
-    version = "3.7.0-5.20367.1";
+    version = "3.9.0-5.21112.8";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.net.compilers.toolset/3.7.0-5.20367.1/microsoft.net.compilers.toolset.3.7.0-5.20367.1.nupkg";
-      sha256 = "1z8hzzmxs8jchq1jmmmwhpf3hsvrj803y3zb8j3xg9xkbnryfzwk";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.net.compilers.toolset/3.9.0-5.21112.8/microsoft.net.compilers.toolset.3.9.0-5.21112.8.nupkg";
+      sha256 = "1drcxgay9ylhs6dr3alnxr4lfapzlr86w3mpwp0gn58mfj5m0g1h";
     };
   }
   {
     name = "microsoft.netcore.platforms";
     version = "1.0.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.0.1/microsoft.netcore.platforms.1.0.1.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.netcore.platforms/1.0.1/microsoft.netcore.platforms.1.0.1.nupkg";
       sha256 = "01al6cfxp68dscl15z7rxfw9zvhm64dncsw09a1vmdkacsa2v6lr";
     };
   }
@@ -187,7 +275,7 @@
     name = "microsoft.netcore.platforms";
     version = "1.1.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.nupkg";
       sha256 = "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm";
     };
   }
@@ -195,31 +283,39 @@
     name = "microsoft.netcore.targets";
     version = "1.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.netcore.targets/1.0.1/microsoft.netcore.targets.1.0.1.nupkg";
-      sha256 = "1gn085ddzn8psqfhmwcjzq2zrmb5gca2liap79a43wyw4gs8ip78";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.netcore.targets/1.0.1/microsoft.netcore.targets.1.0.1.nupkg";
+      sha256 = "0ppdkwy6s9p7x9jix3v4402wb171cdiibq7js7i13nxpdky7074p";
     };
   }
   {
     name = "microsoft.netcore.targets";
     version = "1.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg";
-      sha256 = "0idlsfwd9sn4p9jr1dqi14b8n2ly0k4dnjpvh8jfhxgnzzl98z5k";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg";
+      sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
     };
   }
   {
     name = "microsoft.netframework.referenceassemblies";
     version = "1.0.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netframework.referenceassemblies/1.0.0/microsoft.netframework.referenceassemblies.1.0.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.netframework.referenceassemblies/1.0.0/microsoft.netframework.referenceassemblies.1.0.0.nupkg";
       sha256 = "0na724xhvqm63vq9y18fl9jw9q2v99bdwr353378s5fsi11qzxp9";
+    };
+  }
+  {
+    name = "microsoft.netframework.referenceassemblies.net45";
+    version = "1.0.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.netframework.referenceassemblies.net45/1.0.0/microsoft.netframework.referenceassemblies.net45.1.0.0.nupkg";
+      sha256 = "1ipafi0zjrnzsfmwsisgp8z6m26cbw7vb3jj501nvz3v97b7d7lv";
     };
   }
   {
     name = "microsoft.netframework.referenceassemblies.net472";
     version = "1.0.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netframework.referenceassemblies.net472/1.0.0/microsoft.netframework.referenceassemblies.net472.1.0.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.netframework.referenceassemblies.net472/1.0.0/microsoft.netframework.referenceassemblies.net472.1.0.0.nupkg";
       sha256 = "1bqinq2nxnpqxziypg1sqy3ly0nymxxjpn8fwkn3rl4vl6gdg3rc";
     };
   }
@@ -227,7 +323,7 @@
     name = "microsoft.net.sdk";
     version = "3.1.400-preview.20365.20";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.net.sdk/3.1.400-preview.20365.20/microsoft.net.sdk.3.1.400-preview.20365.20.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d5f6139d-6136-4228-8b2d-9676e9e4eb3d/nuget/v3/flat2/microsoft.net.sdk/3.1.400-preview.20365.20/microsoft.net.sdk.3.1.400-preview.20365.20.nupkg";
       sha256 = "02ann6rsnc6wl84wsk2fz7dpxcp5sq0b6jm3vv23av4b1f86f82y";
     };
   }
@@ -235,7 +331,7 @@
     name = "microsoft.net.sdk.publish";
     version = "3.1.300-servicing.20216.7";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.net.sdk.publish/3.1.300-servicing.20216.7/microsoft.net.sdk.publish.3.1.300-servicing.20216.7.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d5f6139d-6136-4228-8b2d-9676e9e4eb3d/nuget/v3/flat2/microsoft.net.sdk.publish/3.1.300-servicing.20216.7/microsoft.net.sdk.publish.3.1.300-servicing.20216.7.nupkg";
       sha256 = "1xivqihp2zrkmd4f65fgh9hn9ix75sqklbnanqlfk9dq67wscp41";
     };
   }
@@ -243,7 +339,7 @@
     name = "microsoft.net.sdk.razor";
     version = "3.1.6";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.net.sdk.razor/3.1.6/microsoft.net.sdk.razor.3.1.6.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.net.sdk.razor/3.1.6/microsoft.net.sdk.razor.3.1.6.nupkg";
       sha256 = "1vw0zi0lq52frivq8mgfvm79rfx0v492q6fci1jls1zwwjk0v9ia";
     };
   }
@@ -251,7 +347,7 @@
     name = "microsoft.net.sdk.web";
     version = "3.1.300-servicing.20216.7";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.net.sdk.web/3.1.300-servicing.20216.7/microsoft.net.sdk.web.3.1.300-servicing.20216.7.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d5f6139d-6136-4228-8b2d-9676e9e4eb3d/nuget/v3/flat2/microsoft.net.sdk.web/3.1.300-servicing.20216.7/microsoft.net.sdk.web.3.1.300-servicing.20216.7.nupkg";
       sha256 = "001jd2iwww0vb5x5dii915z82syh1aj48n62bn8zi1d3chwacr51";
     };
   }
@@ -259,23 +355,23 @@
     name = "microsoft.net.sdk.web.projectsystem";
     version = "3.1.300-servicing.20216.7";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.net.sdk.web.projectsystem/3.1.300-servicing.20216.7/microsoft.net.sdk.web.projectsystem.3.1.300-servicing.20216.7.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d5f6139d-6136-4228-8b2d-9676e9e4eb3d/nuget/v3/flat2/microsoft.net.sdk.web.projectsystem/3.1.300-servicing.20216.7/microsoft.net.sdk.web.projectsystem.3.1.300-servicing.20216.7.nupkg";
       sha256 = "0601mix6l18h8afxxgdbbv695d0sjskady209z52sf4bvf4h4kal";
     };
   }
   {
     name = "microsoft.net.test.sdk";
-    version = "16.1.1";
+    version = "16.6.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.net.test.sdk/16.1.1/microsoft.net.test.sdk.16.1.1.nupkg";
-      sha256 = "13mcqv85yf4f1rx06sz5ff4pcmbr4rkgqkqzmwl8ywadbh523125";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.net.test.sdk/16.6.1/microsoft.net.test.sdk.16.6.1.nupkg";
+      sha256 = "0jjdg468jc6pv2z764f3xc19lcr772nzjm9cjfqq3bqw8vkpzmhv";
     };
   }
   {
     name = "microsoft.sourcelink.azurerepos.git";
     version = "1.1.0-beta-20206-02";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.sourcelink.azurerepos.git/1.1.0-beta-20206-02/microsoft.sourcelink.azurerepos.git.1.1.0-beta-20206-02.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.sourcelink.azurerepos.git/1.1.0-beta-20206-02/microsoft.sourcelink.azurerepos.git.1.1.0-beta-20206-02.nupkg";
       sha256 = "00hfjh8d3z5np51qgr1s3q4j7bl34mfiypf7nbxcmxa7cyj0rg65";
     };
   }
@@ -283,7 +379,7 @@
     name = "microsoft.sourcelink.common";
     version = "1.1.0-beta-20206-02";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.sourcelink.common/1.1.0-beta-20206-02/microsoft.sourcelink.common.1.1.0-beta-20206-02.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.sourcelink.common/1.1.0-beta-20206-02/microsoft.sourcelink.common.1.1.0-beta-20206-02.nupkg";
       sha256 = "1qv0k0apxv3j1pccki2rzakjfb0868hmg0968da0639f75s3glr9";
     };
   }
@@ -291,15 +387,23 @@
     name = "microsoft.sourcelink.github";
     version = "1.1.0-beta-20206-02";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.sourcelink.github/1.1.0-beta-20206-02/microsoft.sourcelink.github.1.1.0-beta-20206-02.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.sourcelink.github/1.1.0-beta-20206-02/microsoft.sourcelink.github.1.1.0-beta-20206-02.nupkg";
       sha256 = "0q1mgjjkwxvzn5v29pqiyg0j0jwi5qc0q04za9k1x138kliq2iba";
+    };
+  }
+  {
+    name = "microsoft.symboluploader.build.task";
+    version = "1.1.145102";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/microsoft.symboluploader.build.task/1.1.145102/microsoft.symboluploader.build.task.1.1.145102.nupkg";
+      sha256 = "1nmd0cgj3kp2n1k8bzvvq7cfbpbrvk1k6mx9lpnzh1bv7v67rvm2";
     };
   }
   {
     name = "microsoft.visualstudio.sdk.embedinteroptypes";
     version = "15.0.15";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.sdk.embedinteroptypes/15.0.15/microsoft.visualstudio.sdk.embedinteroptypes.15.0.15.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.visualstudio.sdk.embedinteroptypes/15.0.15/microsoft.visualstudio.sdk.embedinteroptypes.15.0.15.nupkg";
       sha256 = "0chr3slzzcanwcyd9isx4gichqzmfh4zd3h83piw0r4xsww1wmpd";
     };
   }
@@ -307,295 +411,319 @@
     name = "microsoft.visualstudio.setup.configuration.interop";
     version = "1.16.30";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.setup.configuration.interop/1.16.30/microsoft.visualstudio.setup.configuration.interop.1.16.30.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.visualstudio.setup.configuration.interop/1.16.30/microsoft.visualstudio.setup.configuration.interop.1.16.30.nupkg";
       sha256 = "14022lx03vdcqlvbbdmbsxg5pqfx1rfq2jywxlyaz9v68cvsb0g4";
     };
   }
   {
     name = "microsoft.web.xdt";
-    version = "2.1.2";
+    version = "3.0.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.web.xdt/2.1.2/microsoft.web.xdt.2.1.2.nupkg";
-      sha256 = "1as6cih26xyxjsa5ibqik1fwbyxl58ivpngidr6w1nh5fi5zg9zw";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.web.xdt/3.0.0/microsoft.web.xdt.3.0.0.nupkg";
+      sha256 = "18biff0hglccy34909zm9hc4lr9p8n2p155snq1dddp0av6m448n";
     };
   }
   {
     name = "microsoft.win32.primitives";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.win32.primitives/4.0.1/microsoft.win32.primitives.4.0.1.nupkg";
-      sha256 = "1pviskapkc6qm108r0q2x15vkgyqsczf9xpmrlm42q68ainc9ai3";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.win32.primitives/4.0.1/microsoft.win32.primitives.4.0.1.nupkg";
+      sha256 = "1n8ap0cmljbqskxpf8fjzn7kh1vvlndsa75k01qig26mbw97k2q7";
     };
   }
   {
     name = "microsoft.win32.primitives";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg";
-      sha256 = "1nvwzj039y9ngdpz7zg0vszvrr3za2vfmjg222jc8c1dibk6y6ah";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg";
+      sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
+    };
+  }
+  {
+    name = "microsoft.win32.registry";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/microsoft.win32.registry/4.5.0/microsoft.win32.registry.4.5.0.nupkg";
+      sha256 = "1zapbz161ji8h82xiajgriq6zgzmb1f3ar517p2h63plhsq5gh2q";
     };
   }
   {
     name = "netstandard.library";
     version = "1.6.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/netstandard.library/1.6.1/netstandard.library.1.6.1.nupkg";
-      sha256 = "03pxpc6dzpw56l8qhcb0wzvirqgs3c008jcakqxvfqmy25m3dnyn";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/netstandard.library/1.6.1/netstandard.library.1.6.1.nupkg";
+      sha256 = "1z70wvsx2d847a2cjfii7b83pjfs34q05gb037fdjikv5kbagml8";
+    };
+  }
+  {
+    name = "newtonsoft.json";
+    version = "11.0.1";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/newtonsoft.json/11.0.1/newtonsoft.json.11.0.1.nupkg";
+      sha256 = "1z68j07if1xf71lbsrgbia52r812i2dv541sy44ph4dzjjp7pd4m";
     };
   }
   {
     name = "newtonsoft.json";
     version = "9.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/newtonsoft.json/9.0.1/newtonsoft.json.9.0.1.nupkg";
-      sha256 = "1qayanmqh3xiw0bjwm825j1n6nvbhc6yqkdpaawpyd0l71d5qh13";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/newtonsoft.json/9.0.1/newtonsoft.json.9.0.1.nupkg";
+      sha256 = "0mcy0i7pnfpqm4pcaiyzzji4g0c8i3a5gjz28rrr28110np8304r";
     };
   }
   {
     name = "nuget.build.tasks";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.build.tasks/5.7.0-rtm.6710/nuget.build.tasks.5.7.0-rtm.6710.nupkg";
-      sha256 = "0zwacvci3y8xyhy6jzc0wd20rzgb6lzv0ci8a4qg8ay315bmd9sp";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.build.tasks/5.9.1-rc.8/nuget.build.tasks.5.9.1-rc.8.nupkg";
+      sha256 = "0610dh53gqmzbl70jxmn9jbvl0lv70qanis1q20rxnnyq6s2xb75";
     };
   }
   {
     name = "nuget.build.tasks.pack";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.build.tasks.pack/5.7.0-rtm.6710/nuget.build.tasks.pack.5.7.0-rtm.6710.nupkg";
-      sha256 = "16scfs0gwfs9r5kp65jfz3ip7w56xyni6fwgpmj0y6dbazzqm6zs";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.build.tasks.pack/5.9.1-rc.8/nuget.build.tasks.pack.5.9.1-rc.8.nupkg";
+      sha256 = "10qkdv165vz71z8ir3161ggaarbqk51gwg8n51iwxa5inz4y22lj";
     };
   }
   {
     name = "nuget.commandline";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/nuget.commandline/4.1.0/nuget.commandline.4.1.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/nuget.commandline/4.1.0/nuget.commandline.4.1.0.nupkg";
       sha256 = "03ik0rcdl7vdwxa9fx5cgl98yzb45swr08jmrnjk1ympjqvf94s1";
     };
   }
   {
     name = "nuget.commands";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.commands/5.7.0-rtm.6710/nuget.commands.5.7.0-rtm.6710.nupkg";
-      sha256 = "0sm2x95q8y0sab7fsb2sqqhvw2x0scsavv968jxjf3ynb5n155q3";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.commands/5.9.1-rc.8/nuget.commands.5.9.1-rc.8.nupkg";
+      sha256 = "0rdziczdkrqwl6wjqs4w29c460kc69v9z2pghqjlkag25c7hqwlr";
     };
   }
   {
     name = "nuget.common";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.common/5.7.0-rtm.6710/nuget.common.5.7.0-rtm.6710.nupkg";
-      sha256 = "07wxir208mmfzi2xxhn8xskbchx9d7nahmy2xqcx09mwkkr7m0qg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.common/5.9.1-rc.8/nuget.common.5.9.1-rc.8.nupkg";
+      sha256 = "056b1h4fvik6z2qc2s6qzz0s4acbipc50af14fbr7hd9h2fxya4c";
     };
   }
   {
     name = "nuget.configuration";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.configuration/5.7.0-rtm.6710/nuget.configuration.5.7.0-rtm.6710.nupkg";
-      sha256 = "1h9r627nj3bhwfwzf2b265s5zl00sj5z5x085a6l8qg2v8sig628";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.configuration/5.9.1-rc.8/nuget.configuration.5.9.1-rc.8.nupkg";
+      sha256 = "0x8vigf0sfp6kf1i98xcr4k84vci596x16hmajdm0zgv3p1w2kvk";
     };
   }
   {
     name = "nuget.credentials";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.credentials/5.7.0-rtm.6710/nuget.credentials.5.7.0-rtm.6710.nupkg";
-      sha256 = "06yd4ny5nzpxl6n3l57n585inj0bjybcmwcz0w3clyib9l2ybsjz";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.credentials/5.9.1-rc.8/nuget.credentials.5.9.1-rc.8.nupkg";
+      sha256 = "128vsgz4rfrp17ys7vbc978y6inmvki93mswm82qvphxymsyrc6v";
     };
   }
   {
     name = "nuget.dependencyresolver.core";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.dependencyresolver.core/5.7.0-rtm.6710/nuget.dependencyresolver.core.5.7.0-rtm.6710.nupkg";
-      sha256 = "0s3qlwg98qd5brfh6k9lsviqpij8n73ci54c9bmal56k12hkvfdm";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.dependencyresolver.core/5.9.1-rc.8/nuget.dependencyresolver.core.5.9.1-rc.8.nupkg";
+      sha256 = "1q9a97s1z3a6fb4p82ag2lqnzl53895prbqwlbvckdw9c3rpz3gc";
     };
   }
   {
     name = "nuget.frameworks";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.frameworks/5.7.0-rtm.6710/nuget.frameworks.5.7.0-rtm.6710.nupkg";
-      sha256 = "05g4aaq3gc1p104dpanr255xcag399918m02vpanf29qpz3g325d";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.frameworks/5.9.1-rc.8/nuget.frameworks.5.9.1-rc.8.nupkg";
+      sha256 = "1n3mp9ns79yq4dwgj7h2av3b485mzgsw0qlj8z7p47krwlzp5hiv";
     };
   }
   {
     name = "nuget.librarymodel";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.librarymodel/5.7.0-rtm.6710/nuget.librarymodel.5.7.0-rtm.6710.nupkg";
-      sha256 = "1pj5y29f21ch4sgwg5xx4n0lsd1qiiyjy6ly6vaabfrimx4d0s23";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.librarymodel/5.9.1-rc.8/nuget.librarymodel.5.9.1-rc.8.nupkg";
+      sha256 = "0sy8422c94wcg8ka85lnawq26mpixl79avk9m6y44lshrpga5v4v";
     };
   }
   {
     name = "nuget.packagemanagement";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.packagemanagement/5.7.0-rtm.6710/nuget.packagemanagement.5.7.0-rtm.6710.nupkg";
-      sha256 = "1kiix6r2birnrlwki5mb5a7sbxh8wqj87f69qid6dr556x2w8h9z";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.packagemanagement/5.9.1-rc.8/nuget.packagemanagement.5.9.1-rc.8.nupkg";
+      sha256 = "0mcxdqq3hfhxyn99pp5b5x2cd8rrmw6z616cbd9y0s9j0i6hm4pg";
     };
   }
   {
     name = "nuget.packaging";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.packaging/5.7.0-rtm.6710/nuget.packaging.5.7.0-rtm.6710.nupkg";
-      sha256 = "16frbw8k81cazary6d8sbdccr6hv57rc7rzdi9bagdnzvpm8h13l";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.packaging/5.9.1-rc.8/nuget.packaging.5.9.1-rc.8.nupkg";
+      sha256 = "0x9c3v741nn6m2xgidna88fa4xj5avhv6asj73hqv4pzpdprlrhv";
     };
   }
   {
     name = "nuget.projectmodel";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.projectmodel/5.7.0-rtm.6710/nuget.projectmodel.5.7.0-rtm.6710.nupkg";
-      sha256 = "11i1kyqvmq70rkqrxhxnhsihaxx32ww0l9175473mmyia3wrbwyw";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.projectmodel/5.9.1-rc.8/nuget.projectmodel.5.9.1-rc.8.nupkg";
+      sha256 = "1xjh7isw467nkc7dkfj3wlw69vi2cns66z152jrzjdmxmia3i3pv";
     };
   }
   {
     name = "nuget.protocol";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.protocol/5.7.0-rtm.6710/nuget.protocol.5.7.0-rtm.6710.nupkg";
-      sha256 = "1515p7a4kdm9wr8iizcmvzwqphxsfwqbnq41jv8mibrx7vih0s90";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.protocol/5.9.1-rc.8/nuget.protocol.5.9.1-rc.8.nupkg";
+      sha256 = "1rnrxzaciqhhgwd4by0dhkvfrm1h161vvmkvlcwaz2589sqq2dzq";
     };
   }
   {
     name = "nuget.resolver";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.resolver/5.7.0-rtm.6710/nuget.resolver.5.7.0-rtm.6710.nupkg";
-      sha256 = "17bm159knhx7iznm9ilk3mwb0n1gh1dp0ihhapyb1fmh9ings30b";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.resolver/5.9.1-rc.8/nuget.resolver.5.9.1-rc.8.nupkg";
+      sha256 = "0q6dqg0d5f9y7ynwqmzkzwl6yan94azvm0cd385k210y8wn4364v";
     };
   }
   {
     name = "nuget.versioning";
-    version = "5.7.0-rtm.6710";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/9d15d80a-6afc-4f7e-901b-9378146a4b8b/nuget/v3/flat2/nuget.versioning/5.7.0-rtm.6710/nuget.versioning.5.7.0-rtm.6710.nupkg";
-      sha256 = "1kj9xvcbwvvhhi45bi6f9m1cv8wx6y4xfmnxc8liwcgwh9gvwdjl";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.versioning/5.9.1-rc.8/nuget.versioning.5.9.1-rc.8.nupkg";
+      sha256 = "1vv7z122ilsk2rsvjm6j3hpifb45g8wa1mgnq1kwi9k8b2dbb6vv";
+    };
+  }
+  {
+    name = "perfolizer";
+    version = "0.2.1";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/perfolizer/0.2.1/perfolizer.0.2.1.nupkg";
+      sha256 = "012aqqi3y3nfikqmn26yajpwd52c04zlzp0p91iyslw7mf26qncy";
     };
   }
   {
     name = "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "10a3jqkh1h23qsn7pjlji61d7dph7qy8c6ssfjqmlgydm4rnin64";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "16rnxzpk5dpbbl1x354yrlsbvwylrq456xzpsha1n9y3glnhyx9d";
     };
   }
   {
     name = "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "1md38ys5h8srinnq9qxz47c9i27x7pv84avdi3rbq68hfkcslx93";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0hkg03sgm2wyq8nqk6dbm9jh5vcq57ry42lkqdmfklrw89lsmr59";
     };
   }
   {
     name = "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "0cgvqxccg4lkxiyvw3jrn71pbybbbcd3i8v6v4przgrr7f7k6nfj";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0c2p354hjx58xhhz7wv6div8xpi90sc6ibdm40qin21bvi7ymcaa";
     };
   }
   {
     name = "runtime.native.system";
     version = "4.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.native.system/4.0.0/runtime.native.system.4.0.0.nupkg";
-      sha256 = "0fwsjhqj235hhy2zl8x3a828whn4nck7jr7hi09ccbk24xf4f17f";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.native.system/4.0.0/runtime.native.system.4.0.0.nupkg";
+      sha256 = "1ppk69xk59ggacj9n7g6fyxvzmk1g5p4fkijm0d7xqfkig98qrkf";
     };
   }
   {
     name = "runtime.native.system";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg";
-      sha256 = "02gnfm33gf163kybkahfza8q10jp890hiczcnbg2aasf1n0jq857";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.native.system/4.3.0/runtime.native.system.4.3.0.nupkg";
+      sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
     };
   }
   {
     name = "runtime.native.system.io.compression";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.native.system.io.compression/4.3.0/runtime.native.system.io.compression.4.3.0.nupkg";
-      sha256 = "05370qi83pxfyn3whzkjjwb4q80vlr3mbz0dfa0hc0cbl5jx4y20";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.native.system.io.compression/4.3.0/runtime.native.system.io.compression.4.3.0.nupkg";
+      sha256 = "1vvivbqsk6y4hzcid27pqpm5bsi6sc50hvqwbcx8aap5ifrxfs8d";
     };
   }
   {
     name = "runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.0/runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "1il7m43j4nq15xf01npgxd8q83q8mkk4xk07dd7g0sfsxm9k127d";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.native.system.security.cryptography.openssl/4.3.0/runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
     };
   }
   {
     name = "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "1pr8ji41rsifx6yh89xg1yw45g5snw96xxqw0g3q48rbdg5j79iw";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0qyynf9nz5i7pc26cwhgi8j62ps27sqmf78ijcfgzab50z9g8ay3";
     };
   }
   {
     name = "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "1r8hllb6fdb4adij7b7ld32hf5r5jxyqh4pacrvfgjckmyx8js8c";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "1klrs545awhayryma6l7g2pvnp9xy4z0r1i40r80zb45q3i9nbyf";
     };
   }
   {
     name = "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "16r149hajvr8ikyjbsw2m67yqfvxg6j1sb2slw9pzrly06mxmpks";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0zcxjv5pckplvkg0r6mw3asggm7aqzbdjimhvsasb0cgm59x09l3";
     };
   }
   {
     name = "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "0j2f2v1nm7sys6qpljhp4s18zz3hblymjl60yrccqfac7yr9hxrq";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "0vhynn79ih7hw7cwjazn87rm9z9fj0rvxgzlab36jybgcpcgphsn";
     };
   }
   {
     name = "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "0wgz0y2fm6xcnlmpl1zh5963ribjbnzr2l6prsw3xi7sbfyjyi8c";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "160p68l2c7cqmyqjwxydcvgw7lvl1cr0znkw8fp24d1by9mqc8p3";
     };
   }
   {
     name = "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "0qr13ykxj7zs7i8z0x63v8za2h33ndnvvw83wffp9xbb2fibj3gi";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "15zrc8fgd8zx28hdghcj5f5i34wf3l6bq5177075m2bc2j34jrqy";
     };
   }
   {
     name = "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
-      sha256 = "1jg8gfh261zqmimf5ba76djr201q0bamm2385zxni5jnyyc4iis4";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0/runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg";
+      sha256 = "1p4dgxax6p7rlgj4q73k73rslcnz4wdcv8q2flg1s8ygwcm58ld5";
     };
   }
   {
     name = "shouldly";
     version = "3.0.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/shouldly/3.0.0/shouldly.3.0.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/shouldly/3.0.0/shouldly.3.0.0.nupkg";
       sha256 = "1hg28w898kl84rx57sclb2z9b76v5hxlwxig1xnb6fr81aahzlw3";
     };
   }
@@ -603,7 +731,7 @@
     name = "sn";
     version = "1.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/sn/1.0.0/sn.1.0.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/sn/1.0.0/sn.1.0.0.nupkg";
       sha256 = "1012fcdc6vq2355v86h434s6p2nnqgpdapb7p25l4h39g5q8p1qs";
     };
   }
@@ -611,31 +739,31 @@
     name = "system.appcontext";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.appcontext/4.1.0/system.appcontext.4.1.0.nupkg";
-      sha256 = "02vsx9l8ahzykjw6psf8yd5grndk63x4rw0lc0rl0s9z203694j3";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.appcontext/4.1.0/system.appcontext.4.1.0.nupkg";
+      sha256 = "0fv3cma1jp4vgj7a8hqc9n7hr1f1kjp541s6z0q1r6nazb4iz9mz";
     };
   }
   {
     name = "system.appcontext";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.appcontext/4.3.0/system.appcontext.4.3.0.nupkg";
-      sha256 = "1ipqwwfphj4ndi6krnbali0f3260bmdg0lb9w7w00k3z20gwpjgy";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.appcontext/4.3.0/system.appcontext.4.3.0.nupkg";
+      sha256 = "1649qvy3dar900z3g817h17nl8jp4ka5vcfmsr05kh0fshn7j3ya";
     };
   }
   {
     name = "system.buffers";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg";
-      sha256 = "1x5m2z3x8s4d0z13l8j6jfbaqpwh8dwyg930pcg67gz88zchfhq8";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.buffers/4.3.0/system.buffers.4.3.0.nupkg";
+      sha256 = "0fgns20ispwrfqll4q1zc1waqcmylb3zc50ys9x8zlwxh9pmd9jy";
     };
   }
   {
     name = "system.buffers";
     version = "4.4.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.buffers/4.4.0/system.buffers.4.4.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.buffers/4.4.0/system.buffers.4.4.0.nupkg";
       sha256 = "183f8063w8zqn99pv0ni0nnwh7fgx46qzxamwnans55hhs2l0g19";
     };
   }
@@ -643,271 +771,335 @@
     name = "system.buffers";
     version = "4.5.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.buffers/4.5.0/system.buffers.4.5.0.nupkg";
-      sha256 = "0c8qh10lhc8gcl58772i91lc97bljy3dvi6s2r8cjlf0240j5yll";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.buffers/4.5.0/system.buffers.4.5.0.nupkg";
+      sha256 = "1ywfqn4md6g3iilpxjn5dsr0f5lx6z0yvhqp4pgjcamygg73cz2c";
+    };
+  }
+  {
+    name = "system.buffers";
+    version = "4.5.1";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.buffers/4.5.1/system.buffers.4.5.1.nupkg";
+      sha256 = "04kb1mdrlcixj9zh1xdi5as0k0qi8byr5mi3p3jcxx72qz93s2y3";
     };
   }
   {
     name = "system.collections";
     version = "4.0.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.collections/4.0.11/system.collections.4.0.11.nupkg";
-      sha256 = "19kjsnpbpznh7qjsyxadw2i8pd4iikrlxwak12l749sli2qd77dj";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.collections/4.0.11/system.collections.4.0.11.nupkg";
+      sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
     };
   }
   {
     name = "system.collections";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.collections/4.3.0/system.collections.4.3.0.nupkg";
-      sha256 = "0209rky2iyiyqxg0amhmvy6c3fww6pbrq9ffynjnmapizmsvq7ya";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.collections/4.3.0/system.collections.4.3.0.nupkg";
+      sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
     };
   }
   {
     name = "system.collections.concurrent";
     version = "4.0.12";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.collections.concurrent/4.0.12/system.collections.concurrent.4.0.12.nupkg";
-      sha256 = "1c4lv39n2i7k146njgk7334izcxjn06cnhmippc1vhwj3bqbzg62";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.collections.concurrent/4.0.12/system.collections.concurrent.4.0.12.nupkg";
+      sha256 = "07y08kvrzpak873pmyxs129g1ch8l27zmg51pcyj2jvq03n0r0fc";
     };
   }
   {
     name = "system.collections.concurrent";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg";
-      sha256 = "0y6jag332kgkj392mrv7i2a3cgc60ff4hl0nx5qw40hq3w2d9j8z";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg";
+      sha256 = "0wi10md9aq33jrkh2c24wr2n9hrpyamsdhsxdcnf43b7y86kkii8";
     };
   }
   {
     name = "system.collections.immutable";
     version = "1.2.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.collections.immutable/1.2.0/system.collections.immutable.1.2.0.nupkg";
-      sha256 = "1ywivzq43lqlh42qywq6v57yf499dya5rbzk6k7fnkj1121fr7kw";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.collections.immutable/1.2.0/system.collections.immutable.1.2.0.nupkg";
+      sha256 = "1jm4pc666yiy7af1mcf7766v710gp0h40p228ghj6bavx7xfa38m";
     };
   }
   {
     name = "system.collections.immutable";
     version = "1.5.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.collections.immutable/1.5.0/system.collections.immutable.1.5.0.nupkg";
-      sha256 = "1yn0g10x5lss68i5n5x9q9z1kbxcbblrwp51ph79cgbi01ga999q";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.collections.immutable/1.5.0/system.collections.immutable.1.5.0.nupkg";
+      sha256 = "1d5gjn5afnrf461jlxzawcvihz195gayqpcfbv6dd7pxa9ialn06";
+    };
+  }
+  {
+    name = "system.collections.immutable";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.collections.immutable/5.0.0/system.collections.immutable.5.0.0.nupkg";
+      sha256 = "1kvcllagxz2q92g81zkz81djkn2lid25ayjfgjalncyc68i15p0r";
     };
   }
   {
     name = "system.collections.nongeneric";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.collections.nongeneric/4.0.1/system.collections.nongeneric.4.0.1.nupkg";
-      sha256 = "1wj1ddyycsggg3sjq0iflzyj93m7ny8mc2dpzvh5iqy89lj3gx1m";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.collections.nongeneric/4.0.1/system.collections.nongeneric.4.0.1.nupkg";
+      sha256 = "19994r5y5bpdhj7di6w047apvil8lh06lh2c2yv9zc4fc5g9bl4d";
+    };
+  }
+  {
+    name = "system.configuration.configurationmanager";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.configuration.configurationmanager/4.7.0/system.configuration.configurationmanager.4.7.0.nupkg";
+      sha256 = "0pav0n21ghf2ax6fiwjbng29f27wkb4a2ddma0cqx04s97yyk25d";
     };
   }
   {
     name = "system.console";
     version = "4.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.console/4.0.0/system.console.4.0.0.nupkg";
-      sha256 = "0fw0ap3c0svxjbkgr5yrkck36lbrijhsx48v53xkam5y6m0vh1s3";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.console/4.0.0/system.console.4.0.0.nupkg";
+      sha256 = "0ynxqbc3z1nwbrc11hkkpw9skw116z4y9wjzn7id49p9yi7mzmlf";
     };
   }
   {
     name = "system.console";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.console/4.3.0/system.console.4.3.0.nupkg";
-      sha256 = "0hyp57lqq986hnj7h017mz1qa1p3qqw3n98nxngdj947ck4mwmpd";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.console/4.3.0/system.console.4.3.0.nupkg";
+      sha256 = "1flr7a9x920mr5cjsqmsy9wgnv3lvd0h1g521pdr1lkb2qycy7ay";
     };
   }
   {
     name = "system.diagnostics.debug";
     version = "4.0.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.diagnostics.debug/4.0.11/system.diagnostics.debug.4.0.11.nupkg";
-      sha256 = "0j4czvcp72qamsj8irwg0sv5lqil4g6q1ghqsm40g5f3380fxcn3";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.debug/4.0.11/system.diagnostics.debug.4.0.11.nupkg";
+      sha256 = "0gmjghrqmlgzxivd2xl50ncbglb7ljzb66rlx8ws6dv8jm0d5siz";
     };
   }
   {
     name = "system.diagnostics.debug";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg";
-      sha256 = "02az3f9n0sy9hpjqq05dkwa4d4bgyrs57b69byya20zydvyxxm9z";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.debug/4.3.0/system.diagnostics.debug.4.3.0.nupkg";
+      sha256 = "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y";
     };
   }
   {
     name = "system.diagnostics.diagnosticsource";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg";
-      sha256 = "0rqi76pqplmk8lzqhwxkkn6ramk56bm66ijg3zki9gzaaqx7fbfk";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg";
+      sha256 = "0z6m3pbiy0qw6rn3n209rrzf9x1k4002zh90vwcrsym09ipm2liq";
+    };
+  }
+  {
+    name = "system.diagnostics.fileversioninfo";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.fileversioninfo/4.3.0/system.diagnostics.fileversioninfo.4.3.0.nupkg";
+      sha256 = "094hx249lb3vb336q7dg3v257hbxvz2jnalj695l7cg5kxzqwai7";
     };
   }
   {
     name = "system.diagnostics.process";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.diagnostics.process/4.1.0/system.diagnostics.process.4.1.0.nupkg";
-      sha256 = "1fzm5jrfs4awz0qc2yav1assdnx45j5crpva50a4s0l0dnnvf2jh";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.process/4.1.0/system.diagnostics.process.4.1.0.nupkg";
+      sha256 = "061lrcs7xribrmq7kab908lww6kn2xn1w3rdc41q189y0jibl19s";
+    };
+  }
+  {
+    name = "system.diagnostics.stacktrace";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.stacktrace/4.3.0/system.diagnostics.stacktrace.4.3.0.nupkg";
+      sha256 = "0ash4h9k0m7xsm0yl79r0ixrdz369h7y922wipp5gladmlbvpyjd";
     };
   }
   {
     name = "system.diagnostics.tools";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.diagnostics.tools/4.3.0/system.diagnostics.tools.4.3.0.nupkg";
-      sha256 = "0fmmnsvnjxh4gjw2jjix3f7ndvhdh9h4rb4nbjk285c2rgfp2kyn";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.tools/4.3.0/system.diagnostics.tools.4.3.0.nupkg";
+      sha256 = "0in3pic3s2ddyibi8cvgl102zmvp9r9mchh82ns9f0ms4basylw1";
     };
   }
   {
     name = "system.diagnostics.tracesource";
     version = "4.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.diagnostics.tracesource/4.0.0/system.diagnostics.tracesource.4.0.0.nupkg";
-      sha256 = "0dwq0z7p3jpxp4y9x1k3pglrs572xx5dsp4nmnz5v5wr6a1kdc8l";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.tracesource/4.0.0/system.diagnostics.tracesource.4.0.0.nupkg";
+      sha256 = "1mc7r72xznczzf6mz62dm8xhdi14if1h8qgx353xvhz89qyxsa3h";
     };
   }
   {
     name = "system.diagnostics.tracing";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.diagnostics.tracing/4.1.0/system.diagnostics.tracing.4.1.0.nupkg";
-      sha256 = "0lzdnq31spwv2xd9xkf0ph4zlg7bqifcvp1915jk1hb5fjjf1byp";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.tracing/4.1.0/system.diagnostics.tracing.4.1.0.nupkg";
+      sha256 = "1d2r76v1x610x61ahfpigda89gd13qydz6vbwzhpqlyvq8jj6394";
     };
   }
   {
     name = "system.diagnostics.tracing";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg";
-      sha256 = "0zwc9qk2ig6h74dnn4hxlyhnfchp6yd6hqv39dy0dhp3xagwfqp3";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg";
+      sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
+    };
+  }
+  {
+    name = "system.dynamic.runtime";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.dynamic.runtime/4.3.0/system.dynamic.runtime.4.3.0.nupkg";
+      sha256 = "1d951hrvrpndk7insiag80qxjbf2y0y39y8h5hnq9612ws661glk";
     };
   }
   {
     name = "system.globalization";
     version = "4.0.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.globalization/4.0.11/system.globalization.4.0.11.nupkg";
-      sha256 = "04pycnih66s15rbwss94ylm0svfr276ym4w4w14bb9g56dk0wwyy";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.globalization/4.0.11/system.globalization.4.0.11.nupkg";
+      sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
     };
   }
   {
     name = "system.globalization";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.globalization/4.3.0/system.globalization.4.3.0.nupkg";
-      sha256 = "1sydnlnaqmarcfs1cvaa3rpax7qhzd8wd67f74k89lr3k77cagfh";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.globalization/4.3.0/system.globalization.4.3.0.nupkg";
+      sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
     };
   }
   {
     name = "system.globalization.calendars";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg";
-      sha256 = "1qfa54p7ab2himyry3lf0j85gpz3mx9yj0sy0v2j9i94ndvk1w7c";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg";
+      sha256 = "1xwl230bkakzzkrggy1l1lxmm3xlhk4bq2pkv790j5lm8g887lxq";
     };
   }
   {
     name = "system.io";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.io/4.1.0/system.io.4.1.0.nupkg";
-      sha256 = "0drs586wimx7vzwqfdb72k640iz24645cwz053n1f08752bjkzq8";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.io/4.1.0/system.io.4.1.0.nupkg";
+      sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
     };
   }
   {
     name = "system.io";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg";
-      sha256 = "1n3qypsgn18pg13vyjcnchz3zbfajdk6swl1wzf0hv6324v8xyd7";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.io/4.3.0/system.io.4.3.0.nupkg";
+      sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
     };
   }
   {
     name = "system.io.compression";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.io.compression/4.3.0/system.io.compression.4.3.0.nupkg";
-      sha256 = "0mxp384amfdapgsf6fkyf3c5q10jc2yy55v3vim8wq1w8aim1qcf";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.io.compression/4.3.0/system.io.compression.4.3.0.nupkg";
+      sha256 = "084zc82yi6yllgda0zkgl2ys48sypiswbiwrv7irb3r0ai1fp4vz";
     };
   }
   {
     name = "system.io.compression.zipfile";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.io.compression.zipfile/4.3.0/system.io.compression.zipfile.4.3.0.nupkg";
-      sha256 = "08fbnsgbbnfj7d6k5zdqvm3580iqwrq4qzbnyq6iw9g93kmlyh5p";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.io.compression.zipfile/4.3.0/system.io.compression.zipfile.4.3.0.nupkg";
+      sha256 = "1yxy5pq4dnsm9hlkg9ysh5f6bf3fahqqb6p8668ndy5c0lk7w2ar";
     };
   }
   {
     name = "system.io.filesystem";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.io.filesystem/4.0.1/system.io.filesystem.4.0.1.nupkg";
-      sha256 = "0mp3n5214lzxz7qn2y5k7f2y9qv067xa23bnbyyhpmlkbl3grwc6";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.io.filesystem/4.0.1/system.io.filesystem.4.0.1.nupkg";
+      sha256 = "0kgfpw6w4djqra3w5crrg8xivbanh1w9dh3qapb28q060wb9flp1";
     };
   }
   {
     name = "system.io.filesystem";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg";
-      sha256 = "1p4r4n4minxgir17xh7rwv503fj1zgnm1vb24and7v2n6id4ma61";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg";
+      sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
     };
   }
   {
     name = "system.io.filesystem.primitives";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.io.filesystem.primitives/4.0.1/system.io.filesystem.primitives.4.0.1.nupkg";
-      sha256 = "12mspig2fvzhvbdm22yk081lpn7rc45xwwricc5vnaszgjp83gns";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.io.filesystem.primitives/4.0.1/system.io.filesystem.primitives.4.0.1.nupkg";
+      sha256 = "1s0mniajj3lvbyf7vfb5shp4ink5yibsx945k6lvxa96r8la1612";
     };
   }
   {
     name = "system.io.filesystem.primitives";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg";
-      sha256 = "0s22vnhy6cxyzicipj3937rldxk1znlykakc6j596mjgsmshpfqn";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg";
+      sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
     };
   }
   {
     name = "system.linq";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.linq/4.1.0/system.linq.4.1.0.nupkg";
-      sha256 = "1n404dvsz6p2d18q9k3ip1vyl8ffbsz6xvc2bl2bba9ccpyjhygm";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.linq/4.1.0/system.linq.4.1.0.nupkg";
+      sha256 = "1ppg83svb39hj4hpp5k7kcryzrf3sfnm08vxd5sm2drrijsla2k5";
     };
   }
   {
     name = "system.linq";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.linq/4.3.0/system.linq.4.3.0.nupkg";
-      sha256 = "1419wbklbn2vliwfy77p759k084h8jp9i3559shbhrzfxjr2fcv9";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.linq/4.3.0/system.linq.4.3.0.nupkg";
+      sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
     };
   }
   {
     name = "system.linq.expressions";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.linq.expressions/4.3.0/system.linq.expressions.4.3.0.nupkg";
-      sha256 = "177cz5hgcbq8lpgvdjmkpsx4kr645wpxhbgh3aw3f28nqlmhl70j";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.linq.expressions/4.3.0/system.linq.expressions.4.3.0.nupkg";
+      sha256 = "0ky2nrcvh70rqq88m9a5yqabsl4fyd17bpr63iy2mbivjs2nyypv";
+    };
+  }
+  {
+    name = "system.management";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.management/4.5.0/system.management.4.5.0.nupkg";
+      sha256 = "19z5x23n21xi94bgl531l9hrm64nyw9d5fpd7klfvr5xfsbh9jwr";
     };
   }
   {
     name = "system.memory";
     version = "4.5.3";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg";
-      sha256 = "1igqq2lqrijpbn66w1020cyyqiwy80i9fkqrmalamjmvmyg28p8m";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.memory/4.5.3/system.memory.4.5.3.nupkg";
+      sha256 = "0naqahm3wljxb5a911d37mwjqjdxv9l0b49p5dmfyijvni2ppy8a";
+    };
+  }
+  {
+    name = "system.memory";
+    version = "4.5.4";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.memory/4.5.4/system.memory.4.5.4.nupkg";
+      sha256 = "14gbbs22mcxwggn0fcfs1b062521azb9fbb7c113x0mq6dzq9h6y";
     };
   }
   {
     name = "system.net.http";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.0/system.net.http.4.3.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.net.http/4.3.0/system.net.http.4.3.0.nupkg";
       sha256 = "1i4gc757xqrzflbk7kc5ksn20kwwfjhw9w7pgdkn19y3cgnl302j";
     };
   }
@@ -915,23 +1107,23 @@
     name = "system.net.primitives";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg";
-      sha256 = "1zfrz4p3nmz3cnb0i8xwc76175328dfgrlmp3bcwvp5vplv3ncnz";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg";
+      sha256 = "0c87k50rmdgmxx7df2khd9qj7q35j9rzdmm2572cc55dygmdk3ii";
     };
   }
   {
     name = "system.net.sockets";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.net.sockets/4.3.0/system.net.sockets.4.3.0.nupkg";
-      sha256 = "026ghgh25lw953aqd83npk856g4bwi6a8y7jc695qj8lb929yp5s";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.net.sockets/4.3.0/system.net.sockets.4.3.0.nupkg";
+      sha256 = "1ssa65k6chcgi6mfmzrznvqaxk8jp0gvl77xhf1hbzakjnpxspla";
     };
   }
   {
     name = "system.numerics.vectors";
     version = "4.4.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.numerics.vectors/4.4.0/system.numerics.vectors.4.4.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.numerics.vectors/4.4.0/system.numerics.vectors.4.4.0.nupkg";
       sha256 = "0rdvma399070b0i46c4qq1h2yvjj3k013sqzkilz4bz5cwmx1rba";
     };
   }
@@ -939,127 +1131,151 @@
     name = "system.numerics.vectors";
     version = "4.5.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.numerics.vectors/4.5.0/system.numerics.vectors.4.5.0.nupkg";
-      sha256 = "1r66gjpvbmgr3216ch2fx9zzd08fb78br4hzblvsvi7wfwp6w7ip";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.numerics.vectors/4.5.0/system.numerics.vectors.4.5.0.nupkg";
+      sha256 = "1kzrj37yzawf1b19jq0253rcs8hsq1l2q8g69d7ipnhzb0h97m59";
     };
   }
   {
     name = "system.objectmodel";
     version = "4.0.12";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.objectmodel/4.0.12/system.objectmodel.4.0.12.nupkg";
-      sha256 = "06abwzrai4k999qmc8bkcvq26px2ws9gk04c01c1ix9fw02pf546";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.objectmodel/4.0.12/system.objectmodel.4.0.12.nupkg";
+      sha256 = "1sybkfi60a4588xn34nd9a58png36i0xr4y4v4kqpg8wlvy5krrj";
     };
   }
   {
     name = "system.objectmodel";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.objectmodel/4.3.0/system.objectmodel.4.3.0.nupkg";
-      sha256 = "18mryszf4a66a52v9din5wgqiykp0ficl5zl5l9grkrisjnl7jh4";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.objectmodel/4.3.0/system.objectmodel.4.3.0.nupkg";
+      sha256 = "191p63zy5rpqx7dnrb3h7prvgixmk168fhvvkkvhlazncf8r3nc2";
     };
   }
   {
     name = "system.private.datacontractserialization";
     version = "4.1.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.private.datacontractserialization/4.1.1/system.private.datacontractserialization.4.1.1.nupkg";
-      sha256 = "1hrbq85s14x7ck6an570z8p7slprlsswxlydz0pdzfmnqwpv0qbi";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.private.datacontractserialization/4.1.1/system.private.datacontractserialization.4.1.1.nupkg";
+      sha256 = "1xk9wvgzipssp1393nsg4n16zbr5481k03nkdlj954hzq5jkx89r";
     };
   }
   {
     name = "system.reflection";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection/4.1.0/system.reflection.4.1.0.nupkg";
-      sha256 = "003bmllpdf35jsbbhgsi4a24rqprdhgjpi3d76jk7sgllbh6p1wj";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection/4.1.0/system.reflection.4.1.0.nupkg";
+      sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
     };
   }
   {
     name = "system.reflection";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection/4.3.0/system.reflection.4.3.0.nupkg";
-      sha256 = "00f1n6r8z6zw3mfhrfg402s6fj95jj9d8z5s62kfmd7pdsnv39xi";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection/4.3.0/system.reflection.4.3.0.nupkg";
+      sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
     };
   }
   {
     name = "system.reflection.emit";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection.emit/4.0.1/system.reflection.emit.4.0.1.nupkg";
-      sha256 = "0s1cpkpnn2x6bicspj1x7z7zlfg1h5iy8mvr5bcq55fgpyf6xin8";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.emit/4.0.1/system.reflection.emit.4.0.1.nupkg";
+      sha256 = "0ydqcsvh6smi41gyaakglnv252625hf29f7kywy2c70nhii2ylqp";
+    };
+  }
+  {
+    name = "system.reflection.emit";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.emit/4.3.0/system.reflection.emit.4.3.0.nupkg";
+      sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
     };
   }
   {
     name = "system.reflection.emit.ilgeneration";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection.emit.ilgeneration/4.0.1/system.reflection.emit.ilgeneration.4.0.1.nupkg";
-      sha256 = "0q789n72y47jkld2076khan7zz2gm04znpnz0nznin7ykp8aa0ih";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.emit.ilgeneration/4.0.1/system.reflection.emit.ilgeneration.4.0.1.nupkg";
+      sha256 = "1pcd2ig6bg144y10w7yxgc9d22r7c7ww7qn1frdfwgxr24j9wvv0";
     };
   }
   {
     name = "system.reflection.emit.lightweight";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection.emit.lightweight/4.0.1/system.reflection.emit.lightweight.4.0.1.nupkg";
-      sha256 = "10hsbdar8vzvq3izv3v8a93rz7brnmrcrcl5c0nvy8vlmdk41jlx";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.emit.lightweight/4.0.1/system.reflection.emit.lightweight.4.0.1.nupkg";
+      sha256 = "1s4b043zdbx9k39lfhvsk68msv1nxbidhkq6nbm27q7sf8xcsnxr";
+    };
+  }
+  {
+    name = "system.reflection.emit.lightweight";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.emit.lightweight/4.3.0/system.reflection.emit.lightweight.4.3.0.nupkg";
+      sha256 = "0ql7lcakycrvzgi9kxz1b3lljd990az1x6c4jsiwcacrvimpib5c";
     };
   }
   {
     name = "system.reflection.extensions";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection.extensions/4.0.1/system.reflection.extensions.4.0.1.nupkg";
-      sha256 = "1n1gig2nlycrz1rzy1gi56gcw568ibdpnbknjy7gv9i76aw2kvy7";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.extensions/4.0.1/system.reflection.extensions.4.0.1.nupkg";
+      sha256 = "0m7wqwq0zqq9gbpiqvgk3sr92cbrw7cp3xn53xvw7zj6rz6fdirn";
     };
   }
   {
     name = "system.reflection.extensions";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection.extensions/4.3.0/system.reflection.extensions.4.3.0.nupkg";
-      sha256 = "020gr3yjb3aa49hm4qyxqrz318ll2rnc8qpcby341ik0gr4ij3wz";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.extensions/4.3.0/system.reflection.extensions.4.3.0.nupkg";
+      sha256 = "02bly8bdc98gs22lqsfx9xicblszr2yan7v2mmw3g7hy6miq5hwq";
     };
   }
   {
     name = "system.reflection.metadata";
     version = "1.6.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection.metadata/1.6.0/system.reflection.metadata.1.6.0.nupkg";
-      sha256 = "1kw4xsm093zd10jf3vjc2lxmv0zq6chi3g8rka8w0d3l3a5hh3ly";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.metadata/1.6.0/system.reflection.metadata.1.6.0.nupkg";
+      sha256 = "1wdbavrrkajy7qbdblpbpbalbdl48q3h34cchz24gvdgyrlf15r4";
+    };
+  }
+  {
+    name = "system.reflection.metadata";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.metadata/5.0.0/system.reflection.metadata.5.0.0.nupkg";
+      sha256 = "17qsl5nanlqk9iz0l5wijdn6ka632fs1m1fvx18dfgswm258r3ss";
     };
   }
   {
     name = "system.reflection.primitives";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection.primitives/4.0.1/system.reflection.primitives.4.0.1.nupkg";
-      sha256 = "1r0a1xhlrdr6kdhia9r6rcywds4r8wbk0jagsac6x3rc0kq5f1yi";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.primitives/4.0.1/system.reflection.primitives.4.0.1.nupkg";
+      sha256 = "1bangaabhsl4k9fg8khn83wm6yial8ik1sza7401621jc6jrym28";
     };
   }
   {
     name = "system.reflection.primitives";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg";
-      sha256 = "1b10cxizldqk8niyihhxsabfjkyrlnkgf4im038lbxs3pq7a12yl";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.primitives/4.3.0/system.reflection.primitives.4.3.0.nupkg";
+      sha256 = "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276";
     };
   }
   {
     name = "system.reflection.typeextensions";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.reflection.typeextensions/4.1.0/system.reflection.typeextensions.4.1.0.nupkg";
-      sha256 = "13y2gvadvzgv5hrizwd53xyciq88p8mpclyqfmikspij4pyb5328";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.reflection.typeextensions/4.1.0/system.reflection.typeextensions.4.1.0.nupkg";
+      sha256 = "1bjli8a7sc7jlxqgcagl9nh8axzfl11f4ld3rjqsyxc516iijij7";
     };
   }
   {
     name = "system.resources.extensions";
     version = "4.6.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.resources.extensions/4.6.0/system.resources.extensions.4.6.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.resources.extensions/4.6.0/system.resources.extensions.4.6.0.nupkg";
       sha256 = "0inch9jgchgmsg3xjivbhh9mpin40mhdd8dgf4i1p3g42i0hzc0j";
     };
   }
@@ -1067,183 +1283,207 @@
     name = "system.resources.reader";
     version = "4.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.resources.reader/4.0.0/system.resources.reader.4.0.0.nupkg";
-      sha256 = "0nipl2mayrbgf62mbi3z9crk9hvcrxnry008a33iyk9xy45rmyk1";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.resources.reader/4.0.0/system.resources.reader.4.0.0.nupkg";
+      sha256 = "1jafi73dcf1lalrir46manq3iy6xnxk2z7gpdpwg4wqql7dv3ril";
     };
   }
   {
     name = "system.resources.resourcemanager";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.resources.resourcemanager/4.0.1/system.resources.resourcemanager.4.0.1.nupkg";
-      sha256 = "1hjlz6rvr5c7qmvmbv1a338zqjl1dbj0qqidwv9z0ldy4jmg89cy";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.resources.resourcemanager/4.0.1/system.resources.resourcemanager.4.0.1.nupkg";
+      sha256 = "0b4i7mncaf8cnai85jv3wnw6hps140cxz8vylv2bik6wyzgvz7bi";
     };
   }
   {
     name = "system.resources.resourcemanager";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg";
-      sha256 = "1bi65kd8fps7gncs053pawc0j44pz4wcgdj3jcw7gpjr4j0zyxwi";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.4.3.0.nupkg";
+      sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
     };
   }
   {
     name = "system.runtime";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime/4.1.0/system.runtime.4.1.0.nupkg";
-      sha256 = "05n73j0s3qgjnp5w2jxaacn93kpq14cldxncv15v04b3lla30mpr";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime/4.1.0/system.runtime.4.1.0.nupkg";
+      sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
     };
   }
   {
     name = "system.runtime";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg";
-      sha256 = "0cffdplihjrivvcayzvz32gmv7yissf2pmyaga4fw7g262rf5mxi";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime/4.3.0/system.runtime.4.3.0.nupkg";
+      sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
     };
   }
   {
     name = "system.runtime.compilerservices.unsafe";
-    version = "4.5.2";
+    version = "5.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.compilerservices.unsafe/4.5.2/system.runtime.compilerservices.unsafe.4.5.2.nupkg";
-      sha256 = "0bp6in9qqhprbk85wd0cnfnpjcwdknyyc9rk0891kldx3alnd4h7";
-    };
-  }
-  {
-    name = "system.runtime.compilerservices.unsafe";
-    version = "4.7.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.7.0/system.runtime.compilerservices.unsafe.4.7.0.nupkg";
-      sha256 = "16r6sn4czfjk8qhnz7bnqlyiaaszr0ihinb7mq9zzr1wba257r54";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.compilerservices.unsafe/5.0.0/system.runtime.compilerservices.unsafe.5.0.0.nupkg";
+      sha256 = "02k25ivn50dmqx5jn8hawwmz24yf0454fjd823qk6lygj9513q4x";
     };
   }
   {
     name = "system.runtime.extensions";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.extensions/4.1.0/system.runtime.extensions.4.1.0.nupkg";
-      sha256 = "0bms87hf2q90kkfg75ljdk09410fl64326wpvhqgfkgw019704yc";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.extensions/4.1.0/system.runtime.extensions.4.1.0.nupkg";
+      sha256 = "0rw4rm4vsm3h3szxp9iijc3ksyviwsv6f63dng3vhqyg4vjdkc2z";
     };
   }
   {
     name = "system.runtime.extensions";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg";
-      sha256 = "18qn6zjvpngda5bd9nrpphwy5lppmkla86jk5bdapz6ar44ic8wy";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.extensions/4.3.0/system.runtime.extensions.4.3.0.nupkg";
+      sha256 = "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60";
     };
   }
   {
     name = "system.runtime.handles";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.handles/4.0.1/system.runtime.handles.4.0.1.nupkg";
-      sha256 = "00kzqs5d8gm1ppc13idybcdrr07yk2a7f5bdrb0mw7c1bafjp1px";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.handles/4.0.1/system.runtime.handles.4.0.1.nupkg";
+      sha256 = "1g0zrdi5508v49pfm3iii2hn6nm00bgvfpjq1zxknfjrxxa20r4g";
     };
   }
   {
     name = "system.runtime.handles";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.handles/4.3.0/system.runtime.handles.4.3.0.nupkg";
-      sha256 = "1klsizwincb42v9yl6m9czgqcmxr7a1h1ri687ldqy4w15718adi";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.handles/4.3.0/system.runtime.handles.4.3.0.nupkg";
+      sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
     };
   }
   {
     name = "system.runtime.interopservices";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.interopservices/4.1.0/system.runtime.interopservices.4.1.0.nupkg";
-      sha256 = "1876kwm4ziikya5s75sb1cp23qwdsd7xhlmlb9gaglibzwkd8b9d";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.interopservices/4.1.0/system.runtime.interopservices.4.1.0.nupkg";
+      sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
     };
   }
   {
     name = "system.runtime.interopservices";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg";
-      sha256 = "0l13wfr3y4rq667cyw1rl3bdq24zhs34jwv61piwnv77flwr4brq";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.interopservices/4.3.0/system.runtime.interopservices.4.3.0.nupkg";
+      sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
     };
   }
   {
     name = "system.runtime.interopservices.runtimeinformation";
     version = "4.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.interopservices.runtimeinformation/4.0.0/system.runtime.interopservices.runtimeinformation.4.0.0.nupkg";
-      sha256 = "05pmsmrjmy3mk4r8xqihc3w7128d4qccjg6wkyd7zc2yq67w7xmg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.interopservices.runtimeinformation/4.0.0/system.runtime.interopservices.runtimeinformation.4.0.0.nupkg";
+      sha256 = "0glmvarf3jz5xh22iy3w9v3wyragcm4hfdr17v90vs7vcrm7fgp6";
     };
   }
   {
     name = "system.runtime.interopservices.runtimeinformation";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.interopservices.runtimeinformation/4.3.0/system.runtime.interopservices.runtimeinformation.4.3.0.nupkg";
-      sha256 = "131108h1vnayxx6ms2axinja3sqckb1b8z9v8fjnaf9ix8zvmaxq";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.interopservices.runtimeinformation/4.3.0/system.runtime.interopservices.runtimeinformation.4.3.0.nupkg";
+      sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
     };
   }
   {
     name = "system.runtime.numerics";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg";
-      sha256 = "06i4k2ng909fvlq9dhglgyp0iv5vj6b42vqlsvk2gcn6ssgkq9ya";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg";
+      sha256 = "19rav39sr5dky7afygh309qamqqmi9kcwvz3i0c5700v0c5cg61z";
     };
   }
   {
     name = "system.runtime.serialization.primitives";
     version = "4.1.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.serialization.primitives/4.1.1/system.runtime.serialization.primitives.4.1.1.nupkg";
-      sha256 = "1mqwgsda61xm2p4chcniypnnrahh8l6j8c9j45jd2r0hmrvnsc4k";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.serialization.primitives/4.1.1/system.runtime.serialization.primitives.4.1.1.nupkg";
+      sha256 = "042rfjixknlr6r10vx2pgf56yming8lkjikamg3g4v29ikk78h7k";
     };
   }
   {
     name = "system.runtime.serialization.xml";
     version = "4.1.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.runtime.serialization.xml/4.1.1/system.runtime.serialization.xml.4.1.1.nupkg";
-      sha256 = "19mwnihzks4l2q73bsg5ylbawxqcji3slzzp0v46v6xvvrq480wq";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.runtime.serialization.xml/4.1.1/system.runtime.serialization.xml.4.1.1.nupkg";
+      sha256 = "11747an5gbz821pwahaim3v82gghshnj9b5c4cw539xg5a3gq7rk";
+    };
+  }
+  {
+    name = "system.security.accesscontrol";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.accesscontrol/4.5.0/system.security.accesscontrol.4.5.0.nupkg";
+      sha256 = "1wvwanz33fzzbnd2jalar0p0z3x0ba53vzx1kazlskp7pwyhlnq0";
+    };
+  }
+  {
+    name = "system.security.accesscontrol";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.accesscontrol/4.7.0/system.security.accesscontrol.4.7.0.nupkg";
+      sha256 = "0n0k0w44flkd8j0xw7g3g3vhw7dijfm51f75xkm1qxnbh4y45mpz";
     };
   }
   {
     name = "system.security.cryptography.algorithms";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg";
-      sha256 = "04lfa74ll34fk2r42fkdldvcgjp27i3d5zbxx5bxx1dfpsqhkavv";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg";
+      sha256 = "03sq183pfl5kp7gkvq77myv7kbpdnq3y0xj7vi4q1kaw54sny0ml";
     };
   }
   {
     name = "system.security.cryptography.encoding";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg";
-      sha256 = "1icdqp1c8f7971h1vkls87m8bdxs7xqg4xs7ygi0x3n56pjbqfpi";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg";
+      sha256 = "1jr6w70igqn07k5zs1ph6xja97hxnb3mqbspdrff6cvssgrixs32";
     };
   }
   {
     name = "system.security.cryptography.primitives";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg";
-      sha256 = "02dsnjxw9bymk0a2qnnlavpi0jq8832dviblv5f9icmwldridc8y";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg";
+      sha256 = "0pyzncsv48zwly3lw4f2dayqswcfvdwq2nz0dgwmi7fj3pn64wby";
     };
   }
   {
     name = "system.security.cryptography.x509certificates";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg";
-      sha256 = "0p02s2k8gcx86ys67ydbgrlnp5q7f073jnlgpliqp4f7d2wiwszd";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg";
+      sha256 = "0valjcz5wksbvijylxijjxb1mp38mdhv03r533vnx1q3ikzdav9h";
+    };
+  }
+  {
+    name = "system.security.permissions";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.permissions/4.7.0/system.security.permissions.4.7.0.nupkg";
+      sha256 = "13f366sj36jwbvld957gk2q64k2xbj48r8b0k9avrri2nlq1fs04";
+    };
+  }
+  {
+    name = "system.security.principal.windows";
+    version = "4.5.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.principal.windows/4.5.0/system.security.principal.windows.4.5.0.nupkg";
+      sha256 = "0rmj89wsl5yzwh0kqjgx45vzf694v9p92r4x4q6yxldk1cv1hi86";
     };
   }
   {
     name = "system.security.principal.windows";
     version = "4.7.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.7.0/system.security.principal.windows.4.7.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.principal.windows/4.7.0/system.security.principal.windows.4.7.0.nupkg";
       sha256 = "1a56ls5a9sr3ya0nr086sdpa9qv0abv31dd6fp27maqa9zclqq5d";
     };
   }
@@ -1251,47 +1491,55 @@
     name = "system.text.encoding";
     version = "4.0.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.text.encoding/4.0.11/system.text.encoding.4.0.11.nupkg";
-      sha256 = "0q829jqhv2sdggb3xjlbdp65g2670w9gw64q2irdzr47gl7zpzyl";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.encoding/4.0.11/system.text.encoding.4.0.11.nupkg";
+      sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
     };
   }
   {
     name = "system.text.encoding";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.text.encoding/4.3.0/system.text.encoding.4.3.0.nupkg";
-      sha256 = "04fsaadvsnjz6jmf88n26md9zcmvwgn2dkwqkjvhf5apph8gi44g";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.encoding/4.3.0/system.text.encoding.4.3.0.nupkg";
+      sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
     };
   }
   {
     name = "system.text.encoding.codepages";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.text.encoding.codepages/4.0.1/system.text.encoding.codepages.4.0.1.nupkg";
-      sha256 = "0ixii299wspn434ccjjv8pcvxww3qjl8257r0dx7myh816v3a9sz";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.encoding.codepages/4.0.1/system.text.encoding.codepages.4.0.1.nupkg";
+      sha256 = "00wpm3b9y0k996rm9whxprngm8l500ajmzgy2ip9pgwk0icp06y3";
+    };
+  }
+  {
+    name = "system.text.encoding.codepages";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.encoding.codepages/4.3.0/system.text.encoding.codepages.4.3.0.nupkg";
+      sha256 = "0lgxg1gn7pg7j0f942pfdc9q7wamzxsgq3ng248ikdasxz0iadkv";
     };
   }
   {
     name = "system.text.encoding.extensions";
     version = "4.0.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.text.encoding.extensions/4.0.11/system.text.encoding.extensions.4.0.11.nupkg";
-      sha256 = "15f89w0vwnfp10544wbq0z6fjqn7ig03q3kl16x2pp47rac6yj17";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.encoding.extensions/4.0.11/system.text.encoding.extensions.4.0.11.nupkg";
+      sha256 = "08nsfrpiwsg9x5ml4xyl3zyvjfdi4mvbqf93kjdh11j4fwkznizs";
     };
   }
   {
     name = "system.text.encoding.extensions";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg";
-      sha256 = "1w6jxdkrczxwyw2bbs9ng0zi2nk3paznyhm1vnh5vc8v10k96v98";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg";
+      sha256 = "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy";
     };
   }
   {
     name = "system.text.encodings.web";
     version = "4.7.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.text.encodings.web/4.7.0/system.text.encodings.web.4.7.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.encodings.web/4.7.0/system.text.encodings.web.4.7.0.nupkg";
       sha256 = "0sd3bihfar5rwm6nib4lhyys306nkm02qvk6p6sgzmnlfmma2wn3";
     };
   }
@@ -1299,7 +1547,7 @@
     name = "system.text.json";
     version = "4.7.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.text.json/4.7.0/system.text.json.4.7.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.json/4.7.0/system.text.json.4.7.0.nupkg";
       sha256 = "0fp3xrysccm5dkaac4yb51d793vywxks978kkl5x4db9gw29rfdr";
     };
   }
@@ -1307,191 +1555,223 @@
     name = "system.text.regularexpressions";
     version = "4.1.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.text.regularexpressions/4.1.0/system.text.regularexpressions.4.1.0.nupkg";
-      sha256 = "1ndgfw99bds4772p7578ylcb4whls76qhiz9a3bh4qy9si48afcv";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.regularexpressions/4.1.0/system.text.regularexpressions.4.1.0.nupkg";
+      sha256 = "1mw7vfkkyd04yn2fbhm38msk7dz2xwvib14ygjsb8dq2lcvr18y7";
     };
   }
   {
     name = "system.text.regularexpressions";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.text.regularexpressions/4.3.0/system.text.regularexpressions.4.3.0.nupkg";
-      sha256 = "1510mdlfdc42vyp738wvmqdy3sir2yyh5w3da3v5i0ar2c4jn6wi";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.text.regularexpressions/4.3.0/system.text.regularexpressions.4.3.0.nupkg";
+      sha256 = "1bgq51k7fwld0njylfn7qc5fmwrk2137gdq7djqdsw347paa9c2l";
     };
   }
   {
     name = "system.threading";
     version = "4.0.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading/4.0.11/system.threading.4.0.11.nupkg";
-      sha256 = "12w6vdai88ldgnv9f71rybwyvlzkk1nr57d7f8cz6rajwliz7h6g";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading/4.0.11/system.threading.4.0.11.nupkg";
+      sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
     };
   }
   {
     name = "system.threading";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading/4.3.0/system.threading.4.3.0.nupkg";
-      sha256 = "1ad1drl7q1f8fmfaq3r2bswg58nbc2y01mrbhlwkv41ij1ij3fz3";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading/4.3.0/system.threading.4.3.0.nupkg";
+      sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
     };
   }
   {
     name = "system.threading.tasks";
     version = "4.0.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.tasks/4.0.11/system.threading.tasks.4.0.11.nupkg";
-      sha256 = "03gvdi1qk4kyws4sjfl5w3fy9qbrq0d0i72n7a8d59lchm6l9zjk";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.tasks/4.0.11/system.threading.tasks.4.0.11.nupkg";
+      sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
     };
   }
   {
     name = "system.threading.tasks";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.tasks/4.3.0/system.threading.tasks.4.3.0.nupkg";
-      sha256 = "0y0gw9q62dchzhk3fcdcdfhk6c5zr0a6rs34qfdbkgksnva10cm1";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.tasks/4.3.0/system.threading.tasks.4.3.0.nupkg";
+      sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
     };
   }
   {
     name = "system.threading.tasks.dataflow";
     version = "4.9.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.tasks.dataflow/4.9.0/system.threading.tasks.dataflow.4.9.0.nupkg";
-      sha256 = "01lhdmb9w4h82yaqrqpzvz5cv2b228kj332k2h6nz0qycpjd6b0y";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.tasks.dataflow/4.9.0/system.threading.tasks.dataflow.4.9.0.nupkg";
+      sha256 = "1g6s9pjg4z8iy98df60y9a01imdqy59zd767vz74rrng78jl2dk5";
     };
   }
   {
     name = "system.threading.tasks.extensions";
     version = "4.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.tasks.extensions/4.0.0/system.threading.tasks.extensions.4.0.0.nupkg";
-      sha256 = "1dxi845z4cd83v2ph7dq9ykf5gxr6gaw9k29wckv5zhx1rjwprfg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.tasks.extensions/4.0.0/system.threading.tasks.extensions.4.0.0.nupkg";
+      sha256 = "1cb51z062mvc2i8blpzmpn9d9mm4y307xrwi65di8ri18cz5r1zr";
     };
   }
   {
     name = "system.threading.tasks.extensions";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.tasks.extensions/4.3.0/system.threading.tasks.extensions.4.3.0.nupkg";
-      sha256 = "1dr14m9c2psrvavv74dzwbi09avn0hxmdvr6z03f96mxkrk3cm1d";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.tasks.extensions/4.3.0/system.threading.tasks.extensions.4.3.0.nupkg";
+      sha256 = "1xxcx2xh8jin360yjwm4x4cf5y3a2bwpn2ygkfkwkicz7zk50s2z";
     };
   }
   {
     name = "system.threading.tasks.extensions";
     version = "4.5.2";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.tasks.extensions/4.5.2/system.threading.tasks.extensions.4.5.2.nupkg";
-      sha256 = "03qkna7pwxaxnxg3ydc1vpjzzrizq55gm7w519gqlmd6yca61vzm";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.tasks.extensions/4.5.2/system.threading.tasks.extensions.4.5.2.nupkg";
+      sha256 = "1sh63dz0dymqcwmprp0nadm77b83vmm7lyllpv578c397bslb8hj";
     };
   }
   {
     name = "system.threading.tasks.parallel";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.tasks.parallel/4.0.1/system.threading.tasks.parallel.4.0.1.nupkg";
-      sha256 = "00l76cv7yys3ilrpi32xrs8qk45gmliqvmw2w2zxg3h21y6r0xc0";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.tasks.parallel/4.0.1/system.threading.tasks.parallel.4.0.1.nupkg";
+      sha256 = "114wdg32hr46dfsnns3pgs67kcha5jn47p5gg0mhxfn5vrkr2p75";
+    };
+  }
+  {
+    name = "system.threading.tasks.parallel";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.tasks.parallel/4.3.0/system.threading.tasks.parallel.4.3.0.nupkg";
+      sha256 = "1rr3qa4hxwyj531s4nb3bwrxnxxwz617i0n9gh6x7nr7dd3ayzgh";
     };
   }
   {
     name = "system.threading.thread";
     version = "4.0.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.thread/4.0.0/system.threading.thread.4.0.0.nupkg";
-      sha256 = "0ay1bjmyk0jv6plj9layh3nhr7lnl5a6gzlqi2pgqglb1s9j1x4s";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.thread/4.0.0/system.threading.thread.4.0.0.nupkg";
+      sha256 = "1gxxm5fl36pjjpnx1k688dcw8m9l7nmf802nxis6swdaw8k54jzc";
+    };
+  }
+  {
+    name = "system.threading.thread";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.thread/4.3.0/system.threading.thread.4.3.0.nupkg";
+      sha256 = "0y2xiwdfcph7znm2ysxanrhbqqss6a3shi1z3c779pj2s523mjx4";
     };
   }
   {
     name = "system.threading.timer";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.timer/4.0.1/system.threading.timer.4.0.1.nupkg";
-      sha256 = "0imrcq43k6ii97xpfkwzsvhs6idvgc6mi5c9p7ah828wbaxqh1my";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.timer/4.0.1/system.threading.timer.4.0.1.nupkg";
+      sha256 = "15n54f1f8nn3mjcjrlzdg6q3520571y012mx7v991x2fvp73lmg6";
     };
   }
   {
     name = "system.threading.timer";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.threading.timer/4.3.0/system.threading.timer.4.3.0.nupkg";
-      sha256 = "11p4yxkcn2amlxhwipyia38k8glpam5c9l47y5dvjdicg42dgxl8";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.threading.timer/4.3.0/system.threading.timer.4.3.0.nupkg";
+      sha256 = "1nx773nsx6z5whv8kaa1wjh037id2f1cxhb69pvgv12hd2b6qs56";
     };
   }
   {
     name = "system.valuetuple";
     version = "4.5.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.valuetuple/4.5.0/system.valuetuple.4.5.0.nupkg";
-      sha256 = "068v2h0v8873jh3zc06bxcfzch9frggak1s9csyisl7xzwdijsqn";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.valuetuple/4.5.0/system.valuetuple.4.5.0.nupkg";
+      sha256 = "00k8ja51d0f9wrq4vv5z2jhq8hy31kac2rg0rv06prylcybzl8cy";
     };
   }
   {
     name = "system.xml.readerwriter";
     version = "4.0.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.xml.readerwriter/4.0.11/system.xml.readerwriter.4.0.11.nupkg";
-      sha256 = "04ijmcrb40x08br0fdpxmrm0fw2ahpiqjs9wmrqx38ngf96irb7l";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.xml.readerwriter/4.0.11/system.xml.readerwriter.4.0.11.nupkg";
+      sha256 = "0c6ky1jk5ada9m94wcadih98l6k1fvf6vi7vhn1msjixaha419l5";
     };
   }
   {
     name = "system.xml.readerwriter";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.xml.readerwriter/4.3.0/system.xml.readerwriter.4.3.0.nupkg";
-      sha256 = "1dsj4s5jwjqix52sizyncvrv5p1h9cdnkh5c4a6407s3gkkh4gzw";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.xml.readerwriter/4.3.0/system.xml.readerwriter.4.3.0.nupkg";
+      sha256 = "0c47yllxifzmh8gq6rq6l36zzvw4kjvlszkqa9wq3fr59n0hl3s1";
     };
   }
   {
     name = "system.xml.xdocument";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.xml.xdocument/4.3.0/system.xml.xdocument.4.3.0.nupkg";
-      sha256 = "14j57hlnmba6rwjwkxx8yp7rk5zf2dzq5j9f22j84jr0xxf00j2f";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.xml.xdocument/4.3.0/system.xml.xdocument.4.3.0.nupkg";
+      sha256 = "08h8fm4l77n0nd4i4fk2386y809bfbwqb7ih9d7564ifcxr5ssxd";
     };
   }
   {
     name = "system.xml.xmldocument";
     version = "4.0.1";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.xml.xmldocument/4.0.1/system.xml.xmldocument.4.0.1.nupkg";
-      sha256 = "1x2iz1l482876vjr11vsrl895n1bbaflxbj239dpf5a48p06gq7y";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.xml.xmldocument/4.0.1/system.xml.xmldocument.4.0.1.nupkg";
+      sha256 = "0ihsnkvyc76r4dcky7v3ansnbyqjzkbyyia0ir5zvqirzan0bnl1";
+    };
+  }
+  {
+    name = "system.xml.xmldocument";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.xml.xmldocument/4.3.0/system.xml.xmldocument.4.3.0.nupkg";
+      sha256 = "0bmz1l06dihx52jxjr22dyv5mxv6pj4852lx68grjm7bivhrbfwi";
     };
   }
   {
     name = "system.xml.xmlserializer";
     version = "4.0.11";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.xml.xmlserializer/4.0.11/system.xml.xmlserializer.4.0.11.nupkg";
-      sha256 = "0987zp4nskf0dbsl3h4s5m1ianjcc398zmp2b98j4834c45jh0bm";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.xml.xmlserializer/4.0.11/system.xml.xmlserializer.4.0.11.nupkg";
+      sha256 = "01nzc3gdslw90qfykq4qzr2mdnqxjl4sj0wp3fixiwdmlmvpib5z";
     };
   }
   {
     name = "system.xml.xpath";
     version = "4.3.0";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/system.xml.xpath/4.3.0/system.xml.xpath.4.3.0.nupkg";
-      sha256 = "0hvn82chjynkixvvk9dy9djqvb0hlkbc2hy00gy27vjhd8i4iqkx";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.xml.xpath/4.3.0/system.xml.xpath.4.3.0.nupkg";
+      sha256 = "1cv2m0p70774a0sd1zxc8fm8jk3i5zk2bla3riqvi8gsm0r4kpci";
+    };
+  }
+  {
+    name = "system.xml.xpath.xdocument";
+    version = "4.3.0";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.xml.xpath.xdocument/4.3.0/system.xml.xpath.xdocument.4.3.0.nupkg";
+      sha256 = "1wxckyb7n1pi433xzz0qcwcbl1swpra64065mbwwi8dhdc4kiabn";
     };
   }
   {
     name = "vswhere";
     version = "2.6.7";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/vswhere/2.6.7/vswhere.2.6.7.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/vswhere/2.6.7/vswhere.2.6.7.nupkg";
       sha256 = "0h4k5i96p7633zzf4xsv7615f9x72rr5qr7b9934ri2y6gshfcwk";
     };
   }
   {
     name = "xlifftasks";
-    version = "1.0.0-beta.20206.1";
+    version = "1.0.0-beta.20502.2";
     src = fetchurl {
-      url = "https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/xlifftasks/1.0.0-beta.20206.1/xlifftasks.1.0.0-beta.20206.1.nupkg";
-      sha256 = "0xsfzws7rn9sfk4mgkbil21m8d3k3kccfk5f4g6lzvc1vk0pa26j";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/1a5f89f6-d8da-4080-b15f-242650c914a8/nuget/v3/flat2/xlifftasks/1.0.0-beta.20502.2/xlifftasks.1.0.0-beta.20502.2.nupkg";
+      sha256 = "17k3dagcxhblzjbh00jsvc150rn7xqp3s3fw2qp1pyjj204y8a90";
     };
   }
   {
     name = "xunit";
     version = "2.4.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/xunit/2.4.1/xunit.2.4.1.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/xunit/2.4.1/xunit.2.4.1.nupkg";
       sha256 = "0xf3kaywpg15flqaqfgywqyychzk15kz0kz34j21rcv78q9ywq20";
     };
   }
@@ -1499,7 +1779,7 @@
     name = "xunit.abstractions";
     version = "2.0.3";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/xunit.abstractions/2.0.3/xunit.abstractions.2.0.3.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/xunit.abstractions/2.0.3/xunit.abstractions.2.0.3.nupkg";
       sha256 = "00wl8qksgkxld76fgir3ycc5rjqv1sqds6x8yx40927q5py74gfh";
     };
   }
@@ -1507,7 +1787,7 @@
     name = "xunit.analyzers";
     version = "0.10.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/xunit.analyzers/0.10.0/xunit.analyzers.0.10.0.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/xunit.analyzers/0.10.0/xunit.analyzers.0.10.0.nupkg";
       sha256 = "15n02q3akyqbvkp8nq75a8rd66d4ax0rx8fhdcn8j78pi235jm7j";
     };
   }
@@ -1515,7 +1795,7 @@
     name = "xunit.assert";
     version = "2.4.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/xunit.assert/2.4.1/xunit.assert.2.4.1.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/xunit.assert/2.4.1/xunit.assert.2.4.1.nupkg";
       sha256 = "1imynzh80wxq2rp9sc4gxs4x1nriil88f72ilhj5q0m44qqmqpc6";
     };
   }
@@ -1523,7 +1803,7 @@
     name = "xunit.core";
     version = "2.4.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/xunit.core/2.4.1/xunit.core.2.4.1.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/xunit.core/2.4.1/xunit.core.2.4.1.nupkg";
       sha256 = "1nnb3j4kzmycaw1g76ii4rfqkvg6l8gqh18falwp8g28h802019a";
     };
   }
@@ -1531,7 +1811,7 @@
     name = "xunit.extensibility.core";
     version = "2.4.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/xunit.extensibility.core/2.4.1/xunit.extensibility.core.2.4.1.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/xunit.extensibility.core/2.4.1/xunit.extensibility.core.2.4.1.nupkg";
       sha256 = "103qsijmnip2pnbhciqyk2jyhdm6snindg5z2s57kqf5pcx9a050";
     };
   }
@@ -1539,7 +1819,7 @@
     name = "xunit.extensibility.execution";
     version = "2.4.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/xunit.extensibility.execution/2.4.1/xunit.extensibility.execution.2.4.1.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/xunit.extensibility.execution/2.4.1/xunit.extensibility.execution.2.4.1.nupkg";
       sha256 = "1pbilxh1gp2ywm5idfl0klhl4gb16j86ib4x83p8raql1dv88qia";
     };
   }
@@ -1547,16 +1827,16 @@
     name = "xunit.runner.console";
     version = "2.4.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/xunit.runner.console/2.4.1/xunit.runner.console.2.4.1.nupkg";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/xunit.runner.console/2.4.1/xunit.runner.console.2.4.1.nupkg";
       sha256 = "13ykz9anhz72xc4q6byvdfwrp54hlcbl6zsfapwfhnzyvfgb9w13";
     };
   }
   {
     name = "xunit.runner.visualstudio";
-    version = "2.4.1";
+    version = "2.4.3";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/xunit.runner.visualstudio/2.4.1/xunit.runner.visualstudio.2.4.1.nupkg";
-      sha256 = "0fln5pk18z98gp0zfshy1p9h6r9wc55nyqhap34k89yran646vhn";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/xunit.runner.visualstudio/2.4.3/xunit.runner.visualstudio.2.4.3.nupkg";
+      sha256 = "0j1d0rbcm7pp6dypi61sjxp8l22sv261252z55b243l39jgv2rp3";
     };
   }
 ]

--- a/pkgs/development/tools/omnisharp-roslyn/create-deps.sh
+++ b/pkgs/development/tools/omnisharp-roslyn/create-deps.sh
@@ -20,6 +20,7 @@ mapfile -t repos < <(
 
 msbuild -t:restore -p:Configuration=Release -p:RestorePackagesPath="$tmpdir" \
         -p:RestoreNoCache=true -p:RestoreForce=true \
+        -p:NuGetPackageVersion=5.9.1-rc.8 \
         src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj >&2
 
 cd "$tmpdir"

--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -97,7 +97,7 @@ in stdenv.mkDerivation rec {
     ln -s ${msbuild}/lib/mono/msbuild/Current/bin $out/src/.msbuild/Current/Bin
 
     makeWrapper ${mono6}/bin/mono $out/bin/omnisharp \
-      --prefix PATH : ${dotnet-sdk}/bin \
+      --suffix PATH : ${dotnet-sdk}/bin \
       --add-flags "$out/src/OmniSharp.exe"
   '';
 

--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -77,10 +77,16 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper msbuild ];
 
+  # NuGetPackageVersion is overridden to be to be compatible with msbuild 16.10,
+  # it needs to be kept in sync with ./create-deps.sh
   buildPhase = ''
     runHook preBuild
 
-    HOME=$(pwd)/fake-home msbuild -r -p:Configuration=Release -p:RestoreConfigFile=${nuget-config} src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj
+    HOME=$(pwd)/fake-home msbuild -r \
+      -p:Configuration=Release \
+      -p:RestoreConfigFile=${nuget-config} \
+      -p:NuGetPackageVersion=5.9.1-rc.8 \
+      src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj
 
     runHook postBuild
   '';

--- a/pkgs/development/tools/omnisharp-roslyn/deps.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/deps.nix
@@ -707,8 +707,8 @@
     name = "microsoft.visualstudio.debugger.contracts";
     version = "17.2.0-beta.21262.1";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/azure-public/3ccf6661-f8ce-4e8a-bb2e-eff943ddd3c7/_packaging/78665e4c-b767-412b-9804-2b1ef7a48b8a/nuget/v3/flat2/microsoft.visualstudio.debugger.contracts/17.2.0-beta.21262.1/microsoft.visualstudio.debugger.contracts.17.2.0-beta.21262.1.nupkg";
-      sha256 = "10fi1jdxnxvww1qzfhqi53fn0a411gvpvcsb0pvwvj7qk0lzs7c9";
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.debugger.contracts/17.2.0-beta.21262.1/microsoft.visualstudio.debugger.contracts.17.2.0-beta.21262.1.nupkg";
+      sha256 = "148gb4k28fch1rhh6kr82dajl7qnvjxvkxvc8igy7zra70nvbx74";
     };
   }
   {
@@ -840,6 +840,14 @@
     };
   }
   {
+    name = "nuget.common";
+    version = "5.9.1-rc.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.common/5.9.1-rc.8/nuget.common.5.9.1-rc.8.nupkg";
+      sha256 = "056b1h4fvik6z2qc2s6qzz0s4acbipc50af14fbr7hd9h2fxya4c";
+    };
+  }
+  {
     name = "nuget.configuration";
     version = "5.2.0";
     src = fetchurl {
@@ -848,11 +856,27 @@
     };
   }
   {
+    name = "nuget.configuration";
+    version = "5.9.1-rc.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.configuration/5.9.1-rc.8/nuget.configuration.5.9.1-rc.8.nupkg";
+      sha256 = "0x8vigf0sfp6kf1i98xcr4k84vci596x16hmajdm0zgv3p1w2kvk";
+    };
+  }
+  {
     name = "nuget.dependencyresolver.core";
     version = "5.2.0";
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/nuget.dependencyresolver.core/5.2.0/nuget.dependencyresolver.core.5.2.0.nupkg";
       sha256 = "156yjfsk9pzqviiwy69lxfqf61yyj4hn4vdgfcbqvw4d567i150r";
+    };
+  }
+  {
+    name = "nuget.dependencyresolver.core";
+    version = "5.9.1-rc.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.dependencyresolver.core/5.9.1-rc.8/nuget.dependencyresolver.core.5.9.1-rc.8.nupkg";
+      sha256 = "1q9a97s1z3a6fb4p82ag2lqnzl53895prbqwlbvckdw9c3rpz3gc";
     };
   }
   {
@@ -872,11 +896,27 @@
     };
   }
   {
+    name = "nuget.frameworks";
+    version = "5.9.1-rc.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.frameworks/5.9.1-rc.8/nuget.frameworks.5.9.1-rc.8.nupkg";
+      sha256 = "1n3mp9ns79yq4dwgj7h2av3b485mzgsw0qlj8z7p47krwlzp5hiv";
+    };
+  }
+  {
     name = "nuget.librarymodel";
     version = "5.2.0";
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/nuget.librarymodel/5.2.0/nuget.librarymodel.5.2.0.nupkg";
       sha256 = "0vxd0y7rzzxvmxji9bzp95p2rx48303r3nqrlhmhhfc4z5fxjlqk";
+    };
+  }
+  {
+    name = "nuget.librarymodel";
+    version = "5.9.1-rc.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.librarymodel/5.9.1-rc.8/nuget.librarymodel.5.9.1-rc.8.nupkg";
+      sha256 = "0sy8422c94wcg8ka85lnawq26mpixl79avk9m6y44lshrpga5v4v";
     };
   }
   {
@@ -888,11 +928,19 @@
     };
   }
   {
-    name = "nuget.packaging.core";
-    version = "5.2.0";
+    name = "nuget.packaging";
+    version = "5.9.1-rc.8";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/nuget.packaging.core/5.2.0/nuget.packaging.core.5.2.0.nupkg";
-      sha256 = "16sm2amzvbpmisb6x6dz1pvj1h3xm67vd2byl1wl13vrda0az3xb";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.packaging/5.9.1-rc.8/nuget.packaging.5.9.1-rc.8.nupkg";
+      sha256 = "0x9c3v741nn6m2xgidna88fa4xj5avhv6asj73hqv4pzpdprlrhv";
+    };
+  }
+  {
+    name = "nuget.packaging.core";
+    version = "5.9.1-rc.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.packaging.core/5.9.1-rc.8/nuget.packaging.core.5.9.1-rc.8.nupkg";
+      sha256 = "0vsaixmla4zh277xpn5ngbmi2f52hb26aqzr0z9l4a3mlpi4l5nx";
     };
   }
   {
@@ -904,6 +952,14 @@
     };
   }
   {
+    name = "nuget.projectmodel";
+    version = "5.9.1-rc.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.projectmodel/5.9.1-rc.8/nuget.projectmodel.5.9.1-rc.8.nupkg";
+      sha256 = "1xjh7isw467nkc7dkfj3wlw69vi2cns66z152jrzjdmxmia3i3pv";
+    };
+  }
+  {
     name = "nuget.protocol";
     version = "5.2.0";
     src = fetchurl {
@@ -912,11 +968,27 @@
     };
   }
   {
+    name = "nuget.protocol";
+    version = "5.9.1-rc.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.protocol/5.9.1-rc.8/nuget.protocol.5.9.1-rc.8.nupkg";
+      sha256 = "1rnrxzaciqhhgwd4by0dhkvfrm1h161vvmkvlcwaz2589sqq2dzq";
+    };
+  }
+  {
     name = "nuget.versioning";
     version = "5.2.0";
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/nuget.versioning/5.2.0/nuget.versioning.5.2.0.nupkg";
       sha256 = "08ay8bhddj9yiq6h9lk814l65fpx5gh1iprkl7pcp78g57a6k45k";
+    };
+  }
+  {
+    name = "nuget.versioning";
+    version = "5.9.1-rc.8";
+    src = fetchurl {
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.versioning/5.9.1-rc.8/nuget.versioning.5.9.1-rc.8.nupkg";
+      sha256 = "1vv7z122ilsk2rsvjm6j3hpifb45g8wa1mgnq1kwi9k8b2dbb6vv";
     };
   }
   {
@@ -1320,14 +1392,6 @@
     };
   }
   {
-    name = "system.diagnostics.process";
-    version = "4.3.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.diagnostics.process/4.3.0/system.diagnostics.process.4.3.0.nupkg";
-      sha256 = "0g4prsbkygq8m21naqmcp70f24a1ksyix3dihb1r1f71lpi3cfj7";
-    };
-  }
-  {
     name = "system.diagnostics.tools";
     version = "4.3.0";
     src = fetchurl {
@@ -1341,14 +1405,6 @@
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg";
       sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
-    };
-  }
-  {
-    name = "system.dynamic.runtime";
-    version = "4.3.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.dynamic.runtime/4.3.0/system.dynamic.runtime.4.3.0.nupkg";
-      sha256 = "1d951hrvrpndk7insiag80qxjbf2y0y39y8h5hnq9612ws661glk";
     };
   }
   {
@@ -1888,6 +1944,14 @@
     };
   }
   {
+    name = "system.security.cryptography.cng";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/5.0.0/system.security.cryptography.cng.5.0.0.nupkg";
+      sha256 = "06hkx2za8jifpslkh491dfwzm5dxrsyxzj5lsc0achb6yzg4zqlw";
+    };
+  }
+  {
     name = "system.security.cryptography.csp";
     version = "4.3.0";
     src = fetchurl {
@@ -1920,6 +1984,14 @@
     };
   }
   {
+    name = "system.security.cryptography.pkcs";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.pkcs/5.0.0/system.security.cryptography.pkcs.5.0.0.nupkg";
+      sha256 = "0hb2mndac3xrw3786bsjxjfh19bwnr991qib54k6wsqjhjyyvbwj";
+    };
+  }
+  {
     name = "system.security.cryptography.primitives";
     version = "4.3.0";
     src = fetchurl {
@@ -1929,10 +2001,10 @@
   }
   {
     name = "system.security.cryptography.protecteddata";
-    version = "4.3.0";
+    version = "4.4.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.protecteddata/4.3.0/system.security.cryptography.protecteddata.4.3.0.nupkg";
-      sha256 = "1kg264xmqabyz8gfg8ymp6qp6aw43vawfp0znf0909d7b5jd3dq9";
+      url = "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.protecteddata/4.4.0/system.security.cryptography.protecteddata.4.4.0.nupkg";
+      sha256 = "1q8ljvqhasyynp94a1d7jknk946m20lkwy2c3wa8zw2pc517fbj6";
     };
   }
   {
@@ -2149,22 +2221,6 @@
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.4/system.threading.tasks.extensions.4.5.4.nupkg";
       sha256 = "0y6ncasgfcgnjrhynaf0lwpkpkmv4a07sswwkwbwb5h7riisj153";
-    };
-  }
-  {
-    name = "system.threading.thread";
-    version = "4.3.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.threading.thread/4.3.0/system.threading.thread.4.3.0.nupkg";
-      sha256 = "0y2xiwdfcph7znm2ysxanrhbqqss6a3shi1z3c779pj2s523mjx4";
-    };
-  }
-  {
-    name = "system.threading.threadpool";
-    version = "4.3.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.threading.threadpool/4.3.0/system.threading.threadpool.4.3.0.nupkg";
-      sha256 = "027s1f4sbx0y1xqw2irqn6x161lzj8qwvnh2gn78ciiczdv10vf1";
     };
   }
   {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11907,7 +11907,7 @@ in
 
   roslyn = callPackage ../development/compilers/roslyn { };
 
-  msbuild = callPackage ../development/tools/build-managers/msbuild { };
+  msbuild = callPackage ../development/tools/build-managers/msbuild { dotnet-sdk = dotnet-sdk_5; };
 
   mosml = callPackage ../development/compilers/mosml { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32507,7 +32507,7 @@ in
     stdenv = crossLibcStdenv;
     };
 
-  omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };
+  omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { dotnet-sdk = dotnet-sdk_5; };
 
   wasmtime = callPackage ../development/interpreters/wasmtime {};
 


### PR DESCRIPTION
Should fix #126477

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
