### PR TITLE
gnomeExtensions.system-monitor: fix system-monitor name collision

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionRenames.nix
+++ b/pkgs/desktops/gnome/extensions/extensionRenames.nix
@@ -13,6 +13,8 @@
   "lockkeys@vaina.lt" = "lock-keys";
   "lockkeys@fawtytoo" = "lock-keys-2";
 
+  "system-monitor@paradoxxx.zero.gmail.com" = "system-monitor"; # manually packaged
+  "System_Monitor@bghome.gmail.com" = "system-monitor-2";
 
 
   # ############################################################################


### PR DESCRIPTION
###### Motivation for this change

`gnomeExtensions.system-monitor` used to point to "`system-monitor@paradoxxx.zero.gmail.com`" (repository [here](https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet)), which is manually packaged.
A change in the way `gnomeExtensions` was packaged made it point to "`System_Monitor@bghome.gmail.com`" (repository [here](https://github.com/elvetemedve/gnome-shell-extension-system-monitor), which is automatically packaged.

Normally the shared name would be caught in `collisions.json` if both were automatically packaged. Since one is manually packaged, it was missed.

This points `gnomeExtensions.system-monitor` to "system-monitor@paradoxxx.zero.gmail.com" and `gnomeExtensions.system-monitor-2` to "system-monitor@paradoxxx.zero.gmail.com".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
