### PR TITLE
obs-studio-plugins.obs-websocket: fix attribute name

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -5,6 +5,7 @@
   obs-move-transition = callPackage ./obs-move-transition.nix {};
   obs-multi-rtmp = libsForQt5.callPackage ./obs-multi-rtmp.nix {};
   obs-ndi = libsForQt5.callPackage ./obs-ndi.nix {};
+  obs-websocket = libsForQt5.callPackage ./obs-websocket.nix {};
   wlrobs = callPackage ./wlrobs.nix {};
   looking-glass-obs = callPackage ./looking-glass-obs.nix {};
 }


### PR DESCRIPTION
###### Motivation for this change

This is a trivial fix.

`obs-websocket.nix` already existed, but no attribute was made for it.
This puts it under `obs-studio-plugins.obs-websocket`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
