### PR TITLE
gdtoolkit: init at 3.2.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1969,6 +1969,12 @@
     githubId = 1222362;
     name = "Matías Lang";
   };
+  critbase = {
+    name = "critbase";
+    email = "12738442+critbase@users.noreply.github.com";
+    github = "critbase";
+    githubId = 12738442;
+  };
   CRTified = {
     email = "carl.schneider+nixos@rub.de";
     github = "CRTified";

--- a/pkgs/development/tools/gdtoolkit/default.nix
+++ b/pkgs/development/tools/gdtoolkit/default.nix
@@ -1,0 +1,35 @@
+{ lib, python3, fetchFromGitHub }:
+
+with python3.pkgs;
+
+let lark-parser080 = lark-parser.overrideAttrs (old: rec {
+      version = "0.8.0";
+      src = fetchFromGitHub {
+        owner = "lark-parser";
+        repo = "lark";
+        rev = version;
+        sha256 = "su7kToZ05OESwRCMPG6Z+XlFUvbEb3d8DgsTEcPJMg4=";
+      };
+    });
+
+in buildPythonApplication rec {
+  pname = "gdtoolkit";
+  version = "3.2.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3+zr1JcCt8HPwDG0j+ttnzGOhvUmaz+qzbE2wGyT86M=";
+  };
+
+  propagatedBuildInputs = [ lark-parser080 docopt pyyaml setuptools ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/Scony/godot-gdscript-toolkit";
+    description = "Independent set of GDScript tools - parser, linter and formatter";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.critbase ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4626,6 +4626,8 @@ in
 
   gdmap = callPackage ../tools/system/gdmap { };
 
+  gdtoolkit = callPackage ../development/tools/gdtoolkit { };
+
   gelasio = callPackage ../data/fonts/gelasio { };
 
   gen-oath-safe = callPackage ../tools/security/gen-oath-safe { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
To package https://github.com/Scony/godot-gdscript-toolkit, an "independent set of GDScript tools."

Had this branch laying around for a while, forgot to upstream it until now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
