### PR TITLE
buildbot: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, makeWrapper, isPy3k
+{ stdenv, lib, buildPythonPackage, fetchPypi, fetchpatch, makeWrapper, isPy3k
 , python, twisted, jinja2, zope_interface, sqlalchemy
 , sqlalchemy_migrate, python-dateutil, txaio, autobahn, pyjwt, pyyaml, unidiff, treq
 , txrequests, pypugjs, boto3, moto, mock, lz4, setuptoolsTrial
@@ -78,6 +78,19 @@ let
       # This patch disables the test that tries to read /etc/os-release which
       # is not accessible in sandboxed builds.
       ./skip_test_linux_distro.patch
+      # Fix compatibility with SQLAlchemy 1.4
+      (fetchpatch {
+        url = "https://github.com/buildbot/buildbot/pull/6156.patch";
+        sha256 = "10pg3wcdy85vymn6hprm7rh68zkz818m2vy6v4s2hi2l189wh5my";
+        stripLen = 1;
+        excludes = [
+          ".bbtravis.yml"
+          "buildbot/test/unit/db/test_enginestrategy.py"
+          "buildbot/test/unit/db_migrate/test_versions_045_worker_transition.py"
+          "requirements-ci.txt"
+          "requirements-cidb.txt"
+        ];
+      })
     ];
 
     postPatch = ''

--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -97,6 +97,7 @@ let
     passthru = {
       inherit withPlugins;
       tests.buildbot = nixosTests.buildbot;
+      updateScript = ./update.sh;
     };
 
     meta = with lib; {

--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -26,11 +26,11 @@ let
 
   package = buildPythonPackage rec {
     pname = "buildbot";
-    version = "3.1.1";
+    version = "3.2.0";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0vh2v1qs65kwcj1x8r1wj2g456kflspyz7mjara9ph9qs7j97y74";
+      sha256 = "sha256-Ji/1anphYaGoP0kaOpArKDKPe9YUFTU1Zd9O4g6V9OA=";
     };
 
     propagatedBuildInputs = [

--- a/pkgs/development/python-modules/buildbot/pkg.nix
+++ b/pkgs/development/python-modules/buildbot/pkg.nix
@@ -6,7 +6,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "13bcshfas3r7hl205il9fzdjfhd18jf0lxrr5wd8r6qzdrl6i1y6";
+    sha256 = "sha256-6PpR/zDy1ZZWFN2qzIeNWk9kmDpecZH40IEMoqyprnk=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/buildbot/plugins.nix
+++ b/pkgs/development/python-modules/buildbot/plugins.nix
@@ -7,7 +7,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1qb82s72mrm39123kwkypa2nhdsks6v9nkpw4vvscnq4p9xbzw2c";
+      sha256 = "sha256-6dG8yCHmysQELodaPXOrI8J8Uc1/7YHwplnvYZyeuo0=";
     };
 
     # Remove unneccessary circular dependency on buildbot
@@ -34,7 +34,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0kwzj28dmhkcr44nf39s82xjc9y5p27w4ywxfpm55cim3hwxbcb1";
+      sha256 = "sha256-bjDVA5478pHtBXIVPSZJURRqU9EVFVXG/933oDQZCpk=";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -56,7 +56,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0vvp6z0d0qf5i5kykzph28hr3g9wgzrmmbbzdnm94yk4wsqq7w86";
+      sha256 = "sha256-I31sryOUW6JVsWpkgvQe9ICyoDZUVewRPtG0JdIVJo8=";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -78,7 +78,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0y839swv9vdkwi4i1hjiyrjbj1bs74sbkpr5f58ivkjlf5alb56b";
+      sha256 = "sha256-FWi67S3wXuISLP0f4VzXisEWXN60xlgU4I946QkX9Eo=";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -100,7 +100,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1zsh1bvrl3byx0ycz5jnhijzifxglm8w7kcxp79k7frw7i02fpvy";
+      sha256 = "sha256-6kXB+hu75V59KMo7tIHbE2Wvig6raTbPc7vYVVl/1y0=";
     };
 
     buildInputs = [ buildbot-pkg ];

--- a/pkgs/development/python-modules/buildbot/update.sh
+++ b/pkgs/development/python-modules/buildbot/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update python3Packages.buildbot
+nix-update --version=skip python3Packages.buildbot-worker
+nix-update --version=skip python3Packages.buildbot-pkg
+nix-update --version=skip python3Packages.buildbot-plugins.www
+nix-update --version=skip python3Packages.buildbot-plugins.console-view
+nix-update --version=skip python3Packages.buildbot-plugins.waterfall-view
+nix-update --version=skip python3Packages.buildbot-plugins.grid-view
+nix-update --version=skip python3Packages.buildbot-plugins.wsgi-dashboards

--- a/pkgs/development/python-modules/buildbot/worker.nix
+++ b/pkgs/development/python-modules/buildbot/worker.nix
@@ -7,7 +7,7 @@ buildPythonPackage (rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0q16vgvlhiybq5rhva9kcj5v2mhfpdb5czm2vng4rrfqqiqq918m";
+    sha256 = "sha256-pIXdqahCWJGRiXKDyih2UjGYdyzwhxnYgMwCzdQfYUo=";
   };
 
   propagatedBuildInputs = [ twisted future ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates buildbot to the latest version. Upstream just merged a patch to fix compatibility with SQLAlchemy 1.4, which allows this package to build again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
