### PR TITLE
androidStudioPackages.{stable,canary}: update

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -1,4 +1,4 @@
-{ channel, pname, version, build ? null, sha256Hash }:
+{ channel, pname, version, sha256Hash }:
 
 { alsa-lib
 , bash
@@ -55,7 +55,7 @@
 
 let
   drvName = "android-studio-${channel}-${version}";
-  filename = "android-studio-" + (if (build != null) then "ide-${build}" else version) + "-linux.tar.gz";
+  filename = "android-studio-${version}-linux.tar.gz";
 
   androidStudio = stdenv.mkDerivation {
     name = "${drvName}-unwrapped";

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -18,8 +18,8 @@ let
     sha256Hash = "04k7c328bl8ixi8bvp2mm33q2hmv40yc9p5dff5cghyycarwpd3f";
   };
   latestVersion = { # canary & dev
-    version = "2021.1.1.4"; # "Android Studio Bumblebee (2021.1.1) Canary 4"
-    sha256Hash = "0s2py7xikzryqrfd9v3in9ia9qv71dd9aad1nzbda6ff61inzizb";
+    version = "2021.1.1.5"; # "Android Studio Bumblebee (2021.1.1) Canary 5"
+    sha256Hash = "0fx6nnazg4548rhb11wzaccm5c2si57mj8qwyl5j17x4k5r3m7nh";
   };
 in {
   # Attributes are named by their corresponding release channels

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -9,9 +9,8 @@ let
     inherit buildFHSUserEnv;
   };
   stableVersion = {
-    version = "4.2.2.0"; # "Android Studio 4.2.2"
-    build = "202.7486908";
-    sha256Hash = "18zc9xr2xmphj6m6a1ilwripmvqzplp2583afq1pzzz3cv5h8fvk";
+    version = "2020.3.1.22"; # "Android Studio Arctic Fox (2020.3.1)"
+    sha256Hash = "0xkjnhq1vvrglcbab90mx5xw1q82lkkvyp6y2ap5jypdfsc7pnsa";
   };
   betaVersion = {
     version = "2020.3.1.21"; # "Android Studio Arctic Fox (2020.3.1) RC 1"


### PR DESCRIPTION
###### Motivation for this change

Update Android Studio to use latest upstream packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
