### PR TITLE
maintainers/haskell/package-list: Only read one line from password-cmd

### DIFF
--- a/maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
+++ b/maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
@@ -12,10 +12,10 @@
 # ~/.cabal/config file.
 
 # e.g. username: maralorn
-#      password-command: pass hackage.haskell.org (this can be any command, but not an arbitrary shell expression.)
+#      password-command: pass hackage.haskell.org (this can be any command, but not an arbitrary shell expression. Like cabal we only read the first output line and ignore the rest.)
 # Those fields are specified under `upload` on the `cabal` man page.
 
 package_list="$(nix-build -A haskell.package-list)/nixos-hackage-packages.csv"
 username=$(grep "^username:" ~/.cabal/config | sed "s/^username: //")
 password_command=$(grep "^password-command:" ~/.cabal/config | sed "s/^password-command: //")
-curl -u "$username:$($password_command)" --digest -H "Content-type: text/csv" -T "$package_list" http://hackage.haskell.org/distro/NixOS/packages.csv
+curl -u "$username:$($password_command | head -n1)" --digest -H "Content-type: text/csv" -T "$package_list" http://hackage.haskell.org/distro/NixOS/packages.csv


### PR DESCRIPTION
This is an alternative to #131971.

Only the first output line of the password command specified in the .cabal/config will be read by the package-list update script. This way we are compatible with cabal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
