### PR TITLE
libdevil: add missing dependency libdeflate

### DIFF
--- a/pkgs/development/libraries/libdevil/default.nix
+++ b/pkgs/development/libraries/libdevil/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libjpeg, libpng, libmng, lcms1, libtiff, openexr, libGL
+{ lib, stdenv, fetchurl, libdeflate, libjpeg, libpng, libmng, lcms1, libtiff, openexr, libGL
 , libX11, pkg-config, OpenGL
 }:
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = [ libjpeg libpng libmng lcms1 libtiff openexr libGL libX11 ]
+  buildInputs = [ libdeflate libjpeg libpng libmng lcms1 libtiff openexr libGL libX11 ]
     ++ lib.optionals stdenv.isDarwin [ OpenGL ];
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
###### Motivation for this change

Fix #132218

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
