### PR TITLE
tree-sitter-fish: init at HEAD

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -7,6 +7,7 @@
   tree-sitter-css = (builtins.fromJSON (builtins.readFile ./tree-sitter-css.json));
   tree-sitter-embedded-template = (builtins.fromJSON (builtins.readFile ./tree-sitter-embedded-template.json));
   tree-sitter-fennel = (builtins.fromJSON (builtins.readFile ./tree-sitter-fennel.json));
+  tree-sitter-fish = (builtins.fromJSON (builtins.readFile ./tree-sitter-fish.json));
   tree-sitter-fluent = (builtins.fromJSON (builtins.readFile ./tree-sitter-fluent.json));
   tree-sitter-go = (builtins.fromJSON (builtins.readFile ./tree-sitter-go.json));
   tree-sitter-haskell = (builtins.fromJSON (builtins.readFile ./tree-sitter-haskell.json));

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/ram02z/tree-sitter-fish",
+  "rev": "db7139393e50765520618fa469f41dfbb0b3822b",
+  "date": "2021-07-06T21:05:19+02:00",
+  "path": "/nix/store/k67b4bn67zd3dj9yg0q7jywy3vnkv8gw-tree-sitter-fish",
+  "sha256": "09l5myivlq3z53nqlx8x8c45sww2k7vmjp8z0rvwzv08rnym0fah",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -106,6 +106,10 @@ let
       orga = "GrayJack";
       repo = "tree-sitter-zig";
     };
+    "tree-sitter-fish" = {
+      orga = "ram02z";
+      repo = "tree-sitter-fish";
+    };
   };
 
   allGrammars =


### PR DESCRIPTION
#### Motivation for this change

Allows using nvim-treesitter when editing Fish files.

#### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).