### PR TITLE
diffoscope: fix build, 178 -> 179

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -9,11 +9,11 @@
 # Note: when upgrading this package, please run the list-missing-tools.sh script as described below!
 python3Packages.buildPythonApplication rec {
   pname = "diffoscope";
-  version = "178";
+  version = "179";
 
   src = fetchurl {
     url = "https://diffoscope.org/archive/diffoscope-${version}.tar.bz2";
-    sha256 = "sha256-uJbTQshf7vRd6EyaaV0itJVrMc/6o+pPXhtUgrjFnzM=";
+    sha256 = "sha256-SIFLWlmENuhgwG0YbIDTWG6uCHEfuoc0IMVz4cp5NX4=";
   };
 
   outputs = [ "out" "man" ];
@@ -66,6 +66,10 @@ python3Packages.buildPythonApplication rec {
     "test_diff_meta"
     "test_diff_meta2"
     "test_obj_no_differences"
+
+    # Failing because of file-v5.40 has a slightly different output.
+    # Upstream issue: https://salsa.debian.org/reproducible-builds/diffoscope/-/issues/271
+    "test_text_proper_indentation"
   ];
 
   meta = with lib; {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ChangeLog: https://diffoscope.org/news/diffoscope-179-released/

Also fixed the build by disabling a failing test because of
`file-v5.40`[1][2].

[1] Upstream bug: https://salsa.debian.org/reproducible-builds/diffoscope/-/issues/271
[2] Similar to: https://github.com/archlinux/svntogit-community/commit/3f906acae3d3c276bae7ed65727052017be84938


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
