### PR TITLE
sirula: init at unstable-2021-07-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11006,6 +11006,12 @@
       fingerprint = "E631 8869 586F 99B4 F6E6  D785 5942 58F0 389D 2802";
     }];
   };
+  twitchyliquid64 = {
+    name = "Tom";
+    email = "twitchyliquid64@ciphersink.net";
+    github = "twitchyliquid64";
+    githubId = 6328589;
+  };
   typetetris = {
     email = "ericwolf42@mail.com";
     github = "typetetris";

--- a/pkgs/tools/wayland/sirula/default.nix
+++ b/pkgs/tools/wayland/sirula/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, gtk3
+, gtk-layer-shell
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sirula";
+  version = "unstable-2021-07-11";
+
+  src = fetchFromGitHub {
+    owner = "DorianRudolph";
+    repo = "sirula";
+    rev = "574725bc307fc704c42380cd0fa50b0b80c4764d";
+    sha256 = "1m58j1hymjw4l2z1jdfirw1vb3rblc1qffpvc2lqy99frfz0dlvp";
+  };
+
+  cargoSha256 = "0wk90p20qkbpr866h8cvdshr8cl2kmc3dh2zxws5mlsh3sx2ld4w";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk3 gtk-layer-shell ];
+
+  meta = with lib; {
+    description = "Simple app launcher for wayland written in rust";
+    homepage = "https://github.com/DorianRudolph/sirula";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ twitchyliquid64 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -656,6 +656,8 @@ in
 
   singularity-tools = callPackage ../build-support/singularity-tools { };
 
+  sirula = callPackage ../tools/wayland/sirula { };
+
   srcOnly = callPackage ../build-support/src-only { };
 
   substituteAll = callPackage ../build-support/substitute/substitute-all.nix { };


### PR DESCRIPTION
This PR packages sirula, a simple app launcher for wayland.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To package [sirula](https://github.com/DorianRudolph/sirula)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions - Debian Buster
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
