### PR TITLE
rabbitmq-server: 3.8.9 -> 3.8.19

### DIFF
--- a/pkgs/servers/amqp/rabbitmq-server/default.nix
+++ b/pkgs/servers/amqp/rabbitmq-server/default.nix
@@ -8,12 +8,12 @@
 stdenv.mkDerivation rec {
   pname = "rabbitmq-server";
 
-  version = "3.8.9";
+  version = "3.8.19";
 
   # when updating, consider bumping elixir version in all-packages.nix
   src = fetchurl {
     url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "0b252l9r45h8r5gibdqcn6hhbm8g6rfzhm1k9d39pwhs5x77cjqv";
+    sha256 = "0pdrpgs2widf16c52mxv5pvmbrl23wglr6jk7iawrjqdwxpkpvrj";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20263,7 +20263,7 @@ in
 
   rabbitmq-server = callPackage ../servers/amqp/rabbitmq-server {
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon Cocoa;
-    elixir = beam_nox.interpreters.elixir_1_8;
+    elixir = beam_nox.interpreters.elixir_1_11;
     erlang = beam_nox.interpreters.erlangR23;
   };
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-22116
https://nvd.nist.gov/vuln/detail/CVE-2021-32718
https://nvd.nist.gov/vuln/detail/CVE-2021-32719

(ignoring CVE-2021-22117 as it is only related to the windows installer)

Switch to `elixir_1_11` as 3.8.19 demands >= elixir 1.10.

I am **not** looking to bring this bump to 21.05, so please no `backport-21.05` label. I will try and patch that (think it should be quite easy) - looking at the release notes (https://www.rabbitmq.com/changelog.html) reveals that despite these being "bugfix" releases, they are screwing around with supported (major) versions of erlang/elixir (hence me having to switch to `elixir_1_11` here) and that's not something that's ok for us to do to stable users. Also if you dig into the full release notes, there are some fairly significant things that get snuck in under `- Bug fixes`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
