### PR TITLE
pympress: 1.5.1 -> 1.6.3

### DIFF
--- a/pkgs/applications/office/pympress/default.nix
+++ b/pkgs/applications/office/pympress/default.nix
@@ -1,20 +1,33 @@
 { lib
+, stdenv
+, fetchpatch
 , python3Packages
 , wrapGAppsHook
 , gtk3
 , gobject-introspection
 , libcanberra-gtk3
 , poppler_gi
+, withGstreamer ? stdenv.isLinux
+, withVLC ? stdenv.isLinux
  }:
 
 python3Packages.buildPythonApplication rec {
   pname = "pympress";
-  version = "1.5.1";
+  version = "1.6.3";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "173d9scf2z29qg279jf33zcl7sgc3wp662fgpm943bn9667q18wf";
+    sha256 = "sha256-f+OjE0x/3yfJYHCLB+on7TT7MJ2vNu87SHRi67qFDCM=";
   };
+
+  patches = [
+    # Should not be needed once v1.6.4 is released
+    (fetchpatch {
+      name = "fix-setuptools-version-parsing.patch";
+      url = "https://github.com/Cimbali/pympress/commit/474514d71396ac065e210fd846e07ed1139602d0.diff";
+      sha256 = "sha256-eiw54sjMrXrNrhtkAXxiSTatzoA0NDA03L+HpTDax58=";
+    })
+  ];
 
   nativeBuildInputs = [
     wrapGAppsHook
@@ -23,16 +36,15 @@ python3Packages.buildPythonApplication rec {
   buildInputs = [
     gtk3
     gobject-introspection
-    libcanberra-gtk3
     poppler_gi
-  ];
+  ] ++ lib.optional withGstreamer libcanberra-gtk3;
 
   propagatedBuildInputs = with python3Packages; [
     pycairo
     pygobject3
-    python-vlc
+    setuptools
     watchdog
-  ];
+  ] ++ lib.optional withVLC python-vlc;
 
   doCheck = false; # there are no tests
 


### PR DESCRIPTION
This also makes the application ready to work on Darwin (but still not working until #113777 is fixed).

Version 1.5.1 did not build on Darwin because `libcanberra-gtk3` is broken, and `python-vlc` is required but only works on Linux.

Version 1.6.x fixed the `python-vlc` requirement to make it optional, so now both `libcanberra-gtk3` and `python-vlc` inputs can be made optional, and enabled by default on Linux. This means that on Darwin there is no support for media, but it is still better than not having the application at all.

Unfortunately, until watchdog 2.x is fixed, the Darwin build will be still broken. (But I did check that it works by downgrading to watchdog 1.x)

The `setup.py` file now parses the setuptools version, so it needs to be patched to fix an error with the 'post0' suffix in the version.

Also, `setuptools` is needed in `propagatedBuildInputs` to fix the `ModuleNotFoundError: No module named 'pkg_resources'` error.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS **(but by downgrading watchdog to 1.x, current watchdog dependency will not build)**.
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
