### PR TITLE
python3Packages.pipdate: 0.5.2 -> 0.5.5

### DIFF
--- a/pkgs/development/python-modules/pipdate/default.nix
+++ b/pkgs/development/python-modules/pipdate/default.nix
@@ -2,23 +2,23 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, isPy27
 , appdirs
 , importlib-metadata
 , requests
-, pytest
+, rich
+, setuptools
 , wheel
 }:
 
 buildPythonPackage rec {
   pname = "pipdate";
-  version = "0.5.2";
+  version = "0.5.5";
   format = "pyproject";
-  disabled = isPy27; # abandoned
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "507065231f2d50b6319d483432cba82aadad78be21b7a2969b5881ed8dee9ab4";
+    sha256 = "03hr9i691cpg9q2xc1xr4lpd90xs8rba0xjh6qmc1vg7lgcdgbaa";
   };
 
   nativeBuildInputs = [ wheel ];
@@ -26,25 +26,19 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     appdirs
     requests
+    rich
+    setuptools
   ] ++ lib.optionals (pythonOlder "3.8") [
     importlib-metadata
   ];
 
-  checkInputs = [
-    pytest
-  ];
-
-  checkPhase = ''
-    HOME=$(mktemp -d) pytest test/test_pipdate.py
-  '';
-
-  # tests require network access
+  # Tests require network access and pythonImportsCheck requires configuration file
   doCheck = false;
 
   meta = with lib; {
     description = "pip update helpers";
     homepage = "https://github.com/nschloe/pipdate";
-    license = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.5.5

Change log:
- https://github.com/nschloe/pipdate/releases/tag/0.5.5
- https://github.com/nschloe/pipdate/releases/tag/v0.5.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
