### PR TITLE
mpvScripts.simple-mpv-webui: 1.0.0 -> 2.1.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -259,6 +259,7 @@ in
   morty = handleTest ./morty.nix {};
   mosquitto = handleTest ./mosquitto.nix {};
   mpd = handleTest ./mpd.nix {};
+  mpv = handleTest ./mpv.nix {};
   mumble = handleTest ./mumble.nix {};
   musescore = handleTest ./musescore.nix {};
   munin = handleTest ./munin.nix {};

--- a/nixos/tests/mpv.nix
+++ b/nixos/tests/mpv.nix
@@ -1,0 +1,28 @@
+import ./make-test-python.nix ({ lib, ... }:
+
+with lib;
+
+let
+  port = toString 4321;
+in
+{
+  name = "mpv";
+  meta.maintainers = with maintainers; [ zopieux ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [
+        pkgs.curl
+        (pkgs.mpv-with-scripts.override {
+          scripts = [ pkgs.mpvScripts.simple-mpv-webui ];
+        })
+      ];
+    };
+
+  testScript = ''
+    machine.execute("set -m; mpv --script-opts=webui-port=${port} --idle=yes &")
+    machine.wait_for_open_port(${port})
+    assert "<title>simple-mpv-webui" in machine.succeed("curl -s localhost:${port}")
+  '';
+})

--- a/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
+++ b/pkgs/applications/video/mpv/scripts/simple-mpv-webui.nix
@@ -2,13 +2,13 @@
 , fetchFromGitHub }:
 stdenvNoCC.mkDerivation rec {
   pname = "simple-mpv-ui";
-  version = "1.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "open-dynaMIX";
     repo = "simple-mpv-webui";
     rev = "v${version}";
-    sha256 = "1glrnnl1slcl0ri0zs4j64lc9aa52p9ffh6av0d81fk95nm98917";
+    sha256 = "1z0y8sdv5mbxznxqh43w5592ym688vkvqg7w26p8cinrhf09pbw8";
   };
 
   dontBuild = true;
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
   meta = with lib; {
     description = "A web based user interface with controls for the mpv mediaplayer";
     homepage = "https://github.com/open-dynaMIX/simple-mpv-webui";
-    maintainers = [ maintainers.cript0nauta ];
+    maintainers = with maintainers; [ cript0nauta zopieux ];
     longDescription = ''
       You can access the webui when accessing http://127.0.0.1:8080 or
       http://[::1]:8080 in your webbrowser. By default it listens on


### PR DESCRIPTION
###### Motivation for this change

The current packaged version (1.0.0) is broken, it cannot find relevant files.
The added test makes sure this can't happen again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
