### PR TITLE
ghostunnel: 1.5.3 -> 1.6.0

### DIFF
--- a/pkgs/tools/networking/ghostunnel/default.nix
+++ b/pkgs/tools/networking/ghostunnel/default.nix
@@ -7,16 +7,25 @@
 
 buildGoModule rec {
   pname = "ghostunnel";
-  version = "1.5.3";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "ghostunnel";
     repo = "ghostunnel";
     rev = "v${version}";
-    sha256 = "15rmd89j7sfpznzznss899smizbyshprsrvsdmrbhb617myd9fpy";
+    sha256 = "sha256-EE8gCm/gOp3lmCx1q4PahulipLoBZnEatNAVUXzHIVw=";
   };
 
-  vendorSha256 = "1i95fx4a0fh6id6iy6afbva4pazr7ym6sbwi9r7la6gxzyncd023";
+  vendorSha256 = "sha256-XgmvqB1PCfL2gSDqwqauSixk8vlINHRmX6U0h9EXXdU=";
+
+  deleteVendor = true;
+
+  # The certstore directory isn't recognized as a subpackage, but is when moved
+  # into the vendor directory.
+  postUnpack = ''
+    mkdir -p $sourceRoot/vendor/ghostunnel
+    mv $sourceRoot/certstore $sourceRoot/vendor/ghostunnel/
+  '';
 
   meta = with lib; {
     description = "A simple TLS proxy with mutual authentication support for securing non-TLS backend applications";

--- a/pkgs/tools/networking/ghostunnel/default.nix
+++ b/pkgs/tools/networking/ghostunnel/default.nix
@@ -35,4 +35,5 @@ buildGoModule rec {
   };
 
   passthru.tests.nixos = nixosTests.ghostunnel;
+  passthru.tests.podman = nixosTests.podman-tls-ghostunnel;
 }


### PR DESCRIPTION


###### Motivation for this change

Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
