### PR TITLE
arcan: 0.6.1pre1+unstable=2021-07-10 -> 0.6.1pre1+unstable=2021-07-30

### DIFF
--- a/pkgs/desktops/arcan/arcan.nix
+++ b/pkgs/desktops/arcan/arcan.nix
@@ -52,13 +52,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "arcan";
-  version = "0.6.1pre1+unstable=2021-07-10";
+  version = "0.6.1pre1+unstable=2021-07-30";
 
   src = fetchFromGitHub {
     owner = "letoram";
     repo = "arcan";
-    rev = "25da999e6e03688c71c7df3852314c01ed610e0d";
-    hash = "sha256-+ZF6mD/Z0N/5QCjXe80z4L6JOE33+Yv4ZlwKvlG/c44=";
+    rev = "885b2f0c9e031fd157af21302af2027ecbe3fe1f";
+    hash = "sha256-tj5kPa5OWCGt7LTzo4ZYV1UjBpOrjQHER/K+ZfL3h+8=";
   };
 
   postUnpack = ''

--- a/pkgs/desktops/arcan/wrapper.nix
+++ b/pkgs/desktops/arcan/wrapper.nix
@@ -20,9 +20,10 @@ symlinkJoin rec {
         --set ARCAN_BINPATH "${placeholder "out"}/bin/arcan_frameserver" \
         --set ARCAN_LIBPATH "${placeholder "out"}/lib/" \
         --set ARCAN_RESOURCEPATH "${placeholder "out"}/share/arcan/resources/" \
-        --set ARCAN_SCRIPTPATH "${placeholder "out"}/share/arcan/scripts/" \
-        --set ARCAN_STATEBASEPATH "\$HOME/.arcan/resources/savestates/"
+        --set ARCAN_SCRIPTPATH "${placeholder "out"}/share/arcan/scripts/"
     done
   '';
 }
 # TODO: set ARCAN_FONTPATH to a set of fonts that can be provided in a parameter
+# TODO: set ARCAN_STATEBASEPATH to $HOME/.arcan/resources/savestates/ - possibly
+# via a suitable script


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
