### PR TITLE
libcanberra/libcanberra-gtk2: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/libcanberra/default.nix
+++ b/pkgs/development/libraries/libcanberra/default.nix
@@ -1,22 +1,25 @@
 { stdenv, lib, fetchurl, fetchpatch, pkg-config, libtool
-, gtk ? null
+, gtk2-x11, gtk3-x11 , gtkSupport ? null
 , libpulseaudio, gst_all_1, libvorbis, libcap
-, CoreServices
+, Carbon, CoreServices
 , withAlsa ? stdenv.isLinux, alsa-lib }:
 
 stdenv.mkDerivation rec {
-  name = "libcanberra-0.30";
+  pname = "libcanberra";
+  version = "0.30";
 
   src = fetchurl {
-    url = "http://0pointer.de/lennart/projects/libcanberra/${name}.tar.xz";
+    url = "http://0pointer.de/lennart/projects/libcanberra/${pname}-${version}.tar.xz";
     sha256 = "0wps39h8rx2b00vyvkia5j40fkak3dpipp1kzilqla0cgvk73dn2";
   };
 
   nativeBuildInputs = [ pkg-config libtool ];
   buildInputs = [
-    libpulseaudio libvorbis gtk
+    libpulseaudio libvorbis
   ] ++ (with gst_all_1; [ gstreamer gst-plugins-base ])
-    ++ lib.optional stdenv.isDarwin CoreServices
+    ++ lib.optional (gtkSupport == "gtk2") gtk2-x11
+    ++ lib.optional (gtkSupport == "gtk3") gtk3-x11
+    ++ lib.optionals stdenv.isDarwin [Carbon CoreServices]
     ++ lib.optional stdenv.isLinux libcap
     ++ lib.optional withAlsa alsa-lib;
 
@@ -30,7 +33,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch = (lib.optional stdenv.isDarwin) ''
+  postPatch = lib.optionalString stdenv.isDarwin ''
     patch -p0 < ${fetchpatch {
       url = "https://raw.githubusercontent.com/macports/macports-ports/master/audio/libcanberra/files/patch-configure.diff";
       sha256 = "1f7h7ifpqvbfhqygn1b7klvwi80zmpv3538vbmq7ql7bkf1q8h31";
@@ -43,8 +46,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  passthru = {
-    gtkModule = "/lib/gtk-2.0/";
+  passthru = lib.optionalAttrs (gtkSupport != null) {
+    gtkModule = if gtkSupport == "gtk2" then "/lib/gtk-2.0" else "/lib/gtk-3.0/";
   };
 
   meta = with lib; {
@@ -62,6 +65,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     # canberra-gtk-module.c:28:10: fatal error: 'gdk/gdkx.h' file not found
     # #include <gdk/gdkx.h>
-    broken = stdenv.isDarwin;
+    broken = stdenv.isDarwin && (gtkSupport == "gtk3");
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16295,13 +16295,13 @@ in
   libcacard = callPackage ../development/libraries/libcacard { };
 
   libcanberra = callPackage ../development/libraries/libcanberra {
-    inherit (darwin.apple_sdk.frameworks) CoreServices;
+    inherit (darwin.apple_sdk.frameworks) Carbon CoreServices;
   };
   libcanberra-gtk2 = pkgs.libcanberra.override {
-    gtk = gtk2-x11;
+    gtkSupport = "gtk2";
   };
   libcanberra-gtk3 = pkgs.libcanberra.override {
-    gtk = gtk3-x11;
+    gtkSupport = "gtk3";
   };
 
   libcanberra_kde = if (config.kde_runtime.libcanberraWithoutGTK or true)


### PR DESCRIPTION
All `libcanberra`/`libcanberra-gtk2`/`libcanberra-gtk3` packages were marked as broken on commit 806d814516c, but only `libcanberra-gtk3` is broken due to the missing header (caused by #132259).

This commit refactors how to enable GTK support, to mark just `libcanberra-gtk3` as broken and allow building `libcanberra` and `libcanberra-gtk2` on darwin.

`libcanberra` builds but the linker fails with:

    ld: file not found: /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon for architecture x86_64
    clang-7: error: linker command failed with exit code 1 (use -v to see invocation)

Adding `Carbon` to the inputs solves the problem.

`libcanberra-gtk2` builds and the linker finishes without the above error, most likely because it depends on `gtk2-x11` and `gtk2-x11` depends on `Cocoa`. I see no harm having `Carbon` in the inputs for the packages with GTK support too.

Also fix some issues with the derivation:

- Use `pname`/`version` instead of `name`.
- Use `lib.optionalString` to set `postPatch`.
- Only set `passthru` if building with GTK support, and ensure that the proper directory is passed for each GTK version.

###### Motivation for this change

I found that `libcanberra` was marked as broken working on #132248, and I was tracking why. My first attempt on #131999 was wrong because I was building just `libcanberra` and not `libcanberra-gtk{2,3}`.

After checking that only `libcanberra-gtk3` is broken I refactored my previous PR to this improved version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I can only see that it builds, since it is a library.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
