### PR TITLE
opentx: 2.3.13 -> 2.3.14

### DIFF
--- a/pkgs/applications/misc/opentx/default.nix
+++ b/pkgs/applications/misc/opentx/default.nix
@@ -44,7 +44,7 @@ mkDerivation rec {
       running radio simulators.
     '';
     homepage = "https://www.open-tx.org/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
     maintainers = with maintainers; [ elitak lopsided98 ];
   };

--- a/pkgs/applications/misc/opentx/default.nix
+++ b/pkgs/applications/misc/opentx/default.nix
@@ -6,13 +6,16 @@
 
 mkDerivation rec {
   pname = "opentx";
-  version = "2.3.13";
+  version = "2.3.14";
 
   src = fetchFromGitHub {
     owner = "opentx";
     repo = "opentx";
-    rev = "release/${version}";
-    sha256 = "sha256-Bi/Cz2T2NdtnJZHav8qvo+gErPsR8Ym7K3KcD5APt6Y=";
+    # 2.3.14 release tag points to the commit before the one that updates the
+    # version number.
+    # rev = "release/${version}";
+    rev = "1e09791a1e2fe2a0ca9835019d634a4c6a4fa3bf";
+    sha256 = "0mhzp1j6nmqvkjxg8lv8xa637m1lavdsak30mdlq0g25dhwg6k92";
   };
 
   nativeBuildInputs = [ cmake gcc-arm-embedded python3Packages.pillow ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates opentx to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
