### PR TITLE
darwin.apple_sdk.frameworks.AVFoundation: Add missing dependencies on aarch64

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
@@ -141,6 +141,15 @@ in rec {
         cp -r ${MacOSX-SDK}/usr/include/libDER $out/include
       '';
     };
+
+    simd = stdenv.mkDerivation {
+      name = "apple-lib-simd";
+      dontUnpack = true;
+      installPhase = ''
+        mkdir -p $out/include
+        cp -r ${MacOSX-SDK}/usr/include/simd $out/include
+      '';
+    };
   };
 
   overrides = super: {

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/frameworks.nix
@@ -1,7 +1,7 @@
 { frameworks, libs, libobjc, Libsystem, libnetwork }: with frameworks; with libs;
 {
   AGL                              = { inherit Carbon OpenGL; };
-  AVFoundation                     = { inherit ApplicationServices AVFCapture AVFCore CoreGraphics; };
+  AVFoundation                     = { inherit ApplicationServices AVFCapture AVFCore CoreGraphics simd UniformTypeIdentifiers; };
   AVKit                            = {};
   Accelerate                       = { inherit CoreWLAN IOBluetooth; };
   Accessibility                    = {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Declares missing dependencies for AVFoundation on Apple SDK 11.0. These were found when porting packages to Apple Silicon that depend on AVFoundation (opencv).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
