### PR TITLE
ocamlPackages.ocsigen_server: 2.18.0 → 4.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip, fetchpatch, which, ocsigen_server, ocaml,
+{ stdenv, lib, fetchzip, which, ocsigen_server, ocaml,
   lwt_react,
   opaline, ppx_deriving, findlib
 , ocaml-migrate-parsetree
@@ -7,34 +7,24 @@
 , js_of_ocaml-lwt
 , js_of_ocaml-tyxml
 , lwt_ppx
+, ocamlnet
 }:
-
-if !lib.versionAtLeast ocaml.version "4.07"
-then throw "eliom is not available for OCaml ${ocaml.version}"
-else
 
 stdenv.mkDerivation rec
 {
   pname = "eliom";
-  version = "6.12.4";
+  version = "8.6.0";
 
   src = fetchzip {
     url = "https://github.com/ocsigen/eliom/archive/${version}.tar.gz";
-    sha256 = "00m6v2k4mg8705dy41934lznl6gj91i6dk7p1nkaccm51nna25kz";
+    sha256 = "0s1hpawwhqp4qcy8w1067n8c6zg8jcjpzplc39bjbb1ycqw667j9";
   };
-
-  patches = [
-    # Compatibility with js_of_ocaml >= 3.9.0, remove at next release
-    (fetchpatch {
-      url = "https://github.com/ocsigen/eliom/commit/4106a4217956f7b74a8ef3f73a1e1f55e02ade45.patch";
-      sha256 = "1cgbvpljn9x6zxirxf3rdjrsdwy319ykz3qq03c36cc40hy2w13p";
-    })
-  ];
 
   buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild
     ocaml-migrate-parsetree
     js_of_ocaml-ppx_deriving_json opaline
     ppx_tools_versioned
+    ocamlnet
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -1,46 +1,55 @@
-{ stdenv, lib, fetchFromGitHub, which, ocaml, findlib, lwt_react, ssl, lwt_ssl
-, lwt_log, ocamlnet, ocaml_pcre, cryptokit, tyxml, xml-light, ipaddr
+{ lib, buildDunePackage, fetchFromGitHub, which, ocaml, lwt_react, ssl, lwt_ssl
+, bigstringaf, lwt, cstruct, mirage-crypto, zarith, mirage-crypto-ec, ptime, mirage-crypto-rng, mtime, ca-certs
+, cohttp, cohttp-lwt-unix, hmap
+, lwt_log, ocaml_pcre, cryptokit, xml-light, ipaddr
 , pgocaml, camlzip, ocaml_sqlite3
 , makeWrapper
 }:
 
-if !lib.versionAtLeast ocaml.version "4.06.1"
-then throw "ocsigenserver is not available for OCaml ${ocaml.version}"
-else
-
-let mkpath = p: n:
-  "${p}/lib/ocaml/${ocaml.version}/site-lib/${n}";
+let mkpath = p:
+  "${p}/lib/ocaml/${ocaml.version}/site-lib/stublibs";
 in
 
-stdenv.mkDerivation rec {
-  version = "2.18.0";
+let caml_ld_library_path =
+  lib.concatMapStringsSep ":" mkpath [
+    bigstringaf lwt ssl cstruct mirage-crypto zarith mirage-crypto-ec ptime mirage-crypto-rng mtime ca-certs cryptokit ocaml_pcre
+  ]
+; in
+
+buildDunePackage rec {
+  version = "4.0.1";
   pname = "ocsigenserver";
+
+  useDune2 = true;
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "ocsigenserver";
     rev = version;
-    sha256 = "0c61wkq8ddy3qxb2x1jz04rz0722hk92r6jl1zvgikh74m5p5ipp";
+    sha256 = "0pid4irkmdmx1d6n2rvcvx5mnljl3hazzdqc3bql72by35izfac6";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ which ocaml findlib lwt_react pgocaml camlzip ocaml_sqlite3 ];
+  nativeBuildInputs = [ makeWrapper which ];
+  buildInputs = [ lwt_react pgocaml camlzip ocaml_sqlite3 ];
 
-  propagatedBuildInputs = [ cryptokit ipaddr lwt_log lwt_ssl ocamlnet
-    ocaml_pcre tyxml xml-light
+  propagatedBuildInputs = [ cohttp cohttp-lwt-unix cryptokit hmap ipaddr lwt_log lwt_ssl
+    ocaml_pcre xml-light
   ];
 
   configureFlags = [ "--root $(out)" "--prefix /" ];
 
   dontAddPrefix = true;
 
-  createFindlibDestdir = true;
+  postConfigure = ''
+    make -C src confs
+  '';
 
   postFixup =
   ''
   rm -rf $out/var/run
   wrapProgram $out/bin/ocsigenserver \
-    --suffix CAML_LD_LIBRARY_PATH : "${mkpath ssl "ssl"}:${mkpath ocamlnet "netsys"}:${mkpath ocamlnet "netstring"}:${mkpath ocaml_pcre "pcre"}:${mkpath ocaml_sqlite3 "sqlite3"}"
+    --suffix CAML_LD_LIBRARY_PATH : "${caml_ld_library_path}"
   '';
 
   dontPatchShebangs = true;
@@ -51,7 +60,7 @@ stdenv.mkDerivation rec {
     longDescription =''
       A full featured Web server. It implements most features of the HTTP protocol, and has a very powerful extension mechanism that make very easy to plug your own OCaml modules for generating pages.
       '';
-    license = lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21Only;
     platforms = ocaml.meta.platforms or [];
     maintainers = [ lib.maintainers.gal_bolle ];
   };

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,29 +1,28 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, pgocaml_ppx, safepass, yojson
 , cohttp-lwt-unix
 , resource-pooling
+, ocamlnet
 }:
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-ocsigen-start-${version}";
-  version = "2.18.0";
+  version = "4.3.0";
 
   buildInputs = [ ocaml findlib ];
-  propagatedBuildInputs = [ pgocaml_ppx safepass ocsigen-toolkit yojson resource-pooling cohttp-lwt-unix ];
+  propagatedBuildInputs = [ pgocaml_ppx safepass ocsigen-toolkit yojson resource-pooling cohttp-lwt-unix ocamlnet ];
 
   patches = [ ./templates-dir.patch ];
-
-  postPatch = ''
-  substituteInPlace "src/os_db.ml" --replace "citext" "text"
-  '';
-
-  createFindlibDestdir = true;
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "ocsigen-start";
     rev = version;
-    sha256 = "0wvh4c26g6qd6i1fryilcqz9giz7v6pnhc90sknhxh6jmwrbjl50";
+    sha256 = "0lkl59dwzyqq2lyr46fyjr27ms0fp9h59xfsn37faaavdd7v0h98";
   };
+
+  preInstall = ''
+    mkdir -p $OCAMLFIND_DESTDIR
+  '';
 
   meta = {
     homepage = "http://ocsigen.org/ocsigen-start";
@@ -31,7 +30,7 @@ stdenv.mkDerivation rec {
     longDescription =''
      An Eliom application skeleton, ready to use to build your own application with users, (pre)registration, notifications, etc.
       '';
-    license = lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21Only;
     inherit (ocaml.meta) platforms;
     maintainers = [ lib.maintainers.gal_bolle ];
   };


### PR DESCRIPTION
ocamlPackages.eliom: 6.12.4 → 8.6.0

ocamlPackages.ocsigen-start: 2.18.0 → 4.3.0

###### Motivation for this change

Major updates.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @FlorentBecker