### PR TITLE
squashfsTools: add NixOS cdrom boot as passthru test

### DIFF
--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -7,6 +7,7 @@
 , lz4
 , lzo
 , zstd
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -46,6 +47,10 @@ stdenv.mkDerivation rec {
     "LZ4_SUPPORT=1"
     "LZO_SUPPORT=1"
   ];
+
+  passthru.tests = {
+    nixos-iso-boots-and-verifies = nixosTests.boot.biosCdrom;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/plougher/squashfs-tools";


### PR DESCRIPTION
This is the same test which blocks nixos-unstable-small:tested. It recently caused a long blockage, due to a regression in squashfsTools itself corrupting the iso image - see #132286.

