### PR TITLE
libertinus: 6.9 -> 7.040

### DIFF
--- a/pkgs/data/fonts/libertinus/default.nix
+++ b/pkgs/data/fonts/libertinus/default.nix
@@ -5,7 +5,7 @@ let
 in fetchurl rec {
   name = "libertinus-${version}";
   url = "https://github.com/alerque/libertinus/releases/download/v${version}/Libertinus-${version}.tar.xz";
-  sha256 = "sha256-GT2kBfTCP1lf8SYG0z6iii/1482hx3uUNsPTCrM+DKQ=";
+  sha256 = "0z658r88p52dyrcslv0wlccw0sw7m5jz8nbqizv95nf7bfw96iyk";
 
   downloadToTemp = true;
   recursiveHash = true;

--- a/pkgs/data/fonts/libertinus/default.nix
+++ b/pkgs/data/fonts/libertinus/default.nix
@@ -1,29 +1,29 @@
-{ lib, fetchFromGitHub }:
+{ lib, fetchurl }:
 
 let
-  version = "6.9";
-in fetchFromGitHub rec {
+  version = "7.040";
+in fetchurl rec {
   name = "libertinus-${version}";
+  url = "https://github.com/alerque/libertinus/releases/download/v${version}/Libertinus-${version}.tar.xz";
+  sha256 = "sha256-GT2kBfTCP1lf8SYG0z6iii/1482hx3uUNsPTCrM+DKQ=";
 
-  owner  = "alif-type";
-  repo   = "libertinus";
-  rev    = "v${version}";
+  downloadToTemp = true;
+  recursiveHash = true;
 
   postFetch = ''
     tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-    install -m444 -Dt $out/share/doc/${name}    *.txt
+    install -m644 -Dt $out/share/fonts/opentype static/OTF/*.otf
   '';
-  sha256 = "0765a7w0askkhrjmjk638gcm9h6fcm1jpaza8iw9afr3sz1s0xlq";
 
   meta = with lib; {
-    description = "A fork of the Linux Libertine and Linux Biolinum fonts";
+    description = "The Libertinus font family";
     longDescription = ''
-      Libertinus fonts is a fork of the Linux Libertine and Linux Biolinum fonts
-      that started as an OpenType math companion of the Libertine font family,
-      but grown as a full fork to address some of the bugs in the fonts.
+      The Libertinus font project began as a fork of the Linux Libertine and
+      Linux Biolinum fonts. The original impetus was to add an OpenType math
+      companion to the Libertine font families. Over time it grew into to a
+      full-fledged fork addressing many of the bugs in the Libertine fonts.
     '';
-    homepage = "https://github.com/alif-type/libertinus";
+    homepage = "https://github.com/alerque/libertinus";
     license = licenses.ofl;
     maintainers = with maintainers; [ siddharthist ];
     platforms = platforms.all;


### PR DESCRIPTION
Besides the version bump, the Nix expression was updated to conform to directory structure changes in the archive file, and to add extra documentation files that were not included before.

Also, the short and long descriptions were updated to match the current contents of the project's README.

Finally, the homepage and owner fields were changed to reflect the current location of the project.

/cc @dtzWill who contributed the previous updates (#31461, #46725, #61556 and #62240).

###### Motivation for this change

Update the Libertinus package to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
