### PR TITLE
python3Packages.distro: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/development/python-modules/distro/default.nix
+++ b/pkgs/development/python-modules/distro/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "distro";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0e58756ae38fbd8fc3020d54badb8eae17c5b9dcbed388b17bb55b8a5928df92";
+    sha256 = "09441261dd3c8b2gv15vhw1cryzg60lmgpkk07v6hpwwkyhfbxc3";
   };
 
   # tests are very targeted at individual linux distributions

--- a/pkgs/development/python-modules/distro/default.nix
+++ b/pkgs/development/python-modules/distro/default.nix
@@ -1,4 +1,8 @@
-{ lib, fetchPypi, buildPythonPackage }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "distro";
@@ -9,15 +13,34 @@ buildPythonPackage rec {
     sha256 = "09441261dd3c8b2gv15vhw1cryzg60lmgpkk07v6hpwwkyhfbxc3";
   };
 
-  # tests are very targeted at individual linux distributions
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Some distributions can't be tested
+    "test_debian8_release"
+    "test_linuxmint17_lsb_release"
+    "test_mageia5_release"
+    "test_mandriva2011_release"
+    "test_manjaro1512_lsb_release"
+    "test_manjaro1512_lsb_release"
+    "test_manjaro1512_release"
+    "test_sles12_release"
+    "test_trailingblanks_lsb_release"
+    "test_trailingblanks_lsb_release"
+    "test_ubuntu14nomodules_lsb_release"
+    "test_ubuntu14nomodules_lsb_release"
+    "test_ubuntu14normal_lsb_release"
+    "test_ubuntu14normal_lsb_release"
+  ];
 
   pythonImportsCheck = [ "distro" ];
 
   meta = with lib; {
+    description = "Python module for getting information about the OS distribution it runs on";
     homepage = "https://github.com/nir0s/distro";
-    description = "Linux Distribution - a Linux OS platform information API.";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -55,18 +55,27 @@ let newPython = python3.override {
         sha256 = "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b";
       };
     });
+    # conan wants distro>=1.0.2, <=1.5.0
+    distro = super.distro.overridePythonAttrs (oldAttrs: rec {
+      version = "1.5.0";
+      src = oldAttrs.src.override {
+        inherit version;
+        sha256 = "14nz51cqlnxmgfqqilxyvjwwa5xfivdvlm0d0b1qzgcgwdm7an0f";
+      };
+      doCheck = false;
+    });
   };
 };
 
 in newPython.pkgs.buildPythonApplication rec {
-  version = "1.35.0";
+  version = "1.39.0";
   pname = "conan";
 
   src = fetchFromGitHub {
     owner = "conan-io";
     repo = "conan";
     rev = version;
-    sha256 = "19rgylkjxvv47vz5vgh46rw108xskpv7lmax8y2fnm2wd1j3bq9c";
+    sha256 = "sha256-MUciWz7EG/9PtEQ+t0nEDT8KMF6A/TlGrEVSIq3Fqqs=";
   };
 
   propagatedBuildInputs = with newPython.pkgs; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.6.0

Change log: https://github.com/python-distro/distro/blob/master/CHANGELOG.md#160-2021730

- Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
