### PR TITLE
bazarr: fix build

### DIFF
--- a/pkgs/servers/bazarr/default.nix
+++ b/pkgs/servers/bazarr/default.nix
@@ -1,25 +1,28 @@
-{ stdenv, lib, fetchurl, makeWrapper, python3, unrar, ffmpeg, nixosTests }:
+{ stdenv, lib, fetchurl, makeWrapper, unzip, python3, unrar, ffmpeg, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "bazarr";
   version = "0.9.6";
 
+  sourceRoot = ".";
+
   src = fetchurl {
-    url = "https://github.com/morpheus65535/bazarr/archive/v${version}.tar.gz";
-    sha256 = "sha256-aO9PIE/YlSIGEcntDCdxIYuuvV5jG266ldhC2QfT+e4=";
+    url = "https://github.com/morpheus65535/bazarr/releases/download/v${version}/bazarr.zip";
+    sha256 = "sha256-ZSQzDlObnv5DEra2+YgXhox583KPyGIjia0SJyTUPWo=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ unzip makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/src
-    cp -r * $out/src
-
-    mkdir -p $out/bin
-    makeWrapper "${(python3.withPackages (ps: [ps.lxml ps.numpy])).interpreter}" \
+    mkdir -p $out/{bin,share/${pname}-${version}}
+    cp -r * $out/share/${pname}-${version}
+    makeWrapper "${
+      (python3.withPackages
+        (ps: [ ps.lxml ps.numpy ps.gevent ps.gevent-websocket ])).interpreter
+    }" \
       $out/bin/bazarr \
-      --add-flags "$out/src/bazarr.py" \
-      --suffix PATH : ${lib.makeBinPath [ unrar ffmpeg ]} \
+      --add-flags "$out/share/${pname}-${version}/bazarr.py" \
+      --suffix PATH : ${lib.makeBinPath [ unrar ffmpeg ]}
   '';
 
   passthru.tests = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Current build is not working as it has missing dependencies `gevent` and `gevent-websocket`.  It also uses wrong source files which don't have some templates needed at runtime (https://github.com/morpheus65535/bazarr/issues/1476). This PR adds missing dependencies and changes the source file.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
