### PR TITLE
lib.systems: m68k is supported by NetBSD as well

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -26,9 +26,9 @@ let
 
     # Linux
     "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux"
-    "armv7l-linux" "i686-linux" "mipsel-linux" "powerpc64-linux"
-    "powerpc64le-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux"
-    "m68k-linux" "s390-linux"
+    "armv7l-linux" "i686-linux" "m68k-linux" "mipsel-linux"
+    "powerpc64-linux" "powerpc64le-linux" "riscv32-linux"
+    "riscv64-linux" "s390-linux" "x86_64-linux"
 
     # MMIXware
     "mmix-mmixware"
@@ -39,9 +39,9 @@ let
     "riscv64-netbsd" "x86_64-netbsd"
 
     # none
-    "aarch64-none" "arm-none" "armv6l-none" "avr-none" "i686-none" "msp430-none"
-    "or1k-none" "powerpc-none" "riscv32-none" "riscv64-none" "vc4-none" "m68k-none"
-    "s390-none" "x86_64-none"
+    "aarch64-none" "arm-none" "armv6l-none" "avr-none" "i686-none"
+    "msp430-none" "or1k-none" "m68k-none" "powerpc-none"
+    "riscv32-none" "riscv64-none" "s390-none" "vc4-none" "x86_64-none"
 
     # OpenBSD
     "i686-openbsd" "x86_64-openbsd"

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -35,8 +35,8 @@ let
 
     # NetBSD
     "aarch64-netbsd" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd"
-    "i686-netbsd" "mipsel-netbsd" "powerpc-netbsd" "riscv32-netbsd"
-    "riscv64-netbsd" "x86_64-netbsd"
+    "i686-netbsd" "m68k-netbsd" "mipsel-netbsd" "powerpc-netbsd"
+    "riscv32-netbsd" "riscv64-netbsd" "x86_64-netbsd"
 
     # none
     "aarch64-none" "arm-none" "armv6l-none" "avr-none" "i686-none"

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -127,9 +127,10 @@ rec {
 
   # GNU build systems assume that older NetBSD architectures are using a.out.
   gnuNetBSDDefaultExecFormat = cpu:
-    if (cpu.family == "x86" && cpu.bits == 32) ||
-       (cpu.family == "arm" && cpu.bits == 32) ||
-       (cpu.family == "sparc" && cpu.bits == 32)
+    if (cpu.family == "arm" && cpu.bits == 32) ||
+       (cpu.family == "sparc" && cpu.bits == 32) ||
+       (cpu.family == "m68k" && cpu.bits == 32) ||
+       (cpu.family == "x86" && cpu.bits == 32)
     then execFormats.aout
     else execFormats.elf;
 

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -29,7 +29,7 @@ with lib.systems.doubles; lib.runTests {
   testgnu = mseteq gnu (linux /* ++ kfreebsd ++ ... */);
   testillumos = mseteq illumos [ "x86_64-solaris" ];
   testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "mipsel-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux" "powerpc64-linux" "powerpc64le-linux" "m68k-linux" "s390-linux" ];
-  testnetbsd = mseteq netbsd [ "aarch64-netbsd" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd" "i686-netbsd" "mipsel-netbsd" "powerpc-netbsd" "riscv32-netbsd" "riscv64-netbsd" "x86_64-netbsd" ];
+  testnetbsd = mseteq netbsd [ "aarch64-netbsd" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd" "i686-netbsd" "m68k-netbsd" "mipsel-netbsd" "powerpc-netbsd" "riscv32-netbsd" "riscv64-netbsd" "x86_64-netbsd" ];
   testopenbsd = mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ];
   testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "i686-windows" "x86_64-windows" ];
   testunix = mseteq unix (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ cygwin ++ redox);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

m68k was recently added for Linux and none, but NetBSD also supports m68k.  Nothing will build yet, but I want to make sure we at least encode the existence of NetBSD support for every applicable architecture we support for other operating systems.

I've additionally re-sorted the doubles list, which was sorted alphabetically within operating systems until s390 and m68k were added.  I just cleaned up this big list, and it was a big mess before, so I want to make sure it stays organised!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
