### PR TITLE
bambootracker: 0.4.6 -> 0.5.0

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , qmake
 , pkg-config
 , qttools
@@ -13,24 +12,15 @@
 
 mkDerivation rec {
   pname = "bambootracker";
-  version = "0.4.6";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
-    owner = "rerrahkr";
+    owner = "BambooTracker";
     repo = "BambooTracker";
     rev = "v${version}";
-    sha256 = "0iddqfw951dw9xpl4w7310sl4z544507ppb12i8g4fzvlxfw2ifc";
+    fetchSubmodules = true;
+    sha256 = "1mpbvhsmrn0wdmxfp3n5dwv4474qlhy47r3vwc2jwdslq6vgl1fa";
   };
-
-  # TODO Remove when updating past 0.4.6
-  # Fixes build failure on darwin
-  patches = [
-    (fetchpatch {
-      name = "bambootracker-Add_braces_in_initialization_of_std-array.patch";
-      url = "https://github.com/rerrahkr/BambooTracker/commit/0fc96c60c7ae6c2504ee696bb7dec979ac19717d.patch";
-      sha256 = "1z28af46mqrgnyrr4i8883gp3wablkk8rijnj0jvpq01s4m2sfjn";
-    })
-  ];
 
   nativeBuildInputs = [ qmake qttools pkg-config ];
 
@@ -40,18 +30,20 @@ mkDerivation rec {
 
   postConfigure = "make qmake_all";
 
-  # installs app bundle on darwin, re-extract the binary
-  # wrapQtAppsHook fails to wrap mach-o binaries, manually call wrapper (https://github.com/NixOS/nixpkgs/issues/102044)
+  # 1. installs app bundle on darwin, move to app bundle dir & link binary to bin
+  # 2. wrapQtAppsHook fails to wrap mach-o binaries automatically, manually call wrapper
+  #    (see https://github.com/NixOS/nixpkgs/issues/102044)
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mv $out/bin/BambooTracker{.app/Contents/MacOS/BambooTracker,}
-    rm -r $out/bin/BambooTracker.app
-    wrapQtApp $out/bin/BambooTracker
+    mkdir -p $out/Applications
+    mv $out/{bin,Applications}/BambooTracker.app
+    wrapQtApp $out/Applications/BambooTracker.app/Contents/MacOS/BambooTracker
+    ln -s $out/{Applications/BambooTracker.app/Contents/MacOS,bin}/BambooTracker
   '';
 
   meta = with lib; {
     description = "A tracker for YM2608 (OPNA) which was used in NEC PC-8801/9801 series computers";
-    homepage = "https://rerrahkr.github.io/BambooTracker";
-    license = licenses.gpl2Only;
+    homepage = "https://bambootracker.github.io/BambooTracker/";
+    license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ OPNA2608 ];
   };


### PR DESCRIPTION
###### Motivation for this change
- Bump
- Updated source location, we migrated to an organisation for the project
- Updated license, we updated some dependencies that restricted us to GPL2 and made some non-OSI-approved dependencies opt-in instead of required so this should all be fine now
- Moving the Darwin appbundle instead of removing it, since some users might prefer having it

Reviewing locally on Darwin & aarch64-linux before I un-draft it.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
