### PR TITLE
nixos/syncthing: fix curl not retrying on network errors

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -37,13 +37,9 @@ let
     do sleep 1; done
 
     curl() {
-        while
-            ${pkgs.curl}/bin/curl -Ss -H "X-API-Key: $api_key" \
-                --retry 100 --retry-delay 1 --retry-connrefused "$@"
-            status=$?
-            [ "$status" -eq 52 ] # retry on empty reply from server
-        do sleep 1; done
-        return "$status"
+        ${pkgs.curl}/bin/curl -sS -H "X-API-Key: $api_key" \
+            --retry 1000 --retry-delay 1 --retry-all-errors \
+            "$@"
     }
 
     # query the old config
@@ -547,6 +543,7 @@ in {
         cfg.devices != {} || cfg.folders != {} || cfg.extraOptions != {}
       ) {
         description = "Syncthing configuration updater";
+        requisite = [ "syncthing.service" ];
         after = [ "syncthing.service" ];
         wantedBy = [ "multi-user.target" ];
 


### PR DESCRIPTION

###### Motivation for this change

#131737 made `syncthing-init.service` fail on boot for me because curl doesn't retry on all network errors by default (I should have tested that...).

This PR adds `--retry-all-errors`, which makes curl retry on all errors except non-transient HTTP errors, and increases the number of retries just to be safe.

It also adds `syncthing.service` as a requisite of `syncthing-init.service` so that the latter fails to start if Syncthing isn't running.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
