### PR TITLE
[21.05] rabbitmq-server: add patches for multiple CVEs

### DIFF
--- a/pkgs/servers/amqp/rabbitmq-server/default.nix
+++ b/pkgs/servers/amqp/rabbitmq-server/default.nix
@@ -3,6 +3,7 @@
 , procps, coreutils, gnused, systemd, glibcLocales
 , AppKit, Carbon, Cocoa
 , nixosTests
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -15,6 +16,24 @@ stdenv.mkDerivation rec {
     url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${version}/${pname}-${version}.tar.xz";
     sha256 = "0b252l9r45h8r5gibdqcn6hhbm8g6rfzhm1k9d39pwhs5x77cjqv";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-22116.patch";
+      url = "https://github.com/rabbitmq/rabbitmq-server/commit/626d5219115d087a2695c0eb243c7ddb7e154563.patch";
+      sha256 = "0wknixb5szwmxyvna793c2qkwnv7kynimibrswxdd1941vv6ijm3";
+    })
+    (fetchpatch {
+      name = "CVE-2021-32718.patch";
+      url = "https://github.com/rabbitmq/rabbitmq-server/commit/5d15ffc5ebfd9818fae488fc05d1f120ab02703c.patch";
+      sha256 = "11bgknnajd38bkqaiqaqbryjxyxg5qaynv6gbflp5fgy4jj8dv7v";
+    })
+    (fetchpatch {
+      name = "CVE-2021-32719.patch";
+      url = "https://github.com/rabbitmq/rabbitmq-server/commit/f191414dbc2ca738f313bb31e432d57870922892.patch";
+      sha256 = "1p5wb4p9cmxmbvrcwxh8m204nabjqgpmn7sk9djgbi1d0ac65w3h";
+    })
+  ];
 
   nativeBuildInputs = [ unzip ];
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-22116
https://nvd.nist.gov/vuln/detail/CVE-2021-32718
https://nvd.nist.gov/vuln/detail/CVE-2021-32719

(ignoring CVE-2021-22117 as it is only related to the windows installer)

CVE-2021-32718 and CVE-2021-32719 are trivial patches, and I'm confident in the CVE-2021-22116 patch's validity mostly because debian use basically the exact same patch against 3.6.6 without apparent issues.

Why not just bump to >=3.8.18? Looking at the release notes (https://www.rabbitmq.com/changelog.html) reveals that despite these being "bugfix" releases, they are screwing around with supported (major) versions of erlang/elixir and that's not something that's ok for us to do to stable users. Also if you dig into the full release notes, there are some fairly significant things that get snuck in under `- Bug fixes`.

See #132242 for master, where the attempted bump is indeed causing some problems. Help welcome there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
