### PR TITLE
libutp: init at unstable-2018-05-15

### DIFF
--- a/pkgs/development/libraries/libutp/default.nix
+++ b/pkgs/development/libraries/libutp/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libutp";
+  version = "unstable-2018-05-15";
+
+  src = fetchFromGitHub {
+    owner = "bittorrent";
+    repo = pname;
+    rev = "2b364cbb0650bdab64a5de2abb4518f9f228ec44";
+    sha256 = "0yaiqksimnhwh14kmsq4kcyq6662b4ask36ni6p5n14dbyq1h2s6";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib $out/include/libutp
+    cp libutp.a libutp.so $out/lib/
+    cp *.h $out/include/libutp/
+  '';
+
+  meta = with lib; {
+    description = "uTorrent Transport Protocol library";
+    homepage = "https://github.com/bittorrent/libutp";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17293,6 +17293,8 @@ in
 
   libutempter = callPackage ../development/libraries/libutempter { };
 
+  libutp = callPackage ../development/libraries/libutp { };
+
   libuldaq = callPackage ../development/libraries/libuldaq { };
 
   libunwind =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

libutp is a dependency of the newer version of the gnome bittorrent client [fragments](https://gitlab.gnome.org/World/Fragments). There are now stable releases for libutp and no stable releases are planned for the future. This is why this version is tagged with unstable.

The app Fragments [haven't been merged yet](https://github.com/NixOS/nixpkgs/pull/56793).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
