### PR TITLE
qarte: 4.6.0 → 4.12.0

### DIFF
--- a/pkgs/applications/video/qarte/default.nix
+++ b/pkgs/applications/video/qarte/default.nix
@@ -3,11 +3,11 @@
 let
   pythonEnv = python3.withPackages (ps: with ps; [ pyqt5_with_qtmultimedia ]);
 in mkDerivation {
-  name = "qarte-4.6.0";
+  name = "qarte-4.12.0";
   src = fetchbzr {
     url = "http://bazaar.launchpad.net/~vincent-vandevyvre/qarte/qarte-4";
-    rev = "22";
-    sha256 = "0v4zpj8w67ydvnmanxbl8pwvn0cfv70c0mlw36a1r4n0rvgxffcn";
+    rev = "56";
+    sha256 = "0cq9dg04grl45xw43gi9wsb0vm8c4bcvh813h5lm4ry8b94lfx2i";
   };
 
   buildInputs = [ pythonEnv ];


### PR DESCRIPTION
###### Motivation for this change

The version of `qarte` that is currently packaged no longer works.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
