### PR TITLE
gnome.caribou: add patch for CVE-2021-3567

### DIFF
--- a/pkgs/desktops/gnome/core/caribou/default.nix
+++ b/pkgs/desktops/gnome/core/caribou/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, lib, stdenv, pkg-config, gnome, glib, gtk3, clutter, dbus, python3, libxml2
 , libxklavier, libXtst, gtk2, intltool, libxslt, at-spi2-core, autoreconfHook
-, wrapGAppsHook, libgee }:
+, wrapGAppsHook, libgee, vala_0_40 }:
 
 let
   pname = "caribou";
@@ -21,9 +21,19 @@ in stdenv.mkDerivation rec {
       url = "https://bugzilla.gnome.org/attachment.cgi?id=364774";
       sha256 = "15k1455grf6knlrxqbjnk7sals1730b0whj30451scp46wyvykvd";
     })
+    (fetchurl {
+      name = "fix-build-modern-vala.patch";
+      url = "https://gitlab.gnome.org/GNOME/caribou/-/commit/76fbd11575f918fc898cb0f5defe07f67c11ec38.patch";
+      sha256 = "0qy27zk7889hg51nx40afgppcx9iaihxbg3aqz9w35d6fmhr2k2y";
+    })
+    (fetchurl {
+      name = "CVE-2021-3567.patch";
+      url = "https://gitlab.gnome.org/GNOME/caribou/-/commit/d41c8e44b12222a290eaca16703406b113a630c6.patch";
+      sha256 = "1vd2j3823k2p3msv7fq2437p3jvxzbd7hyh07i80g9754ylh92y8";
+    })
   ];
 
-  nativeBuildInputs = [ pkg-config intltool libxslt libxml2 autoreconfHook wrapGAppsHook ];
+  nativeBuildInputs = [ pkg-config intltool libxslt libxml2 autoreconfHook wrapGAppsHook vala_0_40 ];
 
   buildInputs = [
     glib gtk3 clutter at-spi2-core dbus pythonEnv python3.pkgs.pygobject3


### PR DESCRIPTION
###### Motivation for this change
https://security-tracker.debian.org/tracker/CVE-2021-3567
https://bugs.launchpad.net/ubuntu/+source/caribou/+bug/1912060

No release with this fix yet, doesn't look like caribou is tremendously actively maintained.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
