### PR TITLE
renderdoc: 1.14 -> 1.15

### DIFF
--- a/pkgs/applications/graphics/renderdoc/default.nix
+++ b/pkgs/applications/graphics/renderdoc/default.nix
@@ -2,6 +2,7 @@
 , qtbase, qtx11extras, qtsvg, makeWrapper
 , vulkan-loader, libglvnd, xorg, python3, python3Packages
 , bison, pcre, automake, autoconf, addOpenGLRunpath
+, waylandSupport ? false, wayland
 }:
 let
   custom_swig = fetchFromGitHub {
@@ -11,22 +12,24 @@ let
     sha256 = "15r2m5kcs0id64pa2fsw58qll3jyh71jzc04wy20pgsh2326zis6";
   };
   pythonPackages = python3Packages;
+  cmakeBool = b: if b then "ON" else "OFF";
 in
 mkDerivation rec {
-  version = "1.14";
+  version = "1.15";
   pname = "renderdoc";
 
   src = fetchFromGitHub {
     owner = "baldurk";
     repo = "renderdoc";
     rev = "v${version}";
-    sha256 = "VO7pOLodXI0J7O4Y9b7YSl5BdtsIxmalFG5mqfuiJEw=";
+    sha256 = "HSWl3FC5YDIADO3h6oHxHdwsrFQKKj2zTtH2e3cc5iI=";
   };
 
   buildInputs = [
     qtbase qtsvg xorg.libpthreadstubs xorg.libXdmcp qtx11extras vulkan-loader python3
-  ]; # ++ (with pythonPackages; [pyside2 pyside2-tools shiboken2]);
+  ] # ++ (with pythonPackages; [pyside2 pyside2-tools shiboken2])
   # TODO: figure out how to make cmake recognise pyside2
+  ++ (lib.optional waylandSupport wayland);
 
   nativeBuildInputs = [ cmake makeWrapper pkg-config bison pcre automake autoconf addOpenGLRunpath ];
 
@@ -42,6 +45,7 @@ mkDerivation rec {
     "-DBUILD_VERSION_DIST_VER=${version}"
     "-DBUILD_VERSION_DIST_CONTACT=https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/graphics/renderdoc"
     "-DBUILD_VERSION_STABLE=ON"
+    "-DENABLE_WAYLAND=${cmakeBool waylandSupport}"
   ];
 
   # TODO: define these in the above array via placeholders, once those are widely supported


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/baldurk/renderdoc/releases/tag/v1.15

Also added some initial Wayland support work, but since that is still very experimental upstream it's disabled for now.

###### Things done

Both qrenderdoc and renderdoccmd run, I can trigger a capture and open it in the GUI. However I can't verify that the capture is correct since I've moved to wayland which is not officially supported by upstream yet and viewing replays on wayland does not work at all.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
