### PR TITLE
corrscope: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/applications/video/corrscope/default.nix
+++ b/pkgs/applications/video/corrscope/default.nix
@@ -1,6 +1,8 @@
 { lib
 , mkDerivationWith
 , python3Packages
+, fetchFromGitHub
+, fetchpatch
 , wrapQtAppsHook
 , ffmpeg
 , qtbase
@@ -8,24 +10,31 @@
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "corrscope";
-  version = "0.7.0";
+  version = "0.7.1";
 
-  src = python3Packages.fetchPypi {
-    inherit pname version;
-    sha256 = "0m62p3jlbx5dlp3j8wn1ka1sqpffsxbpsgv2h5cvj1n1lsgbss2s";
+  src = fetchFromGitHub {
+    owner = "corrscope";
+    repo = "corrscope";
+    rev = version;
+    sha256 = "0c9kmrw6pcda68li04b5j2kmsgdw1q463qlc32wn96zn9hl82v6m";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace 'attrs>=18.2.0,<19.0.0' 'attrs>=18.2.0' \
-      --replace 'numpy>=1.15,<2.0,!=1.19.4' 'numpy>=1.15,<2.0'
-  '';
+  format = "pyproject";
+
+  patches = [
+    # Remove when bumping past 0.7.1
+    (fetchpatch {
+      name = "0001-Use-poetry-core.patch";
+      url = "https://github.com/corrscope/corrscope/commit/d40d1846dd54b8bccd7b8055d6aece48aacbb943.patch";
+      sha256 = "0xxsbmxdbh3agfm6ww3rpa7ab0ysppan490w0gaqwmwzrxmmdljv";
+    })
+  ];
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
   buildInputs = [ ffmpeg qtbase ];
 
-  propagatedBuildInputs = with python3Packages; [ appdirs attrs click matplotlib numpy pyqt5 ruamel_yaml ];
+  propagatedBuildInputs = with python3Packages; [ appdirs atomicwrites attrs click matplotlib numpy poetry-core pyqt5 ruamel_yaml ];
 
   dontWrapQtApps = true;
 
@@ -35,8 +44,6 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
       "''${qtWrapperArgs[@]}"
     )
   '';
-
-  preCheck = "export HOME=$TEMP";
 
   meta = with lib; {
     description = "Render wave files into oscilloscope views, featuring advanced correlation-based triggering algorithm";


### PR DESCRIPTION
###### Motivation for this change
Bump. Includes some backwards-incompatible changes to command-line options so I prolly won't backport it to stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
