### PR TITLE
python3Packages.bellows: 0.25.0 -> 0.26.0, python3Packages.zigpy: 0.35.2 -> 0.36.1, python3Packages.zigpy-znp: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/development/python-modules/bellows/default.nix
+++ b/pkgs/development/python-modules/bellows/default.nix
@@ -3,30 +3,28 @@
 , fetchFromGitHub
 , click
 , click-log
+, dataclasses
 , pure-pcapy3
 , pyserial-asyncio
 , voluptuous
 , zigpy
 , asynctest
+, pythonOlder
 , pytestCheckHook
 , pytest-asyncio
+, pytest-timeout
 }:
 
 buildPythonPackage rec {
   pname = "bellows";
-  version = "0.25.0";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "bellows";
     rev = version;
-    sha256 = "1836wm8whbryp31zdaj3b6w40sx1wjsxgpjdb1x9rgmwff4d1hc0";
+    sha256 = "0qbsk5iv3vrpwz7kfmjdbc66rfkg788p6wwxbf6jzfarfhcgrh3k";
   };
-
-  prePatch = ''
-    substituteInPlace setup.py \
-      --replace "click-log==0.2.1" "click-log>=0.2.1"
-  '';
 
   propagatedBuildInputs = [
     click
@@ -35,16 +33,31 @@ buildPythonPackage rec {
     pyserial-asyncio
     voluptuous
     zigpy
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    dataclasses
   ];
 
   checkInputs = [
-    asynctest
     pytestCheckHook
     pytest-asyncio
+    pytest-timeout
+  ]  ++ lib.optionals (pythonOlder "3.8") [
+    asynctest
+  ];
+
+  disabledTests = [
+    # RuntimeError: coroutine 'test_remigrate_forcibly_downgraded_v4' was never awaited
+    #"test_remigrate_forcibly_downgraded_v4"
+    # RuntimeError: Event loop is closed
+    "test_thread_already_stopped"
+  ];
+
+  pythonImportsCheck = [
+    "bellows"
   ];
 
   meta = with lib; {
-    description = "A Python 3 project to implement EZSP for EmberZNet devices";
+    description = "Python module to implement EZSP for EmberZNet devices";
     homepage = "https://github.com/zigpy/bellows";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ etu mvnetbiz ];

--- a/pkgs/development/python-modules/zigpy-znp/default.nix
+++ b/pkgs/development/python-modules/zigpy-znp/default.nix
@@ -4,7 +4,6 @@
 , buildPythonPackage
 , coloredlogs
 , fetchFromGitHub
-, fetchpatch
 , jsonschema
 , pyserial
 , pyserial-asyncio
@@ -19,22 +18,14 @@
 
 buildPythonPackage rec {
   pname = "zigpy-znp";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = pname;
     rev = "v${version}";
-    sha256 = "152d803jfrvkj4namni41fnbbnq85wd7zsqjhmkwrrmn2gvqjiln";
+    sha256 = "15i93f32dr3a9dgx8s08cxangpkgrkx8rn2n6l18rncjknhk9wmc";
   };
-
-  patches = [
-    (fetchpatch {
-      # Fixes tests/application/test_joining.py::test_new_device_join_and_bind_complex[FormedLaunchpadCC26X2R1]
-      url = "https://github.com/zigpy/zigpy-znp/commit/582cffb68fdf0c5bc14d55efca2a683222d7fed7.patch";
-      sha256 = "0qsfziqqjnnf21gdqv3wwk50vni46i0h1liw5ysq641yjfnas9az";
-    })
-  ];
 
   propagatedBuildInputs = [
     async-timeout

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -5,46 +5,46 @@
 , buildPythonPackage
 , crccheck
 , fetchFromGitHub
-, pycrypto
 , pycryptodome
 , pytest-aiohttp
-, pytest-asyncio
+, pytest-timeout
 , pytestCheckHook
-, tox
-, voluptuous }:
+, pythonOlder
+, voluptuous
+}:
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.35.2";
+  version = "0.36.1";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy";
     rev = version;
-    sha256 = "sha256-p0q0wGp3NaBO7gBTsPAt7FEAHW0MDPJCKqLklY21zBQ=";
+    sha256 = "0rfif8ds6m9ndxnc0f02fivc2pwidf476ylyx9y2b1sa2qz36z5w";
   };
 
   propagatedBuildInputs = [
     aiohttp
     aiosqlite
     crccheck
-    pycrypto
     pycryptodome
     voluptuous
   ];
 
   checkInputs = [
-    asynctest
     pytest-aiohttp
-    pytest-asyncio
+    pytest-timeout
     pytestCheckHook
+  ]  ++ lib.optionals (pythonOlder "3.8") [
+    asynctest
   ];
 
   disabledTests = [
     # RuntimeError: coroutine 'test_remigrate_forcibly_downgraded_v4' was never awaited
-    "test_remigrate_forcibly_downgraded_v4"
+    #"test_remigrate_forcibly_downgraded_v4"
     # RuntimeError: Event loop is closed
-    "test_startup"
+    #"test_startup"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- `bellows`: https://github.com/zigpy/bellows/releases/tag/0.26.0
- `zigpy`: https://github.com/zigpy/zigpy/releases/tag/0.36.0
- `zigpy-znp`: https://github.com/zigpy/zigpy-znp/releases/tag/v0.5.2

- Related Home Assistant change: https://github.com/home-assistant/core/pull/53732
- Target Home Assistant release: 2021.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
