### PR TITLE
I8kutils: init at c993fb1da1bba5c2cd2860c1aa6c3916b4de77e4

### DIFF
--- a/pkgs/os-specific/linux/i8kutils/default.nix
+++ b/pkgs/os-specific/linux/i8kutils/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, tcl }:
+
+stdenv.mkDerivation rec {
+  pname = "i8kutils";
+  version = "c993fb1da1bba5c2cd2860c1aa6c3916b4de77e4";
+
+  src = fetchFromGitHub {
+    owner = "vitorafsr";
+    repo = "i8kutils";
+    rev = version;
+    sha256 = "0dlfv5chc7izqg0rbllw32i3my3sv229mrz1qgwxc01ghbip00y8";
+  };
+
+  buildInputs = [ tcl ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp i8kctl $out/bin/i8kctl
+    sed "s|I8KCTL=/usr/bin/i8kctl|I8KCTL=$out/bin/i8kctl|g" i8kfan > $out/bin/i8kfan
+    sed "s|i8kfan       /usr/bin/i8kfan|i8kfan       $out/bin/i8kfan|g" i8kmon > $out/bin/i8kmon
+    chmod +rx $out/bin/i8kfan $out/bin/i8kmon
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tools to control and monitor fans on some Dell laptops";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rowanG077 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20817,6 +20817,8 @@ in
 
   pcm = callPackage ../os-specific/linux/pcm { };
 
+  i8kutils = callPackage ../os-specific/linux/i8kutils { };
+
   ifmetric = callPackage ../os-specific/linux/ifmetric {};
 
   ima-evm-utils = callPackage ../os-specific/linux/ima-evm-utils {


### PR DESCRIPTION
###### Motivation for this change
I8kutils was not packaged. This is a simple utility that allows fan control on most Dell laptops.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
