### PR TITLE
bottles: update version + bugfixes

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -8,13 +8,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2021.7.14-treviso";
+  version = "2021.7.28-treviso-2";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    sha256 = "0xhfk1ll8vacgrr0kkhynq4bryjhfjs29j824bark5mj9b6lkbix";
+    sha256 = "0kvwcajm9izvkwfg7ir7bks39bpc665idwa8mc8d536ajyjriysn";
   };
 
   postPatch = ''
@@ -52,6 +52,7 @@ python3Packages.buildPythonApplication rec {
     dbus-python
     gst-python
     liblarch
+    patool
   ] ++ [ steam-run-native ];
 
   format = "other";

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -69,6 +69,8 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace src/runner.py \
       --replace " {runner}" " ${steam-run-native}/bin/steam-run {runner}" \
       --replace " {dxvk_setup}" " ${steam-run-native}/bin/steam-run {dxvk_setup}"
+      substituteInPlace src/runner_utilities.py \
+        --replace " {runner}" " ${steam-run-native}/bin/steam-run {runner}" \
   '';
 
   preFixup = ''

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -3,7 +3,7 @@
 , desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy
 , python3Packages, gettext
 , appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3
-, steam-run-native
+, steam-run-native, xdg-utils
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -53,7 +53,10 @@ python3Packages.buildPythonApplication rec {
     gst-python
     liblarch
     patool
-  ] ++ [ steam-run-native ];
+  ] ++ [
+    steam-run-native
+    xdg-utils
+  ];
 
   format = "other";
   strictDeps = false; # broken with gobject-introspection setup hook, see https://github.com/NixOS/nixpkgs/issues/56943

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -3,7 +3,7 @@
 , desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy
 , python3Packages, gettext
 , appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3
-, steam-run-native, xdg-utils
+, steam-run-native, xdg-utils, pciutils
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -56,6 +56,7 @@ python3Packages.buildPythonApplication rec {
   ] ++ [
     steam-run-native
     xdg-utils
+    pciutils
   ];
 
   format = "other";


### PR DESCRIPTION
###### Motivation for this change
Previous state of `bottles` was not able to run any `wine` related commands beside installation of a wine prefix.

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 ✘ asbachb@nixo-t14s  ~/dev/src/nix/nixpkgs   update/bottles  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
these paths will be fetched (0.03 MiB download, 0.12 MiB unpacked):
  /nix/store/7f3hs1kj2jvwia7p2swbfj5by9fn6g2z-nixpkgs-review-2.6.2
copying path '/nix/store/7f3hs1kj2jvwia7p2swbfj5by9fn6g2z-nixpkgs-review-2.6.2' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 147, done.
remote: Counting objects: 100% (101/101), done.
remote: Compressing objects: 100% (17/17), done.
remote: Total 147 (delta 88), reused 86 (delta 84), pack-reused 46
Receiving objects: 100% (147/147), 295.15 KiB | 984.00 KiB/s, done.
Resolving deltas: 100% (92/92), completed with 63 local objects.
From https://github.com/NixOS/nixpkgs
   cec4b2a2740..2c79ed45859  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-c3a6d66834dc75a8f15e88eca6f7838fd5be215b-dirty/nixpkgs 2c79ed45859a07565a49212a262bfd1f29e1546d
Preparing worktree (detached HEAD 2c79ed45859)
Updating files: 100% (27227/27227), done.
HEAD is now at 2c79ed45859 vimPlugins.onedark-nvim: Add lush-nvim dependency (#131987)
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-c3a6d66834dc75a8f15e88eca6f7838fd5be215b-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
