### PR TITLE
nixos/display-managers: update set-session for new "SessionType" property

### DIFF
--- a/nixos/modules/services/x11/display-managers/set-session.py
+++ b/nixos/modules/services/x11/display-managers/set-session.py
@@ -72,11 +72,14 @@ def main():
                     f"Setting session name: {session}, as we found the existing wayland-session: {session_file}"
                 )
                 user.set_session(session)
+                user.set_session_type("wayland")
             elif is_session_xsession(session_file):
                 logging.debug(
                     f"Setting session name: {session}, as we found the existing xsession: {session_file}"
                 )
                 user.set_x_session(session)
+                user.set_session(session)
+                user.set_session_type("x11")
             else:
                 logging.error(f"Couldn't figure out session type for {session_file}")
                 sys.exit(1)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

GDM 40.1 [switched](https://gitlab.gnome.org/GNOME/gdm/-/commit/ab5fee0356c0139dda07d80f7baa7d0f7c08d7fc) from storing X11 sessions in the "XSession" property
on AccountService to "Session" with a "x11" "SessionType".

For compatibility reasons, we should set both, since AccountService
doesn't seem to provide the compatibility for us.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
