### PR TITLE
radicle-upstream: 0.2.3 → 0.2.9, enable on darwin

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/radicle-upstream/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/radicle-upstream/default.nix
@@ -1,16 +1,23 @@
-{ lib, stdenv, appimageTools, gsettings-desktop-schemas, gtk3, autoPatchelfHook, zlib, fetchurl }:
+{ lib, stdenv, appimageTools, gsettings-desktop-schemas, gtk3, autoPatchelfHook, zlib, fetchurl, undmg }:
 
 let
   pname = "radicle-upstream";
-  version = "0.2.3";
+  version = "0.2.9";
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://releases.radicle.xyz/radicle-upstream-${version}.AppImage";
-    sha256 =  "sha256-SL6plXZ+o7JchY/t/1702FK57fVjxllHqB8ZOma/43c=";
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://releases.radicle.xyz/radicle-upstream-${version}.AppImage";
+      sha256 = "sha256-chju3ZEFFLOzE9FakUK2izm/5ejELdL/iWMtM3bRpWY=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://releases.radicle.xyz/radicle-upstream-${version}.dmg";
+      sha256 = "sha256-OOqe4diRcJWHHOa6jBpljPoA3FQOKlghMhKGQ242GnM=";
+    };
   };
+  src = srcs.${stdenv.hostPlatform.system};
 
-  contents = appimageTools.extractType2 { inherit name src; };
+  contents = appimageTools.extract { inherit name src; };
 
   git-remote-rad = stdenv.mkDerivation rec {
     pname = "git-remote-rad";
@@ -25,40 +32,56 @@ let
       cp ${contents}/resources/git-remote-rad $out/bin/git-remote-rad
     '';
   };
-in
 
-# FIXME: a dependency of the `proxy` component of radicle-upstream (radicle-macros
-# v0.1.0) uses unstable rust features, making a from source build impossible at
-# this time. See this PR for discussion: https://github.com/NixOS/nixpkgs/pull/105674
-appimageTools.wrapType2 {
-  inherit name src;
+  # FIXME: a dependency of the `proxy` component of radicle-upstream (radicle-macros
+  # v0.1.0) uses unstable rust features, making a from source build impossible at
+  # this time. See this PR for discussion: https://github.com/NixOS/nixpkgs/pull/105674
+  linux = appimageTools.wrapType2 {
+    inherit name src meta;
 
-  profile = ''
-    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
-  '';
+    profile = ''
+      export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+    '';
 
-  extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/${pname}
+    extraInstallCommands = ''
+      mv $out/bin/${name} $out/bin/${pname}
 
-    # this automatically adds the git-remote-rad binary to the users `PATH` so
-    # they don't need to mess around with shell profiles...
-    ln -s ${git-remote-rad}/bin/git-remote-rad $out/bin/git-remote-rad
+      # this automatically adds the git-remote-rad binary to the users `PATH` so
+      # they don't need to mess around with shell profiles...
+      ln -s ${git-remote-rad}/bin/git-remote-rad $out/bin/git-remote-rad
 
-    # desktop item
-    install -m 444 -D ${contents}/${pname}.desktop $out/share/applications/${pname}.desktop
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
+      # desktop item
+      install -m 444 -D ${contents}/${pname}.desktop $out/share/applications/${pname}.desktop
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace 'Exec=AppRun' 'Exec=${pname}'
 
-    # icon
-    install -m 444 -D ${contents}/${pname}.png \
-      $out/share/icons/hicolor/512x512/apps/${pname}.png
-  '';
+      # icon
+      install -m 444 -D ${contents}/${pname}.png \
+        $out/share/icons/hicolor/512x512/apps/${pname}.png
+    '';
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version src meta;
+
+    nativeBuildInputs = [ undmg ];
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
+    '';
+  };
 
   meta = with lib; {
     description = "A decentralized app for code collaboration";
     homepage = "https://radicle.xyz/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ d-xo ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
-}
+in
+if stdenv.isDarwin
+then darwin
+else linux


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://github.com/radicle-dev/radicle-upstream/blob/master/CHANGELOG.md)
* Enable on darwin

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
