### PR TITLE
hyper: 3.0.2 -> 3.1.2 and fix for desktop files

### DIFF
--- a/pkgs/applications/terminal-emulators/hyper/default.nix
+++ b/pkgs/applications/terminal-emulators/hyper/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, fetchurl, makeDesktopItem, copyDesktopItems, dpkg, atk, glib, pango
-, gdk-pixbuf, gnome2, gtk3, cairo, freetype, fontconfig, dbus, libXi, libXcursor
-, libXdamage, libXrandr, libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst
-, libXScrnSaver, libxcb, nss, nspr, alsa-lib, cups, expat, udev, libpulseaudio
-, at-spi2-atk, at-spi2-core, libxshmfence, libdrm, libxkbcommon, mesa }:
+{ stdenv, lib, fetchurl, dpkg, atk, glib, pango, gdk-pixbuf, gnome2, gtk3, cairo
+, freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr, libXcomposite
+, libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver, libxcb, nss, nspr
+, alsa-lib, cups, expat, udev, libpulseaudio, at-spi2-atk, at-spi2-core, libxshmfence
+, libdrm, libxkbcommon, mesa }:
 
 let
   libPath = lib.makeLibraryPath [
@@ -15,24 +15,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "hyper";
-  version = "3.1.1";
+  version = "3.1.2";
 
   src = fetchurl {
     url = "https://github.com/vercel/hyper/releases/download/v${version}/hyper_${version}_amd64.deb";
-    sha256 = "0j999z649k63rnr1lpbansaxnkrhrp73jdrdmslgnwbh7z1wsp9p";
+    sha256 = "1mixy9hlgdbbnwdgidady7q828dkf09lx1pacwxw386jj7kp4y5g";
   };
 
-  buildInputs = [ copyDesktopItems dpkg ];
-
-  desktopItems = makeDesktopItem {
-    type = "Application";
-    name = pname;
-    desktopName = "Hyper";
-    genericName = "Hyper Terminal";
-    exec = "hyper";
-    icon = "hyper";
-    categories = "System;TerminalEmulator;";
-  };
+  nativeBuildInputs = [ dpkg ];
 
   unpackPhase = ''
     mkdir pkg
@@ -49,7 +39,8 @@ stdenv.mkDerivation rec {
 
     mv usr/* "$out/"
 
-    copyDesktopItems ${desktopItems}/share/applications/* $out/share/applications/
+    substituteInPlace $out/share/applications/hyper.desktop \
+      --replace "/opt/Hyper/hyper" "hyper"
   '';
 
   dontPatchELF = true;

--- a/pkgs/applications/terminal-emulators/hyper/default.nix
+++ b/pkgs/applications/terminal-emulators/hyper/default.nix
@@ -12,29 +12,27 @@ let
     at-spi2-atk at-spi2-core libxshmfence libdrm libxkbcommon mesa
   ];
 
-  name = "hyper";
-  desktopItem = makeDesktopItem {
-    type = "Application";
-    name = name;
-    desktopName = "Hyper";
-    genericName = "Hyper Terminal";
-    exec = name;
-    icon = "hyper";
-    categories = "System;TerminalEmulator;";
-  };
-
 in
 stdenv.mkDerivation rec {
-  pname = name;
+  pname = "hyper";
   version = "3.1.1";
 
   src = fetchurl {
     url = "https://github.com/vercel/hyper/releases/download/v${version}/hyper_${version}_amd64.deb";
     sha256 = "0j999z649k63rnr1lpbansaxnkrhrp73jdrdmslgnwbh7z1wsp9p";
   };
-  nativeBuildInputs = [ copyDesktopItems ];
 
-  buildInputs = [ dpkg ];
+  buildInputs = [ copyDesktopItems dpkg ];
+
+  desktopItems = makeDesktopItem {
+    type = "Application";
+    name = pname;
+    desktopName = "Hyper";
+    genericName = "Hyper Terminal";
+    exec = "hyper";
+    icon = "hyper";
+    categories = "System;TerminalEmulator;";
+  };
 
   unpackPhase = ''
     mkdir pkg
@@ -45,13 +43,14 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin"
     mv opt "$out/"
+
     ln -s "$out/opt/Hyper/hyper" "$out/bin/hyper"
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:$out/opt/Hyper:\$ORIGIN" "$out/opt/Hyper/hyper"
-    mv usr/* "$out/"
-    copyDesktopItems ${desktopItem}/share/applications/* $out/share/applications/
-  '';
 
-  desktopItems = [ desktopItem ];
+    mv usr/* "$out/"
+
+    copyDesktopItems ${desktopItems}/share/applications/* $out/share/applications/
+  '';
 
   dontPatchELF = true;
   meta = with lib; {

--- a/pkgs/applications/terminal-emulators/hyper/default.nix
+++ b/pkgs/applications/terminal-emulators/hyper/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, lib, fetchurl, dpkg, atk, glib, pango, gdk-pixbuf, gnome2, gtk3, cairo
-, freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr
-, libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver
-, libxcb, nss, nspr, alsa-lib, cups, expat, udev, libpulseaudio, at-spi2-atk }:
+{ stdenv, lib, fetchurl, makeDesktopItem, copyDesktopItems, dpkg, atk, glib, pango
+, gdk-pixbuf, gnome2, gtk3, cairo, freetype, fontconfig, dbus, libXi, libXcursor
+, libXdamage, libXrandr, libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst
+, libXScrnSaver, libxcb, nss, nspr, alsa-lib, cups, expat, udev, libpulseaudio
+, at-spi2-atk }:
 
 let
   libPath = lib.makeLibraryPath [
@@ -10,27 +11,47 @@ let
     libXrender libX11 libXtst libXScrnSaver nss nspr alsa-lib cups expat udev libpulseaudio
     at-spi2-atk
   ];
+  name = "hyper";
+  desktopItem = makeDesktopItem {
+    type = "Application";
+    name = name;
+    desktopName = "Hyper";
+    genericName = "Hyper Terminal";
+    exec = name;
+    icon = "hyper";
+    categories = "System;TerminalEmulator;";
+  };
+
 in
 stdenv.mkDerivation rec {
-  version = "3.0.2";
-  pname = "hyper";
+  pname = name;
+  version = "3.1.1";
+
   src = fetchurl {
     url = "https://github.com/zeit/hyper/releases/download/${version}/hyper_${version}_amd64.deb";
     sha256 = "0fv4wv5f8nc739bna83qxmgrvvbyq4w9ch764q2f12wjygrz336p";
   };
+  nativeBuildInputs = [ copyDesktopItems ];
+
   buildInputs = [ dpkg ];
+
   unpackPhase = ''
     mkdir pkg
     dpkg-deb -x $src pkg
     sourceRoot=pkg
   '';
+
   installPhase = ''
     mkdir -p "$out/bin"
     mv opt "$out/"
     ln -s "$out/opt/Hyper/hyper" "$out/bin/hyper"
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:$out/opt/Hyper:\$ORIGIN" "$out/opt/Hyper/hyper"
     mv usr/* "$out/"
+    copyDesktopItems ${desktopItem}/share/applications/* $out/share/applications/
   '';
+
+  desktopItems = [ desktopItem ];
+
   dontPatchELF = true;
   meta = with lib; {
     description = "A terminal built on web technologies";

--- a/pkgs/applications/terminal-emulators/hyper/default.nix
+++ b/pkgs/applications/terminal-emulators/hyper/default.nix
@@ -2,15 +2,16 @@
 , gdk-pixbuf, gnome2, gtk3, cairo, freetype, fontconfig, dbus, libXi, libXcursor
 , libXdamage, libXrandr, libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst
 , libXScrnSaver, libxcb, nss, nspr, alsa-lib, cups, expat, udev, libpulseaudio
-, at-spi2-atk }:
+, at-spi2-atk, at-spi2-core, libxshmfence, libdrm, libxkbcommon, mesa }:
 
 let
   libPath = lib.makeLibraryPath [
     stdenv.cc.cc gtk3 gnome2.GConf atk glib pango gdk-pixbuf cairo freetype fontconfig dbus
     libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes libxcb
     libXrender libX11 libXtst libXScrnSaver nss nspr alsa-lib cups expat udev libpulseaudio
-    at-spi2-atk
+    at-spi2-atk at-spi2-core libxshmfence libdrm libxkbcommon mesa
   ];
+
   name = "hyper";
   desktopItem = makeDesktopItem {
     type = "Application";
@@ -28,8 +29,8 @@ stdenv.mkDerivation rec {
   version = "3.1.1";
 
   src = fetchurl {
-    url = "https://github.com/zeit/hyper/releases/download/${version}/hyper_${version}_amd64.deb";
-    sha256 = "0fv4wv5f8nc739bna83qxmgrvvbyq4w9ch764q2f12wjygrz336p";
+    url = "https://github.com/vercel/hyper/releases/download/v${version}/hyper_${version}_amd64.deb";
+    sha256 = "0j999z649k63rnr1lpbansaxnkrhrp73jdrdmslgnwbh7z1wsp9p";
   };
   nativeBuildInputs = [ copyDesktopItems ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I could not open hyper from the Applications menu on Gnome 34, as the executable in the `hyper.desktop` file was pointing to `/opt/Hyper/hyper`.

PS: This is my first-ever PR to nixpkgs, I hope everything is fine. 😄 

###### Things done

I fixed the hyper-generated desktop file (coming from the .deb package), as it was not pointing to the correct hyper executable. Updated hyper to the newest version 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (OpenSUSE Leap 15.3)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
