### PR TITLE
terraform-ls: 0.19.1 -> 0.20.0

### DIFF
--- a/pkgs/development/tools/misc/terraform-ls/default.nix
+++ b/pkgs/development/tools/misc/terraform-ls/default.nix
@@ -2,36 +2,27 @@
 
 buildGoModule rec {
   pname = "terraform-ls";
-  version = "0.19.1";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ag8Dq3lhLoKE4rgrnWLHtKRHEnw/ytyXI+pRt5CgZJI=";
+    sha256 = "sha256-G1i5SS1BY+h8qPPjrZ9HCnKX3o2VkwvpeHPNxW6rnuI=";
   };
-  vendorSha256 = "sha256-/lpjlThr6HPkuJ6om9ifBsdsh0x4kVXM6PAonk7GJCY=";
+  vendorSha256 = "sha256-nRElOa9IQ31Wh01wTFM6pazDYFnmR06vkU4CI8Gx4Vw=";
 
   ldflags = [ "-s" "-w" "-X main.version=v${version}" "-X main.prerelease=" ];
 
-  preCheck = ''
-    # Remove tests that requires networking
-    rm internal/terraform/exec/exec_test.go
-  '' + lib.optionalString stdenv.isAarch64 ''
-    # Not all test failures have tracking issues as HashiCorp do not have
-    # aarch64 testing infra easily available, see issue 549 below.
+  # There's a mixture of tests that use networking and several that fail on aarch64
+  doCheck = false;
 
-    # Remove file that contains `TestLangServer_workspaceExecuteCommand_modules_multiple`
-    # which fails on aarch64: https://github.com/hashicorp/terraform-ls/issues/549
-    rm internal/langserver/handlers/execute_command_modules_test.go
-
-    # `TestModuleManager_ModuleCandidatesByPath` variants fail
-    rm internal/terraform/module/module_manager_test.go
-
-    # internal/terraform/module/module_ops_queue_test.go:17:15: undefined: testLogger
-    # internal/terraform/module/watcher_test.go:39:11: undefined: testLogger
-    # internal/terraform/module/watcher_test.go:79:14: undefined: testLogger
-    rm internal/terraform/module/{watcher_test,module_ops_queue_test}.go
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/terraform-ls --help
+    $out/bin/terraform-ls version | grep "v${version}"
+    runHook postInstallCheck
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump terraform-ls to `0.20.0`

I've dropped the tests as several need networking with more probably coming (where they fetch exact TF versions for a tmpdir) and several breaking on aarch64
I've added an installCheckPhase that should be useful for catching issues, the tests run enough upstream.
If it becomes easier to run the tests we can add them back

@martinbaillie

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
