### PR TITLE
android-studio-{canary,dev}: properly fix interpreter paths

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -65,10 +65,14 @@ let
       sha256 = sha256Hash;
     };
 
-    nativeBuildInputs = [ unzip ];
-    buildInputs = [
+    nativeBuildInputs = [
+      unzip
       makeWrapper
     ];
+
+    # Causes the shebangs in interpreter scripts deployed to mobile devices to be patched, which Android does not understand
+    dontPatchShebangs = true;
+
     installPhase = ''
       cp -r . $out
       wrapProgram $out/bin/studio.sh \
@@ -151,9 +155,6 @@ let
       ]}"
     '';
   };
-
-  # Causes the shebangs in interpreter scripts deployed to mobile devices to be patched, which Android does not understand
-  dontPatchShebangs = true;
 
   desktopItem = makeDesktopItem {
     name = drvName;


### PR DESCRIPTION
###### Motivation for this change
This makes the native debugger on android-studio work again.

I have no idea how this functioned beforehand, but it seems I messed up the scope of the `dontPatchShebangs` line. The fact that this gets triggered conditionally, and for example not on the `beta` or `stable` branches of AS it really confusing to me. Either way, it now works again on all branches.

Fixes: #117985 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
