### PR TITLE
buf: 0.46.0 -> 0.49.0

### DIFF
--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -7,29 +7,32 @@
 
 buildGoModule rec {
   pname = "buf";
-  version = "0.46.0";
+  version = "0.49.0";
 
   src = fetchFromGitHub {
     owner = "bufbuild";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-5mjk31HuPNO/RhmMhIm3dAZAED/Kk33ObjC8KbPKRxk=";
-    leaveDotGit = true; # Required by TestWorkspaceGit
+    sha256 = "sha256-xP2UbcHwimN09IXrGp3zhBLL74l/8YKotqBNRTITF18=";
   };
-  vendorSha256 = "sha256-K8UZDEhAvD292RCEDKfY9PdZGS389vLF3oukcBndUF4=";
+  vendorSha256 = "sha256-WgQSLe99CbOwJC8ewDcSq6PcBJdmiPRmvAonq8drQ1w=";
 
   patches = [
     # Skip a test that requires networking to be available to work.
     ./skip_test_requiring_network.patch
+    # Skip TestWorkspaceGit which requires .git and commits.
+    ./skip_test_requiring_dotgit.patch
   ];
 
   nativeBuildInputs = [ protobuf ];
+  # Required for TestGitCloner
   checkInputs = [ git ];
 
   ldflags = [ "-s" "-w" ];
 
   preCheck = ''
-    export PATH=$PATH:$GOPATH/bin
+    # The tests need access to some of the built utilities
+    export PATH="$PATH:$GOPATH/bin"
     # To skip TestCloneBranchAndRefToBucket
     export CI=true
   '';
@@ -38,24 +41,32 @@ buildGoModule rec {
     runHook preInstall
 
     mkdir -p "$out/bin"
-    dir="$GOPATH/bin"
     # Only install required binaries, don't install testing binaries
-    for file in \
+    for FILE in \
       "buf" \
       "protoc-gen-buf-breaking" \
       "protoc-gen-buf-lint" \
       "protoc-gen-buf-check-breaking" \
       "protoc-gen-buf-check-lint"; do
-      cp "$dir/$file" "$out/bin/"
+      cp "$GOPATH/bin/$FILE" "$out/bin/"
     done
 
     runHook postInstall
   '';
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/buf --help
+    $out/bin/buf --version 2>&1 | grep "${version}"
+    runHook postInstallCheck
+  '';
+
   meta = with lib; {
-    description = "Create consistent Protobuf APIs that preserve compatibility and comply with design best-practices";
     homepage = "https://buf.build";
+    changelog = "https://github.com/bufbuild/buf/releases/tag/v${version}";
+    description = "Create consistent Protobuf APIs that preserve compatibility and comply with design best-practices";
     license = licenses.asl20;
-    maintainers = with maintainers; [ raboof ];
+    maintainers = with maintainers; [ raboof jk ];
   };
 }

--- a/pkgs/development/tools/buf/skip_test_requiring_dotgit.patch
+++ b/pkgs/development/tools/buf/skip_test_requiring_dotgit.patch
@@ -1,0 +1,14 @@
+diff --git a/internal/buf/cmd/buf/workspace_test.go b/internal/buf/cmd/buf/workspace_test.go
+index e051690..8887837 100644
+--- a/internal/buf/cmd/buf/workspace_test.go
++++ b/internal/buf/cmd/buf/workspace_test.go
+@@ -335,6 +335,9 @@ func TestWorkspaceNestedArchive(t *testing.T) {
+ }
+ 
+ func TestWorkspaceGit(t *testing.T) {
++	// Requires .git directory which we do not retain due to
++	// `leaveDotGit` non-determinism
++	t.Skip()
+ 	// Directory paths specified as a git reference within a workspace.
+ 	t.Parallel()
+ 	testRunStdout(


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump buf to ~`0.48.2`~ `0.49.0`

Drop leaveDotGit (see below)
Slight cleanup
Added myself as a maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
