### PR TITLE
kdeltachat: unstable-2021-07-17 -> unstable-2021-08-02

### DIFF
--- a/pkgs/applications/networking/instant-messengers/kdeltachat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/kdeltachat/default.nix
@@ -1,25 +1,44 @@
 { lib
 , mkDerivation
+, fetchFromGitHub
 , fetchFromSourcehut
 , cmake
 , extra-cmake-modules
 , pkg-config
 , kirigami2
 , libdeltachat
+, qtbase
 , qtimageformats
 , qtmultimedia
 , qtwebengine
+, rustPlatform
 }:
 
-mkDerivation rec {
+let
+  libdeltachat' = libdeltachat.overrideAttrs (old: rec {
+    inherit (old) pname;
+    version = "1.58.0";
+    src = fetchFromGitHub {
+      owner = "deltachat";
+      repo = "deltachat-core-rust";
+      rev = version;
+      sha256 = "03xc0jlfmvmdcipmzavbzkq010qlxzf3mj1zi7wcix7kpl8gwmy7";
+    };
+    cargoDeps = rustPlatform.fetchCargoTarball {
+      inherit src;
+      name = "${pname}-${version}";
+      sha256 = "1zijxyc1xjlbyh1gh2lyw44xjcrhz1msykrlqgfkw5w1w0yh78hd";
+    };
+  });
+in mkDerivation rec {
   pname = "kdeltachat";
-  version = "unstable-2021-07-17";
+  version = "unstable-2021-08-02";
 
   src = fetchFromSourcehut {
     owner = "~link2xt";
     repo = "kdeltachat";
-    rev = "9e5fe2dc856795d0d3d8b6a3adf3fdd3015d9158";
-    sha256 = "12arcrnpacq2fbjbzs6a9yz6lfsj2dkga9chpld1ran3v6by58z9";
+    rev = "950f4f22c01ab75f613479ef831bdf38f395d1dd";
+    sha256 = "007gazqkzcc0w0rq2i8ysa9f50ldj7n9f5gp1mh8bi86bdvdkzsy";
   };
 
   nativeBuildInputs = [
@@ -30,11 +49,17 @@ mkDerivation rec {
 
   buildInputs = [
     kirigami2
-    libdeltachat
+    libdeltachat'
     qtimageformats
     qtmultimedia
     qtwebengine
   ];
+
+  # needed for qmlplugindump to work
+  QT_PLUGIN_PATH = "${qtbase.bin}/${qtbase.qtPluginPrefix}";
+  QML2_IMPORT_PATH = lib.concatMapStringsSep ":"
+    (lib: "${lib}/${qtbase.qtQmlPrefix}")
+    [ kirigami2 qtmultimedia ];
 
   meta = with lib; {
     description = "Delta Chat client using Kirigami framework";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @link2xt 