### PR TITLE
libmbim: 1.24.8 -> 1.26.0

### DIFF
--- a/nixos/modules/programs/captive-browser.nix
+++ b/nixos/modules/programs/captive-browser.nix
@@ -27,6 +27,7 @@ in
       browser = mkOption {
         type = types.str;
         default = concatStringsSep " " [
+          ''env XDG_CONFIG_HOME="$PREV_CONFIG_HOME"''
           ''${pkgs.chromium}/bin/chromium''
           ''--user-data-dir=''${XDG_DATA_HOME:-$HOME/.local/share}/chromium-captive''
           ''--proxy-server="socks5://$PROXY"''
@@ -111,6 +112,7 @@ in
     security.wrappers.captive-browser = {
       capabilities = "cap_net_raw+p";
       source = pkgs.writeShellScript "captive-browser" ''
+        export PREV_CONFIG_HOME="$XDG_CONFIG_HOME"
         export XDG_CONFIG_HOME=${pkgs.writeTextDir "captive-browser.toml" ''
                                   browser = """${cfg.browser}"""
                                   dhcp-dns = """${cfg.dhcp-dns}"""

--- a/pkgs/applications/networking/browsers/captive-browser/default.nix
+++ b/pkgs/applications/networking/browsers/captive-browser/default.nix
@@ -2,20 +2,20 @@
 
 buildGoPackage rec {
   pname = "captive-browser";
-  version = "2019-04-16";
+  version = "2021-08-01";
   goPackagePath = pname;
 
   src = fetchFromGitHub {
     owner  = "FiloSottile";
     repo   = "captive-browser";
-    rev    = "08450562e58bf9564ee98ad64ef7b2800e53338f";
-    sha256 = "17icgjg7h0xm8g4yy38qjhsvlz9pmlmj9kydz01y2nyl0v02i648";
+    rev    = "9c707dc32afc6e4146e19b43a3406329c64b6f3c";
+    sha256 = "sha256-65lPo5tpE0M/VyyvlzlcVSuHX4AhhVuqK0UF4BIAH/Y=";
   };
 
   meta = with lib; {
     description = "Dedicated Chrome instance to log into captive portals without messing with DNS settings";
     homepage = "https://blog.filippo.io/captive-browser";
     license = licenses.mit;
-    maintainers = with maintainers; [ volth ];
+    maintainers = with maintainers; [ volth ma27 ];
   };
 }

--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -1,21 +1,21 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
 , pkg-config
 , glib
 , python3
 , systemd
-, libgudev
 , withIntrospection ? stdenv.hostPlatform == stdenv.buildPlatform
 , gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
   pname = "libmbim";
-  version = "1.24.8";
+  version = "1.26.0";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/libmbim/${pname}-${version}.tar.xz";
-    sha256 = "sha256-AlkHNhY//xDlcyGR/MwbmSCWlhbdxZYToAMFKhFqPCU=";
+    sha256 = "1kqkx139z62w391bz6lwmcjg7v12jxlcm7hj88222xrcn8k0j7qy";
   };
 
   outputs = [ "out" "dev" "man" ];
@@ -33,7 +33,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
-    libgudev
     systemd
   ];
 

--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.freedesktop.org/wiki/Software/libmbim/";
     description = "Library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol";
     platforms = platforms.linux;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
```
Overview of changes in libmbim 1.26
----------------------------------------

 * Build now requires GLib/GObject/GIO 2.56.

 * The GUdev optional build/runtime requirement is now fully dropped, it's no
   longer used.

 * Building from git no longer requires autoconf-archive, the needed AX_ macros
   are now shipped inside m4/.

 * In addition to building from a source release tarball, or building from git
   checkouts using the GNU autotools suite (autoconf/automake/libtool), this
   release includes the initial support for the meson build system. The meson
   port is not fully complete yet, as there are some missing things in the doc
   generation steps, but for system integration or development purposes, the
   port should be fully operational. This major release, including all its
   stable updates in the 1.26.x series, will be the last ones providing support
   for GNU autotools. The next major release will likely be a meson-only one,
   and will therefore not be based on a source release tarball any more, but
   on specific git tags instead.

 * Implemented new link management operations, exclusively for the cdc_mbim
   driver for now. These new operations allow creating or deleting VLAN network
   interfaces in order to run multiplexed data sessions over one single physical
   network interface.

 * Added support for the Microsoft-defined SAR service, including the following
   operations:
   ** MBIM_CID_MS_SAR_CONFIG
   ** MBIM_CID_MS_SAR_TRANSMISSION_STATUS

 * Added support for the Microsoft-defined UICC Low Level Access service,
   including the following operations:
   ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_ATR
   ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_OPEN_CHANNEL
   ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_CLOSE_CHANNEL
   ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_APDU
   ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_TERMINAL_CAPABILITY
   ** MBIM_CID_MS_UICC_LOW_LEVEL_ACCESS_RESET

 * Added support for the Qualcomm-defined QDU service, including the following
   operations:
   ** MBIM_CID_QDU_UPDATE_SESSION
   ** MBIM_CID_QDU_FILE_OPEN
   ** MBIM_CID_QDU_FILE_WRITE

 * Extended the Microsoft-defined Basic Connect Extensions service, including
   the following operations:
   ** MBIM_CID_MS_BASIC_CONNECT_EXTENSIONS_DEVICE_CAPS
   ** MBIM_CID_MS_BASIC_CONNECT_EXTENSIONS_SYS_CAPS
   ** MBIM_CID_MS_BASIC_CONNECT_EXTENSIONS_SLOT_INFO_STATUS
   ** MBIM_CID_MS_BASIC_CONNECT_EXTENSIONS_DEVICE_SLOT_MAPPINGS

 * libmbim-glib:
   ** Logic updated to make sure full packets are written at once, instead of
      writing them in chunks.
   ** Updated the "LTE attach status" APIs in order to avoid creating unneeded
      struct types in the interface. The older methods have been deprecated and
      maintained in the library for compatibility purposes only.

 * mbim-proxy:
   ** Internal buffer size updated from 512 bytes to 4096 bytes.

 * mbimcli:
   ** New '--ms-set-sar-config' and '--ms-query-sar-config' actions.
   ** New '--ms-set-transmission-status' and '--ms-query-transmission-status'
      actions.
   ** Updated '--enter-pin', '--disable-pin' and '--unlock-pin' to allow other
      PIN types, not just assuming PIN1.
   ** New '--link-add', '--link-delete', '--link-list' and '--link-delete-all'
      actions.
   ** New '--ms-query-sys-caps' action.
   ** New '--ms-query-slot-info-status' action.
   ** New '--ms-query-device-slot-mappings' and '--ms-set-device-slot-mappings'
      actions.
   ** Renamed '--ms-query-lte-attach-status' to '--ms-query-lte-attach-info',
      and kept the old name for compatibility purposes.

 * mbim-network:
   ** When using the mbim-proxy, skip trying to manage the MBIM session and
      transaction ids as that is implicitly done by the proxy already.

 * Several other minor improvements and fixes.

The following features which were backported to 1.24.x releases are also present
in libmbim 1.26.0:

 * Fixed merged subscribe list reporting and handling in the proxy.
 * Fixed transaction id handling when multiple fragments are involved.
 * Fixed read overflows on malformed messages.
 * Skip warnings if descriptors file cannot be read, as in new MBIM backends
   other than cdc_mbim.
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
