### PR TITLE
Introduce `types.raw` and `types.unconditional`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -137,7 +137,7 @@ rec {
             # support for that, in turn it's lazy in its values. This means e.g.
             # a `_module.args.pkgs = import (fetchTarball { ... }) {}` won't
             # start a download when `pkgs` wasn't evaluated.
-            type = types.lazyAttrsOf types.unspecified;
+            type = types.lazyAttrsOf types.raw;
             internal = true;
             description = "Arguments passed to each module.";
           };

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -642,7 +642,7 @@ rec {
 
     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
     mergedValue =
-      if isDefined then
+      if defsFinal != [] then
         if all (def: type.check def.value) defsFinal then type.merge loc defsFinal
         else let allInvalid = filter (def: ! type.check def.value) defsFinal;
         in throw "A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefs allInvalid}"
@@ -653,7 +653,9 @@ rec {
         # handling.  If changed here, please change it there too.)
         throw "The option `${showOption loc}' is used but not defined.";
 
-    isDefined = defsFinal != [];
+    # Note: We use `or true` in case `lib.types` from an older nixpkgs version
+    # that doesn't set `conditional` is used. Avoids some trouble down the road
+    isDefined = type.conditional or true -> defsFinal != [];
 
     optionalValue =
       if isDefined then { value = mergedValue; }

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -646,6 +646,8 @@ rec {
         if all (def: type.check def.value) defsFinal then type.merge loc defsFinal
         else let allInvalid = filter (def: ! type.check def.value) defsFinal;
         in throw "A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefs allInvalid}"
+      else if type.emptyValue ? value then
+        type.emptyValue.value
       else
         # (nixos-option detects this specific error message and gives it special
         # handling.  If changed here, please change it there too.)

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -293,6 +293,12 @@ checkConfigOutput "{ }" config.submodule ./emptyValues.nix
 checkConfigError 'The option .int. is used but not defined' config.int ./emptyValues.nix
 checkConfigError 'The option .nonEmptyList. is used but not defined' config.nonEmptyList ./emptyValues.nix
 
+## types.raw
+checkConfigOutput "{ foo = <CODE>; }" config.unprocessedNesting ./raw.nix
+checkConfigOutput "10" config.processedToplevel ./raw.nix
+checkConfigError "The unique option .multiple. is defined multiple times" config.multiple ./raw.nix
+checkConfigOutput "bar" config.priorities ./raw.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -284,6 +284,15 @@ checkConfigOutput '^"a b"$' config.resultFoo ./declare-variants.nix ./define-var
 checkConfigOutput '^"a y z"$' config.resultFooBar ./declare-variants.nix ./define-variant.nix
 checkConfigOutput '^"a b c"$' config.resultFooFoo ./declare-variants.nix ./define-variant.nix
 
+## emptyValue's
+checkConfigOutput "[ ]" config.list ./emptyValues.nix
+checkConfigOutput "{ }" config.attrs ./emptyValues.nix
+checkConfigOutput "null" config.null ./emptyValues.nix
+checkConfigOutput "{ }" config.submodule ./emptyValues.nix
+# These types don't have empty values
+checkConfigError 'The option .int. is used but not defined' config.int ./emptyValues.nix
+checkConfigError 'The option .nonEmptyList. is used but not defined' config.nonEmptyList ./emptyValues.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -299,6 +299,16 @@ checkConfigOutput "10" config.processedToplevel ./raw.nix
 checkConfigError "The unique option .multiple. is defined multiple times" config.multiple ./raw.nix
 checkConfigOutput "bar" config.priorities ./raw.nix
 
+## types.unconditional
+checkConfigOutput "10" config.ifTrue ./unconditional.nix
+checkConfigError "The option .ifFalse. is used but not defined." config.ifFalse ./unconditional.nix
+checkConfigOutput "10" config.attrsIfTrue.foo ./unconditional.nix
+checkConfigError "The option .attrsIfFalse.foo. is used but not defined." config.attrsIfFalse.foo ./unconditional.nix
+checkConfigOutput "[ \"foo\" ]" config.attrKeys ./unconditional.nix
+checkConfigOutput "10" config.listIfTrue.0 ./unconditional.nix
+checkConfigError "The option .listIfFalse.\[definition 1-entry 1\]. is used but not defined." config.listIfFalse.0 ./unconditional.nix
+checkConfigOutput "1" config.listLength ./unconditional.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/emptyValues.nix
+++ b/lib/tests/modules/emptyValues.nix
@@ -1,0 +1,24 @@
+{ lib, ... }: {
+
+  options = {
+    int = lib.mkOption {
+      type = lib.types.int;
+    };
+    list = lib.mkOption {
+      type = lib.types.listOf lib.types.int;
+    };
+    nonEmptyList = lib.mkOption {
+      type = lib.types.nonEmptyListOf lib.types.int;
+    };
+    attrs = lib.mkOption {
+      type = lib.types.attrsOf lib.types.int;
+    };
+    null = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+    };
+    submodule = lib.mkOption {
+      type = lib.types.submodule {};
+    };
+  };
+
+}

--- a/lib/tests/modules/raw.nix
+++ b/lib/tests/modules/raw.nix
@@ -1,0 +1,30 @@
+{ lib, ... }: {
+
+  options = {
+    processedToplevel = lib.mkOption {
+      type = lib.types.raw;
+    };
+    unprocessedNesting = lib.mkOption {
+      type = lib.types.raw;
+    };
+    multiple = lib.mkOption {
+      type = lib.types.raw;
+    };
+    priorities = lib.mkOption {
+      type = lib.types.raw;
+    };
+  };
+
+  config = {
+    processedToplevel = lib.mkIf true 10;
+    unprocessedNesting.foo = throw "foo";
+    multiple = lib.mkMerge [
+      "foo"
+      "foo"
+    ];
+    priorities = lib.mkMerge [
+      "foo"
+      (lib.mkForce "bar")
+    ];
+  };
+}

--- a/lib/tests/modules/unconditional.nix
+++ b/lib/tests/modules/unconditional.nix
@@ -1,0 +1,40 @@
+{ lib, config, ... }: {
+
+  options = {
+    ifTrue = lib.mkOption {
+      type = lib.types.unconditional lib.types.int;
+    };
+    ifFalse = lib.mkOption {
+      type = lib.types.unconditional lib.types.int;
+    };
+    attrsIfTrue = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.unconditional lib.types.int);
+    };
+    attrsIfFalse = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.unconditional lib.types.int);
+    };
+    attrKeys = lib.mkOption {
+      default = lib.attrNames config.attrsIfFalse;
+    };
+    listIfTrue = lib.mkOption {
+      type = lib.types.listOf (lib.types.unconditional lib.types.int);
+    };
+    listIfFalse = lib.mkOption {
+      type = lib.types.listOf (lib.types.unconditional lib.types.int);
+    };
+    listLength = lib.mkOption {
+      default = lib.length config.listIfFalse;
+    };
+  };
+
+  config = {
+    ifTrue = lib.mkIf true 10;
+    ifFalse = lib.mkIf false 10;
+    attrsIfTrue.foo = lib.mkIf true 10;
+    attrsIfFalse.foo = lib.mkIf false 10;
+    listIfTrue = [ (lib.mkIf true 10) ];
+    listIfFalse = [ (lib.mkIf false 10) ];
+  };
+
+
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -162,6 +162,13 @@ rec {
   # nixos/doc/manual/development/option-types.xml!
   types = rec {
 
+    raw = mkOptionType rec {
+      name = "raw";
+      description = "raw value";
+      check = value: true;
+      merge = mergeOneOption;
+    };
+
     anything = mkOptionType {
       name = "anything";
       description = "anything";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -377,7 +377,7 @@ rec {
             ).optionalValue
           ) def.value
         ) defs)));
-      emptyValue = { value = {}; };
+      emptyValue = { value = []; };
       getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["*"]);
       getSubModules = elemType.getSubModules;
       substSubModules = m: listOf (elemType.substSubModules m);
@@ -389,7 +389,7 @@ rec {
       let list = addCheck (types.listOf elemType) (l: l != []);
       in list // {
         description = "non-empty " + list.description;
-        # Note: emptyValue is left as is, because another module may define an element.
+        emptyValue = { };
       };
 
     attrsOf = elemType: mkOptionType rec {

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -210,6 +210,19 @@ Value types are types that take a value parameter.
         requires using a function:
         `the-submodule = { ... }: { options = { ... }; }`.
 
+`types.unconditional` *`t`*
+
+:   The same as *`t`*, but without full support for conditional definitions
+    using `lib.mkIf <cond>`. This has the advantage that when used as the
+    element type in `types.attrsOf` and `types.listOf`, the attribute keys and
+    the list length respectively can be known without evaluating each
+    individual attribute/list value, keeping these structures lazy.
+    For instance, this prevents a case of infinite recursion by allowing elements
+    in an attribute set to reference other elements of the same attribute set
+    via the `config` module argument.
+    If `lib.mkIf <cond>` is used on such a type, the value is assumed to exist,
+    but an error is thrown when evaluated and the condition is false.
+
 ## Composed Types {#sec-option-types-composed}
 
 Composed types are types that take a type as parameter. `listOf

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -63,6 +63,15 @@ merging is handled.
     ```
     :::
 
+`types.raw`
+
+:   A type that accepts exactly a single arbitrary value. This type is
+    recommended for options whose only value is defined by the same module
+    as the option, because its structure is known ahead-of time and doesn't
+    need to be typechecked internally. Especially useful for values where
+    type checking would be too expensive, or where type checking is handled
+    in another way.
+
 `types.attrs`
 
 :   A free-form attribute set.

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -94,6 +94,22 @@
       </varlistentry>
       <varlistentry>
         <term>
+          <literal>types.raw</literal>
+        </term>
+        <listitem>
+          <para>
+            A type that accepts exactly a single arbitrary value. This
+            type is recommended for options whose only value is defined
+            by the same module as the option, because its structure is
+            known ahead-of time and doesn’t need to be typechecked
+            internally. Especially useful for values where type checking
+            would be too expensive, or where type checking is handled in
+            another way.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
           <literal>types.attrs</literal>
         </term>
         <listitem>

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -408,6 +408,31 @@
           </itemizedlist>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term>
+          <literal>types.unconditional</literal>
+          <emphasis><literal>t</literal></emphasis>
+        </term>
+        <listitem>
+          <para>
+            The same as <emphasis><literal>t</literal></emphasis>, but
+            without full support for conditional definitions using
+            <literal>lib.mkIf &lt;cond&gt;</literal>. This has the
+            advantage that when used as the element type in
+            <literal>types.attrsOf</literal> and
+            <literal>types.listOf</literal>, the attribute keys and the
+            list length respectively can be known without evaluating
+            each individual attribute/list value, keeping these
+            structures lazy. For instance, this prevents a case of
+            infinite recursion by allowing elements in an attribute set
+            to reference other elements of the same attribute set via
+            the <literal>config</literal> module argument. If
+            <literal>lib.mkIf &lt;cond&gt;</literal> is used on such a
+            type, the value is assumed to exist, but an error is thrown
+            when evaluated and the condition is false.
+          </para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </section>
   <section xml:id="sec-option-types-composed">


### PR DESCRIPTION
###### Motivation for this change
This PR contains a number of changes which are related or weakly dependent on each other:
- Fixes the `emptyValue` of `types.listOf`, which should be `[]` not `{}`
- For options that don't have any definitions, but whose type has an `emptyValue`, the `emptyValue` is used instead of throwing an error. Types who have an `emptyValue`:
  - `nullOr`: `null`
  - `attrsOf`: `{}`
  - `listOf`: `[]`
  - `submodule`: `{}`
  - And wrapper types of the above
  This means that it's not necessary anymore to define `default = {}` for `submodules` or `attrsOf` to make it work without any definitions.
- Introduce `types.raw` as a type that doesn't do any nested processing for `mkIf`, `mkForce`, etc. on its values. This is useful when this processing would throw errors or where it would be too expensive (such as with package sets like nixpkgs).
- Use `types.raw` for `_module.args`'s type. This finally fixes https://github.com/NixOS/nixpkgs/issues/53458
- Introduce `types.unconditional <elemType>` as a type, which when used as e.g. `attrsOf (unconditional str)` can replace `lazyAttrsOf str`. This type ensures that conditional `mkIf` definitions can't influence whether the option is defined or not, and therefore make the attribute set values be evaluated lazily. This notably also works with `listOf (unconditional str)`, making the list elements evaluated lazily, which was not possible before.

This is probably the last piece needed before we can finally deprecate `types.attrs` and `types.unspecified`.

Ping @roberth @nbp @danbst @sphaugh 

###### Things done

- [x] Write tests
  - [x] For `emptyValue`'s being used
  - [x] For `types.raw`
  - [x] For `types.unconditional <elemType>`
- [x] Write docs
  - [x] For `types.raw`
  - [x] For `types.unconditional <elemType>`