### PR TITLE
vscode-extensions.hashicorp.terraform: 2.13.2 -> 2.14.0

### DIFF
--- a/pkgs/misc/vscode-extensions/terraform/default.nix
+++ b/pkgs/misc/vscode-extensions/terraform/default.nix
@@ -3,19 +3,19 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "terraform";
     publisher = "hashicorp";
-    version = "2.13.2";
+    version = "2.14.0";
   };
 
   vsix = fetchurl {
     name = "${mktplcRef.publisher}-${mktplcRef.name}.zip";
     url = "https://github.com/hashicorp/vscode-terraform/releases/download/v${mktplcRef.version}/${mktplcRef.name}-${mktplcRef.version}.vsix";
-    sha256 = "0h7c6p2dcwsg7wlp49p2fsq0f164pzkx65929imd1m2df77aykqa";
+    sha256 = "1q43a28l6xfp3yw6wlr1kcidik0dbp8b7lg9vc83rhw4rjgvjsfm";
   };
 
   patches = [ ./fix-terraform-ls.patch ];
 
   postPatch = ''
-    substituteInPlace out/clientHandler.js --replace TERRAFORM-LS-PATH ${terraform-ls}/bin/terraform-ls
+    substituteInPlace out/serverPath.js --replace TERRAFORM-LS-PATH ${terraform-ls}/bin/terraform-ls
   '';
 
   meta = with lib; {

--- a/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
+++ b/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
@@ -1,43 +1,19 @@
-diff --git a/out/clientHandler.js b/out/clientHandler.js
-index 7f9716d..a543d60 100644
---- a/out/clientHandler.js
-+++ b/out/clientHandler.js
-@@ -33,8 +33,7 @@ class ClientHandler {
-             this.reporter.sendTelemetryEvent('usePathToBinary');
-         }
-         else {
--            const installPath = path.join(context.extensionPath, 'lsp');
--            this.pathToBinary = path.join(installPath, 'terraform-ls');
-+            this.pathToBinary = 'TERRAFORM-LS-PATH';
-         }
+diff --git a/out/serverPath.js b/out/serverPath.js
+index ffb1b80..990ca2b 100644
+--- a/out/serverPath.js
++++ b/out/serverPath.js
+@@ -8,7 +8,13 @@ exports.CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
+ class ServerPath {
+     constructor(context) {
+         this.context = context;
+-        this.customBinPath = vscode.workspace.getConfiguration('terraform').get(exports.CUSTOM_BIN_PATH_OPTION_NAME);
++
++        const customBinPath = vscode.workspace.getConfiguration('terraform').get(exports.CUSTOM_BIN_PATH_OPTION_NAME);
++        if (!customBinPath) {
++          this.customBinPath = 'TERRAFORM-LS-PATH';
++        } else {
++            this.customBinPath = customBinPath;
++        }
      }
-     startClients(folders) {
-diff --git a/out/extension.js b/out/extension.js
-index 7a271fc..726bbf8 100644
---- a/out/extension.js
-+++ b/out/extension.js
-@@ -149,24 +149,6 @@ function updateLanguageServer(clientHandler, installPath) {
-             updateLanguageServer(clientHandler, installPath);
-         }, 24 * hour);
-         // skip install if a language server binary path is set
--        if (!vscodeUtils_1.config('terraform').get('languageServer.pathToBinary')) {
--            const installer = new languageServerInstaller_1.LanguageServerInstaller(installPath, reporter);
--            const install = yield installer.needsInstall();
--            if (install) {
--                yield clientHandler.stopClients();
--                try {
--                    yield installer.install();
--                }
--                catch (err) {
--                    console.log(err); // for test failure reporting
--                    reporter.sendTelemetryException(err);
--                    throw err;
--                }
--                finally {
--                    yield installer.cleanupZips();
--                }
--            }
--        }
-         return clientHandler.startClients(vscodeUtils_1.prunedFolderNames()); // on repeat runs with no install, this will be a no-op
-     });
- }
+     installPath() {
+         return this.context.asAbsolutePath(INSTALL_FOLDER_NAME);


### PR DESCRIPTION
###### Motivation for this change

Runs with no errors.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
