### PR TITLE
make-initrd: fix #132059

### DIFF
--- a/pkgs/build-support/kernel/make-initrd.nix
+++ b/pkgs/build-support/kernel/make-initrd.nix
@@ -78,7 +78,7 @@ let
 in stdenvNoCC.mkDerivation rec {
   inherit name makeUInitrd extension uInitrdArch prepend;
 
-  ${if makeUInitrd then "uinitrdCompression" else null} = uInitrdCompression;
+  ${if makeUInitrd then "uInitrdCompression" else null} = uInitrdCompression;
 
   builder = ./make-initrd.sh;
 

--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -43,9 +43,9 @@ done
 (cd root && find * .[^.*] -print0 | sort -z | cpio -o -H newc -R +0:+0 --reproducible --null | eval -- $compress >> "$out/initrd")
 
 if [ -n "$makeUInitrd" ]; then
-    mkimage -A $uInitrdArch -O linux -T ramdisk -C "$uInitrdCompression" -d $out/initrd"$extension" $out/initrd.img
+    mkimage -A "$uInitrdArch" -O linux -T ramdisk -C "$uInitrdCompression" -d "$out/initrd" $out/initrd.img
     # Compatibility symlink
-    ln -s "initrd.img" "$out/initrd"
+    ln -sf "initrd.img" "$out/initrd"
 else
     ln -s "initrd" "$out/initrd$extension"
 fi


### PR DESCRIPTION
- [x] Tested `nixos/tests/boot.nix` on `x86_64-linux`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Fixes https://github.com/nixos/nixpkgs/issues/132059.

cc @ius, thanks for reporting!