### PR TITLE
kubernetes-helm-wrapped: fix the wrapper

### DIFF
--- a/pkgs/applications/networking/cluster/helm/wrapper.nix
+++ b/pkgs/applications/networking/cluster/helm/wrapper.nix
@@ -10,8 +10,6 @@ let
   let
 
   initialMakeWrapperArgs = [
-      "${helm}/bin/helm" "${placeholder "out"}/bin/helm"
-      "--argv0" "$0" "--set" "HELM_PLUGINS" "${pluginsDir}"
   ];
 
   pluginsDir = symlinkJoin {
@@ -26,7 +24,8 @@ in
     # extra actions upon
     postBuild = ''
       rm $out/bin/helm
-      makeWrapper ${lib.escapeShellArgs initialMakeWrapperArgs}  ${extraMakeWrapperArgs}
+      makeWrapper "${helm}/bin/helm" "$out/bin/helm" "--argv0" "$0" \
+        "--set" "HELM_PLUGINS" "${pluginsDir}" ${extraMakeWrapperArgs}
     '';
     paths = [ helm pluginsDir ];
 


### PR DESCRIPTION
placeholder out doesn't return a full store path so fixing the derivation

helm was point at `/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9/bin/helm` instead of `/nix/store/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9/bin/helm`  see https://github.com/NixOS/nix/issues/5083 (shame on me)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
