### PR TITLE
discourseAllPlugins: init discourse-checklist, discourse-data-explorer, discourse-migratepassword

### DIFF
--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -6,6 +6,7 @@ in
   discourse-calendar = callPackage ./discourse-calendar {};
   discourse-canned-replies = callPackage ./discourse-canned-replies {};
   discourse-checklist = callPackage ./discourse-checklist {};
+  discourse-data-explorer = callPackage ./discourse-data-explorer {};
   discourse-github = callPackage ./discourse-github {};
   discourse-math = callPackage ./discourse-math {};
   discourse-solved = callPackage ./discourse-solved {};

--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -5,6 +5,7 @@ in
 {
   discourse-calendar = callPackage ./discourse-calendar {};
   discourse-canned-replies = callPackage ./discourse-canned-replies {};
+  discourse-checklist = callPackage ./discourse-checklist {};
   discourse-github = callPackage ./discourse-github {};
   discourse-math = callPackage ./discourse-math {};
   discourse-solved = callPackage ./discourse-solved {};

--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -9,6 +9,7 @@ in
   discourse-data-explorer = callPackage ./discourse-data-explorer {};
   discourse-github = callPackage ./discourse-github {};
   discourse-math = callPackage ./discourse-math {};
+  discourse-migratepassword = callPackage ./discourse-migratepassword {};
   discourse-solved = callPackage ./discourse-solved {};
   discourse-spoiler-alert = callPackage ./discourse-spoiler-alert {};
   discourse-yearly-review = callPackage ./discourse-yearly-review {};

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-checklist/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-checklist/default.nix
@@ -1,0 +1,17 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-checklist";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-checklist";
+    rev = "6e7b9c5040c55795c7fd4db9569b3e93dad092c2";
+    sha256 = "sha256-2KAVBrfAvhLZC9idi+ijbVqOCq9rSXbDVEOZS+mWJ10=";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/discourse/discourse-checklist";
+    maintainers = with maintainers; [ ryantm ];
+    license = licenses.gpl2Only;
+    description = "A simple checklist rendering plugin for discourse ";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-data-explorer/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-data-explorer/default.nix
@@ -1,0 +1,17 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-data-explorer";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-data-explorer";
+    rev = "7a348aaa8b2a6b3a75db72e99a7370a1a6fcb2b8";
+    sha256 = "sha256-4X0oor3dIKrQO5IrScQ9+DBr39R7PJJ8dg9UQseV6IU=";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/discourse/discourse-data-explorer";
+    maintainers = with maintainers; [ ryantm ];
+    license = licenses.mit;
+    description = "SQL Queries for admins in Discourse";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-migratepassword/Gemfile
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-migratepassword/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem 'bcrypt', '3.1.3'
+gem 'unix-crypt', '1.3.0'

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-migratepassword/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-migratepassword/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bcrypt (3.1.3)
+    unix-crypt (1.3.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  bcrypt (= 3.1.3)
+  unix-crypt (= 1.3.0)
+
+BUNDLED WITH
+   2.2.20

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-migratepassword/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-migratepassword/default.nix
@@ -1,0 +1,18 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-migratepassword";
+  bundlerEnvArgs.gemdir = ./.;
+  src = fetchFromGitHub {
+    owner = "communiteq";
+    repo = "discourse-migratepassword";
+    rev = "91d6a008de91853becca01846aa4662bd227670e";
+    sha256 = "sha256-aKj0zXyXDnG20qVdhGvn4fwXiBeHFj2pv4bTUP81MP0=";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/communiteq/discourse-migratepassword";
+    maintainers = with maintainers; [ ryantm ];
+    license = licenses.gpl2Only;
+    description = "Support migrated password hashes";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-migratepassword/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-migratepassword/gemset.nix
@@ -1,0 +1,22 @@
+{
+  bcrypt = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d2gqv8vry4ps0asb7nn1z4zxi3mcscy7yrim0npdd294ffyinvj";
+      type = "gem";
+    };
+    version = "3.1.3";
+  };
+  unix-crypt = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wflipsmmicmgvqilp9pml4x19b337kh6p6jgrzqrzpkq2z52gdq";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -187,9 +187,13 @@ def update_plugins():
 
     """
     plugins = [
+        {'name': 'discourse-calendar'},
         {'name': 'discourse-canned-replies'},
+        {'name': 'discourse-checklist'},
+        {'name': 'discourse-data-explorer'},
         {'name': 'discourse-github'},
         {'name': 'discourse-math'},
+        {'name': 'discourse-migratepassword', 'owner': 'discoursehosting'},
         {'name': 'discourse-solved'},
         {'name': 'discourse-spoiler-alert'},
         {'name': 'discourse-yearly-review'},


### PR DESCRIPTION
###### Motivation for this change

discourse-checklist: allows rendering interactive checkboxes for TODO style posts

![image](https://user-images.githubusercontent.com/4804/128032924-a762ddb7-27d9-4e50-a318-f4c6af609153.png)

discourse-data-explorer: allows admins to run queries, useful for making it easier to export surveys

![image](https://user-images.githubusercontent.com/4804/128033126-9e19f9fc-46cf-4520-a140-5408c31c2f90.png)

discourse-migratepassword: useful when migrating from another forum type while not requiring users to remake their password. For example, phpbb.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
