### PR TITLE
remove vozz as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11328,10 +11328,6 @@
     githubId = 3413119;
     name = "Vonfry";
   };
-  vozz = {
-    email = "oliver.huntuk@gmail.com";
-    name = "Oliver Hunt";
-  };
   vq = {
     email = "vq@erq.se";
     name = "Daniel Nilsson";

--- a/pkgs/development/python-modules/exifread/default.nix
+++ b/pkgs/development/python-modules/exifread/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     description = "Easy to use Python module to extract Exif metadata from tiff and jpeg files";
     homepage    = "https://github.com/ianare/exif-py";
     license     = licenses.bsd0;
-    maintainers = with maintainers; [ vozz ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/development/python-modules/inifile/default.nix
+++ b/pkgs/development/python-modules/inifile/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     description = "A small INI library for Python";
     homepage    = "https://github.com/mitsuhiko/python-inifile";
     license     = licenses.bsd0;
-    maintainers = with maintainers; [ vozz ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/development/python-modules/lektor/default.nix
+++ b/pkgs/development/python-modules/lektor/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     description = "A static content management system";
     homepage    = "https://www.getlektor.com/";
     license     = licenses.bsd0;
-    maintainers = with maintainers; [ vozz costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 
 }

--- a/pkgs/tools/X11/ksuperkey/default.nix
+++ b/pkgs/tools/X11/ksuperkey/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "A tool to be able to bind the super key as a key rather than a modifier";
     homepage = "https://github.com/hanschen/ksuperkey";
     license = licenses.gpl3;
-    maintainers = [ maintainers.vozz ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Removing myself, originally added here https://github.com/NixOS/nixpkgs/pull/4426/files

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
