### PR TITLE
discourseAllPlugins: init discourse-ldap-auth

### DIFF
--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -8,6 +8,7 @@ in
   discourse-checklist = callPackage ./discourse-checklist {};
   discourse-data-explorer = callPackage ./discourse-data-explorer {};
   discourse-github = callPackage ./discourse-github {};
+  discourse-ldap-auth = callPackage ./discourse-ldap-auth {};
   discourse-math = callPackage ./discourse-math {};
   discourse-migratepassword = callPackage ./discourse-migratepassword {};
   discourse-solved = callPackage ./discourse-solved {};

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/Gemfile
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem 'pyu-ruby-sasl', '0.0.3.3', require: false
+gem 'rubyntlm', '0.3.4', require: false
+gem 'net-ldap', '0.14.0'
+gem 'omniauth-ldap', '1.0.5'

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    hashie (4.1.0)
+    net-ldap (0.14.0)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-ldap (1.0.5)
+      net-ldap (~> 0.12)
+      omniauth (~> 1.0)
+      pyu-ruby-sasl (~> 0.0.3.2)
+      rubyntlm (~> 0.3.4)
+    pyu-ruby-sasl (0.0.3.3)
+    rack (2.2.3)
+    rubyntlm (0.3.4)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  net-ldap (= 0.14.0)
+  omniauth-ldap (= 1.0.5)
+  pyu-ruby-sasl (= 0.0.3.3)
+  rubyntlm (= 0.3.4)
+
+BUNDLED WITH
+   2.2.20

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/default.nix
@@ -1,0 +1,18 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-ldap-auth";
+  bundlerEnvArgs.gemdir = ./.;
+  src = fetchFromGitHub {
+    owner = "jonmbake";
+    repo = "discourse-ldap-auth";
+    rev = "eca02c560f2f2bf42feeb1923bc17e074f16b891";
+    sha256 = "sha256-HLNoDvvxkBMvqP6WbRrJY0CYnK92W77nzSpuwgl0VPA=";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/jonmbake/discourse-ldap-auth";
+    maintainers = with maintainers; [ ryantm ];
+    license = licenses.mit;
+    description = "Discourse plugin to enable LDAP/Active Directory authentication.";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-ldap-auth/gemset.nix
@@ -1,0 +1,74 @@
+{
+  hashie = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02bsx12ihl78x0vdm37byp78jjw2ff6035y7rrmbd90qxjwxr43q";
+      type = "gem";
+    };
+    version = "4.1.0";
+  };
+  net-ldap = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18fyxfbh32ai72cwgz8s9w0fg0xq7j534y217flw54mmzsj8i6qp";
+      type = "gem";
+    };
+    version = "0.14.0";
+  };
+  omniauth = {
+    dependencies = ["hashie" "rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "002vi9gwamkmhf0dsj2im1d47xw2n1jfhnzl18shxf3ampkqfmyz";
+      type = "gem";
+    };
+    version = "1.9.1";
+  };
+  omniauth-ldap = {
+    dependencies = ["net-ldap" "omniauth" "pyu-ruby-sasl" "rubyntlm"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1ld3mx46xa1qhc0cpnck1n06xcxs0ag4n41zgabxri27a772f9wz";
+      type = "gem";
+    };
+    version = "1.0.5";
+  };
+  pyu-ruby-sasl = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rcpjiz9lrvyb3rd8k8qni0v4ps08psympffyldmmnrqayyad0sn";
+      type = "gem";
+    };
+    version = "0.0.3.3";
+  };
+  rack = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0i5vs0dph9i5jn8dfc6aqd6njcafmb20rwqngrf759c9cvmyff16";
+      type = "gem";
+    };
+    version = "2.2.3";
+  };
+  rubyntlm = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18d1lxhx62swggf4cqg76h7hp04f5801c8h07w08cm9xng2niqby";
+      type = "gem";
+    };
+    version = "0.3.4";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -206,6 +206,7 @@ def update_plugins():
         {'name': 'discourse-checklist'},
         {'name': 'discourse-data-explorer'},
         {'name': 'discourse-github'},
+        {'name': 'discourse-ldap-auth', 'owner': 'jonmbake'},
         {'name': 'discourse-math'},
         {'name': 'discourse-migratepassword', 'owner': 'discoursehosting'},
         {'name': 'discourse-solved'},


### PR DESCRIPTION
###### Motivation for this change

discourse-ldap-auth enables LDAP authentication.

Note, it looks like our plugin architecture does not support the "register_css" hook because you end up with errors like this:

```
Errno::EACCES: Permission denied @ rb_sysopen - /build/source/plugins/discourse-ldap-auth/auto_generated/plugin_34a2724ed7ad43636a4417a37d190b96c4d34ef6.css
/build/source/lib/plugin/instance.rb:976:in `initialize'
/build/source/lib/plugin/instance.rb:976:in `open'
/build/source/lib/plugin/instance.rb:976:in `write_asset'
/build/source/lib/plugin/instance.rb:372:in `block in generate_automatic_assets!'
/build/source/lib/plugin/instance.rb:371:in `each'
/build/source/lib/plugin/instance.rb:371:in `generate_automatic_assets!'
/build/source/lib/plugin/instance.rb:629:in `activate!'
lib/discourse.rb:246:in `block in activate_plugins!'
lib/discourse.rb:243:in `each'
lib/discourse.rb:243:in `activate_plugins!'
/build/source/config/application.rb:312:in `block in <class:Application>'
/build/source/lib/plugin_initialization_guard.rb:5:in `plugin_initialization_guard'
/build/source/config/application.rb:311:in `<class:Application>'
/build/source/config/application.rb:73:in `<module:Discourse>'
/build/source/config/application.rb:72:in `<top (required)>'
/build/source/Rakefile:7:in `require'
/build/source/Rakefile:7:in `<top (required)>'
/nix/store/c4g15ybzpvh3ynb6d1489l98az063j25-discourse-ruby-env-2.7.5/lib/ruby/gems/2.7.0/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli/exec.rb:63:in `load'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli/exec.rb:63:in `kernel_load'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli/exec.rb:28:in `run'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli.rb:474:in `exec'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli.rb:30:in `dispatch'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli.rb:24:in `start'
/nix/store/c4g15ybzpvh3ynb6d1489l98az063j25-discourse-ruby-env-2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/exe/bundle:49:in `block in <top (required)>'
/nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
/nix/store/c4g15ybzpvh3ynb6d1489l98az063j25-discourse-ruby-env-2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/exe/bundle:37:in `<top (required)>'
/nix/store/2r14xjbp68pvsw44hj9xjy39vmid6vq4-ruby-2.7.4/bin/bundle:23:in `load'
/nix/store/2r14xjbp68pvsw44hj9xjy39vmid6vq4-ruby-2.7.4/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
error: builder for '/nix/store/0j853bqz510bhs11rkf0c777wb5hni6b-discourse-assets-2.7.5.drv' failed with exit code 1;
       last 10 log lines:
       > /nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
       > /nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli.rb:30:in `dispatch'
       > /nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
       > /nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/cli.rb:24:in `start'
       > /nix/store/c4g15ybzpvh3ynb6d1489l98az063j25-discourse-ruby-env-2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/exe/bundle:49:in `block in <top (required)>'
       > /nix/store/3h9n2k5gfm84gk74s77vb23d274c7g83-bundler-2.2.20/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
       > /nix/store/c4g15ybzpvh3ynb6d1489l98az063j25-discourse-ruby-env-2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.20/exe/bundle:37:in `<top (required)>'
       > /nix/store/2r14xjbp68pvsw44hj9xjy39vmid6vq4-ruby-2.7.4/bin/bundle:23:in `load'
       > /nix/store/2r14xjbp68pvsw44hj9xjy39vmid6vq4-ruby-2.7.4/bin/bundle:23:in `<main>'
       > (See full trace by running task with --trace)
       For full logs, run 'nix log /nix/store/0j853bqz510bhs11rkf0c777wb5hni6b-discourse-assets-2.7.5.drv'.
error: 1 dependencies of derivation '/nix/store/6vw3vkf8d1lis6zyv1icwf6bsaphcv6y-discourse-2.7.5.drv' failed to build
```

But this CSS here is just cosmetically changing the color of a button, so it isn't critical to the function of the plugin, so I patched it out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
