### PR TITLE
1password: Install polkit action file

### DIFF
--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -87,8 +87,7 @@ stdenv.mkDerivation rec {
         --replace 'Exec=/opt/1Password/${pname}' 'Exec=${pname}'
 
       # Polkit file
-      mkdir -p $out/share/polkit-1/actions
-      cp -a com.1password.1Password.policy $out/share/polkit-1/actions/
+      install -Dm 0644 -t $out/share/polkit-1/actions com.1password.1Password.policy
 
       # Icons
       cp -a resources/icons $out/share

--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -86,6 +86,10 @@ stdenv.mkDerivation rec {
       substituteInPlace $out/share/applications/${pname}.desktop \
         --replace 'Exec=/opt/1Password/${pname}' 'Exec=${pname}'
 
+      # Polkit file
+      mkdir -p $out/share/polkit-1/actions
+      cp -a com.1password.1Password.policy $out/share/polkit-1/actions/
+
       # Icons
       cp -a resources/icons $out/share
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR install the 1Password polkit action file so we can use system authentication for 1Password. The [1Password Linux docs](https://support.1password.com/system-authentication-linux/#about-system-authentication-security) provide more details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

My main test was to run `NIXPKGS_ALLOW_UNFREE=1 nix-build -A _1password-gui` to build this on my `nixpkgs` fork. I then verified the contents of the polkit action file under `./result`:

```xml
$ cat result/share/polkit-1/actions/com.1password.1Password.policy
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE policyconfig PUBLIC
 "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
 "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">

<policyconfig>
    <action id="com.1password.1Password.unlock">
      <description>Unlock 1Password</description>
      <message>Authenticate to unlock 1Password</message>
      <defaults>
        <allow_any>auth_self</allow_any>
        <allow_inactive>auth_self</allow_inactive>
        <allow_active>auth_self</allow_active>
      </defaults>
    </action>
</policyconfig>
```

I'm open to more testing ideas! I don't actually yet have a working custom polkit setup; 1password was the main thing I wanted to test and I needed this for that to work. I'm trying to figure out how to test this with my flakes-based system configuration (I think I can reference my nixpkgs fork for just this package), but I thought this PR was simple enough I would just open it first for any feedback.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (Tested XML file contents, see above)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
