### PR TITLE
[backport] vbox-image: add new option to set free space in image

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -18,6 +18,13 @@ in {
           The size of the VirtualBox base image in MiB.
         '';
       };
+      baseImageFreeSpace = mkOption {
+        type = with types; int;
+        default = 30 * 1024;
+        description = ''
+          Free space in the VirtualBox base image in MiB.
+        '';
+      };
       memorySize = mkOption {
         type = types.int;
         default = 1536;
@@ -117,6 +124,7 @@ in {
       inherit pkgs lib config;
       partitionTableType = "legacy";
       diskSize = cfg.baseImageSize;
+      additionalSpace = cfg.baseImageFreeSpace;
 
       postVM =
         ''

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -124,7 +124,7 @@ in {
       inherit pkgs lib config;
       partitionTableType = "legacy";
       diskSize = cfg.baseImageSize;
-      additionalSpace = cfg.baseImageFreeSpace;
+      additionalSpace = "${toString cfg.baseImageFreeSpace}M";
 
       postVM =
         ''


### PR DESCRIPTION
###### Motivation for this change
Backport of https://github.com/NixOS/nixpkgs/pull/131312 and https://github.com/NixOS/nixpkgs/pull/132345

Fixes https://github.com/NixOS/nixpkgs/issues/131128

Ping @samueldr @Lassulus @lukegb

###### Things done
- [x] Tested that `nix-build nixos/release.nix -A ova.x86_64-linux` newly has disk space when imported into VirtualBox