### PR TITLE
xorg.xeyes: 1.1.2 -> 1.2.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1915,17 +1915,17 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xeyes = callPackage ({ stdenv, pkg-config, fetchurl, libX11, libXext, libXmu, xorgproto, libXrender, libXt }: stdenv.mkDerivation {
+  xeyes = callPackage ({ stdenv, pkg-config, fetchurl, libX11, libxcb, libXext, libXi, libXmu, xorgproto, libXrender, libXt }: stdenv.mkDerivation {
     pname = "xeyes";
-    version = "1.1.2";
+    version = "1.2.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/app/xeyes-1.1.2.tar.bz2";
-      sha256 = "0lq5j7fryx1wn998jq6h3icz1h6pqrsbs3adskjzjyhn5l6yrg2p";
+      url = "mirror://xorg/individual/app/xeyes-1.2.0.tar.bz2";
+      sha256 = "1nxn443pfhddmwl59wplpjkslhlyfk307qx18nrimvvb2hipx8gq";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ libX11 libXext libXmu xorgproto libXrender libXt ];
+    buildInputs = [ libX11 libxcb libXext libXi libXmu xorgproto libXrender libXt ];
     meta.platforms = lib.platforms.unix;
   }) {};
 

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -36,7 +36,7 @@ mirror://xorg/individual/app/xdm-1.1.12.tar.bz2
 mirror://xorg/individual/app/xdpyinfo-1.3.2.tar.bz2
 mirror://xorg/individual/app/xdriinfo-1.0.6.tar.bz2
 mirror://xorg/individual/app/xev-1.2.3.tar.bz2
-mirror://xorg/individual/app/xeyes-1.1.2.tar.bz2
+mirror://xorg/individual/app/xeyes-1.2.0.tar.bz2
 mirror://xorg/individual/app/xfd-1.1.3.tar.bz2
 mirror://xorg/individual/app/xfontsel-1.0.6.tar.bz2
 mirror://xorg/individual/app/xfs-1.2.0.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-August/003101.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).