### PR TITLE
libprotobuf-mutator: init at 1.0

### DIFF
--- a/pkgs/development/libraries/libprotobuf-mutator/default.nix
+++ b/pkgs/development/libraries/libprotobuf-mutator/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, clangStdenv
+, cmake
+, fetchFromGitHub
+, git
+, libtool
+, lzma
+, ninja
+, pkg-config
+, protobuf
+, zlib
+}:
+
+let
+  # See `src/cmake/external/googletest.cmake`.
+  googletest_src = fetchFromGitHub {
+    owner = "google";
+    repo = "googletest";
+    rev = "release-1.11.0";
+    sha256 = "sha256-SjlJxushfry13RGA7BCjYC9oZqV4z6x8dOiHfl/wpF0=";
+  };
+in
+clangStdenv.mkDerivation rec {
+  pname = "libprotobuf-mutator";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-E4EL0c/v1IAZ7nDQQFRflls5BG5juUfq0ztTBuAGDXk=";
+  };
+
+  patches = [ ./local_googletest.patch ];
+
+  postPatch = ''
+    # Remove examples as they require to pull external repositories.
+    rm -R examples/
+    sed -e 's/add_subdirectory(examples EXCLUDE_FROM_ALL)//' -i CMakeLists.txt
+
+    # Pulls an external git repository; Unused except in examples.
+    rm cmake/external/expat.cmake
+
+    cp -R ${googletest_src}/ googletest/
+    chmod -R +w googletest
+  '';
+
+  nativeBuildInputs = [ cmake ninja pkg-config ];
+
+  buildInputs = [ libtool lzma protobuf zlib ];
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DCMAKE_C_COMPILER=clang"
+    "-DCMAKE_CXX_COMPILER=clang++"
+    "-DCMAKE_BUILD_TYPE=Debug"
+    "-DPKG_CONFIG_PATH=share/pkgconfig"
+  ];
+
+  checkPhase = ''
+    ninja check
+  '';
+
+  meta = with lib; {
+    description = "A library to randomly mutate protobuffers";
+    homepage = "https://github.com/google/libprotobuf-mutator";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/development/libraries/libprotobuf-mutator/local_googletest.patch
+++ b/pkgs/development/libraries/libprotobuf-mutator/local_googletest.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/external/googletest.cmake b/cmake/external/googletest.cmake
+index 825ff9a..4ee459e 100644
+--- a/cmake/external/googletest.cmake
++++ b/cmake/external/googletest.cmake
+@@ -43,8 +43,7 @@ endforeach(lib)
+ include (ExternalProject)
+ ExternalProject_Add(${GTEST_TARGET}
+     PREFIX ${GTEST_TARGET}
+-    GIT_REPOSITORY https://github.com/google/googletest.git
+-    GIT_TAG 3f05f651ae3621db58468153e32016bc1397800b
++    SOURCE_DIR ../googletest
+     UPDATE_COMMAND ""
+     CMAKE_CACHE_ARGS -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+                      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13843,6 +13843,8 @@ in
 
   lenmus = callPackage ../applications/misc/lenmus { };
 
+  libprotobuf-mutator = callPackage ../development/libraries/libprotobuf-mutator { };
+
   libtool = libtool_2;
 
   libtool_1_5 = callPackage ../development/tools/misc/libtool { };


### PR DESCRIPTION
###### Motivation for this change

Might be helpful to fuzz the nix daemon protocol...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
