### PR TITLE
xorg.xwd: 1.0.7 -> 1.0.8

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3312,11 +3312,11 @@ lib.makeScope newScope (self: with self; {
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xwd = callPackage ({ stdenv, pkg-config, fetchurl, libxkbfile, libX11, xorgproto }: stdenv.mkDerivation {
     pname = "xwd";
-    version = "1.0.7";
+    version = "1.0.8";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/app/xwd-1.0.7.tar.bz2";
-      sha256 = "1537i8q8pgf0sjklakzfvjwrq5b246qjywrx9ll8xfg0p6w1as6d";
+      url = "mirror://xorg/individual/app/xwd-1.0.8.tar.bz2";
+      sha256 = "06q36fh55r62ms0igfxsanrn6gv8lh794q1bw9xzw51p2qs2papv";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -844,10 +844,6 @@ self: super:
     postInstall = "mkdir $out/bin";
   });
 
-  xwd = super.xwd.overrideAttrs (attrs: {
-    buildInputs = with self; attrs.buildInputs ++ [libXt];
-  });
-
   xrdb = super.xrdb.overrideAttrs (attrs: {
     configureFlags = [ "--with-cpp=${mcpp}/bin/mcpp" ];
   });

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -70,7 +70,7 @@ mirror://xorg/individual/app/xsm-1.0.4.tar.bz2
 mirror://xorg/individual/app/xstdcmap-1.0.4.tar.bz2
 mirror://xorg/individual/app/xtrap-1.0.3.tar.bz2
 mirror://xorg/individual/app/xvinfo-1.1.4.tar.bz2
-mirror://xorg/individual/app/xwd-1.0.7.tar.bz2
+mirror://xorg/individual/app/xwd-1.0.8.tar.bz2
 mirror://xorg/individual/app/xwininfo-1.1.4.tar.bz2
 mirror://xorg/individual/app/xwud-1.0.5.tar.bz2
 mirror://xorg/individual/data/xbitmaps-1.1.2.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-August/003102.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).