### PR TITLE
xorg.libXfont2: 2.0.4 -> 2.0.5

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1002,11 +1002,11 @@ lib.makeScope newScope (self: with self; {
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   libXfont2 = callPackage ({ stdenv, pkg-config, fetchurl, libfontenc, xorgproto, freetype, xtrans, zlib }: stdenv.mkDerivation {
     pname = "libXfont2";
-    version = "2.0.4";
+    version = "2.0.5";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/lib/libXfont2-2.0.4.tar.bz2";
-      sha256 = "1rk9pjxcm01lbr1dxhnvk4f2qrn6zp068qjbvvz5w0z5d0rin5bd";
+      url = "mirror://xorg/individual/lib/libXfont2-2.0.5.tar.bz2";
+      sha256 = "0gmm20p3qq23pd2bhc5rsxil60wqvj9xi7l1nh55q8gp3hhnyz5a";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -187,7 +187,7 @@ mirror://xorg/individual/lib/libXdmcp-1.1.3.tar.bz2
 mirror://xorg/individual/lib/libXext-1.3.4.tar.bz2
 mirror://xorg/individual/lib/libXfixes-6.0.0.tar.bz2
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
-mirror://xorg/individual/lib/libXfont2-2.0.4.tar.bz2
+mirror://xorg/individual/lib/libXfont2-2.0.5.tar.bz2
 mirror://xorg/individual/lib/libXft-2.3.3.tar.bz2
 mirror://xorg/individual/lib/libXi-1.7.10.tar.bz2
 mirror://xorg/individual/lib/libXinerama-1.1.4.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-August/003103.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).