### PR TITLE
linuxConfig: fix build

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21452,12 +21452,17 @@ in
     inherit name src;
     depsBuildBuild = [ buildPackages.stdenv.cc ]
       ++ lib.optionals (lib.versionAtLeast version "4.16") [ buildPackages.bison buildPackages.flex ];
+    postPatch = ''
+      patchShebangs scripts/
+    '';
     buildPhase = ''
+      (
       set -x
       make \
         ARCH=${stdenv.hostPlatform.linuxArch} \
         HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc \
         ${makeTarget}
+      )
     '';
     installPhase = ''
       cp .config $out


### PR DESCRIPTION
This, in turn, fixes `linuxPackages_custom_tinyconfig_kernel`.

Also added parens to limit the scope of `set -x`'s noise.

###### Things done

I have not validated the fixed `linuxPackages_custom_tinyconfig_kernel` actually runs fine, but this is a "tinyconfig" kernel, which is hard to test for considering it does not even have `printk` to print messages! Though `qemu-system-x86_64 -m 512 --enable-kvm -cpu host -display none -serial stdio -kernel result/bzImage -append "console=ttyS0"` hangs, which makes me think everything is working as expected  ¯\\\_(ツ)\_/¯

Oh, and for the record, `nix-build -A pkgsCross.aarch64-multiplatform.linuxPackages_custom_tinyconfig_kernel.configfile` produces a config file that looks entirely cromulent. The kernel builds, untested too, out of scope :), though I'm confident it works *as much as upstream intends it to work*.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
