### PR TITLE
python3Packages.isort: 5.6.4 → 5.9.3

### DIFF
--- a/pkgs/development/python-modules/isort/default.nix
+++ b/pkgs/development/python-modules/isort/default.nix
@@ -6,17 +6,16 @@
 , pytestCheckHook
 }:
 
-let
-in buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "isort";
-  version = "5.6.4";
+  version = "5.9.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = "isort";
     rev = version;
-    sha256 = "1m7jpqssnbsn1ydrw1dn7nrcrggqcvj9v6mk5ampxmvk94xd2r2q";
+    sha256 = "sha256-JbRZ/3Xz35tGoCNnQesR08Sjoz3yimxZyxhhOXGvmXw=";
   };
 
   nativeBuildInputs = [
@@ -46,6 +45,7 @@ in buildPythonPackage rec {
   '';
 
   pytestFlagsArray = [
+    "--ignore=tests/benchmark/" # requires pytest-benchmark
     "--ignore=tests/integration/" # pulls in 10 other packages
     "--ignore=tests/unit/profiles/test_black.py" # causes infinite recursion to include black
   ];
@@ -63,6 +63,7 @@ in buildPythonPackage rec {
     # plugin not available
     "test_isort_literals_issue_1358"
     "test_isort_supports_formatting_plugins_issue_1353"
+    "test_sort_configurable_sort_issue_1732"
     "test_value_assignment_list"
     # profiles not available
     "test_isort_supports_shared_profiles_issue_970"


### PR DESCRIPTION
###### Motivation for this change

Upgrade isort from 5.6.4 to 5.9.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
