### PR TITLE
python3Packages.httpx: 0.18.0 -> 0.18.2

### DIFF
--- a/pkgs/development/python-modules/httpx-ntlm/default.nix
+++ b/pkgs/development/python-modules/httpx-ntlm/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchPypi
+, httpx
+, ntlm-auth
+}:
+
+buildPythonPackage rec {
+  pname = "httpx-ntlm";
+  version = "0.0.10";
+
+  src = fetchPypi {
+    pname = "httpx_ntlm";
+    inherit version;
+    sha256 = "1rar6smz56y8k5qbgrpabpr639nwvf6whdi093hyakf0m3h9cpfz";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+    httpx
+    ntlm-auth
+  ];
+
+  # https://github.com/ulodciv/httpx-ntlm/issues/5
+  doCheck = false;
+
+  pythonImportsCheck = [ "httpx_ntlm" ];
+
+  meta = with lib; {
+    description = "NTLM authentication support for HTTPX";
+    homepage = "https://github.com/ulodciv/httpx-ntlm";
+    license = licenses.isc;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/httpx-socks/default.nix
+++ b/pkgs/development/python-modules/httpx-socks/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, async-timeout
+, buildPythonPackage
+, curio
+, fetchFromGitHub
+, flask
+, httpcore
+, httpx
+, pytest-asyncio
+, pytest-trio
+, pytestCheckHook
+, python-socks
+, pythonOlder
+, sniffio
+, trio
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "httpx-socks";
+  version = "0.4.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "romis2012";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1rz69z5fcw7d5nzy5q2q0r9gxrsqijgpg70cnyr5br6xnfgy01ar";
+  };
+
+  propagatedBuildInputs = [
+    async-timeout
+    curio
+    httpcore
+    httpx
+    python-socks
+    sniffio
+    trio
+  ];
+
+  checkInputs = [
+    flask
+    pytest-asyncio
+    pytest-trio
+    pytestCheckHook
+    yarl
+  ];
+
+  pythonImportsCheck = [ "httpx_socks" ];
+
+  meta = with lib; {
+    description = "Proxy (HTTP, SOCKS) transports for httpx";
+    homepage = "https://github.com/romis2012/httpx-socks";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, brotli
+, brotlicffi
 , certifi
 , h2
 , httpcore
@@ -11,25 +11,25 @@
 , pytestCheckHook
 , pytest-asyncio
 , pytest-trio
-, pytest-cov
+, typing-extensions
 , trustme
 , uvicorn
 }:
 
 buildPythonPackage rec {
   pname = "httpx";
-  version = "0.18.0";
+  version = "0.18.2";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "sha256-6EYBTRXaVHBgW/JzZvWLz55AqgocOyym2FVtu2Nkp/U=";
+    sha256 = "0rr5b6z96yipvp4riqmmbkbcy0sdyzykcdwf5y9ryh27pxr8q8x4";
   };
 
   propagatedBuildInputs = [
-    brotli
+    brotlicffi
     certifi
     h2
     httpcore
@@ -41,8 +41,8 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
     pytest-trio
-    pytest-cov
     trustme
+    typing-extensions
     uvicorn
   ];
 
@@ -62,6 +62,6 @@ buildPythonPackage rec {
     description = "The next generation HTTP client";
     homepage = "https://github.com/encode/httpx";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc fab ];
   };
 }

--- a/pkgs/development/python-modules/respx/default.nix
+++ b/pkgs/development/python-modules/respx/default.nix
@@ -3,40 +3,46 @@
 , fetchFromGitHub
 , httpcore
 , httpx
+, flask
 , pytest-asyncio
-, pytest-cov
 , pytestCheckHook
+, starlette
 , trio
 }:
 
 buildPythonPackage rec {
   pname = "respx";
-  version = "0.17.0";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     owner = "lundberg";
     repo = pname;
     rev = version;
-    sha256 = "sha256-unGAIsslGXOUHXr0FKzC9bX6+Q3mNGZ9Z/dtjz0gkj4=";
+    sha256 = "0w8idh6l2iq04ydz7r2qisq9jsxq8wszkx97kx4g3yjwg4ypvc6k";
   };
 
-  # Coverage is under 100 % due to the excluded tests
-  postPatch = ''
-    substituteInPlace setup.cfg --replace "--cov-fail-under 100" ""
-  '';
-
-  propagatedBuildInputs = [ httpx ];
+  propagatedBuildInputs = [
+    httpx
+  ];
 
   checkInputs = [
     httpcore
     httpx
+    flask
     pytest-asyncio
-    pytest-cov
     pytestCheckHook
+    starlette
     trio
   ];
 
-  disabledTests = [ "test_pass_through" ];
+  postPatch = ''
+    sed -i "/--cov/d" setup.cfg
+  '';
+
+  disabledTests = [
+    "test_pass_through"
+  ];
+
   pythonImportsCheck = [ "respx" ];
 
   meta = with lib; {

--- a/pkgs/tools/security/wapiti/default.nix
+++ b/pkgs/tools/security/wapiti/default.nix
@@ -5,13 +5,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "wapiti";
-  version = "3.0.4";
+  version = "3.0.5";
 
   src = fetchFromGitHub {
     owner = "wapiti-scanner";
     repo = pname;
     rev = version;
-    sha256 = "0wnz4nq1q5y74ksb1kcss9vdih0kbrmnkfbyc2ngd9id1ixfamxb";
+    sha256 = "0663hzpmn6p5xh65d2gk4yk2zh992lfd9lhdwwabhpv3n85nza75";
   };
 
   nativeBuildInputs = with python3.pkgs; [
@@ -21,24 +21,34 @@ python3.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python3.pkgs; [
     beautifulsoup4
     browser-cookie3
+    cryptography
     Mako
     markupsafe
     pysocks
-    requests
+    httpx
+    httpx-ntlm
+    httpx-socks
     six
     tld
     yaswfp
   ] ++ lib.optionals (python3.pythonOlder "3.8") [ importlib-metadata ];
 
   checkInputs = with python3.pkgs; [
-    responses
+    respx
+    pytest-asyncio
     pytestCheckHook
   ];
 
   postPatch = ''
-    # Is already fixed in the repo. Will be part of the next release
+    # Ignore pinned versions
     substituteInPlace setup.py \
-      --replace "importlib_metadata==2.0.0" "importlib_metadata"
+      --replace "==" ">="
+    substituteInPlace setup.cfg \
+      --replace " --cov" ""
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d);
   '';
 
   disabledTests = [
@@ -47,6 +57,10 @@ python3.pkgs.buildPythonApplication rec {
     "test_bad_separator_used"
     "test_blind"
     "test_chunked_timeout"
+    "test_cookies"
+    "test_drop_cookies"
+    "test_save_and_restore_state"
+    "test_explorer_extract_links"
     "test_cookies_detection"
     "test_csrf_cases"
     "test_detection"
@@ -63,6 +77,8 @@ python3.pkgs.buildPythonApplication rec {
     "test_no_crash"
     "test_options"
     "test_out_of_band"
+    "test_multi_detection"
+    "test_vulnerabilities"
     "test_partial_tag_name_escape"
     "test_prefix_and_suffix_detection"
     "test_qs_limit"
@@ -85,6 +101,9 @@ python3.pkgs.buildPythonApplication rec {
     "test_xss_with_strong_csp"
     "test_xss_with_weak_csp"
     "test_xxe"
+    # Requires a PHP installation
+    "test_timesql"
+    "test_cookies"
   ];
 
   pythonImportsCheck = [ "wapitiCore" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3383,6 +3383,8 @@ in {
 
   httpx = callPackage ../development/python-modules/httpx { };
 
+  httpx-ntlm = callPackage ../development/python-modules/httpx-ntlm { };
+
   httpx-socks = callPackage ../development/python-modules/httpx-socks { };
 
   huawei-lte-api = callPackage ../development/python-modules/huawei-lte-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3383,6 +3383,8 @@ in {
 
   httpx = callPackage ../development/python-modules/httpx { };
 
+  httpx-socks = callPackage ../development/python-modules/httpx-socks { };
+
   huawei-lte-api = callPackage ../development/python-modules/huawei-lte-api { };
 
   huey = callPackage ../development/python-modules/huey { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update httpx to 0.18.2

Change log: https://github.com/encode/httpx/releases/tag/0.18.2

Includes update of packages which depends on `httpx`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
