### PR TITLE
acpica-tools,iasl: 20200430 -> 20210730

### DIFF
--- a/pkgs/development/compilers/iasl/default.nix
+++ b/pkgs/development/compilers/iasl/default.nix
@@ -1,24 +1,27 @@
-{lib, stdenv, fetchurl, fetchpatch, bison, flex}:
+{lib, stdenv, fetchurl, bison, flex}:
 
 stdenv.mkDerivation rec {
   pname = "iasl";
-  version = "20200110";
+  version = "20210730";
 
   src = fetchurl {
     url = "https://acpica.org/sites/acpica/files/acpica-unix-${version}.tar.gz";
-    sha256 = "1cb6aa6acrixmdzvj9vv4qs9lmlsbkd27pjlz14i1kq1x3xn0gwx";
+    sha256 = "1pmm977nyl3bs71ipzcl4dh30qm8x9wm2p2ml0m62rl62kai832a";
   };
 
   NIX_CFLAGS_COMPILE = "-O3";
 
   buildFlags = [ "iasl" ];
 
-  buildInputs = [ bison flex ];
+  nativeBuildInputs = [ bison flex ];
 
   installPhase =
     ''
-      install -d $out/bin
-      install generate/unix/bin*/iasl $out/bin
+      runHook preInstall
+
+      install -Dm755 generate/unix/bin*/iasl -t $out/bin
+
+      runHook postInstall
     '';
 
   meta = {

--- a/pkgs/tools/system/acpica-tools/default.nix
+++ b/pkgs/tools/system/acpica-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "acpica-tools";
-  version = "20200430";
+  version = "20210730";
 
   src = fetchurl {
     url = "https://acpica.org/sites/acpica/files/acpica-unix-${version}.tar.gz";
-    sha256 = "0z19bniqsa8y0n1qrxmb6gz7m63jpwx22zgk5ablyriixhfpz07v";
+    sha256 = "1pmm977nyl3bs71ipzcl4dh30qm8x9wm2p2ml0m62rl62kai832a";
   };
 
   NIX_CFLAGS_COMPILE = "-O3";
@@ -16,9 +16,10 @@ stdenv.mkDerivation rec {
   buildFlags = [
     "acpibin"
     "acpidump"
+    "acpiexamples"
     "acpiexec"
     "acpihelp"
-    "acpinames"
+    "acpisrc"
     "acpixtract"
   ];
 
@@ -29,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "ACPICA Tools";
     homepage = "https://www.acpica.org/";
-    license = with licenses; [ gpl2 bsd3 ];
+    license = with licenses; [ iasl gpl2Only bsd3 ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ tadfisher ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

20210730 release notes: https://acpica.org/node/195

`acpica-tools`: 20200430 -> 20210730
`iasl`: 20200110 -> 20210730

`acpica-tools` has been bumped separately so `iasl` are upgraded from 20200110.

Going to do a version bump first then try to continue #101821

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
