### PR TITLE
networkaudiod: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -251,6 +251,7 @@
   ./services/audio/mpd.nix
   ./services/audio/mpdscribble.nix
   ./services/audio/mopidy.nix
+  ./services/audio/networkaudiod.nix
   ./services/audio/roon-bridge.nix
   ./services/audio/roon-server.nix
   ./services/audio/slimserver.nix

--- a/nixos/modules/services/audio/networkaudiod.nix
+++ b/nixos/modules/services/audio/networkaudiod.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  name = "networkaudiod";
+  cfg = config.services.networkaudiod;
+in {
+  options = {
+    services.networkaudiod = {
+      enable = mkEnableOption "Networkaudiod (NAA)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.packages = [ pkgs.networkaudiod ];
+    systemd.services.networkaudiod.wantedBy = [ "multi-user.target" ];
+  };
+}

--- a/pkgs/servers/networkaudiod/default.nix
+++ b/pkgs/servers/networkaudiod/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, lib
+, alsa-lib
+}:
+let
+  inherit (stdenv.targetPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+in
+stdenv.mkDerivation rec {
+  pname = "networkaudiod";
+  version = "4.1.1-46";
+
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://www.signalyst.eu/bins/naa/linux/buster/${pname}_${version}_amd64.deb";
+      sha256 = "sha256-un5VcCnvCCS/KWtW991Rt9vz3flYilERmRNooEsKCkA=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://www.signalyst.eu/bins/naa/linux/buster/${pname}_${version}_arm64.deb";
+      sha256 = "sha256-fjSCWX9VYhVJ43N2kSqd5gfTtDJ1UiH4j5PJ9I5Skag=";
+    };
+  }.${system} or throwSystem;
+
+  unpackPhase = ''
+    dpkg -x $src .
+  '';
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
+  buildInputs = [
+    alsa-lib
+    stdenv.cc.cc.lib
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # main executable
+    mkdir -p $out/bin
+    cp ./usr/sbin/networkaudiod $out/bin
+
+    # systemd service file
+    mkdir -p $out/lib/systemd/system
+    cp ./lib/systemd/system/networkaudiod.service $out/lib/systemd/system
+
+    # documentation
+    mkdir -p $out/share/doc/networkaudiod
+    cp -r ./usr/share/doc/networkaudiod $out/share/doc/
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/lib/systemd/system/networkaudiod.service \
+      --replace /usr/sbin/networkaudiod $out/bin/networkaudiod
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.signalyst.com/index.html";
+    description = "Network Audio Adapter daemon";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ lovesegfault ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19847,6 +19847,8 @@ in
 
   neard = callPackage ../servers/neard { };
 
+  networkaudiod = callPackage ../servers/networkaudiod { };
+
   unit = callPackage ../servers/http/unit { };
 
   ncdns = callPackage ../servers/dns/ncdns { };


### PR DESCRIPTION
- networkaudiod: init at 4.1.1-46
- nixos/networkaudiod: init

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
