### PR TITLE
libinput: 1.16.4 -> 1.18.1

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitLab, pkg-config, meson, ninja
+{ lib, stdenv, fetchurl, pkg-config, meson, ninja
 , libevdev, mtdev, udev, libwacom
 , documentationSupport ? false, doxygen, graphviz # Documentation
 , eventGUISupport ? false, cairo, glib, gtk3 # GUI event viewer support
@@ -22,14 +22,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "libinput";
-  version = "1.16.4";
+  version = "1.18.1";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.freedesktop.org";
-    owner = pname;
-    repo = pname;
-    rev = version;
-    sha256 = "1c81429kh9av9fanxmnjw5rvsjbzcyi7d0dx0gkyq5yysmpmrppi";
+  src = fetchurl {
+    url = "https://www.freedesktop.org/software/libinput/libinput-${version}.tar.xz";
+    sha256 = "1jx7y48ym89grjz67jmn80h5j8c36qgwb0h5c703nln2zchl18cw";
   };
 
   outputs = [ "bin" "out" "dev" ];
@@ -72,6 +69,9 @@ stdenv.mkDerivation rec {
       test/symbols-leak-test \
       test/check-leftover-udev-rules.sh \
       test/helper-copy-and-exec-from-tmp.sh
+
+    # Don't create an empty /etc directory.
+    sed -i "/install_subdir('libinput', install_dir : dir_etc)/d" meson.build
   '';
 
   doCheck = testsSupport && stdenv.hostPlatform == stdenv.buildPlatform;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
