### PR TITLE
ocamlPackages.sedlex_2: 2.3 → 2.4

### DIFF
--- a/pkgs/development/ocaml-modules/sedlex/2.nix
+++ b/pkgs/development/ocaml-modules/sedlex/2.nix
@@ -13,25 +13,25 @@ then throw "sedlex is not available for OCaml ${ocaml.version}"
 else
 
 let
-  unicodeVersion = "12.1.0";
+  unicodeVersion = "13.0.0";
   baseUrl = "https://www.unicode.org/Public/${unicodeVersion}";
 
   DerivedCoreProperties = fetchurl {
     url = "${baseUrl}/ucd/DerivedCoreProperties.txt";
-    sha256 = "0s6sn1yr9qmb2i6gf8dir2zpsbjv1frdfzy3i2yjylzvf637msx6";
+    sha256 = "0j12x112cd8fpgazkc8izxnhhpia44p1m36ff8yapslxndcmzm55";
   };
   DerivedGeneralCategory = fetchurl {
     url = "${baseUrl}/ucd/extracted/DerivedGeneralCategory.txt";
-    sha256 = "1rifzq9ba6c58dn0lrmcb5l5k4ksx3zsdkira3m5p6h4i2wriy3q";
+    sha256 = "0w6mkz4w79k23bnmwgfxc4yqc2ypv8ilrjn6nk25hrafksbg00j5";
   };
   PropList = fetchurl {
     url = "${baseUrl}/ucd/PropList.txt";
-    sha256 = "0gsb1jpj3mnqbjgbavi4l95gl6g4agq58j82km22fdfg63j3w3fk";
+    sha256 = "1ks0585wimygbk2wqi9hqg8gyl25iffvdad5vya1zgsxs8z5lns8";
   };
 in
 buildDunePackage rec {
   pname = "sedlex";
-  version = "2.3";
+  version = "2.4";
 
   useDune2 = true;
 
@@ -39,7 +39,7 @@ buildDunePackage rec {
     owner = "ocaml-community";
     repo = "sedlex";
     rev = "v${version}";
-    sha256 = "0iw3phlaqr27jdf857hmj5v5hdl0vngbb2h37p2ll18sw991fxar";
+    sha256 = "13g8az4zqg6hrnxmy3qrasslppzlag13dd1dsr8vlpg2vpfmfv6i";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Supports Unicode 13.0.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @marsam