### PR TITLE
chaos-lang: init at 0.2.0

### DIFF
--- a/pkgs/development/compilers/chaos/0001-add-Wno-error-unused-result-to-compiler-flags.patch
+++ b/pkgs/development/compilers/chaos/0001-add-Wno-error-unused-result-to-compiler-flags.patch
@@ -1,0 +1,47 @@
+From c314f44241d1d5ddf78b3a226374ecd5a652b243 Mon Sep 17 00:00:00 2001
+From: Lucas Ransan <lucas@ransan.tk>
+Date: Tue, 3 Aug 2021 11:23:35 +0200
+Subject: [PATCH] add -Wno-error=unused-result to compiler flags
+
+---
+ compiler/compiler.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/compiler/compiler.c b/compiler/compiler.c
+index b4a0470..d6f9b84 100644
+--- a/compiler/compiler.c
++++ b/compiler/compiler.c
+@@ -366,7 +366,7 @@ void compile(char *module, enum Phase phase_arg, char *bin_file, char *extra_fla
+     if (extra_flags_count > 0)
+         extra_flags_count--;
+ 
+-    unsigned arg_count = 29 + extra_flags_count;
++    unsigned arg_count = 30 + extra_flags_count;
+ #   if !defined(__clang__)
+     arg_count++;
+ #   endif
+@@ -404,17 +404,18 @@ void compile(char *module, enum Phase phase_arg, char *bin_file, char *extra_fla
+     c_compiler_args[25] = "-L/usr/local/opt/readline/lib";
+     c_compiler_args[26] = "-ldl";
+     c_compiler_args[27] = "-I/usr/local/include/chaos/";
++    c_compiler_args[28] = "-Wno-error=unused-result";
+ 
+     for (unsigned i = 0; i < (extra_flags_count); i++) {
+-        c_compiler_args[28 + i] = extra_flags_arr.arr[i];
++        c_compiler_args[29 + i] = extra_flags_arr.arr[i];
+     }
+ 
+ #   if !defined(__clang__)
+-    c_compiler_args[28 + extra_flags_count] = "-fcompare-debug-second",
++    c_compiler_args[29 + extra_flags_count] = "-fcompare-debug-second",
+ #   endif
+ 
+ #   if defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)
+-    c_compiler_args[29 + extra_flags_count] = "-Wl,-stack_size,0x100000000",
++    c_compiler_args[30 + extra_flags_count] = "-Wl,-stack_size,0x100000000",
+ #   endif
+ 
+     c_compiler_args[arg_count - 1] = NULL;
+-- 
+2.32.0
+

--- a/pkgs/development/compilers/chaos/default.nix
+++ b/pkgs/development/compilers/chaos/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, bison
+, flex
+, readline
+, getopt
+}:
+
+stdenv.mkDerivation rec {
+  pname = "chaos";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "chaos-lang";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "ts+kzM+yesCS1JLyMkxT/7hHKpCtYxtwIuhyM2w3frc=";
+  };
+
+  nativeBuildInputs = [
+    bison flex
+  ];
+
+  buildInputs = [
+    readline
+    stdenv.cc
+  ];
+
+  checkInputs = [
+    getopt
+  ];
+
+  postPatch = ''
+    sed -i Makefile \
+        -e 's/\({CHAOS_EXTRA_FLAGS}\)/\1 -Wno-error=unused-result/' \
+        -e 's/rsync -av/cp -r/' \
+        -e "s,/usr/local,$out," \
+        -e '/~\//d'
+    sed -i compiler/compiler.c utilities/messages.c \
+        -e "s,/usr/local,$out,"
+  '';
+
+  patches = [
+    ./0001-add-Wno-error-unused-result-to-compiler-flags.patch
+  ];
+
+  buildFlags = lib.optional stdenv.cc.isClang "clang";
+
+  doCheck = true;
+
+  preCheck = ''
+    patchShebangs tests/*.sh tests/shell/*.sh
+    sed -i tests/interpreter.sh tests/shell/interpreter.sh \
+        -e '/test=/s,chaos,/build/source/chaos,' \
+        -e 's,\.\*\\/chaos,.*/build/source,'
+  '';
+
+  checkTarget = "test";
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  doInstallCheck = true;
+
+  preInstallCheck = ''
+    sed -i tests/compiler.sh \
+        -e "/cout=/s,chaos,$out/bin/chaos,"
+  '';
+
+  installCheckTarget = "test-compiler";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10740,6 +10740,8 @@ in
     stdenv = gccStdenv;
   };
 
+  chaos-lang = callPackage ../development/compilers/chaos { };
+
   chez = callPackage ../development/compilers/chez {
     inherit (darwin) cctools;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
