### PR TITLE
ocamlPackages: update a bunch of libraries from the mirage universe

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -4,7 +4,7 @@ with ocamlPackages;
 
 buildDunePackage rec {
   pname = "jackline";
-  version = "unstable-2021-04-23";
+  version = "unstable-2021-08-10";
 
   minimumOCamlVersion = "4.08";
 
@@ -13,8 +13,8 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "jackline";
-    rev    = "861c59bb7cd27ad5c7558ff94cb0d0e8dca249e5";
-    sha256 = "00waw5qr0n70i9l9b25r9ryfi836x4qrj046bb4k9qa4d0p8q1sa";
+    rev    = "73d87e9a62d534566bb0fbe64990d32d75487f11";
+    sha256 = "0wk574rqfg2vqz27nasxzwf67x51pj5fgl4vkc27r741dg4q6c5a";
   };
 
   nativeBuildInpts = [

--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -1,4 +1,6 @@
-{ lib, buildDunePackage, async, async_ssl, ppx_sexp_conv, ppx_here, uri, conduit }:
+{ lib, buildDunePackage, async, async_ssl, ppx_sexp_conv, ppx_here, uri, conduit
+, core, ipaddr, ipaddr-sexp, sexplib
+}:
 
 buildDunePackage {
   pname = "conduit-async";
@@ -11,7 +13,16 @@ buildDunePackage {
 
   buildInputs = [ ppx_sexp_conv ppx_here ];
 
-  propagatedBuildInputs = [ async async_ssl conduit uri ];
+  propagatedBuildInputs = [
+    async
+    async_ssl
+    conduit
+    uri
+    ipaddr
+    ipaddr-sexp
+    core
+    sexplib
+  ];
 
   meta = conduit.meta // {
     description = "A network connection establishment library for Async";

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -5,14 +5,14 @@
 
 buildDunePackage rec {
   pname = "conduit";
-  version = "4.0.0";
+  version = "4.0.1";
   useDune2 = true;
 
   minimumOCamlVersion = "4.03";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-conduit/releases/download/v${version}/conduit-v${version}.tbz";
-    sha256 = "74b29d72bf47adc5d5c4cae6130ad5a2a4923118b9c571331bd1cb3c56decd2a";
+    sha256 = "500d95bf2a524f4851e94373e32d26b6e99ee04e5134db69fe6e151c3aad9b1f";
   };
 
   buildInputs = [ ppx_sexp_conv ];

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "cstruct";
-  version = "6.0.0";
+  version = "6.0.1";
 
   useDune2 = true;
 
@@ -10,7 +10,7 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${version}/cstruct-v${version}.tbz";
-    sha256 = "0xi6cj85z033fqrqdkwac6gg07629vzdhx03c3lhiwwc4lpnv8bq";
+    sha256 = "4a67bb8f042753453c59eabf0e47865631253ba694091ce6062aac05d47a9bed";
   };
 
   propagatedBuildInputs = [ bigarray-compat ];

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -1,6 +1,5 @@
 { lib, buildDunePackage, cstruct, sexplib, ppxlib, stdlib-shims
 , ounit, cppo, ppx_sexp_conv, cstruct-unix, cstruct-sexp
-, fetchpatch
 }:
 
 if !lib.versionAtLeast (cstruct.version or "1") "3"
@@ -11,22 +10,10 @@ buildDunePackage {
   pname = "ppx_cstruct";
   inherit (cstruct) version src useDune2 meta;
 
-  minimumOCamlVersion = "4.07";
-
-  # prevent ANSI escape sequences from messing up the test cases
-  # https://github.com/mirage/ocaml-cstruct/issues/283
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/mirage/ocaml-cstruct/pull/285/commits/60dfed98b4c34455bf339ac60e2ed5ef05feb48f.patch";
-      sha256 = "1x9i62nrlfy9l44vb0a7qjfrg2wyki4c8nmmqnzwpcbkgxi3q6n5";
-    })
-  ];
+  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [ cstruct ppxlib sexplib stdlib-shims ];
 
-  # disable until ppx_sexp_conv uses ppxlib 0.20.0 (or >= 0.16.0)
-  # since the propagation of the older ppxlib breaks the ppx_cstruct
-  # build.
-  doCheck = false;
+  doCheck = true;
   checkInputs = [ ounit cppo ppx_sexp_conv cstruct-sexp cstruct-unix ];
 }

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -8,14 +8,14 @@
 
 buildDunePackage rec {
   pname = "git";
-  version = "3.4.0";
+  version = "3.5.0";
 
   minimumOCamlVersion = "4.08";
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${version}/git-${version}.tbz";
-    sha256 = "6eef1240c7c85a8e495b82ef863c509ad41d75e0c45cf73c34ed1bdafd03413f";
+    sha256 = "bcd5a0aef9957193cbaeeb17c22201e5ca4e815e67bbc696e88efdb38c25ec03";
   };
 
   # remove changelog for the carton package

--- a/pkgs/development/ocaml-modules/git/paf.nix
+++ b/pkgs/development/ocaml-modules/git/paf.nix
@@ -3,8 +3,6 @@
 , mimic
 , paf
 , ca-certs-nss
-, cohttp
-, cohttp-lwt
 , fmt
 , ipaddr
 , logs
@@ -16,6 +14,12 @@
 , rresult
 , tls
 , uri
+, bigarray-compat
+, bigstringaf
+, domain-name
+, httpaf
+, mirage-flow
+, tls-mirage
 }:
 
 buildDunePackage {
@@ -28,8 +32,6 @@ buildDunePackage {
     mimic
     paf
     ca-certs-nss
-    cohttp
-    cohttp-lwt
     fmt
     lwt
     result
@@ -41,6 +43,12 @@ buildDunePackage {
     mirage-time
     tls
     uri
+    bigarray-compat
+    bigstringaf
+    domain-name
+    httpaf
+    mirage-flow
+    tls-mirage
   ];
 
   meta = git.meta // {

--- a/pkgs/development/ocaml-modules/letsencrypt/app.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/app.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildDunePackage
+, letsencrypt
+, letsencrypt-dns
+, cmdliner
+, cohttp-lwt-unix
+, logs
+, fmt
+, lwt
+, mirage-crypto-rng
+, ptime
+, bos
+, fpath
+, randomconv
+}:
+
+buildDunePackage {
+  pname = "letsencrypt-app";
+
+  inherit (letsencrypt)
+    src
+    version
+    useDune2
+    minimumOCamlVersion
+    ;
+
+  buildInputs = [
+    letsencrypt
+    letsencrypt-dns
+    cmdliner
+    cohttp-lwt-unix
+    logs
+    fmt
+    lwt
+    mirage-crypto-rng
+    ptime
+    bos
+    fpath
+    randomconv
+  ];
+
+  meta = letsencrypt.meta // {
+    description = "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml";
+  };
+}

--- a/pkgs/development/ocaml-modules/letsencrypt/default.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/default.nix
@@ -6,11 +6,6 @@
 , uri
 , rresult
 , base64
-, cmdliner
-, cohttp
-, cohttp-lwt
-, cohttp-lwt-unix
-, zarith
 , logs
 , fmt
 , lwt
@@ -20,38 +15,25 @@
 , x509
 , yojson
 , ounit
-, dns
-, dns-tsig
 , ptime
-, bos
-, fpath
-, randomconv
 , domain-name
 }:
 
 buildDunePackage rec {
   pname = "letsencrypt";
-  version = "0.2.5";
+  version = "0.3.0";
 
   src = fetchurl {
     url = "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v${version}/letsencrypt-v${version}.tbz";
-    sha256 = "6e3bbb5f593823d49e83e698c06cf9ed48818695ec8318507b311ae74731e607";
+    sha256 = "8772b7e6dbda0559a03a7b23b75c1431d42ae09a154eefd64b4c7e23b8d92deb";
   };
 
   minimumOCamlVersion = "4.08";
   useDune2 = true;
 
   buildInputs = [
-    cmdliner
-    cohttp
-    cohttp-lwt-unix
-    zarith
     fmt
-    mirage-crypto-rng
     ptime
-    bos
-    fpath
-    randomconv
     domain-name
   ];
 
@@ -65,11 +47,8 @@ buildDunePackage rec {
     asn1-combinators
     x509
     uri
-    dns
-    dns-tsig
     rresult
     astring
-    cohttp-lwt
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/letsencrypt/dns.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/dns.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildDunePackage
+, letsencrypt
+, logs
+, fmt
+, lwt
+, dns
+, dns-tsig
+, domain-name
+}:
+
+buildDunePackage {
+  pname = "letsencrypt-dns";
+
+  inherit (letsencrypt)
+    version
+    src
+    useDune2
+    minimumOCamlVersion
+    ;
+
+  propagatedBuildInputs = [
+    letsencrypt
+    dns
+    dns-tsig
+    domain-name
+    logs
+    lwt
+    fmt
+  ];
+
+  meta = letsencrypt.meta // {
+    description = "A DNS solver for the ACME implementation in OCaml";
+  };
+}

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -4,7 +4,7 @@
 
 buildDunePackage rec {
   pname = "macaddr";
-  version = "5.1.0";
+  version = "5.2.0";
 
   useDune2 = true;
 
@@ -12,7 +12,7 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-ipaddr/releases/download/v${version}/ipaddr-v${version}.tbz";
-    sha256 = "7e9328222c1a5f39b0751baecd7e27a842bdb0082fd48126eacbbad8816fbf5a";
+    sha256 = "f98d237cc1f783a0ba7dff0c6c69b5f519fec056950e3e3e7c15e5511ee5b7ec";
   };
 
   checkInputs = [ ppx_sexp_conv ounit ];

--- a/pkgs/development/ocaml-modules/mirage-block/combinators.nix
+++ b/pkgs/development/ocaml-modules/mirage-block/combinators.nix
@@ -1,8 +1,16 @@
-{ buildDunePackage, mirage-block, io-page, logs }:
+{ buildDunePackage, fetchpatch, mirage-block, io-page, logs }:
 
 buildDunePackage rec {
   pname = "mirage-block-combinators";
   inherit (mirage-block) version src useDune2;
+
+  patches = [
+    (fetchpatch {
+      name = "cstruct-6.0.0-compat.patch";
+      url = "https://github.com/mirage/mirage-block/pull/49/commits/ff54105b21fb32d0d6977b419db0776e6c2ea166.patch";
+      sha256 = "0bwgypnsyn4d9b46q6r7kh5qfcy58db7krs6z5zw83hc7y20y2sd";
+    })
+  ];
 
   propagatedBuildInputs = [ mirage-block io-page logs ];
 

--- a/pkgs/development/ocaml-modules/paf/cohttp.nix
+++ b/pkgs/development/ocaml-modules/paf/cohttp.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildDunePackage
+, paf
+, cohttp-lwt
+, domain-name
+, httpaf
+, ipaddr
+, alcotest-lwt
+, fmt
+, logs
+, mirage-crypto-rng
+, mirage-time-unix
+, tcpip
+, uri
+, lwt
+}:
+
+buildDunePackage {
+  pname = "paf-cohttp";
+
+  inherit (paf)
+    version
+    src
+    useDune2
+    minimumOCamlVersion
+  ;
+
+  propagatedBuildInputs = [
+    paf
+    cohttp-lwt
+    domain-name
+    httpaf
+    ipaddr
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest-lwt
+    fmt
+    logs
+    mirage-crypto-rng
+    mirage-time-unix
+    tcpip
+    uri
+    lwt
+  ];
+
+  meta = paf.meta // {
+    description = "A CoHTTP client with its HTTP/AF implementation";
+  };
+}

--- a/pkgs/development/ocaml-modules/paf/default.nix
+++ b/pkgs/development/ocaml-modules/paf/default.nix
@@ -4,7 +4,6 @@
 , fetchpatch
 , mirage-stack
 , mirage-time
-, httpaf
 , h2
 , tls-mirage
 , mimic
@@ -28,15 +27,16 @@
 , ptime
 , uri
 , alcotest-lwt
+, cstruct
 }:
 
 buildDunePackage rec {
   pname = "paf";
-  version = "0.0.3";
+  version = "0.0.5";
 
   src = fetchurl {
     url = "https://github.com/dinosaure/paf-le-chien/releases/download/${version}/paf-${version}.tbz";
-    sha256 = "a0bbb84b19e1f0255337fc4d7017f3ea3611b241746e391b11c1d8b1f5f30a2b";
+    sha256 = "e85a018046eb062d2399fdbe8d9d3400a4d5cd51bb62840446503f557c3eeff1";
   };
 
   useDune2 = true;
@@ -45,7 +45,6 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     mirage-stack
     mirage-time
-    httpaf
     h2
     tls-mirage
     mimic
@@ -60,6 +59,7 @@ buildDunePackage rec {
     faraday
     tls
     x509
+    cstruct
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/paf/le.nix
+++ b/pkgs/development/ocaml-modules/paf/le.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildDunePackage
+, paf
+, duration
+, emile
+, httpaf
+, letsencrypt
+, mirage-stack
+, mirage-time
+, tls-mirage
+}:
+
+buildDunePackage {
+  pname = "paf-le";
+
+  inherit (paf)
+    version
+    src
+    useDune2
+    minimumOCamlVersion
+  ;
+
+  propagatedBuildInputs = [
+    paf
+    duration
+    emile
+    httpaf
+    letsencrypt
+    mirage-stack
+    mirage-time
+    tls-mirage
+  ];
+
+  doCheck = true;
+
+  meta = paf.meta // {
+    description = "A CoHTTP client with its HTTP/AF implementation";
+  };
+}

--- a/pkgs/development/ocaml-modules/tls/async.nix
+++ b/pkgs/development/ocaml-modules/tls/async.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, tls, async, cstruct-async, core, cstruct, mirage-crypto-rng-async }:
+{ lib, buildDunePackage, tls, async, cstruct-async, core, cstruct, mirage-crypto-rng-async, async_find }:
 
 buildDunePackage rec {
   pname = "tls-async";
@@ -12,6 +12,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [
     async
+    async_find
     core
     cstruct
     cstruct-async

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -5,11 +5,11 @@
 
 buildDunePackage rec {
   pname = "tls";
-  version = "0.13.2";
+  version = "0.14.1";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-v${version}.tbz";
-    sha256 = "sha256-IE6Fuvem8A3lZ/M8GLNYNwCG+v7BbPQ4QdYS+fKT50c=";
+    sha256 = "58cf2d517d6eac5b1ccc5eeb656da690aef2125a19c1eca3fbececd858046216";
   };
 
   minimumOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -8,11 +8,11 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.07";
 
   pname = "x509";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-x509/releases/download/v${version}/x509-v${version}.tbz";
-    sha256 = "9b42f34171261b2193ee662f096566c48c48e087949c186c288f90c9b3b9f498";
+    sha256 = "d91eb4f2790f9d098713c71cc4b5d12706aedb1795666b5e6d667fe5c262f9c3";
   };
 
   useDune2 = true;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -994,6 +994,10 @@ let
 
     paf = callPackage ../development/ocaml-modules/paf { };
 
+    paf-cohttp = callPackage ../development/ocaml-modules/paf/cohttp.nix { };
+
+    paf-le = callPackage ../development/ocaml-modules/paf/le.nix { };
+
     parse-argv = callPackage ../development/ocaml-modules/parse-argv { };
 
     path_glob = callPackage ../development/ocaml-modules/path_glob { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -611,6 +611,10 @@ let
 
     letsencrypt = callPackage ../development/ocaml-modules/letsencrypt { };
 
+    letsencrypt-app = callPackage ../development/ocaml-modules/letsencrypt/app.nix { };
+
+    letsencrypt-dns = callPackage ../development/ocaml-modules/letsencrypt/dns.nix { };
+
     linenoise = callPackage ../development/ocaml-modules/linenoise { };
 
     llvm = callPackage ../development/ocaml-modules/llvm {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* `Cstruct.len` has been finally deprecated in ctruct 6.0.1. A lot of libraries will have to be updated for this (see <https://github.com/ocaml/opam-repository/pull/19143>, <https://github.com/ocaml/opam-repository/pull/19142>).
* `tls` 0.14 breaks `paf`
* `paf` has a new release which supports `tls` 0.14 which breaks `git-paf` ~~which hasn't had a new release yet.~~
* `paf` >= 0.0.4 needs `letsencrypt` 0.3.0

More to come most likely, we are now waiting for a lot of `mirage-*` libraries to update as well as things like `conduit-lwt-unix`.

One thing to watch is also the use of `io-page-unix`. If nothing depends on it in nixpkgs anymore we can update `io-page`.

cc @vbgl for their information

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
