### PR TITLE
ergoscf: init at 3.8

### DIFF
--- a/pkgs/applications/science/chemistry/ergoscf/default.nix
+++ b/pkgs/applications/science/chemistry/ergoscf/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchurl, blas, lapack } :
+
+stdenv.mkDerivation rec {
+  pname = "ergoscf";
+  version = "3.8";
+
+  src = fetchurl {
+    url = "http://www.ergoscf.org/source/tarfiles/ergo-${version}.tar.gz";
+    sha256 = "1s50k2gfs3y6r5kddifn4p0wmj0yk85wm5vf9v3swm1c0h43riix";
+  };
+
+  buildInputs = [ blas lapack ];
+
+  patches = [ ./math-constants.patch ];
+
+  postPatch = ''
+    patchShebangs ./test
+  '';
+
+  configureFlags = [
+    "--enable-linalgebra-templates"
+    "--enable-performance"
+  ] ++ lib.optional stdenv.isx86_64 "--enable-sse-intrinsics";
+
+  LDFLAGS = "-lblas -llapack";
+
+  enableParallelBuilding = true;
+
+  OMP_NUM_THREADS = 2; # required for check phase
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Quantum chemistry program for large-scale self-consistent field calculations";
+    homepage = "http://www.ergoscf.org";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/science/chemistry/ergoscf/math-constants.patch
+++ b/pkgs/applications/science/chemistry/ergoscf/math-constants.patch
@@ -1,0 +1,19 @@
+diff --git a/source/dft/functionals.h b/source/dft/functionals.h
+index fde49ba..f7a61fc 100644
+--- a/source/dft/functionals.h
++++ b/source/dft/functionals.h
+@@ -59,6 +59,14 @@
+ #define EXTERN_C
+ #endif
+ 
++#ifndef M_PI
++#define M_PI 3.14159265358979323846
++#endif
++
++#ifndef M_SQRT2
++#define M_SQRT2        1.41421356237309504880
++#endif
++
+ typedef ergo_real real;
+ 
+ #if defined(FUNC_PRECISION) && FUNC_PRECISION == 1

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30026,6 +30026,8 @@ in
 
   d-seams = callPackage ../applications/science/chemistry/d-seams {};
 
+  ergoscf = callPackage ../applications/science/chemistry/ergoscf { };
+
   gwyddion = callPackage ../applications/science/chemistry/gwyddion {};
 
   jmol = callPackage ../applications/science/chemistry/jmol {


### PR DESCRIPTION
###### Motivation for this change
Quantum chemistry program for large molecules. Transfer from [NixOS-QChem overlay](https://github.com/markuskowa/NixOS-QChem/tree/master/pkgs/apps/ergoscf).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
