### PR TITLE
goocanvas3: init at 3.0.0

### DIFF
--- a/pkgs/development/libraries/goocanvas/3.x.nix
+++ b/pkgs/development/libraries/goocanvas/3.x.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, gettext
+, gobject-introspection
+, gtk-doc
+, python3
+, cairo
+, gtk3
+, glib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "goocanvas";
+  version = "3.0.0";
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/goocanvas/${lib.versions.majorMinor version}/goocanvas-${version}.tar.xz";
+    sha256 = "06j05g2lmwvklmv51xsb7gm7rszcarhm01sal41jfp0qzrbpa2k7";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+    gobject-introspection
+    gtk-doc
+    python3
+  ];
+
+  buildInputs = [
+    cairo
+    gtk3
+    glib
+  ];
+
+  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "$(dev)/share/gir-1.0";
+  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "$(out)/lib/girepository-1.0";
+
+  meta = with lib; {
+    description = "Canvas widget for GTK based on the the Cairo 2D library";
+    homepage = "https://wiki.gnome.org/Projects/GooCanvas";
+    license = licenses.lgpl2; # https://gitlab.gnome.org/GNOME/goocanvas/-/issues/12
+    maintainers = with maintainers; [ bobby285271 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15617,6 +15617,7 @@ in
 
   goocanvas = callPackage ../development/libraries/goocanvas { };
   goocanvas2 = callPackage ../development/libraries/goocanvas/2.x.nix { };
+  goocanvas3 = callPackage ../development/libraries/goocanvas/3.x.nix { };
   goocanvasmm2 = callPackage ../development/libraries/goocanvasmm { };
 
   gflags = callPackage ../development/libraries/gflags { };


### PR DESCRIPTION
###### Motivation for this change

This is needed for upgrading `akira-unstable`. 

https://gitlab.gnome.org/GNOME/goocanvas/-/tags/3.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
