### PR TITLE
emscripten: build multi-threaded libc

### DIFF
--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -92,8 +92,10 @@ stdenv.mkDerivation rec {
       # wasm2c doesn't work with PIC
       $out/bin/emcc -s WASM2C -s STANDALONE_WASM $LTO test.c
 
-      for RELOCATABLE in "" "-s RELOCATABLE"; do
-        $out/bin/emcc $RELOCATABLE $LTO test.c
+      for MT in "" "-s USE_PTHREADS"; do
+        for RELOCATABLE in "" "-s RELOCATABLE"; do
+          $out/bin/emcc $RELOCATABLE $MT $LTO test.c
+        done
       done
     done
     popd


### PR DESCRIPTION
###### Motivation for this change

When building applications with `-sUSE_PTHREADS`, it would have to generate `libc-mt.a` every time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
