### PR TITLE
emacs.pkgs: Drop legacy aliases

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -624,6 +624,14 @@
           move all files to the new directory.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          Deprecated package aliases in <literal>emacs.pkgs.*</literal>
+          have been removed. These aliases were remnants of the old
+          Emacs package infrastructure. We now use exact upstream names
+          wherever possible.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -157,6 +157,8 @@ pt-services.clipcat.enable).
 
 - `services.uptimed` now uses `/var/lib/uptimed` as its stateDirectory instead of `/var/spool/uptimed`. Make sure to move all files to the new directory.
 
+- Deprecated package aliases in `emacs.pkgs.*` have been removed. These aliases were remnants of the old Emacs package infrastructure. We now use exact upstream names wherever possible.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 - The setting [`services.openssh.logLevel`](options.html#opt-services.openssh.logLevel) `"VERBOSE"` `"INFO"`. This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -250,38 +250,4 @@
   rectMark = rect-mark;
   sunriseCommander = sunrise-commander;
 
-  # Legacy aliases, these try to mostly map to melpa stable because it's
-  # closer to the old outdated package infra.
-  #
-  # Ideally this should be dropped some time during/after 20.03
-
-  autoComplete = self.melpaStablePackages.auto-complete;
-  bbdb3 = self.melpaStablePackages.bbdb;
-  colorTheme = self.color-theme;
-  cryptol = self.melpaStablePackages.cryptol-mode;
-  d = self.melpaStablePackages.d-mode;
-  emacsw3m = self.w3m;
-  erlangMode = self.melpaStablePackages.erlang;
-  flymakeCursor = self.melpaStablePackages.flymake-cursor;
-  graphvizDot = self.melpaStablePackages.graphviz-dot-mode;
-  haskellMode = self.melpaStablePackages.haskell-mode;
-  hsc3Mode = self.hsc3-mode;
-  idris = self.melpaStablePackages.idris-mode;
-  jade = self.jade-mode;
-  js2 = self.melpaStablePackages.js2-mode;
-  loremIpsum = self.lorem-ipsum;
-  markdownMode = self.melpaStablePackages.markdown-mode;
-  maudeMode = self.maude-mode;
-  phpMode = self.melpaStablePackages.php-mode;
-  prologMode = self.prolog-mode;
-  proofgeneral = self.melpaStablePackages.proof-general;
-  proofgeneral_HEAD = self.proof-general;
-  rainbowDelimiters = self.melpaStablePackages.rainbow-delimiters;
-  sbtMode = self.melpaStablePackages.sbt-mode;
-  scalaMode1 = self.melpaStablePackages.scala-mode;
-  # scalaMode2 = null;  # No clear mapping as of now
-  structuredHaskellMode = self.melpaStablePackages.shm;
-  tuaregMode = self.melpaStablePackages.tuareg;
-  writeGood = self.melpaStablePackages.writegood-mode;
-  xmlRpc = self.melpaStablePackages.xml-rpc;
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -517,24 +517,7 @@ let
         });
       };
 
-      # Deprecated legacy aliases for backwards compat
-      aliases = lib.listToAttrs (lib.attrValues (lib.mapAttrs (n: v: { name = v; value = builtins.trace "Melpa attribute '${v}' is a legacy alias that will be removed in 21.05, use '${n}' instead" melpaPackages.${n}; }) (lib.filterAttrs (n: v: lib.hasAttr n melpaPackages) {
-        "auto-complete-clang-async" = "emacsClangCompleteAsync";
-        "vterm" = "emacs-libvterm";
-        "0xc" = "_0xc";
-        "2048-game" = "_2048-game";
-        "4clojure" = "_4clojure";
-        "@" = "at";
-        "term+" = "term-plus";
-        "term+key-intercept" = "term-plus-key-intercept";
-        "term+mux" = "term-plus-mux";
-        "xml+" = "xml-plus";
-      })));
-
-      melpaPackages = lib.mapAttrs (n: v: if lib.hasAttr n overrides then overrides.${n} else v) super;
-
-    in
-    melpaPackages // aliases);
+    in lib.mapAttrs (n: v: if lib.hasAttr n overrides then overrides.${n} else v) super);
 
 in
 generateMelpa { }


### PR DESCRIPTION
###### Motivation for this change
These have been deprecated for a very long time now and I see no reason to keep them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
