### PR TITLE
sqlcipher: fix cross build

### DIFF
--- a/pkgs/development/libraries/sqlcipher/default.nix
+++ b/pkgs/development/libraries/sqlcipher/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, openssl, tcl, installShellFiles, readline ? null, ncurses ? null }:
+{ stdenv, lib, fetchFromGitHub, openssl, tcl, installShellFiles, buildPackages, readline ? null, ncurses ? null }:
 
 assert readline != null -> ncurses != null;
 
@@ -13,14 +13,15 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-E23PTNnVZbBQtHL0YjUwHNVUA76XS8rlARBOVvX6zZw=";
   };
 
-  nativeBuildInputs = [ installShellFiles ];
-
-  buildInputs = [ readline ncurses openssl tcl ];
+  nativeBuildInputs = [ installShellFiles tcl ];
+  buildInputs = [ readline ncurses openssl ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   configureFlags = [ "--enable-threadsafe" "--disable-tcl" ];
 
   CFLAGS = [ "-DSQLITE_ENABLE_COLUMN_METADATA=1" "-DSQLITE_SECURE_DELETE=1" "-DSQLITE_ENABLE_UNLOCK_NOTIFY=1" "-DSQLITE_HAS_CODEC" ];
   LDFLAGS = lib.optional (readline != null) "-lncurses";
+  BUILD_CC = "$(CC_FOR_BUILD)";
 
   doCheck = false; # fails. requires tcl?
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`pkgsStatic.sqlcipher` wasn't building because tcl was incorrectly in buildInputs and the Makefile didn't detect the build CC correctly.

This also fixes `pkgsCross.aarch64-multiplatform.sqlcipher` and so on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
