### PR TITLE
manim: fix

### DIFF
--- a/pkgs/applications/video/manim/default.nix
+++ b/pkgs/applications/video/manim/default.nix
@@ -44,7 +44,7 @@ buildPythonApplication rec {
       python3 manim.py example_scenes.py $scene -l
       tail -n 20 files/Tex/*.log  # Print potential LaTeX erorrs
       ${file}/bin/file videos/example_scenes/480p15/$scene.mp4 \
-        | tee | grep -F "ISO Media, MP4 Base Media v1 [IS0 14496-12:2003]"
+        | tee | grep -F "ISO Media, MP4 Base Media v1 [ISO 14496-12:2003]"
     done
   '';
 


### PR DESCRIPTION
Turns out that `O` and `0` are different characters, even though they look the same in many monospace fonts (including mine). Unfortunately, they look very different to `grep -F`...

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It was broken; now it's not.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
