### PR TITLE
python3Packages.deemix: init at 3.4.1

### DIFF
--- a/pkgs/development/python-modules/deemix/default.nix
+++ b/pkgs/development/python-modules/deemix/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, spotipy
+, click
+, pycryptodomex
+, mutagen
+, requests
+, deezer-py
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "deemix";
+  version = "3.4.1";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-FGzMFJOoKQPNq4tGI1KsMO+i9iBZhoz5Z67BFLEuv48=";
+  };
+
+  propagatedBuildInputs = [
+    spotipy
+    click
+    pycryptodomex
+    mutagen
+    requests
+    deezer-py
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [
+    "spotipy"
+    "click"
+    "Cryptodome"
+    "mutagen"
+    "requests"
+    "deezer"
+  ];
+
+  meta = with lib; {
+    homepage = "https://git.freezer.life/RemixDev/deemix-py";
+    description = "Deezer downloader built from the ashes of Deezloader Remix";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ natto1784 ];
+  };
+}

--- a/pkgs/development/python-modules/deezer-py/default.nix
+++ b/pkgs/development/python-modules/deezer-py/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "deezer-py";
+  version = "1.1.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-EAiGMSLrRsF03FMLkizy3Fm+nAldSTxe9KdXFFep0iQ=";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "requests" ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/RemixDev/deezer-py";
+    description = "A wrapper for all Deezer's APIs";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ natto1784 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1874,6 +1874,8 @@ in {
 
   decopatch = callPackage ../development/python-modules/decopatch { };
 
+  deemix = callPackage ../development/python-modules/deemix { };
+
   deep_merge = callPackage ../development/python-modules/deep_merge { };
 
   deepdiff = callPackage ../development/python-modules/deepdiff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1882,6 +1882,8 @@ in {
 
   deeptoolsintervals = callPackage ../development/python-modules/deeptoolsintervals { };
 
+  deezer-py = callPackage ../development/python-modules/deezer-py { };
+
   deezer-python = callPackage ../development/python-modules/deezer-python { };
 
   defcon = callPackage ../development/python-modules/defcon { };


### PR DESCRIPTION
###### Motivation for this change
Wanted to use/package this simple tool to download music from deezer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
