### PR TITLE
python3Packages.pyverilog: init at 1.3.0

### DIFF
--- a/pkgs/development/python-modules/pyverilog/default.nix
+++ b/pkgs/development/python-modules/pyverilog/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, jinja2
+, ply
+, verilog
+, pytest-pythonpath
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyverilog";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1a74k8r21swmfwvgv4c014y6nbcyl229fspxw89ygsgb0j83xnar";
+  };
+
+  disabled = pythonOlder "3.7";
+
+  patchPhase = ''
+    # The path to Icarus can still be overridden via an environment variable at runtime.
+    substituteInPlace pyverilog/vparser/preprocessor.py \
+      --replace "iverilog = 'iverilog'" "iverilog = '${verilog}/bin/iverilog'"
+  '';
+
+  propagatedBuildInputs = [
+    jinja2
+    ply
+    verilog
+  ];
+
+  checkInputs = [
+    pytest-pythonpath
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/PyHDI/Pyverilog";
+    description = "Python-based Hardware Design Processing Toolkit for Verilog HDL";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ trepetti ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7307,6 +7307,8 @@ in {
 
   pyvera = callPackage ../development/python-modules/pyvera { };
 
+  pyverilog = callPackage ../development/python-modules/pyverilog { };
+
   pyvesync = callPackage ../development/python-modules/pyvesync { };
 
   pyvex = callPackage ../development/python-modules/pyvex { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add pyverilog: "Python-based Hardware Design Processing Toolkit for Verilog HDL"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
