### PR TITLE
nixos postgresql-backup: add `compression` option

### DIFF
--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -43,6 +43,7 @@ let
     testScript = let
       backupName = if backup-all then "all" else "postgres";
       backupService = if backup-all then "postgresqlBackup" else "postgresqlBackup-postgres";
+      backupFileBase = "/var/backup/postgresql/${backupName}";
     in ''
       def check_count(statement, lines):
           return 'test $(sudo -u postgres psql postgres -tAc "{}"|wc -l) -eq {}'.format(
@@ -72,9 +73,32 @@ let
       with subtest("Backup service works"):
           machine.succeed(
               "systemctl start ${backupService}.service",
-              "zcat /var/backup/postgresql/${backupName}.sql.gz | grep '<test>ok</test>'",
+              "zcat ${backupFileBase}.sql.gz | grep '<test>ok</test>'",
               "ls -hal /var/backup/postgresql/ >/dev/console",
-              "stat -c '%a' /var/backup/postgresql/${backupName}.sql.gz | grep 600",
+              "stat -c '%a' ${backupFileBase}.sql.gz | grep 600",
+          )
+      with subtest("Backup service removes prev files"):
+          machine.succeed(
+              # Create dummy prev files.
+              "touch ${backupFileBase}.prev.sql{,.gz,.zstd}",
+              "chown postgres:postgres ${backupFileBase}.prev.sql{,.gz,.zstd}",
+
+              # Run backup.
+              "systemctl start ${backupService}.service",
+              "ls -hal /var/backup/postgresql/ >/dev/console",
+
+              # Since nothing has changed in the database, the cur and prev files
+              # should match.
+              "zcat ${backupFileBase}.sql.gz | grep '<test>ok</test>'",
+              "cmp ${backupFileBase}.sql.gz ${backupFileBase}.prev.sql.gz",
+
+              # The prev files with unused suffix should be removed.
+              "[ ! -f '${backupFileBase}.prev.sql' ]",
+              "[ ! -f '${backupFileBase}.prev.sql.zstd' ]",
+
+              # Both cur and prev file should only be accessible by the postgres user.
+              "stat -c '%a' ${backupFileBase}.sql.gz | grep 600",
+              "stat -c '%a' '${backupFileBase}.prev.sql.gz' | grep 600",
           )
       with subtest("Backup service fails gracefully"):
           # Sabotage the backup process
@@ -84,8 +108,8 @@ let
           )
           machine.succeed(
               "ls -hal /var/backup/postgresql/ >/dev/console",
-              "zcat /var/backup/postgresql/${backupName}.prev.sql.gz | grep '<test>ok</test>'",
-              "stat /var/backup/postgresql/${backupName}.in-progress.sql.gz",
+              "zcat ${backupFileBase}.prev.sql.gz | grep '<test>ok</test>'",
+              "stat ${backupFileBase}.in-progress.sql.gz",
           )
           # In a previous version, the second run would overwrite prev.sql.gz,
           # so we test a second run as well.
@@ -93,8 +117,8 @@ let
               "systemctl start ${backupService}.service",
           )
           machine.succeed(
-              "stat /var/backup/postgresql/${backupName}.in-progress.sql.gz",
-              "zcat /var/backup/postgresql/${backupName}.prev.sql.gz | grep '<test>ok</test>'",
+              "stat ${backupFileBase}.in-progress.sql.gz",
+              "zcat ${backupFileBase}.prev.sql.gz | grep '<test>ok</test>'",
           )
 
 


### PR DESCRIPTION
###### Motivation for this change

This option allows basic configuration of the compression technique used in the backup script. Specifically it adds `none` and `zstd` as new alternatives, keeping `gzip` as the default.

FWIW I ended up using "none" since it works relatively well with btrfs with compression enabled and it works _much_ better with Borg backup deduplication. I only have a tiny database though:

``` console
# for f in all.sql* ; do echo ; echo $f; compsize $f ; done

all.sql
Type       Perc     Disk Usage   Uncompressed Referenced
TOTAL       20%      1.7G         8.2G         8.2G
zstd        20%      1.7G         8.2G         8.2G

all.sql.gz
Type       Perc     Disk Usage   Uncompressed Referenced
TOTAL       99%      1.5G         1.5G         1.5G
none       100%      1.5G         1.5G         1.5G
zstd        33%      556K         1.6M         1.6M

all.sql.zstd
Type       Perc     Disk Usage   Uncompressed Referenced
TOTAL       99%     1022M        1022M        1022M
none       100%     1022M        1022M        1022M
zstd        82%      316K         384K         384K
```

On a system with no file system compression I would recommend zstd.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
