### PR TITLE
boost: use b2 from boost-build for building

### DIFF
--- a/pkgs/development/libraries/boost/default.nix
+++ b/pkgs/development/libraries/boost/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, callPackage
+, boost-build
+, fetchurl
+}:
+
+let
+  # for boost 1.55 we need to use 1.56's b2
+  # since 1.55's build system is not working
+  # with our derivation
+  useBoost156 = rec {
+    version = "1.56.0";
+    src = fetchurl {
+      url = "mirror://sourceforge/boost/boost_${lib.replaceStrings ["."] ["_"] version}.tar.bz2";
+      sha256 = "07gz62nj767qzwqm3xjh11znpyph8gcii0cqhnx7wvismyn34iqk";
+    };
+  };
+
+  makeBoost = file:
+    lib.fix (self:
+      callPackage file {
+        boost-build = boost-build.override {
+          # useBoost allows us passing in src and version from
+          # the derivation we are building to get a matching b2 version.
+          useBoost =
+            if lib.versionAtLeast self.version "1.56"
+            then self
+            else useBoost156; # see above
+        };
+      }
+    );
+in {
+  boost155 = makeBoost ./1.55.nix;
+  boost159 = makeBoost ./1.59.nix;
+  boost160 = makeBoost ./1.60.nix;
+  boost165 = makeBoost ./1.65.nix;
+  boost166 = makeBoost ./1.66.nix;
+  boost167 = makeBoost ./1.67.nix;
+  boost168 = makeBoost ./1.68.nix;
+  boost169 = makeBoost ./1.69.nix;
+  boost170 = makeBoost ./1.70.nix;
+  boost171 = makeBoost ./1.71.nix;
+  boost172 = makeBoost ./1.72.nix;
+  boost173 = makeBoost ./1.73.nix;
+  boost174 = makeBoost ./1.74.nix;
+  boost175 = makeBoost ./1.75.nix;
+}

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -3,6 +3,7 @@
 , fetchpatch
 , which
 , toolset ? /**/ if stdenv.cc.isClang  then "clang"
+            else if stdenv.cc.isGNU    then "gcc"
             else null
 , enableRelease ? true
 , enableDebug ? false
@@ -193,6 +194,7 @@ stdenv.mkDerivation {
     "--libdir=$(out)/lib"
     "--with-bjam=b2" # prevent bootstrapping b2 in configurePhase
   ] ++ optional enablePython "--with-python=${python.interpreter}"
+    ++ optional (toolset != null) "--with-toolset=${toolset}"
     ++ [ (if stdenv.hostPlatform == stdenv.buildPlatform then "--with-icu=${icu.dev}" else "--without-icu") ];
 
   buildPhase = ''

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, icu, expat, zlib, bzip2, python ? null, fixDarwinDylibNames, libiconv
+, boost-build
 , fetchpatch
 , which
-, buildPackages
 , toolset ? /**/ if stdenv.cc.isClang  then "clang"
             else null
 , enableRelease ? true
@@ -67,6 +67,8 @@ let
     else
       "$NIX_BUILD_CORES";
 
+  needUserConfig = stdenv.hostPlatform != stdenv.buildPlatform || useMpi || stdenv.isDarwin;
+
   b2Args = concatStringsSep " " ([
     "--includedir=$dev/include"
     "--libdir=$out/lib"
@@ -95,7 +97,7 @@ let
     ++ optional (variant == "release") "debug-symbols=off"
     ++ optional (toolset != null) "toolset=${toolset}"
     ++ optional (!enablePython) "--without-python"
-    ++ optional (useMpi || stdenv.hostPlatform != stdenv.buildPlatform) "--user-config=user-config.jam"
+    ++ optional needUserConfig "--user-config=user-config.jam"
     ++ optionals (stdenv.hostPlatform.libc == "msvcrt") [
     "threadapi=win32"
   ] ++ extraB2Args
@@ -137,22 +139,39 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ peti ];
   };
 
-  preConfigure = ''
-    if test -f tools/build/src/tools/clang-darwin.jam ; then
-        substituteInPlace tools/build/src/tools/clang-darwin.jam \
-          --replace '@rpath/$(<[1]:D=)' "$out/lib/\$(<[1]:D=)";
-    fi;
-  '' + optionalString useMpi ''
+  preConfigure = optionalString useMpi ''
     cat << EOF >> user-config.jam
     using mpi : ${mpi}/bin/mpiCC ;
     EOF
-  '' + optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  ''
+  # On darwin we need to add the `$out/lib` to the libraries' rpath explicitly,
+  # otherwise the dynamic linker is unable to resolve the reference to @rpath
+  # when the boost libraries want to load each other at runtime.
+  + optionalString (stdenv.isDarwin && enableShared) ''
     cat << EOF >> user-config.jam
-    using gcc : cross : ${stdenv.cc.targetPrefix}c++ ;
+    using clang-darwin : : ${stdenv.cc.targetPrefix}c++
+      : <linkflags>"-rpath $out/lib/"
+      ;
     EOF
-    # Build b2 with buildPlatform CC/CXX.
-    sed '2i export CC=$CC_FOR_BUILD; export CXX=$CXX_FOR_BUILD' \
-      -i ./tools/build/src/engine/build.sh
+  ''
+  # b2 has trouble finding the correct compiler and tools for cross compilation
+  # since it apparently ignores $CC, $AR etc. Thus we need to set everything
+  # in user-config.jam. To keep things simple we just set everything in an
+  # uniform way for clang and gcc (which works thanks to our cc-wrapper).
+  # We pass toolset later which will make b2 invoke everything in the right
+  # way -- the other toolset in user-config.jam will be ignored.
+  + optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    cat << EOF >> user-config.jam
+    using gcc : cross : ${stdenv.cc.targetPrefix}c++
+      : <archiver>$AR
+        <ranlib>$RANLIB
+      ;
+
+    using clang : cross : ${stdenv.cc.targetPrefix}c++
+      : <archiver>$AR
+        <ranlib>$RANLIB
+      ;
+    EOF
   '';
 
   NIX_CFLAGS_LINK = lib.optionalString stdenv.isDarwin
@@ -160,9 +179,8 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ which ]
+  nativeBuildInputs = [ which boost-build ]
     ++ optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
   buildInputs = [ expat zlib bzip2 libiconv ]
     ++ optional (stdenv.hostPlatform == stdenv.buildPlatform) icu
     ++ optional enablePython python
@@ -173,13 +191,13 @@ stdenv.mkDerivation {
   configureFlags = [
     "--includedir=$(dev)/include"
     "--libdir=$(out)/lib"
+    "--with-bjam=b2" # prevent bootstrapping b2 in configurePhase
   ] ++ optional enablePython "--with-python=${python.interpreter}"
-    ++ [ (if stdenv.hostPlatform == stdenv.buildPlatform then "--with-icu=${icu.dev}" else "--without-icu") ]
-    ++ optional (toolset != null) "--with-toolset=${toolset}";
+    ++ [ (if stdenv.hostPlatform == stdenv.buildPlatform then "--with-icu=${icu.dev}" else "--without-icu") ];
 
   buildPhase = ''
     runHook preBuild
-    ./b2 ${b2Args}
+    b2 ${b2Args}
     runHook postBuild
   '';
 
@@ -191,7 +209,7 @@ stdenv.mkDerivation {
     cp -a tools/boostbook/{xsl,dtd} $dev/share/boostbook/
 
     # Let boost install everything else
-    ./b2 ${b2Args} install
+    b2 ${b2Args} install
 
     runHook postInstall
   '';

--- a/pkgs/development/tools/boost-build/default.nix
+++ b/pkgs/development/tools/boost-build/default.nix
@@ -2,18 +2,36 @@
 , stdenv
 , fetchFromGitHub
 , bison
+# boost derivation to use for the src and version.
+# This is used by the boost derivation to build
+# a b2 matching their version (by overriding this
+# argument). Infinite recursion is not an issue
+# since we only look at src and version of boost.
+, useBoost ? {}
 }:
 
-stdenv.mkDerivation rec {
-  pname = "boost-build";
-  version = "4.4.1";
+let
+  defaultVersion = "4.4.1";
+in
 
-  src = fetchFromGitHub {
+stdenv.mkDerivation {
+  pname = "boost-build";
+  version =
+    if useBoost ? version
+    then "boost-${useBoost.version}"
+    else defaultVersion;
+
+  src = useBoost.src or (fetchFromGitHub {
     owner = "boostorg";
     repo = "build";
-    rev = version;
+    rev = defaultVersion;
     sha256 = "1r4rwlq87ydmsdqrik4ly5iai796qalvw7603mridg2nwcbbnf54";
-  };
+  });
+
+  # b2 is in a subdirectory of boost source tarballs
+  postUnpack = lib.optionalString (useBoost ? src) ''
+    sourceRoot="$sourceRoot/tools/build"
+  '';
 
   patches = [
     # Upstream defaults to gcc on darwin, but we use clang.
@@ -32,8 +50,13 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     ./b2 install --prefix="$out"
-    ln -s b2 "$out/bin/bjam"
+
+    # older versions of b2 created this symlink,
+    # which we want to support building via useBoost.
+    test -e "$out/bin/bjam" || ln -s b2 "$out/bin/bjam"
+
     runHook postInstall
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14815,22 +14815,25 @@ in
 
   boolstuff = callPackage ../development/libraries/boolstuff { };
 
-  boost155 = callPackage ../development/libraries/boost/1.55.nix { };
-  boost159 = callPackage ../development/libraries/boost/1.59.nix { };
+  inherit (callPackage ../development/libraries/boost { inherit (buildPackages) boost-build; })
+    boost155
+    boost159
+    boost160
+    boost165
+    boost166
+    boost167
+    boost168
+    boost169
+    boost170
+    boost171
+    boost172
+    boost173
+    boost174
+    boost175
+  ;
+
   boost15x = boost159;
-  boost160 = callPackage ../development/libraries/boost/1.60.nix { };
-  boost165 = callPackage ../development/libraries/boost/1.65.nix { };
-  boost166 = callPackage ../development/libraries/boost/1.66.nix { };
-  boost167 = callPackage ../development/libraries/boost/1.67.nix { };
-  boost168 = callPackage ../development/libraries/boost/1.68.nix { };
-  boost169 = callPackage ../development/libraries/boost/1.69.nix { };
   boost16x = boost169;
-  boost170 = callPackage ../development/libraries/boost/1.70.nix { };
-  boost171 = callPackage ../development/libraries/boost/1.71.nix { };
-  boost172 = callPackage ../development/libraries/boost/1.72.nix { };
-  boost173 = callPackage ../development/libraries/boost/1.73.nix { };
-  boost174 = callPackage ../development/libraries/boost/1.74.nix { };
-  boost175 = callPackage ../development/libraries/boost/1.75.nix { };
   boost17x = boost175;
   boost = boost16x;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Fixes a few cross compilation issues which broke e. g. `pkgsLLVM.boost`
* Gets rid of hacks to make boost understand nixpkgs' `CC_FOR_BUILD`
* Should overall decrease build time for boost a little bit

See commit messages for more details.

Built all `boost` versions on `x86_64-linux`, but darwin needs testing, I suspect we may need to reintroduce the removed hack for that in some way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
