### PR TITLE
openipmi: add new package

### DIFF
--- a/pkgs/tools/system/openipmi/default.nix
+++ b/pkgs/tools/system/openipmi/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, popt, ncurses, python3, readline, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "OpenIPMI";
+  version = "2.0.31";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/openipmi/OpenIPMI-${version}.tar.gz";
+    sha256 = "05wpkn74nxqp5p6sa2yaf2ajrh8b0gfkb7y4r86lnigz4rvz6lkh";
+  };
+
+  buildInputs = [ ncurses popt python3 readline ];
+
+  outputs = [ "out" "lib" "dev" "man" ];
+
+  meta = with lib; {
+    homepage = "https://openipmi.sourceforge.io/";
+    description = "A user-level library that provides a higher-level abstraction of IPMI and generic services";
+    license = with licenses; [ gpl2Only lgpl2Only ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ arezvov SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6689,6 +6689,8 @@ in
 
   np2kai = callPackage ../misc/emulators/np2kai { };
 
+  openipmi = callPackage ../tools/system/openipmi { };
+
   ox = callPackage ../applications/editors/ox { };
 
   file-rename = callPackage ../tools/filesystems/file-rename { };


### PR DESCRIPTION
###### Motivation for this change

Some IPMI utils and library. Actually now I need this package as a library for IPMI support in zabbix server, but I hope it's can be useful for someone else.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
