### PR TITLE
chromiumDev: 93.0.4577.18 -> 94.0.4595.0

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -3,6 +3,7 @@
 
 """This script automatically updates chromium, google-chrome, chromedriver, and ungoogled-chromium
 via upstream-info.json."""
+# Usage: ./update.py [--commit]
 
 import csv
 import json
@@ -22,6 +23,7 @@ DEB_URL = 'https://dl.google.com/linux/chrome/deb/pool/main/g'
 BUCKET_URL = 'https://commondatastorage.googleapis.com/chromium-browser-official'
 
 JSON_PATH = dirname(abspath(__file__)) + '/upstream-info.json'
+COMMIT_MESSAGE_SCRIPT = dirname(abspath(__file__)) + '/get-commit-message.py'
 
 
 def load_json(path):
@@ -117,6 +119,21 @@ def channel_name_to_attr_name(channel_name):
     sys.exit(1)
 
 
+def get_channel_key(item):
+    """Orders Chromium channels by their name."""
+    channel_name = item[0]
+    if channel_name == 'stable':
+        return 0
+    if channel_name == 'beta':
+        return 1
+    if channel_name == 'dev':
+        return 2
+    if channel_name == 'ungoogled-chromium':
+        return 3
+    print(f'Error: Unexpected channel: {channel_name}', file=sys.stderr)
+    sys.exit(1)
+
+
 def print_updates(channels_old, channels_new):
     """Print a summary of the updates."""
     print('Updates:')
@@ -192,21 +209,31 @@ with urlopen(HISTORY_URL) as resp:
         channels[channel_name] = channel
 
 
-with open(JSON_PATH, 'w') as out:
-    def get_channel_key(item):
-        """Orders Chromium channels by their name."""
-        channel_name = item[0]
-        if channel_name == 'stable':
-            return 0
-        if channel_name == 'beta':
-            return 1
-        if channel_name == 'dev':
-            return 2
-        if channel_name == 'ungoogled-chromium':
-            return 3
-        print(f'Error: Unexpected channel: {channel_name}', file=sys.stderr)
-        sys.exit(1)
-    sorted_channels = OrderedDict(sorted(channels.items(), key=get_channel_key))
-    json.dump(sorted_channels, out, indent=2)
-    out.write('\n')
+sorted_channels = OrderedDict(sorted(channels.items(), key=get_channel_key))
+if len(sys.argv) == 2 and sys.argv[1] == '--commit':
+    for channel_name in sorted_channels.keys():
+        version_old = last_channels[channel_name]['version']
+        version_new = sorted_channels[channel_name]['version']
+        if LooseVersion(version_old) < LooseVersion(version_new):
+            last_channels[channel_name] = sorted_channels[channel_name]
+            with open(JSON_PATH, 'w') as out:
+                json.dump(last_channels, out, indent=2)
+                out.write('\n')
+            attr_name = channel_name_to_attr_name(channel_name)
+            commit_message = f'{attr_name}: {version_old} -> {version_new}'
+            if channel_name == 'stable':
+                body = subprocess.check_output([COMMIT_MESSAGE_SCRIPT]).decode('utf-8')
+                prefix = f'chromium: TODO -> {version_new}'
+                if not body.startswith(prefix):
+                    print("Error: Couldn't fetch the the release notes for the following update:")
+                    print(commit_message)
+                    sys.exit(1)
+                body = body.removeprefix(prefix)
+                commit_message += body
+            subprocess.run(['git', 'add', JSON_PATH], check=True)
+            subprocess.run(['git', 'commit', '--file=-'], input=commit_message.encode(), check=True)
+else:
+    with open(JSON_PATH, 'w') as out:
+        json.dump(sorted_channels, out, indent=2)
+        out.write('\n')
     print_updates(last_channels, sorted_channels)

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "93.0.4577.18",
-    "sha256": "1h1ppyizj5vbnrv11iy9vlcpcv8mgb9r8m2zmz6vp7q1ch6w0w4x",
-    "sha256bin64": "14cw0k4gsilybg7gbbbmck62i0prq5rm6hwqalmmmiqcldrw05mq",
+    "version": "94.0.4595.0",
+    "sha256": "0ksd7vqpbiplbg2xpm566z7p7qp57r27a3pk6ss1qz8v18490092",
+    "sha256bin64": "1kibyhgwcgby3hnhjdg2vrgbj4dvvbicqlcj4id9761zw1jhz8r4",
     "deps": {
       "gn": {
-        "version": "2021-07-08",
+        "version": "2021-07-31",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "24e2f7df92641de0351a96096fb2c490b2436bb8",
-        "sha256": "1lwkyhfhw0zd7daqz466n7x5cddf0danr799h4jg3s0yvd4galjl"
+        "rev": "eea3906f0e2a8d3622080127d2005ff214d51383",
+        "sha256": "1wc969jrivb502c45wdcbgh0c5888nqxla05is9bimkrk9rqppw3"
       }
     }
   },


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`nix-build nixos/tests/chromium.nix -A chrome-dev` still succeeds. Chromium build is running.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
