### PR TITLE
mkShellMinimal: Create an ultra minimal nix-shell

### DIFF
--- a/doc/builders/special.xml
+++ b/doc/builders/special.xml
@@ -7,4 +7,5 @@
  </para>
  <xi:include href="special/fhs-environments.section.xml" />
  <xi:include href="special/mkshell.section.xml" />
+ <xi:include href="special/mkshellMinimal.section.xml" />
 </chapter>

--- a/doc/builders/special/mkshellMinimal.section.md
+++ b/doc/builders/special/mkshellMinimal.section.md
@@ -1,0 +1,38 @@
+# pkgs.mkShellMinimal {#sec-pkgs-mkShellMinimal}
+
+`pkgs.mkShellMinimal` is similar to `mkShell` but does not rely on the
+`stdenv` or even `bash`. It has a much smaller footprint and feature-set than
+`mkShell` and is useful if you care about your closure size or being very explicit
+about the dependencies (i.e. coreutils vs. busybox).
+
+## Usage {#sec-pkgs-mkShellMinimal-usage}
+
+```nix
+let
+  nixpkgs = import <nixpkgs> { };
+in
+with nixpkgs;
+mkShellMinimal {
+  name = "my-minimal-shell";
+
+  # Place your dependencies here
+  packages = [ ];
+
+  # You can do typical environment variable setting
+  FOO = "bar";
+}
+```
+
+This shell can be started with `nix-shell` and has zero dependencies.
+
+```bash
+❯ nix path-info -rSsh $(nix-build shell.nix)
+This derivation is not meant to be built, unless you want to capture the dependency closure.
+
+/nix/store/8ka1hnlf06z3h2rpd00b4d9w5yxh0n39-setup        	 376.0 	 376.0
+/nix/store/nprykggfqhdkn4r5lxxknjvlqc4qm1yl-builder.sh   	 280.0 	 280.0
+/nix/store/xd8d72ccrxhaz3sxlmiqjnn1z0zwfhm8-my-minimal-shell	 744.0 	   1.4K
+```
+
+`mkShellMinimal` is buildable as opposed to `mkShell`. This is useful if you want to upload the
+transitive closure of the shell to a remote nix-store.

--- a/pkgs/build-support/mkshell/minimal.nix
+++ b/pkgs/build-support/mkshell/minimal.nix
@@ -1,0 +1,62 @@
+{ writeTextFile, writeScript, system }:
+
+# A special kind of derivation that is only meant to be consumed by the
+# nix-shell. This differs from the traditional `mkShell` in that:
+# It does not come with traditional stdenv (i.e. coreutils).
+# Its only dependency is essentially bash.
+{
+# a list of packages to add to the shell environment
+# we simplify here rather than `native` or `propagated` since
+# this is only ever used to be in a nix-shell; which is by default
+# the current system
+packages ? [ ], ... }@attrs:
+derivation ({
+  inherit system;
+
+  name = "minimal-nix-shell";
+
+  # What is the need for this reference to stdenv?
+  # Well Nix itself, checks to see if this attribute exists
+  # and sources the file.
+  # We will setup our nix-shell environment here and do things
+  # like clear the $PATH
+  # reference: https://github.com/NixOS/nix/blob/94ec9e47030c2a7280503d338f0dca7ad92811f5/src/nix-build/nix-build.cc#L494
+  "stdenv" = writeTextFile rec {
+    name = "setup";
+    executable = true;
+    destination = "/${name}";
+    text = ''
+      set -e
+
+      # This is needed for `--pure` to work as expected.
+      # https://github.com/NixOS/nix/issues/5092
+      PATH=
+
+      for p in $packages; do
+        export PATH=$p/bin:$PATH
+      done
+    '';
+  };
+
+  # Typically `mkShell` is not buildable. This has made it in practice, difficult to upload
+  # the dependency closure to a binary cache. Rather than add a confusing attribute to capture this
+  # let's just make the nix-shell buildable but message to the user that it doesn't make much sense.
+  #
+  #
+  # The builtin `export` dumps all current environment variables,
+  # which is where all build input references end up (e.g. $PATH for
+  # binaries). By writing this to $out, Nix can find and register
+  # them as runtime dependencies (since Nix greps for store paths
+  # through $out to find them)
+  # https://github.com/NixOS/nixpkgs/pull/95536/files#diff-282a02cc3871874f16401347d8fadc90d59d7ab11f6a99eaa5173c3867e1a160R358
+  #
+  # For purity you generally don't want to rely on /bin/sh but since this derivation is *strictly* for a nix-shell
+  # we can rely on the fact that the underlying system is POSIX compliant.
+  builder = writeScript "builder.sh" ''
+    #!/bin/sh
+    echo
+    echo "This derivation is not meant to be built, unless you want to capture the dependency closure.";
+    echo
+    export > $out
+  '';
+} // attrs)

--- a/pkgs/build-support/mkshell/minimal.nix
+++ b/pkgs/build-support/mkshell/minimal.nix
@@ -15,11 +15,8 @@ derivation ({
 
   name = "minimal-nix-shell";
 
-  # What is the need for this reference to stdenv?
-  # Well Nix itself, checks to see if this attribute exists
-  # and sources the file.
-  # We will setup our nix-shell environment here and do things
-  # like clear the $PATH
+  # Nix checks if the stdenv attribute exists and sources that
+  # We use it here to setup the pure enviroment and do to clear envs like PATH
   # reference: https://github.com/NixOS/nix/blob/94ec9e47030c2a7280503d338f0dca7ad92811f5/src/nix-build/nix-build.cc#L494
   "stdenv" = writeTextFile rec {
     name = "setup";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -623,6 +623,7 @@ in
 
   mkShell = callPackage ../build-support/mkshell { };
   mkShellNoCC = mkShell.override { stdenv = stdenvNoCC; };
+  mkShellMinimal = callPackage ../build-support/mkshell/minimal.nix { };
 
   nixBufferBuilders = import ../build-support/emacs/buffer.nix { inherit (pkgs) lib writeText; inherit (emacs.pkgs) inherit-local; };
 


### PR DESCRIPTION
###### Motivation for this change
This shell is inspired [some investigation](https://fzakaria.com/2021/08/02/a-minimal-nix-shell.html) I did
and a [follow-up example](https://github.com/jappeace/mt-shell) that demonstrated starting a _nix-shell_ with a minimal _builder.sh_.

The goal is to provide the facility to create an ultra-lightweight _nix-shell_ that only has bash as the direct dependency. Users can set environment variables and add packages but the feature-set is purposely minimal.

> The following Nix expression **works** and is pointing to the latest commit of this PR

```nix
let
  nixpkgs = import (builtins.fetchTarball {
    name = "nixpkgs-fzakaria-fork-2021-08-03";
    url =
      "https://github.com/fzakaria/nixpkgs/archive/refs/heads/faridzakaria/pure-mkShell.tar.gz";
    sha256 = "1h7aqlivq2hax7k7a612mffpfkawn1mfd3jfszzpx19i2fxwmqp2";
  }) { };
in
with nixpkgs;
mkShellMinimal {
  name = "my-test-shell";
  packages = [ ripgrep ];
  FOO = bar;
}
```

This minimal nix-shell has effectively a **0** (1.4 KiB) size closure.
```bash
❯ nix path-info -rSsh $(nix-build -I nixpkgs=/home/fmzakari/code/github.com/NixOS/nixpkgs test-shell-local.nix)
these derivations will be built:
  /nix/store/xaqxyk1y3zjk0qwpxkm0n3n6c05bj6fn-setup.drv
  /nix/store/rxrbwvk7rjvknil7ns1ki00n4vfqcs8h-my-test-shell.drv
building '/nix/store/xaqxyk1y3zjk0qwpxkm0n3n6c05bj6fn-setup.drv'...
building '/nix/store/rxrbwvk7rjvknil7ns1ki00n4vfqcs8h-my-test-shell.drv'...

This derivation is not meant to be built, unless you want to capture the dependency closure.

/nix/store/8ka1hnlf06z3h2rpd00b4d9w5yxh0n39-setup        	 376.0 	 376.0 
/nix/store/nprykggfqhdkn4r5lxxknjvlqc4qm1yl-builder.sh   	 280.0 	 280.0 
/nix/store/xd8d72ccrxhaz3sxlmiqjnn1z0zwfhm8-my-test-shell	 744.0 	   1.4K
```

###### Things TODO
- [x] I am still missing the necessary hook to clear _$PATH_ when _nix-shell_ is started pure. This exercise has actually shown how tied the nix-shell and stdenv concepts are.
- [x] Add support for _inputDerivation_ similar to what @Infinisil added for mkDerivation
- [x] calculate the new closure-size (should be 0?) for the minimal shell.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
