### PR TITLE
nixos/hqplayerd: set HOME to path in state directory

### DIFF
--- a/nixos/modules/services/audio/hqplayerd.nix
+++ b/nixos/modules/services/audio/hqplayerd.nix
@@ -100,8 +100,9 @@ in
 
     systemd = {
       tmpfiles.rules = [
-        "d ${configDir} 0755 ${cfg.user} ${cfg.group} - -"
-        "d ${stateDir}  0755 ${cfg.user} ${cfg.group} - -"
+        "d ${configDir}      0755 ${cfg.user} ${cfg.group} - -"
+        "d ${stateDir}       0755 ${cfg.user} ${cfg.group} - -"
+        "d ${stateDir}/home  0755 ${cfg.user} ${cfg.group} - -"
       ];
 
       services.hqplayerd = {
@@ -109,6 +110,8 @@ in
         wantedBy = [ "multi-user.target" ];
         requires = [ "network-online.target" "sound.target" "systemd-udev-settle.service" ];
         after = [ "network-online.target" "sound.target" "systemd-udev-settle.service" "local-fs.target" "remote-fs.target" "systemd-tmpfiles-setup.service" ];
+
+        environment.HOME = "${stateDir}/home";
 
         unitConfig.ConditionPathExists = [ configDir stateDir ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The service likes to write files uploaded by the user to the service
user's $HOME. In our case the hqplayerd user has no home directory,
since it's a system user, and regardless we'd like to keep the service's
state contained.

With this change the unit forces HOME to point to
/var/lib/hqplayer/home, which works around the issue.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
