### PR TITLE
element-desktop: fix darwin build

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -2,6 +2,9 @@
 , makeWrapper, makeDesktopItem, mkYarnPackage
 , electron, element-web
 , callPackage
+, Security
+, AppKit
+, CoreServices
 }:
 # Notes for maintainers:
 # * versions of `element-web` and `element-desktop` should be kept in sync.
@@ -25,8 +28,8 @@ in mkYarnPackage rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  seshat = callPackage ./seshat {};
-  keytar = callPackage ./keytar {};
+  seshat = callPackage ./seshat { inherit CoreServices; };
+  keytar = callPackage ./keytar { inherit Security AppKit; };
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
@@ -1,4 +1,4 @@
-{ rustPlatform, fetchFromGitHub, callPackage, sqlcipher, nodejs-14_x, python3, yarn, fixup_yarn_lock }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub, callPackage, sqlcipher, nodejs-14_x, python3, yarn, fixup_yarn_lock, CoreServices }:
 
 rustPlatform.buildRustPackage rec {
   pname = "seshat-node";
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   sourceRoot = "source/seshat-node/native";
 
   nativeBuildInputs = [ nodejs-14_x python3 yarn ];
-  buildInputs = [ sqlcipher ];
+  buildInputs = [ sqlcipher ] ++ lib.optional stdenv.isDarwin CoreServices;
 
   npm_config_nodedir = nodejs-14_x;
 
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
   buildPhase = ''
     cd ..
     chmod u+w . ./yarn.lock
-    export HOME=/tmp
+    export HOME=$PWD/tmp
+    mkdir -p $HOME
     yarn config --offline set yarn-offline-mirror ${yarnOfflineCache}
     ${fixup_yarn_lock}/bin/fixup_yarn_lock yarn.lock
     yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
@@ -37,6 +38,7 @@ rustPlatform.buildRustPackage rec {
     shopt -s extglob
     rm -rf native/!(index.node)
     rm -rf node_modules
+    rm -rf $HOME
     cp -r . $out
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2632,7 +2632,9 @@ in
 
   element = callPackage ../applications/science/chemistry/element { };
 
-  element-desktop = callPackage ../applications/networking/instant-messengers/element/element-desktop.nix { };
+  element-desktop = callPackage ../applications/networking/instant-messengers/element/element-desktop.nix {
+    inherit (darwin.apple_sdk.frameworks) Security AppKit CoreServices;
+  };
 
   element-web = callPackage ../applications/networking/instant-messengers/element/element-web.nix {
     conf = config.element-web.conf or {};


### PR DESCRIPTION
###### Motivation for this change
Add Frameworks to native dependencies.
Element-desktop did not build on Darwin after the new changes to keytar end seshat.
Starting element-desktop starting the wrapper seems to be broken, but with a workaround starting it via `Electron.app` message searching works as well

###### Things done
Added the needed Darwin Frameworks

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
