### PR TITLE
[21.05] cabal2nix: 2.17.0 -> 2.18.0

### DIFF
--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -49,5 +49,11 @@ self: super: {
   arion-compose = self.callPackage ../../applications/virtualization/arion/arion-compose.nix {};
   # cabal2nix cabal://ap-normalize-0.1.0.1
   ap-normalize = self.callPackage ../misc/haskell/ap-normalize {};
+  # cabal2nix cabal://distribution-nixpkgs
+  distribution-nixpkgs_1_6_0 = self.callPackage ../misc/haskell/distribution-nixpkgs.nix {};
+  # cabal2nix cabal://cabal2nix-2.18.0
+  cabal2nix = self.callPackage ../misc/haskell/cabal2nix.nix {
+    distribution-nixpkgs = self.distribution-nixpkgs_1_6_0;
+  };
 
 }

--- a/pkgs/development/misc/haskell/cabal2nix.nix
+++ b/pkgs/development/misc/haskell/cabal2nix.nix
@@ -1,0 +1,35 @@
+{ mkDerivation, aeson, ansi-wl-pprint, base, bytestring, Cabal
+, containers, deepseq, directory, distribution-nixpkgs, filepath
+, hackage-db, hopenssl, hpack, language-nix, lens, lib, monad-par
+, monad-par-extras, mtl, optparse-applicative, pretty, process
+, split, tasty, tasty-golden, text, time, transformers, yaml
+}:
+mkDerivation {
+  pname = "cabal2nix";
+  version = "2.18.0";
+  sha256 = "4b90602dc0878c2e4a3e7def2c2ae0e99782b2f0d53d8e3914adaa43038b1f86";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson ansi-wl-pprint base bytestring Cabal containers deepseq
+    directory distribution-nixpkgs filepath hackage-db hopenssl hpack
+    language-nix lens optparse-applicative pretty process split text
+    time transformers yaml
+  ];
+  executableHaskellDepends = [
+    aeson base bytestring Cabal containers directory
+    distribution-nixpkgs filepath hopenssl language-nix lens monad-par
+    monad-par-extras mtl optparse-applicative pretty
+  ];
+  testHaskellDepends = [
+    base Cabal containers directory filepath language-nix lens pretty
+    process tasty tasty-golden
+  ];
+  preCheck = ''
+    export PATH="$PWD/dist/build/cabal2nix:$PATH"
+    export HOME="$TMPDIR/home"
+  '';
+  homepage = "https://github.com/nixos/cabal2nix#readme";
+  description = "Convert Cabal files into Nix build instructions";
+  license = lib.licenses.bsd3;
+}

--- a/pkgs/development/misc/haskell/distribution-nixpkgs.nix
+++ b/pkgs/development/misc/haskell/distribution-nixpkgs.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, aeson, base, bytestring, Cabal, containers, deepseq
+, hspec, language-nix, lens, lib, pretty, process, split
+}:
+mkDerivation {
+  pname = "distribution-nixpkgs";
+  version = "1.6.0";
+  sha256 = "d1804dcb731858d40859f1cf55ea81b3f6bc63a353437c1009c158e0f9e03354";
+  revision = "1";
+  editedCabalFile = "0j35y7ws7rbc68vkmyvpa4m2dyfpzpzzvm4lv7h6r7x34w331dgg";
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    aeson base bytestring Cabal containers deepseq language-nix lens
+    pretty process split
+  ];
+  testHaskellDepends = [ base deepseq hspec lens ];
+  homepage = "https://github.com/NixOS/distribution-nixpkgs";
+  description = "Types and functions to manipulate the Nixpkgs distribution";
+  license = lib.licenses.bsd3;
+}


### PR DESCRIPTION
https://github.com/NixOS/cabal2nix/blob/v2.18.0/CHANGELOG.md

2.18.0 mostly brings bug fixes, especially the one fixing the unclear
error message if a cabal file was missing (which was forgotten in the
changelog). It is not technically a non-breaking change since the
Haskell API changed.

Since there shouldn't be any breakage for users and all known reverse
dependencies of cabal2nix have been broken for a while, the benefits
of backporting outweigh the risks.

Let's wait with merging a bit though, since 2.18 was updated in master
just now, so there may some unknown problems.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
