### PR TITLE
rambox: 0.7.7 -> 0.7.8

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -4,16 +4,16 @@ let
   mkRambox = opts: callPackage (import ./rambox.nix opts) { };
 in mkRambox rec {
   pname = "rambox";
-  version = "0.7.7";
+  version = "0.7.8";
 
   src = {
     x86_64-linux = fetchurl {
       url = "https://github.com/ramboxapp/community-edition/releases/download/${version}/Rambox-${version}-linux-x86_64.AppImage";
-      sha256 = "0f82hq0dzcjicdz6lkzj8889y100yqciqrwh8wjjy9pxkhjcdini";
+      sha256 = "1y3c9xh8594ay95rj9vaqxxzibwpc38n7ixxi2wnsrdbrqrwlc63";
     };
     i686-linux = fetchurl {
       url = "https://github.com/ramboxapp/community-edition/releases/download/${version}/Rambox-${version}-linux-i386.AppImage";
-      sha256 = "1nhgqjha10jvyf9nsghvlkibg7byj8qz140639ygag9qlpd52rfs";
+      sha256 = "07sv384nd2i701fkjgsrlib8jfsa01bvj60gnqdwlnpphlknga3h";
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
 
@@ -24,8 +24,5 @@ in mkRambox rec {
     maintainers = with maintainers; [ ];
     platforms = ["i686-linux" "x86_64-linux"];
     hydraPlatforms = [];
-    knownVulnerabilities = [
-      "Electron 7.2.4 is EOL and contains at least the following vulnerabilities: CVE-2020-6458, CVE-2020-6460 and more (https://www.electronjs.org/releases/stable?version=7). Consider using an alternative such as `ferdi'."
-    ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/rambox/rambox.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/rambox.nix
@@ -1,6 +1,6 @@
 { pname, version, src, meta, desktopName ? "Rambox" }:
 
-{ appimageTools, lib, fetchurl, makeDesktopItem }:
+{ appimageTools, lib, fetchurl, gsettings-desktop-schemas, gtk3, makeDesktopItem }:
 
 let
   name = "${pname}-${version}";
@@ -19,6 +19,9 @@ let
   };
 in appimageTools.wrapType2 rec {
   inherit name src meta;
+  profile = ''
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications $out/share/icons/hicolor/256x256/apps


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream updated Electron dependency from 7.2.4 to 11.4.10 and also dialogs of downloads are fixed with added XDG_DATA_DIRS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
