### PR TITLE
teleport: 6.2.7 -> 6.2.8

### DIFF
--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -4,21 +4,21 @@ let
   webassets = fetchFromGitHub {
     owner = "gravitational";
     repo = "webassets";
-    rev = "8a30ee4e3570c7db0566028b6b562167aa40f646";
-    sha256 = "sha256-noMVcB1cjiMcRke6/qJIzDaEh4uPIewsedLQRdPbzIQ=";
+    rev = "c63397375632f1a4323918dde78334472f3ffbb9";
+    sha256 = "sha256-6YKk0G3s+35PRsUBkKgu/tNoSSwjJ5bTn8DACF4gYr4=";
   };
 in
 
 buildGoModule rec {
   pname = "teleport";
-  version = "6.2.7";
+  version = "6.2.8";
 
   # This repo has a private submodule "e" which fetchgit cannot handle without failing.
   src = fetchFromGitHub {
     owner = "gravitational";
     repo = "teleport";
     rev = "v${version}";
-    sha256 = "0ychs2pqi3awbr0vraz0ksddwk5hihrd1d9raq8mxyw5dz5124ki";
+    sha256 = "sha256-TVjdz97CUXBKCQh9bYrvtcH4StblBMsXiQ9Gix/NIm4=";
   };
 
   vendorSha256 = null;
@@ -27,8 +27,12 @@ buildGoModule rec {
 
   nativeBuildInputs = [ zip makeWrapper ];
 
-  # https://github.com/NixOS/nixpkgs/issues/120738
-  patches = [ ./tsh.patch ];
+  patches = [
+    # https://github.com/NixOS/nixpkgs/issues/120738
+    ./tsh.patch
+    # https://github.com/NixOS/nixpkgs/issues/132652
+    ./test.patch
+  ];
 
   postBuild = ''
     pushd .

--- a/pkgs/servers/teleport/test.patch
+++ b/pkgs/servers/teleport/test.patch
@@ -1,0 +1,13 @@
+diff --git a/tool/tsh/resolve_default_addr_test.go b/tool/tsh/resolve_default_addr_test.go
+index d5976f156..aec5199aa 100644
+--- a/tool/tsh/resolve_default_addr_test.go
++++ b/tool/tsh/resolve_default_addr_test.go
+@@ -237,7 +237,7 @@ func TestResolveDefaultAddrTimeoutBeforeAllRacersLaunched(t *testing.T) {
+
+ 	blockingHandler, doneCh := newWaitForeverHandler()
+
+-	servers := make([]*httptest.Server, 1000)
++	servers := make([]*httptest.Server, 100)
+ 	for i := 0; i < len(servers); i++ {
+ 		servers[i] = makeTestServer(t, blockingHandler)
+ 	}


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #132652

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
