### PR TITLE
Fix libnvidia-container when running x-server on intel

### DIFF
--- a/pkgs/applications/virtualization/libnvidia-container/default.nix
+++ b/pkgs/applications/virtualization/libnvidia-container/default.nix
@@ -8,6 +8,7 @@
 , libseccomp
 , rpcsvc-proto
 , libtirpc
+, nvidia_x11
 , makeWrapper
 , substituteAll
 , go
@@ -75,6 +76,7 @@ stdenv.mkDerivation rec {
       -e 's#all: shared static tools#all: shared tools#g' \
       -e '/$(INSTALL) -m 644 $(LIB_STATIC) $(DESTDIR)$(libdir)/d' \
       -e '/$(INSTALL) -m 755 $(libdir)\/$(LIBGO_SHARED) $(DESTDIR)$(libdir)/d'
+    sed -i "s#/run/nvidia-docker/bin:/run/nvidia-docker/extras/bin#${nvidia_x11.bin}/origBin#" src/nvc_info.c
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19828,7 +19828,9 @@ with pkgs;
     in symlinkJoin {
       inherit name;
       paths = [
-        (callPackage ../applications/virtualization/libnvidia-container { })
+        (callPackage ../applications/virtualization/libnvidia-container {
+          inherit (linuxPackages) nvidia_x11;
+        })
         nvidia-container-runtime
         (callPackage ../applications/virtualization/nvidia-container-toolkit {
           inherit nvidia-container-runtime;


### PR DESCRIPTION
###### Motivation for this change

When using nvidia-docker while running your X-server on intel (internal GPU), nvidia binaries are not propagated in /run/nvida-docker/bin (note: when X-server runs on nvidia, they are linked to /run/nvida-docker/bin from the nix-store (see code)). 
This PR works around this issue, by linking the binaries into docker not via the /run/nvidia-docker path, but via the nix-store directly.

Closes #131608

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
