### PR TITLE
[Backport 21.05] linuxPackages.evdi: unstable-2021-06-11 -> unstable-2021-07-7

### DIFF
--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel, libdrm }:
+{ lib, stdenv, fetchFromGitHub, kernel, libdrm }:
 
 stdenv.mkDerivation rec {
   pname = "evdi";
-  version = "unstable-20210401";
+  version = "unstable-2021-07-07";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = pname;
-    rev = "b0b3d131b26df62664ca33775679eea7b70c47b1";
-    sha256 = "09apbvdc78bbqzja9z3b1wrwmqkv3k7cn3lll5gsskxjnqbhxk9y";
+    rev = "b0b2c80eb63f9b858b71afa772135f434aea192a";
+    sha256 = "sha256-io+CbZovGjEJjwtmARFH23Djt933ONoHMDoea+i6xFo=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
(cherry picked from commit 335632575cef3182d8beee6d96bf76d4cd059898)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

Result of `nixpkgs-review pr 132668` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxPackages-libre.evdi</li>
    <li>linuxPackages_4_14.evdi</li>
    <li>linuxPackages_4_4.evdi</li>
    <li>linuxPackages_4_9.evdi</li>
    <li>linuxPackages_latest-libre.evdi</li>
  </ul>
</details>
<details>
  <summary>12 packages built:</summary>
  <ul>
    <li>displaylink</li>
    <li>linuxPackages.evdi</li>
    <li>linuxPackages_4_19.evdi</li>
    <li>linuxPackages_5_12.evdi</li>
    <li>linuxPackages_5_13.evdi</li>
    <li>linuxPackages_5_4.evdi</li>
    <li>linuxPackages_hardened.evdi</li>
    <li>linuxPackages_latest_hardened.evdi</li>
    <li>linuxPackages_lqx.evdi</li>
    <li>linuxPackages_testing_bcachefs.evdi</li>
    <li>linuxPackages_xanmod.evdi</li>
    <li>linuxPackages_zen.evdi</li>
  </ul>
</details>


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
