### PR TITLE
emacs.pkgs: Propagate overriden scope to emacs package in set

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23951,8 +23951,8 @@ in
   };
 
   emacsPackagesFor = emacs: import ./emacs-packages.nix {
-    inherit (lib) makeScope makeOverridable;
-    inherit emacs;
+    inherit (lib) makeScope makeOverridable dontRecurseIntoAttrs;
+    emacs' = emacs;
     pkgs' = pkgs;  # default pkgs used for bootstrapping the emacs package set
   };
 

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -21,7 +21,12 @@
   (package-initialize)
 */
 
-{ pkgs', makeScope, makeOverridable, emacs }:
+{ pkgs'
+, emacs'
+, makeScope
+, makeOverridable
+, dontRecurseIntoAttrs
+}:
 
 let
 
@@ -71,7 +76,12 @@ in makeScope pkgs'.newScope (self: makeOverridable ({
   // manualPackages // { inherit manualPackages; }
   // {
 
-    inherit emacs;
+    # Propagate overriden scope
+    emacs = emacs'.overrideAttrs(old: {
+      passthru = old.passthru // {
+        pkgs = dontRecurseIntoAttrs self;
+      };
+    });
 
     trivialBuild = pkgs.callPackage ../build-support/emacs/trivial.nix {
       inherit (self) emacs;
@@ -84,7 +94,7 @@ in makeScope pkgs'.newScope (self: makeOverridable ({
     emacsWithPackages = emacsWithPackages { inherit pkgs lib; } self;
     withPackages = emacsWithPackages { inherit pkgs lib; } self;
 
-  }// {
+  } // {
 
     # Package specific priority overrides goes here
 


### PR DESCRIPTION
###### Motivation for this change

This is the true fix for https://github.com/NixOS/nixpkgs/issues/130020.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @neosimsim 