### PR TITLE
roswell: 21.01.14.108 -> 21.06.14.110

### DIFF
--- a/pkgs/development/tools/roswell/0001-get-image-from-environment.patch
+++ b/pkgs/development/tools/roswell/0001-get-image-from-environment.patch
@@ -1,0 +1,25 @@
+From 40c81f684ec2014ea63a712329f61c52aebe4dba Mon Sep 17 00:00:00 2001
+From: Valentin Boettcher <hiro@protagon.space>
+Date: Wed, 4 Aug 2021 17:25:12 +0200
+Subject: [PATCH] get image from environment
+
+---
+ src/cmd-run-sbcl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cmd-run-sbcl.c b/src/cmd-run-sbcl.c
+index a83b56c..dc472bb 100644
+--- a/src/cmd-run-sbcl.c
++++ b/src/cmd-run-sbcl.c
+@@ -12,7 +12,7 @@ char** cmd_run_sbcl(int argc,char** argv,struct sub_command* cmd) {
+   char* impl_path=impldir(arch,os,impl,version);
+   char* help=get_opt("help",0);
+   char* script=get_opt("script",0);
+-  char* image=get_opt("image",0);
++  char* image=get_opt("image",1);
+   char* program=get_opt("program",0);
+   char* dynamic_space_size=get_opt("dynamic-space-size",1);
+   char* control_stack_size=get_opt("control-stack-size",1);
+-- 
+2.32.0
+

--- a/pkgs/development/tools/roswell/default.nix
+++ b/pkgs/development/tools/roswell/default.nix
@@ -2,14 +2,21 @@
 
 stdenv.mkDerivation rec {
   pname = "roswell";
-  version = "21.01.14.108";
+  version = "21.06.14.110";
 
   src = fetchFromGitHub {
     owner = "roswell";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1hj9q3ig7naky3pb3jkl9yjc9xkg0k7js3glxicv0aqffx9hkp3p";
+    sha256 = "18hxhz7skxvzabz5z0yjky4f3fsyfanafh0imkn5macp8aw3wsfm";
   };
+
+  patches = [
+    # Load the name of the image from the environment variable so that
+    # it can be consistently overwritten. Using the command line
+    # argument in the wrapper did not work.
+    ./0001-get-image-from-environment.patch
+  ];
 
   preConfigure = ''
     sh bootstrap
@@ -19,7 +26,8 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/ros \
-      --add-flags 'lisp=sbcl-bin/system sbcl-bin.version=system' \
+      --set image `basename $out` \
+      --add-flags 'lisp=sbcl-bin/system sbcl-bin.version=system -L sbcl-bin' \
       --prefix PATH : ${lib.makeBinPath [ sbcl ]} --argv0 ros
   '';
 


### PR DESCRIPTION
The core is now loaded from an image which is specific to the
derivation version and should not cause errors like `ore was built for runtime "-nixbld-2021-07-18-00-37-37" but this is "-nixbld-2021-07-24-18-10-15"`.


###### Motivation for this change
Update ros.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
