### PR TITLE
glimpse: add graphviz as runtime dependency

### DIFF
--- a/pkgs/applications/graphics/glimpse/default.nix
+++ b/pkgs/applications/graphics/glimpse/default.nix
@@ -51,6 +51,7 @@
 , makeWrapper
 , autoreconfHook
 , gtk-doc
+, graphviz
 }:
 let
   python = python2.withPackages (pp: [ pp.pygtk ]);
@@ -154,7 +155,8 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     wrapProgram $out/bin/glimpse-${lib.versions.majorMinor version} \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --prefix PATH ":" ${ lib.makeBinPath [ graphviz ] }
   '';
 
   passthru = rec {


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/132405

Alternative would be patching glimpse with the [Gimp fix](https://gitlab.gnome.org/GNOME/gimp/-/commit/f83fd22c4b8701ffc4ce14383e5e22756a4bce04), but I'd rather not maintain another patch if it can be fixed so easily.

See also:
https://gitlab.gnome.org/GNOME/gegl/-/issues/279
https://gitlab.gnome.org/GNOME/gimp/-/commit/f83fd22c4b8701ffc4ce14383e5e22756a4bce04



###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
