### PR TITLE
unbreak beam-core by means of doJailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1011,10 +1011,14 @@ self: super: {
   # https://github.com/mgajda/json-autotype/issues/25
   json-autotype = dontCheck super.json-autotype;
 
+  # Requires dlist <0.9 but it works fine with dlist-1.0
+  # https://github.com/haskell-beam/beam/issues/581
+  beam-core = doJailbreak super.beam-core;
+
   # Requires pg_ctl command during tests
   beam-postgres = overrideCabal super.beam-postgres (drv: {
     testToolDepends = (drv.testToolDepends or []) ++ [pkgs.postgresql];
-    });
+  });
 
   # Fix for base >= 4.11
   scat = overrideCabal super.scat (drv: {

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -305,7 +305,6 @@ broken-packages:
   - bdo
   - beam
   - beamable
-  - beam-core
   - bech32
   - bed-and-breakfast
   - beeminder-api


### PR DESCRIPTION
###### Motivation for this change

`beam-core` is currently marked as broken because it wants `dlist < 0.9` but works fine with `dlist-1.0`, this has been [reported upstream](https://github.com/haskell-beam/beam/issues/581).

###### Things done

Now package builds fine.

```
nix-build --no-out-link -A haskellPackages.beam-core --arg config '{ allowBroken = true; }'
```