### PR TITLE
mosquitto: 2.0.10 -> 2.0.11

### DIFF
--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -12,18 +12,28 @@
 , openssl
 , withSystemd ? stdenv.isLinux
 , systemd
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   pname = "mosquitto";
-  version = "2.0.10";
+  version = "2.0.11";
 
   src = fetchFromGitHub {
     owner = "eclipse";
     repo = pname;
     rev = "v${version}";
-    sha256 = "144vw7b9ja4lci4mplbxs048x9aixd9c3s7rg6wc1k31w099rb12";
+    sha256 = "1i0kkqhjxqahkhsl60s46zlywa87jakv7h4sr3fhi1v53vwpb9mg";
   };
+
+  patches = lib.optionals stdenv.isDarwin [
+    (fetchpatch {
+      name = "revert-cmake-shared-to-module.patch"; # See https://github.com/eclipse/mosquitto/issues/2277
+      url = "https://github.com/eclipse/mosquitto/commit/e21eaeca37196439b3e89bb8fd2eb1903ef94845.patch";
+      sha256 = "14syi2c1rks8sl2aw09my276w45yq1iasvzkqcrqwy4drdqrf069";
+      revert = true;
+    })
+  ];
 
   postPatch = ''
     for f in html manpage ; do


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes [CVE-2021-34431](https://nvd.nist.gov/vuln/detail/CVE-2021-34431).

https://github.com/eclipse/mosquitto/blob/v2.0.11/ChangeLog.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>domoticz</li>
  </ul>
</details>
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>collectd</li>
    <li>collectd-data</li>
    <li>mosquitto</li>
  </ul>
</details>

`domoticz` build issue is not introduced by this contribution.
