### PR TITLE
[WIP] librem-ec-acpi: init at 0.9.1

### DIFF
--- a/pkgs/os-specific/linux/librem-ec-acpi/default.nix
+++ b/pkgs/os-specific/linux/librem-ec-acpi/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitLab, kernel }:
+let
+  version = "0.9.1";
+in
+stdenv.mkDerivation {
+  name = "librem-ec-acpi-module-${version}-${kernel.version}";
+
+  passthru.moduleName = "librem_ec_acpi";
+
+  src = fetchFromGitLab {
+    domain = "source.puri.sm";
+    owner = "nicole.faerber";
+    repo = "librem-ec-acpi-dkms";
+    rev = "v${version}";
+    sha256 = "1qnbfj60i8nn2ahgj2zp5ixd79bb0wl1ld36x3igws2f3c0f5pfi";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildFlags = [
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -D librem_ec_acpi.ko $out/lib/modules/${kernel.modDirVersion}/misc/librem_ec_acpi.ko
+  '';
+
+  meta = with lib; {
+    license = [ licenses.gpl2Only ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    broken = versionOlder kernel.version "5.13";
+    description = "Librem Embedded Controller ACPI Driver (DKMS)";
+    homepage = "https://source.puri.sm/nicole.faerber/librem-ec-acpi-dkms";
+    longDescription = ''
+      This provides the librem_ec_acpi in-tree driver for systems missing it.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21407,6 +21407,8 @@ in
 
     system76-io = callPackage ../os-specific/linux/system76-io { };
 
+    librem-ec-acpi = callPackage ../os-specific/linux/librem-ec-acpi { };
+
     tmon = callPackage ../os-specific/linux/tmon { };
 
     tp_smapi = callPackage ../os-specific/linux/tp_smapi { };


### PR DESCRIPTION
This is more or less copied from the system76-acpi package, whose
upstream is the basis for librem-ec-acpi.

###### Motivation for this change

This kernel module is required for power management on Purism Librem 14
laptops because there is no mainline support yet.

###### Things done

Basically nothing is done yet, because I still need to learn about how kernel modules are actually built and managed. Using nix-shell and my own checkout I was able to follow the development guide in the manual and build a module for my kernel, which was enough for me to configure the charging thresholds and ensure I can use my laptop.

---


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
