### PR TITLE
cups: 2.3.3 -> 2.3.3op2

### DIFF
--- a/nixos/modules/hardware/printers.nix
+++ b/nixos/modules/hardware/printers.nix
@@ -116,19 +116,14 @@ in {
       description = "Ensure NixOS-configured CUPS printers";
       wantedBy = [ "multi-user.target" ];
       requires = [ cupsUnit ];
-      # in contrast to cups.socket, for cups.service, this is actually not enough,
-      # as the cups service reports its activation before clients can actually interact with it.
-      # Because of this, commands like `lpinfo -v` will report a bad file descriptor
-      # due to the missing UNIX socket without sufficient sleep time.
       after = [ cupsUnit ];
 
       serviceConfig = {
         Type = "oneshot";
+        RemainAfterExit = true;
       };
 
-       # sleep 10 is required to wait until cups.service is actually initialized and has created its UNIX socket file
-      script = (optionalString (!config.services.printing.startWhenNeeded) "sleep 10\n")
-        + (concatMapStringsSep "\n" ensurePrinter cfg.ensurePrinters)
+      script = concatMapStringsSep "\n" ensurePrinter cfg.ensurePrinters
         + optionalString (cfg.ensureDefaultPrinter != null) (ensureDefaultPrinter cfg.ensureDefaultPrinter);
     };
   };

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -53,18 +53,10 @@ in {
 
     start_all()
 
-    with subtest("Make sure that cups is up on both sides"):
+    with subtest("Make sure that cups is up on both sides and printers are set up"):
         serviceServer.wait_for_unit("cups.service")
         serviceClient.wait_for_unit("cups.service")
-
-    with subtest(
-        "Wait until cups is fully initialized and ensure-printers has "
-        "executed with 10s delay"
-    ):
-        serviceClient.sleep(20)
-        socketActivatedClient.wait_until_succeeds(
-            "systemctl show ensure-printers | grep -q -E 'code=exited ; status=0'"
-        )
+        socketActivatedClient.wait_for_unit("ensure-printers.service")
 
 
     def test_printing(client, server):

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -28,16 +28,15 @@ stdenv.mkDerivation rec {
   pname = "cups";
 
   # After 2.2.6, CUPS requires headers only available in macOS 10.12+
-  version = if stdenv.isDarwin then "2.2.6" else "2.3.3";
+  version = if stdenv.isDarwin then "2.2.6" else "2.3.3op2";
 
-  passthru = { inherit version; };
-
-  src = fetchurl {
+  src = fetchurl (if stdenv.isDarwin then {
     url = "https://github.com/apple/cups/releases/download/v${version}/cups-${version}-source.tar.gz";
-    sha256 = if version == "2.2.6"
-             then "16qn41b84xz6khrr2pa2wdwlqxr29rrrkjfi618gbgdkq9w5ff20"
-             else "1vpk0b2vq830f8fvf9z8qjsm5k141i7pi8djbinpnr78pi4dj7r6";
-  };
+    sha256 = "16qn41b84xz6khrr2pa2wdwlqxr29rrrkjfi618gbgdkq9w5ff20";
+  } else {
+    url = "https://github.com/OpenPrinting/cups/releases/download/v${version}/cups-${version}-source.tar.gz";
+    sha256 = "1pwndz4gwkm7311wkhhzlw2diy7wbck7yy026jbaxh3rprdmgcyy";
+  });
 
   outputs = [ "out" "lib" "dev" "man" ];
 
@@ -49,10 +48,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config removeReferencesTo ];
 
   buildInputs = [ zlib libjpeg libpng libtiff libusb1 gnutls libpaper ]
-    ++ optionals stdenv.isLinux [ avahi pam dbus ]
+    ++ optionals stdenv.isLinux [ avahi pam dbus acl ]
     ++ optional enableSystemd systemd
-    # Separate from above only to not modify order, to avoid mass rebuilds; merge this with the above at next big change.
-    ++ optionals stdenv.isLinux [ acl ]
     ++ optionals stdenv.isDarwin (with darwin; [
       configd apple_sdk.frameworks.ApplicationServices
     ]);
@@ -129,18 +126,8 @@ stdenv.mkDerivation rec {
       sed -e "/^cups_serverbin=/s|$lib|$out|" \
           -i "$dev/bin/cups-config"
 
-      # Rename systemd files provided by CUPS
       for f in "$out"/lib/systemd/system/*; do
-        substituteInPlace "$f" \
-          --replace "$lib/$libexec" "$out/$libexec" \
-          --replace "org.cups.cupsd" "cups" \
-          --replace "org.cups." ""
-
-        if [[ "$f" =~ .*cupsd\..* ]]; then
-          mv "$f" "''${f/org\.cups\.cupsd/cups}"
-        else
-          mv "$f" "''${f/org\.cups\./}"
-        fi
+        substituteInPlace "$f" --replace "$lib/$libexec" "$out/$libexec"
       done
     '' + optionalString stdenv.isLinux ''
       # Use xdg-open when on Linux
@@ -149,9 +136,9 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    homepage = "https://cups.org/";
+    homepage = "https://openprinting.github.io/cups/";
     description = "A standards-based printing system for UNIX";
-    license = licenses.gpl2; # actually LGPL for the library and GPL for the rest
+    license = licenses.asl20;
     maintainers = with maintainers; [ matthewbauer ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
https://github.com/OpenPrinting/cups/releases/tag/v2.3.3op1
https://github.com/OpenPrinting/cups/releases/tag/v2.3.3op2

Switches to the new OpenPrinting fork (https://www.phoronix.com/scan.php?page=news_item&px=Apple-No-More-CUPS).

CUPS now notifies the systemd manager when it's done starting up using `sd_notify` (https://github.com/OpenPrinting/cups/commit/e96e96b4bd0d4e6f634bbb66b95d6e475501541c), so we can stop relying on arbitrary delays in `ensure-printers.service` and `tests/printing.nix`, which is unreliable and [recently](https://hydra.nixos.org/build/149442779) prevented the unstable channel from updating.

I've run the `printing` test about 10 times with no failures on `x86_64-linux`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
