### PR TITLE
nixUnstable: 2.4pre20210707_02dd6bb -> 2.4pre20210802_47e96bb 

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -2,12 +2,12 @@
 
 {
   hydra-unstable = callPackage ./common.nix {
-    version = "2021-05-03";
+    version = "2021-08-11";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "hydra";
-      rev = "886e6f85e45a1f757e9b77d2a9e4539fbde29468";
-      sha256 = "t7Qb57Xjc0Ou+VDGC1N5u9AmeODW6MVOwKSrYRJq5f0=";
+      rev = "9bce425c3304173548d8e822029644bb51d35263";
+      sha256 = "sha256-tGzwKNW/odtAYcazWA9bPVSmVXMGKfXsqCA1UYaaxmU=";
     };
     nix = nixUnstable;
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -234,13 +234,13 @@ in rec {
   nixUnstable = lib.lowPrio (callPackage common rec {
     pname = "nix";
     version = "2.4${suffix}";
-    suffix = "pre20210707_02dd6bb";
+    suffix = "pre20210802_47e96bb";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "02dd6bb610e55a009cd7a4c83639698d3a7acaa2";
-      sha256 = "sha256-ARRiLrDOK+JQtvVXsYegspENYimQzilvdTfO7eiBuaA=";
+      rev = "47e96bb533f8cacc171bec9b688b134de31a48a9";
+      sha256 = "sha256-vwj1fAGn3Pl9Vr/qSL+oDxuwbRzEdI3dsEg6o3xTmWg=";
     };
 
     boehmgc = boehmgc_nixUnstable;


### PR DESCRIPTION
###### Motivation for this change

The [manual](https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-build.html) mentions a `--eval-store` 
trying it with the latest version gives
```
error: unrecognised flag '--eval-store'
Try 'nix --help' for more information.
```

On another note, I was trying that option because I wonder how to evaluate a derivation on a remote machine.

So my question is:
- Does the `--eval-store` flag evaluate on another store ? Will it try to build on local first? 
- Related question is suppose you get a drv file with `nix eval` how can you build that on another machine ?

Finally I understand that you are very busy, so if you don't have time to answer, no worries!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
