### PR TITLE
terraform-providers.kubernetes: 2.1.0 -> 2.4.1, remove kubernetes-alpha

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -57,6 +57,7 @@ let
     cloudfoundry = callPackage ./cloudfoundry {};
     gandi = callPackage ./gandi {};
     hcloud = callPackage ./hcloud {};
+    kubernetes-alpha = throw "This has been merged as beta into the kubernetes provider. See https://www.hashicorp.com/blog/beta-support-for-crds-in-the-terraform-provider-for-kubernetes for details";
     libvirt = callPackage ./libvirt {};
     linuxbox = callPackage ./linuxbox {};
     lxd = callPackage ./lxd {};

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -563,15 +563,6 @@
     "vendorSha256": null,
     "version": "2.4.1"
   },
-  "kubernetes-alpha": {
-    "owner": "hashicorp",
-    "provider-source-address": "registry.terraform.io/hashicorp/kubernetes-alpha",
-    "repo": "terraform-provider-kubernetes-alpha",
-    "rev": "v0.5.0",
-    "sha256": "0yqm3wlya69w9g9kzgvm28mbbwp6wik51syjnbnj8dis5kspx8gd",
-    "vendorSha256": null,
-    "version": "0.5.0"
-  },
   "launchdarkly": {
     "owner": "terraform-providers",
     "repo": "terraform-provider-launchdarkly",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -558,10 +558,10 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/kubernetes",
     "repo": "terraform-provider-kubernetes",
-    "rev": "v2.1.0",
-    "sha256": "02ygydgi3fa8z6qd04hgcilbbwns8f21agaqxly2pf9j23fzi37g",
+    "rev": "v2.4.1",
+    "sha256": "0mk0f12yy58gjkki7xpf9bjfw9h9zdgby2b4bddqp5csq11payhd",
     "vendorSha256": null,
-    "version": "2.1.0"
+    "version": "2.4.1"
   },
   "kubernetes-alpha": {
     "owner": "hashicorp",


### PR DESCRIPTION
###### Motivation for this change
The `kubernetes_manifest` resource has moved into the `kubernetes` provider, and was flagged beta. See https://www.hashicorp.com/blog/beta-support-for-crds-in-the-terraform-provider-for-kubernetes for the announcement.

Note to possible backporters: We should only backport the `terraform-providers.kubernetes` bump, not the `kubernetes-alpha` removal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
