### PR TITLE
vscode: remove default sourceExecutableName

### DIFF
--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -27,7 +27,6 @@ in
     version = "1.58.2";
     pname = "vscode";
 
-    sourceExecutableName = "code";
     executableName = "code" + lib.optionalString isInsiders "-insiders";
     longName = "Visual Studio Code" + lib.optionalString isInsiders " - Insiders";
     shortName = "Code" + lib.optionalString isInsiders " - Insiders";


### PR DESCRIPTION
generic.nix sets it to executableName by default if not set
if set, it prevents the correct sourceExecutableName being set for
-insiders

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
```
these 2 derivations will be built:
  /nix/store/3sr0qga6ilfh97mplnx5vdsik1bgz546-vscode-1.58.2.drv
  /nix/store/hpgkq20ms58lpfsjpgzz9gl652lppjpw-vscode-with-extensions-1.58.2.drv
building '/nix/store/3sr0qga6ilfh97mplnx5vdsik1bgz546-vscode-1.58.2.drv'...
unpacking sources
unpacking source archive /nix/store/ypc4f0yzf8kmgz38c33gh65c1kf2hjxc-VSCode_insiders.tar.gz
source root is VSCode-linux-x64
setting SOURCE_DATE_EPOCH to timestamp 1628111710 of file VSCode-linux-x64/resources/app/node_modules.asar
patching sources
glibPreInstallPhase
installing
sed: can't read /nix/store/g9w664m5wvmf99r0b7zlpq0cyhjlw9ky-vscode-1.58.2/bin/code-insiders: No such file or directory
error: builder for '/nix/store/3sr0qga6ilfh97mplnx5vdsik1bgz546-vscode-1.58.2.drv' failed with exit code 2;
       last 8 log lines:
       > unpacking sources
       > unpacking source archive /nix/store/ypc4f0yzf8kmgz38c33gh65c1kf2hjxc-VSCode_insiders.tar.gz
       > source root is VSCode-linux-x64
       > setting SOURCE_DATE_EPOCH to timestamp 1628111710 of file VSCode-linux-x64/resources/app/node_modules.asar
       > patching sources
       > glibPreInstallPhase
       > installing
       > sed: can't read /nix/store/g9w664m5wvmf99r0b7zlpq0cyhjlw9ky-vscode-1.58.2/bin/code-insiders: No such file or directory
       For full logs, run 'nix log /nix/store/3sr0qga6ilfh97mplnx5vdsik1bgz546-vscode-1.58.2.drv'.
error: 1 dependencies of derivation '/nix/store/hpgkq20ms58lpfsjpgzz9gl652lppjpw-vscode-with-extensions-1.58.2.drv' failed to build
```
fails because bin/code-insiders is a dead symlink 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
