### PR TITLE
gdtoolkit: init at 3.2.7, js2py: init at 0.71, pyjsparser: init at 2.7.1

### DIFF
--- a/pkgs/development/python-modules/gdtoolkit/default.nix
+++ b/pkgs/development/python-modules/gdtoolkit/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildPythonApplication, fetchPypi, fetchFromGitHub, python }:
+
+let
+  py = python.override {
+    packageOverrides = self: super: {
+      lark-parser = super.lark-parser.overridePythonAttrs (oldAttrs: rec {
+        version = "0.8.0";
+        src = fetchFromGitHub {
+          owner = "lark-parser";
+          repo = "lark";
+          rev = version;
+          sha256 = "sha256-su7kToZ05OESwRCMPG6Z+XlFUvbEb3d8DgsTEcPJMg4=";
+        };
+      });
+    };
+  };
+in with py.pkgs;
+buildPythonApplication rec {
+  pname = "gdtoolkit";
+  version = "3.2.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Y3NlBKKmHeL96dbHsaaIjHkLfc4L5k6seMSHEkN24+A=";
+  };
+
+  propagatedBuildInputs = [ docopt pyyaml lark-parser ];
+
+  checkInputs = [ js2py ];
+  dontUseSetuptoolsCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/Scony/godot-gdscript-toolkit";
+    description =
+      "Independent set of GDScript tools - parser, linter and formatter";
+    license = licenses.mit;
+    maintainers = [ payas ];
+  };
+}

--- a/pkgs/development/python-modules/js2py/default.nix
+++ b/pkgs/development/python-modules/js2py/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, python3Packages }:
+buildPythonPackage rec {
+  pname = "js2py";
+  version = "0.71";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "Js2Py";
+    sha256 = "sha256-pBsQCd0UmK59Q2v6WslSoIypKku54x3Kbou5ZrSff84=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ six pyjsparser tzlocal ];
+
+  dontUseSetuptoolsCheck = true;
+
+  meta = with lib; {
+    homepage =
+      "JavaScript to Python Translator & JavaScript interpreter written in 100% pure Python";
+    description =
+      "JavaScript to Python Translator & JavaScript interpreter written in 100% pure Python";
+    license = licenses.mit;
+    maintainers = [ payas ];
+  };
+}

--- a/pkgs/development/python-modules/pyjsparser/default.nix
+++ b/pkgs/development/python-modules/pyjsparser/default.nix
@@ -1,0 +1,17 @@
+{ lib, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  pname = "pyjsparser";
+  version = "2.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-vmDaa3eMxaUpamnY59YU8fhw+vlOGxtqxZHyrV1ylXk=";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/PiotrDabkowski/pyjsparser";
+    description = "Fast JavaScript parser for Python.";
+    license = licenses.mit;
+    maintainers = [ payas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5483,6 +5483,8 @@ in
 
   godot-server = callPackage ../development/tools/godot/server.nix { };
 
+  gdtoolkit = python3Packages.callPackage ../development/python-modules/gdtoolkit/default.nix {};
+
   goklp = callPackage ../tools/networking/goklp {};
 
   go-mtpfs = callPackage ../tools/filesystems/go-mtpfs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3742,6 +3742,8 @@ in {
     inherit (pkgs) jq;
   };
 
+  js2py = callPackage ../development/python-modules/js2py { };
+
   jsbeautifier = callPackage ../development/python-modules/jsbeautifier { };
 
   jsmin = callPackage ../development/python-modules/jsmin { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6150,6 +6150,8 @@ in {
 
   pyjson5 = callPackage ../development/python-modules/pyjson5 { };
 
+  pyjsparser = callPackage ../development/python-modules/pyjsparser { };
+
   pyjwkest = callPackage ../development/python-modules/pyjwkest { };
 
   pyjwt = callPackage ../development/python-modules/pyjwt { };


### PR DESCRIPTION
###### Motivation for this change
Allow editing gdscript (godot engine scripting language) with Emacs (via gdscript-mode)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
