### PR TITLE
ocamlPackages.llvm: 8 -> 10, fix bytecode linking

### DIFF
--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchpatch, python, cmake, libllvm, ocaml, findlib, ctypes }:
+{ stdenv, lib, python, cmake, libllvm, ocaml, findlib, ctypes }:
 
 let version = lib.getVersion libllvm; in
 
@@ -12,12 +12,8 @@ stdenv.mkDerivation {
   buildInputs = [ python ocaml findlib ctypes ];
   propagatedBuildInputs = [ libllvm ];
 
-  patches = [ (fetchpatch {
-    url = "https://raw.githubusercontent.com/ocaml/opam-repository/2bdc193f5a9305ea93bf0f0dfc1fbc327c8b9306/packages/llvm/llvm.7.0.0/files/fix-shared.patch";
-    sha256 = "1p98j3b1vrryfn1xa7i50m6mmm4dyw5ldafq6kyh9sfmdihz4zsx";
-  })];
-
   cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=YES" # fixes bytecode builds
     "-DLLVM_OCAML_OUT_OF_TREE=TRUE"
     "-DLLVM_OCAML_INSTALL_PATH=${placeholder "out"}/ocaml"
     "-DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR=${lib.getLib libllvm}/lib"
@@ -31,6 +27,7 @@ stdenv.mkDerivation {
     mkdir -p $OCAMLFIND_DESTDIR/
     mv $out/ocaml $OCAMLFIND_DESTDIR/llvm
     mv $OCAMLFIND_DESTDIR/llvm/META{.llvm,}
+    mv $OCAMLFIND_DESTDIR/llvm/stublibs $OCAMLFIND_DESTDIR/stublibs
   '';
 
   passthru = {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -610,7 +610,7 @@ let
     linenoise = callPackage ../development/ocaml-modules/linenoise { };
 
     llvm = callPackage ../development/ocaml-modules/llvm {
-      libllvm = pkgs.llvmPackages_8.libllvm;
+      libllvm = pkgs.llvmPackages_10.libllvm;
     };
 
     logs = callPackage ../development/ocaml-modules/logs { };


### PR DESCRIPTION
Fixes #119532

Both the update and the new cmake flags are needed to fix this issue.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
