### PR TITLE
file: fix detection of mimetype of xz files

### DIFF
--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, file, zlib, libgnurx }:
+{ lib, stdenv, fetchurl, file, zlib, libgnurx, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "file";
@@ -15,6 +15,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
   buildInputs = [ zlib ]
               ++ lib.optional stdenv.hostPlatform.isWindows libgnurx;
+
+  patches = [
+    # Fix the mime type detection of xz file. Is merged in master.
+    (fetchpatch {
+      url = "https://github.com/file/file/commit/9b0459afab309a82aa4e46f73a4e50dd641f3d39.patch";
+      sha256 = "sha256-6vjyIn5gVbgmhUlfXJKFRVltm8YKATKmh0/X6+2lLnM=";
+    })
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This issue https://github.com/NixOS/nixpkgs/issues/132476 (and also planning on updating portmod)

a.k.a patool checks doesn't pass due to issue that caused file to not detect the mimetype and extension of xz files

###### Things done

The change are based on a discussion in the arch issue tracker.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested that patool compile with this change.