### PR TITLE
pythonPackages.pyunbound: 1.9.3 -> 1.13.1 and fix build 

### DIFF
--- a/pkgs/tools/networking/unbound/python.nix
+++ b/pkgs/tools/networking/unbound/python.nix
@@ -4,11 +4,11 @@ let
   inherit (pythonPackages) python;
 in stdenv.mkDerivation rec {
   pname = "pyunbound";
-  version = "1.9.3";
+  version = "1.13.1";
 
   src = fetchurl {
     url = "http://unbound.net/downloads/unbound-${version}.tar.gz";
-    sha256 = "1ykdy62sgzv33ggkmzwx2h0ifm7hyyxyfkb4zckv7gz4f28xsm8v";
+    sha256 = "sha256-hQTZe4/FvYlzRcldEW4O4N34yP+ZWQqytL0TJ4yfULg=";
   };
 
   buildInputs = [ openssl expat libevent swig python ];

--- a/pkgs/tools/networking/unbound/python.nix
+++ b/pkgs/tools/networking/unbound/python.nix
@@ -51,7 +51,7 @@ in stdenv.mkDerivation rec {
     $out/bin/unbound-anchor -l | tail --lines=+2 - > $out/etc/${pname}/root.key
     # We don't need anything else
     rm -fR $out/bin $out/share $out/include $out/etc/unbound
-    patchelf --replace-needed libunbound.so.2 $out/${python.sitePackages}/libunbound.so.2 $out/${python.sitePackages}/_unbound.so
+    patchelf --replace-needed libunbound.so.8 $out/${python.sitePackages}/libunbound.so.8 $out/${python.sitePackages}/_unbound.so
     '';
 
   meta = with lib; {
@@ -60,6 +60,5 @@ in stdenv.mkDerivation rec {
     homepage = "http://www.unbound.net";
     maintainers = with maintainers; [ leenaars ];
     platforms = lib.platforms.unix;
-    broken = true;
   };
 }

--- a/pkgs/tools/networking/unbound/python.nix
+++ b/pkgs/tools/networking/unbound/python.nix
@@ -11,12 +11,14 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-hQTZe4/FvYlzRcldEW4O4N34yP+ZWQqytL0TJ4yfULg=";
   };
 
-  buildInputs = [ openssl expat libevent swig python ];
+  nativeBuildInputs = [ swig ];
 
-  patchPhase = ''substituteInPlace Makefile.in \
+  buildInputs = [ openssl expat libevent python ];
+
+  postPatch = ''substituteInPlace Makefile.in \
     --replace "\$(DESTDIR)\$(PYTHON_SITE_PKG)" "$out/${python.sitePackages}" \
     --replace "\$(LIBTOOL) --mode=install cp _unbound.la" "cp _unbound.la"
-    '';
+  '';
 
   preConfigure = "export PYTHON_VERSION=${python.pythonVersion}";
 
@@ -30,18 +32,22 @@ in stdenv.mkDerivation rec {
     "--enable-pie"
     "--enable-relro-now"
     "--with-pyunbound"
-    "DESTDIR=$out PREFIX="
+    "DESTDIR=$out"
+    "PREFIX="
   ];
 
   preInstall = ''
     mkdir -p $out/${python.sitePackages} $out/etc/${pname}
     cp .libs/_unbound.so .libs/libunbound.so* $out/${python.sitePackages}
     substituteInPlace _unbound.la \
-      --replace "-L.libs $PWD/libunbound.la" "-L$out/${python.sitePackages}" \
-      --replace "libdir=\'$PWD/${python.sitePackages}\'" "libdir=\'$out/${python.sitePackages}\'"
+      --replace "-L.libs $PWD/libunbound.la" "-L$out/${python.sitePackages}"
     '';
 
-  installFlags = [ "configfile=\${out}/etc/unbound/unbound.conf pyunbound-install lib" ];
+  installFlags = [
+    "configfile=\${out}/etc/unbound/unbound.conf"
+    "pyunbound-install"
+    "lib"
+  ];
 
   # All we want is the Unbound Python module
   postInstall = ''
@@ -52,7 +58,7 @@ in stdenv.mkDerivation rec {
     # We don't need anything else
     rm -fR $out/bin $out/share $out/include $out/etc/unbound
     patchelf --replace-needed libunbound.so.8 $out/${python.sitePackages}/libunbound.so.8 $out/${python.sitePackages}/_unbound.so
-    '';
+  '';
 
   meta = with lib; {
     description = "Python library for Unbound, the validating, recursive, and caching DNS resolver";

--- a/pkgs/tools/networking/unbound/python.nix
+++ b/pkgs/tools/networking/unbound/python.nix
@@ -57,6 +57,9 @@ in stdenv.mkDerivation rec {
     $out/bin/unbound-anchor -l | tail --lines=+2 - > $out/etc/${pname}/root.key
     # We don't need anything else
     rm -fR $out/bin $out/share $out/include $out/etc/unbound
+  ''
+  # patchelf is only available on Linux and no patching is needed on darwin
+  + lib.optionalString stdenv.isLinux ''
     patchelf --replace-needed libunbound.so.8 $out/${python.sitePackages}/libunbound.so.8 $out/${python.sitePackages}/_unbound.so
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I have started playing around with the `unbound` resolver and accidentally found why this package was broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
