### PR TITLE
python3Packages.open-garage: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/open-garage/default.nix
+++ b/pkgs/development/python-modules/open-garage/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, aiohttp
+, async-timeout
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "open-garage";
+  version = "0.1.5";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "Danielhiversen";
+    repo = "pyOpenGarage";
+    rev = version;
+    sha256 = "1iqcqkbb1ik5lmsvwgy6i780x6y3wlm1gx257anxyvp1b21gm24p";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "opengarage" ];
+
+  meta = with lib; {
+    description = "Python module to communicate with opengarage.io";
+    homepage = "https://github.com/Danielhiversen/pyOpenGarage";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -607,7 +607,7 @@
     "openerz" = ps: with ps; [ openerz-api ];
     "openevse" = ps: with ps; [ ]; # missing inputs: openevsewifi
     "openexchangerates" = ps: with ps; [ ];
-    "opengarage" = ps: with ps; [ ]; # missing inputs: open-garage
+    "opengarage" = ps: with ps; [ open-garage ];
     "openhardwaremonitor" = ps: with ps; [ ];
     "openhome" = ps: with ps; [ openhomedevice ];
     "opensensemap" = ps: with ps; [ opensensemap-api ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4984,6 +4984,8 @@ in {
 
   onnx = callPackage ../development/python-modules/onnx { };
 
+  open-garage = callPackage ../development/python-modules/open-garage { };
+
   openant = callPackage ../development/python-modules/openant { };
 
   openapi-schema-validator = callPackage ../development/python-modules/openapi-schema-validator { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to communicate with opengarage.io

https://github.com/Danielhiversen/pyOpenGarage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
