### PR TITLE
A few version bumps

### DIFF
--- a/pkgs/applications/misc/josm/default.nix
+++ b/pkgs/applications/misc/josm/default.nix
@@ -3,20 +3,20 @@
 }:
 let
   pname = "josm";
-  version = "18004";
+  version = "18118";
   srcs = {
     jar = fetchurl {
       url = "https://josm.openstreetmap.de/download/josm-snapshot-${version}.jar";
-      sha256 = "sha256-Cd+/sE6A0MddHeAxy3gx7ev+9UR3ZNcR0tCTmdX2FtY=";
+      sha256 = "01wcbf1mh1gqxnqkc3j6h64h9sz0yd5wiwpyx4ic4d5fwkh65qym";
     };
     macosx = fetchurl {
       url = "https://josm.openstreetmap.de/download/macosx/josm-macos-${version}-java16.zip";
-      sha256 = "sha256-QSVh8043K/f7gPEjosGo/DNj1d75LUFwf6EMeHk68fM=";
+      sha256 = "0i1vglqg49fd3w2bny01l92wj4hvr3y35rrmd1mdff0lc1zhi397";
     };
     pkg = fetchsvn {
       url = "https://josm.openstreetmap.de/svn/trunk/native/linux/tested";
       rev = version;
-      sha256 = "sha256-Ic6RtQPqpQIci1IbKgTcFmLfMdPxSVybrEAk+ttM0j8=";
+      sha256 = "0gyj9kdzl920mjdmqjgiscqxyqhnvh22l6sjicf059ga0fsr3ki1";
     };
   };
 in

--- a/pkgs/data/fonts/comfortaa/default.nix
+++ b/pkgs/data/fonts/comfortaa/default.nix
@@ -1,17 +1,22 @@
-{ lib, fetchzip }:
+{ lib, fetchFromGitHub }:
 
 let
-  version = "3.001";
-in fetchzip rec {
+  version = "3.101";
+in fetchFromGitHub rec {
   name = "comfortaa-${version}";
 
-  url = "https://orig00.deviantart.net/40a3/f/2017/093/d/4/comfortaa___font_by_aajohan-d1qr019.zip";
+  owner = "googlefonts";
+  repo = "comfortaa";
+  rev = version;
+
   postFetch = ''
-    mkdir -p $out/share/fonts $out/share/doc
-    unzip -j $downloadedFile \*.ttf                        -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*/FONTLOG.txt \*/donate.html -d $out/share/doc/${name}
+    tar -xf $downloadedFile --strip=1
+    mkdir -p $out/share/fonts/truetype $out/share/doc/comfortaa
+    cp fonts/TTF/*.ttf $out/share/fonts/truetype
+    cp FONTLOG.txt README.md $out/share/doc/comfortaa
   '';
-  sha256 = "0z7xr0cnn6ghwivrm5b5awq9bzhnay3y99qq6dkdgfkfdsaz0n9h";
+
+  sha256 = "06jhdrfzl01ma085bp354g002ypmkbp6a51jn1lsj77zfj2mfmfc";
 
   meta = with lib; {
     homepage = "http://aajohan.deviantart.com/art/Comfortaa-font-105395949";

--- a/pkgs/data/fonts/fira-mono/default.nix
+++ b/pkgs/data/fonts/fira-mono/default.nix
@@ -1,13 +1,14 @@
 { lib, fetchzip }:
 
-fetchzip {
-  name = "fira-mono-3.206";
+let version = "4.202";
+in fetchzip {
+  name = "fira-mono-${version}";
 
-  url = "https://github.com/mozilla/Fira/archive/4.106.zip";
+  url = "https://github.com/mozilla/Fira/archive/${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts
-    unzip -j $downloadedFile Fira-4.106/otf/FiraMono\*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile Fira-${version}/otf/FiraMono\*.otf -d $out/share/fonts/opentype
   '';
 
   sha256 = "1ci3fxhdwabvfj4nl16pwcgqnh7s2slp8vblribk8zkpx8cbp1dj";

--- a/pkgs/data/fonts/unifont/default.nix
+++ b/pkgs/data/fonts/unifont/default.nix
@@ -4,16 +4,16 @@
 
 stdenv.mkDerivation rec {
   pname = "unifont";
-  version = "13.0.05";
+  version = "13.0.06";
 
   ttf = fetchurl {
     url = "mirror://gnu/unifont/${pname}-${version}/${pname}-${version}.ttf";
-    sha256 = "0ff7zbyqi45q0171rl9ckj6lpfhcj8a9850d8j89m7wbwky32isf";
+    sha256 = "0hp72lcj8q8cw490lxl5y1ygw9mcicryjwqr1mmkdz8zh4jh8g6p";
   };
 
   pcf = fetchurl {
     url = "mirror://gnu/unifont/${pname}-${version}/${pname}-${version}.pcf.gz";
-    sha256 = "16n666p6rs6l4r8grh67gy4ls33qfnbb5xk7cksywzjwdh42js0r";
+    sha256 = "0y030km1x8mai8zrk661dqsb0yq8rpx6akl7p2sw5ijkcdsfm85f";
   };
 
   nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];
@@ -43,10 +43,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Unicode font for Base Multilingual Plane";
-    homepage = "http://unifoundry.com/unifont.html";
+    homepage = "https://unifoundry.com/unifont/";
 
     # Basically GPL2+ with font exception.
-    license = "http://unifoundry.com/LICENSE.txt";
+    license = "https://unifoundry.com/LICENSE.txt";
     maintainers = [ maintainers.rycee maintainers.vrthra ];
     platforms = platforms.all;
   };

--- a/pkgs/data/fonts/unifont_upper/default.nix
+++ b/pkgs/data/fonts/unifont_upper/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "13.0.05";
+  version = "13.0.06";
 in fetchzip rec {
   name = "unifont_upper-${version}";
 
@@ -9,14 +9,14 @@ in fetchzip rec {
 
   postFetch = "install -Dm644 $downloadedFile $out/share/fonts/truetype/unifont_upper.ttf";
 
-  sha256 = "1cpi44fzsiq3yqg38763awgri1ma46421c3v8167bsxzsx7vzlkp";
+  sha256 = "0bqw30h5b787dw8bn1dj8shz22mlxr1zmcfp68fpyll5vg02540n";
 
   meta = with lib; {
     description = "Unicode font for glyphs above the Unicode Basic Multilingual Plane";
-    homepage = "http://unifoundry.com/unifont.html";
+    homepage = "https://unifoundry.com/unifont/";
 
     # Basically GPL2+ with font exception.
-    license = "http://unifoundry.com/LICENSE.txt";
+    license = "https://unifoundry.com/LICENSE.txt";
     maintainers = [ maintainers.mathnerd314 maintainers.vrthra ];
     platforms = platforms.all;
   };

--- a/pkgs/tools/misc/mimeo/default.nix
+++ b/pkgs/tools/misc/mimeo/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mimeo";
-  version = "2019.7";
+  version = "2021.2";
 
   src = fetchurl {
     url = "https://xyne.archlinux.ca/projects/mimeo/src/${pname}-${version}.tar.xz";
-    sha256 = "0nzn7qvmpbb17d6q16llnhz1qdmyg718q59ic4gw2rq23cd6q47r";
+    sha256 = "113ip024ggajjdx0l406g6lwypdrddxz6k3640y6lzqjivcgybjf";
   };
 
   buildInputs = [ file desktop-file-utils ];


### PR DESCRIPTION
###### Motivation for this change

Bumps

- comfortaa: 3.001 -> 3.101
- fira-mono: 4.106 -> 4.202
- unifont_upper: 13.0.05 -> 13.0.06
- unifont: 13.0.05 -> 13.0.06
- josm: 18004 -> 18118
- mimeo: 2019.7 -> 2021.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
