### PR TITLE
zim: 0.73.1 -> 0.73.5

### DIFF
--- a/pkgs/applications/office/zim/default.nix
+++ b/pkgs/applications/office/zim/default.nix
@@ -9,11 +9,11 @@
 
 python3Packages.buildPythonApplication rec {
   name = "zim-${version}";
-  version = "0.73.1";
+  version = "0.73.5";
 
   src = fetchurl {
     url = "https://zim-wiki.org/downloads/${name}.tar.gz";
-    sha256 = "13vhwsgv6mscgixypc0ixkgj0y7cpcm7z7wn1vmdrwp7kn8m3xgx";
+    sha256 = "sha256-o28V2Sw5lMDVWwf4MlOz2LgmvrNxSGXturwU8cyR1jo=";
   };
 
   buildInputs = [ gtk3 gobject-introspection wrapGAppsHook gnome.adwaita-icon-theme ];


### PR DESCRIPTION
###### Motivation for this change
https://github.com/zim-desktop-wiki/zim-desktop-wiki/releases/tag/0.73.5

Current version (0.73.1) is broken when running under python3.9 (ie in master) (see zim commit [feba6b2c](https://github.com/zim-desktop-wiki/zim-desktop-wiki/commit/feba6b2cf2b23c4c019a7bc770da44064cc6dd42))

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
