### PR TITLE
starship: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -175,19 +175,20 @@
   ./programs/phosh.nix
   ./programs/qt5ct.nix
   ./programs/screen.nix
-  ./programs/sedutil.nix
   ./programs/seahorse.nix
-  ./programs/slock.nix
+  ./programs/sedutil.nix
   ./programs/shadow.nix
-  ./programs/spacefm.nix
   ./programs/singularity.nix
+  ./programs/slock.nix
+  ./programs/spacefm.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
-  ./programs/sysdig.nix
-  ./programs/systemtap.nix
+  ./programs/starship.nix
   ./programs/steam.nix
   ./programs/sway.nix
+  ./programs/sysdig.nix
   ./programs/system-config-printer.nix
+  ./programs/systemtap.nix
   ./programs/thefuck.nix
   ./programs/tilp2.nix
   ./programs/tmux.nix

--- a/nixos/modules/programs/starship.nix
+++ b/nixos/modules/programs/starship.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.starship;
+
+in {
+  meta.maintainers = [ maintainers.imalison ];
+
+  options.programs.starship = {
+    enable = mkEnableOption "starship";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.starship;
+      defaultText = literalExample "pkgs.starship";
+      description = "The package to use for the starship binary.";
+    };
+
+    enableBashIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Bash integration.
+      '';
+    };
+
+    enableZshIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Zsh integration.
+      '';
+    };
+
+    enableFishIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Fish integration.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    programs.bash.promptInit = mkIf cfg.enableBashIntegration ''
+      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm" || ''${STARSHIP_INSIDE_EMACS-no} != "no") ]]; then
+        eval "$(${cfg.package}/bin/starship init bash)"
+      fi
+    '';
+
+    programs.zsh.promptInit = mkIf cfg.enableZshIntegration ''
+      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm" || ''${STARSHIP_INSIDE_EMACS-no} != "no") ]]; then
+        eval "$(${cfg.package}/bin/starship init zsh)"
+      fi
+    '';
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
