### PR TITLE
python3Packages.loca: init at 2.0.1

### DIFF
--- a/pkgs/development/python-modules/loca/default.nix
+++ b/pkgs/development/python-modules/loca/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, pythonOlder, fetchFromSourcehut }:
+
+buildPythonPackage rec {
+  pname = "loca";
+  version = "2.0.1";
+  format = "flit";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromSourcehut {
+    owner = "~cnx";
+    repo = pname;
+    rev = version;
+    sha256 = "1l6jimw3wd81nz1jrzsfw1zzsdm0jm998xlddcqaq0h38sx69w8g";
+  };
+
+  doCheck = false; # all checks are static analyses
+  pythonImportsCheck = [ "loca" ];
+
+  meta = with lib; {
+    description = "Local locations";
+    homepage = "https://pypi.org/project/loca";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.McSinyx ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4230,6 +4230,8 @@ in {
 
   lmtpd = callPackage ../development/python-modules/lmtpd { };
 
+  loca = callPackage ../development/python-modules/loca { };
+
   localimport = callPackage ../development/python-modules/localimport { };
 
   localzone = callPackage ../development/python-modules/localzone { };


### PR DESCRIPTION
###### Motivation for this change

Loca is a redesign of appdirs.  It is one of the forks of the latter as its development has slowed down for the last few years.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
