### PR TITLE
pythonPackages.twisted: 20.3.0 -> 21.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3419,6 +3419,12 @@
     githubId = 454695;
     name = "Artur Taranchiev";
   };
+  exarkun = {
+    email = "exarkun@twistedmatrix.com";
+    github = "exarkun";
+    githubId = 254565;
+    name = "Jean-Paul Calderone";
+  };
   exfalso = {
     email = "0slemi0@gmail.com";
     github = "exfalso";

--- a/pkgs/development/libraries/thrift/0.10.nix
+++ b/pkgs/development/libraries/thrift/0.10.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, boost, zlib, libevent, openssl, python, pkg-config, bison
-, flex, twisted
+{ lib, stdenv, fetchurl, boost, zlib, libevent, openssl, python3, pkg-config, bison
+, flex
 }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    boost zlib libevent openssl python bison flex twisted
+    boost zlib libevent openssl bison flex (python3.withPackages (ps: [ps.twisted]))
   ];
 
   preConfigure = "export PY_PREFIX=$out";

--- a/pkgs/development/libraries/thrift/default.nix
+++ b/pkgs/development/libraries/thrift/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, boost, zlib, libevent, openssl, python, cmake, pkg-config
-, bison, flex, twisted
+{ lib, stdenv, fetchurl, boost, zlib, libevent, openssl, python3, cmake, pkg-config
+, bison, flex
 , static ? stdenv.hostPlatform.isStatic
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config bison flex ];
   buildInputs = [ boost zlib libevent openssl ]
-    ++ lib.optionals (!static) [ python twisted ];
+    ++ lib.optionals (!static) [ (python3.withPackages (ps: [ps.twisted])) ];
 
   preConfigure = "export PY_PREFIX=$out";
 

--- a/pkgs/development/python-modules/klein/default.nix
+++ b/pkgs/development/python-modules/klein/default.nix
@@ -1,35 +1,29 @@
-{ lib, buildPythonPackage, fetchPypi, fetchpatch
-, six, twisted, werkzeug, incremental
-, mock }:
+{ lib, buildPythonPackage, fetchPypi, python
+, attrs, enum34, hyperlink, incremental, six, twisted, typing, tubes, werkzeug, zope_interface
+, hypothesis, treq
+}:
 
 buildPythonPackage rec {
   pname = "klein";
-  version = "17.10.0";
+  version = "21.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "30aaf0d78a987d5dbfe0968a07367ad0c73e02823cc8eef4c54f80ab848370d0";
+    sha256 = "1mpydmz90d0n9dwa7mr6pgj5v0kczfs05ykssrasdq368dssw7ch";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "tests-expect-werkzeug-308.patch";
-      url = "https://github.com/twisted/klein/commit/e2a5835b83e37a2bc5faefbfe1890c529b18b9c6.patch";
-      sha256 = "03j0bj3l3hnf7f96rb27i4bzy1iih79ll5bcah7gybdi1wpznh8w";
-    })
-  ];
+  propagatedBuildInputs = [ attrs enum34 hyperlink incremental six twisted typing tubes werkzeug zope_interface ];
 
-  propagatedBuildInputs = [ six twisted werkzeug incremental ];
-
-  checkInputs = [ mock twisted ];
+  checkInputs = [ hypothesis treq ];
 
   checkPhase = ''
-    trial klein
+    ${python.interpreter} -m twisted.trial -j $NIX_BUILD_CORES klein
   '';
 
   meta = with lib; {
     description = "Klein Web Micro-Framework";
     homepage    = "https://github.com/twisted/klein";
     license     = licenses.mit;
+    maintainers = with maintainers; [ exarkun ];
   };
 }

--- a/pkgs/development/python-modules/tubes/default.nix
+++ b/pkgs/development/python-modules/tubes/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, python
+, characteristic, six, twisted
+}:
+
+buildPythonPackage rec {
+  pname = "tubes";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    pname = "Tubes";
+    inherit version;
+    sha256 = "0sg1gg2002h1xsgxigznr1zk1skwmhss72dzk6iysb9k9kdgymcd";
+  };
+
+  propagatedBuildInputs = [ characteristic six twisted ];
+
+  checkPhase = ''
+    ${python.interpreter} -m twisted.trial -j $NIX_BUILD_CORES tubes
+  '';
+
+  pythonImportsCheck = [ "tubes" ];
+
+  meta = with lib; {
+    description = "a data-processing and flow-control engine for event-driven programs";
+    homepage    = "https://github.com/twisted/tubes";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ exarkun ];
+  };
+}

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -13,18 +13,19 @@
 , service-identity
 , setuptools
 , idna
+, typing-extensions
 }:
 buildPythonPackage rec {
   pname = "Twisted";
-  version = "20.3.0";
+  version = "21.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    extension = "tar.bz2";
-    sha256 = "040yzha6cyshnn6ljgk2birgh6mh2cnra48xp5ina5vfsnsmab6p";
+    extension = "tar.gz";
+    sha256 = "01lh225d7lfnmfx4f4kxwl3963gjc9yg8jfkn1w769v34ia55mic";
   };
 
-  propagatedBuildInputs = [ zope_interface incremental automat constantly hyperlink pyhamcrest attrs setuptools ];
+  propagatedBuildInputs = [ zope_interface incremental automat constantly hyperlink pyhamcrest attrs setuptools typing-extensions ];
 
   passthru.extras.tls = [ pyopenssl service-identity idna ];
 
@@ -32,7 +33,7 @@ buildPythonPackage rec {
   # twisted.python.runtime.platform.supportsINotify() == False
   patchPhase = lib.optionalString stdenv.isLinux ''
     substituteInPlace src/twisted/python/_inotify.py --replace \
-      "ctypes.util.find_library('c')" "'${stdenv.glibc.out}/lib/libc.so.6'"
+      "ctypes.util.find_library(\"c\")" "'${stdenv.glibc.out}/lib/libc.so.6'"
   '';
 
   # Generate Twisted's plug-in cache.  Twisted users must do it as well.  See

--- a/pkgs/development/python-modules/txtorcon/default.nix
+++ b/pkgs/development/python-modules/txtorcon/default.nix
@@ -1,4 +1,4 @@
-{lib, buildPythonPackage, fetchPypi, isPy3k, incremental, ipaddress, twisted
+{ lib, python, buildPythonPackage, pythonOlder, fetchPypi, isPy3k, incremental, ipaddress, twisted
 , automat, zope_interface, idna, pyopenssl, service-identity, pytest, mock, lsof
 , GeoIP, isPy27}:
 
@@ -18,21 +18,18 @@ buildPythonPackage rec {
     sha256 = "aebf0b9ec6c69a029f6b61fd534e785692e28fdcd2fd003ce3cc132b9393b7d6";
   };
 
-  # zope.interface issue
-  doCheck = isPy3k;
-  # Skip a failing test until fixed upstream:
-  # https://github.com/meejah/txtorcon/issues/250
+  # Based on what txtorcon tox.ini will automatically test, allow back as far
+  # as Python 3.5.
+  disabled = pythonOlder "3.5";
+
   checkPhase = ''
-    pytest --ignore=test/test_util.py .
+    ${python.interpreter} -m twisted.trial -j $NIX_BUILD_CORES ./test
   '';
 
   meta = {
     description = "Twisted-based Tor controller client, with state-tracking and configuration abstractions";
     homepage = "https://github.com/meejah/txtorcon";
-    maintainers = with lib.maintainers; [ jluttine ];
-    # Currently broken on Python 2.7. See
-    # https://github.com/NixOS/nixpkgs/issues/71826
-    broken = isPy27;
+    maintainers = with lib.maintainers; [ jluttine exarkun ];
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18916,13 +18916,9 @@ with pkgs;
 
   theft = callPackage ../development/libraries/theft { };
 
-  thrift = callPackage ../development/libraries/thrift {
-    inherit (pythonPackages) twisted;
-  };
+  thrift = callPackage ../development/libraries/thrift { };
 
-  thrift-0_10 = callPackage ../development/libraries/thrift/0.10.nix {
-    inherit (pythonPackages) twisted;
-  };
+  thrift-0_10 = callPackage ../development/libraries/thrift/0.10.nix { };
 
   tidyp = callPackage ../development/libraries/tidyp { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8920,6 +8920,8 @@ in {
 
   ttp = callPackage ../development/python-modules/ttp { };
 
+  tubes = callPackage ../development/python-modules/tubes { };
+
   tunigo = callPackage ../development/python-modules/tunigo { };
 
   tubeup = callPackage ../development/python-modules/tubeup { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Bring over a year of Twisted improvements into Nixpkgs
* Provide better type hints for Twisted APIs
* Provide minimum version required to run latest development version of GridSync (not in nixpkgs yet) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
