### PR TITLE
kind: patch for correct kernal module path

### DIFF
--- a/pkgs/development/tools/kind/default.nix
+++ b/pkgs/development/tools/kind/default.nix
@@ -13,6 +13,11 @@ buildGoModule rec {
     sha256 = "sha256-pjg52ONseKNw06EOBzD6Elge+Cz+C3llPvjJPHkn1cw=";
   };
 
+  patches = [
+    # fix kernel module path used by kind
+    ./kernel-module-path.patch
+  ];
+
   vendorSha256 = "sha256-HiVdekSZrC/RkMSvcwm1mv6AE4bA5kayUsMdVCbckiE=";
 
   doCheck = false;

--- a/pkgs/development/tools/kind/kernel-module-path.patch
+++ b/pkgs/development/tools/kind/kernel-module-path.patch
@@ -1,0 +1,47 @@
+diff --git a/pkg/cluster/internal/providers/common/getmodules.go b/pkg/cluster/internal/providers/common/getmodules.go
+new file mode 100644
+index 00000000..f42a883d
+--- /dev/null
++++ b/pkg/cluster/internal/providers/common/getmodules.go
+@@ -0,0 +1,15 @@
++package common
++
++import "os"
++
++const (
++	fhsKernalModulePath = "/lib/modules"
++	nixKernalModulePath = "/run/booted-system/kernel-modules/lib"
++)
++
++func GetKernelModulePath() string {
++	if _, err := os.Stat(nixKernalModulePath); !os.IsNotExist(err) {
++		return nixKernalModulePath
++	}
++	return fhsKernalModulePath
++}
+diff --git a/pkg/cluster/internal/providers/docker/provision.go b/pkg/cluster/internal/providers/docker/provision.go
+index 50161861..86d5b7b6 100644
+--- a/pkg/cluster/internal/providers/docker/provision.go
++++ b/pkg/cluster/internal/providers/docker/provision.go
+@@ -242,7 +242,7 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
+ 		// (please don't depend on doing this though!)
+ 		"--volume", "/var",
+ 		// some k8s things want to read /lib/modules
+-		"--volume", "/lib/modules:/lib/modules:ro",
++		"--volume", fmt.Sprintf("%s:/lib/modules:ro", common.GetKernelModulePath()),
+ 	},
+ 		args...,
+ 	)
+diff --git a/pkg/cluster/internal/providers/podman/provision.go b/pkg/cluster/internal/providers/podman/provision.go
+index 51dce486..3bc36b42 100644
+--- a/pkg/cluster/internal/providers/podman/provision.go
++++ b/pkg/cluster/internal/providers/podman/provision.go
+@@ -205,7 +205,7 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
+ 		// dev: devices on the volume will be able to be used by processes within the container
+ 		"--volume", fmt.Sprintf("%s:/var:suid,exec,dev", varVolume),
+ 		// some k8s things want to read /lib/modules
+-		"--volume", "/lib/modules:/lib/modules:ro",
++		"--volume", fmt.Sprintf("%s:/lib/modules:ro", common.GetKernelModulePath()),
+ 	},
+ 		args...,
+ 	)


### PR DESCRIPTION
Signed-off-by: Atkins Chang <atkinschang@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Things in `kind` may need kernel module, the hard-coded path in kind is wrong in nixos environment

can be verify via:
```bash
docker inspect kind-control-plane | jq '.[0].Mounts'
````

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
