### PR TITLE
Fix kubebuilder

### DIFF
--- a/pkgs/applications/networking/cluster/kubebuilder/default.nix
+++ b/pkgs/applications/networking/cluster/kubebuilder/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   };
   vendorSha256 = "0zxyd950ksjswja64rfri5v2yaalfg6qmq8215ildgrcavl9974n";
 
-  subPackages = ["cmd" "pkg/..."];
+  subPackages = ["cmd"];
 
   preBuild = ''
     export buildFlagsArray+=("-ldflags=-X main.kubeBuilderVersion=v${version} \

--- a/pkgs/applications/networking/cluster/kubebuilder/default.nix
+++ b/pkgs/applications/networking/cluster/kubebuilder/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, installShellFiles
 , makeWrapper
 , git
 , go
@@ -15,7 +14,7 @@ buildGoModule rec {
     owner = "kubernetes-sigs";
     repo = "kubebuilder";
     rev = "v${version}";
-    sha256 = "1726j2b5jyvllvnk60g6px3g2jyyphd9pc4vgid45mis9b60sh8a";
+    sha256 = "0bl5ff2cplal6hg75800crhyviamk1ws85sq60h4zg21hzf21y68";
   };
   vendorSha256 = "0zxyd950ksjswja64rfri5v2yaalfg6qmq8215ildgrcavl9974n";
 


### PR DESCRIPTION
###### Motivation for this change

- The derivation is not building due to a mismatch on the sha256 sum
- The derivation is building more binaries than needed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
