### PR TITLE
chart-testing: init at 3.4.0

### DIFF
--- a/pkgs/applications/networking/cluster/helm/chart-testing/default.nix
+++ b/pkgs/applications/networking/cluster/helm/chart-testing/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "chart-testing";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "helm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-c7Rjk2YZaQXyFwrDVwYgOCnq/F2ooIUVETXVn5FVlZE=";
+  };
+
+  vendorSha256 = "sha256-1Py66ljDjJC38biJ25D8KnWEi3nXAVt9QSgyH1KkwHM=";
+
+  postPatch = ''
+    substituteInPlace pkg/config/config.go \
+      --replace "\"/etc/ct\"," "\"$out/etc/ct\","
+  '';
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.Version=${version}"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=${src.rev}"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=19700101-00:00:00"
+  ];
+
+  postInstall = ''
+    install -Dm644 -t $out/etc/ct etc/chart_schema.yaml
+    install -Dm644 -t $out/etc/ct etc/lintconf.yaml
+  '';
+
+  meta = with lib; {
+    description = "A tool for testing Helm charts";
+    homepage = "https://github.com/helm/chart-testing";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ atkinschang ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25503,6 +25503,8 @@ in
 
   kubernetes-helmPlugins = dontRecurseIntoAttrs (callPackage ../applications/networking/cluster/helm/plugins { });
 
+  chart-testing = callPackage ../applications/networking/cluster/helm/chart-testing { };
+
   kubetail = callPackage ../applications/networking/cluster/kubetail { } ;
 
   kupfer = callPackage ../applications/misc/kupfer {


### PR DESCRIPTION
[ct](https://github.com/helm/chart-testing) is the the tool for testing Helm charts

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
