### PR TITLE
xmrig-mo: init at 6.14.1-mo1

### DIFF
--- a/pkgs/applications/misc/xmrig/moneroocean.nix
+++ b/pkgs/applications/misc/xmrig/moneroocean.nix
@@ -1,0 +1,21 @@
+{ fetchFromGitHub, lib, xmrig }:
+
+xmrig.overrideAttrs (oldAttrs: rec {
+  pname = "xmrig-mo";
+  version = "6.14.1-mo1";
+
+  src = fetchFromGitHub {
+    owner = "MoneroOcean";
+    repo = "xmrig";
+    rev = "v${version}";
+    sha256 = "sha256-1YG0llNv1VR8ocNFxYLZFXMzowNNqpqSyIu7iCr/rfM=";
+  };
+
+  meta = with lib; {
+    description = "A fork of the XMRig CPU miner with support for algorithm switching";
+    homepage = "https://github.com/MoneroOcean/xmrig";
+    license = licenses.gpl3Plus;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ j0hax ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25911,6 +25911,8 @@ in
 
   xmrig = callPackage ../applications/misc/xmrig { };
 
+  xmrig-mo = callPackage ../applications/misc/xmrig/moneroocean.nix { };
+
   xmrig-proxy = callPackage ../applications/misc/xmrig/proxy.nix { };
 
   molot-lite = callPackage ../applications/audio/molot-lite { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package a popular fork of the xmrig Monero miner. Resolves https://github.com/NixOS/nixpkgs/issues/116741.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
