### PR TITLE
pythonPackages.xml-marshaller: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/xml-marshaller/default.nix
+++ b/pkgs/development/python-modules/xml-marshaller/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, lxml
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "xml-marshaller";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "xml_marshaller";
+    sha256 = "sha256-QvBALLDD8o5nZQ5Z4bembhadK6jcydWKQpJaSmGqqJM=";
+  };
+
+  propagatedBuildInputs = [ lxml six ];
+
+  meta = with lib; {
+    description = "This module allows one to marshal simple Python data types into a custom XML format.";
+    homepage = "https://www.python.org/community/sigs/current/xml-sig/";
+    license = licenses.psfl;
+    maintainers = with maintainers; [ mazurel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9429,6 +9429,8 @@ in {
 
   xmltodict = callPackage ../development/python-modules/xmltodict { };
 
+  xml-marshaller = callPackage ../development/python-modules/xml-marshaller { };
+
   xmodem = callPackage ../development/python-modules/xmodem { };
 
   xnd = callPackage ../development/python-modules/xnd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding missing python library to the nixpkgs.

Description:
This module allows one to marshal simple Python data types into a custom XML format. The Marshaller and Unmarshaller classes can be subclassed in order to implement marshalling into a different XML DTD. Original Authors are XML-SIG (xml-sig@python.org).

Fully compatible with PyXML implementation, enables namespace support for XML Input/Output.

Implemented with lxml


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
