### PR TITLE
teensy-loader-cli: 2.1.20191110 → 2.1+unstable=2021-04-10

### DIFF
--- a/pkgs/development/tools/misc/teensy-loader-cli/default.nix
+++ b/pkgs/development/tools/misc/teensy-loader-cli/default.nix
@@ -1,31 +1,46 @@
-{ lib, stdenv, fetchFromGitHub, go-md2man, installShellFiles, libusb-compat-0_1 }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, go-md2man
+, installShellFiles
+, libusb-compat-0_1
+}:
 
 stdenv.mkDerivation rec {
   pname = "teensy-loader-cli";
-  version = "2.1.20191110";
+  version = "2.1+unstable=2021-04-10";
 
   src = fetchFromGitHub {
     owner = "PaulStoffregen";
     repo = "teensy_loader_cli";
-    rev = "e98b5065cdb9f04aa4dde3f2e6e6e6f12dd97592";
-    sha256 = "1yx8vsh6b29pqr4zb6sx47429i9x51hj9psn8zksfz75j5ivfd5i";
+    rev = "9dbbfa3b367b6c37e91e8a42dae3c6edfceccc4d";
+    sha256 = "lQ1XtaWPr6nvE8NArD1980QVOH6NggO3FlfsntUjY7s=";
   };
 
-  buildInputs = [ libusb-compat-0_1 ];
+  nativeBuildInputs = [
+    go-md2man
+    installShellFiles
+  ];
 
-  nativeBuildInputs = [ go-md2man installShellFiles ];
+  buildInputs = [
+    libusb-compat-0_1
+  ];
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm555 teensy_loader_cli $out/bin/teensy-loader-cli
     install -Dm444 -t $out/share/doc/${pname} *.md *.txt
     go-md2man -in README.md -out ${pname}.1
     installManPage *.1
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Firmware uploader for the Teensy microcontroller boards";
     homepage = "https://www.pjrc.com/teensy/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Add support for Teensy 4.1.

Also clean the expression up a bit.

For testing, you will need:

```nix
  services.udev.extraRules = ''
    # https://www.pjrc.com/teensy/00-teensy.rules
    ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
    ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789a]*", ENV{MTP_NO_PROBE}="1"
    KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", MODE:="0666", RUN:="${pkgs.coreutils}/bin/stty -F /dev/%k raw -echo"
    KERNEL=="hidraw*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", MODE:="0666"
    SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", MODE:="0666"
    KERNEL=="hidraw*", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="013*", MODE:="0666"
    SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="013*", MODE:="0666"
  '';
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

- [x] Successfully flashed a firmware using `teensy-loader-cli -v -w --mcu=TEENSY41 .build/kinesis_kint41_default.hex`
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
