### PR TITLE
python3Packages.envisage: unbreak package by adding setuptools dependency

### DIFF
--- a/pkgs/development/python-modules/envisage/default.nix
+++ b/pkgs/development/python-modules/envisage/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchPypi, isPy27
 , buildPythonPackage
 , traits, apptools, pytestCheckHook
-, ipykernel, ipython
+, ipykernel, ipython, setuptools
 }:
 
 buildPythonPackage rec {
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "0zrxlq4v3091727vf10ngc8418sp26raxa8q83i4h0sydfkh2dic";
   };
 
-  propagatedBuildInputs = [ traits apptools ];
+  propagatedBuildInputs = [ traits apptools setuptools ];
 
   preCheck = ''
     export HOME=$PWD/HOME


### PR DESCRIPTION
###### Motivation for this change

`import envisage.api` fails at runtime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
