### PR TITLE
rgbds: 0.4.2 -> 0.5.1

### DIFF
--- a/pkgs/development/compilers/rgbds/default.nix
+++ b/pkgs/development/compilers/rgbds/default.nix
@@ -1,23 +1,19 @@
 {lib, stdenv, fetchFromGitHub, bison, flex, pkg-config, libpng}:
 
-# TODO: byacc is the recommended parser generator but due to https://github.com/rednex/rgbds/issues/333
-# it does not work for the moment. We should switch back to byacc as soon as the fix is integrated
-# in a published version.
-
 stdenv.mkDerivation rec {
   pname = "rgbds";
-  version = "0.4.2";
+  version = "0.5.1";
   src = fetchFromGitHub {
-    owner = "rednex";
+    owner = "gbdev";
     repo = "rgbds";
     rev = "v${version}";
-    sha256 = "0lygj7jzjlq4w0mkiir7ycysrd1p1akyvzrppjcchja05mi8wy9p";
+    sha256 = "11b1hg2m2f60q5622rb0nxhrzzylsxjx0c8inbxifi6lvmj9ak4x";
   };
   nativeBuildInputs = [ bison flex pkg-config libpng ];
   installFlags = [ "PREFIX=\${out}" ];
 
   meta = with lib; {
-    homepage = "https://rednex.github.io/rgbds/";
+    homepage = "https://rgbds.gbdev.io/";
     description = "A free assembler/linker package for the Game Boy and Game Boy Color";
     license = licenses.mit;
     longDescription =


### PR DESCRIPTION
This also changes the owner of the GitHub repository and the homepage
URL because the repository was moved to a different organisation (the
old GitHub repository now redirects to the new one).

Also, since upstream switched to GNU Bison[1], the comment about byacc
is no longer necessary.

[1] https://github.com/gbdev/rgbds/issues/595

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).