### PR TITLE
emacs.pkgs.ada-mode: pin wisi 3.1.3 to fix build

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -87,7 +87,7 @@ self: let
         ];
 
         preInstall = ''
-          ./build.sh
+          ./build.sh -j$NIX_BUILD_CORES
         '';
 
         postInstall = ''

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -66,7 +66,12 @@ self: let
         phases = "unpackPhase " + old.phases; # not a list, interestingly…
         srcs = [
           super.ada-mode.src
-          self.wisi.src
+          # ada-mode needs a specific version of wisi, check NEWS or ada-mode's
+          # package-requires to find the version to use.
+          (pkgs.fetchurl {
+            url = "https://elpa.gnu.org/packages/wisi-3.1.3.tar.lz";
+            sha256 = "18dwcc0crds7aw466vslqicidlzamf8avn59gqi2g7y2x9k5q0as";
+          })
         ];
 
         sourceRoot = "ada-mode-${self.ada-mode.version}";
@@ -74,6 +79,7 @@ self: let
         nativeBuildInputs = [
           buildPackages.gnat
           buildPackages.gprbuild
+          buildPackages.lzip
         ];
 
         buildInputs = [


### PR DESCRIPTION
Apparently ada-mode is intended to be build with a _specific_ version of
wisi which is not mentioned in the manual (as far as I am aware), but
described in passing in NEWS [1]. Thus the package-overrides in ada-mode.el
are to be interpreted as a strict version requirement.

[1]: https://git.savannah.gnu.org/cgit/emacs/elpa.git/tree/NEWS?h=externals/ada-mode&id=a2b7ec2b4c1b6067348b1d1026dd80c133b3200d#n17

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

(ELPA deleted tarballs again, test using emacs-overlay or if you have the old tarballs in store locally (via `lzip -d … && nix-store --add-fixed sha256 …`))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
