### PR TITLE
emacs: Add custom elpa fetcher

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -41,7 +41,10 @@ self: let
   }: let
 
     imported = import generated {
-      inherit (self) callPackage;
+      callPackage = pkgs: args: self.callPackage pkgs (args // {
+        # Use custom elpa url fetcher with fallback/uncompress
+        fetchurl = buildPackages.callPackage ./fetchelpa.nix { };
+      });
     };
 
     super = removeAttrs imported [ "dash" ];

--- a/pkgs/applications/editors/emacs/elisp-packages/fetchelpa.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/fetchelpa.nix
@@ -1,0 +1,21 @@
+# Elpa only serves the latest version of a given package uncompressed.
+# Once that release is no longer the latest & greatest it gets archived and compressed
+# meaning that both the URL and the hash changes.
+#
+# To work around this issue we fall back to the URL with the .lz suffix and if that's the
+# one we downloaded we uncompress the file to ensure the hash matches regardless of compression.
+
+{ fetchurl, lzip }:
+
+{ url, ... }@args: fetchurl ((removeAttrs args [ "url" ]) // {
+  urls = [
+    url
+    (url + ".lz")
+  ];
+  postFetch = ''
+    if [[ $url == *.lz ]]; then
+      ${lzip}/bin/lzip -c -d $out > uncompressed
+      mv uncompressed $out
+    fi
+  '';
+})

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
@@ -10,7 +10,7 @@ To update the list of packages from nongnu (ELPA),
 
 */
 
-{ lib }:
+{ lib, buildPackages }:
 
 self: let
 
@@ -19,7 +19,10 @@ self: let
   }: let
 
     imported = import generated {
-      inherit (self) callPackage;
+      callPackage = pkgs: args: self.callPackage pkgs (args // {
+        # Use custom elpa url fetcher with fallback/uncompress
+        fetchurl = buildPackages.callPackage ./fetchelpa.nix { };
+      });
     };
 
     super = imported;

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -35,7 +35,8 @@ let
     inherit lib;
   };
 
-  mkNongnuPackages = { lib }: import ../applications/editors/emacs/elisp-packages/nongnu-packages.nix {
+  mkNongnuPackages = { pkgs, lib }: import ../applications/editors/emacs/elisp-packages/nongnu-packages.nix {
+    inherit (pkgs) buildPackages;
     inherit lib;
   };
 
@@ -62,7 +63,7 @@ in makeScope pkgs'.newScope (self: makeOverridable ({
   pkgs ? pkgs'
   , lib ? pkgs.lib
   , elpaPackages ? mkElpaPackages { inherit pkgs lib; } self
-  , nongnuPackages ? mkNongnuPackages { inherit lib; } self
+  , nongnuPackages ? mkNongnuPackages { inherit pkgs lib; } self
   , melpaStablePackages ? melpaGeneric { inherit pkgs lib; } "stable" self
   , melpaPackages ? melpaGeneric { inherit pkgs lib; } "unstable" self
   , orgPackages ? mkOrgPackages { inherit lib; } self


### PR DESCRIPTION
###### Motivation for this change
Elpa (and by extension nongnu) only serves the latest version of a given package uncompressed.
Once that release is no longer the latest & greatest it gets archived and compressed meaning that both the URL and the hash changes.
    
To work around this issue we fall back to the URL with the .lz suffix and if that's the one we downloaded we uncompress the file to ensure the hash matches regardless of compression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
