### PR TITLE
python3Packages.awslambdaric: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/awslambdaric/default.nix
+++ b/pkgs/development/python-modules/awslambdaric/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "awslambdaric";
-  version = "1.1.1";
+  version = "1.2.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-lambda-python-runtime-interface-client";
     rev = version;
-    sha256 = "1f8828y32yrf87bc933jhmjrvj746baibvpn0w21x3ji81vf6mri";
+    sha256 = "120qar8iaxj6dmnhjw1c40n2w06f1nyxy57dwh06xdiany698fg4";
   };
 
   propagatedBuildInputs = [ simplejson ];
@@ -20,6 +20,10 @@ buildPythonPackage rec {
   buildInputs = [ gcc ];
 
   dontUseCmakeConfigure = true;
+
+  preBuild = ''
+    substituteInPlace requirements/base.txt --replace 'simplejson==3' 'simplejson~=3'
+  '';
 
   checkInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
###### Motivation for this change

Update version.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).