### PR TITLE
python3Packages.google-cloud-org-policy: 0.3.0 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/google-cloud-org-policy/default.nix
+++ b/pkgs/development/python-modules/google-cloud-org-policy/default.nix
@@ -1,19 +1,21 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, google-api-core, proto-plus }:
+{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, pythonOlder, google-api-core, mock, proto-plus, protobuf, pytest-asyncio }:
 
 buildPythonPackage rec {
   pname = "google-cloud-org-policy";
-  version = "0.3.0";
+  version = "1.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "eea55e99ceec896ffc98ee3051710a241b7d335f246a0472bbffbb0cb2def453";
+    sha256 = "12qwiqb7xrnq42z777j5nxdgka3vv411l9cngka6cr6mx4s83c9l";
   };
 
   propagatedBuildInputs = [ google-api-core proto-plus ];
 
-  # No tests in repo
-  doCheck = false;
-
+  # prevent google directory from shadowing google imports
+  preCheck = ''
+    rm -r google
+  '';
+  checkInputs = [ mock protobuf pytest-asyncio pytestCheckHook ];
   pythonImportsCheck = [ "google.cloud.orgpolicy" ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Update version, enable tests.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).