### PR TITLE
kmsxx: 2020-08-04 -> 2021-07-26 unbreak

### DIFF
--- a/pkgs/development/libraries/kmsxx/default.nix
+++ b/pkgs/development/libraries/kmsxx/default.nix
@@ -1,22 +1,37 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libdrm
-, withPython ? false, python ? null }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, cmake
+, pkg-config
+, libdrm
+, fmt
+, libevdev
+, withPython ? false
+, python3Packages
+}:
 
 stdenv.mkDerivation {
   pname = "kmsxx";
-  version = "2020-08-04";
+  version = "2021-07-26";
 
   src = fetchFromGitHub {
     owner = "tomba";
     repo = "kmsxx";
     fetchSubmodules = true;
-    rev = "38bee3092f2d477f1baebfcae464f888d3d04bbe";
-    sha256 = "0xz4m9bk0naawxwpx5cy1j3cm6c8c9m5y551csk88y88x1g0z0xh";
+    rev = "54f591ec0de61dd192baf781c9b2ec87d5b461f7";
+    sha256 = "sha256-j+20WY4a2iTKZnYjXhxbNnZZ53K3dHpDMTp+ZulS+7c=";
   };
 
-  cmakeFlags = lib.optional (!withPython) "-DKMSXX_ENABLE_PYTHON=OFF";
+  # Didn't detect pybind11 without cmake
+  nativeBuildInputs = [ meson ninja pkg-config ] ++ lib.optionals withPython [ cmake ];
+  buildInputs = [ libdrm fmt libevdev ]
+    ++ lib.optionals withPython (with python3Packages; [ python pybind11 ]);
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ libdrm ] ++ lib.optionals withPython [ python ];
+  dontUseCmakeConfigure = true;
+
+  mesonFlags = lib.optional (!withPython) "-Dpykms=disabled";
 
   meta = with lib; {
     description = "C++11 library, utilities and python bindings for Linux kernel mode setting";
@@ -24,6 +39,5 @@ stdenv.mkDerivation {
     license = licenses.mpl20;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
-    broken = true; # marked broken 2021-03-26
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3942,10 +3942,9 @@ in {
 
   kmapper = callPackage ../development/python-modules/kmapper { };
 
-  kmsxx = toPythonModule ((callPackage ../development/libraries/kmsxx {
-    inherit (pkgs.kmsxx) stdenv;
+  kmsxx = toPythonModule (pkgs.kmsxx.override {
     withPython = true;
-  }).overrideAttrs (oldAttrs: { name = "${python.libPrefix}-${pkgs.kmsxx.name}"; }));
+  });
 
   knack = callPackage ../development/python-modules/knack { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Supersedes  #111976

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
