### PR TITLE
pinyin-tool: init at 0.1.3

### DIFF
--- a/pkgs/tools/text/pinyin-tool/default.nix
+++ b/pkgs/tools/text/pinyin-tool/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, rustPlatform, fetchFromGitHub, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pinyin-tool";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "briankung";
+    repo = pname;
+    rev = version;
+    sha256 = "1gwqwxlvdrm4sdyqkvpvvfi6jh6qqn6qybn0z66wm06k62f8zj5b";
+  };
+
+  cargoSha256 = "1ixl4bsb8c8dmz9s28a2v5l5f2hi3g9xjy6ribmhybpwmfs4mr4d";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+
+  meta = with lib; {
+    description = "A simple command line tool for converting Chinese characters to space-separate pinyin words";
+    homepage = "https://github.com/briankung/pinyin-tool";
+    license = licenses.mit;
+    maintainers = with maintainers; [ neonfuz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8077,6 +8077,10 @@ in
 
   pixiewps = callPackage ../tools/networking/pixiewps {};
 
+  pinyin-tool = callPackage ../tools/text/pinyin-tool {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   pk2cmd = callPackage ../tools/misc/pk2cmd { };
 
   plantuml = callPackage ../tools/misc/plantuml { };


### PR DESCRIPTION
###### Motivation for this change
Add a straightforward and fast tool to convert Chinese text to pinyin from the command line

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
