### PR TITLE
mit-scheme: 10.1.10 -> 11.2

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11918,14 +11918,11 @@ in
   mint = callPackage ../development/compilers/mint { };
 
   mitscheme = callPackage ../development/compilers/mit-scheme {
-    texLive = texlive.combine { inherit (texlive) scheme-small; };
-    texinfo = texinfo5;
+    texLive = texlive.combine { inherit (texlive) scheme-small epsf texinfo; };
     xlibsWrapper = null;
   };
 
   mitschemeX11 = mitscheme.override {
-    texLive = texlive.combine { inherit (texlive) scheme-small; };
-    texinfo = texinfo5;
     enableX11 = true;
   };
 


### PR DESCRIPTION
Add ncurses as a propagated build input.
Add ghostscript, autoconf, and libtool as native build inputs.
Add epsf and texinfo to the texLive closure.
Support aarch64 Linux, and remove support for i686 Linux.