### PR TITLE
mit-scheme: 10.1.10 -> 11.2

### DIFF
--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -1,12 +1,13 @@
 { fetchurl, lib, stdenv, makeWrapper, gnum4, texinfo, texLive, automake,
+  autoconf, libtool, ghostscript, ncurses,
   enableX11 ? false, xlibsWrapper ? null }:
 
 let
-  version = "10.1.10";
-  bootstrapFromC = ! (stdenv.isi686 || stdenv.isx86_64);
+  version = "11.2";
+  bootstrapFromC = ! ((stdenv.isLinux && stdenv.isAarch64) || stdenv.isx86_64);
 
-  arch = if      stdenv.isi686   then "-i386"
-         else                         "-x86-64";
+  arch = if stdenv.isLinux && stdenv.isAarch64 then "-aarch64le"
+         else                                       "-x86-64";
 in
 stdenv.mkDerivation {
   name = if enableX11 then "mit-scheme-x11-${version}" else "mit-scheme-${version}";
@@ -16,16 +17,18 @@ stdenv.mkDerivation {
   # leads to more efficient code than when building the tarball that contains
   # generated C code instead of those binaries.
   src =
-    if stdenv.isi686
+    if stdenv.isLinux && stdenv.isAarch64
     then fetchurl {
-      url = "mirror://gnu/mit-scheme/stable.pkg/${version}/mit-scheme-${version}-i386.tar.gz";
-      sha256 = "117lf06vcdbaa5432hwqnskpywc6x8ai0gj99h480a4wzkp3vhy6";
+      url = "mirror://gnu/mit-scheme/stable.pkg/${version}/mit-scheme-${version}-aarch64le.tar.gz";
+      sha256 = "11maixldk20wqb5js5p4imq221zz9nf27649v9pqkdf8fv7rnrs9";
   } else fetchurl {
       url = "mirror://gnu/mit-scheme/stable.pkg/${version}/mit-scheme-${version}-x86-64.tar.gz";
-      sha256 = "1rljv6iddrbssm91c0nn08myj92af36hkix88cc6qwq38xsxs52g";
+      sha256 = "17822hs9y07vcviv2af17p3va7qh79dird49nj50bwi9rz64ia3w";
     };
 
   buildInputs = if enableX11 then [xlibsWrapper] else [];
+
+  propagatedBuildInputs = [ ncurses ];
 
   configurePhase =
     '' (cd src && ./configure)
@@ -40,9 +43,6 @@ stdenv.mkDerivation {
 
        cd ../doc
 
-       # Provide a `texinfo.tex'.
-       export TEXINPUTS="$(echo ${automake}/share/automake-*)"
-       echo "\$TEXINPUTS is \`$TEXINPUTS'"
        make
 
        cd ..
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
          $out/lib/mit-scheme${arch}
     '';
 
-  nativeBuildInputs = [ makeWrapper gnum4 texinfo texLive automake ];
+  nativeBuildInputs = [ makeWrapper gnum4 texinfo texLive automake ghostscript autoconf libtool];
 
   # XXX: The `check' target doesn't exist.
   doCheck = false;

--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -30,30 +30,39 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [ ncurses ];
 
-  configurePhase =
-    '' (cd src && ./configure)
-       (cd doc && ./configure)
-    '';
+  configurePhase = ''
+    runHook preConfigure
+    (cd src && ./configure)
+    (cd doc && ./configure)
+    runHook postConfigure
+  '';
 
-  buildPhase =
-    '' cd src
-       ${if bootstrapFromC
-         then "./etc/make-liarc.sh --prefix=$out"
-         else "make compile-microcode"}
+  buildPhase = ''
+    runHook preBuild
+    cd src
 
-       cd ../doc
+   ${if bootstrapFromC
+      then "./etc/make-liarc.sh --prefix=$out"
+      else "make compile-microcode"}
 
-       make
+    cd ../doc
 
-       cd ..
-    '';
+    make
 
-  installPhase =
-    '' make prefix=$out install -C src
-       make prefix=$out install -C doc
-    '';
+    cd ..
 
-  fixupPhase =
+    runHook postBuild
+  '';
+
+
+  installPhase = ''
+    runHook preInstall
+    make prefix=$out install -C src
+    make prefix=$out install -C doc
+    runHook postInstall
+  '';
+
+  postFixup =
     '' wrapProgram $out/bin/mit-scheme${arch} --set MITSCHEME_LIBRARY_PATH \
          $out/lib/mit-scheme${arch}
     '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11918,14 +11918,11 @@ in
   mint = callPackage ../development/compilers/mint { };
 
   mitscheme = callPackage ../development/compilers/mit-scheme {
-    texLive = texlive.combine { inherit (texlive) scheme-small; };
-    texinfo = texinfo5;
+    texLive = texlive.combine { inherit (texlive) scheme-small epsf texinfo; };
     xlibsWrapper = null;
   };
 
   mitschemeX11 = mitscheme.override {
-    texLive = texlive.combine { inherit (texlive) scheme-small; };
-    texinfo = texinfo5;
     enableX11 = true;
   };
 


### PR DESCRIPTION
Add ncurses as a propagated build input.
Add ghostscript, autoconf, and libtool as native build inputs.
Add epsf and texinfo to the texLive closure.
Support aarch64 Linux, and remove support for i686 Linux.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update mit-scheme.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
