### PR TITLE
scorecard: init at 2.1.2

### DIFF
--- a/pkgs/tools/security/scorecard/default.nix
+++ b/pkgs/tools/security/scorecard/default.nix
@@ -1,0 +1,53 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "scorecard";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner = "ossf";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-OUQzgTQbeQfut/ATvUl9RTFZISiGaUhRjZi4Rh7BB2A=";
+  };
+  vendorSha256 = "sha256-/Ltw0qZkLr1qaQixLy5pvWZiNRJucp+bDiY7yVlWmqA=";
+
+  subPackages = [ "." ];
+
+  ldflags = [ "-s" "-w" "-X github.com/ossf/scorecard/v2/cmd.gitVersion=v${version}" ];
+
+  # Install completions post-install
+  nativeBuildInputs = [ installShellFiles ];
+
+  preCheck = ''
+    # Feed in all but the e2e tests for testing
+    # This is because subPackages above limits what is built to just what we
+    # want but also limits the tests
+    getGoDirs() {
+      go list ./... | grep -v e2e
+    }
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd scorecard \
+      --bash <($out/bin/scorecard completion bash) \
+      --fish <($out/bin/scorecard completion fish) \
+      --zsh <($out/bin/scorecard completion zsh)
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/scorecard --help
+    $out/bin/scorecard version | grep "v${version}"
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ossf/scorecard";
+    changelog = "https://github.com/ossf/scorecard/releases/tag/v${version}";
+    description = "Security health metrics for Open Source";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8732,6 +8732,8 @@ in
 
   scmpuff = callPackage ../applications/version-management/git-and-tools/scmpuff { };
 
+  scorecard = callPackage ../tools/security/scorecard { };
+
   scream = callPackage ../applications/audio/scream { };
 
   scimark = callPackage ../misc/scimark { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package ossf scorecard for nixpkgs `2.1.2`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
