### PR TITLE
libantlr3c: fix build on non x86 platforms

### DIFF
--- a/pkgs/development/libraries/libantlr3c/default.nix
+++ b/pkgs/development/libraries/libantlr3c/default.nix
@@ -8,7 +8,10 @@ stdenv.mkDerivation rec {
     sha256 ="0lpbnb4dq4azmsvlhp6khq1gy42kyqyjv8gww74g5lm2y6blm4fa";
   };
 
-  configureFlags = lib.optional stdenv.is64bit "--enable-64bit";
+  configureFlags = lib.optional stdenv.is64bit "--enable-64bit"
+    # libantlr3c wrongly emits the abi flags -m64 and -m32 which imply x86 archs
+    # https://github.com/antlr/antlr3/issues/205
+    ++ lib.optional (!stdenv.hostPlatform.isx86) "--disable-abiflags";
 
   meta = with lib; {
     description = "C runtime libraries of ANTLR v3";
@@ -16,12 +19,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ vbgl ];
-    # The package failed to build with error:
-    #   gcc: error: unrecognized command line option '-m64'
-    #
-    # See:
-    # https://gist.github.com/r-rmcgibbo/15bf2ca9b297e8357887e146076fff7d
-    # https://gist.github.com/r-rmcgibbo/a362535e4b174d4bfb68112503a49fcd
-    broken = stdenv.hostPlatform.isAarch64;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
