### PR TITLE
Misc static improvements (mainly ocaml and a regression linked to b0b5ef7286dca098f40f5075175105c3c0dfbe05)

### DIFF
--- a/pkgs/build-support/ocaml/default.nix
+++ b/pkgs/build-support/ocaml/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, writeText, ocaml, findlib, ocamlbuild, camlp4 }:
 
-{ name, version, buildInputs ? [],
+{ name, version, nativeBuildInputs ? [],
   createFindlibDestdir ?  true,
   dontStrip ? true,
   minimumSupportedOcamlVersion ? null,
@@ -19,7 +19,7 @@ in
 stdenv.mkDerivation (args // {
   name = "ocaml-${name}-${version}";
 
-  buildInputs = [ ocaml findlib ocamlbuild camlp4 ] ++ buildInputs;
+  nativeBuildInputs = [ ocaml findlib ocamlbuild camlp4 ] ++ nativeBuildInputs;
 
   setupHook = if setupHook == null && hasSharedObjects
   then writeText "setupHook.sh" ''

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -12,6 +12,8 @@ else
 stdenv.mkDerivation ({
 
   inherit enableParallelBuilding;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, ocaml, findlib, dune_1, dune_2 }:
 
-{ pname, version, buildInputs ? [], enableParallelBuilding ? true, ... }@args:
+{ pname, version, nativeBuildInputs ? [], enableParallelBuilding ? true, ... }@args:
 
 let Dune = if args.useDune2 or false then dune_2 else dune_1; in
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation ({
 
   name = "ocaml${ocaml.version}-${pname}-${version}";
 
-  buildInputs = [ ocaml Dune findlib ] ++ buildInputs;
+  nativeBuildInputs = [ ocaml Dune findlib ] ++ nativeBuildInputs;
 
   meta = (args.meta or {}) // { platforms = args.meta.platforms or ocaml.meta.platforms; };
 

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -3,7 +3,7 @@
 let
   versionNoPatch = "${toString major_version}.${toString minor_version}";
   version = "${versionNoPatch}.${toString patch_version}";
-  safeX11 = stdenv: !(stdenv.isAarch32 || stdenv.isMips);
+  safeX11 = stdenv: !(stdenv.isAarch32 || stdenv.isMips || stdenv.hostPlatform.isStatic);
 in
 
 { lib, stdenv, fetchurl, ncurses, buildEnv, libunwind
@@ -13,7 +13,7 @@ in
 , spaceTimeSupport ? false
 }:
 
-assert useX11 -> !stdenv.isAarch32 && !stdenv.isMips;
+assert useX11 -> safeX11 stdenv;
 assert aflSupport -> lib.versionAtLeast version "4.05";
 assert flambdaSupport -> lib.versionAtLeast version "4.03";
 assert spaceTimeSupport -> lib.versionAtLeast version "4.04";

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation (args // {
 
   inherit src;
 
+  strictDeps = true;
+
   prefixKey = "-prefix ";
   configureFlags =
     let flags = new: old:

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -26,8 +26,8 @@
 , sourceVersion
 , sha256
 , passthruFun
-, static ? false
-, stripBytecode ? true
+, static ? stdenv.hostPlatform.isStatic
+, stripBytecode ? reproducibleBuild
 , rebuildBytecode ? true
 , reproducibleBuild ? false
 , enableOptimizations ? false
@@ -187,8 +187,9 @@ let
 
   configureFlags = optionals enableOptimizations [
     "--enable-optimizations"
-  ] ++ [
+  ] ++ optionals (!static) [
     "--enable-shared"
+  ] ++ [
     "--with-threads"
     "--enable-unicode=ucs${toString ucsEncoding}"
   ] ++ optionals (stdenv.hostPlatform.isCygwin || stdenv.hostPlatform.isAarch64) [

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -227,6 +227,7 @@ let
   ++ optional stdenv.hostPlatform.isLinux "ac_cv_func_lchmod=no"
   ++ optional static "LDFLAGS=-static";
 
+  strictDeps = true;
   buildInputs =
     optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc ++
     [ bzip2 openssl zlib ]

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -101,6 +101,8 @@ let
 
   version = with sourceVersion; "${major}.${minor}.${patch}${suffix}";
 
+  strictDeps = true;
+
   nativeBuildInputs = optionals (!stdenv.isDarwin) [
     autoreconfHook
   ] ++ optionals (!stdenv.isDarwin && passthru.pythonAtLeast "3.10") [

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -287,10 +287,11 @@ in with passthru; stdenv.mkDerivation {
   PYTHONHASHSEED=0;
 
   configureFlags = [
-    "--enable-shared"
     "--without-ensurepip"
     "--with-system-expat"
     "--with-system-ffi"
+  ] ++ optionals (!static) [
+    "--enable-shared"
   ] ++ optionals enableOptimizations [
     "--enable-optimizations"
   ] ++ optionals enableLTO [

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -189,6 +189,8 @@ stdenv.mkDerivation {
 
   configureScript = "./bootstrap.sh";
   configurePlatforms = [];
+  dontDisableStatic = true;
+  dontAddStaticConfigureFlags = true;
   configureFlags = [
     "--includedir=$(dev)/include"
     "--libdir=$(out)/lib"

--- a/pkgs/development/libraries/libbfd/default.nix
+++ b/pkgs/development/libraries/libbfd/default.nix
@@ -37,9 +37,8 @@ stdenv.mkDerivation {
   configureFlags = [
     "--enable-targets=all" "--enable-64-bit-bfd"
     "--enable-install-libbfd"
-    "--enable-shared"
     "--with-system-zlib"
-  ];
+  ] ++ lib.optional (!stdenv.hostPlatform.isStatic) "--enable-shared";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libbfd/default.nix
+++ b/pkgs/development/libraries/libbfd/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation {
   # We update these ourselves
   dontUpdateAutotoolsGnuConfigScripts = true;
 
+  strictDeps = true;
   nativeBuildInputs = [ autoreconfHook bison ];
   buildInputs = [ libiberty zlib.dev ];
 

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional pythonSupport "py"
     ++ lib.optional (enableStatic && enableShared) "static";
 
+  strictDeps = true;
+
   buildInputs = lib.optional pythonSupport python
     ++ lib.optional (pythonSupport && python?isPy2 && python.isPy2) gettext
     ++ lib.optional (pythonSupport && python?isPy3 && python.isPy3) ncurses

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -2,7 +2,7 @@
 , zlib, xz, libintl, python, gettext, ncurses, findXMLCatalogs
 , pythonSupport ? enableShared && stdenv.buildPlatform == stdenv.hostPlatform
 , icuSupport ? false, icu ? null
-, enableShared ? stdenv.hostPlatform.libc != "msvcrt"
+, enableShared ? stdenv.hostPlatform.libc != "msvcrt" && !stdenv.hostPlatform.isStatic
 , enableStatic ? !enableShared
 }:
 

--- a/pkgs/development/libraries/lzo/default.nix
+++ b/pkgs/development/libraries/lzo/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0wm04519pd3g8hqpjqhfr72q8qmbiwqaxcs3cndny9h86aa95y60";
   };
 
-  configureFlags = [ "--enable-shared" ];
+  configureFlags = lib.optional (!stdenv.hostPlatform.isStatic) "--enable-shared" ;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/lzo/default.nix
+++ b/pkgs/development/libraries/lzo/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   doCheck = true; # not cross;
 
+  strictDeps = true;
+
   meta = with lib; {
     description = "Real-time data (de)compression library";
     longDescription = ''

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -57,11 +57,13 @@ stdenv.mkDerivation (rec {
   # and giving nothing builds both.
   # So we have 3 possible ways to build both:
   # `--static --shared`, `--shared` and giving nothing.
-  # Of these, we choose `--shared`, only because that's
-  # what we did in the past and we can avoid mass rebuilds this way.
-  # As a result, we pass `--static` only when we want just static.
-  configureFlags = lib.optional (static && !shared) "--static"
+  # Of these, we choose `--static --shared`, for clarity and simpler
+  # conditions.
+  configureFlags = lib.optional static "--static"
                    ++ lib.optional shared "--shared";
+  # We do the right thing manually, above, so don't need these.
+  dontDisableStatic = true;
+  dontAddStaticConfigureFlags = true;
 
   # Note we don't need to set `dontDisableStatic`, because static-disabling
   # works by grepping for `enable-static` in the `./configure` script

--- a/pkgs/development/ocaml-modules/bolt/default.nix
+++ b/pkgs/development/ocaml-modules/bolt/default.nix
@@ -42,6 +42,8 @@ EOF
   # The custom `configure` script does not expect the --prefix
   # option. Installation is handled by ocamlfind.
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/easy-format/default.nix
+++ b/pkgs/development/ocaml-modules/easy-format/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation {
     sha256 = "00ga7mrlycjc99gzp3bgx6iwhf7i6j8856f8xzrf1yas7zwzgzm9";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/gen/default.nix
+++ b/pkgs/development/ocaml-modules/gen/default.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation {
     sha256 = "14b8vg914nb0yp1hgxzm29bg692m0gqncjj43b599s98s1cwl92h";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild qtest ounit ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ qtest ounit ];
+  strictDeps = true;
 
   configureFlags = [
     "--enable-tests"

--- a/pkgs/development/ocaml-modules/hacl-star/raw.nix
+++ b/pkgs/development/ocaml-modules/hacl-star/raw.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   installTargets = "install-hacl-star-raw";
 
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   buildInputs = [
     which

--- a/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
@@ -17,6 +17,8 @@ buildOcaml (args // {
   buildInputs = [ ocaml_oasis js_build_tools opaline ] ++ buildInputs;
 
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   configurePhase = "./configure --prefix $out";
 

--- a/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
+++ b/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
@@ -16,6 +16,8 @@ buildOcaml rec {
   buildInputs = [ ocaml_oasis opaline ];
 
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
   configurePhase = "./configure --prefix $prefix";
   installPhase = "opaline -prefix $prefix -libdir $OCAMLFIND_DESTDIR ${name}.install";
 

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   configureScript = "./configure.sh";
   dontAddPrefix = "true";
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   propagatedBuildInputs = [ camlzip extlib ];
 

--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -51,6 +51,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--use-findlib" "--installbindir" "$(out)/bin" ];
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   buildFlags = [ "all" "opt" ];
 

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
   createFindlibDestdir = true;
 
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   preConfigure = ''
     configureFlagsArray=(

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -40,6 +40,8 @@ buildDunePackage rec {
   configureFlags = [ "--root $(out)" "--prefix /" ];
 
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   postConfigure = ''
     make -C src confs

--- a/pkgs/development/ocaml-modules/process/default.nix
+++ b/pkgs/development/ocaml-modules/process/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0m1ldah5r9gcq09d9jh8lhvr77910dygx5m309k1jm60ah9mdcab";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation {
 
   configureScript = "./configure.sh";
   dontAddPrefix = "true";
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   propagatedBuildInputs = [ javalib ];
 

--- a/pkgs/development/ocaml-modules/seq/default.nix
+++ b/pkgs/development/ocaml-modules/seq/default.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation ({
     sha256 = "1cjpsc7q76yfgq9iyvswxgic4kfq2vcqdlmxjdjgd4lx87zvcwrv";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/syslog/default.nix
+++ b/pkgs/development/ocaml-modules/syslog/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1kqpc55ppzv9n555qgqpda49n7nvkqimzisyjx2a7338r7q4r5bw";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+  strictDeps = true;
 
   buildFlags = [ "all" "opt" ];
 

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -15,7 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "1kp72yv4k176i94np0m09g10cviqp2pnpm7jmiq6ik7fmmbknk7c";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  strictDeps = true;
+
+  # x86_64-unknown-linux-musl-ld: -r and -pie may not be used together
+  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   makeFlags = [ "-C" "interpreter" ];
 

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
     sha256 = "1jslm1rv1j0ya818yh23wf3bb6hz7qqj9pn5fwl45y9mqyqa01s9";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ pkg-config ocaml findlib ];
   propagatedBuildInputs = [ gmp ];
+  strictDeps = true;
 
   dontAddPrefix = true;
   configureFlags = [ "-installdir ${placeholder "out"}/lib/ocaml/${ocaml.version}/site-lib" ];

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
   configureFlags = [ "-installdir ${placeholder "out"}/lib/ocaml/${ocaml.version}/site-lib" ];
 
   preInstall = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs";

--- a/pkgs/development/tools/ocaml/dune/1.nix
+++ b/pkgs/development/tools/ocaml/dune/1.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, ocaml, findlib }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ncurses }:
 
 if !lib.versionAtLeast ocaml.version "4.02"
 || lib.versionAtLeast ocaml.version "4.12"
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ ocaml findlib ];
+  buildInputs = [ ncurses ];
   strictDeps = true;
 
   buildFlags = [ "release" ];

--- a/pkgs/development/tools/ocaml/dune/1.nix
+++ b/pkgs/development/tools/ocaml/dune/1.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
   ];
 
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   meta = with lib; {
     homepage = "https://dune.build/";

--- a/pkgs/development/tools/ocaml/dune/1.nix
+++ b/pkgs/development/tools/ocaml/dune/1.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1rkc8lqw30ifjaz8d81la6i8j05ffd0whpxqsbg6dci16945zjvp";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+  strictDeps = true;
 
   buildFlags = [ "release" ];
   makeFlags = [

--- a/pkgs/development/tools/ocaml/dune/2.nix
+++ b/pkgs/development/tools/ocaml/dune/2.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
   buildFlags = "release";
 
   dontAddPrefix = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   installFlags = [ "PREFIX=${placeholder "out"}" "LIBDIR=$(OCAMLFIND_DESTDIR)" ];
 

--- a/pkgs/development/tools/ocaml/dune/2.nix
+++ b/pkgs/development/tools/ocaml/dune/2.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "07m476kgagpd6kzm3jq30yfxqspr2hychah0xfqs14z82zxpq8dv";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+  strictDeps = true;
 
   buildFlags = "release";
 

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -16,19 +16,14 @@ stdenv.mkDerivation rec {
 
   dontAddPrefix=true;
 
-  preConfigure=''
-    configureFlagsArray=(
-      -bindir $out/bin
-      -mandir $out/share/man
-      -sitelib $out/lib/ocaml/${ocaml.version}/site-lib
-      -config $out/etc/findlib.conf
-    )
-  '';
+  configureFlags = [
+      "-bindir" "${placeholder "out"}/bin"
+      "-mandir" "${placeholder "out"}/share/man"
+      "-sitelib" "${placeholder "out"}/lib/ocaml/${ocaml.version}/site-lib"
+      "-config" "${placeholder "out"}/etc/findlib.conf"
+  ];
 
-  buildPhase = ''
-    make all
-    make opt
-  '';
+  buildFlags = [ "all" "opt" ];
 
   setupHook = writeText "setupHook.sh" ''
     addOCamlPath () {

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   patches = [ ./ldconf.patch ./install_topfind.patch ];
 
   dontAddPrefix=true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [];
 
   configureFlags = [
       "-bindir" "${placeholder "out"}/bin"

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
         if test -d "''$1/lib/ocaml/${ocaml.version}/site-lib/stublibs"; then
             export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/stublibs"
         fi
+    }
+    createOcamlDestDir () {
         export OCAMLFIND_DESTDIR="''$out/lib/ocaml/${ocaml.version}/site-lib/"
         if test -n "''${createFindlibDestdir-}"; then
           mkdir -p $OCAMLFIND_DESTDIR
@@ -40,6 +42,7 @@ stdenv.mkDerivation rec {
     }
 
     addEnvHooks "$targetOffset" addOCamlPath
+    preConfigureHooks+=(createOcamlDestDir)
   '';
 
   meta = {

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-K0K4vVRIjWTEvzy3BUtLN70wwdwSvUMeoeTXrYqYD+I=";
   };
 
-  buildInputs = [m4 ncurses ocaml];
+  nativeBuildInputs = [m4 ocaml];
+  buildInputs = [ ncurses ];
 
   patches = [ ./ldconf.patch ./install_topfind.patch ];
 

--- a/pkgs/development/tools/ocaml/ocamlbuild/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlbuild/default.nix
@@ -12,7 +12,11 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+  strictDeps = true;
+
+  # x86_64-unknown-linux-musl-ld: -r and -pie may not be used together
+  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   configurePhase = ''
   make -f configure.make Makefile.config \

--- a/pkgs/development/tools/ocaml/ocamlbuild/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlbuild/default.nix
@@ -19,11 +19,15 @@ stdenv.mkDerivation rec {
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   configurePhase = ''
+  runHook preConfigure
+
   make -f configure.make Makefile.config \
     "OCAMLBUILD_PREFIX=$out" \
     "OCAMLBUILD_BINDIR=$out/bin" \
     "OCAMLBUILD_MANDIR=$out/share/man" \
     "OCAMLBUILD_LIBDIR=$OCAMLFIND_DESTDIR"
+
+  runHook postConfigure
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/ocaml/opaline/default.nix
+++ b/pkgs/development/tools/ocaml/opaline/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1aj1fdqymq3pnr39h47hn3kxk5v9pnwx0jap1z2jzh78x970z21m";
   };
 
-  buildInputs = with ocamlPackages; [ ocaml findlib ocamlbuild opam-file-format ];
+  nativeBuildInputs = with ocamlPackages; [ ocaml findlib ocamlbuild ];
+  buildInputs = with ocamlPackages; [ opam-file-format ];
 
   preInstall = "mkdir -p $out/bin";
 

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -90,6 +90,24 @@ rec {
       });
     });
 
+  # Best effort static binaries. Will still be linked to libSystem,
+  # but more portable than Nix store binaries.
+  makeStaticDarwin = stdenv: stdenv.override (old: {
+    # extraBuildInputs are dropped in cross.nix, but darwin still needs them
+    extraBuildInputs = [ pkgs.buildPackages.darwin.CF ];
+    mkDerivationFromStdenv = extendMkDerivationArgs old (args: {
+      NIX_CFLAGS_LINK = toString (args.NIX_CFLAGS_LINK or "")
+        + lib.optionalString (stdenv.cc.isGNU or false) " -static-libgcc";
+      nativeBuildInputs = (args.nativeBuildInputs or []) ++ [
+        (pkgs.buildPackages.makeSetupHook {
+          substitutions = {
+            libsystem = "${stdenv.cc.libc}/lib/libSystem.B.dylib";
+          };
+        } ./darwin/portable-libsystem.sh)
+      ];
+    });
+  });
+
 
   /* Modify a stdenv so that all buildInputs are implicitly propagated to
      consuming derivations

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  strictDeps = true;
+
   nativeBuildInputs = [ pkg-config perl ];
 
   # Zlib and OpenSSL must be propagated because `libcurl.la' contains

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -7,7 +7,7 @@
 , gnutlsSupport ? false, gnutls ? null
 , wolfsslSupport ? false, wolfssl ? null
 , scpSupport ? zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin, libssh2 ? null
-, gssSupport ? with stdenv.hostPlatform; !(
+, gssSupport ? with stdenv.hostPlatform; (
     !isWindows &&
     # a very sad story re static: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=439039
     !isStatic &&

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -9,6 +9,7 @@
 , scpSupport ? zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin, libssh2 ? null
 , gssSupport ? with stdenv.hostPlatform; (
     !isWindows &&
+    # disable gss becuase of: undefined reference to `k5_bcmp'
     # a very sad story re static: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=439039
     !isStatic &&
     # the "mig" tool does not configure its compiler correctly. This could be
@@ -95,15 +96,15 @@ stdenv.mkDerivation rec {
       "--without-ca-bundle"
       "--without-ca-path"
       # The build fails when using wolfssl with --with-ca-fallback
-      ( if wolfsslSupport then "--without-ca-fallback" else "--with-ca-fallback")
+      (lib.withFeature wolfsslSupport "ca-fallback")
       "--disable-manual"
-      ( if sslSupport then "--with-ssl=${openssl.dev}" else "--without-ssl" )
-      ( if gnutlsSupport then "--with-gnutls=${gnutls.dev}" else "--without-gnutls" )
-      ( if scpSupport then "--with-libssh2=${libssh2.dev}" else "--without-libssh2" )
-      ( if ldapSupport then "--enable-ldap" else "--disable-ldap" )
-      ( if ldapSupport then "--enable-ldaps" else "--disable-ldaps" )
-      ( if idnSupport then "--with-libidn=${libidn.dev}" else "--without-libidn" )
-      ( if brotliSupport then "--with-brotli" else "--without-brotli" )
+      (lib.withFeatureAs sslSupport "ssl" openssl.dev)
+      (lib.withFeatureAs gnutlsSupport "gnutls" gnutls.dev)
+      (lib.withFeatureAs scpSupport "libssh2" libssh2.dev)
+      (lib.enableFeature ldapSupport "ldap")
+      (lib.enableFeature ldapSupport "ldaps")
+      (lib.withFeatureAs idnSupport "libidn" libidn.dev)
+      (lib.withFeature brotliSupport "brotli")
     ]
     ++ lib.optional wolfsslSupport "--with-wolfssl=${wolfssl.dev}"
     ++ lib.optional c-aresSupport "--enable-ares=${c-ares}"

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -51,7 +51,7 @@ self: super: let
     b.overrideAttrs (o: {
       configurePlatforms = [ ];
       dontAddStaticConfigureFlags = true;
-      buildInputs = o.buildInputs ++ o.nativeBuildInputs or [ ];
+      buildInputs = (o.buildInputs or [ ]) ++ o.nativeBuildInputs or [ ];
       propagatedNativeBuildInputs = o.propagatedBuildInputs or [ ];
     });
 

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -47,21 +47,6 @@ self: super: let
     # ++ optional (super.stdenv.hostPlatform.libc == "glibc") ((flip overrideInStdenv) [ self.stdenv.glibc.static ])
   ;
 
-  ocamlFixPackage = b:
-    b.overrideAttrs (o: {
-      configurePlatforms = [ ];
-      dontAddStaticConfigureFlags = true;
-    });
-
-  ocamlStaticAdapter = _: super:
-    self.lib.mapAttrs
-      (_: p: if p ? overrideAttrs then ocamlFixPackage p else p)
-      super
-    // {
-      lablgtk = null; # Currently xlibs cause infinite recursion
-      ocaml = super.ocaml;
-    };
-
 in {
   stdenv = foldl (flip id) super.stdenv staticAdapters;
 
@@ -77,11 +62,6 @@ in {
     # disable gss becuase of: undefined reference to `k5_bcmp'
     gssSupport = false;
   };
-
-  ocaml-ng = self.lib.mapAttrs (_: set:
-    if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
-  ) super.ocaml-ng;
-
 
   zlib = super.zlib.override {
     # Don’t use new stdenv zlib because

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -51,8 +51,6 @@ self: super: let
     b.overrideAttrs (o: {
       configurePlatforms = [ ];
       dontAddStaticConfigureFlags = true;
-      buildInputs = (o.buildInputs or [ ]) ++ o.nativeBuildInputs or [ ];
-      propagatedNativeBuildInputs = o.propagatedBuildInputs or [ ];
     });
 
   ocamlStaticAdapter = _: super:

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -61,20 +61,7 @@ self: super: let
       super
     // {
       lablgtk = null; # Currently xlibs cause infinite recursion
-      ocaml = ((super.ocaml.override { useX11 = false; }).overrideAttrs (o: {
-        configurePlatforms = [ ];
-        dontUpdateAutotoolsGnuConfigScripts = true;
-      })).overrideDerivation (o: {
-        preConfigure = ''
-          configureFlagsArray+=("-cc" "$CC" "-as" "$AS" "-partialld" "$LD -r")
-        '';
-        dontAddStaticConfigureFlags = true;
-        configureFlags = [
-          "--no-shared-libs"
-          "-host ${o.stdenv.hostPlatform.config}"
-          "-target ${o.stdenv.targetPlatform.config}"
-        ];
-      });
+      ocaml = super.ocaml.override { useX11 = false; };
     };
 
 in {

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -61,7 +61,7 @@ self: super: let
       super
     // {
       lablgtk = null; # Currently xlibs cause infinite recursion
-      ocaml = super.ocaml.override { useX11 = false; };
+      ocaml = super.ocaml;
     };
 
 in {


### PR DESCRIPTION

###### Motivation for this change

Bulding static ocaml packages

Most of the PR should be uncontroversial, but there is a change to stdenv linked to a regression in b0b5ef7286dca098f40f5075175105c3c0dfbe05

The gist is `.overrideAttrs (o: { dontAddStaticConfigureFlags = true })` does not work because `o.configureFlags` already contains the faulty flags and they will not be remove any more. You can see this on current nixpkgs with:
```
nix show-derivation $(nix-instantiate . -A pkgsStatic.ocaml-ng.ocamlPackages_4_07.findlib) | jq '.[].env'
```
which has both `dontAddStaticConfigureFlags` set to 1 and `--disable-shared` in `configureFlags`.
(this affects all of ocaml packages)
Proposed solution is to move the logic from nix (which is already complex with all the overrideScope' at play) to bash in stdenv builder.

cc @alyssais for dontAddStaticConfigureFlags and @veprbl for ocaml part.

Tested with
```
nix build -f. {pkgsStatic.,}ocaml-ng.ocamlPackages_4_{06,07,08,09,10,11,12}.{dune_2,ocaml,ocamlgraph}
```

This is a mass rebuild, so please refrain from bikeshedding on spacing as it takes half a day to rebuild.


