### PR TITLE
grafana-loki: 2.2.1 -> 2.3.0

### DIFF
--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -8,14 +8,14 @@
 }:
 
 buildGoModule rec {
-  version = "2.2.1";
+  version = "2.3.0";
   pname = "grafana-loki";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "loki";
-    sha256 = "sha256-ujZD5GIgMewvEQW3Wnt0eHdMIFs77PkkEecgCDw9290=";
+    sha256 = "sha256-Cxg3VRF4p/Kb6LyreGV0g+zPr15wplritSZgkbTiDI0=";
   };
 
   vendorSha256 = null;
@@ -24,7 +24,7 @@ buildGoModule rec {
     # TODO split every executable into its own package
     "cmd/loki"
     "cmd/loki-canary"
-    "cmd/promtail"
+    "clients/cmd/promtail"
     "cmd/logcli"
   ];
 
@@ -38,16 +38,27 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests) loki; };
 
-  buildFlagsArray = let t = "github.com/grafana/loki/pkg/build"; in
-    ''
-      -ldflags=-s -w -X ${t}.Version=${version} -X ${t}.BuildUser=nix@nixpkgs -X ${t}.BuildDate=unknown -X ${t}.Branch=unknown -X ${t}.Revision=unknown
-    '';
+  buildFlagsArray = let t = "github.com/grafana/loki/pkg/util/build"; in
+    [
+      "-ldflags=-s"
+      "-w"
+      "-X"
+      "${t}.Version=${version}"
+      "-X"
+      "${t}.BuildUser=nix@nixpkgs"
+      "-X"
+      "${t}.BuildDate=unknown"
+      "-X"
+      "${t}.Branch=unknown"
+      "-X"
+      "${t}.Revision=unknown"
+    ];
 
   doCheck = true;
 
   meta = with lib; {
     description = "Like Prometheus, but for logs";
-    license = licenses.asl20;
+    license = with licenses; [ agpl3Only asl20 ];
     homepage = "https://grafana.com/oss/loki/";
     maintainers = with maintainers; [ willibutz globin mmahut ];
     platforms = platforms.unix;

--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -38,21 +38,15 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests) loki; };
 
-  buildFlagsArray = let t = "github.com/grafana/loki/pkg/util/build"; in
-    [
-      "-ldflags=-s"
-      "-w"
-      "-X"
-      "${t}.Version=${version}"
-      "-X"
-      "${t}.BuildUser=nix@nixpkgs"
-      "-X"
-      "${t}.BuildDate=unknown"
-      "-X"
-      "${t}.Branch=unknown"
-      "-X"
-      "${t}.Revision=unknown"
-    ];
+  ldflags = let t = "github.com/grafana/loki/pkg/util/build"; in [
+    "-s"
+    "-w"
+    "-X ${t}.Version=${version}"
+    "-X ${t}.BuildUser=nix@nixpkgs"
+    "-X ${t}.BuildDate=unknown"
+    "-X ${t}.Branch=unknown"
+    "-X ${t}.Revision=unknown"
+  ];
 
   doCheck = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19744,7 +19744,7 @@ in
   grafana-agent = callPackage ../servers/monitoring/grafana-agent { };
 
   grafana-loki = callPackage ../servers/monitoring/loki {
-    buildGoModule = buildGo115Module;
+    buildGoModule = buildGo116Module;
   };
 
   grafana_reporter = callPackage ../servers/monitoring/grafana-reporter { };


### PR DESCRIPTION
###### Motivation for this change

upstream update
https://github.com/grafana/loki/releases/tag/v2.3.0
the license changed.
Leaving this a couple of days open in case anybody wants to check it out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
