### PR TITLE
python3Packages.asyncio-dgram: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/asyncio-dgram/default.nix
+++ b/pkgs/development/python-modules/asyncio-dgram/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "asyncio-dgram";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "jsbronder";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-EL3iOoCfLAtfdMI1J2XMf4izOEo9+a+0PNQs+4HuEfo=";
+    sha256 = "1ibyphncb3d8vrs3yk8j6l1smmnibizx9k1vir2njhi09r57h9mx";
   };
 
   # OSError: AF_UNIX path too long
@@ -26,6 +26,7 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [ "test_protocol_pause_resume" ];
+
   pythonImportsCheck = [ "asyncio_dgram" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.0 

Change log: https://github.com/jsbronder/asyncio-dgram/blob/master/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
