### PR TITLE
nushell: 0.33 -> 0.35

### DIFF
--- a/pkgs/shells/nushell/use-system-zstd-lib.diff
+++ b/pkgs/shells/nushell/use-system-zstd-lib.diff
@@ -1,0 +1,32 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 8833c3e5..0c90d2fe 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -3188,6 +3188,7 @@ dependencies = [
+  "nu_plugin_xpath",
+  "rstest",
+  "serial_test",
++ "zstd-sys",
+ ]
+
+ [[package]]
+@@ -6954,4 +6955,5 @@ checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
+ dependencies = [
+  "cc",
+  "libc",
++ "pkg-config",
+ ]
+diff --git a/Cargo.toml b/Cargo.toml
+index 89e8a311..4cc2331a 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -63,6 +63,9 @@ serial_test = "0.5.1"
+ hamcrest2 = "0.3.0"
+ rstest = "0.10.0"
+
++# Specify that the indirect dependency ztsd-sys should pick up the system zstd C library
++zstd-sys = { version = "1", features = [ "pkg-config" ] }
++
+ [build-dependencies]
+
+ [features]


### PR DESCRIPTION
###### Motivation for this change

Latest version of nushell. 

As noted in #130760, nushell 0.34 introduced an issue: the new dataframe support brings in an indirect dependency on `zstd-sys` via a chain:
```
    nushell --> polars --> parquet --> zstd --> zstd-sys
```
`zstd-sys` defaults to an impure build (pulling in a git submodule to build the underlying `zstd` C library). One can specify the `pkg-config` feature flag to `zstd-sys`, to instead provide  a pre-built `zstd` library, but ordinarily that would have to come from way down this dependency chain.

So here we patch `nushell` to add a direct dependency on `zstd-sys` too:
```
    nushell --> polars --> parquet --> zstd --> zstd-sys
          |                                        ^
          +-------->--------->------->------->-----+
```
in which we can specify this feature flag. This makes everything work.

The nushell maintainers have [signalled willingness](https://github.com/nushell/nushell/issues/3772#issuecomment-883342563) to consider accept an upstream change, but so far I haven't thought of a change that seems reasonable to ask of them. Ideas welcome! In the meantime, the patch is at least stable for both 0.34 and 0.35, and I've tested this all works on both NixOS and Darwin.

Cc @Br1ght0ne for any further thoughts - the progress you made definitely accelerated this, so thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
