### PR TITLE
jetbrains: Fix update.pl script for MPS and update [21.05 backport]

### DIFF
--- a/pkgs/applications/editors/jetbrains/common.nix
+++ b/pkgs/applications/editors/jetbrains/common.nix
@@ -50,7 +50,7 @@ with stdenv; lib.makeOverridable mkDerivation rec {
       }
 
       interpreter=$(echo ${stdenv.glibc.out}/lib/ld-linux*.so.2)
-      if [ "${stdenv.hostPlatform.system}" == "x86_64-linux" ]; then
+      if [[ "${stdenv.hostPlatform.system}" == "x86_64-linux" && -e bin/fsnotifier64 ]]; then
         target_size=$(get_file_size bin/fsnotifier64)
         patchelf --set-interpreter "$interpreter" bin/fsnotifier64
         munge_size_hack bin/fsnotifier64 $target_size

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -307,11 +307,12 @@ in
 
   mps = buildMps rec {
     name = "mps-${version}";
-    version = "2021.1"; /* updated by script */
+    version = "2021.1";
+    versionMajorMinor = "2021.1";
     description = "Create your own domain-specific language";
     license = lib.licenses.asl20;
     src = fetchurl {
-      url = "https://download.jetbrains.com/mps/${version}/MPS-${version}.tar.gz";
+      url = "https://download.jetbrains.com/mps/${versionMajorMinor}/MPS-${version}.tar.gz";
       sha256 = "0fdh8lzsi2zryi0xs961vrf3l8kqk5imlj56dhifywi7xkhs3vwn"; /* updated by script */
     };
     wmClass = "jetbrains-mps";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -242,12 +242,12 @@ in
 
   clion = buildClion rec {
     name = "clion-${version}";
-    version = "2021.1.2"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description  = "C/C++ IDE. New. Intelligent. Cross-platform";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/cpp/CLion-${version}.tar.gz";
-      sha256 = "1zx9qwjx7hwjq25y474yj7sxvp9bqnq9l53afs6d4h6131lhjkcz"; /* updated by script */
+      sha256 = "0im14b52b6hgns964m946q68mvyaq8haldm92s9cn5azh8yg1arc"; /* updated by script */
     };
     wmClass = "jetbrains-clion";
     update-channel = "CLion RELEASE"; # channel's id as in http://www.jetbrains.com/updates/updates.xml
@@ -255,12 +255,12 @@ in
 
   datagrip = buildDataGrip rec {
     name = "datagrip-${version}";
-    version = "2021.1.3"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description = "Your Swiss Army Knife for Databases and SQL";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/datagrip/${name}.tar.gz";
-      sha256 = "0lhi3vwhwb359va4sa17y071i03l4mfwqpsp7haqxjf900dcld7d"; /* updated by script */
+      sha256 = "17fzrn20mkldf74965c7abw3znyxskssdz1k4lciz6q7kn5cvdbf"; /* updated by script */
     };
     wmClass = "jetbrains-datagrip";
     update-channel = "DataGrip RELEASE";
@@ -268,12 +268,12 @@ in
 
   goland = buildGoland rec {
     name = "goland-${version}";
-    version = "2021.1.3"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description = "Up and Coming Go IDE";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/go/${name}.tar.gz";
-      sha256 = "0xy9k90v3kcm9sj48l809qn0vws4ygsxxyqwsg6y9a3r1raqgqxd"; /* updated by script */
+      sha256 = "15pxr9w4gs342g9in7a41x0cpb7z68y28hwsamk9ic7yz2qshps8"; /* updated by script */
     };
     wmClass = "jetbrains-goland";
     update-channel = "GoLand RELEASE";
@@ -281,12 +281,12 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2021.1.3"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "1phpfa9i3k7g92ankmibp53c1469ifnb12g6s8gklln7v7xxakmi"; /* updated by script */
+      sha256 = "1zki6myy3wbr1sgp1gli263y32g75gna2r9m7baa06zvc6c7j9vw"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
     update-channel = "IntelliJ IDEA RELEASE";
@@ -294,12 +294,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2021.1.3"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}-no-jbr.tar.gz";
-      sha256 = "13c7a96zbw05w1gy4ds4wzac853hdlnbflww2xaz60jnr1k24gnp"; /* updated by script */
+      sha256 = "0gbx1ngf8i2a0dvysw5g0ikakq4a7gghb4rjk7c99jwzwq9hckjm"; /* updated by script */
     };
     wmClass = "jetbrains-idea";
     update-channel = "IntelliJ IDEA RELEASE";
@@ -307,13 +307,13 @@ in
 
   mps = buildMps rec {
     name = "mps-${version}";
-    version = "2021.1";
-    versionMajorMinor = "2021.1";
+    version = "2021.1.1"; /* updated by script */
+    versionMajorMinor = "2021.1"; /* updated by script */
     description = "Create your own domain-specific language";
     license = lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/mps/${versionMajorMinor}/MPS-${version}.tar.gz";
-      sha256 = "0fdh8lzsi2zryi0xs961vrf3l8kqk5imlj56dhifywi7xkhs3vwn"; /* updated by script */
+      sha256 = "1gp9f4b57pr8c20qxcwax4l0d3w13x4lihxpb9z4agdqjafnc9l6"; /* updated by script */
     };
     wmClass = "jetbrains-mps";
     update-channel = "MPS RELEASE";
@@ -321,12 +321,12 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2021.1.4"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "0p9a8l2bpjm25x4af1hlqhmw5xsirsfajznd6y723yqmjy8hs46l"; /* updated by script */
+      sha256 = "11lm7mja3mc2v329i830j8w1zymlz11sj86qvcg7s4pgc4xwnzd6"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
     update-channel = "PhpStorm RELEASE";
@@ -334,12 +334,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2021.1.3"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description = "PyCharm Community Edition";
     license = lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "0c03grsrjydb6jcnbq1qi4158c14vni3znr7vysnbvldi8al6w8m"; /* updated by script */
+      sha256 = "075lb50g853791hj8ahhi88zbp07cvfs3zrdahvvif2nd121r1mx"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
     update-channel = "PyCharm RELEASE";
@@ -347,12 +347,12 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2021.1.3"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description = "PyCharm Professional Edition";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "01nwc9nprlyrwyij98px915w66g6vxbznsmmmg56rv3rvjvjp7yl"; /* updated by script */
+      sha256 = "1l83a8wfqz4xddscpzf7v29rhq9ibx32ximcqrj1cw0i9v7qnv9g"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm";
     update-channel = "PyCharm RELEASE";
@@ -360,12 +360,12 @@ in
 
   rider = buildRider rec {
     name = "rider-${version}";
-    version = "2021.1.3"; /* updated by script */
+    version = "2021.1.5"; /* updated by script */
     description = "A cross-platform .NET IDE based on the IntelliJ platform and ReSharper";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/rider/JetBrains.Rider-${version}.tar.gz";
-      sha256 = "0k2vpndpachq6g767v2dwfa3xc8mssv0i7wwpm05dgqirpn4n0dw"; /* updated by script */
+      sha256 = "17mxqh6p9jby5qrjqaq5km0j8k1bp8061ch2j059ka3n4ycxy7ph"; /* updated by script */
     };
     wmClass = "jetbrains-rider";
     update-channel = "Rider RELEASE";
@@ -373,12 +373,12 @@ in
 
   ruby-mine = buildRubyMine rec {
     name = "ruby-mine-${version}";
-    version = "2021.1.2"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description = "The Most Intelligent Ruby and Rails IDE";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/ruby/RubyMine-${version}.tar.gz";
-      sha256 = "0r80y8y38rdxgc9sim0q2p7bmgxlp4pdxydr0w9gjikwnjxnvz51"; /* updated by script */
+      sha256 = "169jsd34l83n1pnrhzz548yn7ch1dzxpy8xck7vlymjgrxdqciwi"; /* updated by script */
     };
     wmClass = "jetbrains-rubymine";
     update-channel = "RubyMine RELEASE";
@@ -386,12 +386,12 @@ in
 
   webstorm = buildWebStorm rec {
     name = "webstorm-${version}";
-    version = "2021.1.2"; /* updated by script */
+    version = "2021.2"; /* updated by script */
     description = "Professional IDE for Web and JavaScript development";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webstorm/WebStorm-${version}.tar.gz";
-      sha256 = "0q4hn6npm0c30v23d30dnphd6wajif0im1b9vjwa121lqi997l34"; /* updated by script */
+      sha256 = "1whikk1izzvhq1d7kaf2kn4j4qpxn7aq70hlbxr1kb7zs4mzy9x3"; /* updated by script */
     };
     wmClass = "jetbrains-webstorm";
     update-channel = "WebStorm RELEASE";

--- a/pkgs/applications/editors/jetbrains/update.pl
+++ b/pkgs/applications/editors/jetbrains/update.pl
@@ -56,17 +56,20 @@ sub update_nix_block {
       if ($version eq $latest_versions{$channel}) {
         print("$channel is up to date at $version\n");
       } else {
-        print("updating $channel: $version -> $latest_versions{$channel}\n");
+        my $version_string = $latest_versions{$channel};
+        my $versionMajorMinor = $version_string =~ s/^([0-9]+[.][0-9]+).*/$1/r;
+
+        print("updating $channel: $version -> $version_string\n");
         my ($url) = $block =~ /url\s*=\s*"([^"]+)"/;
         # try to interpret some nix
         my ($name) = $block =~ /name\s*=\s*"([^"]+)"/;
-        $name =~ s/\$\{version\}/$latest_versions{$channel}/;
-        # Some url paattern contain variables more than once
+        $name =~ s/\$\{version\}/$version_string/;
+        # Some url pattern contain variables more than once
         $url =~ s/\$\{name\}/$name/g;
-        $url =~ s/\$\{version\}/$latest_versions{$channel}/g;
+        $url =~ s/\$\{version\}/$version_string/g;
+        $url =~ s/\$\{versionMajorMinor\}/$versionMajorMinor/g;
         die "$url still has some interpolation" if $url =~ /\$/;
         my ($sha256) = get("$url.sha256") =~ /^([0-9a-f]{64})/;
-        my $version_string = $latest_versions{$channel};
         unless ( $sha256 ) {
           my $full_version = $latest_versions{"full1_" . $channel};
           $url =~ s/$version_string/$full_version/;
@@ -79,6 +82,7 @@ sub update_nix_block {
         print "Jetbrains published SHA256: $sha256\n";
         print "Conversion into base32 yields: $sha256Base32\n";
         $block =~ s#version\s*=\s*"([^"]+)".+$#version = "$version_string"; /* updated by script */#m;
+        $block =~ s#versionMajorMinor\s*=\s*"([^"]+)".+$#versionMajorMinor = "$versionMajorMinor"; /* updated by script */#m;
         $block =~ s#sha256\s*=\s*"([^"]+)".+$#sha256 = "$sha256Base32"; /* updated by script */#m;
       }
     } else {


### PR DESCRIPTION
###### Motivation for this change

Backport of #132043 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
Jetbrains seems to have deviated from the usual URL pattern of
`/<product>/<version>/<name>-<version>.<ext>` by only using the major.minor part
of the version number in the first URL segment for MPS.

(cherry picked from commit 597f94bd8a1a9e469eeb8458bb815a350f5df4cc)