### PR TITLE
linuxPackages_latest.nvidia-x11: Fix build on 5.13 kernels

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -23,6 +23,20 @@ rec {
       sha256_64bit = "120ymf59l6nipczszf82lrm2p4ihhqyv2pfwwfg9wy96vqcckc8i";
       settingsSha256 = "08jh7g34p9yxv5fh1cw0r2pjx65ryiv3w2lk1qg0gxn2r7xypkx0";
       persistencedSha256 = "040gx4wqp3hxcfb4aba4sl7b01ixr5slhzw0xldwcqlmhpwqphi5";
+
+      patches = [
+        # Patch to allow building on 5.13+ kernels
+        (fetchurl {
+          url = "https://gist.githubusercontent.com/joanbm/4a9d392e6f2d45c93ef434bda78174e5/raw/60a9d3846e6ba377da8cecaf56dd8eefa35ce03d/nvidia-fix-linux-5.13.patch";
+          sha256 = "bwIZmZlkp02X5SorccTtjNkWpRks61QtvvybNd+0Oqo=";
+
+          # We put the source in kernel/ before patchPhase, so we need to fix the paths.
+          postFetch = ''
+            sed -i 's|--- a/|--- a/kernel/|' $out
+            sed -i 's|--- b/|--- b/kernel/|' $out
+          '';
+        })
+      ];
     }
     else legacy_390;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See #132840. Mainly because I can't update without it, and would like to stay on the latest kernel version as much as possible while staying on 21.05 :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - Don't think that tool worked, though
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Sleep script is working, as is the driver
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
  - To the best of my ability

More than happy to do additional testing, but I can't find a relevant test module. The kernel-generic test doesn't enable nvidia.

I *am* currently writing this from a system that uses this patch :)