### PR TITLE
freshrss: init at 1.18.1, tests and module

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -561,6 +561,13 @@
           <link xlink:href="options.html#opt-services.prometheus.exporters.smartctl.enable">services.prometheus.exporters.smartctl</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://freshrss.org/">FreshRSS</link>, a
+          free, self-hostable RSS feed aggregator. Available as
+          <link linkend="opt-services.freshrss.enable">freshrss</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -164,6 +164,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [smartctl_exporter](https://github.com/prometheus-community/smartctl_exporter), a Prometheus exporter for [S.M.A.R.T.](https://en.wikipedia.org/wiki/S.M.A.R.T.) data. Available as [services.prometheus.exporters.smartctl](options.html#opt-services.prometheus.exporters.smartctl.enable).
 
+- [FreshRSS](https://freshrss.org/), a free, self-hostable RSS feed aggregator. Available as [freshrss](#opt-services.freshrss.enable).
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 - The NixOS VM test framework, `pkgs.nixosTest`/`make-test-python.nix`, now requires detaching commands such as `succeed("foo &")` and `succeed("foo | xclip -i")` to close stdout.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1031,6 +1031,7 @@
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ethercalc.nix
   ./services/web-apps/fluidd.nix
+  ./services/web-apps/freshrss.nix
   ./services/web-apps/galene.nix
   ./services/web-apps/gerrit.nix
   ./services/web-apps/gotify-server.nix

--- a/nixos/modules/services/web-apps/freshrss.nix
+++ b/nixos/modules/services/web-apps/freshrss.nix
@@ -1,0 +1,122 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.freshrss;
+
+  poolName = "freshrss";
+in
+{
+  meta.maintainers = with lib.maintainers; [ etu ];
+
+  options.services.freshrss = {
+    enable = lib.mkEnableOption "FreshRSS feed reader";
+
+    virtualHost = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = "freshrss";
+      description = ''
+        Name of the nginx virtualhost to use and setup. If null, do not setup any virtualhost.
+      '';
+    };
+
+    pool = lib.mkOption {
+      type = lib.types.str;
+      default = poolName;
+      description = ''
+        Name of the phpfpm pool to use and setup. If not specified, a pool will be created
+        with default values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Set up a Nginx virtual host.
+    services.nginx = lib.mkIf (cfg.virtualHost != null) {
+      enable = true;
+      virtualHosts.${cfg.virtualHost} = {
+        root = "/var/lib/freshrss/p";
+
+        locations."~ \.php$".extraConfig = ''
+          fastcgi_pass unix:${config.services.phpfpm.pools.${cfg.pool}.socket};
+          fastcgi_index index.php;
+          include ${pkgs.nginx}/conf/fastcgi_params;
+          include ${pkgs.nginx}/conf/fastcgi.conf;
+        '';
+
+        locations."/" = {
+          tryFiles = "$uri $uri/ index.php";
+          index = "index.php index.html index.htm";
+        };
+      };
+    };
+
+    # Set up phpfpm pool
+    services.phpfpm.pools = lib.mkIf (cfg.pool == poolName) {
+      ${poolName} = {
+        user = "freshrss";
+        settings = {
+          "listen.owner" = "nginx";
+          "listen.group" = "nginx";
+          "listen.mode" = "0600";
+          "pm" = "dynamic";
+          "pm.max_children" = 75;
+          "pm.start_servers" = 10;
+          "pm.min_spare_servers" = 5;
+          "pm.max_spare_servers" = 20;
+          "pm.max_requests" = 500;
+          "catch_workers_output" = 1;
+        };
+      };
+    };
+
+    users.users.freshrss = {
+      description = "FreshRSS service user";
+      isSystemUser = true;
+      group = "freshrss";
+    };
+    users.groups.freshrss = {};
+
+    systemd.services.freshrss-config = {
+      description = "Set up the state directory for FreshRSS before use";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = "freshrss";
+        Group = "freshrss";
+        StateDirectory = "freshrss";
+        WorkingDirectory = "/var/lib/freshrss";
+      };
+      script = ''
+        # Delete all but the "data" folder
+        ls | grep -v data | while read line; do rm -rf $line; done || true
+
+        # Copy all needed source files
+        cp -vr $(find ${pkgs.freshrss} -maxdepth 1 -mindepth 1 | grep -e '/cli' -e '/config' -e '/index' -e '/constants.php' -e '/app' -e '/extensions' -e '/p' -e '/lib') .
+
+        # Copy the user data template directory
+        cp -vr ${pkgs.freshrss}/data .
+
+        # Remove do-install.txt if we're already set up
+        if test -e data/config.php; then
+          rm data/do-install.txt
+        fi
+      '';
+    };
+
+    systemd.services.freshrss-updater = {
+      description = "FreshRSS feed updater";
+      after = [ "freshrss-config.service" ];
+      wantedBy = [ "multi-user.target" ];
+      startAt = "*:0/5";
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = "freshrss";
+        Group = "freshrss";
+        StateDirectory = "freshrss";
+        WorkingDirectory = "/var/lib/freshrss";
+        ExecStart = "${pkgs.php}/bin/php app/actualize_script.php";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -166,6 +166,7 @@ in
   fluidd = handleTest ./fluidd.nix {};
   fontconfig-default-fonts = handleTest ./fontconfig-default-fonts.nix {};
   freeswitch = handleTest ./freeswitch.nix {};
+  freshrss = handleTest ./freshrss.nix {};
   frr = handleTest ./frr.nix {};
   fsck = handleTest ./fsck.nix {};
   ft2-clone = handleTest ./ft2-clone.nix {};

--- a/nixos/tests/freshrss.nix
+++ b/nixos/tests/freshrss.nix
@@ -1,0 +1,20 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }: {
+  name = "freshrss";
+  meta.maintainers = with lib.maintainers; [ etu ];
+
+  machine = { ... }: {
+    services.freshrss.enable = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_open_port(80)
+
+    response = machine.succeed("curl -vvv -s -H 'Host: freshrss' http://127.0.0.1:80/")
+    assert "<title>FreshRSS</title>" in response, "Title not found on page"
+    assert '<meta http-equiv="Refresh" content="0; url=i/" />' in response, "Redirect to install not found on page"
+
+    response = machine.succeed("curl -vvv -s -H 'Host: freshrss' http://127.0.0.1:80/i/")
+    assert '<title>Installation · FreshRSS</title>' in response, "Installation page didn't load successfully"
+  '';
+})

--- a/pkgs/servers/freshrss/default.nix
+++ b/pkgs/servers/freshrss/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenv, lib, fetchFromGitHub, nixosTests }:
 
 let
   pname = "FreshRSS";
@@ -13,6 +13,8 @@ stdenv.mkDerivation {
     rev = version;
     sha256 = "189rwfpp5chv11p12bkyr64wpxap03gkhim90vm961qnixbypbdw";
   };
+
+  passthru.tests = nixosTests.freshrss;
 
   # There's nothing to build.
   dontBuild = true;

--- a/pkgs/servers/freshrss/default.nix
+++ b/pkgs/servers/freshrss/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "FreshRSS";
-  version = "1.18.1";
+  version = "1.19.2";
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "189rwfpp5chv11p12bkyr64wpxap03gkhim90vm961qnixbypbdw";
+    sha256 = "sha256-UUDMYgYPvIuL5Jw2fFhJGoJ4KLNUBpk2pPc2UNa+ZSE=";
   };
 
   passthru.tests = nixosTests.freshrss;

--- a/pkgs/servers/freshrss/default.nix
+++ b/pkgs/servers/freshrss/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+let
+  pname = "FreshRSS";
+  version = "1.18.1";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "189rwfpp5chv11p12bkyr64wpxap03gkhim90vm961qnixbypbdw";
+  };
+
+  # There's nothing to build.
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out
+
+    cp -vr * $out/
+  '';
+
+  meta = with lib; {
+    description = "FreshRSS is a free, self-hostable RSS aggregator";
+    homepage = "https://www.freshrss.org/";
+    license = licenses.agpl3Plus;
+    maintainers = [ maintainers.etu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21615,6 +21615,8 @@ with pkgs;
 
   freeradius = callPackage ../servers/freeradius { };
 
+  freshrss = callPackage ../servers/freshrss { };
+
   freeswitch = callPackage ../servers/sip/freeswitch {
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
   };


### PR DESCRIPTION
###### Motivation for this change
I've been using a module like this in my own configuration repo for quite some time, it worked fine through updates and things.

FreshRSS does some quite weird things in it's data folder. I'm certain that we don't want to even try to replicate that behavior.

So I'd rather just do the php setup and leave the installation to the user. There the user can select the database and such by itself and set it up as they wish as well.

This fixes #77246.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
