### PR TITLE
nixos/etc: use runCommandLocal

### DIFF
--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -8,10 +8,7 @@ let
 
   etc' = filter (f: f.enable) (attrValues config.environment.etc);
 
-  etc = pkgs.runCommand "etc" {
-    preferLocalBuild = true;
-    allowSubstitutes = false;
-
+  etc = pkgs.runCommandLocal "etc" {
     # This is needed for the systemd module
     passthru.targets = map (x: x.target) etc';
   } /* sh */ ''


### PR DESCRIPTION
###### Motivation for this change
Small optmization to use `runCommandLocal` instead of setting `preferLocalBuild` & `allowSubstitutes` explicitly.
Helpful references for reviewers:
https://github.com/NixOS/nixpkgs/blob/8fa19a7a6c8ca33dd57a7596523a2a95146ee1ca/pkgs/build-support/trivial-builders.nix#L28
https://github.com/NixOS/nixpkgs/blob/8fa19a7a6c8ca33dd57a7596523a2a95146ee1ca/pkgs/build-support/trivial-builders.nix#L36-L41
https://github.com/NixOS/nixpkgs/blob/8fa19a7a6c8ca33dd57a7596523a2a95146ee1ca/pkgs/build-support/trivial-builders.nix#L81-L84
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
