### PR TITLE
[Backport release-21.05] add desktopitems

### DIFF
--- a/pkgs/games/dhewm3/default.nix
+++ b/pkgs/games/dhewm3/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, SDL2, libGLU, libGL, zlib, libjpeg, libogg, libvorbis
-, openal, curl }:
+, openal, curl, copyDesktopItems, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
   pname = "dhewm3";
@@ -21,8 +21,17 @@ stdenv.mkDerivation rec {
     cd "$(ls -d dhewm3-*.src)"/neo
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake copyDesktopItems ];
   buildInputs = [ SDL2 libGLU libGL zlib libjpeg libogg libvorbis openal curl ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "dhewm3";
+      exec = "dhewm3";
+      desktopName = "Doom 3";
+      categories = "Game;";
+    })
+  ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, makeWrapper, openal, fluidsynth_1
 , soundfont-fluid, libGL, SDL2, bzip2, zlib, libjpeg, libsndfile, mpg123
-, game-music-emu, pkg-config }:
+, game-music-emu, pkg-config, copyDesktopItems, makeDesktopItem }:
 
 let
   zmusic-src = fetchFromGitHub {
@@ -38,7 +38,7 @@ let
       fetchSubmodules = true;
     };
 
-    nativeBuildInputs = [ cmake makeWrapper pkg-config ];
+    nativeBuildInputs = [ cmake makeWrapper pkg-config copyDesktopItems ];
     buildInputs = [
       SDL2
       libGL
@@ -55,7 +55,18 @@ let
 
     NIX_CFLAGS_LINK = "-lopenal -lfluidsynth";
 
+    desktopItems = [
+      (makeDesktopItem {
+        name = "gzdoom";
+        exec = "gzdoom";
+        desktopName = "GZDoom";
+        categories = "Game;";
+      })
+    ];
+
     installPhase = ''
+      runHook preInstall
+
       install -Dm755 gzdoom "$out/lib/gzdoom/gzdoom"
       for i in *.pk3; do
         install -Dm644 "$i" "$out/lib/gzdoom/$i"
@@ -68,6 +79,8 @@ let
       done
       mkdir $out/bin
       makeWrapper $out/lib/gzdoom/gzdoom $out/bin/gzdoom
+
+      runHook postInstall
     '';
 
     meta = with lib; {

--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, SDL, fetchurl, gzip, libvorbis, libmad }:
+{ lib, stdenv, SDL, fetchurl, gzip, libvorbis, libmad, copyDesktopItems, makeDesktopItem }:
+
 stdenv.mkDerivation rec {
   pname = "quakespasm";
   majorVersion = "0.93";
@@ -11,6 +12,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${pname}-${version}/Quake";
 
+  nativeBuildInputs = [ copyDesktopItems ];
   buildInputs = [
     gzip SDL libvorbis libmad
   ];
@@ -24,7 +26,16 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  desktopItems = [
+    (makeDesktopItem {
+      name = "quakespasm";
+      exec = "quake";
+      desktopName = "Quakespasm";
+      categories = "Game;";
+    })
+  ];
+
+  meta = with lib; {
     description = "An engine for iD software's Quake";
     homepage = "http://quakespasm.sourceforge.net/";
     longDescription = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/132826, with quakespasm fixed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
