### PR TITLE
python3Packages.spleeter: init at 2.2.2

### DIFF
--- a/pkgs/development/python-modules/norbert/default.nix
+++ b/pkgs/development/python-modules/norbert/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, scipy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "norbert";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "sigsep";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1hr030a8wgb5ndvlcng7ng0cjs1ggnb9vbmp9dwkjyyswn1ga1jd";
+  };
+
+  propagatedBuildInputs = [ scipy ];
+
+  checkInputs = [ pytestCheckHook ];
+  preCheck = ''
+    substituteInPlace setup.cfg --replace '--pep8' ""
+  '';
+  pytestFlagsArray = [ "tests/" ];
+
+  pythonImportsCheck = [ "norbert" ];
+
+  meta = with lib; {
+    description = "Painless Wiener Filters";
+    homepage = "https://sigsep.github.io/norbert/";
+    license = licenses.mit;
+    maintainers = [ maintainers.ris ];
+  };
+}

--- a/pkgs/development/python-modules/spleeter/default.nix
+++ b/pkgs/development/python-modules/spleeter/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchurl
+, runCommand
+, ffmpeg
+, ffmpeg-python
+, httpx
+, librosa
+, norbert
+, numpy
+, pandas
+, poetry-core
+, pytest-forked
+, pytestCheckHook
+, tensorflow
+, typer
+}:
+
+buildPythonPackage rec {
+  pname = "spleeter";
+  version = "2.2.2";
+
+  src = fetchFromGitHub {
+    owner = "deezer";
+    repo = pname;
+    # release not tagged: this is the revision that bumps the version in pyproject.toml
+    rev = "72e62a7770c8c1bfec674741f578d8ca5eb3a09b";
+    sha256 = "1zsdz3x1zrlrb4bhzf1i5d29l9y4a4pax7f53qz2a1p9cb9cvg92";
+  };
+  format = "pyproject";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'ffmpeg-python = "0.2.0"' 'ffmpeg-python = "*"' \
+      --replace 'httpx = {extras = ["http2"], version = "^0.16.1"}' 'httpx = "*"' \
+      --replace 'librosa = "0.8.0"' 'librosa = "*"' \
+      --replace 'norbert = "0.2.1"' 'norbert = "*"' \
+      --replace 'numpy = "<1.19.0,>=1.16.0"' 'numpy = "*"' \
+      --replace 'pandas = "1.1.2"' 'pandas = "*"' \
+      --replace 'tensorflow = "2.3.0"' 'tensorflow = "*"' \
+      --replace 'typer = "^0.3.2"' 'typer = "*"' \
+      --replace 'python = ">=3.6.1,<3.9"' 'python = "*"'
+  '';
+  nativeBuildInputs = [ poetry-core ];
+  propagatedBuildInputs = [
+    ffmpeg-python
+    httpx
+    librosa
+    norbert
+    numpy
+    pandas
+    tensorflow
+    typer
+  ];
+
+  checkInputs = [ pytestCheckHook pytest-forked ffmpeg ];
+  preCheck = let
+    model2Stems = fetchurl {
+      url = "https://github.com/deezer/spleeter/releases/download/v1.4.0/2stems.tar.gz";
+      sha256 = "14nn5cakj2n8xxc3j7y692w9gy2xfj38m905ifg2cx18vlwhpagk";
+    };
+    model2StemsUnpacked = runCommand "2stems" {} ''
+      mkdir $out
+      tar -C $out -zxf ${model2Stems}
+    '';
+  in ''
+    export NUMBA_CACHE_DIR="$(mktemp -d)"
+    rm -r spleeter/
+    mkdir pretrained_models
+    ln -s ${model2StemsUnpacked} pretrained_models/2stems
+  '';
+  pytestFlagsArray = [ "tests/" ];
+  disabledTestPaths = [
+    # we don't yet package musdb, required for this functionality
+    "tests/test_eval.py"
+    # requires network access
+    "tests/test_github_model_provider.py"
+  ];
+  # only testing against 2stems to limit download size
+  disabledTests = [ "4stems" "5stems" ];
+
+  pythonImportsCheck = [ "spleeter" ];
+
+  meta = {
+    homepage = "https://github.com/deezer/spleeter";
+    description = "Audio source separation library including pretrained models";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22989,6 +22989,8 @@ in
 
   spleen = callPackage ../data/fonts/spleen { inherit (buildPackages.xorg) mkfontscale; };
 
+  spleeter = with python3Packages; toPythonApplication spleeter;
+
   stilo-themes = callPackage ../data/themes/stilo { };
 
   sudo-font = callPackage ../data/fonts/sudo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4861,6 +4861,8 @@ in {
 
   noiseprotocol = callPackage ../development/python-modules/noiseprotocol { };
 
+  norbert = callPackage ../development/python-modules/norbert { };
+
   normality = callPackage ../development/python-modules/normality { };
 
   nose2 = callPackage ../development/python-modules/nose2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8322,6 +8322,8 @@ in {
 
   spidev = callPackage ../development/python-modules/spidev { };
 
+  spleeter = callPackage ../development/python-modules/spleeter { };
+
   splinter = callPackage ../development/python-modules/splinter { };
 
   spotipy = callPackage ../development/python-modules/spotipy { };


### PR DESCRIPTION
###### Motivation for this change
A tensorflow-based audio source separation tool. I've got fairly decent results with it.

The only downside is that it's designed to pull its models down from github on-demand, which means they could be vulnerable to disappearance and it could be unhelpful if a user doesn't have great network access when they need it.

It might be nice to be able to include some of the models along with the package, however:
 - they're big (hundreds of megs) and this would bloat the package and unnecessarily add to the strain on cache.nixos.org.
 - there isn't any means to do this in the code. I'd have to do some hacking to get it to do this (without breaking the downloading functionality by giving it a readonly models directory), and upstream is very quiet meaning it would probably be our patch forever.

Note that this does actually _download_ the smallest of the available models, but only as a build-time dependency for the tests.

Includes packaging of dependency `norbert` and also added as an application using `toPythonApplication`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @magnetophon through interest in audio tools.