### PR TITLE
kdsoap: format

### DIFF
--- a/pkgs/development/libraries/kdsoap/default.nix
+++ b/pkgs/development/libraries/kdsoap/default.nix
@@ -1,4 +1,6 @@
-{ mkDerivation, lib, fetchurl
+{ mkDerivation
+, lib
+, fetchurl
 , cmake
 , qtbase
 }:
@@ -6,7 +8,27 @@
 mkDerivation rec {
   pname = "kdsoap";
   version = "2.0.0";
-  meta = {
+
+  src = fetchurl {
+    url = "https://github.com/KDAB/KDSoap/releases/download/kdsoap-${version}/kdsoap-${version}.tar.gz";
+    sha256 = "sha256-0YljEE+m99ArBEYxzdvnjxj3DgbGB69oDHrOBNbPBO4=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ qtbase ];
+
+  postInstall = ''
+    moveToOutput bin/kdwsdl2cpp "$dev"
+    sed -i "$out/lib/cmake/KDSoap/KDSoapTargets.cmake" \
+        -e "/^  INTERFACE_INCLUDE_DIRECTORIES/ c   INTERFACE_INCLUDE_DIRECTORIES \"$dev/include\""
+    sed -i "$out/lib/cmake/KDSoap/KDSoapTargets-release.cmake" \
+        -e "s@$out/bin@$dev/bin@"
+  '';
+
+  meta = with lib; {
     description = "A Qt-based client-side and server-side SOAP component";
     longDescription = ''
       KD Soap is a Qt-based client-side and server-side SOAP component.
@@ -15,21 +37,7 @@ mkDerivation rec {
       provides the means to create web services without the need for any further
       component such as a dedicated web server.
     '';
-    license = with lib.licenses; [ gpl2 gpl3 lgpl21 ];
-    maintainers = [ lib.maintainers.ttuegel ];
+    license = with licenses; [ gpl2 gpl3 lgpl21 ];
+    maintainers = [ maintainers.ttuegel ];
   };
-  src = fetchurl {
-    url = "https://github.com/KDAB/KDSoap/releases/download/kdsoap-${version}/kdsoap-${version}.tar.gz";
-    sha256 = "sha256-0YljEE+m99ArBEYxzdvnjxj3DgbGB69oDHrOBNbPBO4=";
-  };
-  outputs = [ "out" "dev" ];
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ qtbase ];
-  postInstall = ''
-    moveToOutput bin/kdwsdl2cpp "$dev"
-    sed -i "$out/lib/cmake/KDSoap/KDSoapTargets.cmake" \
-        -e "/^  INTERFACE_INCLUDE_DIRECTORIES/ c   INTERFACE_INCLUDE_DIRECTORIES \"$dev/include\""
-    sed -i "$out/lib/cmake/KDSoap/KDSoapTargets-release.cmake" \
-        -e "s@$out/bin@$dev/bin@"
-  '';
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
