### PR TITLE
python39Packages.pytest-mockservers,python39Packages.pytest-resource-path: move pytest to buildInputs

### DIFF
--- a/pkgs/development/python-modules/pytest-mockservers/default.nix
+++ b/pkgs/development/python-modules/pytest-mockservers/default.nix
@@ -31,9 +31,12 @@ buildPythonPackage rec {
     poetry-core
   ];
 
+  buildInputs = [
+    pytest
+  ];
+
   propagatedBuildInputs = [
     aiohttp
-    pytest
     pytest-asyncio
   ];
 

--- a/pkgs/development/python-modules/pytest-resource-path/default.nix
+++ b/pkgs/development/python-modules/pytest-resource-path/default.nix
@@ -3,7 +3,6 @@
 , pythonOlder
 , fetchFromGitHub
 , colorama
-, pytest-runner
 , pytest
 , pytestCheckHook
 }:
@@ -20,13 +19,17 @@ buildPythonPackage rec {
     sha256 = "1siv3pk4fsabz254fdzr7c0pxy124habnbw4ym66pfk883fr96g2";
   };
 
-  nativeBuildInputs = [
-    pytest-runner
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "pytest-runner" ""
+  '';
+
+  buildInputs = [
+    pytest
   ];
 
   propagatedBuildInputs = [
     colorama
-    pytest
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/roonapi/default.nix
+++ b/pkgs/development/python-modules/roonapi/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , ifaddr
 , poetry-core
 , pythonOlder


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
