### PR TITLE
lynx: add patch for CVE-2021-38165

### DIFF
--- a/pkgs/applications/networking/browsers/lynx/default.nix
+++ b/pkgs/applications/networking/browsers/lynx/default.nix
@@ -2,6 +2,7 @@
 , fetchurl, pkg-config, ncurses, gzip
 , sslSupport ? true, openssl ? null
 , nukeReferences
+, fetchpatch
 }:
 
 assert sslSupport -> openssl != null;
@@ -21,6 +22,14 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   hardeningEnable = [ "pie" ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-38165.patch";
+      url = "https://git.alpinelinux.org/aports/plain/main/lynx/CVE-2021-38165.patch?id=3400945dbbb8a87065360963e4caa0e17d3dcc61";
+      sha256 = "1aykb9y2g2vdpbbpvjlm4r40x7py2yv6jbywwcqcxrlciqcw4x57";
+    })
+  ];
 
   configureFlags = [
     "--enable-default-colors"


### PR DESCRIPTION
Co-authored-by: nixinator <33lockdown33@protonmail.com>
Co-authored-by: John Bargman <darthpjb@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes the security vulnerability in Lynx that resulted in this meltdown on the mailing list. Code was audited by @DarthPJB

https://lists.nongnu.org/archive/html/lynx-dev/2021-08/msg00007.html

Patch Source: https://git.alpinelinux.org/aports/tree/main/lynx/CVE-2021-38165.patch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
