### PR TITLE
pythonPackages.resolvelib: 0.7.1 -> 0.5.5

### DIFF
--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -42,9 +42,6 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace lib/ansible/executor/task_executor.py \
       --replace "[python," "["
-
-    substituteInPlace requirements.txt \
-      --replace "resolvelib >= 0.5.3, < 0.6.0" "resolvelib"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/resolvelib/default.nix
+++ b/pkgs/development/python-modules/resolvelib/default.nix
@@ -7,13 +7,18 @@
 
 buildPythonPackage rec {
   pname = "resolvelib";
-  version = "0.7.1";
+  # Currently this package is only used by Ansible and breaking changes
+  # are frequently introduced, so when upgrading ensure the new version
+  # is compatible with Ansible
+  # https://github.com/NixOS/nixpkgs/pull/128636
+  # https://github.com/ansible/ansible/blob/devel/requirements.txt
+  version = "0.5.5";
 
   src = fetchFromGitHub {
     owner = "sarugaku";
     repo = "resolvelib";
     rev = version;
-    sha256 = "1fqz75riagizihvf4j7wc3zjw6kmg1dd8sf49aszyml105kb33n8";
+    sha256 = "198vfv78hilpg0d0mjzchzp9zk6239wnra61vlsgwpcgz66d2bgv";
   };
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change

Implements proposed solution from https://github.com/NixOS/nixpkgs/pull/128636, as I understand it at least.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).