### PR TITLE
treewide: buildFlags{,Array} -> ldflags, tags

### DIFF
--- a/pkgs/applications/version-management/gogs/default.nix
+++ b/pkgs/applications/version-management/gogs/default.nix
@@ -29,9 +29,7 @@ buildGoModule rec {
 
   buildInputs = optional pamSupport pam;
 
-  buildFlags = [ "-tags" ];
-
-  buildFlagsArray =
+  tags =
     (  optional sqliteSupport "sqlite"
     ++ optional pamSupport "pam");
 

--- a/pkgs/development/tools/continuous-integration/drone/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone/default.nix
@@ -16,9 +16,7 @@ buildGoModule rec {
     sha256 = "sha256-MKV5kor+Wm9cuIFFcjSNyCgVKtY+/B9sgBOXMMRvMPI=";
   };
 
-  preBuild = ''
-    buildFlagsArray+=( "-tags" "${lib.optionalString (!enableUnfree) "oss nolimit"}" )
-  '';
+  tags = lib.optionals (!enableUnfree) [ "oss" "nolimit" ];
 
   meta = with lib; {
     maintainers = with maintainers; [ elohmeier vdemeester ];

--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -47,21 +47,19 @@ buildGoModule rec {
     ln -s ${webui} web/ui/static/react
   '';
 
-  buildFlags = "-tags=builtinassets";
-  buildFlagsArray =
+  tags = [ "builtinassets" ];
+
+  ldflags =
     let
       t = "${goPackagePath}/vendor/github.com/prometheus/common/version";
     in
     [
-      ''
-        -ldflags=
-           -X ${t}.Version=${version}
-           -X ${t}.Revision=unknown
-           -X ${t}.Branch=unknown
-           -X ${t}.BuildUser=nix@nixpkgs
-           -X ${t}.BuildDate=unknown
-           -X ${t}.GoVersion=${lib.getVersion go}
-      ''
+      "-X ${t}.Version=${version}"
+      "-X ${t}.Revision=unknown"
+      "-X ${t}.Branch=unknown"
+      "-X ${t}.BuildUser=nix@nixpkgs"
+      "-X ${t}.BuildDate=unknown"
+      "-X ${t}.GoVersion=${lib.getVersion go}"
     ];
 
   # only run this in the real build, not during the vendor build

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
 
   nativeBuildInputs = optional withSystemdSupport makeWrapper;
   buildInputs = optional withSystemdSupport systemd;
-  buildFlags = optional (!withSystemdSupport) "-tags nosystemd";
+  tags = optional (!withSystemdSupport) "nosystemd";
 
   goDeps = ./postfix-exporter-deps.nix;
   extraSrcs = optionals withSystemdSupport [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
