### PR TITLE
python3Packages.threadpoolctl: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/threadpoolctl/default.nix
+++ b/pkgs/development/python-modules/threadpoolctl/default.nix
@@ -4,14 +4,13 @@
 , fetchFromGitHub
 , flit
 , pytestCheckHook
-, pytest-cov
 , numpy
 , scipy
 }:
 
 buildPythonPackage rec {
   pname = "threadpoolctl";
-  version = "2.1.0";
+  version = "2.2.0";
 
   disabled = isPy27;
   format = "flit";
@@ -20,10 +19,10 @@ buildPythonPackage rec {
     owner = "joblib";
     repo = pname;
     rev = version;
-    sha256 = "0sl6mp3b2gb0dvqkhnkmrp2g3r5c7clyyyxzq44xih6sw1pgx9df";
+    sha256 = "7UUjbX1IpXtUAgN48Db43Zr1u360UETSUnIHD6rQRLs=";
   };
 
-  checkInputs = [ pytestCheckHook pytest-cov numpy scipy ];
+  checkInputs = [ pytestCheckHook numpy scipy ];
 
   meta = with lib; {
     homepage = "https://github.com/joblib/threadpoolctl";


### PR DESCRIPTION


###### Motivation for this change

Routine update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
