### PR TITLE
fuzzel: update dependencies; add optional flags and switch to fetchFromGitea

### DIFF
--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     description = "Wayland-native application launcher, similar to rofi’s drun mode";
     homepage = "https://codeberg.org/dnkl/fuzzel";
     license = licenses.mit;
-    maintainers = with maintainers; [ fionera ];
+    maintainers = with maintainers; [ fionera polykernel ];
     platforms = with platforms; linux;
     changelog = "https://codeberg.org/dnkl/fuzzel/releases/tag/${version}";
   };

--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -4,18 +4,27 @@
 , pkg-config
 , meson
 , ninja
+, wayland-scanner
 , wayland
 , pixman
-, cairo
-, librsvg
 , wayland-protocols
-, wlroots
 , libxkbcommon
 , scdoc
-, git
 , tllist
 , fcft
+, enableCairo ? true
+, enablePNG ? true
+, enableSVG ? true
+# Optional dependencies
+, cairo
+, librsvg
+, libpng
 }:
+
+let
+  # Courtesy of sternenseemann and FRidh, commit c9a7fdfcfb420be8e0179214d0d91a34f5974c54
+  mesonFeatureFlag = opt: b: "-D${opt}=${if b then "enabled" else "disabled"}";
+in
 
 stdenv.mkDerivation rec {
   pname = "fuzzel";
@@ -31,22 +40,29 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
+    wayland-scanner
     meson
     ninja
     scdoc
-    git
   ];
 
   buildInputs = [
     wayland
     pixman
-    cairo
-    librsvg
     wayland-protocols
-    wlroots
     libxkbcommon
     tllist
     fcft
+  ] ++ lib.optional enableCairo cairo
+    ++ lib.optional enablePNG libpng
+    ++ lib.optional enableSVG librsvg;
+
+  mesonBuildType = "release";
+
+  mesonFlags = [
+    (mesonFeatureFlag "enable-cairo" enableCairo)
+    (mesonFeatureFlag "enable-png" enablePNG)
+    (mesonFeatureFlag "enable-svg" enableSVG)
   ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, lib, fetchzip, pkg-config, meson, ninja, wayland, pixman, cairo, librsvg, wayland-protocols, wlroots, libxkbcommon, scdoc, git, tllist, fcft}:
+{ stdenv, lib, fetchFromGitea, pkg-config, meson, ninja, wayland, pixman, cairo, librsvg, wayland-protocols, wlroots, libxkbcommon, scdoc, git, tllist, fcft}:
 
 stdenv.mkDerivation rec {
   pname = "fuzzel";
   version = "1.6.1";
 
-  src = fetchzip {
-    url = "https://codeberg.org/dnkl/fuzzel/archive/${version}.tar.gz";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "dnkl";
+    repo = "fuzzel";
+    rev = version;
     sha256 = "sha256-JW5sAlTprSRIdFbmSaUreGtNccERgQMGEW+WCSscYQk=";
   };
 

--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -1,4 +1,21 @@
-{ stdenv, lib, fetchFromGitea, pkg-config, meson, ninja, wayland, pixman, cairo, librsvg, wayland-protocols, wlroots, libxkbcommon, scdoc, git, tllist, fcft}:
+{ stdenv
+, lib
+, fetchFromGitea
+, pkg-config
+, meson
+, ninja
+, wayland
+, pixman
+, cairo
+, librsvg
+, wayland-protocols
+, wlroots
+, libxkbcommon
+, scdoc
+, git
+, tllist
+, fcft
+}:
 
 stdenv.mkDerivation rec {
   pname = "fuzzel";
@@ -12,8 +29,25 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-JW5sAlTprSRIdFbmSaUreGtNccERgQMGEW+WCSscYQk=";
   };
 
-  nativeBuildInputs = [ pkg-config meson ninja scdoc git ];
-  buildInputs = [ wayland pixman cairo librsvg wayland-protocols  wlroots libxkbcommon tllist fcft ];
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    scdoc
+    git
+  ];
+
+  buildInputs = [
+    wayland
+    pixman
+    cairo
+    librsvg
+    wayland-protocols
+    wlroots
+    libxkbcommon
+    tllist
+    fcft
+  ];
 
   meta = with lib; {
     description = "Wayland-native application launcher, similar to rofi’s drun mode";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Using per option configurations instead of relying on `mesonAutoFeatures` allows overriding optional features. Update to `fetchFromGitea` allows better automation tooling for package updates. Some dependencies were unnecessary and thus were removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
