### PR TITLE
yambar: update to use fetchFromGitea; format and split into individual backends

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -663,6 +663,15 @@
           group.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>yambar</literal> package has been split into
+          <literal>yambar</literal> and
+          <literal>yambar-wayland</literal>, corresponding to the xorg
+          and wayland backend respectively. Please switch to
+          <literal>yambar-wayland</literal> if you are on wayland.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -166,6 +166,8 @@ pt-services.clipcat.enable).
 
 - The `openrazer` and `openrazer-daemon` packages as well as the `hardware.openrazer` module now require users to be members of the `openrazer` group instead of `plugdev`. With this change, users no longer need be granted the entire set of `plugdev` group permissions, which can include permissions other than those required by `openrazer`. This is desirable from a security point of view. The setting [`harware.openrazer.users`](options.html#opt-services.hardware.openrazer.users) can be used to add users to the `openrazer` group.
 
+- The `yambar` package has been split into `yambar` and `yambar-wayland`, corresponding to the xorg and wayland backend respectively. Please switch to `yambar-wayland` if you are on wayland.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 - The setting [`services.openssh.logLevel`](options.html#opt-services.openssh.logLevel) `"VERBOSE"` `"INFO"`. This brings NixOS in line with upstream and other Linux distributions, and reduces log spam on servers due to bruteforcing botnets.

--- a/pkgs/applications/misc/yambar/default.nix
+++ b/pkgs/applications/misc/yambar/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchgit
+, fetchFromGitea
 , pkg-config
 , meson
 , ninja
@@ -9,50 +9,75 @@
 , fcft
 , json_c
 , libmpdclient
-, libxcb
 , libyaml
 , pixman
 , tllist
 , udev
 , wayland
+, wayland-scanner
 , wayland-protocols
+, waylandSupport ? false
+# Xorg backend
+, libxcb
 , xcbutil
 , xcbutilcursor
 , xcbutilerrors
 , xcbutilwm
 }:
 
+let
+  # Courtesy of sternenseemann and FRidh, commit c9a7fdfcfb420be8e0179214d0d91a34f5974c54
+  mesonFeatureFlag = opt: b: "-D${opt}=${if b then "enabled" else "disabled"}";
+in
+
 stdenv.mkDerivation rec {
   pname = "yambar";
   version = "1.6.2";
 
-  src = fetchgit {
-    url = "https://codeberg.org/dnkl/yambar.git";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "dnkl";
+    repo = "yambar";
     rev = version;
-    sha256 = "sha256-oUNkaWrYIcsK2u+aeRg6DHmH4M1VZ0leNSM0lV9Yy1Y=";
+    sha256 = "sha256-GPKR2BYl3ebxxXbVfH/oZLs7639EYwWU4ZsilJn0Ss8=";
   };
 
-  nativeBuildInputs = [ pkg-config meson ninja scdoc ];
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    scdoc
+    wayland-scanner
+  ];
+
   buildInputs = [
     alsa-lib
     fcft
     json_c
     libmpdclient
-    libxcb
     libyaml
     pixman
     tllist
     udev
     wayland
     wayland-protocols
+  ] ++ lib.optionals (!waylandSupport) [
     xcbutil
     xcbutilcursor
     xcbutilerrors
     xcbutilwm
   ];
 
+  mesonBuildType = "release";
+
+  mesonFlags = [
+    (mesonFeatureFlag "backend-x11" (!waylandSupport))
+    (mesonFeatureFlag "backend-wayland" waylandSupport)
+  ];
+
   meta = with lib; {
     homepage = "https://codeberg.org/dnkl/yambar";
+    changelog = "https://codeberg.org/dnkl/yambar/releases/tag/${version}";
     description = "Modular status panel for X11 and Wayland";
     longDescription = ''
       yambar is a lightweight and configurable status panel (bar, for short) for

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26246,6 +26246,8 @@ in
 
   yambar = callPackage ../applications/misc/yambar { };
 
+  yambar-wayland = callPackage ../applications/misc/yambar { waylandSupport = true; };
+
   polyphone = libsForQt514.callPackage ../applications/audio/polyphone { };
 
   portfolio = callPackage ../applications/office/portfolio {


### PR DESCRIPTION
* Use fetchFromGitea instead of fetchgit, submodules are unnecessary
  as we wlr-protocols are vendored.
* Split into xorg and wayland backends based on an option flag, (By
  default, the xorg backend is used, this might be a breaking change)
* Adhere to syntax style guide for long lists.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
