### PR TITLE
Fix vscode-extensions rust analyzer

### DIFF
--- a/pkgs/misc/vscode-extensions/rust-analyzer/default.nix
+++ b/pkgs/misc/vscode-extensions/rust-analyzer/default.nix
@@ -1,5 +1,9 @@
 # Update script: pkgs/development/tools/rust/rust-analyzer/update.sh
-{ lib, vscode-utils, jq, rust-analyzer, nodePackages
+{ lib
+, vscode-utils
+, jq
+, rust-analyzer
+, nodePackages
 , setDefaultServerPath ? true
 }:
 
@@ -24,7 +28,8 @@ let
     '';
   };
 
-in vscode-utils.buildVscodeExtension {
+in
+vscode-utils.buildVscodeExtension {
   inherit version vsix;
   name = "${pname}-${version}";
   src = "${vsix}/${pname}.zip";

--- a/pkgs/misc/vscode-extensions/rust-analyzer/default.nix
+++ b/pkgs/misc/vscode-extensions/rust-analyzer/default.nix
@@ -5,6 +5,7 @@
 , rust-analyzer
 , nodePackages
 , setDefaultServerPath ? true
+, moreutils
 }:
 
 let
@@ -35,13 +36,12 @@ vscode-utils.buildVscodeExtension {
   src = "${vsix}/${pname}.zip";
   vscodeExtUniqueId = "${publisher}.${pname}";
 
-  nativeBuildInputs = lib.optional setDefaultServerPath jq;
+  nativeBuildInputs = lib.optionals setDefaultServerPath [ jq moreutils ];
 
   preInstall = lib.optionalString setDefaultServerPath ''
-    jq '.contributes.configuration.properties."rust-analyzer.serverPath".default = $s' \
+    jq '.contributes.configuration.properties."rust-analyzer.server.path".default = $s' \
       --arg s "${rust-analyzer}/bin/rust-analyzer" \
-      package.json >package.json.new
-    mv package.json.new package.json
+      package.json | sponge package.json
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

the package.json configuration for server path changed
https://github.com/rust-analyzer/rust-analyzer/blob/master/editors/code/package.json#L324
it must have been recently, because the plugin was working last month when I used it.
the setting is now `server.path` and not `serverPath`
I've formatted with nixpkgs-fmt as well, hope it's not a problem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
