### PR TITLE
nixos/nitter: systemd unit hardening

### DIFF
--- a/nixos/modules/services/misc/nitter.nix
+++ b/nixos/modules/services/misc/nitter.nix
@@ -312,6 +312,31 @@ in
           AmbientCapabilities = lib.mkIf (cfg.server.port < 1024) [ "CAP_NET_BIND_SERVICE" ];
           Restart = "on-failure";
           RestartSec = "5s";
+          # Hardening
+          CapabilityBoundingSet = if (cfg.server.port < 1024) then [ "CAP_NET_BIND_SERVICE" ] else [ "" ];
+          DeviceAllow = [ "" ];
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          PrivateDevices = true;
+          # A private user cannot have process capabilities on the host's user
+          # namespace and thus CAP_NET_BIND_SERVICE has no effect.
+          PrivateUsers = (cfg.server.port >= 1024);
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+          UMask = "0077";
         };
     };
 

--- a/nixos/tests/nitter.nix
+++ b/nixos/tests/nitter.nix
@@ -6,11 +6,13 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
   nodes.machine = {
     services.nitter.enable = true;
+    # Test CAP_NET_BIND_SERVICE
+    services.nitter.server.port = 80;
   };
 
   testScript = ''
     machine.wait_for_unit("nitter.service")
-    machine.wait_for_open_port("8080")
-    machine.succeed("curl --fail http://localhost:8080/")
+    machine.wait_for_open_port("80")
+    machine.succeed("curl --fail http://localhost:80/")
   '';
 })

--- a/pkgs/servers/nitter/default.nix
+++ b/pkgs/servers/nitter/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, nixosTests
 , fetchFromGitHub
 , nim
 , libsass
@@ -119,6 +120,10 @@ in stdenv.mkDerivation rec {
     cp -r public $out/share/nitter/public
     runHook postInstall
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) nitter;
+  };
 
   meta = with lib; {
     description = "Alternative Twitter front-end";


### PR DESCRIPTION
###### Motivation for this change

This increases the isolation of Nitter service. I have been running with those parameters for a week and I did not see any regression.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
