### PR TITLE
python39Packages.awslambdaric: move depedency patching to right phase

### DIFF
--- a/pkgs/development/python-modules/awslambdaric/default.nix
+++ b/pkgs/development/python-modules/awslambdaric/default.nix
@@ -13,6 +13,11 @@ buildPythonPackage rec {
     sha256 = "120qar8iaxj6dmnhjw1c40n2w06f1nyxy57dwh06xdiany698fg4";
   };
 
+  postPatch = ''
+    substituteInPlace requirements/base.txt \
+      --replace 'simplejson==3' 'simplejson~=3'
+  '';
+
   propagatedBuildInputs = [ simplejson ];
 
   nativeBuildInputs = [ autoconf automake cmake libtool perl ];
@@ -20,10 +25,6 @@ buildPythonPackage rec {
   buildInputs = [ gcc ];
 
   dontUseCmakeConfigure = true;
-
-  preBuild = ''
-    substituteInPlace requirements/base.txt --replace 'simplejson==3' 'simplejson~=3'
-  '';
 
   checkInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/xml-marshaller/default.nix
+++ b/pkgs/development/python-modules/xml-marshaller/default.nix
@@ -10,12 +10,14 @@ buildPythonPackage rec {
   version = "1.0.2";
 
   src = fetchPypi {
-    inherit version;
     pname = "xml_marshaller";
+    inherit version;
     sha256 = "sha256-QvBALLDD8o5nZQ5Z4bembhadK6jcydWKQpJaSmGqqJM=";
   };
 
   propagatedBuildInputs = [ lxml six ];
+
+  pythonImportsCheck = [ "xml_marshaller" ];
 
   meta = with lib; {
     description = "This module allows one to marshal simple Python data types into a custom XML format.";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
