### PR TITLE
reg: init at 0.16.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3225,6 +3225,12 @@
       fingerprint = "2D37 1AD2 7E2B BC77 97E1  B759 6C79 278F 3FCD CC02";
     }];
   };
+  ereslibre = {
+    email = "ereslibre@ereslibre.es";
+    github = "ereslibre";
+    githubId = 8706;
+    name = "Rafael Fernández López";
+  };
   ericbmerritt = {
     email = "eric@afiniate.com";
     github = "ericbmerritt";

--- a/pkgs/tools/virtualization/reg/default.nix
+++ b/pkgs/tools/virtualization/reg/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+}:
+
+buildGoModule rec {
+  pname = "reg";
+  version = "0.16.1";
+
+  src = fetchFromGitHub {
+    owner = "genuinetools";
+    repo = "reg";
+    rev = "v${version}";
+    sha256 = "1jlza1czfssssi3y9zi6kr8k9msfa7vp215ibhwbz4h97av5xw5m";
+  };
+
+  vendorSha256 = null;
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Docker registry v2 command line client and repo listing generator with security checks";
+    homepage = "https://github.com/genuinetools/reg";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ereslibre ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3244,6 +3244,8 @@ in
 
   psrecord = python3Packages.callPackage ../tools/misc/psrecord {};
 
+  reg = callPackage ../tools/virtualization/reg { };
+
   river = callPackage ../applications/window-managers/river { };
 
   rmapi = callPackage ../applications/misc/remarkable/rmapi { };


### PR DESCRIPTION
###### Motivation for this change

Add the `reg` tool for interacting with v2 container registries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions: openSUSE Leap 15.3
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
