### PR TITLE
vscode-extensions/rust-analyzer: pin rollup dep to avoid regression.

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/update.sh
+++ b/pkgs/development/tools/rust/rust-analyzer/update.sh
@@ -51,6 +51,9 @@ build_deps="../../../../misc/vscode-extensions/rust-analyzer/build-deps"
 jq '{ name, version, dependencies: (.dependencies + .devDependencies) }' "$node_src/package.json" \
     >"$build_deps/package.json.new"
 
+# FIXME: rollup@2.55.0 breaks the build: https://github.com/rollup/rollup/issues/4195
+sed 's/"rollup": ".*"/"rollup": "=2.51.1"/' --in-place "$build_deps/package.json.new"
+
 if cmp --quiet "$build_deps"/package.json{.new,}; then
     echo "package.json not changed, skip updating nodePackages"
     rm "$build_deps"/package.json.new

--- a/pkgs/misc/vscode-extensions/rust-analyzer/build-deps/package.json
+++ b/pkgs/misc/vscode-extensions/rust-analyzer/build-deps/package.json
@@ -17,7 +17,7 @@
     "eslint": "^7.30.0",
     "glob": "^7.1.6",
     "mocha": "^9.0.2",
-    "rollup": "^2.51.1",
+    "rollup": "=2.51.1",
     "tslib": "^2.3.0",
     "typescript": "^4.3.5",
     "typescript-formatter": "^7.2.2",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #132938 . We need to pin rollup to avoid https://github.com/rollup/rollup/issues/4195. I was able to reproduce the issue & this fixes it.

I feel it would save us a lot of trouble if we also used the extension's `package-lock.json` to generate `rust-analyzer-build-deps`. Is there a reason we don't already do this?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
