### PR TITLE
vieb: use p7zip instead precompiled 7z binary

### DIFF
--- a/pkgs/applications/networking/browsers/vieb/default.nix
+++ b/pkgs/applications/networking/browsers/vieb/default.nix
@@ -1,4 +1,4 @@
-{ mkYarnPackage, fetchFromGitHub, electron, makeWrapper, makeDesktopItem, lib }:
+{ mkYarnPackage, fetchFromGitHub, electron, makeWrapper, makeDesktopItem, lib, autoPatchelfHook, stdenv }:
 
 mkYarnPackage rec {
   pname = "vieb";
@@ -16,7 +16,7 @@ mkYarnPackage rec {
   yarnNix = ./yarn.nix;
   yarnFlags = [ "--production" "--offline" ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper autoPatchelfHook stdenv.cc.cc.lib ];
 
   desktopItem = makeDesktopItem {
     name = "vieb";

--- a/pkgs/applications/networking/browsers/vieb/default.nix
+++ b/pkgs/applications/networking/browsers/vieb/default.nix
@@ -37,7 +37,7 @@ mkYarnPackage rec {
     unlink $out/libexec/vieb/deps/vieb/node_modules
     ln -s $out/libexec/vieb/node_modules $out/libexec/vieb/deps/vieb/node_modules
 
-    find $out/libexec/vieb/node_modules/7zip-bin -name 7za -exec ln -s -f ${p7zip}/bin/7z {} ';'
+    find $out/libexec/vieb/node_modules/7zip-bin -name 7za -exec ln -s -f ${p7zip}/bin/7za {} ';'
 
     install -Dm0644 {${desktopItem},$out}/share/applications/vieb.desktop
 

--- a/pkgs/applications/networking/browsers/vieb/default.nix
+++ b/pkgs/applications/networking/browsers/vieb/default.nix
@@ -34,6 +34,9 @@ mkYarnPackage rec {
   };
 
   postInstall = ''
+    unlink $out/libexec/vieb/deps/vieb/node_modules
+    ln -s $out/libexec/vieb/node_modules $out/libexec/vieb/deps/vieb/node_modules
+
     install -Dm0644 {${desktopItem},$out}/share/applications/vieb.desktop
 
     pushd $out/libexec/vieb/node_modules/vieb/app/img/icons

--- a/pkgs/applications/networking/browsers/vieb/default.nix
+++ b/pkgs/applications/networking/browsers/vieb/default.nix
@@ -1,4 +1,4 @@
-{ mkYarnPackage, fetchFromGitHub, electron, makeWrapper, makeDesktopItem, lib, autoPatchelfHook, stdenv }:
+{ mkYarnPackage, fetchFromGitHub, electron, makeWrapper, makeDesktopItem, lib, p7zip }:
 
 mkYarnPackage rec {
   pname = "vieb";
@@ -16,7 +16,7 @@ mkYarnPackage rec {
   yarnNix = ./yarn.nix;
   yarnFlags = [ "--production" "--offline" ];
 
-  nativeBuildInputs = [ makeWrapper autoPatchelfHook stdenv.cc.cc.lib ];
+  nativeBuildInputs = [ makeWrapper ];
 
   desktopItem = makeDesktopItem {
     name = "vieb";
@@ -36,6 +36,8 @@ mkYarnPackage rec {
   postInstall = ''
     unlink $out/libexec/vieb/deps/vieb/node_modules
     ln -s $out/libexec/vieb/node_modules $out/libexec/vieb/deps/vieb/node_modules
+
+    find $out/libexec/vieb/node_modules/7zip-bin -name 7za -exec ln -s -f ${p7zip}/bin/7z {} ';'
 
     install -Dm0644 {${desktopItem},$out}/share/applications/vieb.desktop
 


### PR DESCRIPTION
###### Motivation for this change

Fix #133077 .

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).