### PR TITLE
foot: refactor derivation

### DIFF
--- a/pkgs/applications/terminal-emulators/foot/default.nix
+++ b/pkgs/applications/terminal-emulators/foot/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchzip
+, fetchFromGitea
 , fetchurl
 , fetchpatch
 , runCommandNoCC
@@ -94,8 +94,11 @@ stdenv.mkDerivation rec {
   pname = "foot";
   inherit version;
 
-  src = fetchzip {
-    url = "https://codeberg.org/dnkl/${pname}/archive/${version}.tar.gz";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "dnkl";
+    repo = pname;
+    rev = version;
     sha256 = "1k0alz991cslls4926c5gq02pdq0vfw9jfpprh2a1vb59xgikv7h";
   };
 
@@ -147,8 +150,9 @@ stdenv.mkDerivation rec {
     export AR="${ar}"
   '';
 
+  mesonBuildType = "release";
+
   mesonFlags = [
-    "--buildtype=release"
     "-Db_lto=true"
     "-Dterminfo-install-location=${placeholder "terminfo"}/share/terminfo"
   ];


### PR DESCRIPTION
* Change from fetchzip to fetchFromGitea
* Set `mesonBuildType` instead of supplying the `--build-type=`
  argument in `mesonFlags` as the build type option will be
  repeated.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Change from using fetchzip to fetchFromGitea for more flexibility. Additionally, set `mesonBuildType` hook directly as the flags specified in `mesonFlags` gets appending to the meson build command, but `--build-type=plain` is already passed as part of `mesonBuildType`, so the option is repeated.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
