### PR TITLE
[21.05] wolfssl: add patches for CVE-2021-37155

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "wolfssl";
@@ -10,6 +10,19 @@ stdenv.mkDerivation rec {
     rev = "v${version}-stable";
     sha256 = "1aa51j0xnhi49izc8djya68l70jkjv25559pgybfb9sa4fa4gz97";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-37155.part-1.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/73076940af8904f98eee085994c176fe1876b95a.patch";
+      sha256 = "1fdg6c49njhxn6yljpqrhrv2s6ci6hyw01xjs42s09ly3xvf2fcx";
+    })
+    (fetchpatch {
+      name = "CVE-2021-37155.part-2.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/822aa92fccf77558e250131c1c6e9bb84d07afe8.patch";
+      sha256 = "1n7774hy9ybbxmg8dldqnhw279k7fkxwvw1s2mjjhkzra9w5x2zy";
+    })
+  ];
 
   # almost same as Debian but for now using --enable-all --enable-reproducible-build instead of --enable-distro to ensure options.h gets installed
   configureFlags = [ "--enable-all" "--enable-reproducible-build" "--enable-pkcs11" "--enable-tls13" "--enable-base64encode" ];


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-37155
See also #132161

Note how this one is scored 9.8 by NVD, but "low" by wolfssl :shrug: 

What gives me confidence in the validity of this patch? Ran the included test successfully.

@mcmtroffaes would be nice to get the unit tests for this enabled properly, but for me it fails part way through complaining it can't find one of the CA files?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
