### PR TITLE
fcft: refactor derivation

### DIFF
--- a/pkgs/development/libraries/fcft/default.nix
+++ b/pkgs/development/libraries/fcft/default.nix
@@ -1,15 +1,23 @@
-{ stdenv, lib, fetchzip, pkg-config, meson, ninja, scdoc
+{ stdenv, lib, fetchFromGitea, pkg-config, meson, ninja, scdoc
 , freetype, fontconfig, pixman, tllist, check
 , withHarfBuzz ? true
 , harfbuzz
 }:
 
+let
+  # Courtesy of sternenseemann and FRidh, commit c9a7fdfcfb420be8e0179214d0d91a34f5974c54
+  mesonFeatureFlag = opt: b: "-D${opt}=${if b then "enabled" else "disabled"}";
+in
+
 stdenv.mkDerivation rec {
   pname = "fcft";
   version = "2.4.4";
 
-  src = fetchzip {
-    url = "https://codeberg.org/dnkl/fcft/archive/${version}.tar.gz";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "dnkl";
+    repo = "fcft";
+    rev = version;
     sha256 = "0ycc2xy9jhxcxwbfk9d4jdxgf2zsc664phbf859kshb822m3jf57";
   };
 
@@ -19,15 +27,16 @@ stdenv.mkDerivation rec {
     ++ lib.optional withHarfBuzz harfbuzz;
   checkInputs = [ check ];
 
+  mesonBuildType = "release";
   mesonFlags = [
-    "--buildtype=release"
-    "-Dtext-shaping=${if withHarfBuzz then "enabled" else "disabled"}"
+    (mesonFeatureFlag "text-shaping" withHarfBuzz)
   ];
 
   doCheck = true;
 
   meta = with lib; {
     homepage = "https://codeberg.org/dnkl/fcft";
+    changelog = "https://codeberg.org/dnkl/fcft/releases/tag/${version}";
     description = "Simple library for font loading and glyph rasterization";
     maintainers = with maintainers; [
       fionera


### PR DESCRIPTION
* Change from fetchzip to fetchFromGitea.
* Set `mesonBuildType` instead of supplying the --build-type=
  argument in `mesonFlags` as the build type option will be
  repeated.
* Abstact optional flag declaration with a helper function.
* Add upstream changelog.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
