### PR TITLE
nixos/fish: remove `promptInit` in favor of `interactiveShellInit`

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -43,6 +43,14 @@ in
 
 {
 
+  imports = [
+    (mkRemovedOptionModule [ "programs" "fish" "promptInit" ] ''
+      Prompt is now configured through the
+        programs.fish.interactiveShellInit
+      option. Please change to use that instead.
+    '')
+  ];
+
   options = {
 
     programs.fish = {
@@ -133,14 +141,6 @@ in
         type = types.lines;
       };
 
-      promptInit = mkOption {
-        default = "";
-        description = ''
-          Shell script code used to initialise fish prompt.
-        '';
-        type = types.lines;
-      };
-
     };
 
   };
@@ -227,7 +227,6 @@ in
 
           ${sourceEnv "interactiveShellInit"}
 
-          ${cfg.promptInit}
           ${cfg.interactiveShellInit}
 
           # and leave a note so we don't source this config section again from


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Derived from nix-community/home-manager#2231

`promptInit` does nothing special and can already be implemented via `interactiveShellInit`, so I suggest just keep the latter.

Things are slightly different in NixOS than Home Manager that both `bash` and `zsh` have a meaningful `promptInit`, so it may also be kept for consistency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
