### PR TITLE
ecl, ecl_16_1_2: fix linking of natively built libraries and executables

### DIFF
--- a/pkgs/development/compilers/ecl/16.1.2.nix
+++ b/pkgs/development/compilers/ecl/16.1.2.nix
@@ -71,7 +71,12 @@ stdenv.mkDerivation {
   postInstall = ''
     sed -e 's/@[-a-zA-Z_]*@//g' -i $out/bin/ecl-config
     wrapProgram "$out/bin/ecl" \
-      --prefix PATH ':' "${gcc}/bin" \
+      --prefix PATH ':' "${
+        lib.makeBinPath [
+          gcc                   # for the C compiler
+          gcc.bintools.bintools # for ar
+        ]
+      }" \
   ''
   # ecl 16.1.2 is too old to have -libdir for libffi and boehmgc, so we need to
   # use NIX_LDFLAGS_BEFORE to make gcc find these particular libraries.

--- a/pkgs/development/compilers/ecl/16.1.2.nix
+++ b/pkgs/development/compilers/ecl/16.1.2.nix
@@ -38,8 +38,10 @@ stdenv.mkDerivation {
 
   configureFlags = [
     (if threadSupport then "--enable-threads" else "--disable-threads")
-    "--with-gmp-prefix=${gmp.dev}"
-    "--with-libffi-prefix=${libffi.dev}"
+    "--with-gmp-incdir=${lib.getDev gmp}/include"
+    "--with-gmp-libdir=${lib.getLib gmp}/lib"
+    # -incdir, -libdir doesn't seem to be supported for libffi
+    "--with-libffi-prefix=${lib.getDev libffi}"
     ]
     ++
     (lib.optional (! noUnicode)
@@ -70,8 +72,18 @@ stdenv.mkDerivation {
     sed -e 's/@[-a-zA-Z_]*@//g' -i $out/bin/ecl-config
     wrapProgram "$out/bin/ecl" \
       --prefix PATH ':' "${gcc}/bin" \
-      --prefix NIX_LDFLAGS ' ' "-L${gmp.lib or gmp.out or gmp}/lib" \
-      --prefix NIX_LDFLAGS ' ' "-L${libffi.lib or libffi.out or libffi}/lib"
+  ''
+  # ecl 16.1.2 is too old to have -libdir for libffi and boehmgc, so we need to
+  # use NIX_LDFLAGS_BEFORE to make gcc find these particular libraries.
+  # Since it is missing even the prefix flag for boehmgc we also need to inject
+  # the correct -I flag via NIX_CFLAGS_COMPILE. Since we have access to it, we
+  # create the variables with suffixSalt (which seems to be necessary for
+  # NIX_CFLAGS_COMPILE even).
+  + lib.optionalString useBoehmgc ''
+      --prefix NIX_CFLAGS_COMPILE_${gcc.suffixSalt} ' ' "-I${lib.getDev boehmgc}/include" \
+      --prefix NIX_LDFLAGS_BEFORE_${gcc.bintools.suffixSalt} ' ' "-L${lib.getLib boehmgc}/lib" \
+  '' + ''
+      --prefix NIX_LDFLAGS_BEFORE_${gcc.bintools.suffixSalt} ' ' "-L${lib.getLib libffi}/lib"
   '';
 
   meta = {

--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -58,7 +58,12 @@ stdenv.mkDerivation {
 
   postInstall = ''
     sed -e 's/@[-a-zA-Z_]*@//g' -i $out/bin/ecl-config
-    wrapProgram "$out/bin/ecl" --prefix PATH ':' "${gcc}/bin"
+    wrapProgram "$out/bin/ecl" --prefix PATH ':' "${
+      lib.makeBinPath [
+        gcc                   # for the C compiler
+        gcc.bintools.bintools # for ar
+      ]
+    }"
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -45,20 +45,20 @@ stdenv.mkDerivation {
 
   configureFlags = [
     (if threadSupport then "--enable-threads" else "--disable-threads")
-    "--with-gmp-prefix=${lib.getDev gmp}"
-    "--with-libffi-prefix=${lib.getDev libffi}"
-  ] ++ lib.optional useBoehmgc "--with-libgc-prefix=${lib.getDev boehmgc}"
-  ++ lib.optional (!noUnicode) "--enable-unicode";
+    "--with-gmp-incdir=${lib.getDev gmp}/include"
+    "--with-gmp-libdir=${lib.getLib gmp}/lib"
+    "--with-libffi-incdir=${lib.getDev libffi}/include"
+    "--with-libffi-libdir=${lib.getLib libffi}/lib"
+  ] ++ lib.optionals useBoehmgc [
+    "--with-libgc-incdir=${lib.getDev boehmgc}/include"
+    "--with-libgc-libdir=${lib.getLib boehmgc}/lib"
+  ] ++ lib.optional (!noUnicode) "--enable-unicode";
 
   hardeningDisable = [ "format" ];
 
-  postInstall = let
-    ldArgs = lib.strings.concatMapStringsSep " "
-      (l: ''--prefix NIX_LDFLAGS ' ' "-L${l.lib or l.out or l}/lib"'')
-      ([ gmp libffi ] ++ lib.optional useBoehmgc boehmgc);
-  in ''
+  postInstall = ''
     sed -e 's/@[-a-zA-Z_]*@//g' -i $out/bin/ecl-config
-    wrapProgram "$out/bin/ecl" --prefix PATH ':' "${gcc}/bin" ${ldArgs}
+    wrapProgram "$out/bin/ecl" --prefix PATH ':' "${gcc}/bin"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

On current master, both ecl versions are unable to link a native fasl using `c:build-fasl` from a bunch of objects that are built using `compile-file` with `:system-p t`. This change addresses this.

I tested compiling `alexandria` and `babel` manually in this fashion using the new ecl derivations to verify my change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
