### PR TITLE
terraform-providers.cloudfoundry: 0.12.6 -> 0.14.2

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/cloudfoundry/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/cloudfoundry/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "terraform-provider-cloudfoundry";
-  version = "0.12.6";
+  version = "0.14.2";
 
   src = fetchFromGitHub {
     owner = "cloudfoundry-community";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0n5ybpzk6zkrnd9vpmbjlkm8fdp7nbfr046wih0jk72pmiyrcygi";
+    sha256 = "12mx87dip6vn10zvkf4rgrd27k708lnl149j9xj7bmb8v9m1082v";
   };
 
-  vendorSha256 = "01lfsd9aw9w3kr1a2a5b7ac6d8jaij83lhxl4y4qsnjlqk86fbxq";
+  vendorSha256 = "0kydjnwzj0fylizvk1vg42zyiy17qhz40z3iwa1r5bb20qkrlz93";
 
   # needs a running cloudfoundry
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
Routine bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
