### PR TITLE
crowdin-cli: init at 3.6.4

### DIFF
--- a/pkgs/tools/text/crowdin-cli/default.nix
+++ b/pkgs/tools/text/crowdin-cli/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchurl
+, gawk
+, git
+, gnugrep
+, installShellFiles
+, jre
+, makeWrapper
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "crowdin-cli";
+  version = "3.6.4";
+
+  src = fetchurl {
+    url = "https://github.com/crowdin/${pname}/releases/download/${version}/${pname}.zip";
+    sha256 = "123mv0s1jppidmwsvr8a6f8429xmpskxmnv4p8jpnfa9zrw86aaw";
+  };
+
+  nativeBuildInputs = [ installShellFiles makeWrapper unzip ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D crowdin-cli.jar $out/lib/crowdin-cli.jar
+
+    installShellCompletion --cmd crowdin --bash ./crowdin_completion
+
+    makeWrapper ${jre}/bin/java $out/bin/crowdin \
+      --argv0 crowdin \
+      --add-flags "-jar $out/lib/crowdin-cli.jar" \
+      --prefix PATH : ${lib.makeBinPath [ gawk gnugrep git ]}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/crowdin/crowdin-cli/";
+    description = "A command-line client for the Crowdin API";
+    license = licenses.mit;
+    maintainers = with maintainers; [ DamienCassou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13883,6 +13883,8 @@ with pkgs;
 
   gtkdialog = callPackage ../development/tools/misc/gtkdialog { };
 
+  crowdin-cli = callPackage ../tools/text/crowdin-cli { };
+
   gtranslator = callPackage ../tools/text/gtranslator { };
 
   guff = callPackage ../tools/graphics/guff { };


### PR DESCRIPTION
###### Motivation for this change

Add crowdin-cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
