### PR TITLE
aws-sdk-cpp: fix cross-OS crosscompilation

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -7,6 +7,14 @@
   customMemoryManagement ? true
 }:
 
+let
+  host_os = if stdenv.hostPlatform.isDarwin then "APPLE"
+       else if stdenv.hostPlatform.isAndroid then "ANDROID"
+       else if stdenv.hostPlatform.isWindows then "WINDOWS"
+       else if stdenv.hostPlatform.isLinux then "LINUX"
+       else throw "Unknown host OS";
+in
+
 stdenv.mkDerivation rec {
   pname = "aws-sdk-cpp";
   version = "1.8.130";
@@ -49,6 +57,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_TESTING=OFF"
     "-DCURL_HAS_H2=1"
     "-DCURL_HAS_TLS_PROXY=1"
+    "-DTARGET_ARCH=${host_os}"
   ] ++ lib.optional (apis != ["*"])
     "-DBUILD_ONLY=${lib.concatStringsSep ";" apis}";
 


### PR DESCRIPTION
The TARGET_ARCH cmake variable is used to specify the host OS, which if
unspecified defaults to the same as the build OS. So to crosscompile
aws-sdk-cpp to another OS, the TARGET_ARCH variable must be specified.

Example hydra failure: https://hydra.nixos.org/build/149290553/nixlog/3

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
