### PR TITLE
paraview: 5.8.0 -> 5.9.1, install documentation, cleanup

### DIFF
--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -108,7 +108,7 @@ in mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.paraview.org/";
     description = "3D Data analysis and visualization application";
-    license = licenses.free;
+    license = licenses.bsd3;
     maintainers = with maintainers; [ guibert ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -4,28 +4,18 @@
 
 mkDerivation rec {
   pname = "paraview";
-  version = "5.8.0";
+  version = "5.9.1";
 
   src = fetchFromGitHub {
     owner = "Kitware";
     repo = "ParaView";
     rev = "v${version}";
-    sha256 = "1mka6wwg9mbkqi3phs29mvxq6qbc44sspbm4awwamqhilh4grhrj";
+    sha256 = "0pzic95br0vr785jnpxqmfxcljw3wk7bhm2xy0jfmwm1dh2b7xac";
     fetchSubmodules = true;
   };
 
-  # Avoid error: format not a string literal and
-  # no format arguments [-Werror=format-security]
-  preConfigure = ''
-    substituteInPlace VTK/Common/Core/vtkLogger.h \
-      --replace 'vtkLogScopeF(verbosity_name, __func__)' 'vtkLogScopeF(verbosity_name, "%s", __func__)'
-
-    substituteInPlace VTK/Common/Core/vtkLogger.h \
-      --replace 'vtkVLogScopeF(level, __func__)' 'vtkVLogScopeF(level, "%s", __func__)'
-  '';
-
   # Find the Qt platform plugin "minimal"
-  patchPhase = ''
+  preConfigure = ''
     export QT_PLUGIN_PATH=${qtbase.bin}/${qtbase.qtPluginPrefix}
   '';
 

--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -1,4 +1,4 @@
-{ boost, cmake, fetchFromGitHub, ffmpeg, qtbase, qtx11extras,
+{ boost, cmake, fetchFromGitLab, ffmpeg, qtbase, qtx11extras,
   qttools, qtxmlpatterns, qtsvg, gdal, gfortran, libXt, makeWrapper,
   mkDerivation, ninja, mpi, python3, lib, tbb, libGLU, libGL }:
 
@@ -6,9 +6,10 @@ mkDerivation rec {
   pname = "paraview";
   version = "5.9.1";
 
-  src = fetchFromGitHub {
-    owner = "Kitware";
-    repo = "ParaView";
+  src = fetchFromGitLab {
+    domain = "gitlab.kitware.com";
+    owner = "paraview";
+    repo = "paraview";
     rev = "v${version}";
     sha256 = "0pzic95br0vr785jnpxqmfxcljw3wk7bhm2xy0jfmwm1dh2b7xac";
     fetchSubmodules = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Paraview 5.8.0 doesn't work with Python 3.9 by default (although it could be patched); 5.9.1 does.

Also:
 - use `fetchFromGitLab` rather than `fetchFromGitHub`, since [the official repo](https://gitlab.kitware.com/paraview/paraview) is there
 - install documentation `.pdf`s from the website by default (only 50MB more out of an >500MB package)
 - clarify that the license is [BSD 3-Clause](https://gitlab.kitware.com/paraview/paraview/-/blob/master/Copyright.txt)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
