### PR TITLE
notcurses: 2.3.8 -> 2.4.0

### DIFF
--- a/pkgs/development/libraries/notcurses/default.nix
+++ b/pkgs/development/libraries/notcurses/default.nix
@@ -4,6 +4,7 @@
 , pandoc
 , libunistring
 , ncurses
+, zlib
 , ffmpeg
 , readline
 , fetchFromGitHub
@@ -13,20 +14,20 @@
 
 stdenv.mkDerivation rec {
   pname = "notcurses";
-  version = "2.3.8";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "dankamongmen";
     repo = "notcurses";
     rev = "v${version}";
-    sha256 = "sha256-CTMFXTmOnBUCm0KdVNBoDT08arr01XTHdELFiTayk3E=";
+    sha256 = "sha256-Oyjdmmb+rqPgkwVJw3y4NKGPABmCZFyGFBzBJn6IEHk=";
   };
 
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake pkg-config pandoc ];
 
-  buildInputs = [ libunistring ncurses readline ]
+  buildInputs = [ libunistring ncurses readline zlib ]
     ++ lib.optional multimediaSupport ffmpeg;
 
   cmakeFlags = [ "-DUSE_QRCODEGEN=OFF" ]


### PR DESCRIPTION
###### Motivation for this change
New upstream. https://github.com/dankamongmen/notcurses/releases/tag/v2.3.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
