### PR TITLE
scala-runners: unstable-2020-02-02 -> unstable-2021-07-28

### DIFF
--- a/pkgs/development/compilers/scala-runners/default.nix
+++ b/pkgs/development/compilers/scala-runners/default.nix
@@ -2,15 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "scala-runners";
-  version = "unstable-2020-02-02";
+  version = "unstable-2021-07-28";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "dwijnand";
-    rev = "95e03c9f9de0fe0ab61eeb6dea2a364f9d081d31";
-    sha256 = "0mvlc6fxsh5d6gsyak9n3g98g4r061n8pir37jpiqb7z00m9lfrx";
+    rev = "9bf096ca81f4974d7327e291eac291e22b344a8f";
+    sha256 = "032fds5nr102h1lc81n9jc60jmxzivi4md4hcjrlqn076hfhj4ax";
   };
 
+  dontBuild = true;
   installPhase = ''
     mkdir -p $out/bin $out/lib
     sed -ie "s| cs | ${coursier}/bin/coursier |" scala-runner


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This brings support for Scala 3 (Dotty) with the `-3` flag.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
