### PR TITLE
nodejs-16_x: 16.5.0 -> 16.6.1

### DIFF
--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -18,7 +18,7 @@ in
         sha256 = "1narhk5dqdkbndh9hg0dn5ghhgrd6gsamjqszpivmp33nl5hgsx3";
       })
       # Brings Node version to 16.6.1 which may or may not be needed for Discord.js v13
-      # (Originally was, now isn't? Confusing, but should still be updated regardless)       
+      # (Originally was, now isn't? Confusing, but should still be updated regardless)
       (fetchpatch {
         url = "https://github.com/nodejs/node/commit/3d53ff8ff0e721f908d8aff7a3709bc6dbb07ebb.patch";
         sha256 = "0mz5wfhf2k1qf3d57h4r8b30izhyg93g5m9c8rljlzy6ih2ymcbr";

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -1,4 +1,4 @@
-{ callPackage, openssl, python3, enableNpm ? true }:
+{ callPackage, openssl, python3, fetchpatch, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -8,6 +8,20 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "16.6.1";
-    sha256 = "0mz5wfhf2k1qf3d57h4r8b30izhyg93g5m9c8rljlzy6ih2ymcbr";
+    version = "16.5.0";
+    sha256 = "16dapj5pm2y1m3ldrjjlz8rq9axk85nn316iz02nk6qjs66y6drz";
+    patches = [
+      # Fix CVE-2021-22930 https://github.com/nodejs/node/pull/39423.
+      # It should be fixed by Node.js 16.6.0, but currently it fails to build on Darwin
+      (fetchpatch {
+        url = "https://github.com/nodejs/node/commit/9d950a0956bf2c3dd87bacb56807f37e16a91db4.patch";
+        sha256 = "1narhk5dqdkbndh9hg0dn5ghhgrd6gsamjqszpivmp33nl5hgsx3";
+      })
+      # Brings Node version to 16.6.1 which may or may not be needed for Discord.js v13
+      # (Originally was, now isn't? Confusing, but should still be updated regardless)       
+      (fetchpatch {
+        url = "https://github.com/nodejs/node/commit/3d53ff8ff0e721f908d8aff7a3709bc6dbb07ebb.patch";
+        sha256 = "0mz5wfhf2k1qf3d57h4r8b30izhyg93g5m9c8rljlzy6ih2ymcbr";
+      })
+    ];
   }

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -16,7 +16,7 @@ in
       (fetchpatch {
         url = "https://github.com/nodejs/node/commit/9d950a0956bf2c3dd87bacb56807f37e16a91db4.patch";
         sha256 = "1narhk5dqdkbndh9hg0dn5ghhgrd6gsamjqszpivmp33nl5hgsx3";
-      }), 
+      })
       # Brings Node version to 16.6.1 which may or may not be needed for Discord.js v13
       # (Originally was, now isn't? Confusing, but should still be updated regardless)       
       (fetchpatch {

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -1,4 +1,4 @@
-{ callPackage, openssl, python3, fetchpatch, enableNpm ? true }:
+{ callPackage, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -8,20 +8,6 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "16.5.0";
-    sha256 = "16dapj5pm2y1m3ldrjjlz8rq9axk85nn316iz02nk6qjs66y6drz";
-    patches = [
-      # Fix CVE-2021-22930 https://github.com/nodejs/node/pull/39423.
-      # It should be fixed by Node.js 16.6.0, but currently it fails to build on Darwin
-      (fetchpatch {
-        url = "https://github.com/nodejs/node/commit/9d950a0956bf2c3dd87bacb56807f37e16a91db4.patch";
-        sha256 = "1narhk5dqdkbndh9hg0dn5ghhgrd6gsamjqszpivmp33nl5hgsx3";
-      })
-      # Brings Node version to 16.6.1 which may or may not be needed for Discord.js v13
-      # (Originally was, now isn't? Confusing, but should still be updated regardless)       
-      (fetchpatch {
-        url = "https://github.com/nodejs/node/commit/3d53ff8ff0e721f908d8aff7a3709bc6dbb07ebb.patch";
-        sha256 = "0mz5wfhf2k1qf3d57h4r8b30izhyg93g5m9c8rljlzy6ih2ymcbr";
-      })
-    ];
+    version = "16.6.1";
+    sha256 = "0mz5wfhf2k1qf3d57h4r8b30izhyg93g5m9c8rljlzy6ih2ymcbr";
   }

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -16,6 +16,12 @@ in
       (fetchpatch {
         url = "https://github.com/nodejs/node/commit/9d950a0956bf2c3dd87bacb56807f37e16a91db4.patch";
         sha256 = "1narhk5dqdkbndh9hg0dn5ghhgrd6gsamjqszpivmp33nl5hgsx3";
+      }), 
+      # Brings Node version to 16.6.1 which may or may not be needed for Discord.js v13
+      # (Originally was, now isn't? Confusing, but should still be updated regardless)       
+      (fetchpatch {
+        url = "https://github.com/nodejs/node/commit/3d53ff8ff0e721f908d8aff7a3709bc6dbb07ebb.patch";
+        sha256 = "0mz5wfhf2k1qf3d57h4r8b30izhyg93g5m9c8rljlzy6ih2ymcbr";
       })
     ];
   }


### PR DESCRIPTION
###### Motivation for this change
https://github.com/nodejs/node/releases/tag/v16.6.1
TLDR:
- Brings NPM version to 7.20.3
- Fixes some bugs
- (Hopefully) Fixes issue with building for Darwin (16.6.0 wouldn't build for some reason - https://github.com/NixOS/nixpkgs/commit/c73d1006a216134713593a54686bca21976b443e)

> BTW this is one of my first commits to a large repo so if I've done anything wrong please let me know so I can fix it. I've done my best to follow examples and instructions, though I know that due to me being new I am prone to mistakes. Thank you.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
