### PR TITLE
nixos/fish: simplify config guards

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -196,32 +196,21 @@ in
         etc."fish/config.fish".text = ''
         # /etc/fish/config.fish: DO NOT EDIT -- this file has been generated automatically.
 
-        # if we haven't sourced the general config, do it
-        if not set -q __fish_nixos_general_config_sourced
-          ${sourceEnv "shellInit"}
+        # Only execute this file once per shell.
+        set -q __fish_nixos_config_sourced; and exit
+        set -g __fish_nixos_config_sourced 1
 
-          ${cfg.shellInit}
+        ${sourceEnv "shellInit"}
 
-          # and leave a note so we don't source this config section again from
-          # this very shell (children will source the general config anew)
-          set -g __fish_nixos_general_config_sourced 1
-        end
+        ${cfg.shellInit}
 
-        # if we haven't sourced the login config, do it
-        status --is-login; and not set -q __fish_nixos_login_config_sourced
-        and begin
+        status --is-login; and begin
           ${sourceEnv "loginShellInit"}
 
           ${cfg.loginShellInit}
-
-          # and leave a note so we don't source this config section again from
-          # this very shell (children will source the general config anew)
-          set -g __fish_nixos_login_config_sourced 1
         end
 
-        # if we haven't sourced the interactive config, do it
-        status --is-interactive; and not set -q __fish_nixos_interactive_config_sourced
-        and begin
+        status --is-interactive; and begin
           ${fishAbbrs}
           ${fishAliases}
 
@@ -229,11 +218,6 @@ in
 
           ${cfg.promptInit}
           ${cfg.interactiveShellInit}
-
-          # and leave a note so we don't source this config section again from
-          # this very shell (children will source the general config anew,
-          # allowing configuration changes in, e.g, aliases, to propagate)
-          set -g __fish_nixos_interactive_config_sourced 1
         end
       '';
       }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Derived from nix-community/home-manager#2230

There's no need to use separate variables for each section. We only use one variable for such usage in NixOS's [Bash](https://github.com/NixOS/nixpkgs/blob/5f746317f10f7206f1dbb8dfcfc2257b04507eee/nixos/modules/programs/bash/bash.nix#L151-L153) and [Zsh](https://github.com/NixOS/nixpkgs/blob/5f746317f10f7206f1dbb8dfcfc2257b04507eee/nixos/modules/programs/zsh/zsh.nix#L173-L175) module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
