### PR TITLE
nodejs-16_x: 16.5.0 -> 16.6.1

### DIFF
--- a/pkgs/development/web/nodejs/disable-darwin-v8-system-instrumentation.patch
+++ b/pkgs/development/web/nodejs/disable-darwin-v8-system-instrumentation.patch
@@ -1,0 +1,16 @@
+Disable v8 system instrumentation on Darwin
+
+On Darwin, the v8 system instrumentation requires the header "os/signpost.h"
+which is available since apple_sdk 11+. See: https://github.com/nodejs/node/issues/39584
+
+--- old/tools/v8_gypfiles/features.gypi
++++ new/tools/v8_gypfiles/features.gypi
+@@ -62,7 +62,7 @@
+       }, {
+         'is_component_build': 0,
+       }],
+-      ['OS == "win" or OS == "mac"', {
++      ['OS == "win"', {
+         # Sets -DSYSTEM_INSTRUMENTATION. Enables OS-dependent event tracing
+         'v8_enable_system_instrumentation': 1,
+       }, {

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -1,4 +1,4 @@
-{ callPackage, openssl, python3, fetchpatch, enableNpm ? true }:
+{ callPackage, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -8,14 +8,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "16.5.0";
-    sha256 = "16dapj5pm2y1m3ldrjjlz8rq9axk85nn316iz02nk6qjs66y6drz";
-    patches = [
-      # Fix CVE-2021-22930 https://github.com/nodejs/node/pull/39423.
-      # It should be fixed by Node.js 16.6.0, but currently it fails to build on Darwin
-      (fetchpatch {
-        url = "https://github.com/nodejs/node/commit/9d950a0956bf2c3dd87bacb56807f37e16a91db4.patch";
-        sha256 = "1narhk5dqdkbndh9hg0dn5ghhgrd6gsamjqszpivmp33nl5hgsx3";
-      })
-    ];
+    version = "16.6.1";
+    sha256 = "0mz5wfhf2k1qf3d57h4r8b30izhyg93g5m9c8rljlzy6ih2ymcbr";
+    patches = [ ./disable-darwin-v8-system-instrumentation.patch ];
   }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/nodejs/node/releases/tag/v16.6.0
https://github.com/nodejs/node/releases/tag/v16.6.1

cc: @happysalada 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
