### PR TITLE
wolfssl: remove myself from maintainers

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.wolfssl.com/";
     platforms = platforms.all;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ fab mcmtroffaes ];
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
I haven't been able to keep up to date with the latest wolfssl developments for quite some time. Since this might have security implications, I think it is better for me to remove myself from wolfssl's list of maintainers.

cc @fabaff 