### PR TITLE
zeroad: 0.0.24b -> 0.0.25

### DIFF
--- a/pkgs/games/0ad/data.nix
+++ b/pkgs/games/0ad/data.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://releases.wildfiregames.com/0ad-${version}-alpha-unix-data.tar.xz";
-    sha256 = "0b53jzl64i49rk3n3c3x0hibwbl7vih2xym8jq5s56klg61qdxa1";
+    sha256 = "1d8c58s2fwdmjjpna57gk0d2ar17f2fqcrkgsn45x6s3ickf984p";
   };
 
   installPhase = ''

--- a/pkgs/games/0ad/game.nix
+++ b/pkgs/games/0ad/game.nix
@@ -26,11 +26,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "0ad";
-  version = "0.0.24b";
+  version = "0.0.25";
 
   src = fetchurl {
     url = "http://releases.wildfiregames.com/0ad-${version}-alpha-unix-build.tar.xz";
-    sha256 = "1a1py45hkh2cswi09vbf9chikgxdv9xplsmg6sv6xhdznv4j6p1j";
+    sha256 = "03s38pknggsbzkhgj692yd3vm16ass7k4bgjn63qwn51q4vsnbjr";
   };
 
   nativeBuildInputs = [ python2 perl pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30006,7 +30006,7 @@ with pkgs;
   keen4 = callPackage ../games/keen4 { };
 
   zeroadPackages = dontRecurseIntoAttrs (callPackage ../games/0ad {
-    wxGTK = wxGTK30;
+    wxGTK = wxGTK31;
   });
 
   zeroad = zeroadPackages.zeroad;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[New alpha release of 0 A.D.](https://play0ad.com/new-release-0-a-d-alpha-25-yauna/)

I’ve run the game and it seems to work fine, but the `ActorEditor` binary gives me an error `Failed to load image from file "ICON_ActorEditor".` I’m not sure if this was working for Alpha 24 though, and their [development wiki](https://trac.wildfiregames.com/wiki/Actor_Editor) says that editor is broken on Linux anyway.

I also observed that the archives I downloaded yesterday had a different hash from today. In both cases, the md5sums matched the ones on the release page, so I assume they made some last-minute changes. Hopefully it won’t change further, otherwise the build would break again.

The `wxGTK` update is probably not necessary but since 3.1 is available and appears to work fine I thought it’s better to update the dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
