### PR TITLE
libint: cmake build and SSE

### DIFF
--- a/pkgs/development/libraries/libint/default.nix
+++ b/pkgs/development/libraries/libint/default.nix
@@ -1,76 +1,101 @@
 { lib, stdenv, fetchFromGitHub, autoconf, automake, libtool
-, python3, perl, gmpxx, mpfr, boost, eigen, gfortran
-, enableFMA ? false
+, python3, perl, gmpxx, mpfr, boost, eigen, gfortran, cmake
+, enableFMA ? false, enableFortran ? true
 }:
 
-stdenv.mkDerivation rec {
-  pname = "libint2";
+let
+  pname = "libint";
   version = "2.6.0";
-
-  src = fetchFromGitHub {
-    owner = "evaleev";
-    repo = "libint";
-    rev = "v${version}";
-    sha256 = "0pbc2j928jyffhdp4x5bkw68mqmx610qqhnb223vdzr0n2yj5y19";
-  };
-
-  patches = [
-    ./fix-paths.patch
-  ];
-
-  nativeBuildInputs = [
-    autoconf
-    automake
-    libtool
-    gfortran
-    mpfr
-    python3
-    perl
-    gmpxx
-  ];
-
-  buildInputs = [ boost ];
-
-  enableParallelBuilding = true;
-
-  doCheck = true;
-
-  configureFlags = [
-    "--enable-eri=2"
-    "--enable-eri3=2"
-    "--enable-eri2=2"
-    "--with-eri-max-am=7,5,4"
-    "--with-eri-opt-am=3"
-    "--with-eri3-max-am=7"
-    "--with-eri2-max-am=7"
-    "--with-g12-max-am=5"
-    "--with-g12-opt-am=3"
-    "--with-g12dkh-max-am=5"
-    "--with-g12dkh-opt-am=3"
-    "--enable-contracted-ints"
-    "--enable-shared"
-   ] ++ lib.optional enableFMA "--enable-fma";
-
-  preConfigure = ''
-    ./autogen.sh
-  '';
-
-  postBuild = ''
-    # build the fortran interface file
-    cd export/fortran
-    make libint_f.o ENABLE_FORTRAN=yes
-    cd ../..
-  '';
-
-  postInstall = ''
-    cp export/fortran/libint_f.mod $out/include/
-  '';
 
   meta = with lib; {
     description = "Library for the evaluation of molecular integrals of many-body operators over Gaussian functions";
     homepage = "https://github.com/evaleev/libint";
     license = with licenses; [ lgpl3Only gpl3Only ];
-    maintainers = [ maintainers.markuskowa ];
+    maintainers = with maintainers; [ markuskowa sheepforce ];
     platforms = [ "x86_64-linux" ];
   };
-}
+
+  codeGen = stdenv.mkDerivation {
+    inherit pname version;
+
+    src = fetchFromGitHub {
+      owner = "evaleev";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "0pbc2j928jyffhdp4x5bkw68mqmx610qqhnb223vdzr0n2yj5y19";
+    };
+
+    patches = [ ./fix-paths.patch ];
+
+    nativeBuildInputs = [
+      autoconf
+      automake
+      libtool
+      mpfr
+      python3
+      perl
+      gmpxx
+    ] ++ lib.optional enableFortran gfortran;
+
+    buildInputs = [ boost eigen ];
+
+    preConfigure = "./autogen.sh";
+
+    configureFlags = [
+      "--enable-eri=2"
+      "--enable-eri3=2"
+      "--enable-eri2=2"
+      "--with-eri-max-am=7,5,4"
+      "--with-eri-opt-am=3"
+      "--with-eri3-max-am=7"
+      "--with-eri2-max-am=7"
+      "--with-g12-max-am=5"
+      "--with-g12-opt-am=3"
+      "--with-g12dkh-max-am=5"
+      "--with-g12dkh-opt-am=3"
+      "--enable-contracted-ints"
+      "--enable-shared"
+    ] ++ lib.optional enableFMA "--enable-fma"
+      ++ lib.optional enableFortran "--enable-fortran";
+
+    makeFlags = [ "export" ];
+
+    installPhase = ''
+      mkdir -p $out
+      cp ${pname}-${version}.tgz $out/.
+    '';
+
+    enableParallelBuilding = true;
+
+    inherit meta;
+  };
+
+  codeComp = stdenv.mkDerivation {
+    inherit pname version;
+
+    src = "${codeGen}/${pname}-${version}.tgz";
+
+    nativeBuildInputs = [
+      python3
+      cmake
+    ] ++ lib.optional enableFortran gfortran;
+
+    buildInputs = [ boost eigen ];
+
+    # Default is just "double", but SSE2 is available on all x86_64 CPUs.
+    # AVX support is advertised, but does not work in 2.6 (possibly in 2.7).
+    # Fortran interface is incompatible with changing the LIBINT2_REALTYPE.
+    cmakeFlags = [
+      (if enableFortran
+        then "-DENABLE_FORTRAN=ON"
+        else "-DLIBINT2_REALTYPE=libint2::simd::VectorSSEDouble"
+      )
+    ];
+
+    # Can only build in the source-tree. A lot of preprocessing magic fails otherwise.
+    dontUseCmakeBuildDir = true;
+
+    inherit meta;
+  };
+
+in codeComp


### PR DESCRIPTION
###### Motivation for this change
@markuskowa 

#132879 

Libint docs recommend to perform the code compilation step with cmake. This also installs the required CMake files for Psi4. 

There are some caveats currently:
  - the fortran interface does not build anymore. In principle `-DENABLE_FORTRAN` should do the trick, but here it complains about missing fields of an imported struct and does not build
  - it only works with a build within the source-tree (I also don't know why, but this alone isn't a catastrophe I would say). The actual problem is, that cmake and ninja don't want to do this by default and I've bent the `configurePhase` and `buildPhase` somehow to allow this. But it seems hacky.


###### Things done

Code compilation phase is executed by CMake now.
I've added an option to use AVX optimisations and enabled SSE2 by default, as all x86_64 CPUs should have at least SSE2.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
