### PR TITLE
ethminer: fix global-context

### DIFF
--- a/pkgs/tools/misc/ethminer/add-global-context.patch
+++ b/pkgs/tools/misc/ethminer/add-global-context.patch
@@ -1,0 +1,25 @@
+diff --git a/libethcore/CMakeLists.txt b/libethcore/CMakeLists.txt
+index 1a53de8..832e926 100644
+--- a/libethcore/CMakeLists.txt
++++ b/libethcore/CMakeLists.txt
+@@ -7,7 +7,7 @@ set(SOURCES
+ include_directories(BEFORE ..)
+ 
+ add_library(ethcore ${SOURCES})
+-target_link_libraries(ethcore PUBLIC devcore ethash::ethash PRIVATE hwmon)
++target_link_libraries(ethcore PUBLIC devcore ethash::ethash ethash-global-context PRIVATE hwmon)
+ 
+ if(ETHASHCL)
+ 	target_link_libraries(ethcore PRIVATE ethash-cl)
+diff --git a/libethcore/EthashAux.h b/libethcore/EthashAux.h
+index d9aadc7..fe5c6cf 100644
+--- a/libethcore/EthashAux.h
++++ b/libethcore/EthashAux.h
+@@ -22,6 +22,7 @@
+ #include <libdevcore/Worker.h>
+ 
+ #include <ethash/ethash.hpp>
++#include <ethash/global_context.hpp>
+ 
+ namespace dev
+ {

--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -64,6 +64,11 @@ stdenv.mkDerivation rec {
     cudatoolkit
   ];
 
+  patches = [
+    # global context library is separated from libethash
+    ./add-global-context.patch
+  ];
+
   preConfigure = ''
     sed -i 's/_lib_static//' libpoolprotocols/CMakeLists.txt
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix building ethminer.

Fixes #133215 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
