### PR TITLE
pleroma: 2.3.0 -> 2.4.0

### DIFF
--- a/nixos/tests/pleroma.nix
+++ b/nixos/tests/pleroma.nix
@@ -163,7 +163,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
   '';
 
   tls-cert = pkgs.runCommandNoCC "selfSignedCerts" { buildInputs = [ pkgs.openssl ]; } ''
-    openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -subj '/CN=pleroma.nixos.test'
+    openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -subj '/CN=pleroma.nixos.test' -days 36500
     mkdir -p $out
     cp key.pem cert.pem $out
   '';

--- a/nixos/tests/pleroma.nix
+++ b/nixos/tests/pleroma.nix
@@ -202,6 +202,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
       security.pki.certificateFiles = [ "${tls-cert}/cert.pem" ];
       networking.extraHosts = hosts nodes;
       networking.firewall.enable = false;
+      virtualisation.memorySize = 512;
       environment.systemPackages = with pkgs; [
         provision-db
         provision-secrets

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -7,14 +7,14 @@
 
 beamPackages.mixRelease rec {
   pname = "pleroma";
-  version = "2.3.50";
+  version = "2.4.0";
 
   src = fetchFromGitLab {
     domain = "git.pleroma.social";
     owner = "pleroma";
     repo = "pleroma";
-    rev = "94687e23938b808a3fff95c92956ec337160cd0b";
-    sha256 = "160ss6qhx3007lyb0f5cjzbm5dzxq9q8rfn83l8qfxgan8hliag6";
+    rev = "v${version}";
+    sha256 = "sha256-1zp/qVk2K3q8AtkfXab0MBAHaQnY5enVtfdu64FFPhg=";
   };
 
   mixNixDeps = import ./mix.nix {
@@ -35,18 +35,6 @@ beamPackages.mixRelease rec {
           sha256 = "1v0q4bi7sb253i8q016l7gwlv5562wk5zy3l2sa446csvsacnpjk";
         };
         beamDeps = with final; [ prometheus ];
-      };
-      eblurhash = beamPackages.buildRebar3 rec {
-        name = "eblurhash";
-        version = "0.0.0";
-
-        src = fetchFromGitHub {
-          owner = "zotonic";
-          repo = "eblurhash";
-          rev = "04a0b76eadf4de1be17726f39b6313b88708fd12";
-          sha256 = "1b9r41scg9rn3skx65ssv1q5lczmg0ky6h1y39qajsvdi5w3swyx";
-        };
-        beamDeps = with final; [ ];
       };
       captcha = beamPackages.buildMix rec {
         name = "captcha";

--- a/pkgs/servers/pleroma/mix.nix
+++ b/pkgs/servers/pleroma/mix.nix
@@ -346,14 +346,27 @@ let
       beamDeps = [];
     };
 
-    ecto = buildMix rec {
-      name = "ecto";
-      version = "3.4.6";
+    eblurhash = buildRebar3 rec {
+      name = "eblurhash";
+      version = "1.1.0";
 
       src = fetchHex {
         pkg = "${name}";
         version = "${version}";
-        sha256 = "02zpyd5mm2zfkz4b839nz1x3ias5av3by1vjzkfc4x9flviaj4vg";
+        sha256 = "07dmkbyafpxffh8ar6af4riqfxiqc547rias7i73gpgx16fqhsrf";
+      };
+
+      beamDeps = [];
+    };
+
+    ecto = buildMix rec {
+      name = "ecto";
+      version = "3.6.2";
+
+      src = fetchHex {
+        pkg = "${name}";
+        version = "${version}";
+        sha256 = "0kl893yi9jxzxnpd5gafivzazn96z2q24y04lfw8dyg60kxnvbgg";
       };
 
       beamDeps = [ decimal jason telemetry ];
@@ -372,27 +385,14 @@ let
       beamDeps = [ ecto ecto_sql postgrex ];
     };
 
-    ecto_explain = buildMix rec {
-      name = "ecto_explain";
-      version = "0.1.2";
-
-      src = fetchHex {
-        pkg = "${name}";
-        version = "${version}";
-        sha256 = "0c3366grl2r7k29a7sxwgqmq670c98sya4p96k7g9v1hmsc7f3hx";
-      };
-
-      beamDeps = [];
-    };
-
     ecto_sql = buildMix rec {
       name = "ecto_sql";
-      version = "3.4.5";
+      version = "3.6.2";
 
       src = fetchHex {
         pkg = "${name}";
         version = "${version}";
-        sha256 = "1hlar4r206szv84qbxc4igg2grvmqaa4mls110y6mcvr6mm0r69i";
+        sha256 = "0syv5wjdkywaxx9mmps0x9sdawqp3nnakbnf7av3ksj2yzkdgjay";
       };
 
       beamDeps = [ db_connection ecto postgrex telemetry ];
@@ -842,12 +842,12 @@ let
 
     linkify = buildMix rec {
       name = "linkify";
-      version = "0.5.0";
+      version = "0.5.1";
 
       src = fetchHex {
         pkg = "${name}";
         version = "${version}";
-        sha256 = "1mzjkn0f2svn44fhazkhpaxnwn9hbnqha7z2i4fcbrxfa21rbkac";
+        sha256 = "0i7r9z49sdxs7nrnh2igmwzzmq9ih4fm02a046klmnps49z8q4m3";
       };
 
       beamDeps = [];
@@ -1154,12 +1154,12 @@ let
 
     plug = buildMix rec {
       name = "plug";
-      version = "1.11.1";
+      version = "1.10.4";
 
       src = fetchHex {
         pkg = "${name}";
         version = "${version}";
-        sha256 = "07w83cx4xx90x4l1kmil4lpby55lpw83jfw3y08pqn5vxx7lwli3";
+        sha256 = "1874ixvvjklg0hnxr6d990qzarvvfxhd4s35c5bfqbixwwzj67md";
       };
 
       beamDeps = [ mime plug_crypto telemetry ];
@@ -1517,4 +1517,3 @@ let
     };
   };
 in self
-


### PR DESCRIPTION
## Update to Pleroma 2.4.0

Eblurhash has been released to hex, we do not need to manually fetch it from a git repository anymore.

The rest of the diffs have been generated by mix2nix.

A minor bug in mix2nix forced us to manually alter the base64url dependency. The bug was already fixed upstream and should be resolved for us once mix2nix branches off a new release. See https://github.com/ydlr/mix2nix/issues/11 for more infos.

Release notes: https://pleroma.social/announcements/2021/08/08/pleroma-major-release-2-4-0/

## Some Tweaks to the Pleroma VM Test

### Increase certificate validity duration

Analogous to 6325d15.

The test certificate expiration date was set to the default 30 days. This certificate is generated through its own derivation. As with every derivation, it gets cached by cache.nixos.org once we build it.

In practice, we rebuild this derivation only if one of its input changes. The only inputs here being openssl and stdenv.

While it's not an issue on the unstable branches, it can be problematic on a stable release: the test will fail after 30 days.

Extending the certificate lifespan from 1 month to 100 years to prevent it from getting expired while being cached.

###  Increase server memory size

The server VM machine is sometimes OOMing, making the test flaky. Increasing the memory size to 512MB fixes the issue.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
