### PR TITLE
proxmark3-rrg: 4.9237 -> 4.13441

### DIFF
--- a/pkgs/tools/security/proxmark3/proxmark3-rrg.nix
+++ b/pkgs/tools/security/proxmark3/proxmark3-rrg.nix
@@ -7,13 +7,13 @@
 
 mkDerivation rec {
   pname = "proxmark3-rrg";
-  version = "4.9237";
+  version = "4.13441";
 
   src = fetchFromGitHub {
     owner = "RfidResearchGroup";
     repo = "proxmark3";
     rev = "v${version}";
-    sha256 = "13xrhvrsm73rfgqpgca6a37c3jixdkxvfggmacnnx5fdfb393bfx";
+    sha256 = "1ffchqnm8023zcm4ywncf1j6076s78226h72m9dfmi0zbj3pbj4m";
   };
 
   nativeBuildInputs = [ pkg-config gcc-arm-embedded ];


### PR DESCRIPTION
###### Motivation for this change

Update `proxmark3-rrg` to the latest release.

Tested reading some 14a tags, works OK.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
