### PR TITLE
neovim: avoid using system libraries

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -98,7 +98,6 @@ in
       "-DGPERF_PRG=${gperf}/bin/gperf"
       "-DLUA_PRG=${neovimLuaEnv.interpreter}"
       "-DLIBLUV_LIBRARY=${luvpath}"
-      "-DUSE_BUNDLED=OFF"
     ]
     ++ optional doCheck "-DBUSTED_PRG=${neovimLuaEnv}/bin/busted"
     ++ optional (!lua.pkgs.isLuaJIT) "-DPREFER_LUA=ON"


### PR DESCRIPTION
###### Motivation for this change
(I believe) closes https://github.com/NixOS/nixpkgs/issues/132433

In https://github.com/NixOS/nixpkgs/pull/110837/commits/58ba227160122cea95df57ce71edd44e44e4e233 I added `"-DUSE_BUNDLED=OFF"` to be consistent with the upstream flake at that time (https://github.com/neovim/neovim/blob/2bcf18deaa32ad371b6de349b353d42e9b1c9ea0/contrib/flake.nix#L25).
The flake has been since updated and this line was removed upstream in https://github.com/neovim/neovim/commit/de909bf48b5b845602204d84597af38a93a6ebd1
Judging by the discussion in https://github.com/neovim/neovim/issues/15054 it seems that the option is not what we want and would fix https://github.com/NixOS/nixpkgs/issues/132433. We have no reason to use system libraries anyway as far as I understand.

cc @teto @mjlbach 
@gpanders for testing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
