### PR TITLE
zeroad: make sure hydra builds zeroad-unwrapped

### DIFF
--- a/pkgs/games/0ad/wrapper.nix
+++ b/pkgs/games/0ad/wrapper.nix
@@ -4,7 +4,6 @@ assert zeroad-unwrapped.version == zeroad-data.version;
 
 buildEnv {
   name = "zeroad-${zeroad-unwrapped.version}";
-  inherit (zeroad-unwrapped) meta;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -18,4 +17,8 @@ buildEnv {
         --set ZEROAD_ROOTDIR "$out/share/0ad"
     done
   '';
+
+  meta = zeroad-unwrapped.meta // {
+    hydraPlatforms = [];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30009,9 +30009,9 @@ with pkgs;
 
   keen4 = callPackage ../games/keen4 { };
 
-  zeroadPackages = dontRecurseIntoAttrs (callPackage ../games/0ad {
+  zeroadPackages = callPackage ../games/0ad {
     wxGTK = wxGTK31;
-  });
+  };
 
   zeroad = zeroadPackages.zeroad;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Hydra hasn't built zeroad since the 0.0.24 bump:
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.zeroad.x86_64-linux/all
This is due to the data package becoming larger than the output
limit. Even though the data package is already marked with
`hydraPlatforms = [];`, hydra still tried to build it, since it is a
dependency of `zeroad`. This makes it so `zeroad` isn't built by hydra
either. Only `zeroad-unwrapped` (which takes significant compilation
time) will be built by hydra.

###### Things done

Built and run locally, but the derivation didn't actually change so that doesn't really matter.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
