### PR TITLE
rust-analyzer: 2021-08-02 -> 2021-08-09 and some fixes for the extension

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -7,14 +7,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-analyzer-unwrapped";
-  version = "2021-08-02";
-  cargoSha256 = "10mdkqf6fqbzx49gwc283ms56yvrcdlvyk4y98jf33b8g5jmr8j5";
+  version = "2021-08-09";
+  cargoSha256 = "sha256-r01riAztIlwxRjvqQXofmqv5875nqQ0Qb9KALvKy4u8=";
 
   src = fetchFromGitHub {
     owner = "rust-analyzer";
     repo = "rust-analyzer";
     rev = version;
-    sha256 = "1nh1naaqc6f40raz31a0vwypaxm5drzdl2bwjfqx2gydy6051gcl";
+    sha256 = "sha256-l9F/cznYHxBdnb3NerIXzOMrzRnxdka0vExzUtKkBfw=";
   };
 
   buildAndTestSubdir = "crates/rust-analyzer";

--- a/pkgs/development/tools/rust/rust-analyzer/update.sh
+++ b/pkgs/development/tools/rust/rust-analyzer/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq nix-prefetch
+#!nix-shell -i bash -p curl jq nix-prefetch libarchive
 set -euo pipefail
 cd "$(dirname "$0")"
 owner=rust-analyzer
@@ -46,19 +46,31 @@ sed "s#cargoSha256 = \".*\"#cargoSha256 = \"$cargo_sha256\"#" \
 
 # Update vscode extension
 
+extension_ver=$(curl "https://github.com/rust-analyzer/rust-analyzer/releases/download/$ver/rust-analyzer.vsix" -L |
+    bsdtar -xf - --to-stdout extension/package.json | # Use bsdtar to extract vsix(zip).
+    jq --raw-output '.version')
+echo "Extension version: $extension_ver"
+
 build_deps="../../../../misc/vscode-extensions/rust-analyzer/build-deps"
 # We need devDependencies to build vsix.
-jq '{ name, version, dependencies: (.dependencies + .devDependencies) }' "$node_src/package.json" \
+jq '{ name, version: $ver, dependencies: (.dependencies + .devDependencies) }' "$node_src/package.json" \
+    --arg ver "$extension_ver" \
     >"$build_deps/package.json.new"
 
 # FIXME: rollup@2.55.0 breaks the build: https://github.com/rollup/rollup/issues/4195
 sed 's/"rollup": ".*"/"rollup": "=2.51.1"/' --in-place "$build_deps/package.json.new"
 
-if cmp --quiet "$build_deps"/package.json{.new,}; then
-    echo "package.json not changed, skip updating nodePackages"
-    rm "$build_deps"/package.json.new
+old_deps="$(jq '.dependencies' "$build_deps"/package.json)"
+new_deps="$(jq '.dependencies' "$build_deps"/package.json.new)"
+if [[ "$old_deps" == "$new_deps" ]]; then
+    echo "package.json dependencies not changed, do simple version change"
+
+    sed -E '/^  "rust-analyzer-build-deps/,+3 s/version = ".*"/version = "'"$extension_ver"'"/' \
+        --in-place ../../../node-packages/node-packages.nix
+    mv "$build_deps"/package.json{.new,}
+
 else
-    echo "package.json changed, updating nodePackages"
+    echo "package.json dependencies changed, updating nodePackages"
     mv "$build_deps"/package.json{.new,}
 
     pushd "../../../node-packages"

--- a/pkgs/misc/vscode-extensions/rust-analyzer/build-deps/package.json
+++ b/pkgs/misc/vscode-extensions/rust-analyzer/build-deps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-analyzer",
-  "version": "0.2.694",
+  "version": "0.2.702",
   "dependencies": {
     "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.1",

--- a/pkgs/misc/vscode-extensions/rust-analyzer/build-deps/package.json
+++ b/pkgs/misc/vscode-extensions/rust-analyzer/build-deps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-analyzer",
-  "version": "0.4.0-dev",
+  "version": "0.2.694",
   "dependencies": {
     "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`rust-analyzer`:
- Bump version

`vscode-extension.matklad.rust-analyzer`:
- Use individual extension version instead of "0.4.0-dev" forever. The extension version is from upstream released vsix file and is the same as the one published on vscode market place.
- Apply some patches to extension's `package.json`, which follows [upstream dist script](https://github.com/rust-analyzer/rust-analyzer/blob/41949748a6123fd6061eb984a47f4fe780525e63/xtask/src/dist.rs#L39-L65).

Tested to work in vscodium.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
