### PR TITLE
sdcc: honour dontStrip

### DIFF
--- a/pkgs/development/compilers/sdcc/default.nix
+++ b/pkgs/development/compilers/sdcc/default.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation rec {
 
   configureFlags = map (f: "--disable-${f}-port") excludedPorts;
 
+  preConfigure = ''
+    if test -n "''${dontStrip-}"; then
+      export STRIP=none
+    fi
+  '';
+
   meta = {
     description = "Small Device C Compiler";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

sdcc crashes when compiling https://github.com/emmebrusa/TSDZ2-Smart-EBike-1
on Linux, and this helps diagnose such problems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).