### PR TITLE
blackbox: 1.20181219 -> 2.0.0 and enable tests

### DIFF
--- a/pkgs/applications/version-management/blackbox/default.nix
+++ b/pkgs/applications/version-management/blackbox/default.nix
@@ -1,24 +1,62 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, expect
+, which
+, gnupg
+, coreutils
+, git
+, pinentry
+, gnutar
+, procps
+}:
 
 stdenv.mkDerivation rec {
-  version = "1.20181219";
-  pname   = "blackbox";
+  pname = "blackbox";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
-    owner  = "stackexchange";
-    repo   = pname;
-    rev    = "v${version}";
-    sha256 = "1lpwwwc3rf992vdf3iy1ds07n1xkmad065im2bqzc6kdsbkn7rjx";
+    owner = "stackexchange";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1plwdmzds6dq2rlp84dgiashrfg0kg4yijhnxaapz2q4d1vvx8lq";
   };
 
+  buildInputs = [ gnupg ];
+
+  doCheck = true;
+
+  checkInputs = [
+    expect
+    which
+    coreutils
+    pinentry.tty
+    git
+    gnutar
+    procps
+  ];
+
+  postPatch = ''
+    patchShebangs bin tools
+    substituteInPlace Makefile \
+      --replace "PREFIX?=/usr/local" "PREFIX=$out"
+
+    substituteInPlace tools/confidence_test.sh \
+      --replace 'PATH="''${blackbox_home}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/local/bin:/usr/pkg/bin:/usr/pkg/gnu/bin:''${blackbox_home}"' \
+        "PATH=/build/source/bin/:$PATH"
+  '';
+
   installPhase = ''
-    mkdir -p $out/bin && cp -r bin/* $out/bin
+    runHook preInstall
+    mkdir -p $out/bin
+    make copy-install
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Safely store secrets in a VCS repo";
     maintainers = with maintainers; [ ericsagnes ];
-    license     = licenses.mit;
-    platforms   = platforms.all;
+    license = licenses.mit;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
supersedes #104629

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
