### PR TITLE
python3Packages.mutesync: 0.0.1 -> 0.0.2

### DIFF
--- a/pkgs/development/python-modules/mutesync/default.nix
+++ b/pkgs/development/python-modules/mutesync/default.nix
@@ -2,17 +2,16 @@
 , aiohttp
 , async-timeout
 , buildPythonPackage
-, fetchpatch
 , fetchPypi
 }:
 
 buildPythonPackage rec {
   pname = "mutesync";
-  version = "0.0.1";
+  version = "0.0.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "05r8maq59glwgysg98y1vrysfb1mkh9jpbag3ixl13n8jw8clp85";
+    sha256 = "1lz3q3q9lw8qxxb8jyrak77v6hkxwi39akyx96j8hd5jjaq2k5qc";
   };
 
   propagatedBuildInputs = [
@@ -20,17 +19,9 @@ buildPythonPackage rec {
     async-timeout
   ];
 
-  patches = [
-    # Don't parse requirements.txt, https://github.com/currentoor/pymutesync/pull/1
-    (fetchpatch {
-      name = "add-requirements.patch";
-      url = "https://github.com/currentoor/pymutesync/commit/d66910fc83b1ae3060cdb3fe22a6f91fb70a67f0.patch";
-      sha256 = "0axhgriyyv31b1r1yidxcrv0nyrqbb63xw5qrmv2iy2h0v96ijsk";
-    })
-  ];
-
   # Project has not published tests yet
   doCheck = false;
+
   pythonImportsCheck = [ "mutesync" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
