### PR TITLE
nixos/hidpi: scale X11 core cursor

### DIFF
--- a/nixos/modules/config/fonts/fonts.nix
+++ b/nixos/modules/config/fonts/fonts.nix
@@ -2,6 +2,52 @@
 
 with lib;
 
+let
+  # A scalable variant of the X11 "core" cursor
+  #
+  # If not running a fancy desktop environment, the cursor is likely set to
+  # the default `cursor.pcf` bitmap font. This is 17px wide, so it's very
+  # small and almost invisible on 4K displays.
+  fontcursormisc_hidpi = pkgs.xorg.fontcursormisc.overrideAttrs (old:
+    let
+      # The scaling constant is 230/96: the scalable `left_ptr` glyph at
+      # about 23 points is rendered as 17px, on a 96dpi display.
+      # Note: the XLFD font size is in decipoints.
+      size = 2.39583 * config.services.xserver.dpi;
+      sizeString = builtins.head (builtins.split "\\." (toString size));
+    in
+    {
+      postInstall = ''
+        alias='cursor -xfree86-cursor-medium-r-normal--0-${sizeString}-0-0-p-0-adobe-fontspecific'
+        echo "$alias" > $out/lib/X11/fonts/Type1/fonts.alias
+      '';
+    });
+
+  hasHidpi =
+    config.hardware.video.hidpi.enable &&
+    config.services.xserver.dpi != null;
+
+  defaultFonts =
+    [ pkgs.dejavu_fonts
+      pkgs.freefont_ttf
+      pkgs.gyre-fonts # TrueType substitutes for standard PostScript fonts
+      pkgs.liberation_ttf
+      pkgs.unifont
+      pkgs.noto-fonts-emoji
+    ];
+
+  defaultXFonts =
+    [ (if hasHidpi then fontcursormisc_hidpi else pkgs.xorg.fontcursormisc)
+      pkgs.xorg.fontmiscmisc
+    ] ++ optionals (config.nixpkgs.config.allowUnfree or false)
+    [ # these are unfree, and will make usage with xserver fail
+      pkgs.xorg.fontbhlucidatypewriter100dpi
+      pkgs.xorg.fontbhlucidatypewriter75dpi
+      pkgs.xorg.fontbh100dpi
+    ];
+
+in
+
 {
   imports = [
     (mkRemovedOptionModule [ "fonts" "enableCoreFonts" ] "Use fonts.fonts = [ pkgs.corefonts ]; instead.")
@@ -32,25 +78,9 @@ with lib;
 
   };
 
-  config = {
-
-    fonts.fonts = mkIf config.fonts.enableDefaultFonts
-      ([
-        pkgs.dejavu_fonts
-        pkgs.freefont_ttf
-        pkgs.gyre-fonts # TrueType substitutes for standard PostScript fonts
-        pkgs.liberation_ttf
-        pkgs.xorg.fontmiscmisc
-        pkgs.xorg.fontcursormisc
-        pkgs.unifont
-        pkgs.noto-fonts-emoji
-      ] ++ lib.optionals (config.nixpkgs.config.allowUnfree or false) [
-        # these are unfree, and will make usage with xserver fail
-        pkgs.xorg.fontbhlucidatypewriter100dpi
-        pkgs.xorg.fontbhlucidatypewriter75dpi
-        pkgs.xorg.fontbh100dpi
-      ]);
-
-  };
+  config = mkMerge [
+    { fonts.fonts = mkIf config.fonts.enableDefaultFonts defaultFonts; }
+    { fonts.fonts = mkIf config.services.xserver.enable defaultXFonts; }
+  ];
 
 }


### PR DESCRIPTION
###### Motivation for this change

Most desktop environments manage the cursor using the Xcursor library
by default; this comes with scalable or multiple-sized cursor themes.
However, when running just a simple WM (twm, bspwm, ...) the cursor
handling is left to the X server, which uses a very simple fixed bitmap
font (this is called a "core" cursor). The font is uncomfortably small
on a high DPI display and must be replaced with a saner default.

Up until recently[1] it used to be possible to change the font on the
xserver command line, however the font name is now hardcoded. It's still
possible to change it, though: here I override the `fontcursormisc`
package and set an alias that points to a vector variant of the original
cursor font. The font size is set to match the standard cursor
dimensions on a 96dpi display. It's not perfect but it's a very simple
and effective solution.

[1]: https://gitlab.freedesktop.org/xorg/xserver/-/commit/56ea4c769c2d65df2de86009e8e499f39a8a3d4d


###### Things done

- [x] Tested on 96 and 384 dpi displays (physical cursor size is similar)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
