### PR TITLE
python3Packages.rich: 10.4.0 -> 10.7.0

### DIFF
--- a/pkgs/development/python-modules/rich/default.nix
+++ b/pkgs/development/python-modules/rich/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "rich";
-  version = "10.4.0";
+  version = "10.7.0";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "willmcgugan";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0z01bvn8zx69simk26jv5ngvqv35fs7i0wbg1hjcd37lmv3v6261";
+    sha256 = "1drh08cmcn8dqi0mpfwscz3ljsv2s60kyhxy6iiw5si7rf717j4p";
   };
 
   nativeBuildInputs = [ poetry-core ];


### PR DESCRIPTION
###### Motivation for this change
Routine bump

Tested the vast majority of rebuilds through `nixpkgs-review`, except on nixos I wasn't going to sit around and watch emojis re-compress themselves, and on macos where around 5% of packages have always caused my machine to grind to a halt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
