### PR TITLE
squeak: 4.10.2.2614 -> 5.3-19459

### DIFF
--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -1,31 +1,191 @@
-{ lib, stdenv, fetchurl, cmake, coreutils, dbus, freetype, glib, gnused
-, libpthreadstubs, pango, pkg-config, libpulseaudio, which }:
+{ lib, stdenv, fetchFromGitHub, fetchurl, fetchzip
+, autoconf, automake, autoreconfHook, bash, clang, dos2unix, file, gzip, perl
+, pkg-config
+, alsa-lib, coreutils, freetype, glib, glibc, gnugrep, libpulseaudio, libtool
+, libuuid, openssl, pango, xorg
+, squeakImageHash ? null, squeakSourcesHash ? null, squeakSourcesVersion ? null
+, squeakVersion ? null, squeakVmCommitHash ? null, squeakVmCommitHashHash ? null
+, squeakVmVersion ? null
+} @ args:
 
-stdenv.mkDerivation rec {
+let
+  inherit (builtins) elemAt;
+  nullableOr = o: default: if o == null then default else o;
+
+  bits = stdenv.hostPlatform.parsed.cpu.bits;
+
+  squeakVersion = nullableOr args.squeakVersion or null "5.3-19459";
+  squeakVersionSplit = builtins.split "-" squeakVersion;
+  squeakVersionBase = elemAt squeakVersionSplit 0;
+  squeakVersionBaseSplit = lib.splitVersion squeakVersionBase;
+  squeakVersionMajor = elemAt squeakVersionBaseSplit 0;
+  squeakVersionMinor = elemAt squeakVersionBaseSplit 1;
+
+  squeakImageVersion = elemAt squeakVersionSplit 2;
+
+  squeakSourcesVersion = nullableOr args.squeakSourcesVersion or null "50";
+
+  squeakVmVersion = nullableOr args.squeakVmVersion or null "5.0-202003021730";
+  squeakVmVersionSplit = builtins.split "-" squeakVmVersion;
+  squeakVmVersionBase = elemAt squeakVmVersionSplit 0;
+  squeakVmVersionBaseSplit = lib.splitVersion squeakVmVersionBase;
+  squeakVmVersionMajor = elemAt squeakVmVersionBaseSplit 0;
+  squeakVmVersionMinor = elemAt squeakVmVersionBaseSplit 1;
+  squeakVmVersionRelease = elemAt squeakVmVersionSplit 2;
+
+  squeakVmCommitHash = nullableOr args.squeakVmCommitHash or null (fetchurl {
+    url = "https://api.github.com/repos/OpenSmalltalk/opensmalltalk-vm/commits/${squeakVmVersionRelease}";
+    curlOpts = "--header Accept:application/vnd.github.v3.sha";
+    hash = nullableOr args.squeakVmCommitHashHash or null
+      "sha256-quwmhpJlb2fp0fI9b03fBxSR44j1xmHPW20wkSqTOhQ=";
+  });
+in stdenv.mkDerivation {
   pname = "squeak";
-  version = "4.10.2.2614";
+  version = squeakVersion;
 
-  src = fetchurl {
-    sha256 = "0bpwbnpy2sb4gylchfx50sha70z36bwgdxraym4vrr93l8pd3dix";
-    url = "http://squeakvm.org/unix/release/Squeak-${version}-src.tar.gz";
+  vmVersionRelease = squeakVmVersionRelease; # "202003021730"
+  vmHash = squeakVmCommitHash;
+
+  vmSrcUrl = "https://github.com/OpenSmalltalk/opensmalltalk-vm.git";
+  src = fetchFromGitHub {
+    owner = "OpenSmalltalk";
+    repo = "opensmalltalk-vm";
+    rev = squeakVmVersion;
+    hash = nullableOr args.squeakVmHash or null
+      "sha256-rNJn5ya+7ggC21MpwSrl2ByJDjVycONKHADboH7dQLM=";
+  };
+  imageSrc = let
+    squeakImageName = "Squeak${squeakVersionBase}-${squeakImageVersion}-${toString bits}bit";
+  in fetchzip {
+    url = "https://files.squeak.org/${squeakVersionBase}/${squeakImageName}/${squeakImageName}.zip";
+    name = "source";
+    stripRoot = false;
+    hash = nullableOr args.squeakImageHash or null
+      "sha256-wDuRyc/DNqG1D4DzyBkUvrzFkBlXBtbpnANZlRV/Fas=";
+  };
+  sourcesSrc = fetchurl {
+    url = "https://files.squeak.org/sources_files/SqueakV${squeakSourcesVersion}.sources.gz";
+    hash = nullableOr args.squeakSourcesHash or null
+      "sha256-ZViZ1VgI32LwLTEyw7utp8oaAK3UmCNJnHqsGm1IKYE=";
   };
 
-  buildInputs = [ coreutils dbus freetype glib gnused libpthreadstubs
-    pango libpulseaudio which ];
-  nativeBuildInputs = [ cmake pkg-config ];
+  vmBuild = "linux64x64";
 
-  postPatch = ''
-    for i in squeak.in squeak.sh.in; do
-      substituteInPlace unix/cmake/$i --replace "PATH=" \
-        "PATH=${lib.makeBinPath [ coreutils gnused which ]} #"
+  nativeBuildInputs = [
+    autoconf
+    automake
+    autoreconfHook
+    bash
+    clang
+    dos2unix
+    file
+    gzip
+    perl
+    pkg-config
+  ];
+  buildInputs = [
+    alsa-lib
+    coreutils
+    freetype
+    glib
+    glibc
+    gnugrep
+    libpulseaudio
+    libtool
+    libuuid
+    openssl
+    pango
+    xorg.libX11
+  ];
+
+  postUnpack = ''
+    for file in "$imageSrc"/*.{image,changes}; do
+      gzip -c "$file" > "$sourceRoot/''${file##"$imageSrc"/}.gz"
     done
   '';
 
-  configurePhase = ''
-    unix/cmake/configure --prefix=$out --enable-mpg-{mmx,pthreads}
+  prePatch = ''
+    dos2unix platforms/unix/plugins/*/{Makefile.inc,acinclude.m4}
   '';
 
-  hardeningDisable = [ "format" ];
+  patches = [
+    ./squeak-configure-version.patch
+    ./squeak-plugins-discovery.patch
+    ./squeak-squeaksh-nixpkgs.patch
+  ];
+
+  postPatch = ''
+    vmVersionDate=$(sed 's/\([0-9][0-9][0-9][0-9]\)\([0-9][0-9]\)\([0-9][0-9]\)\([0-9][0-9]\)\([0-9][0-9]\)/\1-\2-\3T\4:\5+0000/' <<< "$vmVersionRelease")
+    vmVersionDate=$(date -u '+%a %b %-d %T %Y %z' -d "$vmVersionDate")
+    vmVersionFiles=$(sed -n 's/^versionfiles="\(.*\)"/\1/p' ./scripts/updateSCCSVersions)
+    vmHash=$(< "$vmHash")
+    vmAbbrevHash=''${vmHash:0:12}
+    printf '%s\n' "$vmAbbrevHash"
+    for vmVersionFile in $vmVersionFiles; do
+      substituteInPlace "$vmVersionFile" \
+        --replace "\$Date\$" "\$Date: ''${vmVersionDate} \$" \
+        --replace "\$URL\$" "\$URL: ''${vmSrcUrl} \$" \
+        --replace "\$Rev\$" "\$Rev: ''${vmVersionRelease} \$" \
+        --replace "\$CommitHash\$" "\$CommitHash: ''${vmAbbrevHash} \$"
+    done
+    patchShebangs --build ./"build.$vmBuild"/squeak.cog.spur ./scripts
+    for squeaksh in ./platforms/unix/config/{,bin.}squeak.sh.in; do
+      substituteInPlace "$squeaksh" \
+        --subst-var-by 'glibc' ${lib.escapeShellArg (lib.getBin glibc)} \
+        --subst-var-by 'gnugrep' ${lib.escapeShellArg (lib.getBin gnugrep)}
+    done
+    substituteInPlace ./platforms/unix/config/mkmf \
+      --replace '/bin/rm ' '${coreutils}/bin/rm '
+  '';
+
+  preAutoreconf = ''
+    pushd ./platforms/unix/config > /dev/null
+    ./mkacinc > ./acplugins.m4
+  '';
+  postAutoreconf = ''
+    rm ./acplugins.m4
+    popd > /dev/null
+  '';
+
+  preConfigure = ''
+    if [ -z "''${dontFixLibtool:-}" ]; then
+        local i
+        find ./platforms/unix/config -iname "ltmain.sh" -print0 | while IFS=''' read -r -d ''' i; do
+            echo "fixing libtool script $i"
+            fixLibtool "$i"
+        done
+    fi
+
+    substituteInPlace ./platforms/unix/config/configure \
+      --replace "/usr/bin/file" "${file}/bin/file"
+    cd ./"build.$vmBuild"/squeak.cog.spur/build
+    substituteInPlace ./mvm \
+      --replace 'read a' 'a=y' \
+      --replace $'if [ $# -ge 1 ]; then\n\tINSTALLDIR="$1"; shift\nfi\n' "" \
+      --replace 'config/configure' 'config/configure "$@"' \
+      --replace 'make install' '# make install'
+  '';
+
+  configureFlags = [
+    "--disable-dynamicopenssl"
+    "SQ_MAJOR=${squeakVersionMajor}"
+    "SQ_MINOR=${squeakVersionMinor}"
+    "SQ_UPDATE=${squeakImageVersion}"
+    "SQ_VERSION=${squeakVersion}-${toString bits}bit"
+    "SQ_SRC_VERSION=${squeakSourcesVersion}"
+    "VM_MAJOR=${squeakVmVersionMajor}"
+    "VM_MINOR=${squeakVmVersionMinor}"
+    "VM_RELEASE=${squeakVmVersionRelease}"
+    "VM_VERSION=${squeakVmVersion}"
+  ];
+  configureScript = "./mvm";
+
+  installTargets = [ "install" "install-image" ];
+
+  postInstall = ''
+    rm "$out/squeak"
+    cp --no-preserve mode "$sourcesSrc" "$out"/lib/squeak/SqueakV${lib.escapeShellArg squeakSourcesVersion}.sources
+  '';
 
   meta = with lib; {
     description = "Smalltalk programming language and environment";
@@ -37,8 +197,8 @@ stdenv.mkDerivation rec {
       capabilities. It also includes a customisable framework for creating
       dynamic HTTP servers and interactively extensible Web sites.
     '';
-    homepage = "http://squeakvm.org/";
-    downloadPage = "http://squeakvm.org/unix/index.html";
+    homepage = "https://squeakvm.org/";
+    downloadPage = "https://squeakvm.org/unix/index.html";
     license = with licenses; [ asl20 mit ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -50,7 +50,7 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "OpenSmalltalk";
     repo = "opensmalltalk-vm";
-    rev = squeakVmVersion;
+    rev = squeakVmVersionRelease;
     hash = nullableOr args.squeakVmHash or null
       "sha256-rNJn5ya+7ggC21MpwSrl2ByJDjVycONKHADboH7dQLM=";
   };
@@ -188,18 +188,10 @@ in stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "Smalltalk programming language and environment";
-    longDescription = ''
-      Squeak is a full-featured implementation of the Smalltalk programming
-      language and environment based on (and largely compatible with) the
-      original Smalltalk-80 system. Squeak has very powerful 2- and 3-D
-      graphics, sound, video, MIDI, animation and other multimedia
-      capabilities. It also includes a customisable framework for creating
-      dynamic HTTP servers and interactively extensible Web sites.
-    '';
-    homepage = "https://squeakvm.org/";
-    downloadPage = "https://squeakvm.org/unix/index.html";
+    description = "Squeak virtual machine";
+    homepage = "https://opensmalltalk.org/";
     license = with licenses; [ asl20 mit ];
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ ehmry ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/compilers/squeak/squeak-configure-version.patch
+++ b/pkgs/development/compilers/squeak/squeak-configure-version.patch
@@ -1,0 +1,94 @@
+--- a/platforms/unix/config/Makefile.install
++++ b/platforms/unix/config/Makefile.install
+@@ -101,10 +101,10 @@ uninstall-image : getversion
+ 
+ install-sources :
+ 	$(MKINSTALLDIRS) $(ROOT)$(imgdir)
+-	$(INSTALL_DATA) $(topdir)/SqueakV$(SQ_MAJOR).sources $(ROOT)$(imgdir)
++	$(INSTALL_DATA) $(topdir)/SqueakV$(SQ_SRC_VERSION).sources $(ROOT)$(imgdir)
+ 
+ uninstall-sources :
+-	@$(UNINSTALL) $(ROOT)$(imgdir) SqueakV$(SQ_MAJOR).sources
++	@$(UNINSTALL) $(ROOT)$(imgdir) SqueakV$(SQ_SRC_VERSION).sources
+ 
+ # npsqueak
+ 
+--- a/platforms/unix/config/configure.ac
++++ b/platforms/unix/config/configure.ac
+@@ -122,7 +122,7 @@ AC_SUBST(vmpdir)
+ AC_SUBST(vmmcfg)
+ AC_SUBST(blddir)
+ 
+-SQ_VERSION=${SQ_MAJOR}.${SQ_MINOR}-${SQ_UPDATE}
++AS_VAR_SET_IF([SQ_VERSION], [], [SQ_VERSION=${SQ_MAJOR}.${SQ_MINOR}-${SQ_UPDATE}])
+ 
+ AC_DEFINE_UNQUOTED(SQ_VERSION, "${SQ_VERSION}", [Squeak version])
+ 
+@@ -131,21 +131,24 @@ AC_SUBST(SQ_MINOR)
+ AC_SUBST(SQ_UPDATE)
+ AC_SUBST(SQ_VERSION)
+ 
++AS_VAR_SET_IF([SQ_SRC_VERSION], [], [SQ_SRC_VERSION=${SQ_MAJOR}])
++AC_SUBST(SQ_SRC_VERSION)
++
+ #VM_VERSION=${VM_MAJOR}.${VM_MINOR}-${VM_RELEASE}
+ 
+ #AC_DEFINE_UNQUOTED(VM_VERSION, "${VM_VERSION}", [VM version])
+ 
+-#AC_SUBST(VM_MAJOR)
+-#AC_SUBST(VM_MINOR)
+-#AC_SUBST(VM_RELEASE)
+-#AC_SUBST(VM_VERSION)
++AC_SUBST(VM_MAJOR)
++AC_SUBST(VM_MINOR)
++AC_SUBST(VM_RELEASE)
++AC_SUBST(VM_VERSION)
+ 
+ # libdir contains ${exec_prefix}, so we have to default and expand early
+ test "x$prefix" = xNONE && prefix=$ac_default_prefix
+ test "x$exec_prefix" = xNONE && exec_prefix='${prefix}'
+ imgdir=`eval echo ${libdir}/squeak`
+ expanded_relative_imgdir=`eval echo lib/squeak/${VM_VERSION}`
+-plgdir='${imgdir}/`${blddir}/getversion VERSION_TAG`'
++plgdir=`eval echo '${imgdir}'/${VM_VERSION}`
+ 
+ AC_SUBST(imgdir)
+ AC_SUBST(expanded_relative_imgdir)
+--- a/platforms/unix/config/inisqueak.in
++++ b/platforms/unix/config/inisqueak.in
+@@ -32,6 +32,7 @@
+ 
+ MAJOR=@SQ_MAJOR@
+ VERSION=@SQ_VERSION@
++SRC_VERSION=@SQ_SRC_VERSION@
+ 
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+@@ -77,7 +78,7 @@ if test "$1" != ""; then
+ fi
+ 
+ SQUEAK=${bindir}/squeak
+-SOURCES=SqueakV${MAJOR}.sources
++SOURCES=SqueakV${SRC_VERSION}.sources
+ IMAGE=squeak.image.gz
+ CHANGES=squeak.changes.gz
+ 
+--- a/platforms/unix/config/make.cfg.in
++++ b/platforms/unix/config/make.cfg.in
+@@ -96,6 +96,16 @@ X_INCLUDES=	@X_INCLUDES@
+ X_LIBS=		@X_LIBS@
+ 
+ 
++SQ_MAJOR=	@SQ_MAJOR@
++SQ_MINOR=	@SQ_MINOR@
++SQ_UPDATE=	@SQ_UPDATE@
++SQ_VERSION=	@SQ_VERSION@
++SQ_SRC_VERSION=	@SQ_SRC_VERSION@
++VM_MAJOR=	@VM_MAJOR@
++VM_MINOR=	@VM_MINOR@
++VM_RELEASE=	@VM_RELEASE@
++VM_VERSION=	@VM_VERSION@
++
+ INTERP=		@INTERP@
+ 
+ VM_APP_ICONS=	@VM_APP_ICONS@

--- a/pkgs/development/compilers/squeak/squeak-plugins-discovery.patch
+++ b/pkgs/development/compilers/squeak/squeak-plugins-discovery.patch
@@ -1,0 +1,34 @@
+--- a/platforms/unix/plugins/UnicodePlugin/Makefile.inc
++++ b/platforms/unix/plugins/UnicodePlugin/Makefile.inc
+@@ -1,2 +1,2 @@
+-XCPPFLAGS=	-I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/glib-2.0  -I/usr/lib/glib-2.0/include -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include -I/usr/lib/i386-linux-gnu/glib-2.0/include
++XCPPFLAGS=	[unicode_plugin_cflags]
+-XLDFLAGS= -lpangocairo-1.0 -lcairo -lpango-1.0 -lgobject-2.0 -lglib-2.0
++XLDFLAGS=	[unicode_plugin_libs]
+--- a/platforms/unix/plugins/UnicodePlugin/acinclude.m4
++++ b/platforms/unix/plugins/UnicodePlugin/acinclude.m4
+@@ -2,9 +2,14 @@
+ 
+ AC_MSG_CHECKING([for PangoCairo libraries])
+ save_CPPFLAGS="$CPPFLAGS"
+-CPPFLAGS="-I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include -I/usr/lib/i386-linux-gnu/glib-2.0/include"
++CPPFLAGS=`pkg-config --cflags glib-2.0 pangocairo`
+ AC_TRY_COMPILE([#include <pango/pangocairo.h>],[{}],[
+   AC_MSG_RESULT(yes)
++  PKG_CHECK_MODULES([UNICODE_PLUGIN],[glib-2.0 pangocairo])
++  AC_SUBST([UNICODE_PLUGIN_CFLAGS])
++  AC_SUBST([UNICODE_PLUGIN_LIBS])
++  AC_PLUGIN_DEFINE_UNQUOTED([unicode_plugin_cflags],[$UNICODE_PLUGIN_CFLAGS])
++  AC_PLUGIN_DEFINE_UNQUOTED([unicode_plugin_libs],[$UNICODE_PLUGIN_LIBS])
+ ],[
+   AC_MSG_RESULT(no)
+   AC_PLUGIN_DISABLE
+--- a/platforms/unix/plugins/XDisplayControlPlugin/acinclude.m4
++++ b/platforms/unix/plugins/XDisplayControlPlugin/acinclude.m4
+@@ -1,5 +1,3 @@
+ # Require X11
+ 
+-AC_CHECK_LIB(X11,XOpenDisplay,
+-  [AC_PLUGIN_USE_LIB(X11)],
+-  [AC_PLUGIN_DISABLE])
++AC_PLUGIN_CHECK_LIB(X11,XOpenDisplay)

--- a/pkgs/development/compilers/squeak/squeak-squeaksh-nixpkgs.patch
+++ b/pkgs/development/compilers/squeak/squeak-squeaksh-nixpkgs.patch
@@ -1,0 +1,40 @@
+--- a/platforms/unix/config/bin.squeak.sh.in
++++ b/platforms/unix/config/bin.squeak.sh.in
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ # Run the VM, setting SQUEAK_PLUGINS if unset to the VM's containing directory
+ # if unset, and ensuring LD_LIBRARY_PATH includes the VM's containing directory.
+-BIN=`/usr/bin/dirname "$0"`/../@expanded_relative_imgdir@
++BIN=`dirname "$0"`/../@expanded_relative_imgdir@
+ GDB=
+ if [ "${SQUEAK_PLUGINS-unset}" = unset ]; then
+        export SQUEAK_PLUGINS="$BIN"
+@@ -26,7 +26,7 @@ fi
+ # libc (e.g. through the FFI) then it must use the same version that the VM uses
+ # and so it should take precedence over /lib libc.  This is done by setting
+ # LD_LIBRARY_PATH appropriately, based on ldd's idea of the libc use by the VM.
+-LIBC_SO="`/usr/bin/ldd "$BIN/squeak" | /bin/fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
++LIBC_SO="`@glibc@/bin/ldd "$BIN/squeak" | @gnugrep@/bin/fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
+ PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/libc.*'`
+ 
+ if [ "$PLATFORMLIBDIR" = "" ]; then
+--- a/platforms/unix/config/squeak.sh.in
++++ b/platforms/unix/config/squeak.sh.in
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ # Run the VM, setting SQUEAK_PLUGINS if unset to the VM's containing directory
+ # if unset, and ensuring LD_LIBRARY_PATH includes the VM's containing directory.
+-BIN=`/usr/bin/dirname "$0"`/@expanded_relative_imgdir@
++BIN=`dirname "$0"`/@expanded_relative_imgdir@
+ GDB=
+ if [ "${SQUEAK_PLUGINS-unset}" = unset ]; then
+        export SQUEAK_PLUGINS="$BIN"
+@@ -26,7 +26,7 @@ fi
+ # libc (e.g. through the FFI) then it must use the same version that the VM uses
+ # and so it should take precedence over /lib libc.  This is done by setting
+ # LD_LIBRARY_PATH appropriately, based on ldd's idea of the libc use by the VM.
+-LIBC_SO="`/usr/bin/ldd "$BIN/squeak" | /bin/fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
++LIBC_SO="`@glibc@/bin/ldd "$BIN/squeak" | @gnugrep@/bin/fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
+ PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/libc.*'`
+ 
+ if [ "$PLATFORMLIBDIR" = "" ]; then


### PR DESCRIPTION
Credit to @BenBals for starting work on this patch in <https://github.com/NixOS/nixpkgs/pull/86741>. This package probably still needs more testing, but basic `inisqueak` execution works out of the box.

This patch doesn't use a newer release of the OpenSmalltalk VM because current Squeak doesn't use one. I don't know enough about Squeak to feel comfortable bumping the VM version.

###### Motivation for this change

`inisqueak` works in a fresh directory. I like that.

This patch tries to replicate the recommended sorta-bootstrapping arrangement for Squeak, as best as I can tell. It's not super well documented. https://github.com/squeak-smalltalk/squeak-app was a helpful reference.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
