### PR TITLE
atomicparsley: 20210617.200601.1ac7c08 -> 20210715.151551.e7ad03a

### DIFF
--- a/pkgs/tools/video/atomicparsley/default.nix
+++ b/pkgs/tools/video/atomicparsley/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "atomicparsley";
-  version = "20210617.200601.1ac7c08";
+  version = "20210715.151551.e7ad03a";
 
   src = fetchFromGitHub {
     owner = "wez";
     repo = pname;
     rev = version;
-    sha256 = "sha256-IhZe0vM41JhO8H79ZrRx4FRA4zfB6X0daC8QoE5MHmU=";
+    sha256 = "sha256-77yWwfdEul4uLsUNX1dLwj8K0ilcuBaTVKMyXDvKVx4=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -20,6 +20,23 @@ stdenv.mkDerivation rec {
     runHook preInstall
     install -D AtomicParsley $out/bin/AtomicParsley
     runHook postInstall
+  '';
+
+  doCheck = true;
+
+  postPatch = ''
+    patchShebangs tests/test.sh
+  '';
+
+  # copying files so that we dont need to patch the test.sh
+  checkPhase = ''
+    (
+    cp AtomicParsley ../tests
+    cd ../tests
+    mkdir tests
+    mv *.mp4 tests
+    ./test.sh
+    )
   '';
 
   meta = with lib; {


### PR DESCRIPTION
and enable tests

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
 #130662 but with a test 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
