### PR TITLE
portmidi: add support for darwin

### DIFF
--- a/pkgs/development/libraries/portmidi/default.nix
+++ b/pkgs/development/libraries/portmidi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, unzip, cmake, /*jdk,*/ alsa-lib }:
+{ lib, stdenv, fetchurl, unzip, cmake, /*jdk,*/ alsa-lib, Carbon, CoreAudio, CoreFoundation, CoreMIDI, CoreServices }:
 
 stdenv.mkDerivation rec {
   pname = "portmidi";
@@ -20,14 +20,31 @@ stdenv.mkDerivation rec {
     "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=Release"
     "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=Release"
     "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=Release"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DCMAKE_OSX_ARCHITECTURES=${if stdenv.isAarch64 then "arm64" else "x86_64"}"
+    "-DCOREAUDIO_LIB=${CoreAudio}"
+    "-DCOREFOUNDATION_LIB=${CoreFoundation}"
+    "-DCOREMIDI_LIB=${CoreMIDI}"
+    "-DCORESERVICES_LIB=${CoreServices}"
   ];
 
-  # XXX: This is to deactivate Java support.
-  patches = lib.singleton (fetchurl {
-    url = "https://raw.github.com/Rogentos/argent-gentoo/master/media-libs/"
-        + "portmidi/files/portmidi-217-cmake-libdir-java-opts.patch";
-    sha256 = "1jbjwan61iqq9fqfpq2a4fd30k3clg7a6j0gfgsw87r8c76kqf6h";
-  });
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin [
+    "-framework CoreAudio"
+    "-framework CoreFoundation"
+    "-framework CoreMIDI"
+    "-framework CoreServices"
+  ];
+
+  patches = [
+    # XXX: This is to deactivate Java support.
+    (fetchurl {
+      url = "https://raw.github.com/Rogentos/argent-gentoo/master/media-libs/portmidi/files/portmidi-217-cmake-libdir-java-opts.patch";
+      sha256 = "1jbjwan61iqq9fqfpq2a4fd30k3clg7a6j0gfgsw87r8c76kqf6h";
+    })
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Remove hardcoded variables so we can set them properly
+    ./remove-darwin-variables.diff
+  ];
 
   postPatch = ''
     sed -i -e 's|/usr/local/|'"$out"'|' -e 's|/usr/share/|'"$out"'/share/|' \
@@ -40,19 +57,24 @@ stdenv.mkDerivation rec {
         pm_java/CMakeLists.txt
   '';
 
-  postInstall = ''
-    ln -s libportmidi.so "$out/lib/libporttime.so"
+  postInstall = let ext = stdenv.hostPlatform.extensions.sharedLibrary; in ''
+    ln -s libportmidi.${ext} "$out/lib/libporttime.${ext}"
   '';
 
   nativeBuildInputs = [ unzip cmake ];
-  buildInputs = [ alsa-lib ];
+  buildInputs = lib.optionals stdenv.isLinux [
+    alsa-lib
+  ] ++ lib.optionals stdenv.isDarwin [
+    Carbon CoreAudio CoreFoundation CoreMIDI CoreServices
+  ];
 
   hardeningDisable = [ "format" ];
 
-  meta = {
+  meta = with lib; {
     homepage = "http://portmedia.sourceforge.net/portmidi/";
     description = "Platform independent library for MIDI I/O";
-    license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ angustrau ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/portmidi/remove-darwin-variables.diff
+++ b/pkgs/development/libraries/portmidi/remove-darwin-variables.diff
@@ -1,0 +1,52 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4919b78..758eccb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,8 +36,6 @@ set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "" CACHE INTERNAL "Unused")
+ set(CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO "" CACHE INTERNAL "Unused")
+ set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "" CACHE INTERNAL "Unused")
+ 
+-set(CMAKE_OSX_ARCHITECTURES i386 ppc x86_64 CACHE STRING "change to needed architecture for a smaller library" FORCE)
+-
+ PROJECT(portmidi)
+ 
+ if(UNIX)
+diff --git a/pm_common/CMakeLists.txt b/pm_common/CMakeLists.txt
+index e171047..aafa09c 100644
+--- a/pm_common/CMakeLists.txt
++++ b/pm_common/CMakeLists.txt
+@@ -22,7 +22,7 @@ else(APPLE OR WIN32)
+ endif(APPLE OR WIN32)
+ 
+ if(APPLE)
+-  set(CMAKE_OSX_SYSROOT /Developer/SDKs/MacOSX10.5.sdk CACHE 
++  set(CMAKE_OSX_SYSROOT / CACHE 
+       PATH "-isysroot parameter for compiler" FORCE)
+   set(CMAKE_C_FLAGS "-mmacosx-version-min=10.5" CACHE 
+       STRING "needed in conjunction with CMAKE_OSX_SYSROOT" FORCE)
+@@ -54,10 +54,6 @@ if(UNIX)
+ 
+     include_directories(${CMAKE_OSX_SYSROOT}/Developer/Headers/FlatCarbon)
+     set(FRAMEWORK_PATH ${CMAKE_OSX_SYSROOT}/System/Library/Frameworks)
+-    set(COREAUDIO_LIB "${FRAMEWORK_PATH}/CoreAudio.framework")
+-    set(COREFOUNDATION_LIB "${FRAMEWORK_PATH}/CoreFoundation.framework")
+-    set(COREMIDI_LIB "${FRAMEWORK_PATH}/CoreMIDI.framework")
+-    set(CORESERVICES_LIB "${FRAMEWORK_PATH}/CoreServices.framework")
+     set(PM_NEEDED_LIBS ${COREAUDIO_LIB} ${COREFOUNDATION_LIB}
+                              ${COREMIDI_LIB} ${CORESERVICES_LIB}
+         CACHE INTERNAL "")
+diff --git a/pm_dylib/CMakeLists.txt b/pm_dylib/CMakeLists.txt
+index f693dd6..1dc5cd6 100644
+--- a/pm_dylib/CMakeLists.txt
++++ b/pm_dylib/CMakeLists.txt
+@@ -49,10 +49,6 @@ if(UNIX)
+ 
+     include_directories(${CMAKE_OSX_SYSROOT}/Developer/Headers/FlatCarbon)
+     set(FRAMEWORK_PATH ${CMAKE_OSX_SYSROOT}/System/Library/Frameworks)
+-    set(COREAUDIO_LIB "${FRAMEWORK_PATH}/CoreAudio.framework")
+-    set(COREFOUNDATION_LIB "${FRAMEWORK_PATH}/CoreFoundation.framework")
+-    set(COREMIDI_LIB "${FRAMEWORK_PATH}/CoreMIDI.framework")
+-    set(CORESERVICES_LIB "${FRAMEWORK_PATH}/CoreServices.framework")
+     set(PM_NEEDED_LIBS ${COREAUDIO_LIB} ${COREFOUNDATION_LIB}
+                              ${COREMIDI_LIB} ${CORESERVICES_LIB}
+         CACHE INTERNAL "")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18136,7 +18136,9 @@ with pkgs;
     };
   });
 
-  portmidi = callPackage ../development/libraries/portmidi {};
+  portmidi = callPackage ../development/libraries/portmidi {
+    inherit (darwin.apple_sdk.frameworks) Carbon CoreAudio CoreFoundation CoreMIDI CoreServices;
+  };
 
   presage = callPackage ../development/libraries/presage { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds macOS support to portmidi. It has been tested to build on `x86_64-linux`, `x86_64-darwin`, and `aarch64-darwin`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
