### PR TITLE
python3Packages.connexion: 2.7.0 -> 2.9.0

### DIFF
--- a/pkgs/development/python-modules/connexion/default.nix
+++ b/pkgs/development/python-modules/connexion/default.nix
@@ -7,6 +7,7 @@
 , clickclick
 , decorator
 , fetchFromGitHub
+, fetchpatch
 , flask
 , inflection
 , jsonschema
@@ -22,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "connexion";
-  version = "2.7.0";
+  version = "2.9.0";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "zalando";
     repo = pname;
     rev = version;
-    sha256 = "15iflq5403diwda6n6qrpq67wkdcvl3vs0gsg0fapxqnq3a2m7jj";
+    sha256 = "13smcg2w24zr2sv1968g9p9m6f18nqx688c96qdlmldnszgzf5ik";
   };
 
   propagatedBuildInputs = [
@@ -52,6 +53,15 @@ buildPythonPackage rec {
     pytest-aiohttp
     pytestCheckHook
     testfixtures
+  ];
+
+  patches = [
+    # No minor release for later versions, https://github.com/zalando/connexion/pull/1402
+    (fetchpatch {
+      name = "allow-later-flask-and-werkzeug-releases.patch";
+      url = "https://github.com/zalando/connexion/commit/4a225d554d915fca17829652b7cb8fe119e14b37.patch";
+      sha256 = "0dys6ymvicpqa3p8269m4yv6nfp58prq3fk1gcx1z61h9kv84g1k";
+    })
   ];
 
   pythonImportsCheck = [ "connexion" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.9.0

Change log: https://github.com/zalando/connexion/releases/tag/2.9.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
