### PR TITLE
gjs: 1.68.1 -> 1.68.2

### DIFF
--- a/pkgs/development/libraries/gjs/default.nix
+++ b/pkgs/development/libraries/gjs/default.nix
@@ -30,13 +30,13 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "gjs";
-  version = "1.68.1";
+  version = "1.68.2";
 
   outputs = [ "out" "dev" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0w2cbfpmc6alz7z8ycchhlkn586av5y8zk2xmgwzq10i0k13xyig";
+    sha256 = "sha256-cP8CraaC8TAzjsXMTFEQPcDlyrjVN+t2sYHsUSpl7jA=";
   };
 
   patches = [
@@ -126,6 +126,7 @@ in stdenv.mkDerivation rec {
 
     updateScript = gnome.updateScript {
       packageName = "gjs";
+      versionPolicy = "odd-unstable";
     };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://gitlab.gnome.org/GNOME/gjs/-/blob/1.68.2/NEWS
```
Version 1.68.2
--------------

- Crash and regression fixes backported from the development branch.

- Build fix to adjust to GLib renaming its main branch.

- Closed bugs and merge requests:

  * Fix crash in ByteArray.fromGBytes / ByteArray.fromString with 0-length input
    [!628, Philip Chimento]
  * subprojects: Use GLib main branch [!633, Philip Withnall]
  * Construct-only properties and GTK Builder. [#422, !635, Carlos Garnacho]
  * Data corruption when passing a 0-terminated array of GVariant [#269, !636,
    Evan Welsh]
  * Fix race condition in dynamic module resolution. [!641, Evan Welsh]
  * Ensure the correct realm is entered in the async executor [!644, Evan Welsh]
  * Assertion failure in toggle refs with debug mozjs [#416, !646, Evan Welsh]
```

This PR replaces #132924.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
