### PR TITLE
portmod: 2.0_beta9 -> 2.0.3

### DIFF
--- a/pkgs/games/portmod/default.nix
+++ b/pkgs/games/portmod/default.nix
@@ -1,22 +1,22 @@
 { lib, callPackage, python3Packages, fetchFromGitLab, cacert,
   rustPlatform, bubblewrap, git, perlPackages, imagemagick, fetchurl, fetchzip,
-  jre, makeWrapper, tr-patcher, tes3cmd }:
+  jre, makeWrapper, tr-patcher, tes3cmd, fetchpatch }:
 
 let
-  version = "2.0_beta9";
+  version = "2.0.3";
 
   src = fetchFromGitLab {
     owner = "portmod";
     repo = "Portmod";
     rev = "v${version}";
-    sha256 = "0a598rb0z6gsdyr4n0lc0yc583njjii07p6vxw75xsh7292vxksc";
+    sha256 = "sha256-vMdyaI1Ps7bFoRvwdVNVG9vPFEiGb7CPvKEWfxiM128=";
   };
 
   portmod-rust = rustPlatform.buildRustPackage rec {
     inherit src version;
     pname = "portmod-rust";
 
-    cargoHash = "sha256-7Ce+EIbZuOur7iGOUXNWiXReuZO54LQJu+sJPw1CJGg=";
+    cargoHash = "sha256-tAghZmlg34jHr8gtNgL3MQ8EI7K6/TfDcTbBjxdWLr0=";
 
     nativeBuildInputs = [ python3Packages.python ];
 
@@ -44,8 +44,17 @@ python3Packages.buildPythonApplication rec {
   prePatch = ''
     substituteInPlace setup.py \
       --replace "from setuptools_rust import Binding, RustExtension" "" \
-      --replace "RustExtension(\"portmod.portmod\", binding=Binding.PyO3, strip=True)" ""
+      --replace "RustExtension(\"portmodlib.portmod\", binding=Binding.PyO3, strip=True)" ""
   '';
+
+  patches = [
+    (fetchpatch {
+      # fix error when symlinks are present in the path (https://gitlab.com/portmod/portmod/-/merge_requests/393)
+      # happen with ~/.nix-profile
+      url = "https://gitlab.com/portmod/portmod/-/merge_requests/393.patch";
+      sha256 = "sha256-XHifwD/Nh7UiMZdvSNudVF7qpBOpjGTKSr4VVdJqUdA=";
+    })
+  ];
 
   propagatedBuildInputs = with python3Packages; [
     setuptools-scm
@@ -61,6 +70,7 @@ python3Packages.buildPythonApplication rec {
     redbaron
     patool
     packaging
+    fasteners
   ];
 
   checkInputs = with python3Packages; [
@@ -68,7 +78,7 @@ python3Packages.buildPythonApplication rec {
   ] ++ bin-programs;
 
   preCheck = ''
-    cp ${portmod-rust}/lib/libportmod.so portmod/portmod.so
+    cp ${portmod-rust}/lib/libportmod.so portmodlib/portmod.so
     export HOME=$(mktemp -d)
   '';
 
@@ -79,11 +89,14 @@ python3Packages.buildPythonApplication rec {
     "test_execute_network_permissions"
     "test_execute_permissions_bleed"
     "test_git"
+    "test_sync"
+    "test_manifest"
+    "test_add_repo"
   ];
 
   # for some reason, installPhase doesn't copy the compiled binary
   postInstall = ''
-    cp ${portmod-rust}/lib/libportmod.so $out/${python3Packages.python.sitePackages}/portmod/portmod.so
+    cp ${portmod-rust}/lib/libportmod.so $out/${python3Packages.python.sitePackages}/portmodlib/portmod.so
 
     makeWrapperArgs+=("--prefix" "GIT_SSL_CAINFO" ":" "${cacert}/etc/ssl/certs/ca-bundle.crt" \
       "--prefix" "PATH" ":" "${lib.makeBinPath bin-programs }")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
compilation failed (https://gitlab.com/portmod/portmod/-/issues/301) + just updating to latest stable version

###### Things done

Tested the installation and use of some mod

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Note

target staging due to a fix to "file" to fix "patool" test (and expected functionality), a depency of portmod