### PR TITLE
modemmanager: 1.16.8 -> 1.16.10

### DIFF
--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "modem-manager";
-  version = "1.16.8";
+  version = "1.16.10";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/ModemManager/ModemManager-${version}.tar.xz";
-    sha256 = "sha256-If36+UFxJhrZ2ZdxiU9a3kvDnvPR/x1CEFTRRxPpeIA=";
+    sha256 = "sha256-LM8fcWwtEh6OZwm8+K8p7oaXGpCtrMoujWKIswJ4hi4=";
   };
 
   nativeBuildInputs = [ vala gobject-introspection gettext pkg-config ];

--- a/pkgs/tools/networking/modemmanager/default.nix
+++ b/pkgs/tools/networking/modemmanager/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "modem-manager";
+  pname = "modemmanager";
   version = "1.16.10";
 
   src = fetchurl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7175,7 +7175,7 @@ with pkgs;
 
   mmixware = callPackage ../development/tools/mmixware { };
 
-  modemmanager = callPackage ../tools/networking/modem-manager {};
+  modemmanager = callPackage ../tools/networking/modemmanager {};
 
   modem-manager-gui = callPackage ../applications/networking/modem-manager-gui {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://lists.freedesktop.org/archives/modemmanager-devel/2021-August/008788.html
```
ModemManager 1.16.10
-------------------------------------------

  * QMI:
    ** Fixed use of uninitialized memory in the 3GPP registration logic when running NAS Set System Selection Preference.

  * MBIM:
    ** Remove trailing 'F' in ICCIDs.
    ** Increased the timeout of the first MBIM command after the port is opened, in order to leave time to the module to finish booting properly.

  * plugins:
    ** icera: fixed segfault during the connection reset logic.
    ** fibocom: add port type hints for the NL668-AM.
    ** fibocom: fix supporting QMI based devices.
    ** huawei: ignored ^LWURC URCs.
    ** huawei: fixed memory leak when processing GETPORTMODE hints.
    ** cinterion: increased ^SCFG? timeout to 120s.
    ** Updated all AT/QCDM/GPS port type hints in all plugins to bind them to TTY ports only.

  * Several other minor improvements and fixes.
```

Additionally fixes pname/directory to match the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
