### PR TITLE
fetchzip: add extension parameter

### DIFF
--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -13,10 +13,17 @@
 , urls ? []
 , extraPostFetch ? ""
 , name ? "source"
+, # Allows to set the extension for the intermediate downloaded
+  # file. This can be used as a hint for the unpackCmdHooks to select
+  # an appropriate unpacking tool.
+  extension ? null
 , ... } @ args:
 
 (fetchurl (let
-  basename = baseNameOf (if url != "" then url else builtins.head urls);
+  tmpFilename =
+    if extension != null
+    then "download.${extension}"
+    else baseNameOf (if url != "" then url else builtins.head urls);
 in {
   inherit name;
 
@@ -30,7 +37,7 @@ in {
       mkdir "$unpackDir"
       cd "$unpackDir"
 
-      renamed="$TMPDIR/${basename}"
+      renamed="$TMPDIR/${tmpFilename}"
       mv "$downloadedFile" "$renamed"
       unpackFile "$renamed"
     ''
@@ -56,7 +63,7 @@ in {
     + ''
       chmod 755 "$out"
     '';
-} // removeAttrs args [ "stripRoot" "extraPostFetch" ])).overrideAttrs (x: {
+} // removeAttrs args [ "stripRoot" "extraPostFetch" "extension" ])).overrideAttrs (x: {
   # Hackety-hack: we actually need unzip hooks, too
   nativeBuildInputs = x.nativeBuildInputs ++ [ unzip ];
 })


### PR DESCRIPTION
###### Motivation for this change

fetchzip downloads the file from specified URL, renames it to basename of that url, and then relies on unzip to do the unpacking.

The first consequence is that this requires URL to end with proper extension—otherwise it will fail to unpack. This is not always the
case and input-fonts workarounds this by adding “&.zip” query parameter (which is obviously a hack and is not guaranteed to work
with every URL).

The second consequence is that basename of the url must be a valid filename. I’ve tried to build a custom configuration of input-fonts and I get an error from mv that the filename is too long:

```
trying https://input.djr.com/build/?fontSelection=fourStyleFamily&regular=InputMonoNarrow-Regular&italic=InputMonoNarrow-Italic&bold=InputMonoNarrow-Bold&boldItalic=InputMonoNarrow-BoldItalic&a=0&g=0&i=topserif&l=serifs_round&zero=0&asterisk=height&braces=straight&preset=default&line-height=1.2&accept=I+do&email=&.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  406k  100  406k    0     0   230k      0  0:00:01  0:00:01 --:--:--  230k
mv: failed to access '/build/?fontSelection=fourStyleFamily&regular=InputMonoNarrow-Regular&italic=InputMonoNarrow-Italic&bold=InputMonoNarrow-Bold&boldItalic=InputMonoNarrow-BoldItalic&a=0&g=0&i=topserif&l=serifs_round&zero=0&asterisk=height&braces=straight&preset=default&line-height=1.2&accept=I+do&email=&.zip': File name too long
```

We could use “name” parameter as the filename (that’s how it is used in fetchurl). However, the previous attempt to do
so (fc01353703426458d6990239936659ed3130d294) was reverted (24b5eb61eb944036b5716788ead1b204fba08719) because of the introduced regression—many fetchzip invocations use names without extension (also the default name is just “source”).

This commit adds an optional “downloadName” parameter that allows renaming the temporary filename without tweaking the url. This way we can workaround the issues above without introducing a massive regression.

This is a no-op for all existing packages.

Tested by updating my NixOS setup + the extra inputs-fonts configuration mentioned above + tons of unstable emacs packages after a nix-collect-garbage (3Gb downloaded) with this patch applied.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Closes: #118662
