### PR TITLE
[21.05] firefox: introduce nspr_latest, update nss_latest

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -19,6 +19,7 @@
 
 ## backported libraries
 
+, nspr_latest
 , nss_latest
 , rust-cbindgen_latest
 
@@ -95,6 +96,7 @@ let
             then "/Applications/${binaryNameCapitalized}.app/Contents/MacOS"
             else "/bin";
 
+  nspr_pkg = if lib.versionAtLeast ffversion "91" then nspr_latest else nspr;
   rust-cbindgen_pkg = if lib.versionAtLeast ffversion "89" then rust-cbindgen_latest else rust-cbindgen;
 
   # 78 ESR won't build with rustc 1.47
@@ -185,7 +187,7 @@ buildStdenv.mkDerivation ({
     # yasm can potentially be removed in future versions
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1501796
     # https://groups.google.com/forum/#!msg/mozilla.dev.platform/o-8levmLU80/SM_zQvfzCQAJ
-    nspr nss_pkg
+    nspr_pkg nss_pkg
   ]
   ++ lib.optional  alsaSupport alsaLib
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
@@ -371,7 +373,7 @@ buildStdenv.mkDerivation ({
     version = ffversion;
     inherit alsaSupport;
     inherit pipewireSupport;
-    inherit nspr;
+    inherit nspr_pkg;
     inherit ffmpegSupport;
     inherit gssSupport;
     inherit execdir;

--- a/pkgs/development/libraries/nspr/latest.nix
+++ b/pkgs/development/libraries/nspr/latest.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, fetchurl
+, CoreServices ? null
+, buildPackages }:
+
+stdenv.mkDerivation rec {
+  pname = "nspr";
+  version = "4.32";
+
+  src = fetchurl {
+    url = "mirror://mozilla/nspr/releases/v${version}/src/nspr-${version}.tar.gz";
+    sha256 = "0v3zds1id71j5a5si42a658fjz8nv2f6zp6w4gqrqmdr6ksz8sxv";
+  };
+
+  patches = [
+    ./0001-Makefile-use-SOURCE_DATE_EPOCH-for-reproducibility.patch
+  ];
+
+  outputs = [ "out" "dev" ];
+  outputBin = "dev";
+
+  preConfigure = ''
+    cd nspr
+  '' + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace configure --replace '@executable_path/' "$out/lib/"
+    substituteInPlace configure.in --replace '@executable_path/' "$out/lib/"
+  '';
+
+  HOST_CC = "cc";
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  configureFlags = [
+    "--enable-optimize"
+    "--disable-debug"
+  ] ++ lib.optional stdenv.is64bit "--enable-64bit";
+
+  postInstall = ''
+    find $out -name "*.a" -delete
+    moveToOutput share "$dev" # just aclocal
+  '';
+
+  buildInputs = [] ++ lib.optionals stdenv.isDarwin [ CoreServices ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "http://www.mozilla.org/projects/nspr/";
+    description = "Netscape Portable Runtime, a platform-neutral API for system-level and libc-like functions";
+    platforms = platforms.all;
+    license = licenses.mpl20;
+  };
+}

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -18,7 +18,7 @@ let
   #       It will rebuild itself using the version of this package (NSS) and if
   #       an update is required do the required changes to the expression.
   #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
-  version = "3.67";
+  version = "3.68";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${pname}-${version}.tar.gz";
-    sha256 = "0zyfi27lbdz1bmk9dmsivcya4phx25rzlxqcnjab69yd928rlm7n";
+    sha256 = "sha256-xAKzLKyDA07Bw9gm70MGzRSgZtfZpvTDDYKzvAQ8cls=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17167,6 +17167,10 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  nspr_latest = callPackage ../development/libraries/nspr/latest.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
+
   nss = lowPrio (callPackage ../development/libraries/nss { });
   nssTools = nss.tools;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```
ERROR: Requested 'nspr >= 4.32' but version of NSPR is 4.30.0 
ERROR: Requested 'nss >= 3.68' but version of NSS is 3.67.0
```

Fixup #133305 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
