### PR TITLE
conda: invoke bash login shell to source /etc/profile

### DIFF
--- a/pkgs/tools/package-management/conda/default.nix
+++ b/pkgs/tools/package-management/conda/default.nix
@@ -66,6 +66,8 @@ in
       source ${installationPath}/etc/profile.d/conda.sh
     '';
 
+    runScript = "bash -l";
+
     meta = {
       description = "Conda is a package manager for Python";
       homepage = "https://conda.io/";


### PR DESCRIPTION
The `profile` parameter in `buildFHSUserEnv` is used to create an /etc/profile file
which should be sourced by bash. However, the default runScript is a non-login bash
which does not source /etc/profile. Therefore the conda package breaks, as a script
which is required for `conda activate`, is not sourced. Also the installationPath
parameter is ignored as it is setup in the /etc/profile file.

EDIT: after further discussion, this issue seems more fine-grained.
To use `conda activate` inside a `conda-shell` environment a specific script file has to be sourced. However, this script file primarily exports bash functions (and not environment variables), so after exec is called in the current `buildFHSUserEnv` these functions disappear. Therefore /etc/profile has to be explicitly sourced in the bash process which is going to be used by the user which only happens when it is a login shell.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
