### PR TITLE
SDL2_image: ensure image libraries are statically linked

### DIFF
--- a/pkgs/development/libraries/SDL2_image/default.nix
+++ b/pkgs/development/libraries/SDL2_image/default.nix
@@ -12,8 +12,18 @@ stdenv.mkDerivation rec {
   buildInputs = [ SDL2 libpng libjpeg libtiff giflib libwebp libXpm zlib ]
     ++ lib.optional stdenv.isDarwin Foundation;
 
-
-  configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
+  configureFlags = [
+    # Disable dynamically loaded dependencies
+    "--disable-jpg-shared"
+    "--disable-png-shared"
+    "--disable-tif-shared"
+    "--disable-webp-shared"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Darwin headless will hang when trying to run the SDL test program
+    "--disable-sdltest"
+    # Don't use native macOS frameworks
+    "--disable-imageio"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Disables dynamically loaded image libraries. This caused dependencies to not be found at runtime on macOS. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
