### PR TITLE
rnp: 0.15.1 -> 0.15.2

### DIFF
--- a/pkgs/tools/security/rnp/cmake_nogit.patch
+++ b/pkgs/tools/security/rnp/cmake_nogit.patch
@@ -1,0 +1,51 @@
+diff --git i/cmake/version.cmake w/cmake/version.cmake
+index 0ed123b5..4348e7e1 100644
+--- i/cmake/version.cmake
++++ w/cmake/version.cmake
+@@ -90,41 +90,12 @@ function(determine_version source_dir var_prefix)
+   else()
+     message(STATUS "Found no version.txt.")
+   endif()
+-  # for GIT_EXECUTABLE
+-  find_package(Git REQUIRED)
+-  # get a description of the version, something like:
+-  #   v1.9.1-0-g38ffe82        (a tagged release)
+-  #   v1.9.1-0-g38ffe82-dirty  (a tagged release with local modifications)
+-  #   v1.9.0-3-g5b92266        (post-release snapshot)
+-  #   v1.9.0-3-g5b92266-dirty  (post-release snapshot with local modifications)
+-  _git(version describe --abbrev=${GIT_REV_LEN} --match "v[0-9]*" --long --dirty)
+-  if (NOT _git_ec EQUAL 0)
+-    # no annotated tags, fake one
+-    message(STATUS "Found no annotated tags.")
+-    _git(revision rev-parse --short=${GIT_REV_LEN} --verify HEAD)
+-    if (_git_ec EQUAL 0)
+-      set(version "v${base_version}-0-g${revision}")
+-      # check if dirty (this won't detect untracked files, but should be ok)
+-      _git(changes diff-index --quiet HEAD --)
+-      if (NOT _git_ec EQUAL 0)
+-        string(APPEND version "-dirty")
+-      endif()
+-      # append the commit timestamp of the most recent commit (only
+-      # in non-release branches -- typically master)
+-      _git(commit_timestamp show -s --format=%ct)
+-      if (_git_ec EQUAL 0)
+-        string(APPEND version "+${commit_timestamp}")
+-      endif()
+-    elseif(has_version_txt)
+-      # Nothing to get from git - so use version.txt completely
+-      set(version "${version_file}")
+-    else()
+-      # Sad case - no git, no version.txt
+-      set(version "v${base_version}")
+-    endif()
++  if(has_version_txt)
++    # Nothing to get from git - so use version.txt completely
++    set(version "${version_file}")
+   else()
+-    set(has_release_tag YES)
+-    message(STATUS "Found annotated tag ${version}")
++    # Sad case - no git, no version.txt
++    set(version "v${base_version}")
+   endif()
+   extract_version_info("${version}" "${local_prefix}")
+   if ("${has_version_txt}" AND NOT ${base_version} STREQUAL ${local_prefix}_VERSION)

--- a/pkgs/tools/security/rnp/default.nix
+++ b/pkgs/tools/security/rnp/default.nix
@@ -15,14 +15,16 @@
 
 stdenv.mkDerivation rec {
   pname = "rnp";
-  version = "0.15.1";
+  version = "0.15.2";
 
   src = fetchFromGitHub {
     owner = "rnpgp";
     repo = "rnp";
     rev = "v${version}";
-    sha256 = "1l7y99rcss5w24lil6nqwr0dzh2jvq0qxmdvq7j5yx3fdssd5xsv";
+    sha256 = "1jph69nsz245fbv04nalh1qmhniyh88sacsf3nxv1vxm190314i9";
   };
+
+  patches = [ ./cmake_nogit.patch ];
 
   buildInputs = [ zlib bzip2 json_c botan2 ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

   - Version update

###### To inspect upstream changes

  -  [Release on GitHub](https://github.com/rnpgp/rnp/releases/tag/v0.15.2)

  -  [Compare changes on GitHub](https://github.com/rnpgp/rnp/compare/v0.15.1...v0.15.2)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
