### PR TITLE
xorg.xrdb: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3177,11 +3177,11 @@ lib.makeScope newScope (self: with self; {
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xrdb = callPackage ({ stdenv, pkg-config, fetchurl, libX11, libXmu, xorgproto }: stdenv.mkDerivation {
     pname = "xrdb";
-    version = "1.2.0";
+    version = "1.2.1";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/app/xrdb-1.2.0.tar.bz2";
-      sha256 = "0ik9gh6363c47pr0dp7q22nfs8vmavjg2v4bsr0604ppl77nafpj";
+      url = "mirror://xorg/individual/app/xrdb-1.2.1.tar.bz2";
+      sha256 = "1d78prd8sfszq2rwwlb32ksph4fymf988lp75aj8iysg44f06pag";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -62,7 +62,7 @@ mirror://xorg/individual/app/xmore-1.0.3.tar.bz2
 mirror://xorg/individual/app/xpr-1.0.5.tar.bz2
 mirror://xorg/individual/app/xprop-1.2.5.tar.bz2
 mirror://xorg/individual/app/xrandr-1.5.1.tar.xz
-mirror://xorg/individual/app/xrdb-1.2.0.tar.bz2
+mirror://xorg/individual/app/xrdb-1.2.1.tar.bz2
 mirror://xorg/individual/app/xrefresh-1.0.6.tar.bz2
 mirror://xorg/individual/app/xset-1.2.4.tar.bz2
 mirror://xorg/individual/app/xsetroot-1.1.2.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-August/003107.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).