### PR TITLE
zeroadPackages.zeroad-unwrapped: make it build on Hydra

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30025,9 +30025,9 @@ with pkgs;
 
   keen4 = callPackage ../games/keen4 { };
 
-  zeroadPackages = callPackage ../games/0ad {
+  zeroadPackages = recurseIntoAttrs (callPackage ../games/0ad {
     wxGTK = wxGTK31;
-  };
+  });
 
   zeroad = zeroadPackages.zeroad;
 


### PR DESCRIPTION
This time for real, I hope.  I'm sorry for my incomplete advice;
the explicit `dontRecurseIntoAttrs` confused me about what's the default
behavior in here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

_(nothing applies... no hashes change)_