### PR TITLE
nixos/tests: unbreak the tested job

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -127,6 +127,7 @@ in
   fcitx = handleTest ./fcitx {};
   ferm = handleTest ./ferm.nix {};
   firefox = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox; };
+  firefox-esr    = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox-esr; }; # used in `tested` job
   firefox-esr-78 = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox-esr-78; };
   firefox-esr-91 = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox-esr-91; };
   firejail = handleTest ./firejail.nix {};


### PR DESCRIPTION
I expect it suffices that the channel only blocks on one firefox ESR
test - the one for the default ESR.  I didn't want to have the
information about the default in two places, so either of the tests will
be evaluated twice (but to the same *.drv I hope).

###### Motivation for this change

Hydra evaluations are blocked!

###### Things done
_N/A... this doesn't change hashes._