### PR TITLE
tpm2-tss: fix support for abrmd

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -38,9 +38,7 @@ stdenv.mkDerivation rec {
     substituteInPlace src/tss2-tcti/tctildr-dl.c \
       --replace '@PREFIX@' $out/lib/
     substituteInPlace ./test/unit/tctildr-dl.c \
-      --replace ', "libtss2' ", \"$out/lib/libtss2" \
-      --replace ', "foo' ", \"$out/lib/foo" \
-      --replace ', TEST_TCTI_NAME' ", \"$out/lib/\"TEST_TCTI_NAME"
+      --replace '@PREFIX@' $out/lib
   '';
 
   configureFlags = [

--- a/pkgs/development/libraries/tpm2-tss/no-dynamic-loader-path.patch
+++ b/pkgs/development/libraries/tpm2-tss/no-dynamic-loader-path.patch
@@ -1,12 +1,16 @@
 diff --git a/src/tss2-tcti/tctildr-dl.c b/src/tss2-tcti/tctildr-dl.c
-index b364695c..b13be3ef 100644
+index b364695c..d026de71 100644
 --- a/src/tss2-tcti/tctildr-dl.c
 +++ b/src/tss2-tcti/tctildr-dl.c
-@@ -85,7 +85,15 @@ handle_from_name(const char *file,
-     if (handle == NULL) {
-         return TSS2_TCTI_RC_BAD_REFERENCE;
+@@ -116,6 +116,50 @@ handle_from_name(const char *file,
+         return TSS2_TCTI_RC_BAD_VALUE;
      }
--    *handle = dlopen(file, RTLD_NOW);
+     *handle = dlopen(file_xfrm, RTLD_NOW);
++    if (*handle != NULL) {
++        return TSS2_RC_SUCCESS;
++    } else {
++        LOG_DEBUG("Failed to load TCTI for name \"%s\": %s", file, dlerror());
++    }
 +    size = snprintf(file_xfrm,
 +                    sizeof (file_xfrm),
 +                    "@PREFIX@%s",
@@ -16,24 +20,206 @@ index b364695c..b13be3ef 100644
 +        return TSS2_TCTI_RC_BAD_VALUE;
 +    }
 +    *handle = dlopen(file_xfrm, RTLD_NOW);
-     if (*handle != NULL) {
-         return TSS2_RC_SUCCESS;
-     } else {
-@@ -94,7 +102,7 @@ handle_from_name(const char *file,
-     /* 'name' alone didn't work, try libtss2-tcti-<name>.so.0 */
-     size = snprintf(file_xfrm,
-                     sizeof (file_xfrm),
--                    TCTI_NAME_TEMPLATE_0,
++    if (*handle != NULL) {
++        return TSS2_RC_SUCCESS;
++    } else {
++        LOG_DEBUG("Could not load TCTI file: \"%s\": %s", file, dlerror());
++    }
++    /* 'name' alone didn't work, try libtss2-tcti-<name>.so.0 */
++    size = snprintf(file_xfrm,
++                    sizeof (file_xfrm),
 +                    "@PREFIX@" TCTI_NAME_TEMPLATE_0,
-                     file);
-     if (size >= sizeof (file_xfrm)) {
-         LOG_ERROR("TCTI name truncated in transform.");
-@@ -109,7 +117,7 @@ handle_from_name(const char *file,
-     /* libtss2-tcti-<name>.so.0 didn't work, try libtss2-tcti-<name>.so */
-     size = snprintf(file_xfrm,
-                     sizeof (file_xfrm),
--                    TCTI_NAME_TEMPLATE,
++                    file);
++    if (size >= sizeof (file_xfrm)) {
++        LOG_ERROR("TCTI name truncated in transform.");
++        return TSS2_TCTI_RC_BAD_VALUE;
++    }
++    *handle = dlopen(file_xfrm, RTLD_NOW);
++    if (*handle != NULL) {
++        return TSS2_RC_SUCCESS;
++    } else {
++        LOG_DEBUG("Could not load TCTI file \"%s\": %s", file, dlerror());
++    }
++    /* libtss2-tcti-<name>.so.0 didn't work, try libtss2-tcti-<name>.so */
++    size = snprintf(file_xfrm,
++                    sizeof (file_xfrm),
 +                    "@PREFIX@" TCTI_NAME_TEMPLATE,
-                     file);
-     if (size >= sizeof (file_xfrm)) {
-         LOG_ERROR("TCTI name truncated in transform.");
++                    file);
++    if (size >= sizeof (file_xfrm)) {
++        LOG_ERROR("TCTI name truncated in transform.");
++        return TSS2_TCTI_RC_BAD_VALUE;
++    }
++    *handle = dlopen(file_xfrm, RTLD_NOW);
+     if (*handle == NULL) {
+         LOG_DEBUG("Failed to load TCTI for name \"%s\": %s", file, dlerror());
+         return TSS2_TCTI_RC_NOT_SUPPORTED;
+diff --git a/test/unit/tctildr-dl.c b/test/unit/tctildr-dl.c
+index 873a4531..c17b939e 100644
+--- a/test/unit/tctildr-dl.c
++++ b/test/unit/tctildr-dl.c
+@@ -223,6 +223,18 @@ test_get_info_default_success (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-default.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, HANDLE);
+@@ -255,6 +267,18 @@ test_get_info_default_info_fail (void **state)
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
+ 
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-default.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, HANDLE);
+@@ -407,6 +431,15 @@ test_tcti_fail_all (void **state)
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-default.so.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-default.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-default.so.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+ 
+     /* Skip over libtss2-tcti-tabrmd.so */
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-tabrmd.so.0");
+@@ -418,6 +451,15 @@ test_tcti_fail_all (void **state)
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-tabrmd.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-tabrmd.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-tabrmd.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-tabrmd.so.0.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+ 
+     /* Skip over libtss2-tcti-device.so, /dev/tpmrm0 */
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-device.so.0");
+@@ -429,6 +471,15 @@ test_tcti_fail_all (void **state)
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-device.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-device.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-device.so.0.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+ 
+     /* Skip over libtss2-tcti-device.so, /dev/tpm0 */
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-device.so.0");
+@@ -440,6 +491,15 @@ test_tcti_fail_all (void **state)
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-device.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-device.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-device.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-device.so.0.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+ 
+     /* Skip over libtss2-tcti-swtpm.so */
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-swtpm.so.0");
+@@ -451,6 +511,15 @@ test_tcti_fail_all (void **state)
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-swtpm.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-swtpm.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-swtpm.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-swtpm.so.0.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+ 
+     /* Skip over libtss2-tcti-mssim.so */
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-mssim.so.0");
+@@ -462,6 +531,15 @@ test_tcti_fail_all (void **state)
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-libtss2-tcti-mssim.so.0.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-mssim.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-mssim.so.0.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-libtss2-tcti-mssim.so.0.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+ 
+     TSS2_RC r;
+     TSS2_TCTI_CONTEXT *tcti;
+@@ -490,6 +568,15 @@ test_info_from_name_handle_fail (void **state)
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-foo.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/foo");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-foo.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-foo.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+ 
+     TSS2_RC rc = info_from_name ("foo", &info, &data);
+     assert_int_equal (rc, TSS2_TCTI_RC_NOT_SUPPORTED);
+@@ -606,6 +693,15 @@ test_tctildr_get_info_from_name (void **state)
+     expect_string(__wrap_dlopen, filename, "libtss2-tcti-foo.so");
+     expect_value(__wrap_dlopen, flags, RTLD_NOW);
+     will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/foo");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-foo.so.0");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
++    expect_string(__wrap_dlopen, filename, "@PREFIX@/libtss2-tcti-foo.so");
++    expect_value(__wrap_dlopen, flags, RTLD_NOW);
++    will_return(__wrap_dlopen, NULL);
+ 
+     TSS2_RC rc = tctildr_get_info ("foo", &info, &data);
+     assert_int_equal (rc, TSS2_TCTI_RC_NOT_SUPPORTED);


### PR DESCRIPTION
###### Motivation for this change

When introduced in #114080, the full path dlopen lookup patch introduced
a regression which made it impossible to load tabrmd modules

see https://github.com/NixOS/nixpkgs/issues/133248
    https://github.com/NixOS/nixpkgs/pull/114080

Fixes #133248

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
