### PR TITLE
pymupdf: fix version incorrect cause build error

### DIFF
--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , mupdf
 , swig
 , freetype
@@ -26,10 +25,7 @@ buildPythonPackage rec {
   patches = [
     # Add NIX environment support.
     # Should be removed next pyMuPDF release.
-    (fetchpatch {
-      url = "https://github.com/pymupdf/PyMuPDF/commit/d9b2d42019e5705a1c6621ea0cdfa26da1ce9ad5.patch";
-      sha256 = "fc3f6ad88c8f3933ed9ab9d4db9ebec8bc30ed5113f6ca9d72080b56dfa52ad6";
-    })
+    ./nix-support.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/pymupdf/nix-support.patch
+++ b/pkgs/development/python-modules/pymupdf/nix-support.patch
@@ -1,0 +1,17 @@
+--- a/setup.py
++++ b/setup.py
+@@ -36,10 +36,14 @@ LIBRARIES = {
+     "opensuse": OPENSUSE,
+     "fedora": FEDORA,
+     "alpine": ALPINE,
++    "nix": FEDORA,
+ }
+ 
+ 
+ def load_libraries():
++    if os.getenv("NIX_STORE"):
++        return LIBRARIES["nix"]
++
+     try:
+         import distro
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@SuperSandro2000 I resubmit to fix build error.

https://github.com/NixOS/nixpkgs/pull/133211#issuecomment-896117126