### PR TITLE
lib/options: Better mergeEqualOption error for uncomparable types

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -11,6 +11,7 @@ let
     filter
     foldl'
     head
+    tail
     isAttrs
     isBool
     isDerivation
@@ -144,7 +145,7 @@ rec {
       if def.value != first.value then
         throw "The option `${showOption loc}' has conflicting definition values:${showDefs [ first def ]}"
       else
-        first) (head defs) defs).value;
+        first) (head defs) (tail defs)).value;
 
   /* Extracts values of all "value" keys of the given list.
 


### PR DESCRIPTION
###### Motivation for this change

For an option definition that uses `lib.options.mergeEqualOption`
underneath, like `types.anything`, an error is thrown when multiple
functions are assigned, indicating that functions can't be compared for
equivalence:

    error: The option `test' has conflicting definition values:
    - In `xxx': <function>
    - In `xxx': <function>
    (use '--show-trace' to show detailed location information)

However, the error message didn't use the correct files. While above
error indicates that both definitions are in the xxx file, that's in
fact not true. Above error was generated with

    options.test = lib.mkOption {
      type = lib.types.anything;
    };


    imports = [
      {
        _file = "yyy";
        test = y: y;
      }
      {
        _file = "xxx";
        test = x: x;
      }
    ];

With this change, the error uses the correct file locations:

    error: The option `test' has conflicting definition values:
    - In `xxx': <function>
    - In `yyy': <function>
    (use '--show-trace' to show detailed location information)

Ping @roberth 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
