### PR TITLE
[Backport release-21.05] betterlockscreen 3.2.0 -> 4.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9051,6 +9051,12 @@
     githubId = 1567527;
     name = "Sebastian Hyberts";
   };
+  sebtm = {
+    email = "mail@sebastian-sellmeier.de";
+    github = "sebtm";
+    githubId = 17243347;
+    name = "Sebastian Sellmeier";
+  };
   sellout = {
     email = "greg@technomadic.org";
     github = "sellout";

--- a/pkgs/misc/screensavers/betterlockscreen/default.nix
+++ b/pkgs/misc/screensavers/betterlockscreen/default.nix
@@ -1,17 +1,31 @@
-{
-  lib, stdenv, makeWrapper, fetchFromGitHub,
-  imagemagick, i3lock-color, xdpyinfo, xrandr, bc, feh, procps, xrdb
+{ fetchFromGitHub
+, lib
+, makeWrapper
+, stdenv
+
+# Dependencies (@see https://github.com/pavanjadhaw/betterlockscreen/blob/master/shell.nix)
+, bc
+, coreutils
+, i3lock-color
+, gawk
+, gnugrep
+, gnused
+, imagemagick
+, procps
+, xdpyinfo
+, xrandr
+, xset
 }:
 
 stdenv.mkDerivation rec {
   pname = "betterlockscreen";
-  version = "3.1.0";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "pavanjadhaw";
     repo = "betterlockscreen";
-    rev = version;
-    sha256 = "14vkgdzw7mprjsvmhm3aav8gds73ngn2xxij4syq7l1mhk701wak";
+    rev = "v${version}";
+    sha256 = "1ha1yddrcmbsdljdg3gn7i42csbw8h3zgf4i3mcsmbz8nsvc2wdc";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -20,18 +34,22 @@ stdenv.mkDerivation rec {
     let
       PATH =
         lib.makeBinPath
-        [imagemagick i3lock-color xdpyinfo xrandr bc feh procps xrdb];
+        [ bc coreutils i3lock-color gawk gnugrep gnused imagemagick procps xdpyinfo xrandr xset ];
     in ''
+      runHook preInstall
+
       mkdir -p $out/bin
       cp betterlockscreen $out/bin/betterlockscreen
       wrapProgram "$out/bin/betterlockscreen" --prefix PATH : "$out/bin:${PATH}"
+
+      runHook postInstall
     '';
 
   meta = with lib; {
-    description = "A simple minimal lock screen which allows you to cache images with different filters and lockscreen with blazing speed";
+    description = "Fast and sweet looking lockscreen for linux systems with effects!";
     homepage = "https://github.com/pavanjadhaw/betterlockscreen";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ eyjhb ];
+    maintainers = with maintainers; [ eyjhb sebtm ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24298,7 +24298,7 @@ in
   i3lock-pixeled = callPackage ../misc/screensavers/i3lock-pixeled { };
 
   betterlockscreen = callPackage ../misc/screensavers/betterlockscreen {
-    inherit (xorg) xrdb;
+    inherit (xorg) xdpyinfo xrandr xset;
   };
 
   multilockscreen = callPackage ../misc/screensavers/multilockscreen { };


### PR DESCRIPTION
(cherry picked from commit 2f59b54e3f1318c4e0a6079baebf621b9b402880)
**Please note changes from 3.2 to 4.0 are breaking, depending on how/how intense Betterlockscreen is used. But as there are multiple fundamental bugs in v3.2 we are not able to provide fixes for this.** 

###### Motivation for this change
Backport new major release after taking-over maintenance for the project

###### Things done
Adjusted derivation and included all dependencies

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
