### PR TITLE
ossutil: init at 1.7.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5280,6 +5280,12 @@
     githubId = 20675;
     name = "Joël Perras";
   };
+  jpetrucciani = {
+    email = "j@cobi.dev";
+    github = "jpetrucciani";
+    githubId = 8117202;
+    name = "Jacobi Petrucciani";
+  };
   jpierre03 = {
     email = "nix@prunetwork.fr";
     github = "jpierre03";

--- a/pkgs/tools/admin/ossutil/default.nix
+++ b/pkgs/tools/admin/ossutil/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildGoModule, fetchFromGitHub, fetchpatch }:
+
+buildGoModule rec {
+  version = "1.7.6";
+  pname = "ossutil";
+
+  src = fetchFromGitHub {
+    owner = "aliyun";
+    repo = "ossutil";
+    rev = version;
+    sha256 = "1hkdk0hidnm7vz320i7s4z7jngx2j70acc93agii2b3r2bb91l3d";
+  };
+
+  # this patch is required to add go mods to fetch dependencies
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/aliyun/ossutil/commit/64067e979fb24ffb198a0c4eca718e81b63f514e.patch";
+      sha256 = "2pn0BcbNNL+iMema54LRpG/ca5kyDugLIZQ/TMhYG/8=";
+    })
+  ];
+
+  vendorSha256 = "lem9Jg4Ywv3qcIwhiZHNi1VH5HxxNr6mnefOLCzPL70=";
+
+  # don't run tests as they require secret access keys that only travis has
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/aliyun/ossutil";
+    description = "A user friendly command line tool to access Alibaba Cloud OSS";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3186,6 +3186,8 @@ with pkgs;
 
   odafileconverter = libsForQt5.callPackage ../applications/graphics/odafileconverter {};
 
+  ossutil = callPackage ../tools/admin/ossutil {};
+
   pastel = callPackage ../applications/misc/pastel {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I'd like to be able to use the [`ossutil`](https://github.com/aliyun/ossutil/) cli tool for Alibaba Cloud's [Object Storage Service](https://www.alibabacloud.com/product/oss) (OSS) through nix!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
