### PR TITLE
obs-studio, libcef: support aarch64

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -1,4 +1,6 @@
-{ config, lib, stdenv
+{ config
+, lib
+, stdenv
 , mkDerivation
 , fetchFromGitHub
 , addOpenGLRunpath
@@ -41,7 +43,8 @@
 let
   inherit (lib) optional optionals;
 
-in mkDerivation rec {
+in
+mkDerivation rec {
   pname = "obs-studio";
   version = "27.0.0";
 
@@ -61,7 +64,13 @@ in mkDerivation rec {
     ./Change-product_version-to-user_agent_product.patch
   ];
 
-  nativeBuildInputs = [ addOpenGLRunpath cmake pkg-config ];
+  nativeBuildInputs = [
+    addOpenGLRunpath
+    cmake
+    pkg-config
+    makeWrapper
+  ]
+  ++ optional scriptingSupport swig;
 
   buildInputs = [
     curl
@@ -81,10 +90,9 @@ in mkDerivation rec {
     wayland
     x264
     libvlc
-    makeWrapper
     mbedtls
   ]
-  ++ optionals scriptingSupport [ luajit swig python3 ]
+  ++ optionals scriptingSupport [ luajit python3 ]
   ++ optional alsaSupport alsa-lib
   ++ optional pulseaudioSupport libpulseaudio
   ++ optional pipewireSupport pipewire;
@@ -132,7 +140,7 @@ in mkDerivation rec {
     '';
     homepage = "https://obsproject.com";
     maintainers = with maintainers; [ jb55 MP2E V ];
-    license = licenses.gpl2;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -61,6 +61,11 @@ let
       projectArch = "arm64";
       sha256 = "1j93qawh9h6k2ic70i10npppv5f9dch961lc1wxwsi68daq8r081";
     };
+    "i686-linux" = {
+      platformStr = "linux32";
+      projectArch = "x86";
+      sha256 = "0ki4zr8ih06kirgbpxbinv4baw3qvacx208q6qy1cvpfh6ll4fwb";
+    };
     "x86_64-linux" = {
       platformStr = "linux64";
       projectArch = "x86_64";
@@ -102,6 +107,6 @@ stdenv.mkDerivation rec {
     homepage = "https://cef-builds.spotifycdn.com/index.html";
     maintainers = with maintainers; [ puffnfresh ];
     license = licenses.bsd3;
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, fetchurl, cmake
+{ lib
+, stdenv
+, fetchurl
+, cmake
 , glib
 , nss
 , nspr
@@ -52,18 +55,34 @@ let
     cups
     libxshmfence
   ];
-in stdenv.mkDerivation rec {
+  platforms = {
+    "aarch64-linux" = {
+      platformStr = "linuxarm64";
+      projectArch = "arm64";
+      sha256 = "1j93qawh9h6k2ic70i10npppv5f9dch961lc1wxwsi68daq8r081";
+    };
+    "x86_64-linux" = {
+      platformStr = "linux64";
+      projectArch = "x86_64";
+      sha256 = "1ja711x9fdlf21qw1k9xn3lvjc5zsfgnjga1w1r8sysam73jk7xj";
+    };
+  };
+
+  platformInfo = builtins.getAttr stdenv.targetPlatform.system platforms;
+in
+stdenv.mkDerivation rec {
   pname = "cef-binary";
   version = "90.6.7";
   gitRevision = "19ba721";
   chromiumVersion = "90.0.4430.212";
 
   src = fetchurl {
-    url = "https://cef-builds.spotifycdn.com/cef_binary_${version}+g${gitRevision}+chromium-${chromiumVersion}_linux64_minimal.tar.bz2";
-    sha256 = "1ja711x9fdlf21qw1k9xn3lvjc5zsfgnjga1w1r8sysam73jk7xj";
+    url = "https://cef-builds.spotifycdn.com/cef_binary_${version}+g${gitRevision}+chromium-${chromiumVersion}_${platformInfo.platformStr}_minimal.tar.bz2";
+    inherit (platformInfo) sha256;
   };
 
   nativeBuildInputs = [ cmake ];
+  cmakeFlags = "-DPROJECT_ARCH=${platformInfo.projectArch}";
   makeFlags = [ "libcef_dll_wrapper" ];
   dontStrip = true;
   dontPatchELF = true;
@@ -83,6 +102,6 @@ in stdenv.mkDerivation rec {
     homepage = "https://cef-builds.spotifycdn.com/index.html";
     maintainers = with maintainers; [ puffnfresh ];
     license = licenses.bsd3;
-    platforms = with platforms; linux;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
~~All functionality is supported except for the OBS browser, which does not work due to our libcef being broken on aarch64. I don't think this is inherent, Chromium definitely works on aarch64, it's probably a packaging/other thing. Regardless that's outside the scope of my work here.~~

~~I also marked libcef x86_64-linux only because it seems to be doing x86 specific stuff.
This is probably a bug in that package.~~

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) thanks @Hoverbear for testing
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
