### PR TITLE
python3Packages.geomet: 0.2.1 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -35,6 +35,10 @@ buildPythonPackage rec {
     sha256 = "1dn7iiavsrhh6i9hcyw0mk8j95r5ym0gbrvdca998hx2rnz5ark6";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py --replace 'geomet>=0.1,<0.3' 'geomet'
+  '';
+
   nativeBuildInputs = [ cython ];
   buildInputs = [ libev ];
   propagatedBuildInputs = [ six geomet ]
@@ -80,6 +84,8 @@ buildPythonPackage rec {
     "_PoolTests"
     # attempts to make connection to localhost
     "test_connection_initialization"
+    # time-sensitive
+    "test_nts_token_performance"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/geomet/default.nix
+++ b/pkgs/development/python-modules/geomet/default.nix
@@ -1,30 +1,21 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , click
 , six
 }:
 
 buildPythonPackage rec {
   pname = "geomet";
-  version = "0.2.1";
+  version = "0.3.0";
 
   # pypi tarball doesn't include tests
   src = fetchFromGitHub {
     owner = "geomet";
     repo = "geomet";
     rev = version;
-    sha256 = "0fdi26glsmrsyqk86rnsfcqw79svn2b0ikdv89pq98ihrpwhn85y";
+    sha256 = "1lb0df78gkivsb7hy3ix0xccvcznvskip11hr5sgq5y76qnfc8p0";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "python-3.8-support.patch";
-      url = "https://github.com/geomet/geomet/commit/dc4cb4a856d3ad814b57b4b7487d86d9e0f0fad4.patch";
-      sha256 = "1f1cdfqyp3z01jdjvax77219l3gc75glywqrisqpd2k0m0g7fwh3";
-    })
-  ];
 
   propagatedBuildInputs = [ click six ];
 


### PR DESCRIPTION
###### Motivation for this change
Routine bump. Had to relax `cassandra-driver`'s version constraints to get it to work though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
