### PR TITLE
ioquake3: 2020-12-26 -> 2021-07-20

### DIFF
--- a/pkgs/games/quake3/ioquake/default.nix
+++ b/pkgs/games/quake3/ioquake/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation {
   pname = "ioquake3-git";
-  version = "2020-12-26";
+  version = "2021-07-20";
 
   src = fetchFromGitHub {
     owner = "ioquake";
     repo = "ioq3";
-    rev = "05180e32dcfb9a4552e1b9652b56127248a9950c";
-    sha256 = "0hcxxa1ambpdwhg7nb5hvb32g49rl5p9dcflpzcv5cax9drn166i";
+    rev = "bc8737d707595aebd7cc11d6d5a5d65ede750f59";
+    sha256 = "1icrkaw6c5c5ndy886bn65lycwnxzxwvz0ndz4p9i6r716k11add";
   };
 
   nativeBuildInputs = [ which pkg-config ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option Symbol’s value as variable is void: sandbox in [Symbol’s value as variable is void: nix\.conf](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using Symbol’s value as variable is void: nix-shell
- [x] Tested execution of all binary files (usually in Symbol’s value as variable is void: \./result/bin/)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).