### PR TITLE
neovide: Fix and update

### DIFF
--- a/pkgs/applications/editors/neovim/neovide/default.nix
+++ b/pkgs/applications/editors/neovim/neovide/default.nix
@@ -22,16 +22,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "neovide";
-  version = "unstable-2021-06-21";
+  version = "unstable-2021-08-08";
 
   src = fetchFromGitHub {
     owner = "Kethku";
     repo = "neovide";
-    rev = "4159c47ff4f30073b92b9d63fc6ab70e07b74b6d";
-    sha256 = "sha256-XwirJGXMGxc/NkpSeHBUc16ppvJ+H4ECnrOVu030Qfg=";
+    rev = "725f12cafd4a26babd0d6bbcbca9a99c181991ac";
+    sha256 = "sha256-ThMobWKe3wHhR15TmmKrI6Gp1wvGVfJ52MzibK0ubkc=";
   };
 
-  cargoSha256 = "sha256-WCk9kt81DtBwpEEdKH9gKQSVxAvH+vkyP2y24tU+vzY=";
+  cargoSha256 = "sha256-5lOGncnyA8DwetY5bU6k2KXNClFgp+xIBEeA0/iwGF0=";
 
   SKIA_SOURCE_DIR =
     let
@@ -39,8 +39,8 @@ rustPlatform.buildRustPackage rec {
         owner = "rust-skia";
         repo = "skia";
         # see rust-skia:skia-bindings/Cargo.toml#package.metadata skia
-        rev = "m90-0.38.3";
-        sha256 = "sha256-l8c4vfO1PELAT8bDyr/yQGZetZsaufAlJ6bBOXz7E1w=";
+        rev = "m91-0.39.4";
+        sha256 = "sha256-ovlR1vEZaQqawwth/UYVUSjFu+kTsywRpRClBaE1CEA=";
       };
       # The externals for skia are taken from skia/DEPS
       externals = lib.mapAttrs (n: v: fetchgit v) (lib.importJSON ./skia-externals.json);

--- a/pkgs/applications/editors/neovim/neovide/default.nix
+++ b/pkgs/applications/editors/neovim/neovide/default.nix
@@ -3,6 +3,7 @@
 , lib
 , fetchFromGitHub
 , fetchgit
+, fetchurl
 , makeWrapper
 , pkg-config
 , python2
@@ -10,6 +11,7 @@
 , openssl
 , SDL2
 , fontconfig
+, freetype
 , ninja
 , gn
 , llvmPackages
@@ -82,7 +84,18 @@ rustPlatform.buildRustPackage rec {
     expat
     openssl
     SDL2
-    fontconfig
+    (fontconfig.overrideAttrs (old: {
+      propagatedBuildInputs = [
+        # skia is not compatible with freetype 2.11.0
+        (freetype.overrideAttrs (old: rec {
+          version = "2.10.4";
+          src = fetchurl {
+            url = "mirror://savannah/${old.pname}/${old.pname}-${version}.tar.xz";
+            sha256 = "112pyy215chg7f7fmp2l9374chhhpihbh8wgpj5nj6avj3c59a46";
+          };
+        }))
+      ];
+    }))
   ];
 
   postFixup = ''

--- a/pkgs/applications/editors/neovim/neovide/default.nix
+++ b/pkgs/applications/editors/neovim/neovide/default.nix
@@ -7,7 +7,6 @@
 , makeWrapper
 , pkg-config
 , python2
-, expat
 , openssl
 , SDL2
 , fontconfig
@@ -81,7 +80,6 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   buildInputs = [
-    expat
     openssl
     SDL2
     (fontconfig.overrideAttrs (old: {


### PR DESCRIPTION
###### Motivation for this change

- Fix #133409 by backporting freetype
- Remove expat
- 2021-06-21 -> 2021-08-08

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
