### PR TITLE
Fix packages using sv-parser which Rust 1.53 breaks

### DIFF
--- a/pkgs/development/tools/misc/svls/default.nix
+++ b/pkgs/development/tools/misc/svls/default.nix
@@ -5,16 +5,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "svls";
-  version = "0.1.27";
+  version = "0.1.28";
 
   src = fetchFromGitHub {
     owner = "dalance";
     repo = "svls";
     rev = "v${version}";
-    sha256 = "sha256-+/4D0pRZs1Gy6DJnsDZA8wWi1FKhr7gRS0oq1TyWpuE=";
+    sha256 = "0k3njqdhcbgj6l1rwyk6crylpwzgg70fsh5yfgp4p2zvynw4hrx2";
   };
 
-  cargoSha256 = "sha256-xkRlUXlkXQwvzIuhExf+tSSBi+8BZv58btvln05UI+k=";
+  cargoSha256 = "0aj5d0ca70ggiarjkrj4z34zbdpwlhbsssqf3l9ypblqhfvq2wvl";
 
   meta = with lib; {
     description = "SystemVerilog language server";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14334,7 +14334,11 @@ in
     rustPlatform = rustPackages_1_45.rustPlatform;
   };
 
-  svls = callPackage ../development/tools/misc/svls { };
+  svls = callPackage ../development/tools/misc/svls {
+    # Version 0.1.28 has a dependency on lexical_core 0.7.4 that will not build with Rust 1.53.
+    # To be fixed in the next release.
+    rustPlatform = rustPackages_1_45.rustPlatform;
+  };
 
   swarm = callPackage ../development/tools/analysis/swarm { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14328,7 +14328,11 @@ in
 
   summon = callPackage ../development/tools/summon { };
 
-  svlint = callPackage ../development/tools/analysis/svlint { };
+  svlint = callPackage ../development/tools/analysis/svlint {
+    # Version 0.4.18 has a dependency on lexical_core 0.7.4 that will not build with Rust 1.53.
+    # To be fixed in the next release.
+    rustPlatform = rustPackages_1_45.rustPlatform;
+  };
 
   svls = callPackage ../development/tools/misc/svls { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The [`sv_parser`](https://github.com/dalance/sv-parser) Rust library has an underlying dependency on `lexical_core` 0.7.4 which will not compile under Rust 1.53 which was recently merged into master. This affects two of the packages I maintain, `svlint` and `svls`, and this commit reverts those packages to use Rust 1.45 following the model of https://github.com/NixOS/nixpkgs/pull/129852 which faced similar compatibility issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
