### PR TITLE
rtl8814au: switch to actively-maintained aircrack driver

### DIFF
--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 
-stdenv.mkDerivation {
-  pname = "rtl8814au";
-  version = "${kernel.version}-unstable-2021-05-18";
+stdenv.mkDerivation rec {
+  name = "rtl8814au-${kernel.version}-${version}";
+  version = "5.8.51";
 
   src = fetchFromGitHub {
-    owner = "morrownr";
-    repo = "8814au";
-    rev = "388786c864f9b1437fc4d934b1eccf6d7f1e1355";
-    sha256 = "sha256-2EnheODPFWTGN/fz45LWRSOGeV6pTENEUrehahj+PJ4=";
+    owner = "aircrack-ng";
+    repo = "rtl8814au";
+    rev = "bdf80b5a932d5267cd1aff66fee8ac244cd38777";
+    sha256 = "07m1wg2xbi60x1l1qcn7xbb7m2lfa9af61q2llqryx30m9rk2idk";
   };
 
   buildInputs = kernel.moduleBuildDependencies;
@@ -31,8 +31,9 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Realtek 8814AU USB WiFi driver";
-    homepage = "https://github.com/morrownr/8814au";
+    homepage = "https://github.com/aircrack-ng/rtl8814au";
     license = licenses.gpl2Only;
-    maintainers = [ maintainers.lassulus ];
+    maintainers = [ maintainers.lassulus maintainers.chaduffy ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The previously-used rtl8814au driver is unmaintained; its former maintainer suggests using the aircrack driver instead.

This PR switches to the aforementioned aircrack driver.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
