### PR TITLE
python3Packages.websocket-client: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/websocket-client/default.nix
+++ b/pkgs/development/python-modules/websocket-client/default.nix
@@ -3,28 +3,34 @@
 , fetchPypi
 , pythonOlder
 , pytestCheckHook
-, pysocks
+, python-socks
 }:
 
 buildPythonPackage rec {
   pname = "websocket-client";
-  version = "1.1.0";
+  version = "1.2.0";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-to5JWdcEdo+iDjXJ1QjI3Cu8BB/Y0mfA1zRc/+KCRWg=";
+    sha256 = "sha256-dmW6bGRZibKLYWcIdKt1PmkpF56fyQVlrOasCQ9ZxVk=";
   };
 
-  checkInputs = [ pytestCheckHook pysocks ];
+  propagatedBuildInputs = [
+    python-socks
+   ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "websocket" ];
 
   meta = with lib; {
     description = "Websocket client for Python";
     homepage = "https://github.com/websocket-client/websocket-client";
+    changelog = "https://github.com/websocket-client/websocket-client/blob/v${version}/ChangeLog";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ fab ];
-    changelog = "https://github.com/websocket-client/websocket-client/blob/v${version}/ChangeLog";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.2.0

Change log: https://github.com/websocket-client/websocket-client/blob/v1.2.0/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
