### PR TITLE
sparse: add perl to buildInputs

### DIFF
--- a/pkgs/development/tools/analysis/sparse/default.nix
+++ b/pkgs/development/tools/analysis/sparse/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, lib, stdenv, pkg-config, libxml2, llvm }:
+{ fetchurl, lib, stdenv, pkg-config, libxml2, llvm, perl }:
 
 stdenv.mkDerivation rec {
   pname = "sparse";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libxml2 llvm ];
+  buildInputs = [ libxml2 llvm perl ];
   doCheck = true;
 
   meta = {


### PR DESCRIPTION
cgcc command has shebang of /usr/bin/perl, which obviously does not
work for nixos, adding perl to buildInputs seems to make all the magic
happen, as per usual.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cgcc failed with 
```
bash: /nix/store/rg1cza9j0i7cqf9q9b9j94kvkd7sfrvg-sparse-0.5.0/bin/cgcc: /usr/bin/perl: bad interpreter: No such file or directory
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
