### PR TITLE
mingw: Disalbe FORTIFY_SOURCE by default.

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -472,7 +472,7 @@ stdenv.mkDerivation {
     + optionalString hostPlatform.isCygwin ''
       hardening_unsupported_flags+=" pic"
     '' + optionalString targetPlatform.isMinGW ''
-      hardening_unsupported_flags+=" stackprotector"
+      hardening_unsupported_flags+=" stackprotector fortify"
     '' + optionalString targetPlatform.isAvr ''
       hardening_unsupported_flags+=" stackprotector pic"
     '' + optionalString (targetPlatform.libc == "newlib") ''

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "libsodium";
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" ];
+
+  patches = lib.optional stdenv.targetPlatform.isMinGW ./mingw-no-fortify.patch;
+
+  nativeBuildInputs = lib.optional stdenv.targetPlatform.isMinGW autoreconfHook;
+
   separateDebugInfo = stdenv.isLinux && stdenv.hostPlatform.libc != "musl";
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libsodium/mingw-no-fortify.patch
+++ b/pkgs/development/libraries/libsodium/mingw-no-fortify.patch
@@ -1,0 +1,15 @@
+diff -Naur libsodium-1.0.18-orig/configure.ac libsodium-1.0.18/configure.ac
+--- libsodium-1.0.18-orig/configure.ac	2019-05-30 16:20:24.000000000 -0400
++++ libsodium-1.0.18/configure.ac	2021-08-11 08:09:54.653907245 -0400
+@@ -217,11 +217,6 @@
+ 
+ AC_CHECK_DEFINE([__wasi__], [WASI="yes"], [])
+ 
+-AC_CHECK_DEFINE([_FORTIFY_SOURCE], [], [
+-  AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=2],
+-    [CPPFLAGS="$CPPFLAGS -D_FORTIFY_SOURCE=2"])
+-])
+-
+ AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],
+   [CFLAGS="$CFLAGS -fvisibility=hidden"])
+ 


### PR DESCRIPTION
In newer versions of mingw, programs compiled with FORTIFY_SOURCE need
to link to libssp or they will have link-time errors.

gmp has been broken since @pstn updated mingw-64 in c60a0b044747037b87e7ec24b60d221e261b8a6b


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
