### PR TITLE
portmidi: 217 -> 234

### DIFF
--- a/pkgs/development/libraries/portmidi/default.nix
+++ b/pkgs/development/libraries/portmidi/default.nix
@@ -2,12 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "portmidi";
-  version = "217";
+  version = "234";
 
   src = fetchurl {
-    url = "mirror://sourceforge/portmedia/portmidi-src-${version}.zip";
-    sha256 = "03rfsk7z6rdahq2ihy5k13qjzgx757f75yqka88v3gc0pn9ais88";
+    url = "mirror://sourceforge/portmedia/portmedia-code-r${version}.zip";
+    sha256 = "1g7i8hgarihycadbgy2f7lifiy5cbc0mcrcazmwnmbbh1bqx6dyp";
   };
+
+  prePatch = ''
+    cd portmidi/trunk
+  '';
 
   cmakeFlags = let
     #base = "${jdk}/jre/lib/${jdk.architecture}";

--- a/pkgs/development/libraries/portmidi/remove-darwin-variables.diff
+++ b/pkgs/development/libraries/portmidi/remove-darwin-variables.diff
@@ -12,17 +12,17 @@ index 4919b78..758eccb 100644
  
  if(UNIX)
 diff --git a/pm_common/CMakeLists.txt b/pm_common/CMakeLists.txt
-index e171047..aafa09c 100644
+index cbeeade..f765430 100644
 --- a/pm_common/CMakeLists.txt
 +++ b/pm_common/CMakeLists.txt
 @@ -22,7 +22,7 @@ else(APPLE OR WIN32)
  endif(APPLE OR WIN32)
  
  if(APPLE)
--  set(CMAKE_OSX_SYSROOT /Developer/SDKs/MacOSX10.5.sdk CACHE 
+-  set(CMAKE_OSX_SYSROOT /Developer/SDKs/MacOSX10.6.sdk CACHE 
 +  set(CMAKE_OSX_SYSROOT / CACHE 
-       PATH "-isysroot parameter for compiler" FORCE)
-   set(CMAKE_C_FLAGS "-mmacosx-version-min=10.5" CACHE 
+       PATH "-isysroot parameter for compiler")
+   set(CMAKE_C_FLAGS "-mmacosx-version-min=10.6" CACHE 
        STRING "needed in conjunction with CMAKE_OSX_SYSROOT" FORCE)
 @@ -54,10 +54,6 @@ if(UNIX)
  


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
