### PR TITLE
fceux: 2021-01-29 -> 2.4.0

### DIFF
--- a/pkgs/misc/emulators/fceux/default.nix
+++ b/pkgs/misc/emulators/fceux/default.nix
@@ -1,40 +1,24 @@
-{lib, stdenv, fetchFromGitHub, scons, zlib, SDL, lua5_1, pkg-config}:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, wrapQtAppsHook, SDL2, lua5_1, minizip, x264 }:
 
-stdenv.mkDerivation {
-  pname = "fceux-unstable";
-  version = "2020-01-29";
+stdenv.mkDerivation rec {
+  pname = "fceux";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "TASVideos";
-    repo = "fceux";
-    rev = "fb8d46d9697cb24b0ebe79d84eedf282f69ab337";
-    sha256 = "0gpz411dzfwx9mr34yi4zb1hphd5hha1nvwgzxki0sviwafca992";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "sha256-i0mb0vy46D97oOpAjMw3CPbG4w/LWP9YRVEMWjdYgs0=";
   };
 
-  nativeBuildInputs = [ pkg-config scons ];
-  buildInputs = [
-    zlib SDL lua5_1
-  ];
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
+  buildInputs = [ SDL2 lua5_1 minizip x264 ];
 
-  sconsFlags = "OPENGL=false GTK=false CREATE_AVI=false LOGO=false";
-  prefixKey = "--prefix=";
-
-  # sed allows scons to find libraries in nix.
-  # mkdir is a hack to make scons succeed.  It still doesn't
-  # actually put the files in there due to a bug in the SConstruct file.
-  # OPENGL doesn't work because fceux dlopens the library.
-  preBuild = ''
-    sed -e 's/env *= *Environment *.*/&; env['"'"'ENV'"'"']=os.environ;/' -i SConstruct
-    export CC="gcc"
-    export CXX="g++"
-    mkdir -p "$out" "$out/share/applications" "$out/share/pixmaps"
-  '';
-
-  meta = {
+  meta = with lib; {
     description = "A Nintendo Entertainment System (NES) Emulator";
-    license = lib.licenses.gpl2;
-    maintainers = [ lib.maintainers.scubed2 ];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ sbruder scubed2 ];
     homepage = "http://www.fceux.com/";
-    platforms = lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31347,7 +31347,7 @@ with pkgs;
 
   faustStk = callPackage ../applications/audio/faustStk  { };
 
-  fceux = callPackage ../misc/emulators/fceux { };
+  fceux = libsForQt5.callPackage ../misc/emulators/fceux { };
 
   flockit = callPackage ../tools/backup/flockit { };
 


### PR DESCRIPTION
This reorganises the whole derivation because upstream switched from GTK
(optional) to Qt (required) and now uses CMake instead of SCons as build
system.

This supersedes/closes #47543 (adding a switch for the GTK UI, which now no longer exists).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Keeping packages up-to-date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
