### PR TITLE
bash: upgrade default version to 5

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -48,6 +48,11 @@
           actions.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          bash now defaults to major version 5.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-new-services">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -18,12 +18,14 @@ In addition to numerous new and upgraded packages, this release has the followin
   This allows activation scripts to output what they would change if the activation was really run.
   The users/modules activation script supports this and outputs some of is actions.
 
+- bash now defaults to major version 5.
+
 ## New Services {#sec-release-21.11-new-services}
 
 - [btrbk](https://digint.ch/btrbk/index.html), a backup tool for btrfs subvolumes, taking advantage of btrfs specific capabilities to create atomic snapshots and transfer them incrementally to your backup locations. Available as [services.btrbk](options.html#opt-services.brtbk.instances).
 
 - [clipcat](https://github.com/xrelkd/clipcat/), an X11 clipboard manager written in Rust. Available at [services.clipcat](options.html#o
-pt-services.clipcat.enable).
+  pt-services.clipcat.enable).
 
 - [geoipupdate](https://github.com/maxmind/geoipupdate), a GeoIP database updater from MaxMind. Available as [services.geoipupdate](options.html#opt-services.geoipupdate.enable).
 
@@ -59,7 +61,7 @@ pt-services.clipcat.enable).
   Available as [isso](#opt-services.isso.enable)
 
 * [navidrome](https://www.navidrome.org/), a personal music streaming server with
-subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable).
+  subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable).
 
 - [fluidd](https://docs.fluidd.xyz/), a Klipper web interface for managing 3d printers using moonraker. Available as [fluidd](#opt-services.fluidd.enable).
 
@@ -75,53 +77,55 @@ subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable
 
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
-
 - The `paperless` module and package have been removed. All users should migrate to the
   successor `paperless-ng` instead. The Paperless project [has been
   archived](https://github.com/the-paperless-project/paperless/commit/9b0063c9731f7c5f65b1852cb8caff97f5e40ba4)
   and advises all users to use `paperless-ng` instead.
 
   Users can use the `services.paperless-ng` module as a replacement while noting the following incompatibilities:
-    - `services.paperless.ocrLanguages` has no replacement. Users should migrate to [`services.paperless-ng.extraConfig`](options.html#opt-services.paperless-ng.extraConfig) instead:
-     ```nix
-     {
-       services.paperless-ng.extraConfig = {
-         # Provide languages as ISO 639-2 codes
-         # separated by a plus (+) sign.
-         # https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
-         PAPERLESS_OCR_LANGUAGE = "deu+eng+jpn"; # German & English & Japanse
-       };
-     }
-     ```
 
-    - If you previously specified `PAPERLESS_CONSUME_MAIL_*` settings in
-      `services.paperless.extraConfig` you should remove those options now. You
-      now *must* define those settings in the admin interface of paperless-ng.
+  - `services.paperless.ocrLanguages` has no replacement. Users should migrate to [`services.paperless-ng.extraConfig`](options.html#opt-services.paperless-ng.extraConfig) instead:
 
-    - Option `services.paperless.manage` no longer exists.
-      Use the script at `${services.paperless-ng.dataDir}/paperless-ng-manage` instead.
-      Note that this script only exists after the `paperless-ng` service has been
-      started at least once.
+  ```nix
+  {
+    services.paperless-ng.extraConfig = {
+      # Provide languages as ISO 639-2 codes
+      # separated by a plus (+) sign.
+      # https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
+      PAPERLESS_OCR_LANGUAGE = "deu+eng+jpn"; # German & English & Japanse
+    };
+  }
+  ```
 
-    - After switching to the new system configuration you should run the Django
-      management command to reindex your documents and optionally create a user,
-      if you don't have one already.
+  - If you previously specified `PAPERLESS_CONSUME_MAIL_*` settings in
+    `services.paperless.extraConfig` you should remove those options now. You
+    now _must_ define those settings in the admin interface of paperless-ng.
 
-      To do so, enter the data directory (the value of
-      `services.paperless-ng.dataDir`, `/var/lib/paperless` by default), switch
-      to the paperless user and execute the management command like below:
-      ```
-      $ cd /var/lib/paperless
-      $ su paperless -s /bin/sh
-      $ ./paperless-ng-manage document_index reindex
-      # if not already done create a user account, paperless-ng requires a login
-      $ ./paperless-ng-manage createsuperuser
-      Username (leave blank to use 'paperless'): my-user-name
-      Email address: me@example.com
-      Password: **********
-      Password (again): **********
-      Superuser created successfully.
-      ```
+  - Option `services.paperless.manage` no longer exists.
+    Use the script at `${services.paperless-ng.dataDir}/paperless-ng-manage` instead.
+    Note that this script only exists after the `paperless-ng` service has been
+    started at least once.
+
+  - After switching to the new system configuration you should run the Django
+    management command to reindex your documents and optionally create a user,
+    if you don't have one already.
+
+    To do so, enter the data directory (the value of
+    `services.paperless-ng.dataDir`, `/var/lib/paperless` by default), switch
+    to the paperless user and execute the management command like below:
+
+    ```
+    $ cd /var/lib/paperless
+    $ su paperless -s /bin/sh
+    $ ./paperless-ng-manage document_index reindex
+    # if not already done create a user account, paperless-ng requires a login
+    $ ./paperless-ng-manage createsuperuser
+    Username (leave blank to use 'paperless'): my-user-name
+    Email address: me@example.com
+    Password: **********
+    Password (again): **********
+    Superuser created successfully.
+    ```
 
 - The `staticjinja` package has been upgraded from 1.0.4 to 4.1.0
 
@@ -199,28 +203,32 @@ subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable
 * The `bitwarden_rs` packages and modules were renamed to `vaultwarden`
   [following upstream](https://github.com/dani-garcia/vaultwarden/discussions/1642). More specifically,
 
-  * `pkgs.bitwarden_rs`, `pkgs.bitwarden_rs-sqlite`, `pkgs.bitwarden_rs-mysql` and
+  - `pkgs.bitwarden_rs`, `pkgs.bitwarden_rs-sqlite`, `pkgs.bitwarden_rs-mysql` and
     `pkgs.bitwarden_rs-postgresql` were renamed to `pkgs.vaultwarden`, `pkgs.vaultwarden-sqlite`,
     `pkgs.vaultwarden-mysql` and `pkgs.vaultwarden-postgresql`, respectively.
-    * Old names are preserved as aliases for backwards compatibility, but may be removed in the future.
-    * The `bitwarden_rs` executable was also renamed to `vaultwarden` in all packages.
 
-  * `pkgs.bitwarden_rs-vault` was renamed to `pkgs.vaultwarden-vault`.
-    * `pkgs.bitwarden_rs-vault` is preserved as an alias for backwards compatibility, but may be removed in the future.
-    * The static files were moved from `/usr/share/bitwarden_rs` to `/usr/share/vaultwarden`.
+    - Old names are preserved as aliases for backwards compatibility, but may be removed in the future.
+    - The `bitwarden_rs` executable was also renamed to `vaultwarden` in all packages.
 
-  * The `services.bitwarden_rs` config module was renamed to `services.vaultwarden`.
-    * `services.bitwarden_rs` is preserved as an alias for backwards compatibility, but may be removed in the future.
+  - `pkgs.bitwarden_rs-vault` was renamed to `pkgs.vaultwarden-vault`.
 
-  * `systemd.services.bitwarden_rs`, `systemd.services.backup-bitwarden_rs` and `systemd.timers.backup-bitwarden_rs`
+    - `pkgs.bitwarden_rs-vault` is preserved as an alias for backwards compatibility, but may be removed in the future.
+    - The static files were moved from `/usr/share/bitwarden_rs` to `/usr/share/vaultwarden`.
+
+  - The `services.bitwarden_rs` config module was renamed to `services.vaultwarden`.
+
+    - `services.bitwarden_rs` is preserved as an alias for backwards compatibility, but may be removed in the future.
+
+  - `systemd.services.bitwarden_rs`, `systemd.services.backup-bitwarden_rs` and `systemd.timers.backup-bitwarden_rs`
     were renamed to `systemd.services.vaultwarden`, `systemd.services.backup-vaultwarden` and
     `systemd.timers.backup-vaultwarden`, respectively.
-    * Old names are preserved as aliases for backwards compatibility, but may be removed in the future.
 
-  * `users.users.bitwarden_rs` and `users.groups.bitwarden_rs` were renamed to `users.users.vaultwarden` and
+    - Old names are preserved as aliases for backwards compatibility, but may be removed in the future.
+
+  - `users.users.bitwarden_rs` and `users.groups.bitwarden_rs` were renamed to `users.users.vaultwarden` and
     `users.groups.vaultwarden`, respectively.
 
-  * The data directory remains located at `/var/lib/bitwarden_rs`, for backwards compatibility.
+  - The data directory remains located at `/var/lib/bitwarden_rs`, for backwards compatibility.
 
 - `yggdrasil` was upgraded to a new major release with breaking changes, see [upstream changelog](https://github.com/yggdrasil-network/yggdrasil-go/releases/tag/v0.4.0).
 
@@ -233,6 +241,7 @@ subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable
 - `tt-rss` was upgraded to the commit on 2021-06-21, which has breaking changes. If you use `services.tt-rss.extraConfig` you should migrate to the `putenv`-style configuration. See [this Discourse post](https://community.tt-rss.org/t/rip-config-php-hello-classes-config-php/4337) in the tt-rss forums for more details.
 
 - The following Visual Studio Code extensions were renamed to keep the naming convention uniform.
+
   - `bbenoist.Nix` -> `bbenoist.nix`
   - `CoenraadS.bracket-pair-colorizer` -> `coenraads.bracket-pair-colorizer`
   - `golang.Go` -> `golang.go`
@@ -252,12 +261,12 @@ subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable
 - The `yambar` package has been split into `yambar` and `yambar-wayland`, corresponding to the xorg and wayland backend respectively. Please switch to `yambar-wayland` if you are on wayland.
 
 - The `services.minio` module gained an additional option `consoleAddress`, that
-configures the address and port the web UI is listening, it defaults to `:9001`.
-To be able to access the web UI this port needs to be opened in the firewall.
+  configures the address and port the web UI is listening, it defaults to `:9001`.
+  To be able to access the web UI this port needs to be opened in the firewall.
 
 - The `varnish` package was upgraded from 6.3.x to 6.5.x. `varnish60` for the last LTS release is also still available.
 
-- The `kubernetes` package was upgraded to 1.22.  The `kubernetes.apiserver.kubeletHttps` option was removed and HTTPS is always used.
+- The `kubernetes` package was upgraded to 1.22. The `kubernetes.apiserver.kubeletHttps` option was removed and HTTPS is always used.
 
 - The attribute `linuxPackages_latest_hardened` was dropped because the hardened patches
   lag behind the upstream kernel which made version bumps harder. If you want to use
@@ -288,7 +297,7 @@ To be able to access the web UI this port needs to be opened in the firewall.
 
 - The `claws-mail` package now references the new GTK+ 3 release branch, major version 4. To use the GTK+ 2 releases, one can install the `claws-mail-gtk2` package.
 
-- The wordpress module provides a new interface which allows to use different webservers with the new option [`services.wordpress.webserver`](options.html#opt-services.wordpress.webserver).  Currently `httpd` and `nginx` are supported. The definitions of wordpress sites should now be set in [`services.wordpress.sites`](options.html#opt-services.wordpress.sites).
+- The wordpress module provides a new interface which allows to use different webservers with the new option [`services.wordpress.webserver`](options.html#opt-services.wordpress.webserver). Currently `httpd` and `nginx` are supported. The definitions of wordpress sites should now be set in [`services.wordpress.sites`](options.html#opt-services.wordpress.sites).
 
   Sites definitions that use the old interface are automatically migrated in the new option. This backward compatibility will be removed in 22.05.
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -736,9 +736,11 @@ substituteStream() {
     printf "%s" "${!var}"
 }
 
+# put the content of a file in a variable
+# fail loudly if provided with a binary (containing null bytes)
 consumeEntire() {
     # read returns non-0 on EOF, so we want read to fail
-    if IFS='' read -r -N 0 $1; then
+    if IFS='' read -r -d '' $1 ; then
         echo "consumeEntire(): ERROR: Input null bytes, won't process" >&2
         return 1
     fi

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -66,6 +66,8 @@ mapAliases ({
   badtouch = authoscope; # Project was renamed, added 20210626
   bar-xft = lemonbar-xft;  # added 2015-01-16
   bashCompletion = bash-completion; # Added 2016-09-28
+  bash_5 = bash; # added 2021-08-20
+  bashInteractive_5 = bashInteractive; # added 2021-08-20
   batti = throw "batti has been removed from nixpkgs, as it was unmaintained"; # added 2019-12-10
   bazaar = throw "bazaar has been deprecated by breezy."; # added 2020-04-19
   bazaarTools = throw "bazaar has been deprecated by breezy."; # added 2020-04-19

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10654,24 +10654,24 @@ with pkgs;
 
   any-nix-shell = callPackage ../shells/any-nix-shell { };
 
-  bash = lowPrio (callPackage ../shells/bash/4.4.nix {
+  bash_4 = lowPrio (callPackage ../shells/bash/4.4.nix {
     binutils = stdenv.cc.bintools;
   });
-  bash_5 = lowPrio (callPackage ../shells/bash/5.1.nix {
+  bash = lowPrio (callPackage ../shells/bash/5.1.nix {
     binutils = stdenv.cc.bintools;
   });
-  bashInteractive_5 = lowPrio (callPackage ../shells/bash/5.1.nix {
-    binutils = stdenv.cc.bintools;
-    interactive = true;
-    withDocs = true;
-  });
-
   # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed
-  bashInteractive = callPackage ../shells/bash/4.4.nix {
+  bashInteractive = callPackage ../shells/bash/5.1.nix {
     binutils = stdenv.cc.bintools;
     interactive = true;
     withDocs = true;
   };
+
+  bashInteractive_4 = lowPrio (callPackage ../shells/bash/4.4.nix {
+    binutils = stdenv.cc.bintools;
+    interactive = true;
+    withDocs = true;
+  });
 
   bash-completion = callPackage ../shells/bash/bash-completion { };
 


### PR DESCRIPTION
###### Motivation for this change

bash default version upgrade

cc @SuperSandro2000 @06kellyjac 

@vcunat just leaving a comment here to test this on hydra at some point to verify nothing major breaks. (no rush, I know you are busy).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
