### PR TITLE
teleport: 6.2.8 -> 7.0.0

### DIFF
--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -4,26 +4,26 @@ let
   webassets = fetchFromGitHub {
     owner = "gravitational";
     repo = "webassets";
-    rev = "c63397375632f1a4323918dde78334472f3ffbb9";
-    sha256 = "sha256-6YKk0G3s+35PRsUBkKgu/tNoSSwjJ5bTn8DACF4gYr4=";
+    rev = "2891baa0de7283f61c08ff2fa4494e53f9d4afc1";
+    sha256 = "sha256-AvhCOLa+mgty9METlOCARlUOEDMAW6Kk1esSmBbVcok=";
   };
 in
-
 buildGoModule rec {
   pname = "teleport";
-  version = "6.2.8";
+  version = "7.0.0";
 
   # This repo has a private submodule "e" which fetchgit cannot handle without failing.
   src = fetchFromGitHub {
     owner = "gravitational";
     repo = "teleport";
     rev = "v${version}";
-    sha256 = "sha256-TVjdz97CUXBKCQh9bYrvtcH4StblBMsXiQ9Gix/NIm4=";
+    sha256 = "sha256-2GQ3IP5jfT6vSni5hfDex09wXrnUmTpcvH2S6zc399I=";
   };
 
   vendorSha256 = null;
 
   subPackages = [ "tool/tctl" "tool/teleport" "tool/tsh" ];
+  tags = [ "webassets_embed" ];
 
   nativeBuildInputs = [ zip makeWrapper ];
 
@@ -34,26 +34,15 @@ buildGoModule rec {
     ./test.patch
   ];
 
-  postBuild = ''
-    pushd .
-    mkdir -p build
-    echo "making webassets"
-    cp -r ${webassets}/* webassets/
-    make build/webassets.zip
-    cat build/webassets.zip >> $NIX_BUILD_TOP/go/bin/teleport
-    rm -fr build/webassets.zip
-    cd $NIX_BUILD_TOP/go/bin
-    zip -q -A teleport
-    popd
-  '';
-
-  # Do not strip the embedded web assets
-  dontStrip = true;
-
   # Reduce closure size for client machines
   outputs = [ "out" "client" ];
 
-  buildTargets = [ "full" ];
+  preBuild = ''
+    mkdir -p build
+    echo "making webassets"
+    cp -r ${webassets}/* webassets/
+    make lib/web/build/webassets.zip
+  '';
 
   preCheck = ''
     export HOME=$(mktemp -d)


### PR DESCRIPTION
###### Motivation for this change

New major version. Web asset embedding now done through Go's `embed` facility, therefore there is no more need for the "append zip to the executable" hack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
