### PR TITLE
canon-cups-ufr2: deprecate phases

### DIFF
--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -1,16 +1,27 @@
-{ lib, stdenv, fetchurl, unzip, autoreconfHook, libtool, makeWrapper, cups
-, ghostscript, pkgsi686Linux, zlib }:
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, autoconf
+, automake
+, libtool
+, makeWrapper
+, cups
+, ghostscript
+, pkgsi686Linux
+, zlib
+}:
 
 let
 
-  i686_NIX_GCC = pkgsi686Linux.callPackage ({gcc}: gcc) {};
-  i686_libxml2 = pkgsi686Linux.callPackage ({libxml2}: libxml2) {};
+  i686_NIX_GCC = pkgsi686Linux.callPackage ({ gcc }: gcc) { };
+  i686_libxml2 = pkgsi686Linux.callPackage ({ libxml2 }: libxml2) { };
 
   commonVer = "4.10";
   version = "3.70";
   dl = "8/0100007658/08";
 
-  versionNoDots = builtins.replaceStrings ["."] [""] version;
+  versionNoDots = builtins.replaceStrings [ "." ] [ "" ] version;
   src_canon = fetchurl {
     url = "http://gdlp01.c-wss.com/gds/${dl}/linux-UFRII-drv-v${versionNoDots}-uken-05.tar.gz";
     sha256 = "0424lvyrsvsb94qga4p4ldis7f714c5yw5ydv3f84mdl2a7papg0";
@@ -24,18 +35,18 @@ stdenv.mkDerivation {
   inherit version;
   src = src_canon;
 
-  phases = [ "unpackPhase" "installPhase" ];
-
   postUnpack = ''
     (cd $sourceRoot; tar -xzf Sources/cndrvcups-common-${commonVer}-1.tar.gz)
     (cd $sourceRoot; tar -xzf Sources/cndrvcups-lb-${version}-1.tar.gz)
   '';
 
-  nativeBuildInputs = [ makeWrapper unzip autoreconfHook libtool ];
+  nativeBuildInputs = [ makeWrapper unzip autoconf automake libtool ];
 
   buildInputs = [ cups zlib ];
 
   installPhase = ''
+    runHook preInstall
+
     ##
     ## cndrvcups-common buildPhase
     ##
@@ -213,7 +224,9 @@ stdenv.mkDerivation {
     makeWrapper "${ghostscript}/bin/gs" "$out/bin/gs" \
       --prefix LD_LIBRARY_PATH ":" "$out/lib" \
       --prefix PATH ":" "$out/bin"
-    '';
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "CUPS Linux drivers for Canon printers";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#28910
having the `autoreconfHook` breaks things, so i believe adding `autoconf` and `automake` is desired.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
