### PR TITLE
unetbootin: use libsForQt5.callPackage

### DIFF
--- a/pkgs/tools/cd-dvd/unetbootin/default.nix
+++ b/pkgs/tools/cd-dvd/unetbootin/default.nix
@@ -5,7 +5,10 @@
 , libsForQt5
 , mtools
 , p7zip
-, qt5
+, wrapQtAppsHook
+, qtbase
+, qttools
+, qmake
 , syslinux
 , util-linux
 , which
@@ -27,14 +30,12 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    qt5.qtbase
-    qt5.qttools
-    libsForQt5.qmake
+    qtbase
+    qttools
+    qmake
   ];
 
-  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ wrapQtAppsHook ];
 
   # Lots of nice hard-coded paths...
   postPatch = ''
@@ -76,7 +77,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A tool to create bootable live USB drives from ISO images";
-    homepage = "http://unetbootin.github.io/";
+    homepage = "https://unetbootin.github.io/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ ebzzry ];
     platforms = platforms.linux;

--- a/pkgs/tools/cd-dvd/unetbootin/default.nix
+++ b/pkgs/tools/cd-dvd/unetbootin/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , coreutils
 , fetchFromGitHub
-, libsForQt5
 , mtools
 , p7zip
 , wrapQtAppsHook

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9664,7 +9664,7 @@ with pkgs;
 
   umlet = callPackage ../tools/misc/umlet { };
 
-  unetbootin = callPackage ../tools/cd-dvd/unetbootin { };
+  unetbootin = libsForQt5.callPackage ../tools/cd-dvd/unetbootin { };
 
   unfs3 = callPackage ../servers/unfs3 { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
