### PR TITLE
gusb: 0.3.5 -> 0.3.7

### DIFF
--- a/pkgs/development/libraries/gusb/default.nix
+++ b/pkgs/development/libraries/gusb/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, gettext, gobject-introspection
+{ lib, stdenv, fetchurl, substituteAll, meson, ninja, pkg-config, gettext, gobject-introspection
 , gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_44, python3
 , glib, systemd, libusb1, vala, hwdata
 }:
@@ -10,14 +10,21 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "gusb";
-  version = "0.3.5";
+  version = "0.3.7";
 
   outputs = [ "bin" "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/libgusb-${version}.tar.xz";
-    sha256 = "1pv5ivbwxb9anq2j34i68r8fgs8nwsi4hmss7h9v1i3wk7300ajv";
+    sha256 = "sha256-2l8l1oc2ImibM1FIbL4CjvwlRAP2Rt2BIl3+hULYxn0=";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-python-path.patch;
+      python = "${pythonEnv}/bin/python3";
+    })
+  ];
 
   nativeBuildInputs = [
     meson ninja pkg-config gettext pythonEnv

--- a/pkgs/development/libraries/gusb/fix-python-path.patch
+++ b/pkgs/development/libraries/gusb/fix-python-path.patch
@@ -1,0 +1,14 @@
+diff --git a/gusb/meson.build b/gusb/meson.build
+index 8236a2b..282aa48 100644
+--- a/gusb/meson.build
++++ b/gusb/meson.build
+@@ -147,7 +147,7 @@ libgusb_gir = libgusb_girtarget[0]
+ libgusb_typelib = libgusb_girtarget[1]
+ 
+ pymod = import('python')
+-py_installation = pymod.find_installation()
++py_installation = pymod.find_installation('@python@')
+ 
+ # Verify the map file is correct -- note we can't actually use the generated
+ # file for two reasons:
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/hughsie/libgusb/blob/0.3.7/NEWS
```
Version 0.3.7
~~~~~~~~~~~~~
Released: 2021-05-24

New Features:
 - Add a FreeBSD CI target (Richard Hughes)

Bugfixes:
 - Do not depend on libusb_get_parent() to fix FreeBSD compile (Richard Hughes)
 - Do not depend on libusb_get_port_number() to fix DragonFlyBSD compile (Richard Hughes)
 - Do not double-reference USB devices (Marco Trevisan)
 - Do not run the tests on FreeBSD (Richard Hughes)
 - Require *any* python3 to fix FreeBSD build (Richard Hughes)

Version 0.3.6
~~~~~~~~~~~~~
Released: 2021-03-12

New Features:
 - Add g_usb_device_get_string_descriptor_bytes() (Richard Hughes)

Bugfixes:
 - Properly set dylib versions on darwin (Caleb Xu)
 - Fix cancellation if cancellable is already cancelled (Benjamin Berg)
```

Because of the FreeBSD changes in upstream, meson was picking up the wrong python. The patch just passes the right path - perhaps there's a better way to do it though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
