### PR TITLE
python3Packages.gudhi: init + several dependencies

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11812,6 +11812,12 @@
     githubId = 26011724;
     name = "Burim Augustin Berisa";
   };
+  yl3dy = {
+    email = "aleksandr.kiselyov@gmail.com";
+    github = "yl3dy";
+    githubId = 1311192;
+    name = "Alexander Kiselyov";
+  };
   yochai = {
     email = "yochai@titat.info";
     github = "yochai";

--- a/pkgs/development/python-modules/POT/default.nix
+++ b/pkgs/development/python-modules/POT/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, numpy
+, scipy
+, cython
+, matplotlib
+, scikit-learn
+, cupy
+, pymanopt
+, autograd
+, pytestCheckHook
+, enableDimensionalityReduction ? false
+, enableGPU ? false
+}:
+
+buildPythonPackage rec {
+  pname = "pot";
+  version = "0.7.0";
+
+  src = fetchPypi {
+    pname = "POT";
+    inherit version;
+    sha256 = "01mdsiv8rlgqzvm3bds9aj49khnn33i523c2cqqrl10zg742pb6l";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov-report= --cov=ot" \
+                ""
+  '';
+
+  nativeBuildInputs = [ numpy cython ];
+  propagatedBuildInputs = [ numpy scipy ]
+    ++ lib.optionals enableGPU [ cupy ]
+    ++ lib.optionals enableDimensionalityReduction [ pymanopt autograd ];
+  checkInputs = [ matplotlib scikit-learn pytestCheckHook ];
+
+  preCheck = ''
+    rm -r ot
+  '';
+
+  # GPU tests are always skipped because of sandboxing
+  disabledTests = [ "warnings" ];
+
+  pythonImportsCheck = [ "ot" "ot.lp" ];
+
+  meta = {
+    description = "Python Optimal Transport Library";
+    homepage = "https://pythonot.github.io/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yl3dy ];
+  };
+}

--- a/pkgs/development/python-modules/gudhi/default.nix
+++ b/pkgs/development/python-modules/gudhi/default.nix
@@ -37,8 +37,11 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ numpy scipy ];
   checkInputs = [ pytest ];
 
-  enableParallelBuilding = true;
-  cmakeFlags = "-DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3";
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DWITH_GUDHI_PYTHON=ON"
+    "-DPython_ADDITIONAL_VERSIONS=3"
+  ];
 
   preBuild = ''
     cd src/python
@@ -53,7 +56,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Library for Computational Topology and Topological Data Analysis (TDA)";
-    homepage = "https://gudhi.inria.fr/python/3.4.1/";
+    homepage = "https://gudhi.inria.fr/python/latest/";
     downloadPage = "https://github.com/GUDHI/gudhi-devel";
     license = with lib.licenses; [ mit gpl3 ];
     maintainers = with lib.maintainers; [ yl3dy ];

--- a/pkgs/development/python-modules/gudhi/default.nix
+++ b/pkgs/development/python-modules/gudhi/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, cmake
+, boost
+, eigen
+, gmp
+, cgal_5  # see https://github.com/NixOS/nixpkgs/pull/94875 about cgal
+, mpfr
+, tbb
+, numpy
+, cython
+, pybind11
+, matplotlib
+, scipy
+, pytest
+, enableTBB ? false
+}:
+
+buildPythonPackage rec {
+  pname = "gudhi";
+  version = "3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "GUDHI";
+    repo = "gudhi-devel";
+    rev = "tags/gudhi-release-${version}";
+    fetchSubmodules = true;
+    sha256 = "1m03qazzfraxn62l1cb11icjz4x8q2sg9c2k3syw5v0yv9ndgx1v";
+  };
+
+  patches = [ ./remove_explicit_PYTHONPATH.patch ];
+
+  nativeBuildInputs = [ cmake numpy cython pybind11 matplotlib ];
+  buildInputs = [ boost eigen gmp cgal_5 mpfr ]
+    ++ lib.optionals enableTBB [ tbb ];
+  propagatedBuildInputs = [ numpy scipy ];
+  checkInputs = [ pytest ];
+
+  enableParallelBuilding = true;
+  cmakeFlags = "-DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3";
+
+  preBuild = ''
+    cd src/python
+  '';
+
+  checkPhase = ''
+    rm -r gudhi
+    ${cmake}/bin/ctest --output-on-failure
+  '';
+
+  pythonImportsCheck = [ "gudhi" "gudhi.hera" "gudhi.point_cloud" "gudhi.clustering" ];
+
+  meta = {
+    description = "Library for Computational Topology and Topological Data Analysis (TDA)";
+    homepage = "https://gudhi.inria.fr/python/3.4.1/";
+    downloadPage = "https://github.com/GUDHI/gudhi-devel";
+    license = with lib.licenses; [ mit gpl3 ];
+    maintainers = with lib.maintainers; [ yl3dy ];
+  };
+}

--- a/pkgs/development/python-modules/gudhi/remove_explicit_PYTHONPATH.patch
+++ b/pkgs/development/python-modules/gudhi/remove_explicit_PYTHONPATH.patch
@@ -1,0 +1,174 @@
+diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
+index 5c1402a..48a1250 100644
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -271,9 +271,6 @@ if(PYTHONINTERP_FOUND)
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+         COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/setup.py" "build_ext" "--inplace")
+ 
+-    add_custom_target(python ALL DEPENDS gudhi.so
+-                      COMMENT "Do not forget to add ${CMAKE_CURRENT_BINARY_DIR}/ to your PYTHONPATH before using examples or tests")
+-
+     install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install)")
+ 
+   # Documentation generation is available through sphinx - requires all modules
+@@ -295,14 +292,14 @@ if(PYTHONINTERP_FOUND)
+                   # sphinx target requires gudhi.so, because conf.py reads gudhi version from it
+                   add_custom_target(sphinx
+                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc
+-                      COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++                      COMMAND ${CMAKE_COMMAND} -E env
+                       ${SPHINX_PATH} -b html ${CMAKE_CURRENT_SOURCE_DIR}/doc ${CMAKE_CURRENT_BINARY_DIR}/sphinx
+                       DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/gudhi.so"
+                       COMMENT "${GUDHI_SPHINX_MESSAGE}" VERBATIM)
+ 
+                   add_test(NAME sphinx_py_test
+                            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-                           COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++                           COMMAND ${CMAKE_COMMAND} -E env
+                            ${SPHINX_PATH} -b doctest ${CMAKE_CURRENT_SOURCE_DIR}/doc ${CMAKE_CURRENT_BINARY_DIR}/doctest)
+ 
+                   # Set missing or not modules
+@@ -346,13 +343,13 @@ if(PYTHONINTERP_FOUND)
+       # Bottleneck and Alpha
+       add_test(NAME alpha_rips_persistence_bottleneck_distance_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/alpha_rips_persistence_bottleneck_distance.py"
+                -f ${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off -t 0.15 -d 3)
+       # Tangential
+       add_test(NAME tangential_complex_plain_homology_from_off_file_example_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/tangential_complex_plain_homology_from_off_file_example.py"
+                --no-diagram -i 2 -f ${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off)
+ 
+@@ -361,13 +358,13 @@ if(PYTHONINTERP_FOUND)
+       # Witness complex
+       add_test(NAME euclidean_strong_witness_complex_diagram_persistence_from_off_file_example_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/euclidean_strong_witness_complex_diagram_persistence_from_off_file_example.py"
+                --no-diagram -f ${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off -a 1.0 -n 20 -d 2)
+ 
+       add_test(NAME euclidean_witness_complex_diagram_persistence_from_off_file_example_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/euclidean_witness_complex_diagram_persistence_from_off_file_example.py"
+                --no-diagram -f ${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off -a 1.0 -n 20 -d 2)
+ 
+@@ -379,7 +376,7 @@ if(PYTHONINTERP_FOUND)
+       # Bottleneck
+       add_test(NAME bottleneck_basic_example_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/bottleneck_basic_example.py")
+ 
+       if (PYBIND11_FOUND)
+@@ -392,26 +389,26 @@ if(PYTHONINTERP_FOUND)
+       file(COPY ${CMAKE_SOURCE_DIR}/data/points/COIL_database/lucky_cat_PCA1 DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+       add_test(NAME cover_complex_nerve_example_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/nerve_of_a_covering.py"
+                -f human.off -c 2 -r 10 -g 0.3)
+ 
+       add_test(NAME cover_complex_coordinate_gic_example_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/coordinate_graph_induced_complex.py"
+                -f human.off -c 0 -v)
+ 
+       add_test(NAME cover_complex_functional_gic_example_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/functional_graph_induced_complex.py"
+                -o lucky_cat.off
+                -f lucky_cat_PCA1 -v)
+ 
+       add_test(NAME cover_complex_voronoi_gic_example_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/voronoi_graph_induced_complex.py"
+                -f human.off -n 700 -v)
+ 
+@@ -422,11 +419,11 @@ if(PYTHONINTERP_FOUND)
+       # Alpha
+       add_test(NAME alpha_complex_from_points_example_py_test
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-               COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++               COMMAND ${CMAKE_COMMAND} -E env
+                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/alpha_complex_from_points_example.py")
+       add_test(NAME alpha_complex_diagram_persistence_from_off_file_example_py_test
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-             COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++             COMMAND ${CMAKE_COMMAND} -E env
+              ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/alpha_complex_diagram_persistence_from_off_file_example.py"
+              --no-diagram -f ${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off -a 0.6)
+       add_gudhi_py_test(test_alpha_complex)
+@@ -441,13 +438,13 @@ if(PYTHONINTERP_FOUND)
+     # Cubical
+     add_test(NAME periodic_cubical_complex_barcode_persistence_from_perseus_file_example_py_test
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-             COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++             COMMAND ${CMAKE_COMMAND} -E env
+              ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/periodic_cubical_complex_barcode_persistence_from_perseus_file_example.py"
+              --no-barcode -f ${CMAKE_SOURCE_DIR}/data/bitmap/CubicalTwoSphere.txt)
+ 
+     add_test(NAME random_cubical_complex_persistence_example_py_test
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-             COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++             COMMAND ${CMAKE_COMMAND} -E env
+              ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/random_cubical_complex_persistence_example.py"
+              10 10 10)
+ 
+@@ -456,19 +453,19 @@ if(PYTHONINTERP_FOUND)
+     # Rips
+     add_test(NAME rips_complex_diagram_persistence_from_distance_matrix_file_example_py_test
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-             COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++             COMMAND ${CMAKE_COMMAND} -E env
+              ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/rips_complex_diagram_persistence_from_distance_matrix_file_example.py"
+              --no-diagram -f ${CMAKE_SOURCE_DIR}/data/distance_matrix/lower_triangular_distance_matrix.csv -e 12.0 -d 3)
+ 
+     add_test(NAME rips_complex_diagram_persistence_from_off_file_example_py_test
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-             COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++             COMMAND ${CMAKE_COMMAND} -E env
+              ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/example/rips_complex_diagram_persistence_from_off_file_example.py
+              --no-diagram -f ${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off  -e 0.25 -d 3)
+ 
+     add_test(NAME rips_complex_from_points_example_py_test
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-             COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++             COMMAND ${CMAKE_COMMAND} -E env
+              ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/example/rips_complex_from_points_example.py)
+ 
+     add_gudhi_py_test(test_rips_complex)
+@@ -476,7 +473,7 @@ if(PYTHONINTERP_FOUND)
+     # Simplex tree
+     add_test(NAME simplex_tree_example_py_test
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-             COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++             COMMAND ${CMAKE_COMMAND} -E env
+              ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/example/simplex_tree_example.py)
+ 
+     add_gudhi_py_test(test_simplex_tree)
+@@ -485,7 +482,7 @@ if(PYTHONINTERP_FOUND)
+     # Witness
+     add_test(NAME witness_complex_from_nearest_landmark_table_py_test
+              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-             COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
++             COMMAND ${CMAKE_COMMAND} -E env
+              ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/example/witness_complex_from_nearest_landmark_table.py)
+ 
+     add_gudhi_py_test(test_witness_complex)

--- a/pkgs/development/python-modules/pot/default.nix
+++ b/pkgs/development/python-modules/pot/default.nix
@@ -26,8 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "--cov-report= --cov=ot" \
-                ""
+      --replace "--cov-report= --cov=ot" ""
   '';
 
   nativeBuildInputs = [ numpy cython ];
@@ -36,6 +35,8 @@ buildPythonPackage rec {
     ++ lib.optionals enableDimensionalityReduction [ pymanopt autograd ];
   checkInputs = [ matplotlib scikit-learn pytestCheckHook ];
 
+  # To prevent importing of an incomplete package from the build directory
+  # instead of nix store (`ot` is the top-level package name).
   preCheck = ''
     rm -r ot
   '';

--- a/pkgs/development/python-modules/pymanopt/default.nix
+++ b/pkgs/development/python-modules/pymanopt/default.nix
@@ -5,7 +5,6 @@
 , scipy
 , autograd
 , nose2
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -20,13 +19,14 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ numpy scipy ];
-  checkInputs = [ nose2 autograd pytestCheckHook ];
+  checkInputs = [ nose2 autograd ];
 
-  disabledTestPaths = [
-    "tests/test_problem.py"
-    "tests/test_tensorflow.py"
-    "tests/test_theano.py"
-  ];
+  checkPhase = ''
+    # nose2 doesn't properly support excludes
+    rm tests/test_{problem,tensorflow,theano}.py
+
+    nose2 tests -v
+  '';
 
   pythonImportsCheck = [ "pymanopt" ];
 

--- a/pkgs/development/python-modules/pymanopt/default.nix
+++ b/pkgs/development/python-modules/pymanopt/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, numpy
+, scipy
+, autograd
+, nose2
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pymanopt";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "0zk775v281375sangc5qkwrkb8yc9wx1g8b1917s4s8wszzkp8k6";
+  };
+
+  propagatedBuildInputs = [ numpy scipy ];
+  checkInputs = [ nose2 autograd pytestCheckHook ];
+
+  disabledTestPaths = [
+    "tests/test_problem.py"
+    "tests/test_tensorflow.py"
+    "tests/test_theano.py"
+  ];
+
+  pythonImportsCheck = [ "pymanopt" ];
+
+  meta = {
+    description = "Python toolbox for optimization on Riemannian manifolds with support for automatic differentiation";
+    homepage = "https://www.pymanopt.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ yl3dy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3206,6 +3206,8 @@ in {
 
   guestfs = callPackage ../development/python-modules/guestfs { };
 
+  gudhi = callPackage ../development/python-modules/gudhi { };
+
   gumath = callPackage ../development/python-modules/gumath { };
 
   gunicorn = callPackage ../development/python-modules/gunicorn { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5571,6 +5571,8 @@ in {
 
   postorius = callPackage ../servers/mail/mailman/postorius.nix { };
 
+  POT = callPackage ../development/python-modules/POT { };
+
   potr = callPackage ../development/python-modules/potr { };
 
   power = callPackage ../development/python-modules/power { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6273,6 +6273,8 @@ in {
 
   pymaging_png = callPackage ../development/python-modules/pymaging_png { };
 
+  pymanopt = callPackage ../development/python-modules/pymanopt { };
+
   pymata-express = callPackage ../development/python-modules/pymata-express { };
 
   pymatgen = callPackage ../development/python-modules/pymatgen { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5571,7 +5571,7 @@ in {
 
   postorius = callPackage ../servers/mail/mailman/postorius.nix { };
 
-  POT = callPackage ../development/python-modules/POT { };
+  pot = callPackage ../development/python-modules/pot { };
 
   potr = callPackage ../development/python-modules/potr { };
 


### PR DESCRIPTION
###### Motivation for this change

Packages init'ed here are useful for Topological Data Analysis. POT and pymanopt are optional runtime dependencies, but are required for Wasserstein distance calculation.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
