### PR TITLE
pinentry: remove multiple outputs

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -66,7 +66,7 @@ with lib;
       networkmanager-sstp = super.networkmanager-vpnc.override { withGnome = false; };
       networkmanager-vpnc = super.networkmanager-vpnc.override { withGnome = false; };
       pango = super.pango.override { x11Support = false; };
-      pinentry = super.pinentry.override { enabledFlavors = [ "curses" "tty" "emacs" ]; withLibsecret = false; };
+      pinentry-curses = super.pinentry-curses.override { withLibsecret = false; };
       pipewire = super.pipewire.override { vulkanSupport = false; x11Support = false; };
       pythonPackagesExtensions = super.pythonPackagesExtensions ++ [
         (python-final: python-prev: {

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -152,6 +152,7 @@ in {
             '';
           }
         ];
+
         environment = {
           systemPackages = optional (cfg.package != null) cfg.package ++ cfg.extraPackages;
           # Needed for the default wallpaper:
@@ -166,8 +167,12 @@ in {
             "sway/config".source = mkOptionDefault "${cfg.package}/etc/sway/config";
           };
         };
+
+        programs.gnupg.agent.pinentryPackage = lib.mkDefault pkgs.pinentry-gnome3;
+
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050913
         xdg.portal.config.sway.default = mkDefault [ "wlr" "gtk" ];
+
         # To make a Sway session available if a display manager like SDDM is enabled:
         services.xserver.displayManager.sessionPackages = optionals (cfg.package != null) [ cfg.package ]; }
       (import ./wayland-session.nix { inherit lib pkgs; })

--- a/nixos/modules/services/security/yubikey-agent.nix
+++ b/nixos/modules/services/security/yubikey-agent.nix
@@ -6,9 +6,6 @@ with lib;
 
 let
   cfg = config.services.yubikey-agent;
-
-  # reuse the pinentryFlavor option from the gnupg module
-  pinentryFlavor = config.programs.gnupg.agent.pinentryFlavor;
 in
 {
   ###### interface
@@ -41,13 +38,8 @@ in
     # This overrides the systemd user unit shipped with the
     # yubikey-agent package
     systemd.user.services.yubikey-agent = mkIf (pinentryFlavor != null) {
-      path = [ pkgs.pinentry.${pinentryFlavor} ];
-      wantedBy = [
-        (if pinentryFlavor == "tty" || pinentryFlavor == "curses" then
-          "default.target"
-        else
-          "graphical-session.target")
-      ];
+      path = [ config.programs.gnupg.agent.pinentryPackage ];
+      wantedBy = [ "default.target" ];
     };
 
     # Yubikey-agent expects pcsd to be running in order to function.

--- a/nixos/modules/services/x11/desktop-managers/deepin.nix
+++ b/nixos/modules/services/x11/desktop-managers/deepin.nix
@@ -66,6 +66,7 @@ in
       services.upower.enable = mkDefault config.powerManagement.enable;
       networking.networkmanager.enable = mkDefault true;
       programs.dconf.enable = mkDefault true;
+      programs.gnupg.agent.pinentryPackage = pkgs.pinentry-qt;
 
       fonts.packages = with pkgs; [ noto-fonts ];
       xdg.mime.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -62,6 +62,8 @@ in
     # Link some extra directories in /run/current-system/software/share
     environment.pathsToLink = [ "/share" ];
 
+    programs.gnupg.agent.pinentryPackage = pkgs.pinentry-qt;
+
     # virtual file systems support for PCManFM-QT
     services.gvfs.enable = true;
 

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -336,6 +336,7 @@ in
         serif = [ "Noto Serif" ];
       };
 
+      programs.gnupg.agent.pinentryPackage = pkgs.pinentry-qt;
       programs.ssh.askPassword = mkDefault "${pkgs.plasma5Packages.ksshaskpass.out}/bin/ksshaskpass";
 
       # Enable helpful DBus services.

--- a/nixos/modules/services/x11/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma6.nix
@@ -210,6 +210,7 @@ in {
       serif = ["Noto Serif"];
     };
 
+    programs.gnupg.agent.pinentryPackage = pkgs.pinentry-qt;
     programs.ssh.askPassword = mkDefault "${kdePackages.ksshaskpass.out}/bin/ksshaskpass";
 
     # Enable helpful DBus services.

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -131,6 +131,7 @@ in
         xfdesktop
       ] ++ optional cfg.enableScreensaver xfce4-screensaver) excludePackages;
 
+    programs.gnupg.agent.pinentryPackage = pkgs.pinentry-gtk2;
     programs.xfconf.enable = true;
     programs.thunar.enable = true;
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -749,6 +749,8 @@ in
     boot.kernel.sysctl."fs.inotify.max_user_instances" = mkDefault 524288;
     boot.kernel.sysctl."fs.inotify.max_user_watches" = mkDefault 524288;
 
+    programs.gnupg.agent.pinentryPackage = lib.mkDefault pkgs.pinentry-gnome3;
+
     systemd.defaultUnit = mkIf cfg.autorun "graphical.target";
 
     systemd.services.display-manager =

--- a/nixos/tests/pass-secret-service.nix
+++ b/nixos/tests/pass-secret-service.nix
@@ -26,7 +26,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
       programs.gnupg = {
         agent.enable = true;
-        agent.pinentryFlavor = "tty";
         dirmngr.enable = true;
       };
     };

--- a/pkgs/applications/version-management/blackbox/default.nix
+++ b/pkgs/applications/version-management/blackbox/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     expect
     which
     coreutils
-    pinentry.tty
+    pinentry
     git
     gnutar
     procps

--- a/pkgs/by-name/go/goldwarden/package.nix
+++ b/pkgs/by-name/go/goldwarden/package.nix
@@ -4,7 +4,7 @@
 , makeBinaryWrapper
 , libfido2
 , dbus
-, pinentry
+, pinentry-gnome3
 , nix-update-script
 }:
 
@@ -29,7 +29,7 @@ buildGoModule rec {
 
   postInstall = ''
     wrapProgram $out/bin/goldwarden \
-      --suffix PATH : ${lib.makeBinPath [dbus pinentry]}
+      --suffix PATH : ${lib.makeBinPath [dbus pinentry-gnome3]}
 
     install -Dm644 $src/resources/com.quexten.goldwarden.policy -t $out/share/polkit-1/actions
   '';

--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,100 +1,120 @@
-{ fetchurl, mkDerivation, fetchpatch, stdenv, lib, pkg-config, autoreconfHook, wrapGAppsHook
-, libgpg-error, libassuan, qtbase, wrapQtAppsHook
-, ncurses, gtk2, gcr
-, withLibsecret ? true, libsecret
-, enabledFlavors ? [ "curses" "tty" "gtk2" "emacs" ]
-  ++ lib.optionals stdenv.isLinux [ "gnome3" ]
-  ++ lib.optionals (!stdenv.isDarwin) [ "qt" ]
+{ stdenv
+, lib
+, fetchurl
+, fetchpatch
+, pkg-config
+, autoreconfHook
+, wrapGAppsHook
+, libgpg-error
+, libassuan
+, libsForQt5
+, ncurses
+, gtk2
+, gcr
+, withLibsecret ? true
+, libsecret
 }:
 
-assert lib.isList enabledFlavors && enabledFlavors != [];
-
 let
-  pinentryMkDerivation =
-    if (builtins.elem "qt" enabledFlavors)
-      then mkDerivation
-      else stdenv.mkDerivation;
-
-  enableFeaturePinentry = f:
-    let
-      flag = flavorInfo.${f}.flag or null;
-    in
-      lib.optionalString (flag != null)
-        (lib.enableFeature (lib.elem f enabledFlavors) ("pinentry-" + flag));
-
   flavorInfo = {
-    curses = { bin = "curses"; flag = "curses"; buildInputs = [ ncurses ]; };
-    tty = { bin = "tty"; flag = "tty"; };
-    gtk2 = { bin = "gtk-2"; flag = "gtk2"; buildInputs = [ gtk2 ]; };
-    gnome3 = { bin = "gnome3"; flag = "gnome3"; buildInputs = [ gcr ]; nativeBuildInputs = [ wrapGAppsHook ]; };
-    qt = { bin = "qt"; flag = "qt"; buildInputs = [ qtbase ]; nativeBuildInputs = [ wrapQtAppsHook ]; };
-    emacs = { bin = "emacs"; flag = "emacs"; buildInputs = []; };
+    tty = { flag = "tty"; };
+    curses = {
+      flag = "curses";
+      buildInputs = [ ncurses ];
+    };
+    gtk2 = {
+      flag = "gtk2";
+      buildInputs = [ gtk2 ];
+    };
+    gnome3 = {
+      flag = "gnome3";
+      buildInputs = [ gcr ];
+      nativeBuildInputs = [ wrapGAppsHook ];
+    };
+    qt = {
+      flag = "qt";
+      buildInputs = [ libsForQt5.qtbase ];
+      nativeBuildInputs = [ libsForQt5.wrapQtAppsHook ];
+    };
+    emacs = { flag = "emacs"; };
   };
 
+  buildPinentry = pinentryExtraPname: buildFlavors:
+    let
+      enableFeaturePinentry = f:
+        lib.enableFeature (lib.elem f buildFlavors) ("pinentry-" + flavorInfo.${f}.flag);
+
+      pinentryMkDerivation =
+        if (lib.elem "qt" buildFlavors)
+        then libsForQt5.mkDerivation
+        else stdenv.mkDerivation;
+
+    in
+    pinentryMkDerivation rec {
+      pname = "pinentry-${pinentryExtraPname}";
+      version = "1.2.1";
+
+      src = fetchurl {
+        url = "mirror://gnupg/pinentry/pinentry-${version}.tar.bz2";
+        hash = "sha256-RXoYXlqFI4+5RalV3GNSq5YtyLSHILYvyfpIx1QKQGc=";
+      };
+
+      nativeBuildInputs = [ pkg-config autoreconfHook ]
+        ++ lib.concatMap (f: flavorInfo.${f}.nativeBuildInputs or [ ]) buildFlavors;
+
+      buildInputs = [ libgpg-error libassuan ]
+        ++ lib.optional withLibsecret libsecret
+        ++ lib.concatMap (f: flavorInfo.${f}.buildInputs or [ ]) buildFlavors;
+
+      dontWrapGApps = true;
+      dontWrapQtApps = true;
+
+      patches = [
+        ./autoconf-ar.patch
+      ] ++ lib.optionals (lib.elem "gtk2" buildFlavors) [
+        (fetchpatch {
+          url = "https://salsa.debian.org/debian/pinentry/raw/debian/1.1.0-1/debian/patches/0007-gtk2-When-X11-input-grabbing-fails-try-again-over-0..patch";
+          sha256 = "15r1axby3fdlzz9wg5zx7miv7gqx2jy4immaw4xmmw5skiifnhfd";
+        })
+      ];
+
+      configureFlags = [
+        "--with-libgpg-error-prefix=${libgpg-error.dev}"
+        "--with-libassuan-prefix=${libassuan.dev}"
+        (lib.enableFeature withLibsecret "libsecret")
+      ] ++ (map enableFeaturePinentry (lib.attrNames flavorInfo));
+
+      postInstall =
+        lib.optionalString (lib.elem "gnome3" buildFlavors) ''
+          wrapGApp $out/bin/pinentry-gnome3
+        '' + lib.optionalString (lib.elem "qt" buildFlavors) ''
+          wrapQtApp $out/bin/pinentry-qt
+        '';
+
+      passthru = { flavors = buildFlavors; };
+
+      meta = with lib; {
+        homepage = "https://gnupg.org/software/pinentry/index.html";
+        description = "GnuPG’s interface to passphrase input";
+        license = licenses.gpl2Plus;
+        platforms =
+          if elem "gnome3" buildFlavors then platforms.linux else
+          if elem "qt" buildFlavors then (remove "aarch64-darwin" platforms.all) else
+          platforms.all;
+        longDescription = ''
+          Pinentry provides a console and (optional) GTK and Qt GUIs allowing users
+          to enter a passphrase when `gpg' or `gpg2' is run and needs it.
+        '';
+        maintainers = with maintainers; [ fpletz ];
+        mainProgram = "pinentry";
+      };
+    };
 in
-
-pinentryMkDerivation rec {
-  pname = "pinentry";
-  version = "1.2.1";
-
-  src = fetchurl {
-    url = "mirror://gnupg/pinentry/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-RXoYXlqFI4+5RalV3GNSq5YtyLSHILYvyfpIx1QKQGc=";
-  };
-
-  nativeBuildInputs = [ pkg-config autoreconfHook ]
-    ++ lib.concatMap(f: flavorInfo.${f}.nativeBuildInputs or []) enabledFlavors;
-
-  buildInputs = [ libgpg-error libassuan ]
-    ++ lib.optional withLibsecret libsecret
-    ++ lib.concatMap(f: flavorInfo.${f}.buildInputs or []) enabledFlavors;
-
-  dontWrapGApps = true;
-  dontWrapQtApps = true;
-
-  patches = [
-    ./autoconf-ar.patch
-  ] ++ lib.optionals (lib.elem "gtk2" enabledFlavors) [
-    (fetchpatch {
-      url = "https://salsa.debian.org/debian/pinentry/raw/debian/1.1.0-1/debian/patches/0007-gtk2-When-X11-input-grabbing-fails-try-again-over-0..patch";
-      sha256 = "15r1axby3fdlzz9wg5zx7miv7gqx2jy4immaw4xmmw5skiifnhfd";
-    })
-  ];
-
-  configureFlags = [
-    "--with-libgpg-error-prefix=${libgpg-error.dev}"
-    "--with-libassuan-prefix=${libassuan.dev}"
-    (lib.enableFeature withLibsecret "libsecret")
-  ] ++ (map enableFeaturePinentry (lib.attrNames flavorInfo));
-
-  postInstall =
-    lib.concatStrings (lib.flip map enabledFlavors (f:
-      let
-        binary = "pinentry-" + flavorInfo.${f}.bin;
-      in ''
-        moveToOutput bin/${binary} ${placeholder f}
-        ln -sf ${placeholder f}/bin/${binary} ${placeholder f}/bin/pinentry
-      '' + lib.optionalString (f == "gnome3") ''
-        wrapGApp ${placeholder f}/bin/${binary}
-      '' + lib.optionalString (f == "qt") ''
-        wrapQtApp ${placeholder f}/bin/${binary}
-      '')) + ''
-      ln -sf ${placeholder (lib.head enabledFlavors)}/bin/pinentry-${flavorInfo.${lib.head enabledFlavors}.bin} $out/bin/pinentry
-    '';
-
-  outputs = [ "out" ] ++ enabledFlavors;
-
-  passthru = { flavors = enabledFlavors; };
-
-  meta = with lib; {
-    homepage = "http://gnupg.org/aegypten2/";
-    description = "GnuPG’s interface to passphrase input";
-    license = licenses.gpl2Plus;
-    platforms = platforms.all;
-    longDescription = ''
-      Pinentry provides a console and (optional) GTK and Qt GUIs allowing users
-      to enter a passphrase when `gpg' or `gpg2' is run and needs it.
-    '';
-    maintainers = with maintainers; [ ttuegel fpletz ];
-  };
+{
+  pinentry-curses = buildPinentry "curses" [ "curses" "tty" ];
+  pinentry-gtk2 = buildPinentry "gtk2" [ "gtk2" "curses" "tty" ];
+  pinentry-gnome3 = buildPinentry "gnome3" [ "gnome3" "curses" "tty" ];
+  pinentry-qt = buildPinentry "qt" [ "qt" "curses" "tty" ];
+  pinentry-emacs = buildPinentry "emacs" [ "emacs" "curses" "tty" ];
+  pinentry-all = buildPinentry "all" [ "curses" "tty" "gtk2" "gnome3" "qt" "emacs" ];
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -891,12 +891,23 @@ mapAliases ({
   timescaledb = postgresqlPackages.timescaledb;
   tsearch_extras = postgresqlPackages.tsearch_extras;
 
+  # pinentry was using multiple outputs, this emulates the old interface for i.e. home-manager
+  # soon: throw "'pinentry' has been removed. Pick an appropriate variant like 'pinentry-curses' or 'pinentry-gnome3'";
+  pinentry = pinentry-all // {
+    curses = pinentry-curses;
+    gtk2 = pinentry-gtk2;
+    gnome2 = pinentry-gnome3;
+    qt = pinentry-qt;
+    emacs = pinentry-emacs;
+    flavors = [ "curses" "gtk2" "gnome2" "qt" "emacs" ];
+  }; # added 2024-01-15
   pinentry_curses = throw "'pinentry_curses' has been renamed to/replaced by 'pinentry-curses'"; # Converted to throw 2023-09-10
   pinentry_emacs = throw "'pinentry_emacs' has been renamed to/replaced by 'pinentry-emacs'"; # Converted to throw 2023-09-10
   pinentry_gnome = throw "'pinentry_gnome' has been renamed to/replaced by 'pinentry-gnome'"; # Converted to throw 2023-09-10
   pinentry_gtk2 = throw "'pinentry_gtk2' has been renamed to/replaced by 'pinentry-gtk2'"; # Converted to throw 2023-09-10
   pinentry_qt = throw "'pinentry_qt' has been renamed to/replaced by 'pinentry-qt'"; # Converted to throw 2023-09-10
   pinentry_qt5 = pinentry-qt; # Added 2020-02-11
+
   PlistCpp = plistcpp; # Added 2024-01-05
   pocket-updater-utility = pupdate; # Added 2024-01-25
   poetry2nix = throw "poetry2nix is now maintained out-of-tree. Please use https://github.com/nix-community/poetry2nix/"; # Added 2023-10-26

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11999,13 +11999,13 @@ with pkgs;
 
   piknik = callPackage ../tools/networking/piknik { };
 
-  pinentry = libsForQt5.callPackage ../tools/security/pinentry { };
-
-  pinentry-curses = (lib.getOutput "curses" pinentry);
-  pinentry-emacs = (lib.getOutput "emacs" pinentry);
-  pinentry-gtk2 = (lib.getOutput "gtk2" pinentry);
-  pinentry-qt = (lib.getOutput "qt" pinentry);
-  pinentry-gnome = (lib.getOutput "gnome3" pinentry);
+  inherit (callPackages ../tools/security/pinentry { })
+    pinentry-curses
+    pinentry-emacs
+    pinentry-gtk2
+    pinentry-gnome3
+    pinentry-qt
+    pinentry-all;
 
   pinentry_mac = callPackage ../tools/security/pinentry/mac.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30374,7 +30374,9 @@ with pkgs;
 
   bgpq4 = callPackage ../tools/networking/bgpq4 { };
 
-  blackbox = callPackage ../applications/version-management/blackbox { };
+  blackbox = callPackage ../applications/version-management/blackbox {
+    pinentry = pinentry-curses;
+  };
 
   bleachbit = callPackage ../applications/misc/bleachbit { };
 
@@ -41310,7 +41312,9 @@ with pkgs;
 
   linkchecker = callPackage ../tools/networking/linkchecker { };
 
-  tomb = callPackage ../os-specific/linux/tomb { };
+  tomb = callPackage ../os-specific/linux/tomb {
+    pinentry = pinentry-curses;
+  };
 
   sccache = callPackage ../development/tools/misc/sccache { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14920,7 +14920,9 @@ self: super: with self; {
 
   treq = callPackage ../development/python-modules/treq { };
 
-  trezor-agent = callPackage ../development/python-modules/trezor-agent { };
+  trezor-agent = callPackage ../development/python-modules/trezor-agent {
+    pinentry = pkgs.pinentry-curses;
+  };
 
   trezor = callPackage ../development/python-modules/trezor { };
 


### PR DESCRIPTION
###### Motivation for this change

Previously `pinentry` was a package with multiple outputs. This caused lots of rebuilds and always needs the dependencies of all flavors to build. Fixes #133156 #124753.

~~This PR refactors the different pinentry flavors into separate package builds and keeps the old interface for compatibility. As the attribute name `pinentry` would be misleading now it was renamed to `pinentryFlavors`.~~ The old multiple outputs based interface is aliased for compatibility since this was not only used in the gnupg NixOS module but also the corresponding home-manager module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
