### PR TITLE
cryptpad: add meta longDescription and mainProgram

### DIFF
--- a/pkgs/servers/web-apps/cryptpad/default.nix
+++ b/pkgs/servers/web-apps/cryptpad/default.nix
@@ -75,7 +75,15 @@ let
       chmod +x $out/bin/cryptpad
     '';
 
-    meta.maintainers = with lib.maintainers; [ davhau ];
+    meta = {
+      longDescription = ''
+        CryptPad is a collaboration suite that is end-to-end-encrypted and open-source.
+        It is built to enable collaboration, synchronizing changes to documents in real time.
+        Because all data is encrypted, the service and its administrators have no way of seeing the content being edited and stored.
+      '';
+      maintainers = with lib.maintainers; [ davhau ];
+      mainProgram = "cryptpad";
+    };
 
   };
 in


### PR DESCRIPTION
###### Motivation for this change

followup of https://github.com/NixOS/nixpkgs/pull/133202

see https://github.com/ngi-nix/ngi/issues/43

###### Things done
added attributes `meta.longDescription` and `meta.mainProgram`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
