### PR TITLE
fwupd-efi: init at 1.1, fwupd: 1.5.12 -> 1.7.1

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd-efi/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd-efi/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitHub
+, substituteAll
+, pkg-config
+, meson
+, ninja
+, gnu-efi
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fwupd-efi";
+  version = "1.1";
+
+  src = fetchurl {
+    url = "https://people.freedesktop.org/~hughsient/releases/${pname}-${version}.tar.xz";
+    sha256 = "1w879qxlnsaz5xyp168a08f2p8yrgfpkfycls28jw8qxmz6g20aw";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    gnu-efi
+  ];
+
+  postPatch = ''
+    patchShebangs \
+      efi/generate_binary.py \
+      efi/generate_sbat.py
+  '';
+
+  mesonFlags = [
+    "-Defi-includedir=${gnu-efi}/include/efi"
+    "-Defi-libdir=${gnu-efi}/lib"
+    "-Defi-ldsdir=${gnu-efi}/lib"
+    "-Defi_sbat_distro_id=nixos"
+    "-Defi_sbat_distro_summary=NixOS"
+    "-Defi_sbat_distro_pkgname=${pname}"
+    "-Defi_sbat_distro_version=${version}"
+    "-Defi_sbat_distro_url=https://search.nixos.org/packages?channel=unstable&show=fwupd-efi&from=0&size=50&sort=relevance&query=fwupd-efi"
+  ];
+
+  meta = with lib; {
+    homepage = "https://fwupd.org/";
+    maintainers = with maintainers; [ maxeaubrey ];
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,21 +1,21 @@
 diff --git a/data/meson.build b/data/meson.build
-index 50154569..f8058a8e 100644
+index f10d4ff6..2dc66fb6 100644
 --- a/data/meson.build
 +++ b/data/meson.build
-@@ -17,7 +17,7 @@ endif
+@@ -21,7 +21,7 @@ endif
  
  if build_standalone
    install_data(['daemon.conf'],
 -    install_dir : join_paths(sysconfdir, 'fwupd')
 +    install_dir : join_paths(sysconfdir_install, 'fwupd')
    )
- endif
- 
+   install_data(['power.quirk'],
+     install_dir: join_paths(datadir, 'fwupd', 'quirks.d'))
 diff --git a/data/pki/meson.build b/data/pki/meson.build
-index 94bb0b6f..1ea6a9ac 100644
+index dcd9e128..ff137f3a 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
-@@ -3,24 +3,23 @@ install_data([
+@@ -2,24 +2,23 @@ install_data([
      'GPG-KEY-Linux-Foundation-Firmware',
      'GPG-KEY-Linux-Vendor-Firmware-Service',
    ],
@@ -45,19 +45,28 @@ index 94bb0b6f..1ea6a9ac 100644
  )
 -
 diff --git a/data/remotes.d/meson.build b/data/remotes.d/meson.build
-index 826a3c1d..b78db663 100644
+index 02d8777b..2c89d593 100644
 --- a/data/remotes.d/meson.build
 +++ b/data/remotes.d/meson.build
-@@ -3,7 +3,7 @@ if build_daemon and get_option('lvfs')
-       'lvfs.conf',
+@@ -2,7 +2,7 @@ if build_standalone and get_option('lvfs') != 'false'
+   install_data([
        'lvfs-testing.conf',
      ],
 -    install_dir : join_paths(sysconfdir, 'fwupd', 'remotes.d')
 +    install_dir : join_paths(sysconfdir_install, 'fwupd', 'remotes.d')
    )
+   con3 = configuration_data()
+   if get_option('lvfs') == 'disabled'
+@@ -15,7 +15,7 @@ if build_standalone and get_option('lvfs') != 'false'
+     output : 'lvfs.conf',
+     configuration : con3,
+     install: true,
+-    install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
++    install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
+   )
    i18n.merge_file(
      input: 'lvfs.metainfo.xml',
-@@ -37,12 +37,12 @@ configure_file(
+@@ -49,12 +49,12 @@ configure_file(
    output : 'vendor.conf',
    configuration : con2,
    install: true,
@@ -73,10 +82,10 @@ index 826a3c1d..b78db663 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index b075ca89..8d504d3c 100644
+index 7557cd4a..4c98de6d 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -194,6 +194,12 @@ endif
+@@ -190,6 +190,12 @@ endif
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
  
@@ -90,43 +99,44 @@ index b075ca89..8d504d3c 100644
  gio = dependency('gio-2.0', version : '>= 2.45.8')
  giounix = dependency('gio-unix-2.0', version : '>= 2.45.8', required: false)
 diff --git a/meson_options.txt b/meson_options.txt
-index bc76c0ab..8a67d012 100644
+index 94f73898..5de6cc7b 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -1,3 +1,4 @@
 +option('sysconfdir_install', type: 'string', value: '', description: 'sysconfdir to use during installation')
  option('build', type : 'combo', choices : ['all', 'standalone', 'library'], value : 'all', description : 'build type')
- option('agent', type : 'boolean', value : true, description : 'enable the fwupd agent')
  option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
+ option('firmware-packager', type : 'boolean', value : true, description : 'enable firmware-packager installation')
 diff --git a/plugins/dell-esrt/meson.build b/plugins/dell-esrt/meson.build
-index ed4eee70..76dbdb1d 100644
+index e9f12879..a0126dbb 100644
 --- a/plugins/dell-esrt/meson.build
 +++ b/plugins/dell-esrt/meson.build
-@@ -37,5 +37,5 @@ configure_file(
+@@ -38,6 +38,6 @@ configure_file(
    output : 'dell-esrt.conf',
    configuration : con2,
    install: true,
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
+ endif
 diff --git a/plugins/redfish/meson.build b/plugins/redfish/meson.build
-index 205d1394..3223f404 100644
+index 5263048c..c46fac64 100644
 --- a/plugins/redfish/meson.build
 +++ b/plugins/redfish/meson.build
-@@ -27,7 +27,7 @@ shared_module('fu_plugin_redfish',
+@@ -53,7 +53,7 @@ shared_module('fu_plugin_redfish',
  )
  
  install_data(['redfish.conf'],
--  install_dir:  join_paths(sysconfdir, 'fwupd')
-+  install_dir:  join_paths(sysconfdir_install, 'fwupd')
+-  install_dir:  join_paths(sysconfdir, 'fwupd'),
++  install_dir:  join_paths(sysconfdir_install, 'fwupd'),
+   install_mode: 'rw-r-----',
  )
  
- if get_option('tests')
 diff --git a/plugins/thunderbolt/meson.build b/plugins/thunderbolt/meson.build
-index 6b2368fb..2bd06fed 100644
+index 646ed6cb..8d7c59aa 100644
 --- a/plugins/thunderbolt/meson.build
 +++ b/plugins/thunderbolt/meson.build
-@@ -31,7 +31,7 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
+@@ -35,7 +35,7 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
  )
  
  install_data(['thunderbolt.conf'],
@@ -136,10 +146,19 @@ index 6b2368fb..2bd06fed 100644
  # we use functions from 2.52 in the tests
  if get_option('tests') and umockdev.found() and gio.version().version_compare('>= 2.52')
 diff --git a/plugins/uefi-capsule/meson.build b/plugins/uefi-capsule/meson.build
-index 0b793a07..ebd3e5ea 100644
+index 708586b0..f29536b1 100644
 --- a/plugins/uefi-capsule/meson.build
 +++ b/plugins/uefi-capsule/meson.build
-@@ -97,7 +97,7 @@ if get_option('man')
+@@ -21,7 +21,7 @@ if host_machine.system() == 'linux'
+     output : '35_fwupd',
+     configuration : con2,
+     install: true,
+-    install_dir: join_paths(sysconfdir, 'grub.d')
++    install_dir: join_paths(sysconfdir_install, 'grub.d')
+   )
+ elif host_machine.system() == 'freebsd'
+   backend_srcs += 'fu-uefi-backend-freebsd.c'
+@@ -116,7 +116,7 @@ if get_option('man')
  endif
  
  install_data(['uefi_capsule.conf'],
@@ -147,15 +166,4 @@ index 0b793a07..ebd3e5ea 100644
 +  install_dir:  join_paths(sysconfdir_install, 'fwupd')
  )
  
- if get_option('tests')
-diff --git a/plugins/upower/meson.build b/plugins/upower/meson.build
-index 290a3eb6..9ab2f452 100644
---- a/plugins/upower/meson.build
-+++ b/plugins/upower/meson.build
-@@ -23,5 +23,5 @@ shared_module('fu_plugin_upower',
- )
- 
- install_data(['upower.conf'],
--  install_dir:  join_paths(sysconfdir, 'fwupd')
-+  install_dir:  join_paths(sysconfdir_install, 'fwupd')
- )
+ # add all the .po files as inputs to watch

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -1,9 +1,10 @@
 # Updating? Keep $out/etc synchronized with passthru keys
 
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchurl
+, fetchpatch
 , fetchFromGitHub
-, substituteAll
 , gtk-doc
 , pkg-config
 , gobject-introspection
@@ -15,13 +16,11 @@
 , sqlite
 , libarchive
 , curl
-, help2man
 , libjcat
 , libxslt
 , elfutils
 , libsmbios
 , efivar
-, gnu-efi
 , valgrind
 , meson
 , libuuid
@@ -31,6 +30,7 @@
 , ninja
 , gcab
 , gnutls
+, protobufc
 , python3
 , wrapGAppsHook
 , json-glib
@@ -40,30 +40,22 @@
 , vala
 , makeFontsConf
 , freefont_ttf
-, cairo
-, freetype
-, fontconfig
 , pango
 , tpm2-tss
 , bubblewrap
 , efibootmgr
 , flashrom
 , tpm2-tools
+, fwupd-efi
 , nixosTests
 , runCommand
+, unstableGitUpdater
 }:
 
 let
   python = python3.withPackages (p: with p; [
     pygobject3
-    pycairo
-    pillow
     setuptools
-  ]);
-
-  installedTestsPython = python3.withPackages (p: with p; [
-    pygobject3
-    requests
   ]);
 
   isx86 = stdenv.isx86_64 || stdenv.isi686;
@@ -89,9 +81,38 @@ let
     exec python3 -c "$buildCommandPython"
   '';
 
+  test-firmware =
+    let
+      version = "unstable-2021-11-02";
+      src = fetchFromGitHub {
+        name = "fwupd-test-firmware-${version}";
+        owner = "fwupd";
+        repo = "fwupd-test-firmware";
+        rev = "aaa2f9fd68a40684c256dd85b86093cba38ffd9d";
+        sha256 = "Slk7CNfkmvmOh3WtIBkPs3NYT96co6i8PwqcbpeVFgA=";
+        passthru = {
+          inherit src version; # For update script
+          updateScript = unstableGitUpdater {
+            url = "${test-firmware.meta.homepage}.git";
+          };
+        };
+      };
+    in
+      src // {
+        meta = src.meta // {
+          # For update script
+          position =
+            let
+              pos = builtins.unsafeGetAttrPos "updateScript" test-firmware;
+            in
+            pos.file + ":" + toString pos.line;
+        };
+      };
+
+
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
-    version = "1.5.12";
+    version = "1.7.1";
 
     # libfwupd goes to lib
     # daemon, plug-ins and libfwupdplugin go to out
@@ -100,27 +121,27 @@ let
 
     src = fetchurl {
       url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      sha256 = "sha256-BluwLlm6s/2H/USARQpAvDR0+X8WP/q0h8VvxA6Qftc=";
+      sha256 = "sha256-rlbOtEt4byH1TRM6xwvF2cuM1L2gFnM5xmmiKNpn+jw=";
     };
 
     patches = [
-      # Do not try to create useless paths in /var.
-      ./fix-paths.patch
-
-      # Allow installing
+      # Since /etc is the domain of NixOS, not Nix,
+      # we cannot install files there.
+      # Let’s install the files to $prefix/etc
+      # while still reading them from /etc.
+      # NixOS module for fwupd will take take care of copying the files appropriately.
       ./add-option-for-installation-sysconfdir.patch
 
-      # Install plug-ins and libfwupdplugin to out,
+      # Install plug-ins and libfwupdplugin to $out output,
       # they are not really part of the library.
       ./install-fwupdplugin-to-out.patch
 
       # Installed tests are installed to different output
       # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle.
-      (substituteAll {
-        src = ./installed-tests-path.patch;
-        # Needs a different set of modules than po/make-images.
-        inherit installedTestsPython;
-      })
+      ./installed-tests-path.patch
+
+      # Tests detect fwupd is installed when prefix is /usr.
+      ./fix-install-detection.patch
     ];
 
     nativeBuildInputs = [
@@ -136,8 +157,8 @@ let
       gnutls
       docbook_xml_dtd_43
       docbook-xsl-nons
-      help2man
       libxslt
+      protobufc # for protoc
       python
       wrapGAppsHook
       vala
@@ -151,7 +172,6 @@ let
       libarchive
       curl
       elfutils
-      gnu-efi
       libgudev
       colord
       libjcat
@@ -159,18 +179,17 @@ let
       json-glib
       umockdev
       bash-completion
-      cairo
-      freetype
-      fontconfig
       pango
       tpm2-tss
       efivar
+      fwupd-efi
+      protobufc
     ] ++ lib.optionals haveDell [
       libsmbios
     ];
 
     mesonFlags = [
-      "-Dgtkdoc=true"
+      "-Ddocs=gtkdoc"
       "-Dplugin_dummy=true"
       # We are building the official releases.
       "-Dsupported_build=true"
@@ -180,17 +199,10 @@ let
       "-Dudevdir=lib/udev"
       "-Dsystemd_root_prefix=${placeholder "out"}"
       "-Dinstalled_test_prefix=${placeholder "installedTests"}"
-      "-Defi-libdir=${gnu-efi}/lib"
-      "-Defi-ldsdir=${gnu-efi}/lib"
-      "-Defi-includedir=${gnu-efi}/include/efi"
-      "-Defi_sbat_distro_id=nixos"
-      "-Defi_sbat_distro_summary=NixOS"
-      "-Defi_sbat_distro_pkgname=fwupd"
-      "-Defi_sbat_distro_version=${version}"
-      "-Defi_sbat_distro_url=https://search.nixos.org/packages?channel=unstable&show=fwupd&from=0&size=50&sort=relevance&query=fwupd"
       "--localstatedir=/var"
       "--sysconfdir=/etc"
       "-Dsysconfdir_install=${placeholder "out"}/etc"
+      "-Defi_os_dir=nixos"
 
       # We do not want to place the daemon into lib (cyclic reference)
       "--libexecdir=${placeholder "out"}/libexec"
@@ -232,13 +244,8 @@ let
 
     postPatch = ''
       patchShebangs \
-        contrib/get-version.py \
         contrib/generate-version-script.py \
         meson_post_install.sh \
-        plugins/uefi-capsule/efi/generate_sbat.py \
-        plugins/uefi-capsule/efi/generate_binary.py \
-        po/make-images \
-        po/make-images.sh \
         po/test-deps
     '';
 
@@ -246,18 +253,20 @@ let
       addToSearchPath XDG_DATA_DIRS "${shared-mime-info}/share"
     '';
 
-    postInstall =
-      let
-        testFw = fetchFromGitHub {
-          owner = "fwupd";
-          repo = "fwupd-test-firmware";
-          rev = "c13bfb26cae5f4f115dd4e08f9f00b3cb9acc25e";
-          sha256 = "US81i7mtLEe85KdWz5r+fQTk61IhqjVkzykBaBPuKL4=";
-        };
-      in ''
-        # These files have weird licenses so they are shipped separately.
-        cp --recursive --dereference "${testFw}/installed-tests/tests" "$installedTests/libexec/installed-tests/fwupd"
-      '';
+    preInstall = ''
+      # We have pkexec on PATH so Meson will try to use it when installation fails
+      # due to being unable to write to e.g. /etc.
+      # Let’s pretend we already ran pkexec –
+      # the pkexec on PATH would complain it lacks setuid bit,
+      # obscuring the underlying error.
+      # https://github.com/mesonbuild/meson/blob/492cc9bf95d573e037155b588dc5110ded4d9a35/mesonbuild/minstall.py#L558
+      export PKEXEC_UID=-1
+    '';
+
+    postInstall = ''
+      # These files have weird licenses so they are shipped separately.
+      cp --recursive --dereference "${test-firmware}/installed-tests/tests" "$installedTests/libexec/installed-tests/fwupd"
+    '';
 
     preFixup = let
       binPath = [
@@ -294,7 +303,6 @@ let
         "fwupd/remotes.d/vendor.conf"
         "fwupd/remotes.d/vendor-directory.conf"
         "fwupd/thunderbolt.conf"
-        "fwupd/upower.conf"
         "fwupd/uefi_capsule.conf"
         "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
         "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"
@@ -302,6 +310,7 @@ let
         "pki/fwupd-metadata/GPG-KEY-Linux-Foundation-Metadata"
         "pki/fwupd-metadata/GPG-KEY-Linux-Vendor-Firmware-Service"
         "pki/fwupd-metadata/LVFS-CA.pem"
+        "grub.d/35_fwupd"
       ] ++ lib.optionals haveDell [
         "fwupd/remotes.d/dell-esrt.conf"
       ] ++ lib.optionals haveRedfish [
@@ -314,6 +323,9 @@ let
         "test_ble"
         "invalid"
       ];
+
+      # For updating.
+      inherit test-firmware;
 
       tests = let
         listToPy = list: "[${lib.concatMapStringsSep ", " (f: "'${f}'") list}]";

--- a/pkgs/os-specific/linux/firmware/fwupd/fix-install-detection.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/fix-install-detection.patch
@@ -1,0 +1,13 @@
+diff --git a/plugins/redfish/fu-self-test.c b/plugins/redfish/fu-self-test.c
+index 4710c769..1c68fdb9 100644
+--- a/plugins/redfish/fu-self-test.c
++++ b/plugins/redfish/fu-self-test.c
+@@ -27,7 +27,7 @@ fu_test_is_installed_test(void)
+ 	const gchar *builddir = g_getenv("G_TEST_BUILDDIR");
+ 	if (builddir == NULL)
+ 		return FALSE;
+-	return g_str_has_prefix(builddir, "/usr");
++	return g_str_has_prefix(builddir, "/nix");
+ }
+ 
+ static void

--- a/pkgs/os-specific/linux/firmware/fwupd/fix-paths.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/fix-paths.patch
@@ -1,8 +1,0 @@
-diff --git a/data/builder/meson.build b/data/builder/meson.build
-index c7a430c0..e69de29b 100644
---- a/data/builder/meson.build
-+++ b/data/builder/meson.build
-@@ -1,3 +0,0 @@
--install_data('README.md',
--  install_dir : join_paths(localstatedir, 'lib', 'fwupd', 'builder')
--)

--- a/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/install-fwupdplugin-to-out.patch
@@ -1,8 +1,8 @@
 diff --git a/libfwupdplugin/meson.build b/libfwupdplugin/meson.build
-index 0abcd45c..51cbc912 100644
+index d6a2ed68..12c82a95 100644
 --- a/libfwupdplugin/meson.build
 +++ b/libfwupdplugin/meson.build
-@@ -114,7 +114,8 @@
+@@ -216,7 +216,8 @@ fwupdplugin = library(
    ],
    link_args : vflag,
    link_depends : fwupdplugin_mapfile,
@@ -12,26 +12,26 @@ index 0abcd45c..51cbc912 100644
  )
  
  fwupdplugin_pkgg = import('pkgconfig')
-@@ -167,7 +168,8 @@
-       'GUsb-1.0',
+@@ -276,7 +277,8 @@ if get_option('introspection')
+       girtargets,
        fwupd_gir[0],
      ],
 -    install : true
 +    install : true,
 +    install_dir_typelib : bindir / '..' / 'lib' / 'girepository-1.0',
    )
-   gnome.generate_vapi('fwupdplugin',
-     sources : fwupd_gir[0],
+ 
+   # Verify the map file is correct -- note we can't actually use the generated
 diff --git a/meson.build b/meson.build
-index b1a523d2..00125997 100644
+index 38aa36b0..3fb7e579 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -389,7 +389,7 @@
+@@ -521,7 +521,7 @@ if build_standalone
  if host_machine.system() == 'windows'
-   plugin_dir = 'fwupd-plugins-3'
+   plugin_dir = 'fwupd-plugins-@0@'.format(libfwupdplugin_lt_current)
  else
--  plugin_dir = join_paths(libdir, 'fwupd-plugins-3')
-+  plugin_dir = join_paths(bindir, '..', 'lib', 'fwupd-plugins-3')
+-  plugin_dir = join_paths(libdir, 'fwupd-plugins-@0@'.format(libfwupdplugin_lt_current))
++  plugin_dir = join_paths(bindir, '..', 'lib', 'fwupd-plugins-@0@'.format(libfwupdplugin_lt_current))
  endif
  conf.set_quoted('FWUPD_PLUGINDIR', plugin_dir)
  endif

--- a/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
@@ -1,13 +1,3 @@
-diff --git a/data/device-tests/hardware.py b/data/device-tests/hardware.py
-index 7f1e1907..10fee1b8 100755
---- a/data/device-tests/hardware.py
-+++ b/data/device-tests/hardware.py
-@@ -1,4 +1,4 @@
--#!/usr/bin/python3
-+#!@installedTestsPython@/bin/python3
- # pylint: disable=wrong-import-position,too-many-locals,unused-argument,wrong-import-order
- #
- # Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
 diff --git a/data/installed-tests/meson.build b/data/installed-tests/meson.build
 index adadbcdd..1b51bb9c 100644
 --- a/data/installed-tests/meson.build

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21576,6 +21576,8 @@ with pkgs;
 
   fwupd = callPackage ../os-specific/linux/firmware/fwupd { };
 
+  fwupd-efi = callPackage ../os-specific/linux/firmware/fwupd-efi { };
+
   firmware-manager = callPackage ../os-specific/linux/firmware/firmware-manager { };
 
   fwts = callPackage ../os-specific/linux/fwts { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Changelogs:
- https://github.com/fwupd/fwupd/releases/tag/1.6.0
- https://github.com/fwupd/fwupd/releases/tag/1.6.1
- https://github.com/fwupd/fwupd/releases/tag/1.6.2
- https://github.com/fwupd/fwupd/releases/tag/1.6.3
- https://github.com/fwupd/fwupd/releases/tag/1.6.4
- https://github.com/fwupd/fwupd/releases/tag/1.7.0
- https://github.com/fwupd/fwupd/releases/tag/1.7.1

Announcement: https://blogs.gnome.org/hughsie/2021/04/26/fwupd-1-6-0/

There is some overlap with 1.5.x for those changes as 1.6.0 came out in April already.

Opening as a draft because it fails on the install step (seemingly in `meson_post_install.sh`), but I did not have the time to properly look into the "why" yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
