### PR TITLE
graphene-hardened-malloc: 2 -> 8, overhaul tests

### DIFF
--- a/pkgs/development/libraries/graphene-hardened-malloc/default.nix
+++ b/pkgs/development/libraries/graphene-hardened-malloc/default.nix
@@ -1,15 +1,23 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, python3, runCommand, makeWrapper, stress-ng }:
 
-stdenv.mkDerivation rec {
+lib.fix (self: stdenv.mkDerivation rec {
   pname = "graphene-hardened-malloc";
-  version = "2";
+  version = "8";
 
   src = fetchurl {
     url = "https://github.com/GrapheneOS/hardened_malloc/archive/${version}.tar.gz";
-    sha256 = "0zsl4vl65ic6lw5rzcjzvcxg8makg683abnwvy60zfap8hvijvjb";
+    sha256 = "0lipyd2pb1bmghkyv9zmg25jwcglj7m281f01zlh3ghz3xlfh0ym";
   };
 
+  doCheck = true;
+  checkInputs = [ python3 ];
+  # these tests cover use as a build-time-linked library
+  checkPhase = ''
+    make test
+  '';
+
   installPhase = ''
+    install -Dm444 -t $out/include include/*
     install -Dm444 -t $out/lib libhardened_malloc.so
 
     mkdir -p $out/bin
@@ -19,28 +27,51 @@ stdenv.mkDerivation rec {
 
   separateDebugInfo = true;
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    pushd test
-    make
-    $out/bin/preload-hardened-malloc ./offset
+  passthru = {
+    ld-preload-tests = stdenv.mkDerivation {
+      name = "${self.name}-ld-preload-tests";
+      src = self.src;
 
-    pushd simple-memory-corruption
-    make
+      nativeBuildInputs = [ makeWrapper ];
 
-    # these tests don't actually appear to generate overflows currently
-    rm read_after_free_small string_overflow eight_byte_overflow_large
+      # reuse the projects tests to cover use with LD_PRELOAD. we have
+      # to convince the test programs to build as though they're naive
+      # standalone executables. this includes disabling tests for
+      # malloc_object_size, which doesn't make sense to use via LD_PRELOAD.
+      buildPhase = ''
+        pushd test/simple-memory-corruption
+        make LDLIBS= LDFLAGS=-Wl,--unresolved-symbols=ignore-all CXXFLAGS=-lstdc++
+        substituteInPlace test_smc.py \
+          --replace 'test_malloc_object_size' 'dont_test_malloc_object_size' \
+          --replace 'test_invalid_malloc_object_size' 'dont_test_invalid_malloc_object_size'
+        popd # test/simple-memory-corruption
+      '';
 
-    for t in `find . -regex ".*/[a-z_]+"` ; do
-      echo "Running $t..."
-      # the program being aborted (as it should be) would result in an exit code > 128
-      (($out/bin/preload-hardened-malloc $t) && false) \
-        || (test $? -gt 128 || (echo "$t was not aborted" && false))
-    done
-    popd
+      installPhase = ''
+        mkdir -p $out/test
+        cp -r test/simple-memory-corruption $out/test/simple-memory-corruption
 
-    popd
-  '';
+        mkdir -p $out/bin
+        makeWrapper ${python3.interpreter} $out/bin/run-tests \
+          --add-flags "-I -m unittest discover --start-directory $out/test/simple-memory-corruption"
+      '';
+    };
+    tests = {
+      ld-preload = runCommand "ld-preload-test-run" {} ''
+        ${self}/bin/preload-hardened-malloc ${self.ld-preload-tests}/bin/run-tests
+        touch $out
+      '';
+      # to compensate for the lack of tests of correct normal malloc operation
+      stress = runCommand "stress-test-run" {} ''
+        ${self}/bin/preload-hardened-malloc ${stress-ng}/bin/stress-ng \
+          --no-rand-seed \
+          --malloc 8 \
+          --malloc-ops 1000000 \
+          --verify
+        touch $out
+      '';
+    };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/GrapheneOS/hardened_malloc";
@@ -54,4 +85,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ris ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
-}
+})


### PR DESCRIPTION
###### Motivation for this change
Supersedes #115546

Upstream's tests now have a real driver, so overhaul our use of them to cover both build-time-linking and `LD_PRELOAD` use, and simplifying the hardened nixos test to allow it to reuse this test setup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @NeQuissimus @zzywysm