### PR TITLE
WIP phosh: 0.12.1 -> 0.13.0

### DIFF
--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -40,8 +40,9 @@ in stdenv.mkDerivation rec {
   version = "0.12.1";
 
   src = fetchFromGitLab {
-    domain = "source.puri.sm";
-    owner = "Librem5";
+    domain = "gitlab.gnome.org";
+    group = "World";
+    owner = "Phosh";
     repo = pname;
     rev = "v${version}";
     sha256 = "048g5sp9jgfiwq6n8my4msm7wy3pdhbg0wxqxvps4m8qf8wa7ffq";

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -13,6 +13,7 @@
 , gtk3
 , gnome
 , gcr
+, libgudev
 , pam
 , systemd
 , upower
@@ -37,7 +38,7 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "phosh";
-  version = "0.12.1";
+  version = "0.13.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -45,7 +46,7 @@ in stdenv.mkDerivation rec {
     owner = "Phosh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "048g5sp9jgfiwq6n8my4msm7wy3pdhbg0wxqxvps4m8qf8wa7ffq";
+    sha256 = "1rk6jca08vab92dyajg5ziv4wi5sn555schxacf6jr239g88vrwj";
   };
 
   nativeBuildInputs = [
@@ -57,6 +58,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    libgudev
     phoc
     libhandy
     libsecret


### PR DESCRIPTION
###### Motivation for this change
https://gitlab.gnome.org/World/Phosh/phosh/-/releases/v0.13.0

###### Things done

This not currently build successfully, but I figured I'd raise this to let people know I was working on it.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
