### PR TITLE
bump yabridge: 3.3.1 -> 3.5.2; also add bitbridge support

### DIFF
--- a/pkgs/tools/audio/yabridge/hardcode-wine.patch
+++ b/pkgs/tools/audio/yabridge/hardcode-wine.patch
@@ -1,13 +1,13 @@
 diff --git a/src/plugin/utils.cpp b/src/plugin/utils.cpp
-index 1ff05bc..0723456 100644
+index 7fb7d1b3..eb227101 100644
 --- a/src/plugin/utils.cpp
 +++ b/src/plugin/utils.cpp
-@@ -351,7 +351,7 @@ std::string get_wine_version() {
+@@ -105,5 +105,5 @@ std::string PluginInfo::wine_version() const {
          access(wineloader_path.c_str(), X_OK) == 0) {
          wine_path = wineloader_path;
      } else {
 -        wine_path = bp::search_path("wine").string();
 +        wine_path = "@wine@/bin/wine";
      }
- 
+
      bp::ipstream output;

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   src = yabridge.src;
   sourceRoot = "source/tools/yabridgectl";
-  cargoHash = "sha256-f5k5OF+bEzH0b6M14Mdp8t4Qd5dP5Qj2fDsdiG1MkYk=";
+  cargoHash = "sha256-2x3qB0LbCBUZ4zqKIXPtYdWis+4QANTaJdFvoFbccGE=";
 
   patches = [
     # By default, yabridgectl locates libyabridge.so by using


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bump yabridge and yabridgectl to the latest version; also add in bitbridge support.

closes #132935
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
