### PR TITLE
python3Packages.chess: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10006,6 +10006,12 @@
       fingerprint = "6F8A 18AE 4101 103F 3C54  24B9 6AA2 3A11 93B7 064B";
     }];
   };
+  smancill = {
+    email = "smancill@smancill.dev";
+    github = "smancill";
+    githubId = 238528;
+    name = "Sebastián Mancilla";
+  };
   smaret = {
     email = "sebastien.maret@icloud.com";
     github = "smaret";

--- a/pkgs/development/python-modules/chess/default.nix
+++ b/pkgs/development/python-modules/chess/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "chess";
+  version = "1.6.1";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "niklasf";
+    repo = "python-${pname}";
+    rev = "v${version}";
+    sha256 = "sha256-2pyABmr6q1Y2/ivtvMYqRHE2Zjlyz2QO0us0w4l2HQM=";
+  };
+
+  pythonImportsCheck = [ "chess" ];
+
+  checkPhase = ''
+    ${python.interpreter} ./test.py -v
+  '';
+
+  meta = with lib; {
+    description = "A chess library for Python, with move generation, move validation, and support for common formats";
+    homepage = "https://github.com/niklasf/python-chess";
+    maintainers = with maintainers; [ smancill ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1427,6 +1427,8 @@ in {
 
   cherrypy = callPackage ../development/python-modules/cherrypy { };
 
+  chess = callPackage ../development/python-modules/chess { };
+
   chevron = callPackage ../development/python-modules/chevron { };
 
   chiabip158 = callPackage ../development/python-modules/chiabip158 { };


### PR DESCRIPTION
###### Motivation for this change

I wanted this Python library packaged.

###### Things done

Added the new Python 3 library [chess](https://github.com/niklasf/python-chess/).

Supports Python 3.7+. No tests are available in the PyPI release.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
