### PR TITLE
lib/licenses: add warning about deprecated licenses being used

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -14,10 +14,12 @@ lib.mapAttrs (lname: lset: let
       then license // { url = "https://spdx.org/licenses/${license.spdxId}.html"; }
       else license;
     applyRedistributable = license: { redistributable = license.free; } // license;
+    applyDeprecated = license: if license ? "deprecated" && license.deprecated then builtins.trace "Deprecated license ${license.shortName} used" license else license;
   in lib.pipe licenseDeclaration [
     applyDefaults
     applySpdx
     applyRedistributable
+    applyDeprecated
   ];
 in mkLicense lset) ({
   /* License identifiers from spdx.org where possible.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This triggers in repl during evaluation like so
```
nix-repl> :l ./.
Added 14775 variables.

nix-repl> qbs
trace: Deprecated license lgpl3 used
trace: Deprecated license fdl13 used
trace: Deprecated license gpl2 used
trace: Deprecated license lgpl21 used
trace: Deprecated license gpl3 used
trace: Deprecated license lgpl2 used
«derivation /nix/store/mf9m4r6b2k0m54hb2i7gbgs7xhir4zxz-qbs-1.19.1.drv»
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
