### PR TITLE
pkgs/*: add version to the name/store path of several buildFHSUserEnv packages

### DIFF
--- a/pkgs/applications/misc/houdini/default.nix
+++ b/pkgs/applications/misc/houdini/default.nix
@@ -3,7 +3,7 @@
 let
   houdini-runtime = callPackage ./runtime.nix { };
 in buildFHSUserEnv {
-  name = "houdini-${houdini-runtime.version}";
+  name = houdini-runtime.name;
 
   extraBuildCommands = ''
     mkdir -p $out/usr/lib/sesi
@@ -15,4 +15,3 @@ in buildFHSUserEnv {
 
   runScript = "${undaemonize}/bin/undaemonize ${houdini-runtime}/bin/houdini";
 }
-

--- a/pkgs/applications/misc/lutris/fhsenv.nix
+++ b/pkgs/applications/misc/lutris/fhsenv.nix
@@ -14,7 +14,7 @@ let
   ];
 
 in buildFHSUserEnv {
-  name = "lutris";
+  name = "lutris-${lutris-unwrapped.version}";
 
   runScript = "lutris";
 

--- a/pkgs/applications/misc/sidequest/default.nix
+++ b/pkgs/applications/misc/sidequest/default.nix
@@ -39,7 +39,7 @@
       '';
     };
   in buildFHSUserEnv {
-    name = "SideQuest";
+    name = sidequest.name;
 
     passthru = {
       inherit pname version;

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -30,7 +30,7 @@ let
 in
 
 buildFHSUserEnv {
-  name = "dropbox";
+  name = "dropbox-${version}";
 
   targetPkgs = pkgs: with pkgs; with xorg; [
     libICE libSM libX11 libXcomposite libXdamage libXext libXfixes libXrender

--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -81,7 +81,7 @@ let
   };
 
   vmwareFHSUserEnv = buildFHSUserEnv {
-    name = "vmware-view";
+    name = "vmware-view-${version}";
 
     runScript = "${vmwareHorizonClientFiles}/bin/vmware-view_wrapper";
 
@@ -131,7 +131,8 @@ let
 
 in
 stdenv.mkDerivation {
-  name = "vmware-view";
+  pname = "vmware-view";
+  inherit version;
 
   dontUnpack = true;
 

--- a/pkgs/development/tools/hover/default.nix
+++ b/pkgs/development/tools/hover/default.nix
@@ -85,7 +85,7 @@ let
 
 in
 buildFHSUserEnv rec {
-  name = pname;
+  name = hover.name;
   targetPkgs = pkgs: [
     binutils
     dejavu_fonts

--- a/pkgs/games/anki/bin.nix
+++ b/pkgs/games/anki/bin.nix
@@ -35,7 +35,7 @@ let
 in
 
 if stdenv.isLinux then buildFHSUserEnv (appimageTools.defaultFhsEnvArgs // {
-  name = "anki";
+  name = "${pname}-${version}";
 
   runScript = writeShellScript "anki-wrapper.sh" ''
     # Wayland support is broken, disable via ENV variable

--- a/pkgs/games/clonehero/fhs-wrapper.nix
+++ b/pkgs/games/clonehero/fhs-wrapper.nix
@@ -17,7 +17,7 @@ let
   };
 in
 buildFHSUserEnv {
-  inherit name;
+  name = "${name}-${clonehero-unwrapped.version}";
   inherit (clonehero-unwrapped) meta;
 
   # Clone Hero has /usr/share/fonts hard-coded in its binary for looking up fonts.

--- a/pkgs/games/shticker-book-unwritten/default.nix
+++ b/pkgs/games/shticker-book-unwritten/default.nix
@@ -4,7 +4,7 @@ let
   shticker-book-unwritten-unwrapped = callPackage ./unwrapped.nix { };
 
 in buildFHSUserEnv {
-  name = "shticker_book_unwritten";
+  name = "shticker_book_unwritten-${shticker-book-unwritten-unwrapped.version}";
   targetPkgs = pkgs: with pkgs; [
       alsa-lib
       xorg.libX11

--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -10,7 +10,7 @@
 }:
 
 buildFHSUserEnv {
-  name = "plexmediaserver";
+  name = "plexmediaserver-${plexRaw.version}";
   inherit (plexRaw) meta;
 
   # This script is run when we start our Plex binary

--- a/pkgs/tools/package-management/conda/default.nix
+++ b/pkgs/tools/package-management/conda/default.nix
@@ -50,7 +50,7 @@ let
     '';
 in
   buildFHSUserEnv {
-    name = "conda-shell";
+    name = "conda-shell-${version}";
     targetPkgs = pkgs: (builtins.concatLists [ [ conda ] condaDeps extraPkgs]);
     profile = ''
       # Add conda to PATH

--- a/pkgs/tools/virtualization/ovftool/default.nix
+++ b/pkgs/tools/virtualization/ovftool/default.nix
@@ -8,7 +8,7 @@ let
 
   # FHS environment required to unpack ovftool on x86.
   ovftoolX86Unpacker = buildFHSUserEnv rec {
-    name = "ovftool-unpacker";
+    name = "ovftool-unpacker-${version}";
     targetPkgs = pkgs: [ pkgs.bash ];
     multiPkgs = targetPkgs;
     runScript = "bash";


### PR DESCRIPTION
###### Motivation for this change

It's convenient to be able to distinguish multiple store paths for the same package based on their version. This pattern is kept for `mkDerivation` (where `name = "${pname}-${version}`).

`buildFHSUserEnv` is used to create user-visible derivations as well, but only provides the 'name' knob. Several packages have versions available too. This manually plumbs the version into the `buildFHSUserEnv` name.

Notably, this lets things like `readlink -f $(which anki)` display more readable output.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
