### PR TITLE
listadmin: init at 2.73

### DIFF
--- a/pkgs/applications/networking/listadmin/default.nix
+++ b/pkgs/applications/networking/listadmin/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenvNoCC, fetchurl, makeWrapper, perl, installShellFiles }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "listadmin";
+  version = "2.73";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/listadmin/${version}/listadmin-${version}.tar.gz";
+    sha256 = "00333d65ygdbm1hqr4yp2j8vh1cgh3hyfm7iy9y1alf0p0f6aqac";
+  };
+
+  buildInputs = [ perl ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  # There is a Makefile, but we don’t need it, and it prints errors
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man1
+    install -m 755 listadmin.pl $out/bin/listadmin
+    installManPage listadmin.1
+
+    wrapProgram $out/bin/listadmin \
+      --prefix PERL5LIB : "${with perl.pkgs; makeFullPerlPath [
+        TextReform NetINET6Glue LWPProtocolhttps
+        ]}"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/listadmin --help 2> /dev/null
+  '';
+
+  meta = with lib; {
+    description = "Command line mailman moderator queue manipulation";
+    longDescription = ''
+       listadmin is a command line tool to manipulate the queues of messages
+       held for moderator approval by mailman. It is designed to keep user
+       interaction to a minimum, in theory you could run it from cron to prune
+       the queue. It can use the score from a header added by SpamAssassin to
+       filter, or it can match specific senders, subjects, or reasons.
+    '';
+    homepage = "https://sourceforge.net/projects/listadmin/";
+    license = licenses.publicDomain;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ nomeata ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19887,6 +19887,8 @@ with pkgs;
 
   mailman-web = with python3.pkgs; toPythonApplication mailman-web;
 
+  listadmin = callPackage ../applications/networking/listadmin {};
+
   maker-panel = callPackage ../tools/misc/maker-panel { };
 
   mastodon = callPackage ../servers/mastodon { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15181,6 +15181,20 @@ let
     };
   };
 
+  NetINET6Glue = buildPerlPackage {
+    pname = "Net-INET6Glue";
+    version = "0.604";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SU/SULLR/Net-INET6Glue-0.604.tar.gz";
+      sha256 = "05xvbdrqq88npzg14bjm9wmjykzplwirzcm8rp61852hz6c67hwh";
+    };
+    meta = {
+      homepage = "https://github.com/noxxi/p5-net-inet6glue";
+      description = "Make common modules IPv6 ready by hotpatching";
+      license = lib.licenses.artistic1;
+    };
+  };
+
   NetAddrIP = buildPerlPackage {
     pname = "NetAddr-IP";
     version = "4.079";


### PR DESCRIPTION
###### Motivation for this change

The listadmin tool is useful, and missing in nixos

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

fixes: #133239