### PR TITLE
SDL2: 2.0.14 -> 2.0.16

### DIFF
--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -11,6 +11,10 @@
 , udevSupport ? false, udev
 , ibusSupport ? false, ibus
 , fcitxSupport ? false, fcitx
+, libdecorSupport ? stdenv.isLinux && !stdenv.hostPlatform.isAndroid
+, libdecor
+, pipewireSupport ? stdenv.isLinux && !stdenv.hostPlatform.isAndroid
+, pipewire # Note: must be built with SDL2 without pipewire support
 , pulseaudioSupport ? config.pulseaudio or stdenv.isLinux && !stdenv.hostPlatform.isAndroid
 , libpulseaudio
 , AudioUnit, Cocoa, CoreAudio, CoreServices, ForceFeedback, OpenGL
@@ -25,11 +29,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "SDL2";
-  version = "2.0.14";
+  version = "2.0.16";
 
   src = fetchurl {
     url = "https://www.libsdl.org/release/${pname}-${version}.tar.gz";
-    sha256 = "1g1jahknv5r4yhh1xq5sf0md20ybdw1zh1i15lry26sq39bmn8fq";
+    sha256 = "0yr8bw3rfihy1ap2sjww2q7r650qvfjba9wrrsrbad2003v9zgk5";
   };
   dontDisableStatic = withStatic;
   outputs = [ "out" "dev" ];
@@ -60,8 +64,10 @@ stdenv.mkDerivation rec {
     ++ optionals x11Support [ libX11 xorgproto ];
 
   dlopenBuildInputs = [ ]
-    ++ optionals  alsaSupport [ alsa-lib audiofile ]
+    ++ optionals alsaSupport [ alsa-lib audiofile ]
     ++ optional  dbusSupport dbus
+    ++ optional  libdecorSupport libdecor
+    ++ optional  pipewireSupport pipewire
     ++ optional  pulseaudioSupport libpulseaudio
     ++ optional  udevSupport udev
     ++ optionals waylandSupport [ wayland wayland-protocols libxkbcommon ]

--- a/pkgs/development/libraries/SDL2/find-headers.patch
+++ b/pkgs/development/libraries/SDL2/find-headers.patch
@@ -1,37 +1,22 @@
-diff -ru3 SDL2-2.0.14/sdl2-config.cmake.in SDL2-2.0.14-new/sdl2-config.cmake.in
---- SDL2-2.0.14/sdl2-config.cmake.in	2020-12-21 18:44:36.000000000 +0100
-+++ SDL2-2.0.14-new/sdl2-config.cmake.in	2021-01-16 23:53:40.721121792 +0100
-@@ -6,7 +6,8 @@
- set(SDL2_PREFIX "@prefix@")
- set(SDL2_EXEC_PREFIX "@prefix@")
- set(SDL2_LIBDIR "@libdir@")
--set(SDL2_INCLUDE_DIRS "@includedir@/SDL2")
-+set(SDL2_INCLUDE_DIRS "@includedir@/SDL2" $ENV{SDL2_PATH})
+diff --git a/sdl2-config.cmake.in b/sdl2-config.cmake.in
+index c570511fa..ca694f595 100644
+--- a/sdl2-config.cmake.in
++++ b/sdl2-config.cmake.in
+@@ -7,7 +7,8 @@ set(includedir "@includedir@")
+ set(SDL2_PREFIX "${prefix}")
+ set(SDL2_EXEC_PREFIX "${exec_prefix}")
+ set(SDL2_LIBDIR "${libdir}")
+-set(SDL2_INCLUDE_DIRS "${includedir}/SDL2")
++set(SDL2_INCLUDE_DIRS "${includedir}/SDL2" $ENV{SDL2_PATH})
 +separate_arguments(SDL2_INCLUDE_DIRS)
  set(SDL2_LIBRARIES "-L${SDL2_LIBDIR} @SDL_RLD_FLAGS@ @SDL_LIBS@")
  string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
  
-@@ -20,14 +21,14 @@
- 
-   add_library(SDL2::SDL2 SHARED IMPORTED)
-   set_target_properties(SDL2::SDL2 PROPERTIES
--    INTERFACE_INCLUDE_DIRECTORIES "@includedir@/SDL2"
-+    INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
-     IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-     IMPORTED_LOCATION "@libdir@/${CMAKE_SHARED_LIBRARY_PREFIX}SDL2${CMAKE_SHARED_LIBRARY_SUFFIX}"
-     INTERFACE_LINK_LIBRARIES "${SDL2_EXTRA_LINK_FLAGS}")
- 
-   add_library(SDL2::SDL2-static STATIC IMPORTED)
-   set_target_properties(SDL2::SDL2-static PROPERTIES
--    INTERFACE_INCLUDE_DIRECTORIES "@includedir@/SDL2"
-+    INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
-     IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-     IMPORTED_LOCATION "@libdir@/${CMAKE_STATIC_LIBRARY_PREFIX}SDL2${CMAKE_STATIC_LIBRARY_SUFFIX}"
-     INTERFACE_LINK_LIBRARIES "${SDL2_EXTRA_LINK_FLAGS_STATIC}")
-diff -ru3 SDL2-2.0.14/sdl2-config.in SDL2-2.0.14-new/sdl2-config.in
---- SDL2-2.0.14/sdl2-config.in	2020-12-21 18:44:36.000000000 +0100
-+++ SDL2-2.0.14-new/sdl2-config.in	2021-01-16 23:57:11.940353171 +0100
-@@ -42,7 +42,11 @@
+diff --git a/sdl2-config.in b/sdl2-config.in
+index 5a2aed292..7c55f0a28 100644
+--- a/sdl2-config.in
++++ b/sdl2-config.in
+@@ -42,7 +42,11 @@ while test $# -gt 0; do
        echo @SDL_VERSION@
        ;;
      --cflags)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13198,7 +13198,18 @@ with pkgs;
 
   pipenv = callPackage ../development/tools/pipenv {};
 
-  pipewire = callPackage ../development/libraries/pipewire {};
+  pipewire =
+    let
+      # Break a dependency cycle
+      customSDL2 = SDL2.override {
+        pipewireSupport = false;
+      };
+    in callPackage ../development/libraries/pipewire {
+      SDL2 = customSDL2;
+      ffmpeg = ffmpeg.override {
+        SDL2 = customSDL2;
+      };
+    };
   pipewire_0_2 = callPackage ../development/libraries/pipewire/0.2.nix {};
 
   pyradio = callPackage ../applications/audio/pyradio {};


### PR DESCRIPTION
###### Motivation for this change

Package update

###### Missing

From skimming the diff on `configure.ac`, the new release of SDL2 brings two new, optional dependencies:

- libdecor, for client-side decorations
  - libdecor is not packaged in nixpkgs #133724
- ~~pipewire, for audio~~ This has been added
  - Note that to use it you must use `SDL_AUDIODRIVER=pipewire`, OR disable pipewire-pulse and pipewire-jack, OR build SDL2 without pulseaudio or jack support
  - There are two dependency cycles: SDL2 -> pipewire -> SDL2 (for examples) and SDL2 -> pipewire -> ffmpeg -> SDL2
  - patch that adds pipewire support and breaks the cycle: [gist](https://gist.github.com/jakobrs/23ec7a25041c561cb1a24a72516aee2c)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
