### PR TITLE
fetchpatch: add "decoder" argument for gerrit

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -71,6 +71,7 @@ The main difference between `fetchurl` and `fetchzip` is in how they store the c
 
 - `relative`: Similar to using `git-diff`'s `--relative` flag, only keep changes inside the specified directory, making paths relative to it.
 - `stripLen`: Remove the first `stripLen` components of pathnames in the patch.
+- `decode`: Pipe the downloaded data through this command before processing it as a patch.
 - `extraPrefix`: Prefix pathnames by this string.
 - `excludes`: Exclude files matching these patterns (applies after the above arguments).
 - `includes`: Include only files matching these patterns (applies after the above arguments).

--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -8,6 +8,7 @@
 
 { relative ? null
 , stripLen ? 0
+, decode ? "cat" # custom command to decode patch e.g. base64 -d
 , extraPrefix ? null
 , excludes ? []
 , includes ? []
@@ -35,6 +36,17 @@ fetchurl ({
       echo "error: Fetched patch file '$out' is empty!" 1>&2
       exit 1
     fi
+
+    set +e
+    ${decode} < "$out" > "$tmpfile"
+    if [ $? -ne 0 ] || [ ! -s "$tmpfile" ]; then
+        echo 'Failed to decode patch with command "'${lib.escapeShellArg decode}'"' >&2
+        echo 'Fetched file was (limited to 128 bytes):' >&2
+        od -A x -t x1z -v -N 128 "$out" >&2
+        exit 1
+    fi
+    set -e
+    mv "$tmpfile" "$out"
 
     "${patchutils}/bin/lsdiff" \
       ${lib.optionalString (relative != null) "-p1 -i ${lib.escapeShellArg relative}/'*'"} \
@@ -76,5 +88,6 @@ fetchurl ({
     mv "$tmpfile" "$out"
   '' + postFetch;
 } // builtins.removeAttrs args [
-  "relative" "stripLen" "extraPrefix" "excludes" "includes" "revert" "postFetch"
+  "relative" "stripLen" "decode" "extraPrefix" "excludes" "includes" "revert"
+  "postFetch"
 ])

--- a/pkgs/build-support/fetchpatch/tests.nix
+++ b/pkgs/build-support/fetchpatch/tests.nix
@@ -25,4 +25,11 @@ in
     revert = true;
     sha256 = if isFetchpatch2 then "sha256-+UKmEbr2rIAweCav/hR/7d4ZrYV84ht/domTrHtm8sM=" else "sha256-+UKmEbr2rIAweCav/hR/7d4ZrYV84ht/domTrHtm8sM=";
   };
+
+  decode = testers.invalidateFetcherByDrvHash fetchpatch {
+    name = "gcc.patch";
+    url = "https://chromium.googlesource.com/aosp/platform/external/libchrome/+/f37ae3b1a873d74182a2ac31d96742ead9c1f523^!?format=TEXT";
+    decode = "base64 -d";
+    sha256 = if isFetchpatch2 then "sha256-oMvPlmzE51ArI+EvFxONXkqmNee39106/O1ikG0Bdso=" else "sha256-SJHk8XrutqAyoIdORlhCpBCN626P+uzed7mjKz5eQYY=";
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

(and gitiles)

This allows fetching a patch from servers that return them
base64-encoded, like this:

    fetchpatch {
      name = "gcc.patch";
      url = "https://chromium.googlesource.com/aosp/platform/external/libchrome/+/f37ae3b1a873d74182a2ac31d96742ead9c1f523^!?format=TEXT";
      decode = "base64 -d";
      sha256 = "11j1bqz2p8xrfzgfrylgdvmqs45489c4ckl7l0ra1dpfgbqy94a8";
    }

This will mean fewer patches have to be directly included in Nixpkgs, permanently bloating the repository size.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
