### PR TITLE
discourse: 2.7.5 -> 2.7.7, plugin updates and fixes

### DIFF
--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -771,7 +771,6 @@ in
           "tmp"
           "assets/javascripts/plugins"
           "public"
-          "plugins"
           "sockets"
         ];
         RuntimeDirectoryMode = 0750;

--- a/nixos/modules/services/web-apps/discourse.xml
+++ b/nixos/modules/services/web-apps/discourse.xml
@@ -284,9 +284,20 @@ services.discourse = {
       Ruby dependencies are listed in its
       <filename>plugin.rb</filename> file as function calls to
       <literal>gem</literal>. To construct the corresponding
-      <filename>Gemfile</filename>, run <command>bundle
+      <filename>Gemfile</filename> manually, run <command>bundle
       init</command>, then add the <literal>gem</literal> lines to it
       verbatim.
+    </para>
+
+    <para>
+      Much of the packaging can be done automatically by the
+      <filename>nixpkgs/pkgs/servers/web-apps/discourse/update.py</filename>
+      script - just add the plugin to the <literal>plugins</literal>
+      list in the <function>update_plugins</function> function and run
+      the script:
+      <programlisting language="bash">
+./update.py update-plugins
+</programlisting>.
     </para>
 
     <para>

--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -4,7 +4,7 @@
 #  3. replying to that message via email.
 
 import ./make-test-python.nix (
-  { pkgs, lib, ... }:
+  { pkgs, lib, package ? pkgs.discourse, ... }:
   let
     certs = import ./common/acme/server/snakeoil-certs.nix;
     clientDomain = "client.fake.domain";
@@ -55,7 +55,7 @@ import ./make-test-python.nix (
 
         services.discourse = {
           enable = true;
-          inherit admin;
+          inherit admin package;
           hostname = discourseDomain;
           sslCertificate = "${certs.${discourseDomain}.cert}";
           sslCertificateKey = "${certs.${discourseDomain}.key}";

--- a/pkgs/servers/web-apps/discourse/auto_generated_path.patch
+++ b/pkgs/servers/web-apps/discourse/auto_generated_path.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/plugin/instance.rb b/lib/plugin/instance.rb
+index 380a63e987..b2ce7fa982 100644
+--- a/lib/plugin/instance.rb
++++ b/lib/plugin/instance.rb
+@@ -403,7 +403,7 @@ class Plugin::Instance
+   end
+ 
+   def auto_generated_path
+-    File.dirname(path) << "/auto_generated"
++    "#{Rails.root}/public/assets/auto_generated_plugin_assets/#{name}"
+   end
+ 
+   def after_initialize(&block)

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -274,7 +274,6 @@ let
       ln -sf /run/discourse/config $out/share/discourse/config
       ln -sf /run/discourse/assets/javascripts/plugins $out/share/discourse/app/assets/javascripts/plugins
       ln -sf /run/discourse/public $out/share/discourse/public
-      ln -sf /run/discourse/plugins $out/share/discourse/plugins
       ln -sf ${assets} $out/share/discourse/public.dist/assets
       ${lib.concatMapStringsSep "\n" (p: "ln -sf ${p} $out/share/discourse/plugins/${p.pluginName or ""}") plugins}
 

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, runCommand, lib, nixosTests, writeShellScript
+{ stdenv, pkgs, makeWrapper, runCommand, lib, writeShellScript
 , fetchFromGitHub, bundlerEnv, callPackage
 
 , ruby, replace, gzip, gnutar, git, cacert, util-linux, gawk
@@ -6,7 +6,7 @@
 , redis, postgresql, which, brotli, procps, rsync, nodePackages, v8
 
 , plugins ? []
-}:
+}@args:
 
 let
   version = "2.7.7";
@@ -293,7 +293,7 @@ let
       enabledPlugins = plugins;
       plugins = callPackage ./plugins/all-plugins.nix { inherit mkDiscoursePlugin; };
       ruby = rubyEnv.wrappedRuby;
-      tests = nixosTests.discourse;
+      tests = import ../../../../nixos/tests/discourse.nix { package = pkgs.discourse.override args; };
     };
   };
 in discourse

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -55,6 +55,7 @@ let
     , version ? null
     , meta ? null
     , bundlerEnvArgs ? {}
+    , preserveGemsDir ? false
     , src
     , ...
     }@args:
@@ -71,11 +72,20 @@ let
           runHook preInstall
           mkdir -p $out
           cp -r * $out/
-        '' + lib.optionalString (bundlerEnvArgs != {}) ''
-          ln -sf ${rubyEnv}/lib/ruby/gems $out/gems
-        '' + ''
+        '' + lib.optionalString (bundlerEnvArgs != {}) (
+          if preserveGemsDir then ''
+            cp -r ${rubyEnv}/lib/ruby/gems/* $out/gems/
+          ''
+          else ''
+            if [[ -e $out/gems ]]; then
+              echo "Warning: The repo contains a 'gems' directory which will be removed!"
+              echo "         If you need to preserve it, set 'preserveGemsDir = true'."
+              rm -r $out/gems
+            fi
+            ln -sf ${rubyEnv}/lib/ruby/gems $out/gems
+          '' + ''
           runHook postInstall
-        '';
+        '');
       });
 
   rake = runCommand "discourse-rake" {

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -158,6 +158,11 @@ let
       # Use the Ruby API version in the plugin gem path, to match the
       # one constructed by bundlerEnv
       ./plugin_gem_api_version.patch
+
+      # Change the path to the auto generated plugin assets, which
+      # defaults to the plugin's directory and isn't writable at the
+      # time of asset generation
+      ./auto_generated_path.patch
     ];
 
     # We have to set up an environment that is close enough to
@@ -244,6 +249,11 @@ let
       # Use mv instead of rename, since rename doesn't work across
       # device boundaries
       ./use_mv_instead_of_rename.patch
+
+      # Change the path to the auto generated plugin assets, which
+      # defaults to the plugin's directory and isn't writable at the
+      # time of asset generation
+      ./auto_generated_path.patch
     ];
 
     postPatch = ''

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -9,13 +9,13 @@
 }:
 
 let
-  version = "2.7.5";
+  version = "2.7.7";
 
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse";
     rev = "v${version}";
-    sha256 = "sha256-OykWaiBAHcZy41i+aRzBHCRgwnfQUBijHjb+ofIk25M=";
+    sha256 = "sha256-rhcTQyirgPX0ITjgotJAYLLSU957GanxAYYhy9j123U=";
   };
 
   runtimeDeps = [

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/Gemfile
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/Gemfile
@@ -2,4 +2,7 @@
 
 source "https://rubygems.org"
 
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+# gem "rails"
 gem 'rrule', '0.4.2', require: false

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   rrule (= 0.4.2)

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-calendar/default.nix
@@ -6,8 +6,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-calendar";
-    rev = "567712d8c02640574fbab081eb54b2f26349c88d";
-    sha256 = "sha256-r6rfbi/ScbM+SiAjeijXmr5R9wpJxzxGl52X5oV++5w=";
+    rev = "519cf403ae3003291de20145aca243e2ffbcb4a2";
+    sha256 = "0398cf7k03i7j7v5w1mysjzk2npbkvr7icj5sjwa8i8xzg34gck4";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-calendar";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-canned-replies/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-canned-replies/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-canned-replies";
-    rev = "e3f1de8928df5955b64994079b7e2073556e5456";
-    sha256 = "1g4fazm6cn6hbfd08mq2zhc6dgm4qj1r1f1amhbgxhk6qsxf42cd";
+    rev = "672a96a8160d3767cf5fd6647309c7b5dcf8a55d";
+    sha256 = "105zgpc7j3xmlkaz3cgxw1rfgy5d3dzln58ix569jmzifbsijml7";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-canned-replies";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-data-explorer/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-data-explorer/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-data-explorer";
-    rev = "7a348aaa8b2a6b3a75db72e99a7370a1a6fcb2b8";
-    sha256 = "sha256-4X0oor3dIKrQO5IrScQ9+DBr39R7PJJ8dg9UQseV6IU=";
+    rev = "23287ece952cb45203819e7b470ebc194c58cb13";
+    sha256 = "1vc2072r72fkvcfpy6vpn9x4gl9lpjk29pnj8095xs22im8j5in1";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-data-explorer";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    faraday (1.5.0)
+    faraday (1.7.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -11,6 +11,7 @@ GEM
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
@@ -18,20 +19,21 @@ GEM
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+    faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
     multipart-post (2.1.1)
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     public_suffix (4.0.6)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   octokit (= 4.21.0)

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/default.nix
@@ -6,8 +6,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-github";
-    rev = "154fd5ea597640c2259ce489b4ce75b48ac1973c";
-    sha256 = "0wb5p219z42rc035rnh2iwrbsj000nxa9shbmc325rzcg6xlhdhw";
+    rev = "b6ad8e39a13e2ad5c6943ea697ca23f2c5f9fec1";
+    sha256 = "0vxwp4kbf44clcqilb8ni0ykk4jrgiv4rbd05pgfvndcp3izm2i6";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-github";

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-github/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-github/gemset.nix
@@ -11,15 +11,15 @@
     version = "2.8.0";
   };
   faraday = {
-    dependencies = ["faraday-em_http" "faraday-em_synchrony" "faraday-excon" "faraday-httpclient" "faraday-net_http" "faraday-net_http_persistent" "faraday-patron" "multipart-post" "ruby2_keywords"];
+    dependencies = ["faraday-em_http" "faraday-em_synchrony" "faraday-excon" "faraday-httpclient" "faraday-net_http" "faraday-net_http_persistent" "faraday-patron" "faraday-rack" "multipart-post" "ruby2_keywords"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0gwbii45plm9bljk22bwzhzxrc5xid8qx24f54vrm74q3zaz00ah";
+      sha256 = "0r6ik2yvsbx6jj30vck32da2bbvj4m0gf4jhp09vr75i1d6jzfvb";
       type = "gem";
     };
-    version = "1.5.0";
+    version = "1.7.0";
   };
   faraday-em_http = {
     groups = ["default"];
@@ -76,10 +76,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0l2c835wl7gv34xp49fhd1bl4czkpw2g3ahqsak2251iqv5589ka";
+      sha256 = "0dc36ih95qw3rlccffcb0vgxjhmipsvxhn6cw71l7ffs0f7vq30b";
       type = "gem";
     };
-    version = "1.1.0";
+    version = "1.2.0";
   };
   faraday-patron = {
     groups = ["default"];
@@ -87,6 +87,16 @@
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "19wgsgfq0xkski1g7m96snv39la3zxz6x7nbdgiwhg5v82rxfb6w";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  faraday-rack = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1h184g4vqql5jv9s9im6igy00jp6mrah2h14py6mpf9bkabfqq7g";
       type = "gem";
     };
     version = "1.0.0";
@@ -127,10 +137,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "15wfcqxyfgka05v2a7kpg64x57gl1y4xzvnc9lh60bqx5sf1iqrs";
+      sha256 = "1vz322p8n39hz3b4a9gkmz9y7a5jaz41zrm2ywf31dvkqm03glgz";
       type = "gem";
     };
-    version = "0.0.4";
+    version = "0.0.5";
   };
   sawyer = {
     dependencies = ["addressable" "faraday"];

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-solved/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-solved/default.nix
@@ -5,8 +5,8 @@ mkDiscoursePlugin {
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse-solved";
-    rev = "b96374bf4ab7e6d5cecb0761918b060a524eb9bf";
-    sha256 = "0zrv70p0wz93akpcj6gpwjkw7az3iz9bx4n2z630kyrlmxdbj32a";
+    rev = "8bf54370200fe9d94541f69339430a7dc1019d62";
+    sha256 = "1sk91h4dilkxm1wpv8zw59wgw860ywwlcgiw2kd23ybdk9n7b3lh";
   };
   meta = with lib; {
     homepage = "https://github.com/discourse/discourse-solved";

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -12,6 +12,7 @@ import os
 import stat
 import json
 import requests
+import textwrap
 from distutils.version import LooseVersion
 from pathlib import Path
 from typing import Iterable
@@ -77,7 +78,11 @@ def _call_nix_update(pkg, version):
 
 def _nix_eval(expr: str):
     nixpkgs_path = Path(__file__).parent / '../../../../'
-    return json.loads(subprocess.check_output(['nix', 'eval', '--json', f'(with import {nixpkgs_path} {{}}; {expr})'], text=True))
+    try:
+        output = subprocess.check_output(['nix', 'eval', '--json', f'(with import {nixpkgs_path} {{}}; {expr})'], text=True)
+    except subprocess.CalledProcessError:
+        return None
+    return json.loads(output)
 
 
 def _get_current_package_version(pkg: str):
@@ -206,13 +211,59 @@ def update_plugins():
         repo_name = plugin.get('repo_name') or name
 
         repo = DiscourseRepo(owner=owner, repo=repo_name)
+
+        filename = _nix_eval(f'builtins.unsafeGetAttrPos "src" discourse.plugins.{name}')
+        if filename is None:
+            filename = Path(__file__).parent / 'plugins' / name / 'default.nix'
+            filename.parent.mkdir()
+
+            has_ruby_deps = False
+            for line in repo.get_file('plugin.rb', repo.latest_commit_sha).splitlines():
+                if 'gem ' in line:
+                    has_ruby_deps = True
+                    break
+
+            with open(filename, 'w') as f:
+                f.write(textwrap.dedent(f"""
+                         {{ lib, mkDiscoursePlugin, fetchFromGitHub }}:
+
+                         mkDiscoursePlugin {{
+                           name = "{name}";"""[1:] + ("""
+                           bundlerEnvArgs.gemdir = ./.;""" if has_ruby_deps else "") + f"""
+                           src = {fetcher} {{
+                             owner = "{owner}";
+                             repo = "{repo_name}";
+                             rev = "replace-with-git-rev";
+                             sha256 = "replace-with-sha256";
+                           }};
+                           meta = with lib; {{
+                             homepage = "";
+                             maintainers = with maintainers; [ ];
+                             license = licenses.mit; # change to the correct license!
+                             description = "";
+                           }};
+                         }}"""))
+
+            all_plugins_filename = Path(__file__).parent / 'plugins' / 'all-plugins.nix'
+            with open(all_plugins_filename, 'r+') as f:
+                content = f.read()
+                pos = -1
+                while content[pos] != '}':
+                    pos -= 1
+                content = content[:pos] + f'  {name} = callPackage ./{name} {{}};' + os.linesep + content[pos:]
+                f.seek(0)
+                f.write(content)
+                f.truncate()
+
+        else:
+            filename = filename['file']
+
         prev_commit_sha = _nix_eval(f'discourse.plugins.{name}.src.rev')
 
         if prev_commit_sha == repo.latest_commit_sha:
             click.echo(f'Plugin {name} is already at the latest revision')
             continue
 
-        filename = _nix_eval(f'builtins.unsafeGetAttrPos "src" discourse.plugins.{name}')['file']
         prev_hash = _nix_eval(f'discourse.plugins.{name}.src.outputHash')
         new_hash = subprocess.check_output([
             'nix-universal-prefetch', fetcher,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Update `discourse` to the latest stable version
- Update the plugins
- Run tests on the correct package, i.e. `discourseAllPlugins.tests` now runs the tests on the `discourseAllPlugins` package
- Change the auto generated plugin assets path to one that is writable at asset build time (fixes the issue in #132475)
- Make the `update.py` script able to package plugins from scratch

Closes #132112
Closes #133949

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
