### PR TITLE
nixos/doas: fix recursive calls to doas

### DIFF
--- a/nixos/tests/doas.nix
+++ b/nixos/tests/doas.nix
@@ -78,6 +78,13 @@ import ./make-test-python.nix (
               'su - test7 -c "SSH_AUTH_SOCK=HOLEY doas env"'
           ):
               raise Exception("failed to exclude SSH_AUTH_SOCK")
+
+      # Test that the doas setuid wrapper precedes the unwrapped version in PATH after
+      # calling doas.
+      # The PATH set by doas is defined in
+      # ../../pkgs/tools/security/doas/0001-add-NixOS-specific-dirs-to-safe-PATH.patch
+      with subtest("recursive calls to doas from subprocesses should succeed"):
+          machine.succeed('doas -u test0 sh -c "doas -u test0 true"')
     '';
   }
 )

--- a/pkgs/tools/security/doas/0001-add-NixOS-specific-dirs-to-safe-PATH.patch
+++ b/pkgs/tools/security/doas/0001-add-NixOS-specific-dirs-to-safe-PATH.patch
@@ -15,7 +15,7 @@ index e253905..2fdb20f 100644
  main(int argc, char **argv)
  {
  	const char *safepath = "/bin:/sbin:/usr/bin:/usr/sbin:"
-+	    "/run/current-system/sw/bin:/run/current-system/sw/sbin:/run/wrappers/bin:"
++	    "/run/wrappers/bin:/run/current-system/sw/bin:/run/current-system/sw/sbin:"
  	    "/usr/local/bin:/usr/local/sbin";
  	const char *confpath = NULL;
  	char *shargv[] = { NULL, NULL };


### PR DESCRIPTION
### Copy of main commit msg
Previously, for processes launched by `doas` the unwrapped `doas` binary preceded the setuid-wrapped `doas` binary in `PATH`.

This caused error `doas: not installed setuid` when running `doas` from processes launched by `doas`.

`doas` seems to short-circuit the `PATH` lookup when called like `doas -u myuser doas -u myuser ...` so the error doesn't appear in this case.

###### Things done
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change 