### PR TITLE
staticjinja: 3.0.1 -> 4.1.0, pythonPackages.docopt-ng: init at 0.7.2

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -273,7 +273,7 @@ Superuser created successfully.
       <listitem>
         <para>
           The <literal>staticjinja</literal> package has been upgraded
-          from 1.0.4 to 3.0.1
+          from 1.0.4 to 4.1.0
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -105,7 +105,7 @@ subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable
       Superuser created successfully.
       ```
 
-- The `staticjinja` package has been upgraded from 1.0.4 to 3.0.1
+- The `staticjinja` package has been upgraded from 1.0.4 to 4.1.0
 
 - The `erigon` ethereum node has moved to a new database format in `2021-05-04`, and requires a full resync
 

--- a/pkgs/development/python-modules/docopt-ng/default.nix
+++ b/pkgs/development/python-modules/docopt-ng/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "docopt-ng";
+  version = "0.7.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-hs7qAy8M+lnmB3brDPOKxzZTWBAihyMg9H3IdGeNckQ=";
+  };
+
+  pythonImportsCheck = [ "docopt" ];
+  doCheck = false; # no tests in the package
+
+  meta = with lib; {
+    description = "More-magic command line arguments parser. Now with more maintenance!";
+    homepage = "https://github.com/bazaar-projects/docopt-ng";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/development/python-modules/staticjinja/default.nix
+++ b/pkgs/development/python-modules/staticjinja/default.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , buildPythonPackage
 , poetry
-, docopt
+, docopt-ng
 , easywatch
 , jinja2
 , pytestCheckHook
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "staticjinja";
-  version = "3.0.1";
+  version = "4.1.0";
   format = "pyproject";
 
   # No tests in pypi
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "staticjinja";
     repo = pname;
     rev = version;
-    sha256 = "sha256-W4q0vG8Kl2gCmA8UnUbdiGRtghhdnWxIJXFIIa6BogA=";
+    sha256 = "sha256-4IL+7ncJPd1e7k5oFRjQ6yvDjozcBAAZPf88biNTiLU=";
   };
 
   nativeBuildInputs = [
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     jinja2
-    docopt
+    docopt-ng
     easywatch
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2165,6 +2165,8 @@ in {
 
   docopt = callPackage ../development/python-modules/docopt { };
 
+  docopt-ng = callPackage ../development/python-modules/docopt-ng { };
+
   docplex = callPackage ../development/python-modules/docplex { };
 
   docrep = callPackage ../development/python-modules/docrep { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
