### PR TITLE
jedi 2020-08-06 -> 0.18.0

### DIFF
--- a/pkgs/development/python-modules/jedi/default.nix
+++ b/pkgs/development/python-modules/jedi/default.nix
@@ -1,34 +1,36 @@
-{ lib, buildPythonPackage, fetchFromGitHub, fetchPypi, pytest, glibcLocales, tox, pytest-cov, parso }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pytest
+, glibcLocales
+, tox
+, parso }:
 
 buildPythonPackage rec {
   pname = "jedi";
-  # switch back to stable version on the next release.
-  # current stable is incompatible with parso
-  version = "2020-08-06";
+  version = "0.18.0";
 
-  src = fetchFromGitHub {
-    owner = "davidhalter";
-    repo = "jedi";
-    rev = "216f976fd5cab7a460e5d287e853d11759251e52";
-    sha256 = "1kb2ajzigadl95pnwglg8fxz9cvpg9hx30hqqj91jkgrc7djdldj";
-    fetchSubmodules = true;
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-klUKQEutiv7YgaE37JpGH+1J7KZhQUvkUFkylhTtBwc=";
   };
 
-  checkInputs = [ pytest glibcLocales tox pytest-cov ];
+  checkInputs = [ glibcLocales tox pytestCheckHook ];
 
   propagatedBuildInputs = [ parso ];
 
-  checkPhase = ''
-    LC_ALL="en_US.UTF-8" py.test test
-  '';
-
-  # tox required for tests: https://github.com/davidhalter/jedi/issues/808
+  # NOTE(breakds): There are 21 tests among ~ 4000 of them failing at
+  # this moment. I am not confident enough to be able to fix them,
+  # therefore disabling the tests for now.
   doCheck = false;
+
+  pythonImportsCheck = [ "jedi" ];
 
   meta = with lib; {
     homepage = "https://github.com/davidhalter/jedi";
     description = "An autocompletion tool for Python that can be used for text editors";
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ breakds ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is an attempt to bring `jedi` to its latest release. It is a dependency for a few of the other packages, which means that not upgrading jedi may be blocking the upgrade of others.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
