### PR TITLE
[Backport release-21.05] git-sync: Wrap both binaries

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
@@ -31,8 +31,13 @@ stdenv.mkDerivation rec {
   fixupPhase = ''
     patchShebangs $out/bin
 
+    wrap_path="${wrapperPath}":$out/bin
+
     wrapProgram $out/bin/git-sync \
-      --prefix PATH : "${wrapperPath}"
+      --prefix PATH : $wrap_path
+
+    wrapProgram $out/bin/git-sync-on-inotify \
+      --prefix PATH : $wrap_path
   '';
 
   meta = {

--- a/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
@@ -28,9 +28,7 @@ stdenv.mkDerivation rec {
     gnused
   ];
 
-  fixupPhase = ''
-    patchShebangs $out/bin
-
+  postFixup = ''
     wrap_path="${wrapperPath}":$out/bin
 
     wrapProgram $out/bin/git-sync \

--- a/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-sync/default.nix
@@ -1,15 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, coreutils, gnugrep, gnused, makeWrapper, git
-}:
+{ lib, stdenv, fetchFromGitHub, coreutils, git, gnugrep, gnused, makeWrapper, inotify-tools }:
 
 stdenv.mkDerivation rec {
   pname = "git-sync";
-  version = "20151024";
+  version = "unstable-2021-07-14";
 
   src = fetchFromGitHub {
     owner = "simonthum";
     repo = "git-sync";
-    rev = "eb9adaf2b5fd65aac1e83d6544b9076aae6af5b7";
-    sha256 = "01if8y93wa0mwbkzkzx2v1vqh47zlz4k1dysl6yh5rmppd1psknz";
+    rev = "7d3d34bf3ee2483fba00948f5b97f964b849a590";
+    sha256 = "sha256-PuYREW5NBkYF1tlcLTbOI8570nvHn5ifN8OIInfNNxI=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -18,10 +17,11 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -a git-sync $out/bin/git-sync
+    cp -a git-* $out/bin/
   '';
 
   wrapperPath = with lib; makeBinPath [
+    inotify-tools
     coreutils
     git
     gnugrep


### PR DESCRIPTION
(cherry picked from commit 633993eee29d4a0092ea12b58741c108718a7308)<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
