### PR TITLE
cheese: add pipewire as a dependency

### DIFF
--- a/pkgs/desktops/gnome/apps/cheese/default.nix
+++ b/pkgs/desktops/gnome/apps/cheese/default.nix
@@ -30,6 +30,7 @@
 , ninja
 , dbus
 , python3
+, pipewire
 }:
 
 stdenv.mkDerivation rec {
@@ -85,6 +86,7 @@ stdenv.mkDerivation rec {
     gtk3
     libcanberra-gtk3
     librsvg
+    pipewire # PipeWire provides a gstreamer plugin for using PipeWire for video
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Lets you use pipewire for recording the camera. Allows sharing access to the camera with other processes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
