### PR TITLE
nixos/lighttpd: support new authentication modules

### DIFF
--- a/nixos/modules/services/web-servers/lighttpd/default.nix
+++ b/nixos/modules/services/web-servers/lighttpd/default.nix
@@ -38,10 +38,13 @@ let
     "mod_rrdtool"
     "mod_accesslog"
     # Remaining list of modules, order assumed to be unimportant.
+    "mod_authn_dbi"
     "mod_authn_file"
     "mod_authn_gssapi"
     "mod_authn_ldap"
     "mod_authn_mysql"
+    "mod_authn_pam"
+    "mod_authn_sasl"
     "mod_cml"
     "mod_deflate"
     "mod_evasive"
@@ -129,6 +132,15 @@ in
         type = types.bool;
         description = ''
           Enable the lighttpd web server.
+        '';
+      };
+
+      package = mkOption {
+        default = pkgs.lighttpd;
+        defaultText = "pkgs.lighttpd";
+        type = types.package;
+        description = ''
+          lighttpd package to use.
         '';
       };
 
@@ -240,7 +252,7 @@ in
       description = "Lighttpd Web Server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      serviceConfig.ExecStart = "${pkgs.lighttpd}/sbin/lighttpd -D -f ${configFile}";
+      serviceConfig.ExecStart = "${cfg.package}/sbin/lighttpd -D -f ${configFile}";
       # SIGINT => graceful shutdown
       serviceConfig.KillSignal = "SIGINT";
     };

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -1,15 +1,22 @@
 { lib, stdenv, buildPackages, fetchurl, pkg-config, pcre, libxml2, zlib, bzip2, which, file
-, openssl, enableMagnet ? false, lua5_1 ? null
+, openssl
+, enableDbi ? false, libdbi ? null
+, enableMagnet ? false, lua5_1 ? null
 , enableMysql ? false, libmysqlclient ? null
 , enableLdap ? false, openldap ? null
+, enablePam ? false, linux-pam ? null
+, enableSasl ? false, cyrus_sasl ? null
 , enableWebDAV ? false, sqlite ? null, libuuid ? null
 , enableExtendedAttrs ? false, attr ? null
 , perl
 }:
 
+assert enableDbi -> libdbi != null;
 assert enableMagnet -> lua5_1 != null;
 assert enableMysql -> libmysqlclient != null;
 assert enableLdap -> openldap != null;
+assert enablePam -> linux-pam != null;
+assert enableSasl -> cyrus_sasl != null;
 assert enableWebDAV -> sqlite != null;
 assert enableWebDAV -> libuuid != null;
 assert enableExtendedAttrs -> attr != null;
@@ -33,16 +40,22 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ pcre pcre.dev libxml2 zlib bzip2 which file openssl ]
+             ++ lib.optional enableDbi libdbi
              ++ lib.optional enableMagnet lua5_1
              ++ lib.optional enableMysql libmysqlclient
              ++ lib.optional enableLdap openldap
+             ++ lib.optional enablePam linux-pam
+             ++ lib.optional enableSasl cyrus_sasl
              ++ lib.optional enableWebDAV sqlite
              ++ lib.optional enableWebDAV libuuid;
 
   configureFlags = [ "--with-openssl" ]
+                ++ lib.optional enableDbi "--with-dbi"
                 ++ lib.optional enableMagnet "--with-lua"
                 ++ lib.optional enableMysql "--with-mysql"
                 ++ lib.optional enableLdap "--with-ldap"
+                ++ lib.optional enablePam "--with-pam"
+                ++ lib.optional enableSasl "--with-sasl"
                 ++ lib.optional enableWebDAV "--with-webdav-props"
                 ++ lib.optional enableWebDAV "--with-webdav-locks"
                 ++ lib.optional enableExtendedAttrs "--with-attr";
@@ -69,6 +82,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.lighttpd.net/";
     license = lib.licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = with maintainers; [ bjornfor brecht ];
   };
 }

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -1,25 +1,15 @@
 { lib, stdenv, buildPackages, fetchurl, pkg-config, pcre, libxml2, zlib, bzip2, which, file
 , openssl
-, enableDbi ? false, libdbi ? null
-, enableMagnet ? false, lua5_1 ? null
-, enableMysql ? false, libmysqlclient ? null
-, enableLdap ? false, openldap ? null
-, enablePam ? false, linux-pam ? null
-, enableSasl ? false, cyrus_sasl ? null
-, enableWebDAV ? false, sqlite ? null, libuuid ? null
-, enableExtendedAttrs ? false, attr ? null
+, enableDbi ? false, libdbi
+, enableMagnet ? false, lua5_1
+, enableMysql ? false, libmysqlclient
+, enableLdap ? false, openldap
+, enablePam ? false, linux-pam
+, enableSasl ? false, cyrus_sasl
+, enableWebDAV ? false, sqlite, libuuid
+, enableExtendedAttrs ? false, attr
 , perl
 }:
-
-assert enableDbi -> libdbi != null;
-assert enableMagnet -> lua5_1 != null;
-assert enableMysql -> libmysqlclient != null;
-assert enableLdap -> openldap != null;
-assert enablePam -> linux-pam != null;
-assert enableSasl -> cyrus_sasl != null;
-assert enableWebDAV -> sqlite != null;
-assert enableWebDAV -> libuuid != null;
-assert enableExtendedAttrs -> attr != null;
 
 stdenv.mkDerivation rec {
   pname = "lighttpd";


### PR DESCRIPTION
###### Motivation for this change

Adds support for new authentication methods that were recently added to `lighttpd` (supercedes https://github.com/NixOS/nixpkgs/pull/133427)

The first commit adds build options for the new authentication methods to the `lighttpd` packages, all disabled by default. The second commit adds the new authentication methods to the list of known methods, as well as a new `services.lighttpd.package` option. This new option is necessary to be able to pass in a build that supports the added authentication methods.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
