### PR TITLE
drawterm: init at unstable-2021-08-02

### DIFF
--- a/pkgs/tools/admin/drawterm/default.nix
+++ b/pkgs/tools/admin/drawterm/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, lib
+, fetchgit
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "drawterm";
+  version = "unstable-2021-08-02";
+
+  src = fetchgit {
+    url = "git://git.9front.org/plan9front/drawterm";
+    rev = "a130d441722ac3f759d2d83b98eb6aef7e84f97e";
+    sha256 = "R+W1XMqQqCrMwgX9lHRhxJPG6ZOvtQrU6HUsKfvfrBQ=";
+  };
+
+  buildInputs = [
+    xorg.libX11
+    xorg.libXt
+  ];
+
+  # TODO: macos
+  makeFlags = [ "CONF=unix" ];
+
+  installPhase = ''
+    install -Dm755 -t $out/bin/ drawterm
+    install -Dm644 -t $out/man/man1/ drawterm.1
+  '';
+
+  meta = with lib; {
+    description = "Connect to Plan9 CPU servers from other operating systems.";
+    homepage = "https://drawterm.9front.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ luc65r ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23775,6 +23775,8 @@ in
     buildServerGui = false;
   };
 
+  drawterm = callPackage ../tools/admin/drawterm { };
+
   droopy = python3Packages.callPackage ../applications/networking/droopy { };
 
   drumgizmo = callPackage ../applications/audio/drumgizmo { };


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/111002

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
