### PR TITLE
nomacs: fix animated WebP support

### DIFF
--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -8,6 +8,7 @@
 , qtbase
 , qttools
 , qtsvg
+, qtimageformats
 
 , exiv2
 , opencv4
@@ -46,6 +47,7 @@ mkDerivation rec {
   buildInputs = [qtbase
                  qttools
                  qtsvg
+                 qtimageformats
                  exiv2
                  opencv4
                  libraw


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).