### PR TITLE
nixos/test-driver: minor fixes for `nixos-build-vms(8)`

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -1029,10 +1029,11 @@ if __name__ == "__main__":
 
     args = arg_parser.parse_args()
     global test_script
+    testscript = pathlib.Path(args.testscript).read_text()
 
     def test_script() -> None:
         with log.nested("running the VM test script"):
-            exec(pathlib.Path(args.testscript).read_text(), globals())
+            exec(testscript, globals())
 
     log = Logger()
 
@@ -1061,7 +1062,8 @@ if __name__ == "__main__":
                 process.terminate()
         log.close()
 
+    interactive = args.interactive or (not bool(testscript))
     tic = time.time()
-    run_tests(args.interactive)
+    run_tests(interactive)
     toc = time.time()
     print("test script finished in {:.2f}s".format(toc - tic))

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -186,6 +186,12 @@ rec {
           --set startScripts "''${vmStartScripts[*]}" \
           --set testScript "$out/test-script" \
           --set vlans '${toString vlans}'
+
+        ln -s ${testDriver}/bin/nixos-test-driver $out/bin/nixos-run-vms
+        wrapProgram $out/bin/nixos-run-vms \
+          --set startScripts "''${vmStartScripts[*]}" \
+          --set testScript "${pkgs.writeText "start-all" "start_all(); join_all();"}" \
+          --set vlans '${toString vlans}'
       '');
 
   # Make a full-blown test

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -187,11 +187,13 @@ rec {
           --set testScript "$out/test-script" \
           --set vlans '${toString vlans}'
 
-        ln -s ${testDriver}/bin/nixos-test-driver $out/bin/nixos-run-vms
-        wrapProgram $out/bin/nixos-run-vms \
-          --set startScripts "''${vmStartScripts[*]}" \
-          --set testScript "${pkgs.writeText "start-all" "start_all(); join_all();"}" \
-          --set vlans '${toString vlans}'
+        ${lib.optionalString (testScript == "") ''
+          ln -s ${testDriver}/bin/nixos-test-driver $out/bin/nixos-run-vms
+          wrapProgram $out/bin/nixos-run-vms \
+            --set startScripts "''${vmStartScripts[*]}" \
+            --set testScript "${pkgs.writeText "start-all" "start_all(); join_all();"}" \
+            --set vlans '${toString vlans}'
+        ''}
       '');
 
   # Make a full-blown test


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Follow-up for https://github.com/NixOS/nixpkgs/pull/125979. While I agree with the overall approach from said PR, I don't really like the current implications for `nixos-build-vms(8)`. This PR aims to fix that.

Further details for the actual changes can be found in the commit-messages.

cc @blaggacao 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
