### PR TITLE
rtsp-simple-server: 0.15.4 -> 0.17.1

### DIFF
--- a/pkgs/servers/rtsp-simple-server/default.nix
+++ b/pkgs/servers/rtsp-simple-server/default.nix
@@ -5,22 +5,24 @@
 
 buildGoModule rec {
   pname = "rtsp-simple-server";
-  version = "0.15.4";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     owner = "aler9";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-6XdX4HEjDRt9WtqyHIv/NLt7IytNDeJLgCeTHTGybRI=";
+    sha256 = "sha256-8g9taSFEprJEEPM0hrbCf5QDE41uVdgVVIWjhfEICpU=";
   };
 
-  vendorSha256 = "sha256-T5LWbxYsKnG5eaYLR/rms6+2DXv2lV9o39BvF7HapZY=";
+  vendorSha256 = "sha256-buQW5jMnHyHc/oYdmfTnoktFRG3V3SNxn7t5mAwmiJI=";
 
   # Tests need docker
   doCheck = false;
 
   buildFlagsArray = [
-    "-ldflags=-X main.Version=${version}"
+    # In the future, we might need to switch to `main.Version`, considering:
+    # https://github.com/aler9/rtsp-simple-server/issues/503
+    "-ldflags=-X github.com/aler9/rtsp-simple-server/internal/core.version=v${version}"
   ];
 
   meta = with lib; {


### PR DESCRIPTION


###### Motivation for this change
Upgrade to latest version for access to HTTP API. Verified the binary starts and that `rtsp-simple-server --version` prints the right value.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
