### PR TITLE
footswitch: init at unstable-2021-03-17

### DIFF
--- a/pkgs/tools/inputmethods/footswitch/default.nix
+++ b/pkgs/tools/inputmethods/footswitch/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ hidapi ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile \
       --replace /usr/local $out \
       --replace /usr/bin/install install \

--- a/pkgs/tools/inputmethods/footswitch/default.nix
+++ b/pkgs/tools/inputmethods/footswitch/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, hidapi }:
+
+stdenv.mkDerivation {
+  pname = "footswitch";
+  version = "unstable-20201-03-17";
+
+  src = fetchFromGitHub {
+    owner = "rgerganov";
+    repo = "footswitch";
+    rev = "aa0b10f00d3e76dac27b55b88c8d44c0c406f7f0";
+    sha256 = "sha256-SikYiBN7jbH5I1x5wPCF+buwFp1dt35cVxAN6lWkTN0=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ hidapi ];
+
+  patchPhase = ''
+    substituteInPlace Makefile \
+      --replace /usr/local $out \
+      --replace /usr/bin/install install \
+      --replace /etc/udev/rules.d $out/lib/udev/rules.d
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin $out/lib/udev/rules.d
+  '';
+
+  meta = with lib; {
+    description = "Command line utlities for programming PCsensor and Scythe foot switches.";
+    homepage    = "https://github.com/rgerganov/footswitch";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ baloo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4958,6 +4958,8 @@ with pkgs;
 
   fontmatrix = libsForQt514.callPackage ../applications/graphics/fontmatrix {};
 
+  footswitch = callPackage ../tools/inputmethods/footswitch { };
+
   foremost = callPackage ../tools/system/foremost { };
 
   forktty = callPackage ../os-specific/linux/forktty {};


### PR DESCRIPTION
###### Motivation for this change

Footswitch is a tool to configure HID foot pedals

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
