### PR TITLE
Backport 21.05 emacs pkgs updates

### DIFF
--- a/nixos/modules/services/continuous-integration/hercules-ci-agent/common.nix
+++ b/nixos/modules/services/continuous-integration/hercules-ci-agent/common.nix
@@ -105,7 +105,7 @@ let
       pkgs.stdenv.mkDerivation {
         name = "hercules-ci-check-system-nix-src";
         inherit (config.nix.package) src patches;
-        configurePhase = ":";
+        dontConfigure = true;
         buildPhase = ''
           echo "Checking in-memory pathInfoCache expiry"
           if ! grep 'PathInfoCacheValue' src/libstore/store-api.hh >/dev/null; then

--- a/nixos/modules/services/hardware/sane_extra_backends/brscan4_etc_files.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan4_etc_files.nix
@@ -54,8 +54,7 @@ stdenv.mkDerivation {
     ${addAllNetDev netDevices}
   '';
 
-  installPhase = ":";
-
+  dontInstall = true;
   dontStrip = true;
   dontPatchELF = true;
 

--- a/pkgs/applications/editors/emacs/elisp-packages/apheleia/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/apheleia/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "apheleia";
+  version = "2021-05-23";
+
+  src = fetchFromGitHub {
+    owner = "raxod502";
+    repo = "apheleia";
+    rev = "f865c165dac606187a66b2b25a57d5099b452120";
+    sha256 = "sha256-n37jJsNOGhSjUtQysG3NVIjjayhbOa52iTXBc8SyKXE=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Reformat buffer stably";
+    homepage = "https://github.com/raxod502/apheleia";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/cedille/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/cedille/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ emacs ];
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     install -d $out/share/emacs/site-lisp

--- a/pkgs/applications/editors/emacs/elisp-packages/ebuild-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/ebuild-mode/default.nix
@@ -5,7 +5,7 @@ trivialBuild rec {
   version = "1.52";
 
   src = fetchurl {
-    url = "https://dev.gentoo.org/~ulm/emacs/ebuild-mode-${version}.tar.xz";
+    url = "https://dev.gentoo.org/~ulm/emacs/${pname}-${version}.tar.xz";
     sha256 = "10nikbbwh612qlnms2i31963a0h3ccyg85vrxlizdpsqs4cjpg6h";
   };
 

--- a/pkgs/applications/editors/emacs/elisp-packages/ebuild-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/ebuild-mode/default.nix
@@ -1,0 +1,17 @@
+{ lib, trivialBuild, fetchurl }:
+
+trivialBuild rec {
+  pname = "ebuild-mode";
+  version = "1.52";
+
+  src = fetchurl {
+    url = "https://dev.gentoo.org/~ulm/emacs/ebuild-mode-${version}.tar.xz";
+    sha256 = "10nikbbwh612qlnms2i31963a0h3ccyg85vrxlizdpsqs4cjpg6h";
+  };
+
+  meta = with lib; {
+    description = "Major modes for Gentoo package files";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ qyliss ];
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -125,20 +125,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    aggressive-indent = callPackage ({ cl-lib ? null
-                                     , elpaBuild
-                                     , emacs
-                                     , fetchurl
-                                     , lib }:
+    aggressive-indent = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "aggressive-indent";
         ename = "aggressive-indent";
-        version = "1.8.3";
+        version = "1.10.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/aggressive-indent-1.8.3.el";
-          sha256 = "0jnzccl50x0wapprgwxinp99pwwa6j43q6msn4gv437j7swy8wnj";
+          url = "https://elpa.gnu.org/packages/aggressive-indent-1.10.0.tar";
+          sha256 = "166jk1z0vw481lfi3gbg7f9vsgwfv8fiyxpkfphgvgcmf5phv4q1";
         };
-        packageRequires = [ cl-lib emacs ];
+        packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/aggressive-indent.html";
           license = lib.licenses.free;
@@ -670,10 +666,10 @@
       elpaBuild {
         pname = "corfu";
         ename = "corfu";
-        version = "0.9";
+        version = "0.10";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/corfu-0.9.tar";
-          sha256 = "0710bq07j6w6zm49ci1bbx580frdbc62b3hbxwzkwm5204nf78bf";
+          url = "https://elpa.gnu.org/packages/corfu-0.10.tar";
+          sha256 = "0sqr4cld84vgfnf0fjgvbbix1p23s0n2xsszfap6d8a2xzzpp044";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -775,10 +771,10 @@
       elpaBuild {
         pname = "dash";
         ename = "dash";
-        version = "2.18.1";
+        version = "2.19.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/dash-2.18.1.tar";
-          sha256 = "17mrvmrfh5c3kri4r3gf1c3gz4i5vl9ac60grpx4103b56y4cgra";
+          url = "https://elpa.gnu.org/packages/dash-2.19.0.tar";
+          sha256 = "0qszjs60xxqjiqf5f2bgmnbx5jiqii4ghcydwg500za0n2j0f5sx";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1015,10 +1011,10 @@
       elpaBuild {
         pname = "ebdb";
         ename = "ebdb";
-        version = "0.6.24";
+        version = "0.7";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-0.6.24.tar";
-          sha256 = "0156rh6fkv2yp509h6i8qzh4gsda2mcmfrxl4r6ywn1z5ahijc3r";
+          url = "https://elpa.gnu.org/packages/ebdb-0.7.tar";
+          sha256 = "0q4ywgh87d6hjac3031s21w91gld2hh7s8nbva94dnzwn6y9d0v1";
         };
         packageRequires = [ cl-lib emacs seq ];
         meta = {
@@ -1075,10 +1071,10 @@
       elpaBuild {
         pname = "eev";
         ename = "eev";
-        version = "20210618";
+        version = "20210710";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/eev-20210618.tar";
-          sha256 = "13sb9shpj9fhns8sl3dxdgnn8z4wf14mgi4s87k5x4nrr012sscf";
+          url = "https://elpa.gnu.org/packages/eev-20210710.tar";
+          sha256 = "19k5yncyjg7afvkx54k9mplm86jyr3svjjyprrj1frdi219i5piw";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2321,10 +2317,10 @@
       elpaBuild {
         pname = "modus-themes";
         ename = "modus-themes";
-        version = "1.4.0";
+        version = "1.5.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/modus-themes-1.4.0.tar";
-          sha256 = "0ssckl06jk08vaq4g7sxpzvc3ybm339fzbn9qw21w82v1l60rzpm";
+          url = "https://elpa.gnu.org/packages/modus-themes-1.5.0.tar";
+          sha256 = "0y5a7g66iiai20fvc6qff3ki792bzca87zxbmxl8hpks4a6znc80";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2889,10 +2885,10 @@
       elpaBuild {
         pname = "pyim";
         ename = "pyim";
-        version = "3.8.2";
+        version = "3.9.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-3.8.2.tar";
-          sha256 = "05sgciqb0hzy07j8pvbg7h2vpa9z5z60m6pknxd3b1kpi45vaihw";
+          url = "https://elpa.gnu.org/packages/pyim-3.9.2.tar";
+          sha256 = "18m5wni1zns8fad2ll9flbfgxfy14gi03apnycajdbqxsqfp65j9";
         };
         packageRequires = [ async emacs xr ];
         meta = {
@@ -3396,6 +3392,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shell-command-plus";
+        ename = "shell-command+";
+        version = "2.2.0";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
+          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";
@@ -3430,10 +3441,10 @@
       elpaBuild {
         pname = "slime-volleyball";
         ename = "slime-volleyball";
-        version = "1.1.7";
+        version = "1.2.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/slime-volleyball-1.1.7.tar";
-          sha256 = "0dl1x0ghfwg4vv2asz3g4plghjxpzd56fyw09vsa3s3k9xsmy3yy";
+          url = "https://elpa.gnu.org/packages/slime-volleyball-1.2.0.tar";
+          sha256 = "07xavg6xq5ckrfy5sk5k5ldb46m5w8nw1r1k006ck8f23ajaw5z2";
         };
         packageRequires = [ cl-lib ];
         meta = {
@@ -3561,16 +3572,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    spinner = callPackage ({ elpaBuild, fetchurl, lib }:
+    spinner = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "spinner";
         ename = "spinner";
-        version = "1.7.3";
+        version = "1.7.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/spinner-1.7.3.el";
-          sha256 = "19kp1mmndbmw11sgvv2ggfjl4pyf5zrsbh3871f0965pw9z8vahd";
+          url = "https://elpa.gnu.org/packages/spinner-1.7.4.tar";
+          sha256 = "140kss25ijbwf8hzflbjz67ry76w2cyrh02axk95n6qcxv7jr7pv";
         };
-        packageRequires = [];
+        packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/spinner.html";
           license = lib.licenses.free;
@@ -3824,10 +3835,10 @@
       elpaBuild {
         pname = "transient";
         ename = "transient";
-        version = "0.3.5";
+        version = "0.3.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/transient-0.3.5.tar";
-          sha256 = "15dlj21gn0zxywic9wdcp5zc8skm1s170bq7smgkpd3p3lxslf68";
+          url = "https://elpa.gnu.org/packages/transient-0.3.6.tar";
+          sha256 = "11n2551kvfjrqyk0x78bz6pirnfs126cbchiv1pchqwyk8z8c9ks";
         };
         packageRequires = [ emacs ];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -39,10 +39,10 @@
       elpaBuild {
         pname = "ada-mode";
         ename = "ada-mode";
-        version = "7.1.5";
+        version = "7.1.7";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ada-mode-7.1.5.tar";
-          sha256 = "037v25mqpg1n52hz89b49vf9zw68fmc0m7l6c1f8vnbw3dibyk8d";
+          url = "https://elpa.gnu.org/packages/ada-mode-7.1.7.tar";
+          sha256 = "0bzykgzc3kx1dgngishsf9w4czq3ig6wvrv3832zlxb7q3rmw8j2";
         };
         packageRequires = [ emacs uniquify-files wisi ];
         meta = {
@@ -1007,16 +1007,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    ebdb = callPackage ({ cl-lib ? null, elpaBuild, emacs, fetchurl, lib, seq }:
+    ebdb = callPackage ({ elpaBuild, emacs, fetchurl, lib, seq }:
       elpaBuild {
         pname = "ebdb";
         ename = "ebdb";
-        version = "0.7";
+        version = "0.7.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-0.7.tar";
-          sha256 = "0q4ywgh87d6hjac3031s21w91gld2hh7s8nbva94dnzwn6y9d0v1";
+          url = "https://elpa.gnu.org/packages/ebdb-0.7.1.tar";
+          sha256 = "1z5lh1mib60mvs5kbdsrw2h4whz4n5ad4qkpphs2xjvaz92jgq6s";
         };
-        packageRequires = [ cl-lib emacs seq ];
+        packageRequires = [ emacs seq ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/ebdb.html";
           license = lib.licenses.free;
@@ -1417,6 +1417,21 @@
         packageRequires = [ cl-lib emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/fsm.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    ftable = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "ftable";
+        ename = "ftable";
+        version = "1.0";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/ftable-1.0.tar";
+          sha256 = "1qi0fxw94hb7p2s8n2dzbziialbjbjxgpwx2m4mvrmicrq375r5p";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/ftable.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -1964,16 +1979,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    kiwix = callPackage ({ elpaBuild, emacs, fetchurl, lib, request }:
+    kiwix = callPackage ({ elpaBuild, elquery, emacs, fetchurl, lib, request }:
       elpaBuild {
         pname = "kiwix";
         ename = "kiwix";
-        version = "1.0.3";
+        version = "1.1.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/kiwix-1.0.3.tar";
-          sha256 = "061b816xp8ykqd56z0nvc69aql9y4mba42p6x6vc0j6gr9n3c1j6";
+          url = "https://elpa.gnu.org/packages/kiwix-1.1.0.tar";
+          sha256 = "1clp0q34bs395d0hrqdyvm9ds665hgf5qrdiqa14k31h4lbv2wsn";
         };
-        packageRequires = [ emacs request ];
+        packageRequires = [ elquery emacs request ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/kiwix.html";
           license = lib.licenses.free;
@@ -2780,10 +2795,10 @@
       elpaBuild {
         pname = "phps-mode";
         ename = "phps-mode";
-        version = "0.4.3";
+        version = "0.4.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/phps-mode-0.4.3.tar";
-          sha256 = "0yvwfaj7l4z3zgycvnf1j0r5jx4lryaapljbw2sqvwqpbgyiw0y0";
+          url = "https://elpa.gnu.org/packages/phps-mode-0.4.6.tar";
+          sha256 = "0mfwyz9rwnrs0xcd1jmq1ngdhbwygm6hbfhyr14djywxx0b4hpm5";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2885,10 +2900,10 @@
       elpaBuild {
         pname = "pyim";
         ename = "pyim";
-        version = "3.9.3";
+        version = "3.9.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-3.9.3.tar";
-          sha256 = "0rjaimvbh0fadbqiq4ggyxr0y4pfzld76wb64v7l5874qczn8dfr";
+          url = "https://elpa.gnu.org/packages/pyim-3.9.4.tar";
+          sha256 = "0ggnl2jidcklyhqd5av5kk1f855gsq29wq2nhvp1yjzn35hz6xij";
         };
         packageRequires = [ async emacs xr ];
         meta = {
@@ -3362,21 +3377,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
-      elpaBuild {
-        pname = "shell-command-plus";
-        ename = "shell-command+";
-        version = "2.2.0";
-        src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
-          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
-          license = lib.licenses.free;
-        };
-      }) {};
     shelisp = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shelisp";
@@ -3389,6 +3389,21 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/shelisp.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shell-command-plus";
+        ename = "shell-command+";
+        version = "2.2.0";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
+          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -3501,10 +3516,10 @@
       elpaBuild {
         pname = "so-long";
         ename = "so-long";
-        version = "1.0";
+        version = "1.1.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/so-long-1.0.el";
-          sha256 = "00z9gnxz32rakd0k7lqaj050fwmqzq5vr9d6rb7ji3fn01rjp7kj";
+          url = "https://elpa.gnu.org/packages/so-long-1.1.1.tar";
+          sha256 = "0qgdnkb702mkm886v0zv0hnm5y7zlifgx9ji6xmdsxycpsfkjz1f";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3775,10 +3790,10 @@
       elpaBuild {
         pname = "tramp";
         ename = "tramp";
-        version = "2.5.1";
+        version = "2.5.1.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-2.5.1.tar";
-          sha256 = "1r7wifhzy2ipdlc4fqnx6549fnx45ggz57wh0cp7s6y25761si7q";
+          url = "https://elpa.gnu.org/packages/tramp-2.5.1.1.tar";
+          sha256 = "0v3rvvhjcnyvg6l4vyxz6513mxzvv9n0skkmr62ry8yi5x9wnqp1";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4224,10 +4239,10 @@
       elpaBuild {
         pname = "wisi";
         ename = "wisi";
-        version = "3.1.4";
+        version = "3.1.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/wisi-3.1.4.tar";
-          sha256 = "1j35ln5x3dgypq3hn6xcdpg6vp6yjj6avcjakc2r6wx19vxixciw";
+          url = "https://elpa.gnu.org/packages/wisi-3.1.5.tar";
+          sha256 = "07jc8x6xdhpjv9hlghmvk7ga4gwww33nj5pizlx5scvpp0qvikpy";
         };
         packageRequires = [ emacs seq ];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -3396,21 +3396,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
-      elpaBuild {
-        pname = "shell-command-plus";
-        ename = "shell-command+";
-        version = "2.1.0";
-        src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.1.0.tar";
-          sha256 = "1jyrnv89989bi03m5h8dj0cllsw3rvyxkiyfrh9v6gpxjwfy8lmq";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
-          license = lib.licenses.free;
-        };
-      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -238,10 +238,10 @@
       elpaBuild {
         pname = "auctex";
         ename = "auctex";
-        version = "13.0.11";
+        version = "13.0.12";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/auctex-13.0.11.tar";
-          sha256 = "0sy4f1n38q58vyzw5l0f80ci3j99rb25gbwj0frl0pglfmgzl44k";
+          url = "https://elpa.gnu.org/packages/auctex-13.0.12.tar";
+          sha256 = "0fx3l6yyq63mlnapxiqpdhi5l314r3aj63404nly6hcdvc28g9nm";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -636,6 +636,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    consult = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "consult";
+        ename = "consult";
+        version = "0.8";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/consult-0.8.tar";
+          sha256 = "0vkq8dsj6k3gsdhiyg6ccv49fqgjw6f0db4wjsvm5zbkadjvlm86";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/consult.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     context-coloring = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "context-coloring";
@@ -816,6 +831,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    devdocs = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "devdocs";
+        ename = "devdocs";
+        version = "0.1";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/devdocs-0.1.tar";
+          sha256 = "1ps2jpp1ckq9839l63p6npqrf85b8zb5akwvjvv7fkm8nvspdkil";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/devdocs.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     dict-tree = callPackage ({ elpaBuild, fetchurl, heap, lib, tNFA, trie }:
       elpaBuild {
         pname = "dict-tree";
@@ -906,16 +936,16 @@
           license = lib.licenses.free;
         };
       }) {};
-    dismal = callPackage ({ cl-lib ? null, elpaBuild, fetchurl, lib }:
+    dismal = callPackage ({ cl-lib ? null, elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "dismal";
         ename = "dismal";
-        version = "1.5";
+        version = "1.5.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/dismal-1.5.tar";
-          sha256 = "1vhs6w6c2klsrfjpw8vr5c4gwiw83ppdjhsn2la0fvkm60jmc476";
+          url = "https://elpa.gnu.org/packages/dismal-1.5.2.tar";
+          sha256 = "0pl5cnziilm4ps1xzh1fa8irazn7vcp9nsxnxcvjqbkflpcpq5c7";
         };
-        packageRequires = [ cl-lib ];
+        packageRequires = [ cl-lib emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/dismal.html";
           license = lib.licenses.free;
@@ -985,10 +1015,10 @@
       elpaBuild {
         pname = "ebdb";
         ename = "ebdb";
-        version = "0.6.22";
+        version = "0.6.23";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-0.6.22.tar";
-          sha256 = "0dljl21n6508c7ash7l6zgxhpn2wdfzga0va63d4k9nwnqmkvsgz";
+          url = "https://elpa.gnu.org/packages/ebdb-0.6.23.tar";
+          sha256 = "0j3jvy9s606qjqcmcjzgck3dp8bhpgly2g00wnswzcgk4makdzld";
         };
         packageRequires = [ cl-lib emacs seq ];
         meta = {
@@ -1045,10 +1075,10 @@
       elpaBuild {
         pname = "eev";
         ename = "eev";
-        version = "20210512";
+        version = "20210607";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/eev-20210512.tar";
-          sha256 = "0dj49lpqv5vsx02h8mla8cmv5cr5f2qbz74f9dn8q4adpzxsajin";
+          url = "https://elpa.gnu.org/packages/eev-20210607.tar";
+          sha256 = "0avd58m8630s4d3ys9g84csscdmf2y1swwwkgzjkrrq8q0j5yd3l";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1241,10 +1271,10 @@
       elpaBuild {
         pname = "excorporate";
         ename = "excorporate";
-        version = "0.9.6";
+        version = "1.0.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/excorporate-0.9.6.tar";
-          sha256 = "0ljav8g1npg0a36x1xxpfs2gvk622fh3si95s3w2vmwa27ynirzj";
+          url = "https://elpa.gnu.org/packages/excorporate-1.0.0.tar";
+          sha256 = "1g0wc2kp15ra323b4rxvdh58q9c4h7m20grw6a0cs53m7l9xi62f";
         };
         packageRequires = [
           cl-lib
@@ -1742,10 +1772,10 @@
       elpaBuild {
         pname = "isearch-mb";
         ename = "isearch-mb";
-        version = "0.2";
+        version = "0.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/isearch-mb-0.2.tar";
-          sha256 = "1mfjppv33cb5f5f6cc1486msxjxfjnnkryc1yax43k6fgzjr0j4h";
+          url = "https://elpa.gnu.org/packages/isearch-mb-0.3.tar";
+          sha256 = "01yq1skc6rm9yp80vz2fhh9lbkdb9nhf57h424mrkycdky2w50mx";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1987,10 +2017,10 @@
       elpaBuild {
         pname = "leaf";
         ename = "leaf";
-        version = "4.4.4";
+        version = "4.4.8";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/leaf-4.4.4.tar";
-          sha256 = "1npg06zmy21kg2qsqgfm03l7vjib697i96awypcdb0hw5mvmc1a1";
+          url = "https://elpa.gnu.org/packages/leaf-4.4.8.tar";
+          sha256 = "0h0ksmgrhn29ci6z8y54dbbzcqlvfs1ra0kmf226gz0dqzk45vb3";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2115,6 +2145,21 @@
         packageRequires = [ emacs ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/map.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    marginalia = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "marginalia";
+        ename = "marginalia";
+        version = "0.6";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/marginalia-0.6.tar";
+          sha256 = "05pwaz9643shxnv63l6r9m2c0qf1nc1hy6jiqw01bkvvgg8g4jag";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/marginalia.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -2276,10 +2321,10 @@
       elpaBuild {
         pname = "modus-themes";
         ename = "modus-themes";
-        version = "1.3.2";
+        version = "1.4.0";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/modus-themes-1.3.2.tar";
-          sha256 = "085zi3ckf4s1kjskqb04b78rgrhbdhrrp74yksb5w0hl58bd8rsc";
+          url = "https://elpa.gnu.org/packages/modus-themes-1.4.0.tar";
+          sha256 = "0ssckl06jk08vaq4g7sxpzvc3ybm339fzbn9qw21w82v1l60rzpm";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2784,10 +2829,10 @@
       elpaBuild {
         pname = "posframe";
         ename = "posframe";
-        version = "1.0.2";
+        version = "1.0.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/posframe-1.0.2.tar";
-          sha256 = "19a1dkjyw9m74aamyqrsvzrdwshngqpmjzdngx6v5nifvcilrlnk";
+          url = "https://elpa.gnu.org/packages/posframe-1.0.3.tar";
+          sha256 = "0c3lnrydsysv8j25brgc0cckf1hz54yhkginncmw81y1ia43rqmx";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2844,10 +2889,10 @@
       elpaBuild {
         pname = "pyim";
         ename = "pyim";
-        version = "3.7.6";
+        version = "3.7.9";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-3.7.6.tar";
-          sha256 = "1crimmvyppjmds9shfvxy9j5zi3mk133bv5av0fgicm7ddkivksr";
+          url = "https://elpa.gnu.org/packages/pyim-3.7.9.tar";
+          sha256 = "00ff1izdwcy53dcwpdn18wwndnw2jsw4bhg8gkqaa60xm468xzkl";
         };
         packageRequires = [ async emacs xr ];
         meta = {
@@ -3340,6 +3385,21 @@
       elpaBuild {
         pname = "shell-command-plus";
         ename = "shell-command+";
+        version = "2.2.0";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
+          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shell-command-plus";
+        ename = "shell-command+";
         version = "2.1.0";
         src = fetchurl {
           url = "https://elpa.gnu.org/packages/shell-command+-2.1.0.tar";
@@ -3734,10 +3794,10 @@
       elpaBuild {
         pname = "tramp";
         ename = "tramp";
-        version = "2.5.0.4";
+        version = "2.5.0.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-2.5.0.4.tar";
-          sha256 = "0yk4ckk45gkjp24nfywz49j8pazq33m6pga3lirb5h6zc8an5z24";
+          url = "https://elpa.gnu.org/packages/tramp-2.5.0.5.tar";
+          sha256 = "1dclxffynfacvwi2scpda35sxjb42603yyf2p0477qa9b0i4xha0";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3779,10 +3839,10 @@
       elpaBuild {
         pname = "transient";
         ename = "transient";
-        version = "0.3.2";
+        version = "0.3.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/transient-0.3.2.tar";
-          sha256 = "10zqa245dn6z689z7ap6nx6q9s95whzgybpwl2slpmnawxix2q6i";
+          url = "https://elpa.gnu.org/packages/transient-0.3.4.tar";
+          sha256 = "1m71w52cr8f9wm6lybfa003w408lkrl6q9whs53hpp3pl5phhfvb";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3970,10 +4030,10 @@
       elpaBuild {
         pname = "vertico";
         ename = "vertico";
-        version = "0.10";
+        version = "0.11";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vertico-0.10.tar";
-          sha256 = "07bzhxgp3k6q4wl9ijhx4vg8diinn782xhr8axn790a5vj199j78";
+          url = "https://elpa.gnu.org/packages/vertico-0.11.tar";
+          sha256 = "0hzwddkac85i449173az8crlksj9ivrqf969r81kbr45ksgr1ij6";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -4093,10 +4153,10 @@
       elpaBuild {
         pname = "webfeeder";
         ename = "webfeeder";
-        version = "1.1.1";
+        version = "1.1.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/webfeeder-1.1.1.tar";
-          sha256 = "09caj12hfdfhlbcsmjyhw728w1f7yq13hdslh793yvfqv83ipvc4";
+          url = "https://elpa.gnu.org/packages/webfeeder-1.1.2.tar";
+          sha256 = "1l128q424qsq9jv2wk8cv4zli71rk34q5kgwa9axdz0d27p9l6v4";
         };
         packageRequires = [ emacs ];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -3362,6 +3362,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shell-command-plus";
+        ename = "shell-command+";
+        version = "2.2.0";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
+          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     shelisp = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shelisp";
@@ -3374,36 +3389,6 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/shelisp.html";
-          license = lib.licenses.free;
-        };
-      }) {};
-    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
-      elpaBuild {
-        pname = "shell-command-plus";
-        ename = "shell-command+";
-        version = "2.2.0";
-        src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
-          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
-          license = lib.licenses.free;
-        };
-      }) {};
-    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
-      elpaBuild {
-        pname = "shell-command-plus";
-        ename = "shell-command+";
-        version = "2.2.0";
-        src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
-          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
           license = lib.licenses.free;
         };
       }) {};

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -3392,6 +3392,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shell-command-plus";
+        ename = "shell-command+";
+        version = "2.2.0";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
+          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -3396,21 +3396,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
-      elpaBuild {
-        pname = "shell-command-plus";
-        ename = "shell-command+";
-        version = "2.2.0";
-        src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
-          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
-          license = lib.licenses.free;
-        };
-      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -640,10 +640,10 @@
       elpaBuild {
         pname = "consult";
         ename = "consult";
-        version = "0.8";
+        version = "0.9";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/consult-0.8.tar";
-          sha256 = "0vkq8dsj6k3gsdhiyg6ccv49fqgjw6f0db4wjsvm5zbkadjvlm86";
+          url = "https://elpa.gnu.org/packages/consult-0.9.tar";
+          sha256 = "1n3bnvgj92fjd9dai9f95wvyfb20yhaw7b722lkqjg42i10jqzfn";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -670,10 +670,10 @@
       elpaBuild {
         pname = "corfu";
         ename = "corfu";
-        version = "0.8";
+        version = "0.9";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/corfu-0.8.tar";
-          sha256 = "1qrrky1g4k5vw56435dgkwnmnri7i51gkydd76as3l0ixm4pnp05";
+          url = "https://elpa.gnu.org/packages/corfu-0.9.tar";
+          sha256 = "0710bq07j6w6zm49ci1bbx580frdbc62b3hbxwzkwm5204nf78bf";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -835,10 +835,10 @@
       elpaBuild {
         pname = "devdocs";
         ename = "devdocs";
-        version = "0.1";
+        version = "0.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/devdocs-0.1.tar";
-          sha256 = "1ps2jpp1ckq9839l63p6npqrf85b8zb5akwvjvv7fkm8nvspdkil";
+          url = "https://elpa.gnu.org/packages/devdocs-0.2.tar";
+          sha256 = "1npc7yra7pvf86ahmz1h7hnjxrz15ar1vjcalg4ilizypycpgrwj";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1015,10 +1015,10 @@
       elpaBuild {
         pname = "ebdb";
         ename = "ebdb";
-        version = "0.6.23";
+        version = "0.6.24";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-0.6.23.tar";
-          sha256 = "0j3jvy9s606qjqcmcjzgck3dp8bhpgly2g00wnswzcgk4makdzld";
+          url = "https://elpa.gnu.org/packages/ebdb-0.6.24.tar";
+          sha256 = "0156rh6fkv2yp509h6i8qzh4gsda2mcmfrxl4r6ywn1z5ahijc3r";
         };
         packageRequires = [ cl-lib emacs seq ];
         meta = {
@@ -1075,10 +1075,10 @@
       elpaBuild {
         pname = "eev";
         ename = "eev";
-        version = "20210607";
+        version = "20210618";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/eev-20210607.tar";
-          sha256 = "0avd58m8630s4d3ys9g84csscdmf2y1swwwkgzjkrrq8q0j5yd3l";
+          url = "https://elpa.gnu.org/packages/eev-20210618.tar";
+          sha256 = "13sb9shpj9fhns8sl3dxdgnn8z4wf14mgi4s87k5x4nrr012sscf";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -1198,10 +1198,10 @@
       elpaBuild {
         pname = "emms";
         ename = "emms";
-        version = "7.2";
+        version = "7.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/emms-7.2.tar";
-          sha256 = "11vqqh9rnzibsfw7wx62rgzl8i8ldpf0hv1sj43nhl5c6dlc8d5z";
+          url = "https://elpa.gnu.org/packages/emms-7.5.tar";
+          sha256 = "0d7nsx2idzbp6d5im5rrsnwppbr2cimvxgx31bhwsm2aq3ya5v2j";
         };
         packageRequires = [ cl-lib nadvice seq ];
         meta = {
@@ -1867,10 +1867,10 @@
       elpaBuild {
         pname = "ivy-posframe";
         ename = "ivy-posframe";
-        version = "0.6.0";
+        version = "0.6.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ivy-posframe-0.6.0.tar";
-          sha256 = "07dzglrcdl54lkznyphw97xwd9bcwzdcgzkav0vqfk7f5cwh1wkf";
+          url = "https://elpa.gnu.org/packages/ivy-posframe-0.6.1.tar";
+          sha256 = "1nay2sfbwm2fkp3f1y89innd9h6j3q70q9y4yddrwa69cxlj9m23";
         };
         packageRequires = [ emacs ivy posframe ];
         meta = {
@@ -2017,10 +2017,10 @@
       elpaBuild {
         pname = "leaf";
         ename = "leaf";
-        version = "4.4.8";
+        version = "4.5.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/leaf-4.4.8.tar";
-          sha256 = "0h0ksmgrhn29ci6z8y54dbbzcqlvfs1ra0kmf226gz0dqzk45vb3";
+          url = "https://elpa.gnu.org/packages/leaf-4.5.2.tar";
+          sha256 = "0i90shhhkpdcwmfi8zv0008qgmg4g3cqd2yvpycfv9n2axvhag54";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2152,10 +2152,10 @@
       elpaBuild {
         pname = "marginalia";
         ename = "marginalia";
-        version = "0.6";
+        version = "0.7";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/marginalia-0.6.tar";
-          sha256 = "05pwaz9643shxnv63l6r9m2c0qf1nc1hy6jiqw01bkvvgg8g4jag";
+          url = "https://elpa.gnu.org/packages/marginalia-0.7.tar";
+          sha256 = "1nz55nx6xp72nahs4g6asl5y5yrlnlnza58bjrlwwzmwsf7daz18";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2829,10 +2829,10 @@
       elpaBuild {
         pname = "posframe";
         ename = "posframe";
-        version = "1.0.3";
+        version = "1.0.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/posframe-1.0.3.tar";
-          sha256 = "0c3lnrydsysv8j25brgc0cckf1hz54yhkginncmw81y1ia43rqmx";
+          url = "https://elpa.gnu.org/packages/posframe-1.0.4.tar";
+          sha256 = "0i2pw90gw9zb22gj8yyvcp3b2k1bxxhbjj0idvr5iz1vd9023bc6";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2889,10 +2889,10 @@
       elpaBuild {
         pname = "pyim";
         ename = "pyim";
-        version = "3.7.9";
+        version = "3.8.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-3.7.9.tar";
-          sha256 = "00ff1izdwcy53dcwpdn18wwndnw2jsw4bhg8gkqaa60xm468xzkl";
+          url = "https://elpa.gnu.org/packages/pyim-3.8.2.tar";
+          sha256 = "05sgciqb0hzy07j8pvbg7h2vpa9z5z60m6pknxd3b1kpi45vaihw";
         };
         packageRequires = [ async emacs xr ];
         meta = {
@@ -3355,10 +3355,10 @@
       elpaBuild {
         pname = "setup";
         ename = "setup";
-        version = "0.2.0";
+        version = "0.2.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/setup-0.2.0.tar";
-          sha256 = "1xhjkyksilw1vbx12a4yz4bpj0dhl3m02yi8d9nyd19z098cfa9y";
+          url = "https://elpa.gnu.org/packages/setup-0.2.1.tar";
+          sha256 = "15paand086g33w2vb6jkyxd3i2pmpp84f31y3j5v8w9ia68pjzms";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3378,6 +3378,21 @@
         packageRequires = [];
         meta = {
           homepage = "https://elpa.gnu.org/packages/shelisp.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "shell-command-plus";
+        ename = "shell-command+";
+        version = "2.2.0";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
+          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
           license = lib.licenses.free;
         };
       }) {};
@@ -3595,10 +3610,10 @@
       elpaBuild {
         pname = "sql-indent";
         ename = "sql-indent";
-        version = "1.5";
+        version = "1.6";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/sql-indent-1.5.tar";
-          sha256 = "07k5rn9hbxppnka7nq0a3a6zyqqa1hp8j6qrb344js6zyak0cb63";
+          url = "https://elpa.gnu.org/packages/sql-indent-1.6.tar";
+          sha256 = "000pimlg0k4mrv2wpqq8w8l51wpr1lzlaq6ai8iaximm2a92ap5b";
         };
         packageRequires = [ cl-lib ];
         meta = {
@@ -3610,10 +3625,10 @@
       elpaBuild {
         pname = "ssh-deploy";
         ename = "ssh-deploy";
-        version = "3.1.12";
+        version = "3.1.13";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ssh-deploy-3.1.12.tar";
-          sha256 = "0fz49l63jfw9zy459f07bq2irdb8ispnx8m2c3wxwiim9yw5xnjg";
+          url = "https://elpa.gnu.org/packages/ssh-deploy-3.1.13.tar";
+          sha256 = "006jr8yc5qvxdfk0pn40604a2b7a1ah6l6hi6rhxm3p5b08d9i5w";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3779,10 +3794,10 @@
       elpaBuild {
         pname = "tramp";
         ename = "tramp";
-        version = "2.5.0.5";
+        version = "2.5.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/tramp-2.5.0.5.tar";
-          sha256 = "1dclxffynfacvwi2scpda35sxjb42603yyf2p0477qa9b0i4xha0";
+          url = "https://elpa.gnu.org/packages/tramp-2.5.1.tar";
+          sha256 = "1r7wifhzy2ipdlc4fqnx6549fnx45ggz57wh0cp7s6y25761si7q";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3824,10 +3839,10 @@
       elpaBuild {
         pname = "transient";
         ename = "transient";
-        version = "0.3.4";
+        version = "0.3.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/transient-0.3.4.tar";
-          sha256 = "1m71w52cr8f9wm6lybfa003w408lkrl6q9whs53hpp3pl5phhfvb";
+          url = "https://elpa.gnu.org/packages/transient-0.3.5.tar";
+          sha256 = "15dlj21gn0zxywic9wdcp5zc8skm1s170bq7smgkpd3p3lxslf68";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3949,6 +3964,21 @@
           license = lib.licenses.free;
         };
       }) {};
+    vc-hgcmd = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "vc-hgcmd";
+        ename = "vc-hgcmd";
+        version = "1.14";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/vc-hgcmd-1.14.tar";
+          sha256 = "0pg6fg0znsmky3iwdpxn2sx5bbn72kw83s077000ilawi6zqwc2d";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/vc-hgcmd.html";
+          license = lib.licenses.free;
+        };
+      }) {};
     vcard = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
       elpaBuild {
         pname = "vcard";
@@ -4015,10 +4045,10 @@
       elpaBuild {
         pname = "vertico";
         ename = "vertico";
-        version = "0.11";
+        version = "0.12";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/vertico-0.11.tar";
-          sha256 = "0hzwddkac85i449173az8crlksj9ivrqf969r81kbr45ksgr1ij6";
+          url = "https://elpa.gnu.org/packages/vertico-0.12.tar";
+          sha256 = "14qlc438bysg23wfj04zpvpraqzzi4jlz3r11vc56vd0k2hfmvmn";
         };
         packageRequires = [ emacs ];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -39,10 +39,10 @@
       elpaBuild {
         pname = "ada-mode";
         ename = "ada-mode";
-        version = "7.1.4";
+        version = "7.1.5";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ada-mode-7.1.4.tar";
-          sha256 = "13zcs7kn7rca82c80qshbdpmmmgkf5phr88hf7p5nwxqhkazy9cd";
+          url = "https://elpa.gnu.org/packages/ada-mode-7.1.5.tar";
+          sha256 = "037v25mqpg1n52hz89b49vf9zw68fmc0m7l6c1f8vnbw3dibyk8d";
         };
         packageRequires = [ emacs uniquify-files wisi ];
         meta = {
@@ -4224,10 +4224,10 @@
       elpaBuild {
         pname = "wisi";
         ename = "wisi";
-        version = "3.1.3";
+        version = "3.1.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/wisi-3.1.3.tar";
-          sha256 = "0cbjcm35lp164wd06mn3clikga07qxfsfnkvadswsapsd0cn2b4k";
+          url = "https://elpa.gnu.org/packages/wisi-3.1.4.tar";
+          sha256 = "1j35ln5x3dgypq3hn6xcdpg6vp6yjj6avcjakc2r6wx19vxixciw";
         };
         packageRequires = [ emacs seq ];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -3392,21 +3392,6 @@
           license = lib.licenses.free;
         };
       }) {};
-    shell-command-plus = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
-      elpaBuild {
-        pname = "shell-command-plus";
-        ename = "shell-command+";
-        version = "2.2.0";
-        src = fetchurl {
-          url = "https://elpa.gnu.org/packages/shell-command+-2.2.0.tar";
-          sha256 = "1ms2xk7xfgd3ngwm90hnmlxwpvyb167bislc2wr3ilfrirbbw476";
-        };
-        packageRequires = [ emacs ];
-        meta = {
-          homepage = "https://elpa.gnu.org/packages/shell-command+.html";
-          license = lib.licenses.free;
-        };
-      }) {};
     shen-mode = callPackage ({ elpaBuild, fetchurl, lib }:
       elpaBuild {
         pname = "shen-mode";

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -2885,10 +2885,10 @@
       elpaBuild {
         pname = "pyim";
         ename = "pyim";
-        version = "3.9.2";
+        version = "3.9.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/pyim-3.9.2.tar";
-          sha256 = "18m5wni1zns8fad2ll9flbfgxfy14gi03apnycajdbqxsqfp65j9";
+          url = "https://elpa.gnu.org/packages/pyim-3.9.3.tar";
+          sha256 = "0rjaimvbh0fadbqiq4ggyxr0y4pfzld76wb64v7l5874qczn8dfr";
         };
         packageRequires = [ async emacs xr ];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -87,7 +87,7 @@ self: let
         ];
 
         preInstall = ''
-          ./build.sh
+          ./build.sh -j$NIX_BUILD_CORES
         '';
 
         postInstall = ''

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -66,7 +66,12 @@ self: let
         phases = "unpackPhase " + old.phases; # not a list, interestingly…
         srcs = [
           super.ada-mode.src
-          self.wisi.src
+          # ada-mode needs a specific version of wisi, check NEWS or ada-mode's
+          # package-requires to find the version to use.
+          (pkgs.fetchurl {
+            url = "https://elpa.gnu.org/packages/wisi-3.1.3.tar.lz";
+            sha256 = "18dwcc0crds7aw466vslqicidlzamf8avn59gqi2g7y2x9k5q0as";
+          })
         ];
 
         sourceRoot = "ada-mode-${self.ada-mode.version}";
@@ -74,6 +79,7 @@ self: let
         nativeBuildInputs = [
           buildPackages.gnat
           buildPackages.gprbuild
+          buildPackages.lzip
         ];
 
         buildInputs = [

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -21,7 +21,7 @@ formats commits for you.
 
 */
 
-{ lib, stdenv, texinfo, writeText }:
+{ lib, stdenv, texinfo, writeText, gcc }:
 
 self: let
 
@@ -34,6 +34,7 @@ self: let
   elpaBuild = import ../../../../build-support/emacs/elpa.nix {
     inherit lib stdenv texinfo writeText;
     inherit (self) emacs;
+    inherit gcc;
   };
 
   generateElpa = lib.makeOverridable ({

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -32,9 +32,8 @@ self: let
   };
 
   elpaBuild = import ../../../../build-support/emacs/elpa.nix {
-    inherit lib stdenv texinfo writeText;
+    inherit lib stdenv texinfo writeText gcc;
     inherit (self) emacs;
-    inherit gcc;
   };
 
   generateElpa = lib.makeOverridable ({

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -41,7 +41,10 @@ self: let
   }: let
 
     imported = import generated {
-      inherit (self) callPackage;
+      callPackage = pkgs: args: self.callPackage pkgs (args // {
+        # Use custom elpa url fetcher with fallback/uncompress
+        fetchurl = buildPackages.callPackage ./fetchelpa.nix { };
+      });
     };
 
     super = removeAttrs imported [ "dash" ];

--- a/pkgs/applications/editors/emacs/elisp-packages/emacs2nix.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/emacs2nix.nix
@@ -2,10 +2,10 @@ let
   pkgs = import ../../../../.. { };
 
   src = pkgs.fetchgit {
-    url = "https://github.com/ttuegel/emacs2nix.git";
+    url = "https://github.com/nix-community/emacs2nix.git";
     fetchSubmodules = true;
-    rev = "860da04ca91cbb69c9b881a54248d16bdaaf9923";
-    sha256 = "1r3xmyk9rfgx7ln69dk8mgbnh3awcalm3r1c5ia2shlsrymvv1df";
+    rev = "703b144eeb490e87133c777f82e198b4e515c312";
+    sha256 = "sha256-YBbRh/Cb8u9+Pn6/Bc0atI6knKVjr8jiTGgFkD2FNGI=";
   };
 in
 pkgs.mkShell {

--- a/pkgs/applications/editors/emacs/elisp-packages/emacspeak/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/emacspeak/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "emacspeak";
-  version = "51.0";
+  version = "54.0";
 
   src = fetchurl {
     url = "https://github.com/tvraman/emacspeak/releases/download/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "09a0ywxlqa8jmc0wmvhaf7bdydnkyhy9nqfsdqcpbsgdzj6qpg90";
+    sha256 = "sha256-wsIqiW4UtgdAhqPqgCKgF37+hAtmAelAEnme1W9PKes=";
   };
 
   nativeBuildInputs = [ makeWrapper emacs ];

--- a/pkgs/applications/editors/emacs/elisp-packages/evil-markdown/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/evil-markdown/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, emacs, emacsPackages, lib }:
+
+let
+  runtimeDeps = with emacsPackages; [
+    evil
+    markdown-mode
+  ];
+in
+stdenv.mkDerivation {
+  pname = "evil-markdown";
+  version = "2020-06-01";
+
+  src = fetchFromGitHub {
+    owner = "Somelauw";
+    repo = "evil-markdown";
+    rev = "064fe9b4767470472356d20bdd08e2f30ebbc9ac";
+    sha256 = "sha256-Kt2wxG1XCFowavVWtj0urM/yURKegonpZcxTy/+CrJY=";
+  };
+
+  buildInputs = [
+    emacs
+  ] ++ runtimeDeps;
+
+  propagatedUserEnvPkgs = runtimeDeps;
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Vim-like keybindings for markdown-mode";
+    homepage = "https://github.com/Somelauw/evil-markdown";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/fetchelpa.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/fetchelpa.nix
@@ -1,0 +1,21 @@
+# Elpa only serves the latest version of a given package uncompressed.
+# Once that release is no longer the latest & greatest it gets archived and compressed
+# meaning that both the URL and the hash changes.
+#
+# To work around this issue we fall back to the URL with the .lz suffix and if that's the
+# one we downloaded we uncompress the file to ensure the hash matches regardless of compression.
+
+{ fetchurl, lzip }:
+
+{ url, ... }@args: fetchurl ((removeAttrs args [ "url" ]) // {
+  urls = [
+    url
+    (url + ".lz")
+  ];
+  postFetch = ''
+    if [[ $url == *.lz ]]; then
+      ${lzip}/bin/lzip -c -d $out > uncompressed
+      mv uncompressed $out
+    fi
+  '';
+})

--- a/pkgs/applications/editors/emacs/elisp-packages/font-lock-plus/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/font-lock-plus/default.nix
@@ -1,6 +1,6 @@
-{ fetchurl, lib, melpaBuild, writeText }:
+{ fetchurl, lib, trivialBuild, writeText }:
 
-melpaBuild {
+trivialBuild {
   pname = "font-lock+";
   version = "20180101.25";
 
@@ -9,8 +9,6 @@ melpaBuild {
     sha256 = "0197yzn4hbjmw5h3m08264b7zymw63pdafph5f3yzfm50q8p7kp4";
     name = "font-lock+.el";
   };
-
-  recipe = writeText "recipe" "(font-lock+ :fetcher github :repo \"\")";
 
   meta = {
     homepage = "https://melpa.org/#/font-lock+";

--- a/pkgs/applications/editors/emacs/elisp-packages/git-undo/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/git-undo/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "git-undo";
+  version = "2019-10-13";
+
+  src = fetchFromGitHub {
+    owner = "jwiegley";
+    repo = "git-undo-el";
+    rev = "cf31e38e7889e6ade7d2d2b9f8719fd44f52feb5";
+    sha256 = "sha256-cVkK9EF6qQyVV3uVqnBEjF8e9nEx/8ixnM8PvxqCyYE=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Revert region to most recent Git-historical version";
+    homepage = "https://github.com/jwiegley/git-undo-el";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/isearch-plus/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/isearch-plus/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "isearch-plus";
+  version = "2021-01-01";
+
+  src = fetchFromGitHub {
+    owner = "emacsmirror";
+    repo = "isearch-plus";
+    rev = "376a8f9f8a9666d7e61d125abcdb645847cb8619";
+    sha256 = "sha256-Kd5vpu+mI1tJPcsu7EpnnBcPVdVAijkAeTz+bLB3WlQ=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Extensions to isearch";
+    homepage = "https://www.emacswiki.org/emacs/download/isearch%2b.el";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/isearch-prop/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/isearch-prop/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "isearch-prop";
+  version = "2019-05-01";
+
+  src = fetchFromGitHub {
+    owner = "emacsmirror";
+    repo = "isearch-prop";
+    rev = "4a2765f835dd115d472142da05215c4c748809f4";
+    sha256 = "sha256-A1Kt4nm7iRV9J5yaLupwiNL5g7ddZvQs79dggmqZ7Rk=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Search text- or overlay-property contexts";
+    homepage = "https://www.emacswiki.org/emacs/download/isearch-prop.el";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/libgenerated.nix
@@ -67,8 +67,7 @@ in {
         lib.nameValuePair ename (
           self.callPackage ({ melpaBuild, fetchurl, ... }@pkgargs:
           melpaBuild {
-            inherit pname;
-            ename = ename;
+            inherit pname ename commit;
             version = if isNull version then "" else
               lib.concatStringsSep "." (map toString version);
             # TODO: Broken should not result in src being null (hack to avoid eval errors)

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -185,6 +185,8 @@
 
   };
 
+  mu4e-patch = callPackage ./mu4e-patch { };
+
   org-mac-link =
     callPackage ./org-mac-link { };
 

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -111,6 +111,8 @@
 
   helm-words = callPackage ./helm-words { };
 
+  isearch-plus = callPackage ./isearch-plus { };
+
   jam-mode = callPackage ./jam-mode { };
 
   llvm-mode = trivialBuild {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -1,25 +1,33 @@
 { lib, pkgs }: self: with self; with lib.licenses; {
 
-  elisp-ffi = melpaBuild rec {
+  elisp-ffi = let
+    rev = "da37c516a0e59bdce63fb2dc006a231dee62a1d9";
+  in melpaBuild {
     pname = "elisp-ffi";
-    version = "1.0.0";
+    version = "20170518.0";
+
+    commit = rev;
 
     src = pkgs.fetchFromGitHub {
       owner = "skeeto";
       repo = "elisp-ffi";
-      rev = version;
-      sha256 = "0z2n3h5l5fj8wl8i1ilfzv11l3zba14sgph6gz7dx7q12cnp9j22";
+      inherit rev;
+      sha256 = "sha256-StOezQEnNTjRmjY02ub5FRh59aL6gWfw+qgboz0wF94=";
     };
+
+    nativeBuildInputs = [ pkgs.pkg-config ];
 
     buildInputs = [ pkgs.libffi ];
 
-    preBuild = "make";
+    preBuild = ''
+      mv ffi.el elisp-ffi.el
+      make
+    '';
 
     recipe = pkgs.writeText "recipe" ''
       (elisp-ffi
       :repo "skeeto/elisp-ffi"
-      :fetcher github
-      :files ("ffi-glue" "ffi.el"))
+      :fetcher github)
     '';
 
     meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -3,20 +3,25 @@
   elisp-ffi = melpaBuild rec {
     pname = "elisp-ffi";
     version = "1.0.0";
+
     src = pkgs.fetchFromGitHub {
       owner = "skeeto";
       repo = "elisp-ffi";
       rev = version;
       sha256 = "0z2n3h5l5fj8wl8i1ilfzv11l3zba14sgph6gz7dx7q12cnp9j22";
     };
+
     buildInputs = [ pkgs.libffi ];
+
     preBuild = "make";
+
     recipe = pkgs.writeText "recipe" ''
       (elisp-ffi
       :repo "skeeto/elisp-ffi"
       :fetcher github
       :files ("ffi-glue" "ffi.el"))
     '';
+
     meta = {
       description = "Emacs Lisp Foreign Function Interface";
       longDescription = ''
@@ -65,27 +70,22 @@
     };
   };
 
-  apheleia = callPackage ./apheleia {};
-
-  emacspeak = callPackage ./emacspeak {};
-
-  ess-R-object-popup =
-    callPackage ./ess-R-object-popup { };
-
-  evil-markdown = callPackage ./evil-markdown { };
-
-  font-lock-plus = callPackage ./font-lock-plus { };
-
   ghc-mod = melpaBuild {
     pname = "ghc";
     version = pkgs.haskellPackages.ghc-mod.version;
+
     src = pkgs.haskellPackages.ghc-mod.src;
+
     packageRequires = [ haskell-mode ];
+
     propagatedUserEnvPkgs = [ pkgs.haskellPackages.ghc-mod ];
+
     recipe = pkgs.writeText "recipe" ''
       (ghc-mod :repo "DanielG/ghc-mod" :fetcher github :files ("elisp/*.el"))
     '';
+
     fileSpecs = [ "elisp/*.el" ];
+
     meta = {
       description = "An extension of haskell-mode that provides completion of symbols and documentation browsing";
       license = bsd3;
@@ -97,31 +97,27 @@
   haskell-unicode-input-method = melpaBuild {
     pname = "emacs-haskell-unicode-input-method";
     version = "20110905.2307";
+
     src = pkgs.fetchFromGitHub {
       owner = "roelvandijk";
       repo = "emacs-haskell-unicode-input-method";
       rev = "d8d168148c187ed19350bb7a1a190217c2915a63";
       sha256 = "09b7bg2s9aa4s8f2kdqs4xps3jxkq5wsvbi87ih8b6id38blhf78";
     };
+
     recipe = pkgs.writeText "recipe" ''
       (emacs-haskell-unicode-input-method
        :repo "roelvandijk/emacs-haskell-unicode-input-method"
        :fetcher github)
     '';
+
     packageRequires = [];
+
     meta = {
       homepage = "https://melpa.org/#haskell-unicode-input-method/";
       license = lib.licenses.free;
     };
   };
-
-  helm-words = callPackage ./helm-words { };
-
-  isearch-plus = callPackage ./isearch-plus { };
-
-  isearch-prop = callPackage ./isearch-prop { };
-
-  jam-mode = callPackage ./jam-mode { };
 
   llvm-mode = trivialBuild {
     pname = "llvm-mode";
@@ -150,6 +146,7 @@
     };
 
     patches = [
+      # Fix: avatar loading when imagemagick support is not available
       (pkgs.fetchpatch {
         url = "https://github.com/alphapapa/matrix-client.el/commit/5f49e615c7cf2872f48882d3ee5c4a2bff117d07.patch";
         sha256 = "07bvid7s1nv1377p5n61q46yww3m1w6bw4vnd4iyayw3fby1lxbm";
@@ -187,11 +184,6 @@
 
   };
 
-  mu4e-patch = callPackage ./mu4e-patch { };
-
-  org-mac-link =
-    callPackage ./org-mac-link { };
-
   ott-mode = self.trivialBuild {
     pname = "ott-mod";
 
@@ -205,10 +197,23 @@
     };
   };
 
-  perl-completion =
-    callPackage ./perl-completion { };
+  # Packages made the classical callPackage way
+
+  emacspeak = callPackage ./emacspeak { };
+
+  ess-R-object-popup = callPackage ./ess-R-object-popup { };
+
+  font-lock-plus = callPackage ./font-lock-plus { };
+
+  helm-words = callPackage ./helm-words { };
+
+  jam-mode = callPackage ./jam-mode { };
+
   nano-theme = callPackage ./nano-theme { };
 
+  org-mac-link = callPackage ./org-mac-link { };
+
+  perl-completion = callPackage ./perl-completion { };
 
   pod-mode = callPackage ./pod-mode { };
 
@@ -247,34 +252,34 @@
   # closer to the old outdated package infra.
   #
   # Ideally this should be dropped some time during/after 20.03
+
+  autoComplete = self.melpaStablePackages.auto-complete;
   bbdb3 = self.melpaStablePackages.bbdb;
-  jade = self.jade-mode;
-  # scalaMode2 = null;  # No clear mapping as of now
-  flymakeCursor = self.melpaStablePackages.flymake-cursor;
+  colorTheme = self.color-theme;
   cryptol = self.melpaStablePackages.cryptol-mode;
+  d = self.melpaStablePackages.d-mode;
+  emacsw3m = self.w3m;
+  erlangMode = self.melpaStablePackages.erlang;
+  flymakeCursor = self.melpaStablePackages.flymake-cursor;
+  graphvizDot = self.melpaStablePackages.graphviz-dot-mode;
+  haskellMode = self.melpaStablePackages.haskell-mode;
+  hsc3Mode = self.hsc3-mode;
+  idris = self.melpaStablePackages.idris-mode;
+  jade = self.jade-mode;
+  js2 = self.melpaStablePackages.js2-mode;
+  loremIpsum = self.lorem-ipsum;
+  markdownMode = self.melpaStablePackages.markdown-mode;
   maudeMode = self.maude-mode;
   phpMode = self.melpaStablePackages.php-mode;
-  idris = self.melpaStablePackages.idris-mode;
-  rainbowDelimiters = self.melpaStablePackages.rainbow-delimiters;
-  colorTheme = self.color-theme;
-  sbtMode = self.melpaStablePackages.sbt-mode;
-  markdownMode = self.melpaStablePackages.markdown-mode;
-  scalaMode1 = self.melpaStablePackages.scala-mode;
   prologMode = self.prolog-mode;
-  hsc3Mode = self.hsc3-mode;
-  graphvizDot = self.melpaStablePackages.graphviz-dot-mode;
-  proofgeneral_HEAD = self.proof-general;
   proofgeneral = self.melpaStablePackages.proof-general;
-  haskellMode = self.melpaStablePackages.haskell-mode;
-  writeGood = self.melpaStablePackages.writegood-mode;
-  erlangMode = self.melpaStablePackages.erlang;
-  d = self.melpaStablePackages.d-mode;
-  autoComplete = self.melpaStablePackages.auto-complete;
-  tuaregMode = self.melpaStablePackages.tuareg;
+  proofgeneral_HEAD = self.proof-general;
+  rainbowDelimiters = self.melpaStablePackages.rainbow-delimiters;
+  sbtMode = self.melpaStablePackages.sbt-mode;
+  scalaMode1 = self.melpaStablePackages.scala-mode;
+  # scalaMode2 = null;  # No clear mapping as of now
   structuredHaskellMode = self.melpaStablePackages.shm;
+  tuaregMode = self.melpaStablePackages.tuareg;
+  writeGood = self.melpaStablePackages.writegood-mode;
   xmlRpc = self.melpaStablePackages.xml-rpc;
-  emacsw3m = self.w3m;
-  loremIpsum = self.lorem-ipsum;
-  js2 = self.melpaStablePackages.js2-mode;
-
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -134,14 +134,19 @@
     };
   };
 
-  matrix-client = melpaBuild {
+  matrix-client = let
+    rev = "d2ac55293c96d4c95971ed8e2a3f6f354565c5ed";
+  in melpaBuild
+  {
     pname = "matrix-client";
     version = "0.3.0";
+
+    commit = rev;
 
     src = pkgs.fetchFromGitHub {
       owner = "alphapapa";
       repo = "matrix-client.el";
-      rev = "d2ac55293c96d4c95971ed8e2a3f6f354565c5ed";
+      inherit rev;
       sha256 = "1scfv1502yg7x4bsl253cpr6plml1j4d437vci2ggs764sh3rcqq";
     };
 

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -212,6 +212,8 @@
 
   pod-mode = callPackage ./pod-mode { };
 
+  power-mode = callPackage ./power-mode { };
+
   railgun = callPackage ./railgun { };
 
   structured-haskell-mode = self.shm;

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -65,6 +65,8 @@
     };
   };
 
+  apheleia = callPackage ./apheleia {};
+
   emacspeak = callPackage ./emacspeak {};
 
   ess-R-object-popup =

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -199,6 +199,8 @@
 
   # Packages made the classical callPackage way
 
+  ebuild-mode = callPackage ./ebuild-mode { };
+
   emacspeak = callPackage ./emacspeak { };
 
   ess-R-object-popup = callPackage ./ess-R-object-popup { };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -212,6 +212,8 @@
 
   tramp = callPackage ./tramp { };
 
+  youtube-dl = callPackage ./youtube-dl { };
+
   zeitgeist = callPackage ./zeitgeist { };
 
   # From old emacsPackages (pre emacsPackagesNg)

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -70,6 +70,8 @@
   ess-R-object-popup =
     callPackage ./ess-R-object-popup { };
 
+  evil-markdown = callPackage ./evil-markdown { };
+
   font-lock-plus = callPackage ./font-lock-plus { };
 
   ghc-mod = melpaBuild {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -113,6 +113,8 @@
 
   isearch-plus = callPackage ./isearch-plus { };
 
+  isearch-prop = callPackage ./isearch-prop { };
+
   jam-mode = callPackage ./jam-mode { };
 
   llvm-mode = trivialBuild {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -102,19 +102,23 @@
 
   git-undo = callPackage ./git-undo { };
 
-  haskell-unicode-input-method = melpaBuild {
-    pname = "emacs-haskell-unicode-input-method";
+  haskell-unicode-input-method = let
+    rev = "d8d168148c187ed19350bb7a1a190217c2915a63";
+  in melpaBuild {
+    pname = "haskell-unicode-input-method";
     version = "20110905.2307";
+
+    commit = rev;
 
     src = pkgs.fetchFromGitHub {
       owner = "roelvandijk";
       repo = "emacs-haskell-unicode-input-method";
-      rev = "d8d168148c187ed19350bb7a1a190217c2915a63";
+      inherit rev;
       sha256 = "09b7bg2s9aa4s8f2kdqs4xps3jxkq5wsvbi87ih8b6id38blhf78";
     };
 
     recipe = pkgs.writeText "recipe" ''
-      (emacs-haskell-unicode-input-method
+      (haskell-unicode-input-method
        :repo "roelvandijk/emacs-haskell-unicode-input-method"
        :fetcher github)
     '';

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -88,6 +88,8 @@
     };
   };
 
+  git-undo = callPackage ./git-undo { };
+
   haskell-unicode-input-method = melpaBuild {
     pname = "emacs-haskell-unicode-input-method";
     version = "20110905.2307";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -250,38 +250,4 @@
   rectMark = rect-mark;
   sunriseCommander = sunrise-commander;
 
-  # Legacy aliases, these try to mostly map to melpa stable because it's
-  # closer to the old outdated package infra.
-  #
-  # Ideally this should be dropped some time during/after 20.03
-
-  autoComplete = self.melpaStablePackages.auto-complete;
-  bbdb3 = self.melpaStablePackages.bbdb;
-  colorTheme = self.color-theme;
-  cryptol = self.melpaStablePackages.cryptol-mode;
-  d = self.melpaStablePackages.d-mode;
-  emacsw3m = self.w3m;
-  erlangMode = self.melpaStablePackages.erlang;
-  flymakeCursor = self.melpaStablePackages.flymake-cursor;
-  graphvizDot = self.melpaStablePackages.graphviz-dot-mode;
-  haskellMode = self.melpaStablePackages.haskell-mode;
-  hsc3Mode = self.hsc3-mode;
-  idris = self.melpaStablePackages.idris-mode;
-  jade = self.jade-mode;
-  js2 = self.melpaStablePackages.js2-mode;
-  loremIpsum = self.lorem-ipsum;
-  markdownMode = self.melpaStablePackages.markdown-mode;
-  maudeMode = self.maude-mode;
-  phpMode = self.melpaStablePackages.php-mode;
-  prologMode = self.prolog-mode;
-  proofgeneral = self.melpaStablePackages.proof-general;
-  proofgeneral_HEAD = self.proof-general;
-  rainbowDelimiters = self.melpaStablePackages.rainbow-delimiters;
-  sbtMode = self.melpaStablePackages.sbt-mode;
-  scalaMode1 = self.melpaStablePackages.scala-mode;
-  # scalaMode2 = null;  # No clear mapping as of now
-  structuredHaskellMode = self.melpaStablePackages.shm;
-  tuaregMode = self.melpaStablePackages.tuareg;
-  writeGood = self.melpaStablePackages.writegood-mode;
-  xmlRpc = self.melpaStablePackages.xml-rpc;
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -207,6 +207,8 @@
 
   perl-completion =
     callPackage ./perl-completion { };
+  nano-theme = callPackage ./nano-theme { };
+
 
   pod-mode = callPackage ./pod-mode { };
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -116,6 +116,13 @@ let
           stripDebugList = [ "share" ];
         });
 
+        erlang = super.erlang.overrideAttrs (attrs: {
+          buildInputs = attrs.buildInputs ++ [
+            pkgs.perl
+            pkgs.ncurses
+          ];
+        });
+
         # https://github.com/syl20bnr/evil-escape/pull/86
         evil-escape = super.evil-escape.overrideAttrs (attrs: {
           postPatch = ''

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -325,14 +325,6 @@ let
           buildInputs = old.buildInputs ++ [ pkgs.tdlib ];
           nativeBuildInputs = [ pkgs.pkg-config ];
 
-          patches = [
-            (pkgs.fetchpatch {
-              name = "telega-server-bin-store-prefer.patch";
-              url = "https://github.com/zevlg/telega.el/commit/72550f984ca869309d197203ef7de99182d71729.patch";
-              sha256 = "18xvz53bygksak6h5f8cz79y83p2va15i8qz7n4s3g9gsklmkj2p";
-            })
-          ];
-
           postPatch = ''
             substituteInPlace telega-customize.el \
               --replace 'defcustom telega-server-command "telega-server"' \

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -80,8 +80,8 @@ let
 
         auto-complete-clang-async = super.auto-complete-clang-async.overrideAttrs (old: {
           buildInputs = old.buildInputs ++ [ pkgs.llvmPackages.llvm ];
-          CFLAGS = "-I${pkgs.llvmPackages.clang}/include";
-          LDFLAGS = "-L${pkgs.llvmPackages.clang}/lib";
+          CFLAGS = "-I${pkgs.llvmPackages.libclang.lib}/include";
+          LDFLAGS = "-L${pkgs.llvmPackages.libclang.lib}/lib";
         });
 
         # part of a larger package
@@ -195,7 +195,7 @@ let
           dontUseCmakeBuildDir = true;
           doCheck = true;
           packageRequires = [ self.emacs ];
-          nativeBuildInputs = [ pkgs.cmake pkgs.llvmPackages.llvm pkgs.llvmPackages.clang ];
+          nativeBuildInputs = [ pkgs.cmake pkgs.llvmPackages.llvm pkgs.llvmPackages.libclang ];
         });
 
         # tries to write a log file to $HOME

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -8,7 +8,7 @@ To update the list of packages from MELPA,
 2. Check for evaluation errors:
      env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../../ -A emacs.pkgs.melpaStablePackages
      env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../../ -A emacs.pkgs.melpaPackages
-3. Run `git commit -m "melpa-packages: $(date -Idate)" recipes-archive-melpa.json`
+3. Run `git commit -m "melpa-packages $(date -Idate)" recipes-archive-melpa.json`
 
 ## Update from overlay
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -70,7 +70,48 @@ let
         )
       );
 
-      overrides = {
+      overrides = lib.optionalAttrs (variant == "stable") {
+
+        # upstream issue: missing file header
+        speech-tagger = markBroken super.speech-tagger;
+
+        # upstream issue: missing file header
+        textmate = markBroken super.textmate;
+
+        # upstream issue: missing file header
+        window-numbering = markBroken super.window-numbering;
+
+        # upstream issue: missing file header
+        voca-builder = markBroken super.voca-builder;
+
+        # upstream issue: missing file header
+        initsplit = markBroken super.initsplit;
+
+        # upstream issue: missing file header
+        jsfmt = markBroken super.jsfmt;
+
+        # upstream issue: missing file header
+        maxframe = markBroken super.maxframe;
+
+        # upstream issue: missing file header
+        connection = markBroken super.connection;
+
+        # upstream issue: missing file header
+        dictionary = markBroken super.dictionary;
+
+        # upstream issue: missing file header
+        link = markBroken super.link;
+
+        # upstream issue: missing file header
+        bufshow = markBroken super.bufshow;
+
+        # upstream issue: missing file header
+        elmine = markBroken super.elmine;
+
+        # upstream issue: missing file header
+        ido-complete-space-or-hyphen = markBroken super.ido-complete-space-or-hyphen;
+
+      } // {
         # Expects bash to be at /bin/bash
         ac-rtags = fix-rtags super.ac-rtags;
 
@@ -392,31 +433,7 @@ let
         rect-plus = super."rect+";
 
         # upstream issue: missing file header
-        bufshow = markBroken super.bufshow;
-
-        # upstream issue: missing file header
-        connection = markBroken super.connection;
-
-        # upstream issue: missing file header
-        dictionary = markBroken super.dictionary;
-
-        # upstream issue: missing file header
-        elmine = markBroken super.elmine;
-
-        # upstream issue: missing file header
-        ido-complete-space-or-hyphen = markBroken super.ido-complete-space-or-hyphen;
-
-        # upstream issue: missing file header
-        initsplit = markBroken super.initsplit;
-
-        # upstream issue: missing file header
         instapaper = markBroken super.instapaper;
-
-        # upstream issue: missing file header
-        jsfmt = markBroken super.jsfmt;
-
-        # upstream issue: missing file header
-        maxframe = markBroken super.maxframe;
 
         # upstream issue: doesn't build
         magit-stgit = markBroken super.magit-stgit;
@@ -434,22 +451,7 @@ let
         qiita = markBroken super.qiita;
 
         # upstream issue: missing file header
-        speech-tagger = markBroken super.speech-tagger;
-
-        # upstream issue: missing file header
         sql-presto = markBroken super.sql-presto;
-
-        # upstream issue: missing file header
-        textmate = markBroken super.textmate;
-
-        # upstream issue: missing file header
-        link = markBroken super.link;
-
-        # upstream issue: missing file header
-        voca-builder = markBroken super.voca-builder;
-
-        # upstream issue: missing file header
-        window-numbering = markBroken super.window-numbering;
 
         editorconfig = super.editorconfig.overrideAttrs (attrs: {
           propagatedUserEnvPkgs = [ pkgs.editorconfig-core-c ];

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -517,24 +517,7 @@ let
         });
       };
 
-      # Deprecated legacy aliases for backwards compat
-      aliases = lib.listToAttrs (lib.attrValues (lib.mapAttrs (n: v: { name = v; value = builtins.trace "Melpa attribute '${v}' is a legacy alias that will be removed in 21.05, use '${n}' instead" melpaPackages.${n}; }) (lib.filterAttrs (n: v: lib.hasAttr n melpaPackages) {
-        "auto-complete-clang-async" = "emacsClangCompleteAsync";
-        "vterm" = "emacs-libvterm";
-        "0xc" = "_0xc";
-        "2048-game" = "_2048-game";
-        "4clojure" = "_4clojure";
-        "@" = "at";
-        "term+" = "term-plus";
-        "term+key-intercept" = "term-plus-key-intercept";
-        "term+mux" = "term-plus-mux";
-        "xml+" = "xml-plus";
-      })));
-
-      melpaPackages = lib.mapAttrs (n: v: if lib.hasAttr n overrides then overrides.${n} else v) super;
-
-    in
-    melpaPackages // aliases);
+    in lib.mapAttrs (n: v: if lib.hasAttr n overrides then overrides.${n} else v) super);
 
 in
 generateMelpa { }

--- a/pkgs/applications/editors/emacs/elisp-packages/mu4e-patch/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/mu4e-patch/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "mu4e-patch";
+  version = "2019-05-09";
+
+  src = fetchFromGitHub {
+    owner = "seanfarley";
+    repo = "mu4e-patch";
+    rev = "522da46c1653b1cacc79cde91d6534da7ae9517d";
+    sha256 = "sha256-1lV4dDuCdyCUXi/In2DzYJPEHuAc9Jfbz2ZecNZwn4I=";
+  };
+
+  buildInputs = [
+    emacs
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Colorize patch emails in mu4e";
+    homepage = "https://github.com/seanfarley/mu4e-patch";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/nano-theme/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nano-theme/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, emacs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nano-theme";
+  version = "2021-06-05";
+
+  src = fetchFromGitHub {
+    owner = "rougier";
+    repo  = pname;
+    rev = "99ff1c5e78296a073c6e63b966045e0d83a136e7";
+    hash = "sha256-IDVnl4J4hx2mlLaiA+tKxxRGcIyBULr2HBeY/GMHD90=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/emacs/site-lisp
+    install *.el $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/rougier/nano-theme";
+    description = "GNU Emacs / N Λ N O Theme";
+    inherit (emacs.meta) platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -1,0 +1,93 @@
+{ callPackage }:
+  {
+    caml = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "caml";
+        ename = "caml";
+        version = "4.7.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/caml-4.7.1.tar";
+          sha256 = "1bv2fscy7zg7r1hyg4rpvh3991vmhy4zid7bv1qbhxa95m9c49j3";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/caml.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    markdown-mode = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "markdown-mode";
+        ename = "markdown-mode";
+        version = "2.4";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/markdown-mode-2.4.tar";
+          sha256 = "002nvc2p7jzznr743znbml3vj8a3kvdd89rlbi28f5ha14g2567z";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/markdown-mode.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    org-contrib = callPackage ({ elpaBuild, emacs, fetchurl, lib, org }:
+      elpaBuild {
+        pname = "org-contrib";
+        ename = "org-contrib";
+        version = "0.1";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/org-contrib-0.1.tar";
+          sha256 = "07hzywvgj11wd21dw4lbkvqv32da03407f9qynlzgg1qa7wknm2k";
+        };
+        packageRequires = [ emacs org ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/org-contrib.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    request = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "request";
+        ename = "request";
+        version = "0.3.3";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/request-0.3.3.tar";
+          sha256 = "168yy902bcjfdaahsbzhzb4wgqbw1mq1lfwdjh66fpzqs75c5q00";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/request.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    sly = callPackage ({ elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "sly";
+        ename = "sly";
+        version = "1.0.43";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/sly-1.0.43.tar";
+          sha256 = "0qgji539qwk7lv9g1k11w0i2nn7n7nk456gwa0bh556mcqz2ndr8";
+        };
+        packageRequires = [ emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/sly.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    tuareg = callPackage ({ caml, elpaBuild, emacs, fetchurl, lib }:
+      elpaBuild {
+        pname = "tuareg";
+        ename = "tuareg";
+        version = "2.3.0";
+        src = fetchurl {
+          url = "https://elpa.nongnu.org/nongnu/tuareg-2.3.0.tar";
+          sha256 = "0a24q64yk4bbgsvm56j1y68zs9yi25qyl83xydx3ff75sk27f1yb";
+        };
+        packageRequires = [ caml emacs ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/tuareg.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+  }

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
@@ -10,7 +10,7 @@ To update the list of packages from nongnu (ELPA),
 
 */
 
-{ lib }:
+{ lib, buildPackages }:
 
 self: let
 
@@ -19,7 +19,10 @@ self: let
   }: let
 
     imported = import generated {
-      inherit (self) callPackage;
+      callPackage = pkgs: args: self.callPackage pkgs (args // {
+        # Use custom elpa url fetcher with fallback/uncompress
+        fetchurl = buildPackages.callPackage ./fetchelpa.nix { };
+      });
     };
 
     super = imported;

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
@@ -1,0 +1,32 @@
+/*
+
+# Updating
+
+To update the list of packages from nongnu (ELPA),
+
+1. Run `./update-nongnu`.
+2. Check for evaluation errors: `nix-instantiate ../../../../.. -A emacs.pkgs.nongnuPackages`.
+3. Run `git commit -m "org-packages $(date -Idate)" -- nongnu-generated.nix`
+
+*/
+
+{ lib }:
+
+self: let
+
+  generateNongnu = lib.makeOverridable ({
+    generated ? ./nongnu-generated.nix
+  }: let
+
+    imported = import generated {
+      inherit (self) callPackage;
+    };
+
+    super = imported;
+
+    overrides = {
+    };
+
+  in super // overrides);
+
+in generateNongnu { }

--- a/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20210719";
+        version = "20210726";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-20210719.tar";
-          sha256 = "1aravj0krdi8bnfinfj1d92vq3g06djxcnpipibkrw9ggk0d01d6";
+          url = "https://orgmode.org/elpa/org-20210726.tar";
+          sha256 = "0bz5dwnknxb5mwb3rk6ckwq8a5imd2cjsx40ql9p9vc0c8rirqd4";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20210719";
+        version = "20210726";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-plus-contrib-20210719.tar";
-          sha256 = "1knjkf365cnjd8sdhaisjx0n6n0l2zfpql1b2gzw0gj62kbpl476";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20210726.tar";
+          sha256 = "0fxjmb1773skyq76qmgx1jqfcglxrxxxqysqiirm48cc6yf13kp7";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20210712";
+        version = "20210719";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-20210712.tar";
-          sha256 = "0xdxzfk7hvsmlyivn61ivci6hy2alxg2ysdm5xad4xxz337jrj7x";
+          url = "https://orgmode.org/elpa/org-20210719.tar";
+          sha256 = "1aravj0krdi8bnfinfj1d92vq3g06djxcnpipibkrw9ggk0d01d6";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20210712";
+        version = "20210719";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-plus-contrib-20210712.tar";
-          sha256 = "1cdpwsfjmjplyik1r9kl4lvd5lm52zrixlfg2ml1mhh28s680k0q";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20210719.tar";
+          sha256 = "1knjkf365cnjd8sdhaisjx0n6n0l2zfpql1b2gzw0gj62kbpl476";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20210628";
+        version = "20210712";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-20210628.tar";
-          sha256 = "1sn2yyynndk8qf43ss8bayll33r4ina8xfx4ywzcs3m1lm6xy1zl";
+          url = "https://orgmode.org/elpa/org-20210712.tar";
+          sha256 = "0xdxzfk7hvsmlyivn61ivci6hy2alxg2ysdm5xad4xxz337jrj7x";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20210628";
+        version = "20210712";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-plus-contrib-20210628.tar";
-          sha256 = "0r4kxp1hbhkwvi7939fglng8db4h4n7vigy8pd2gia3a02xcw8l5";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20210712.tar";
+          sha256 = "1cdpwsfjmjplyik1r9kl4lvd5lm52zrixlfg2ml1mhh28s680k0q";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20210607";
+        version = "20210628";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-20210607.tar";
-          sha256 = "178z9bnzcdaymnwxf0kkw1yzlzkj5dmdjjwdklc9qb9iv6rckfji";
+          url = "https://orgmode.org/elpa/org-20210628.tar";
+          sha256 = "1sn2yyynndk8qf43ss8bayll33r4ina8xfx4ywzcs3m1lm6xy1zl";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20210607";
+        version = "20210628";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-plus-contrib-20210607.tar";
-          sha256 = "03liivgfcmp0lh6p57bh2gyn85n3sc4p91y374kq8kzc7fzrgzyr";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20210628.tar";
+          sha256 = "0r4kxp1hbhkwvi7939fglng8db4h4n7vigy8pd2gia3a02xcw8l5";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20210519";
+        version = "20210607";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-20210519.tar";
-          sha256 = "14vchfg69wai1yxv1fzvjk185gnfr7d9qrdijf0qmbbr5znci8rf";
+          url = "https://orgmode.org/elpa/org-20210607.tar";
+          sha256 = "178z9bnzcdaymnwxf0kkw1yzlzkj5dmdjjwdklc9qb9iv6rckfji";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20210519";
+        version = "20210607";
         src = fetchurl {
-          url = "https://orgmode.org/elpa/org-plus-contrib-20210519.tar";
-          sha256 = "0g765fsc7ssn779xnhjzrxy1sz5b019h7dk1q26yk2w6i540ybfl";
+          url = "https://orgmode.org/elpa/org-plus-contrib-20210607.tar";
+          sha256 = "03liivgfcmp0lh6p57bh2gyn85n3sc4p91y374kq8kzc7fzrgzyr";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/power-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/power-mode/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, emacs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "power-mode";
+  version = "2021-06-06";
+
+  src = fetchFromGitHub {
+    owner = "elizagamedev";
+    repo  = "power-mode.el";
+    rev = "940e0aa36220f863e8f43840b4ed634b464fbdbb";
+    hash = "sha256-Wy8o9QTWqvH9cP7xsTpF5QSd4mWNIPXJTadoADKeHWY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/emacs/site-lisp
+    install *.el $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/rougier/nano-theme";
+    description = "Imbue Emacs with power!";
+    inherit (emacs.meta) platforms;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -25,17 +25,17 @@
  },
  {
   "ename": "0x0",
-  "commit": "982788433004ba644a372c50130613e3c56bba10",
-  "sha256": "0447s6jq57g0p5myb295930wyqk7q5qj00r8qi3l39670xsgbqdl",
-  "fetcher": "git",
-  "url": "https://git.sr.ht/~pkal/nullpointer-emacs",
+  "commit": "f725830dd12dcf466b7b1efe54b9eb3b55e5f959",
+  "sha256": "0s8q6wzzbqlpxsf9757r44lf8i8h72x4j020wmv4hvbxdvprqxq4",
+  "fetcher": "gitlab",
+  "repo": "willvaughn/emacs-0x0",
   "unstable": {
    "version": [
-    20210628,
-    1207
+    20210701,
+    839
    ],
-   "commit": "a613afa08271a75551a4d2165b4ab872b131edc0",
-   "sha256": "1ngaq8ldyv9h0g5c83y4g5z1a19z4k90dha5y4g7v3lpzmqx4jgn"
+   "commit": "63cd5eccc85e527f28e1acc89502a53245000428",
+   "sha256": "1cd0drlhi0lf1vmarcfl3vc7ldkymaj50dhqb1ajm7r0s5ps3asb"
   },
   "stable": {
    "version": [
@@ -119,6 +119,21 @@
    ],
    "commit": "6f494d3905284ccdd57aae3d8ac16fc7ab431596",
    "sha256": "19mbfh504mli8mnf95xaych45nqnayrspymf5r80dky4jv43zzv8"
+  }
+ },
+ {
+  "ename": "750words",
+  "commit": "bee7108d3b0f4861ec23ab7a87ddd5fbf17952c7",
+  "sha256": "0j63ry8x617xdrffiwkwdngp6y3rik0nq2w61yf6sa097fmzpl2p",
+  "fetcher": "github",
+  "repo": "zzamboni/750words-client",
+  "unstable": {
+   "version": [
+    20210701,
+    1950
+   ],
+   "commit": "0fed7621c04debad64ea6455455494d4e6eb03fa",
+   "sha256": "1qglbfdc6526aqsba93ngw1a6hp19lqx1wlxzzy9yvggbb02mii2"
   }
  },
  {
@@ -1585,8 +1600,8 @@
   "repo": "chumpage/ack-menu",
   "unstable": {
    "version": [
-    20150504,
-    2022
+    20130107,
+    640
    ],
    "deps": [
     "mag-menu"
@@ -1936,8 +1951,8 @@
     "annotation",
     "eri"
    ],
-   "commit": "007a26fb5f7d9eb54db16484fb116d6e47c8cc5e",
-   "sha256": "1w9pra3qqmidsf5mvp0lmk9liw1ryaf8kjiawfgyyc6mzgw6nrvz"
+   "commit": "3543ef3df19228012a1ac5be766cc38fd2f65f6a",
+   "sha256": "0wlqrl8ikqc7q61i2qzmwp6h0mrv9kn5229pbsrb1ris7gxgi13b"
   },
   "stable": {
    "version": [
@@ -1979,23 +1994,20 @@
   "repo": "Malabarba/aggressive-indent-mode",
   "unstable": {
    "version": [
-    20200824,
-    2352
+    20210701,
+    2224
    ],
-   "commit": "b0ec0047aaae071ad1647159613166a253410a63",
-   "sha256": "0rz010ypy1rg8v6na05zs942ikzqg1l32inzpzqg2q2rnfa3wkx1"
+   "commit": "cb416faf61c46977c06cf9d99525b04dc109a33c",
+   "sha256": "1mlvdxs4jbxxfj57h2hc6yapgz4zzqj80k4psds116kpp0y2r5ja"
   },
   "stable": {
    "version": [
     1,
-    9,
+    10,
     0
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "d6778ae89cd2d40949aa076a43e327f7acff59c3",
-   "sha256": "0xya19w1bwpqrrqvmms0lfhqb168iv7j6kvnn49zbynnf9dhgr9w"
+   "commit": "cb416faf61c46977c06cf9d99525b04dc109a33c",
+   "sha256": "1mlvdxs4jbxxfj57h2hc6yapgz4zzqj80k4psds116kpp0y2r5ja"
   }
  },
  {
@@ -2268,11 +2280,11 @@
   "repo": "jgkamat/alda-mode",
   "unstable": {
    "version": [
-    20180608,
-    605
+    20210705,
+    654
    ],
-   "commit": "1692b9003d2c3de403251ec452c6ce43ec819c84",
-   "sha256": "0kz0b2c1np088wbmnlvznizsv8nwiidgs67cn4dz46k66g9yg3g5"
+   "commit": "4de011d572e958a377fb16daae05a1b411f0c8ad",
+   "sha256": "1x4apig2hrvvy6pjciklmz5afpq5l4rmfjahc2wvyzs79abh0icx"
   },
   "stable": {
    "version": [
@@ -2321,16 +2333,20 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "bf859fdb80a46c6d0d9fd8f8540a8ae96d5c1016",
-   "sha256": "1bp3q84alqwkglifhwc5kcrb2dc22kjd3l0h9r0bh1klz70sjss4"
+   "commit": "3fad996473200fa07b0381cd66179089d10fcc6f",
+   "sha256": "0qj4cjra1kyiw8h2qm024wgy9fy3xjwik7sr1mfkhk1gbndl8m3w"
   },
   "stable": {
    "version": [
     1,
-    0
+    2,
+    1
    ],
-   "commit": "55fc849cdb7a05bbaab6f9359386d8830bdcfb87",
-   "sha256": "0v5jfmqcvridh8z7y8i5hklybfxicgmbnambi21ml34px3p9fldc"
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "7b7041fd58c2b1893e4b65b18045880ecc7a1c73",
+   "sha256": "1lvhzi6fxnmpcr7xac6ri3904cqbp016ivziih3nfchdzznmzljj"
   }
  },
  {
@@ -2425,11 +2441,11 @@
   "repo": "domtronn/all-the-icons.el",
   "unstable": {
    "version": [
-    20210603,
-    1604
+    20210703,
+    2203
    ],
-   "commit": "facbde4a7be292bf9490932cbe403b443273f45d",
-   "sha256": "0lwgvgnqf7vihglm0c5bwsxbl4x7f641289cji5s7jwy2dbsqk7g"
+   "commit": "9d97c074b08000eacefc03ebc5dadbdc33888cc2",
+   "sha256": "06ya21isl47cfs4fsl8k3qzh7d27gss0snxv7mmv8a0c7rgjyx7j"
   },
   "stable": {
    "version": [
@@ -2503,8 +2519,8 @@
    "deps": [
     "all-the-icons"
    ],
-   "commit": "5a984b4d7f811e2ad08fdc461a1e89205804b7bd",
-   "sha256": "05bglgqc4q5p9zr6ylllg16crpxcnb6p51xkk5v1nljgi3n9786l"
+   "commit": "f304d283cbb815cd28b86c1cbe74b706c0678e25",
+   "sha256": "1afjcv94p8za3ri9c324j1wdg4klpcaippby3r1avwnjy5l9qpav"
   },
   "stable": {
    "version": [
@@ -2566,8 +2582,8 @@
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "07b8c5271719afa6a4c598c2a19f4a096ca6efe8",
-   "sha256": "1blr46w08s9f3wrcarqds09is9akdsq8faghshby5fnk9s5srkq3"
+   "commit": "78ee2fb4eb43c970e12a91949f7efd26ca1834d5",
+   "sha256": "04pgr5xjk84kksck7f1y9gpvxxnsy803zq252hg1pzg1pl6bx3ga"
   },
   "stable": {
    "version": [
@@ -2633,8 +2649,8 @@
     20200723,
     1037
    ],
-   "commit": "b36c2b2bccc628da1579016381d5c3195c9e12b2",
-   "sha256": "19nqpg91in65gj59zndhncx6c1005k0wh05rprv1z6465j5gd40g"
+   "commit": "4aba676d49b0705cb4431b7e7c733ef8eac7d5aa",
+   "sha256": "1z5b5ivn81hmvndd7ari07kj1bsp9ziyxcrgf7xq21g1dfsbq8cs"
   },
   "stable": {
    "version": [
@@ -3201,8 +3217,8 @@
     20200914,
     644
    ],
-   "commit": "007a26fb5f7d9eb54db16484fb116d6e47c8cc5e",
-   "sha256": "1w9pra3qqmidsf5mvp0lmk9liw1ryaf8kjiawfgyyc6mzgw6nrvz"
+   "commit": "3543ef3df19228012a1ac5be766cc38fd2f65f6a",
+   "sha256": "0wlqrl8ikqc7q61i2qzmwp6h0mrv9kn5229pbsrb1ris7gxgi13b"
   },
   "stable": {
    "version": [
@@ -3655,8 +3671,8 @@
     20210223,
     1539
    ],
-   "commit": "a45c426b7e4a450faea004ef5b842fd37e17a7c6",
-   "sha256": "1f7bvcv4qqqa5bsfrcs69yc1phgnyrh5mbnb2hhgq72z8ymmrn7q"
+   "commit": "267a1453f58a6a6577a1d5752c876fdaa2896a6d",
+   "sha256": "0l5nfj5wz9cjpl9906w8q3p6ciwr6imf4nqh8i2s4dzip4n9w6nl"
   },
   "stable": {
    "version": [
@@ -4086,7 +4102,7 @@
   "unstable": {
    "version": [
     20210501,
-    1527
+    1536
    ],
    "commit": "9a8cd0c3d5c120bfa03187c54dba6e33f6e3ca19",
    "sha256": "1s2gdilaf38m2dg6nm4kcz5n4n455a9127pl4cbz9lg7mp3l2pg5"
@@ -4175,8 +4191,8 @@
     20201026,
     339
    ],
-   "commit": "449596a61f551ba5f8f3ff731984316e3b99faba",
-   "sha256": "0r21mxadvx4scnmx76kqnqmnvw9mx1394dvs34i5mr02nal3vhsg"
+   "commit": "375488bed4f279cf56a5c60ff236b320d3bfa169",
+   "sha256": "1kms5dkxz5ppf2iw95p4mvnkssp2iwp483mn4x0xvv53lglnjlxw"
   },
   "stable": {
    "version": [
@@ -4199,8 +4215,8 @@
     20200810,
     845
    ],
-   "commit": "79adac0149bb6083ad3a327c6bbdf56537282ee9",
-   "sha256": "1kd9fk1f3aaw0ikkbf9n6w5b2sy7v0xzsch688h8ac9rp6s2yws8"
+   "commit": "67b67de68f3d878f98c96ea7e340344aed6e6e46",
+   "sha256": "0qg04bn50s2chnwk7krdfkhq6y944fbgbwxs507qgmg4n0iyzkln"
   },
   "stable": {
    "version": [
@@ -4482,8 +4498,8 @@
     "keytar",
     "s"
    ],
-   "commit": "9ecdd6226b50a1a04675b65589e6cc36fd3aea2c",
-   "sha256": "04vr0i4y9i96vm1pliac8snnvlwqzafy7xrq39wpvhvd99qr4845"
+   "commit": "ab6f89a412ae47d257352b26f9667c3c062a7328",
+   "sha256": "1ha0v6np9qwg7lqcj0srq0qljs6yx2rgdj0dzwk74mqlk1xb5lzv"
   },
   "stable": {
    "version": [
@@ -4947,22 +4963,25 @@
   "repo": "jcs-elpa/auto-highlight-symbol",
   "unstable": {
    "version": [
-    20210629,
-    1535
+    20210715,
+    1416
    ],
    "deps": [
     "ht"
    ],
-   "commit": "45c472cf72df1d477550dcc07e556047b2fc5852",
-   "sha256": "1xbkcpidmzlbv3qs8r9i880pbkf7w78xagh85nvcrv965ra66k6c"
+   "commit": "3425ee2eac724d1d64170a8b9d23afc18f8951a9",
+   "sha256": "08m6wyfvy6i99q25nk6b7d1bvlfalvdlafh7ajglj6fnpdjmnk0h"
   },
   "stable": {
    "version": [
     1,
-    60
+    61
    ],
-   "commit": "d5125800b038d1275aabd14008ede75a3a858587",
-   "sha256": "1mi4mayfavkfm9fkg1j1wcv6kvb2cfgf5nr5kk15jhy7x1ajwphp"
+   "deps": [
+    "ht"
+   ],
+   "commit": "ca285d84e4a22514adaff2f0ba39657e296f4fff",
+   "sha256": "0lkdx247isrjsn8v51dqmxv6xcg4shqbnz5jxmw05isvhvm9k3xb"
   }
  },
  {
@@ -5100,8 +5119,8 @@
     20210629,
     1537
    ],
-   "commit": "ac7b7183c5e84da110e2f4850c5d8bc5325d058a",
-   "sha256": "1hzh6ajccmkc2p5kcbl7vjh16rdh4nw3kmncw8ca32ij3l01rmb1"
+   "commit": "9511446c4359100d0b6433579e663852bf8f36ef",
+   "sha256": "0gkkgkqvs7sq5s43srzzi8s5xm4pj53x9lifg79cad15a6i9a8sc"
   },
   "stable": {
    "version": [
@@ -5305,14 +5324,11 @@
   "url": "https://git.sr.ht/~pkal/autocrypt",
   "unstable": {
    "version": [
-    20210412,
-    1127
+    20210709,
+    1230
    ],
-   "deps": [
-    "cl-generic"
-   ],
-   "commit": "1dc4e5983382093fc74c81d84a45cd2b53adfd90",
-   "sha256": "0r99h100v43i7wr2c1jqgyzixlc1y973swwfa9cfmnaxck3ibk93"
+   "commit": "32786dc552569c7cc9970628f580b0b7b8e0b03d",
+   "sha256": "0vs8kwgxvmbr1yy1f8jvxpixy4jfxpdk17mq0gfvlcmnqb560gdr"
   }
  },
  {
@@ -5727,11 +5743,11 @@
   "url": "https://bitbucket.org/pdo/axiom-environment",
   "unstable": {
    "version": [
-    20210312,
-    2248
+    20210714,
+    1912
    ],
-   "commit": "ac8228a702290732ba12c5d13b38576a57afb0d6",
-   "sha256": "1nrlgrckvh2fiwis9bmr95h2bpxfkz1nknxdz61380f2caqwwhw7"
+   "commit": "7d72e6319b98b334f74b78f3d4151e92fb7dcbad",
+   "sha256": "1hwcndb1x3i51l0kvzk4mj6sil8h10mxmazic9zvwjhia9qz9hz3"
   }
  },
  {
@@ -6078,11 +6094,11 @@
   "repo": "belak/base16-emacs",
   "unstable": {
    "version": [
-    20210506,
-    1530
+    20210710,
+    1645
    ],
-   "commit": "59692942f34b9be0447a7766ad03115d04e79874",
-   "sha256": "1la7671sz666in8zx35j517sbj2y4jyasnj0x9yxh5n4g5qdrnbp"
+   "commit": "7f1db3df9bb6f4a3c9f4d3c10b9a6cf231752547",
+   "sha256": "0ycxj4lmmkbpmb8yizys25rdh0zrmw4sbgj19wb6zp2d30xk32qf"
   },
   "stable": {
    "version": [
@@ -6296,11 +6312,11 @@
   "repo": "bazelbuild/emacs-bazel-mode",
   "unstable": {
    "version": [
-    20210605,
-    906
+    20210715,
+    2325
    ],
-   "commit": "667554f76696a3cbb50c4c01b121c1aef882195a",
-   "sha256": "169x8d52hkb30w2c4ww7lpipdin5406nm2i95fbbxs1sz1068b8r"
+   "commit": "3b0a3a2200cd93497563812d4026c4d67b13e91a",
+   "sha256": "0pgn1j6fpj2qjns2zvzaswk5l65mkd6sxs08l6z0q2926gb7dpx9"
   }
  },
  {
@@ -6760,11 +6776,11 @@
   "repo": "gilbertw1/better-jumper",
   "unstable": {
    "version": [
-    20210110,
-    1317
+    20210713,
+    1426
    ],
-   "commit": "411ecdf6e7a3e1b4ced7605070d2309e5fc46556",
-   "sha256": "03jgfrpjlvn7fkv9grcqayphz2bjjkfh4rd6k1s7vmdpd3hm0xpb"
+   "commit": "7f328a886ba4dd01993d269eee01c8ee3d0ddf52",
+   "sha256": "1xfap2db1ncfdnv8d3vdn8gxgkzamz8vz9jsyn0jiminhy0hb2na"
   }
  },
  {
@@ -6775,11 +6791,11 @@
   "repo": "jcs-elpa/better-scroll",
   "unstable": {
    "version": [
-    20201013,
-    1355
+    20210715,
+    1004
    ],
-   "commit": "eaa8dae6f048fcff773f3cca2e3113c52ad0463f",
-   "sha256": "0r8g5gc454mnk6jbmdx56dfjkw57003c677csb30pf15fxnxp2r4"
+   "commit": "eb389204f9dadd8a040a78e79a17732daca7e253",
+   "sha256": "1m3v51hnhrfxpqqalkx26d1x6v109w83w7h5mwfa64hmgpax9r7i"
   },
   "stable": {
    "version": [
@@ -7022,14 +7038,14 @@
   "repo": "bdarcus/bibtex-actions",
   "unstable": {
    "version": [
-    20210625,
-    1718
+    20210714,
+    1030
    ],
    "deps": [
     "bibtex-completion"
    ],
-   "commit": "ee09acded11c160001e60c47de700e5fee6e9426",
-   "sha256": "0i4476gydsyandyb3r53hk8izx9jpmg03ny8f4glxcvlsm1ysvzf"
+   "commit": "f5b73bce4fcc31d55044d17949569b35dc50283b",
+   "sha256": "06wv37ck15i4m90lwksyc4zq9pwx4ljr90g8yqjmmracpgbm967y"
   },
   "stable": {
    "version": [
@@ -7869,8 +7885,8 @@
   "repo": "boogie-org/boogie-friends",
   "unstable": {
    "version": [
-    20210323,
-    1836
+    20210703,
+    238
    ],
    "deps": [
     "cl-lib",
@@ -7879,8 +7895,8 @@
     "flycheck",
     "yasnippet"
    ],
-   "commit": "bc5572f796bc3ecafadadcbd93de73052304c856",
-   "sha256": "0x1lw3cx9vx0l9xr9683p2385msny8dkp2w5l6kfa8imbyclpkp2"
+   "commit": "1e3b6a8aee9fa7c113468838c5b647080caf3703",
+   "sha256": "1h3j7a1y5p90dd1vj4kyngj5xvbr2z4dkzkq74s85bqf61j66yw2"
   }
  },
  {
@@ -8556,16 +8572,16 @@
   "repo": "countvajhula/buffer-ring",
   "unstable": {
    "version": [
-    20210624,
-    1642
+    20210707,
+    1745
    ],
    "deps": [
     "dynaring",
     "ht",
     "s"
    ],
-   "commit": "4a226bc410ec7b5b0323879b03aad73be1b69728",
-   "sha256": "02l4wh4qykbk58cda8l3cyg4lpf5zjr0ss4927ac48nlxnawcrsa"
+   "commit": "25c44a39742b21122e1e2adf1f6c5828148cd3ee",
+   "sha256": "130304bmlz46z6g56bsr745zfb8mxw5kzkslb8vdz7hvcp75wfc4"
   },
   "stable": {
    "version": [
@@ -8664,8 +8680,8 @@
     20200924,
     345
    ],
-   "commit": "2b12ed29cbcd733ad21d91475d1fcbd4092c604e",
-   "sha256": "1x9vayhq5cpqglkz4bzd9iaa1p0j0qsvh5pr6vkqi2z1nrjcwi8g"
+   "commit": "a14568210e212a4dfb93898218c4df58ff204089",
+   "sha256": "0b7lc14sn88r3wf8yqnx41wr704fm8kd6nxbd4874jaw01yp8x63"
   },
   "stable": {
    "version": [
@@ -8685,18 +8701,17 @@
   "repo": "alphapapa/bufler.el",
   "unstable": {
    "version": [
-    20201226,
-    2149
+    20210716,
+    1006
    ],
    "deps": [
     "dash",
-    "dash-functional",
     "f",
     "magit-section",
     "pretty-hydra"
    ],
-   "commit": "097f4349920215bdd829fceabc1afdbba172c32a",
-   "sha256": "1a4y3p7cwygw09b9f9j9m821aiyjiji55mrm83pvv0xzc9rhwd3h"
+   "commit": "d466eac6c4b2ee25c765e7f31e44beb38dd44e4b",
+   "sha256": "00gyqpm0g437z71vbfd4kmih23vh6909dvygng133vxzly9k4f24"
   },
   "stable": {
    "version": [
@@ -8911,14 +8926,14 @@
   "repo": "alphapapa/burly.el",
   "unstable": {
    "version": [
-    20210621,
-    845
+    20210709,
+    415
    ],
    "deps": [
     "map"
    ],
-   "commit": "c6d6aaeded0ef892af307652503de21db2a2a5b3",
-   "sha256": "1ic6qgmcj4l7a4775wwz45qwadj4ha4z3v2qlr4s54hzzldwc9w7"
+   "commit": "a67a026db0937b26c0b7a2fcf81bf44498ad2dd1",
+   "sha256": "0xck02i9l0yw7yzy6sgzg17k2hyqaj9lvafp7r229xzw8rdzl8cr"
   },
   "stable": {
    "version": [
@@ -9601,7 +9616,7 @@
   "unstable": {
    "version": [
     20210311,
-    831
+    830
    ],
    "deps": [
     "anaconda-mode",
@@ -10154,8 +10169,8 @@
     20210621,
     654
    ],
-   "commit": "720f9145d88b3e54b5388742c8a1a2b963d74581",
-   "sha256": "1mgjw93b5mag1ivvxsm416nkvappi4rkddpjlpjcvqw7lwzgps3d"
+   "commit": "614a8d94f67cdc1eeef8371f7b6b90aef8a78158",
+   "sha256": "1i9la8rh1sgvnk1kwd180x3daaglh3xzlbbfirnjsiqn3yyl9flk"
   },
   "stable": {
    "version": [
@@ -10409,8 +10424,8 @@
     20171115,
     2108
    ],
-   "commit": "3a5929f70b2b258e4786f86383edee6db76bd5a7",
-   "sha256": "05a004z6lxafi9x16br3hhflv7dr1ndlgqrfsb88rjm17w6afpc3"
+   "commit": "d87317f360d64b5f68809a564d03436d2b07e96a",
+   "sha256": "1g2q4fg95wpg1d77zrk80923553w2sgsby3ylrrq92y11ks4yiq5"
   },
   "stable": {
    "version": [
@@ -10860,6 +10875,21 @@
   }
  },
  {
+  "ename": "chemtable",
+  "commit": "5ffceb52fe572dec4203b6cb8f48da23a698cc06",
+  "sha256": "1s1fscgp6b8haq30fxvbxrczgzzs2sh3ggq6ib3ydyxa1vp6aggp",
+  "fetcher": "github",
+  "repo": "sergiruiztrepat/chemtable",
+  "unstable": {
+   "version": [
+    20210713,
+    1551
+   ],
+   "commit": "05fc1449db497e715b33b8e08359fa17c3148c7b",
+   "sha256": "16sdhias8ws93lhfhbf5hm05gff1r3imphk7gdziy51xfgyml619"
+  }
+ },
+ {
   "ename": "cherry-blossom-theme",
   "commit": "401ae22f11f7ee808eb696a4c1f869cd824702c0",
   "sha256": "1i3kafj3m7iij5mr0vhg45zdnkl9pg9ndrq0b0i3k3mw7d5siq7w",
@@ -11041,30 +11071,30 @@
   "url": "https://tildegit.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
-    20210622,
-    44
+    20210707,
+    2147
    ],
    "deps": [
     "dash",
     "seq",
     "ts"
    ],
-   "commit": "e7561cf0bb6cbe129edec7f3e15265c985e6e117",
-   "sha256": "1x8jb65pmzw3218skqmgn95bvl5wx02yghp5wmn1gd4xdhran2qc"
+   "commit": "524ba9592fc7095209e380392915b376f75bec00",
+   "sha256": "07fclq7dllz4nsrx51j4vrds1ciylxhkp9g945vc7xk6bi8syl4d"
   },
   "stable": {
    "version": [
     0,
-    8,
-    1
+    9,
+    0
    ],
    "deps": [
     "dash",
     "seq",
     "ts"
    ],
-   "commit": "e9164ecca1e2f43676e5a071aca7644177866deb",
-   "sha256": "0fp0p1sv7jpam2vbgkv2yg7lsdlxa02213ka06cn8rb54lw7k702"
+   "commit": "73e6d98612187aa64f4adacd26e058349cf131c6",
+   "sha256": "156hj3sxjcfpwimnrykh4n3krkbzas9jg8m6xzy42rnzhx28ja6k"
   }
  },
  {
@@ -11113,20 +11143,20 @@
    "deps": [
     "chronometrist"
    ],
-   "commit": "e7561cf0bb6cbe129edec7f3e15265c985e6e117",
-   "sha256": "1x8jb65pmzw3218skqmgn95bvl5wx02yghp5wmn1gd4xdhran2qc"
+   "commit": "524ba9592fc7095209e380392915b376f75bec00",
+   "sha256": "07fclq7dllz4nsrx51j4vrds1ciylxhkp9g945vc7xk6bi8syl4d"
   },
   "stable": {
    "version": [
     0,
-    8,
-    1
+    9,
+    0
    ],
    "deps": [
     "chronometrist"
    ],
-   "commit": "e9164ecca1e2f43676e5a071aca7644177866deb",
-   "sha256": "0fp0p1sv7jpam2vbgkv2yg7lsdlxa02213ka06cn8rb54lw7k702"
+   "commit": "73e6d98612187aa64f4adacd26e058349cf131c6",
+   "sha256": "156hj3sxjcfpwimnrykh4n3krkbzas9jg8m6xzy42rnzhx28ja6k"
   }
  },
  {
@@ -11185,8 +11215,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20210625,
-    1100
+    20210706,
+    1151
    ],
    "deps": [
     "clojure-mode",
@@ -11197,8 +11227,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "af140ced2286ff646471b067b94c2b18d42616df",
-   "sha256": "0nwh1pi31jrhxjxy7q92hpis5lf1k6f6l6k5vdb0y2lfsd7acqii"
+   "commit": "fe8cf244fd3426261f9f630c981a6296afd433a4",
+   "sha256": "02xj7g6jnwd9vjr8jipqvwy89zadkzsak08pq8418hz2af26bvaf"
   },
   "stable": {
    "version": [
@@ -11383,20 +11413,20 @@
  },
  {
   "ename": "circe",
-  "commit": "a2b295656d53fddc76cacc86b239e5648e49e3a4",
-  "sha256": "1f54d8490gfx0r0cdvgmcjdxqpni43msy0k2mgqd1qz88a4b5l07",
+  "commit": "8229522ba39b4b542421664ad3fef76439fbbfc9",
+  "sha256": "0wzpx6qpl89zixbsqyfgmda35qbjpqyq60xm61qjzi36hf9f9wcb",
   "fetcher": "github",
-  "repo": "jorgenschaefer/circe",
+  "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20210614,
-    912
+    20210713,
+    1609
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d6f1fa18646f6ed2a1c0f06a4888130bd694ff19",
-   "sha256": "1l6v02aa072jvhq4b9dpkprqs14py0d4jm3xvihm05lvrbf9v6c6"
+   "commit": "07d6d82cba864b1e38d3bd46654f2e1928a997c2",
+   "sha256": "04h60s6ig43sj144s7dlip1saf9kdwvzlfys8qwwx48003rbs0dp"
   },
   "stable": {
    "version": [
@@ -11467,8 +11497,8 @@
   "repo": "andras-simonyi/citeproc-el",
   "unstable": {
    "version": [
-    20201031,
-    1642
+    20210709,
+    602
    ],
    "deps": [
     "dash",
@@ -11478,8 +11508,8 @@
     "s",
     "string-inflection"
    ],
-   "commit": "0857973409e3ef2ef0238714f2ef7ff724230d1c",
-   "sha256": "1vi62fzl3bcn24j7pvb39jdf1njrdvdvwz88qlz6l0ijaxhrv0vp"
+   "commit": "dc118772ad4585c0511f4f8f25c81faf69952038",
+   "sha256": "0v8z6fhrsi9kszqcbrm1ggvin0jff744byaiw06d3id1hc428iq5"
   },
   "stable": {
    "version": [
@@ -11545,11 +11575,20 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20210701,
-    1448
+    20210716,
+    403
    ],
-   "commit": "01ed8539e8068f1e1ff658ab4b1931d9b7907809",
-   "sha256": "1ihxy871wqdpy3ri77kl1wwd21bnl484x343z9xvggl9z6dz8pw4"
+   "commit": "813e8c32a41f84ff099feddb5a4d5a51c5c200b5",
+   "sha256": "02482ln1458hb6z1x89b7294q4bwwdqi08h6m0mmvgd3vz2nwmqs"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "dcb5ec12d077c9a8f1c165a0868f98098494f78c",
+   "sha256": "1mf0d9avyhz83kb5fz2flwwn1knrbgrs0245q0layda9bya5i5yk"
   }
  },
  {
@@ -11573,36 +11612,6 @@
    ],
    "commit": "4380cb8009c47cc6d9098b383082b93b1aefa460",
    "sha256": "108s96viral3s62a77jfgvjam08hdk97frfmxjg3xpp2ifccjs7h"
-  }
- },
- {
-  "ename": "cl-lib-highlight",
-  "commit": "696c79669478b0d1c9769cc6f0fe581ee056cf32",
-  "sha256": "13qdrvpxq928p27b1xdcbsscyhqk042rwfa17037gp9h02fd42j8",
-  "fetcher": "github",
-  "repo": "skeeto/cl-lib-highlight",
-  "unstable": {
-   "version": [
-    20200210,
-    1951
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "72afc4dd0107c357543244d09903767f49651c5c",
-   "sha256": "1ndjjdada219fgs68np4r7vg50s2h6060wd6wf0x3pnj8b0ca5wm"
-  },
-  "stable": {
-   "version": [
-    1,
-    0,
-    0
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "c117451df8455769701af6c8e92a8fb29c05e1fa",
-   "sha256": "12vgi5dicx3lxzngjcg9g3nflrhfy9wdw6ldm72zarp1h96jy5cw"
   }
  },
  {
@@ -11636,11 +11645,11 @@
   "url": "https://git.sr.ht/~pkal/clang-capf",
   "unstable": {
    "version": [
-    20210625,
-    1107
+    20210707,
+    1127
    ],
-   "commit": "e422f339395aac6d023954880d19bc76a0d1072d",
-   "sha256": "1gdd674m1vbl8acwsgx6qfmx1gr7h8a6yadzp1jjaandpmc9jlrf"
+   "commit": "258863d5cd77d2c9d07cc5dfa41b20db22a178f7",
+   "sha256": "1zg192hy2mf6r6fiy2ahkprxjnb79lh9n6wv6nvxqnc5cq0969i4"
   },
   "stable": {
    "version": [
@@ -12188,11 +12197,11 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20210505,
-    712
+    20210706,
+    1318
    ],
-   "commit": "33f267ac182afe8fa82cc321e9f515c0397e35f6",
-   "sha256": "1v5gqpkw63h4h1c5kyw8dwg08famp89vbgi789yb32md5819l52s"
+   "commit": "3e426b3a479f479963f2c7d1147cc826ed1a0ee1",
+   "sha256": "16smnr1hlbv347wnzhncasz5ihy0sb4fcpx5dw9v8az5r3q8xpak"
   },
   "stable": {
    "version": [
@@ -12218,8 +12227,8 @@
    "deps": [
     "clojure-mode"
    ],
-   "commit": "33f267ac182afe8fa82cc321e9f515c0397e35f6",
-   "sha256": "1v5gqpkw63h4h1c5kyw8dwg08famp89vbgi789yb32md5819l52s"
+   "commit": "3e426b3a479f479963f2c7d1147cc826ed1a0ee1",
+   "sha256": "16smnr1hlbv347wnzhncasz5ihy0sb4fcpx5dw9v8az5r3q8xpak"
   },
   "stable": {
    "version": [
@@ -12521,19 +12530,17 @@
     20210104,
     1831
    ],
-   "commit": "bf6c9567920965f7b3aba37079cc1b51f31d969d",
-   "sha256": "1hk1qmvw9hmq8xarcnc3pspgsa2fkr8cra8g43i12b8011dz6hpb"
+   "commit": "4e17e90988e9f23dece4c04f574d456309d7a50c",
+   "sha256": "1gqbgs8zxn9dcpxmbykz0mrqy6p229b0pdz3hnk0kncqkk004lx1"
   },
   "stable": {
    "version": [
     3,
     21,
-    0,
-    -1,
-    2
+    0
    ],
-   "commit": "e610e99ad34a545ac67f1977e78ea59a52fdcf79",
-   "sha256": "1jss6aavq89kmhdbjml6qamv9jm92xf74g1wz4dsr36wh0mypgfk"
+   "commit": "ff7a2e37bfff23ce1751a93b3eba179fbf32a9b6",
+   "sha256": "061cjj5mni91p6b0mpp6a2zrkrmw1hc3l4cci6lcqbx733y192fq"
   }
  },
  {
@@ -13157,8 +13164,8 @@
    "deps": [
     "s"
    ],
-   "commit": "61244e12594f117ffac047454311212604399d52",
-   "sha256": "104iq411nwnv3dnm5x9myn4vf36yg3v46jcag9ln0cj0kypmjdrv"
+   "commit": "e91006ba4a77b8ea8c4fe4085ba5676c97cf0315",
+   "sha256": "0icjcmfmwdwas59425baf2s3zw2iblidx6v3jy6k53y1ac5qn7iy"
   },
   "stable": {
    "version": [
@@ -13390,20 +13397,20 @@
   "repo": "pzel/commentary-theme",
   "unstable": {
    "version": [
-    20181213,
-    1045
+    20210714,
+    1757
    ],
-   "commit": "dede0f8ecb72156fa6ae81198ea570ead02997ff",
-   "sha256": "1ykicd6yp495s7795mlfwd54lp0427j8mw6ajbqsw2c2w0f7jcjr"
+   "commit": "a73e1256f667065933e96bd6032c463cb115201d",
+   "sha256": "0dwd42afh4brcwz1jahxmn8l3aj6dmplidqv4x55z3di1spdjs98"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
-   "commit": "9a825ae98166c9dbbf106e7be62ee69dd9f0342f",
-   "sha256": "1x30iyvvxggbh7xvp8lwpirvpqijchqf2fdaw4xrlbw5vajlaxcx"
+   "commit": "a73e1256f667065933e96bd6032c463cb115201d",
+   "sha256": "0dwd42afh4brcwz1jahxmn8l3aj6dmplidqv4x55z3di1spdjs98"
   }
  },
  {
@@ -13492,11 +13499,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20210618,
-    2105
+    20210709,
+    1110
    ],
-   "commit": "1fd1b363eee68e4cdcf0e610005c0bdbf9940604",
-   "sha256": "00502ffyfx9zc6bs2pzn3zj3rj2zz8sdm1g046ijkgbya8wszkcm"
+   "commit": "d77184094b9a45b204813d824918e1ec2aac8504",
+   "sha256": "09f59ipp6c2b1xpnmk82ygxcfkfhh36h4g1c07dmxf7m3z1hwlgi"
   },
   "stable": {
    "version": [
@@ -13634,8 +13641,8 @@
     "axiom-environment",
     "company"
    ],
-   "commit": "ac8228a702290732ba12c5d13b38576a57afb0d6",
-   "sha256": "1nrlgrckvh2fiwis9bmr95h2bpxfkz1nknxdz61380f2caqwwhw7"
+   "commit": "7d72e6319b98b334f74b78f3d4151e92fb7dcbad",
+   "sha256": "1hwcndb1x3i51l0kvzk4mj6sil8h10mxmazic9zvwjhia9qz9hz3"
   }
  },
  {
@@ -13666,8 +13673,8 @@
   "repo": "sebastiencs/company-box",
   "unstable": {
    "version": [
-    20210330,
-    1155
+    20210712,
+    843
    ],
    "deps": [
     "company",
@@ -13675,8 +13682,8 @@
     "dash-functional",
     "frame-local"
    ],
-   "commit": "aa5f09a5492344e3cc831f0f169a6a8345dec358",
-   "sha256": "15wbhf04qj8wplf03hbwixhwbrw3r3vb2ih2lvxjhgpg0lq1gjz5"
+   "commit": "156f65cfbf690ed84e0e84f90277d665d873ff24",
+   "sha256": "1lafm8kpn0i688gk53711mazksy96c7fmr8qhjmdxpxwdk56jcy2"
   }
  },
  {
@@ -13737,8 +13744,8 @@
   "repo": "cpitclaudel/company-coq",
   "unstable": {
    "version": [
-    20210420,
-    215
+    20210708,
+    2357
    ],
    "deps": [
     "cl-lib",
@@ -13747,8 +13754,8 @@
     "dash",
     "yasnippet"
    ],
-   "commit": "6a23da61e4008f54cf1b713f8b8bffd37887e172",
-   "sha256": "15rd9ga4ydhl6ljzdg26a3kcaqlhaygp67507wrrf8j3801ivks4"
+   "commit": "382db93374380e5db56f02934ee32bbe39159019",
+   "sha256": "1vlbw54a02qy77ad2qgd6sy7y3b6x1y1nm3bjxcd7f67hnncjg0p"
   },
   "stable": {
    "version": [
@@ -14013,16 +14020,16 @@
   "repo": "jcs-elpa/company-fuzzy",
   "unstable": {
    "version": [
-    20210608,
-    1454
+    20210716,
+    926
    ],
    "deps": [
     "company",
     "ht",
     "s"
    ],
-   "commit": "b35c6fd89ad111c662916751cf8b3facc8acb1c0",
-   "sha256": "0h9ly6jpbkbcraxs8l0245vqld61jap1vw3cfrbp885jyyzpfb0v"
+   "commit": "b4fd1c8d128ae345176f713dad2c04944a9cf27c",
+   "sha256": "1fhkc49xp4yfqry6a0w7bsz80c7v5kc60jzd3ran0yjr9q9yzx8i"
   },
   "stable": {
    "version": [
@@ -14809,15 +14816,15 @@
   "repo": "jcs-elpa/company-quickhelp-terminal",
   "unstable": {
    "version": [
-    20200904,
-    305
+    20210715,
+    1010
    ],
    "deps": [
     "company-quickhelp",
     "popup"
    ],
-   "commit": "c2e077e8d32610f80a506c410ab51a4ba747a47f",
-   "sha256": "014gk5ara9xh218wm2ygh2nilyp3s1rbg6y5y2z2ki460biwi166"
+   "commit": "2e82273e206f78f015e67f799f51e3f3458d6d94",
+   "sha256": "0miylw8lhs4jgfa47mis6k68jm69jwbmpgms0dl9rnjgpmyvr133"
   },
   "stable": {
    "version": [
@@ -15706,11 +15713,11 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20210629,
-    1951
+    20210716,
+    1219
    ],
-   "commit": "6ce9aa58e74da92e391cfe938bc3da4f47ab591e",
-   "sha256": "1ji5ilakwahipp23avzjpi5vfp5f17pm6m1prygk065zqdianrv9"
+   "commit": "5fb6248c8e12630ce1247985c67ea28ae4077e4f",
+   "sha256": "1cgk144alm3pbig9acm62q3r7479x69ig76q3z6agamdvf91ay29"
   },
   "stable": {
    "version": [
@@ -15838,14 +15845,14 @@
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
    "deps": [
     "consult",
     "notmuch"
    ],
-   "commit": "5cc6684f6e9cbeb23a06280a1cc9332658d37514",
-   "sha256": "1s1imciy8yb3kkgbdsqsvlv0j40sm94lvv9z5kq58w6n9c2dmb48"
+   "commit": "9e65c421cf54ca12234acad727818fa0fe60fa3e",
+   "sha256": "19flyh3v1xm2zswzjkvjbijvpbq5r8isafza4fd0yicvqbjyklhx"
   }
  },
  {
@@ -16205,8 +16212,8 @@
     "ivy",
     "swiper"
    ],
-   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
-   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
+   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
+   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
   },
   "stable": {
    "version": [
@@ -17226,11 +17233,11 @@
   "repo": "emacs-pe/crontab-mode",
   "unstable": {
    "version": [
-    20200330,
-    920
+    20210715,
+    133
    ],
-   "commit": "9625228cbfce29ac3b443c6eff893ff828268f7d",
-   "sha256": "01s32ivn1fdqq99ms3s6a73hrqdc2r5khrg4jv3sniviql2k3i31"
+   "commit": "7412f3df0958812bfcacd5875a409fa795fa8ecc",
+   "sha256": "0jfdak85r9j0qlbzc53mkbfqqgqs9ghg0x6fhlv8i22873y650gm"
   }
  },
  {
@@ -18053,17 +18060,17 @@
     20190111,
     2150
    ],
-   "commit": "e7e5d1dc652755bd0ac0a45e4f970b1a2b137308",
-   "sha256": "0900w9ddx0i942spji7jg6ssv9d898isggzy9yjhirwn8fs0a2jb"
+   "commit": "5bf5aa63d6b6742144071a2af896067c21b3752a",
+   "sha256": "1nnyca4bagdbpmzy64pqy95vxbj3dx7lfbapvs120zbpxj193p7a"
   },
   "stable": {
    "version": [
     0,
     29,
-    23
+    24
    ],
-   "commit": "17670781083e3ccfedb1af4adcec614d4599eef9",
-   "sha256": "1yri0ay0p3p80h9ypq692470y1b99y4hk468zqlmfzb87yv8vv7j"
+   "commit": "3a34c5fb48ee86be9d0a819fee1ff3cb3efd1a1e",
+   "sha256": "0jsbmgqxhyjsrjc2h6lw4yqjjqaiqmgz4yjg580j76q8zk9vkjyb"
   }
  },
  {
@@ -18261,8 +18268,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20210519,
-    1554
+    20210711,
+    1427
    ],
    "deps": [
     "bui",
@@ -18274,8 +18281,8 @@
     "posframe",
     "s"
    ],
-   "commit": "cc395e066755c7513d4862f5639f3d162b3bd30f",
-   "sha256": "0nmpldvkhgi668zpn5wym6rfvsdnib9ny2snzwsrrfgqa70lmky6"
+   "commit": "685168efc72e61bca2a248155bace7ec633269a5",
+   "sha256": "1mwy92rj9jj4ziflhzpy774vrp5m7zwzy2x1iyj33mn2rmykwl2w"
   },
   "stable": {
    "version": [
@@ -18528,20 +18535,20 @@
   "repo": "magnars/dash.el",
   "unstable": {
    "version": [
-    20210609,
-    1330
+    20210708,
+    2009
    ],
-   "commit": "88d799595e8f1b4154637ce8a3f81b97b0520c1a",
-   "sha256": "0b68kivrvwwp51q7cizgdd5i69n7p322gzd305zb377aksl98rbj"
+   "commit": "2675596b9ac1c4b9d47b93e227f06f8ec6755ec6",
+   "sha256": "0wycrcl79mv253vzf2y92qz9i52mi5xa82f9i4rgnqa02f2m633h"
   },
   "stable": {
    "version": [
     2,
-    18,
-    1
+    19,
+    0
    ],
-   "commit": "1a53e13d7964c84cf756ead353eb6dc094b65fd5",
-   "sha256": "1cvfd36vv0wqb16bnqqxh99hy2yks0j2i4l8qjkg3bxjgk7ldmva"
+   "commit": "2675596b9ac1c4b9d47b93e227f06f8ec6755ec6",
+   "sha256": "0wycrcl79mv253vzf2y92qz9i52mi5xa82f9i4rgnqa02f2m633h"
   }
  },
  {
@@ -18607,20 +18614,20 @@
    "deps": [
     "dash"
    ],
-   "commit": "88d799595e8f1b4154637ce8a3f81b97b0520c1a",
-   "sha256": "0b68kivrvwwp51q7cizgdd5i69n7p322gzd305zb377aksl98rbj"
+   "commit": "2675596b9ac1c4b9d47b93e227f06f8ec6755ec6",
+   "sha256": "0wycrcl79mv253vzf2y92qz9i52mi5xa82f9i4rgnqa02f2m633h"
   },
   "stable": {
    "version": [
     2,
-    18,
-    1
+    19,
+    0
    ],
    "deps": [
     "dash"
    ],
-   "commit": "1a53e13d7964c84cf756ead353eb6dc094b65fd5",
-   "sha256": "1cvfd36vv0wqb16bnqqxh99hy2yks0j2i4l8qjkg3bxjgk7ldmva"
+   "commit": "2675596b9ac1c4b9d47b93e227f06f8ec6755ec6",
+   "sha256": "0wycrcl79mv253vzf2y92qz9i52mi5xa82f9i4rgnqa02f2m633h"
   }
  },
  {
@@ -18631,14 +18638,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20210427,
-    705
+    20210714,
+    305
    ],
-   "deps": [
-    "page-break-lines"
-   ],
-   "commit": "9983aa0838ce5a2219ef4b674e6b37de41b5b585",
-   "sha256": "1mi1jn5gknvs7xjgj2v4dcq7z1a7xknksgfqi66bby7cl6cr3hqd"
+   "commit": "09932ef488b47c6b645a081fee4a82be437f98d8",
+   "sha256": "1kfsc5f37i4k4j8rqmi70cd6yvwxhhq2q513gby8qj2bqsgiwkhb"
   },
   "stable": {
    "version": [
@@ -18688,8 +18692,8 @@
     "f",
     "s"
    ],
-   "commit": "91b3c79aa3af3842f1477825f967370414dc77b2",
-   "sha256": "0q456m64wkbwxc99bwr8b3n7z2f2qkrbcdij0kji35rg89rxbgph"
+   "commit": "947c8c99e9abb38852d895f8792258783e3c4e1d",
+   "sha256": "1iwm1kzjbvfamdzz79bkyq848z3wgr3cf2692dmfah58gy5wkb0z"
   },
   "stable": {
    "version": [
@@ -19275,8 +19279,8 @@
     "s",
     "wiki-summary"
    ],
-   "commit": "8df0505babf930bafe3fd28d472cc325637f886b",
-   "sha256": "1czdnvwf2z0za296sn392w52hb2akw2sh27f3b7nw0987iz9qa0s"
+   "commit": "1861c57e67315bcb1ff88f37184cf7e2d6167642",
+   "sha256": "104dfryn6ql2a4l7nd9x0984qpyxhn6kv0432h1lha5adb8g1h10"
   },
   "stable": {
    "version": [
@@ -19361,11 +19365,11 @@
   "repo": "jrblevin/deft",
   "unstable": {
    "version": [
-    20210101,
-    1519
+    20210707,
+    1633
    ],
-   "commit": "c4af44827f4257e7619e63abfd22094a29a9ab52",
-   "sha256": "0xphl5r8q884ml6clrfrzaiqznfrrpsvysakigjqpgazic5d60g2"
+   "commit": "28be94d89bff2e1c7edef7244d7c5ba0636b1296",
+   "sha256": "074d8apvfp9na14q080w14i9ixbswvp7akjyv8gmxmy5im4gm0y3"
   },
   "stable": {
    "version": [
@@ -19653,11 +19657,11 @@
   "repo": "blahgeek/emacs-devdocs-browser",
   "unstable": {
    "version": [
-    20210629,
-    1601
+    20210703,
+    306
    ],
-   "commit": "23e62096b98b9b509efc453d7fee0810acea4bf8",
-   "sha256": "0f6ld4m1x419677snbpd3qyx782zpj61rahphgc5nfj6aanvll0w"
+   "commit": "f8572f208d58b2122df63ffef87fdd5112d83233",
+   "sha256": "10ywfkkczi6hzcz4hnjqxr77708hi22hgrvrykmwrh4lsfxl0iyq"
   }
  },
  {
@@ -19876,8 +19880,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "1077c734b3b6de02c80456035a4939b028cb4179",
-   "sha256": "18vk7rhysavm8j02kd4lw6j6zr2l13gyvrjxq7psy1flhvmkxknc"
+   "commit": "d225def4a473a16ac994124e063695ef9cef3308",
+   "sha256": "1wizqf5qj0bxx9b5d0j726in1alqv0wy508y5ivaw7hcyggkg9i7"
   },
   "stable": {
    "version": [
@@ -20135,6 +20139,18 @@
    ],
    "commit": "d85409dc3cba57a390ca85da95822f8078ecbfa2",
    "sha256": "1cm4l2ycaw47mfgc6ms021zxkas1jajgwpnykqlkcwcbakbczxjl"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "dylan"
+   ],
+   "commit": "d85409dc3cba57a390ca85da95822f8078ecbfa2",
+   "sha256": "1cm4l2ycaw47mfgc6ms021zxkas1jajgwpnykqlkcwcbakbczxjl"
   }
  },
  {
@@ -20168,11 +20184,11 @@
   "repo": "jcs-elpa/diminish-buffer",
   "unstable": {
    "version": [
-    20201206,
-    1238
+    20210715,
+    1026
    ],
-   "commit": "387858aaa23d5d1145c98dfa70bbd39bb8c3fa5f",
-   "sha256": "13a3jkc5yf1m2gqabvfxfzxgblyhyni9f2clqx9i0pvr9dvvb9r8"
+   "commit": "fcc43f38431d4b16b2fd8d15e799488a7fb60966",
+   "sha256": "1r5a98viw7j2nfmhgf5v9whkya3h9s392drz764a9ivj2znc0qg5"
   },
   "stable": {
    "version": [
@@ -20289,20 +20305,20 @@
   "repo": "HKey/dired-atool",
   "unstable": {
    "version": [
-    20181228,
-    1422
+    20210706,
+    1456
    ],
-   "commit": "52ce4ac88fa39a0ebdf732435fd831ea9a8d0764",
-   "sha256": "00br8f8rw0rrzmi3nvacwn14d122jw243z1izlsm8h8q95hh8f6l"
+   "commit": "c01e0a79c952a29db17c262c9ce8a90632b04b3a",
+   "sha256": "1r44s3f29p70li6k6646xcby3ypz1ljgd4j1fhdd0x4d7a09zl0v"
   },
   "stable": {
    "version": [
     1,
-    2,
+    3,
     0
    ],
-   "commit": "09dbb769fe02f546da470369a12468ab4a0cceb2",
-   "sha256": "0j2dz4vy4i22185hhlwg2kprpis97xb12qvfdhvdcnz2vwy61sxa"
+   "commit": "c01e0a79c952a29db17c262c9ce8a90632b04b3a",
+   "sha256": "1r44s3f29p70li6k6646xcby3ypz1ljgd4j1fhdd0x4d7a09zl0v"
   }
  },
  {
@@ -22079,8 +22095,8 @@
    "deps": [
     "s"
    ],
-   "commit": "32196031f60627e88a67b676d643ab51c251711f",
-   "sha256": "19bm4fr38hkh6mrbf0vgafwq2hfldkcn2b5flllvizq2qh86hq81"
+   "commit": "5b80126a71662a4bcd3dff7cfbcf70954610092e",
+   "sha256": "0ywm29gfqfb8dhv3mwwb8fx1vl363gkhba9vdkx0w3r2wvh17l80"
   },
   "stable": {
    "version": [
@@ -22222,16 +22238,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20210627,
-    1731
+    20210706,
+    604
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "07d03c4626eaaf2cc9c346308add3700ad4a3a06",
-   "sha256": "0c9g5i9cyqcc934rz778zia24bls99i9hfl0s61354ncgw4qndfy"
+   "commit": "06606e0b8b3c19fbe56e25702e2a664deec593c3",
+   "sha256": "0akyzih955j2ijnrvfnajwpml5xb3v9pg9wbn4z8nkcw33hvxgk9"
   },
   "stable": {
    "version": [
@@ -22275,14 +22291,14 @@
   "repo": "hlissner/emacs-doom-themes",
   "unstable": {
    "version": [
-    20210701,
-    707
+    20210714,
+    1511
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "bd5b9065dea54472519da67ccfcc3185bf5e35c3",
-   "sha256": "0g12rlkfg9ijgd2csrcmcqf6yrs33x9gfkw3g7azp74pvx3cvcmi"
+   "commit": "b7995ac041f8dadb021cd2445e85d29c9bf718ae",
+   "sha256": "09hhplhb0832ja9nnsq3d4p6g0fdw2sp9kl2y4n2kk6zq909ar54"
   },
   "stable": {
    "version": [
@@ -22936,11 +22952,11 @@
   "repo": "ocaml/dune",
   "unstable": {
    "version": [
-    20210213,
-    757
+    20210715,
+    548
    ],
-   "commit": "846b38c1efab4757240d131d2c45102930fc305c",
-   "sha256": "1vw500g9jfa4za1f0r90bzzb6ra9jyn52z1g4nwvqcnha1sixj7m"
+   "commit": "48bd29decb847bd9357aceeca9ad1c916f199913",
+   "sha256": "02fy271d8s77l2g4rykgpnqvy4sq2ri88xz97ink00r1r12cdvk9"
   },
   "stable": {
    "version": [
@@ -23066,6 +23082,15 @@
    ],
    "commit": "d85409dc3cba57a390ca85da95822f8078ecbfa2",
    "sha256": "1cm4l2ycaw47mfgc6ms021zxkas1jajgwpnykqlkcwcbakbczxjl"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "d85409dc3cba57a390ca85da95822f8078ecbfa2",
+   "sha256": "1cm4l2ycaw47mfgc6ms021zxkas1jajgwpnykqlkcwcbakbczxjl"
   }
  },
  {
@@ -23188,14 +23213,14 @@
   "repo": "ahyatt/emacs-dyncloze",
   "unstable": {
    "version": [
-    20210613,
-    1956
+    20210712,
+    145
    ],
    "deps": [
     "dash"
    ],
-   "commit": "fe5baf6d324800779f80f5c6298a56e2dcb87598",
-   "sha256": "0c7bh3swwmfc1z834f79jakg1n6li5prd33r5k92id8kl18hb8fj"
+   "commit": "aafc5adc25c7f714b619109bccf92e475d6c84ef",
+   "sha256": "0l3y8xvjy0f2wacnh03i8ny06apcgyzvippsm8k80qhzjc8dxs2i"
   }
  },
  {
@@ -24869,8 +24894,8 @@
     20210613,
     1418
    ],
-   "commit": "ec135b5353867ce3564a675e99024944b834395d",
-   "sha256": "1mpc4gnrpvqvhfvjvp4hqb4x6nzn1kfzgsqi4sdjgbfjqll2jzv0"
+   "commit": "463f5e985fc53300f87ab7eb054d1738fc6ac93b",
+   "sha256": "122xbfag9ykvcwq549r3aglrdip1nk68abgqlzhm5mqfpqi0l8a8"
   },
   "stable": {
    "version": [
@@ -25219,20 +25244,20 @@
   "repo": "doublep/eldev",
   "unstable": {
    "version": [
-    20210530,
-    1641
+    20210711,
+    1204
    ],
-   "commit": "d51ce6152519b5cf32d0dcc40cad6787eb605997",
-   "sha256": "1nkc9fwg7fn8gvj4zg515320p7m2h3b1nyd6zzbp2v60qj7277jq"
+   "commit": "f9d034ff330d657fa3cbbb1df3a582cd417da78a",
+   "sha256": "13pd4kwak8fvzbmj8lcasxpi6m8i1cffrs6hg1wnd1j6w68jl4yg"
   },
   "stable": {
    "version": [
     0,
     9,
-    1
+    2
    ],
-   "commit": "70167056fd81e8477b0a5508cf7e28d7a48a2367",
-   "sha256": "1jfj4f5w20qd12k6ygv0jazn2x9pxjrmqmlmibppc4ybrhhgmg0s"
+   "commit": "2b6513ac12bfc73dd954effc68734bc84607b31c",
+   "sha256": "1agg69ji032k9a1r23cdcgb0ihmcxxlbjgsqx647igv3mw7r6ff0"
   }
  },
  {
@@ -26172,15 +26197,15 @@
   "repo": "Silex/elmacro",
   "unstable": {
    "version": [
-    20200905,
-    2130
+    20210716,
+    639
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "4888d1baa8b943adf0bab94419357c55b7e6e697",
-   "sha256": "0g1iavy7f0n14c34b808kv5sf3imvc9aqv5814r231i6qjck5vj4"
+   "commit": "d2e05012cee4f54fab6d8d8d6aced6e5eeef4f31",
+   "sha256": "1mmhgl85880bhhwibf9ksifghdc7w22vrhpg8y8rvpjh91fdg0lz"
   },
   "stable": {
    "version": [
@@ -26254,21 +26279,11 @@
   "repo": "jcaw/elnode",
   "unstable": {
    "version": [
-    20190702,
-    1509
+    20190608,
+    1623
    ],
-   "deps": [
-    "creole",
-    "dash",
-    "db",
-    "fakir",
-    "kv",
-    "noflet",
-    "s",
-    "web"
-   ],
-   "commit": "29ef0f51a65a24fca7fdcdb4140d2e4556e4bb29",
-   "sha256": "1bks7aakhvdab56gbsa44ca9kbilajisdd9bns485d9wr62d2lgj"
+   "commit": "305c532b6e59f58c4afcfb76466dbfbdc4e58b9c",
+   "sha256": "1214216wrdhfw3lbf59vnddk28hi4g3s1ksdi5walksihd3gh7my"
   }
  },
  {
@@ -26426,11 +26441,11 @@
   "url": "https://thelambdalab.xyz/git/elpher.git",
   "unstable": {
    "version": [
-    20200919,
-    1025
+    20210716,
+    1445
    ],
-   "commit": "3561c2815bc6bc896fc7a6da8f094edca48c55b8",
-   "sha256": "0vy1ak5gphnih90c1n7js91p0fdyccdqqbagdjqdfbpbir41gba5"
+   "commit": "7e0919bd74952fb229862f1280e01817721b7fc2",
+   "sha256": "13fjp20hf4jv3325ipnjrzqvxa122sfhs44dgsr52g9mkhhc6kbm"
   },
   "stable": {
    "version": [
@@ -27590,8 +27605,8 @@
     "emojify",
     "request"
    ],
-   "commit": "d512c2babb412820945444c6daf309b470e2eb12",
-   "sha256": "1llqn6ik0dnrpmvdxcgiyadbffjlbxqv6i7bxh2rnqiy4fhk9s1n"
+   "commit": "f05ab06436e13b3578f3d4d183fcb1bc3a4eeab1",
+   "sha256": "01dnab8mqz03rdd3xcb48csx56cv2ik07sykyqscbiib5vcw5k5k"
   },
   "stable": {
    "version": [
@@ -27739,8 +27754,8 @@
   "repo": "rejeep/enclose.el",
   "unstable": {
    "version": [
-    20121008,
-    1614
+    20120618,
+    2019
    ],
    "commit": "2747653e84af39017f503064bc66ed1812a77259",
    "sha256": "0dz5xm05d7irh1j8iy08jk521p19cjai1kw68z2nngnyf1az7cim"
@@ -27880,7 +27895,7 @@
   "unstable": {
    "version": [
     20130407,
-    1348
+    1236
    ],
    "commit": "7fd2f48ef4ff32c8f013c634ea2dd6b1d1409f80",
    "sha256": "0v5p97dvzrk3j59yjc6iny71j3fdw9bb8737wnnzm098ff42dfmd"
@@ -28684,8 +28699,8 @@
     20200914,
     644
    ],
-   "commit": "007a26fb5f7d9eb54db16484fb116d6e47c8cc5e",
-   "sha256": "1w9pra3qqmidsf5mvp0lmk9liw1ryaf8kjiawfgyyc6mzgw6nrvz"
+   "commit": "3543ef3df19228012a1ac5be766cc38fd2f65f6a",
+   "sha256": "0wlqrl8ikqc7q61i2qzmwp6h0mrv9kn5229pbsrb1ris7gxgi13b"
   },
   "stable": {
    "version": [
@@ -28708,8 +28723,8 @@
     20210315,
     1640
    ],
-   "commit": "3517ac9f6b48641b949e19971a1a2d022b7494a0",
-   "sha256": "1r9adb0x370c3cj93lgaag2ifkgi954gh5hnshkr3wz8bpqirvk1"
+   "commit": "81c6d94625a04f6550e77a068489ca6378cabfee",
+   "sha256": "1kkjyradh316xcqsh9pn4l1nvz1krn8cm3zch0vfp47dkkg54w1y"
   },
   "stable": {
    "version": [
@@ -28929,8 +28944,8 @@
   "repo": "dakrone/es-mode",
   "unstable": {
    "version": [
-    20201125,
-    2059
+    20201112,
+    2317
    ],
    "deps": [
     "cl-lib",
@@ -29570,11 +29585,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20210616,
-    1806
+    20210707,
+    917
    ],
-   "commit": "a5df6aa81351385e9813b722afcacdba1648226d",
-   "sha256": "0di7s1k9lizvbr4n59qhn6ipc67klcyimlkdqw4if7nkfjif5bsn"
+   "commit": "4fefd0feaae688e28d6a0c36c9eaa219c448903f",
+   "sha256": "0m9w0l6x67s5mx76ixgh42abblzi8jbp9xpps4flv08jhz1lkc5i"
   },
   "stable": {
    "version": [
@@ -30165,15 +30180,15 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20210628,
-    1913
+    20210715,
+    1839
    ],
    "deps": [
     "cl-lib",
     "goto-chg"
    ],
-   "commit": "f20d442ff006aa5a6dc48ac654906b48b95107fd",
-   "sha256": "0bl854036zpjg5p5asamvlnl9lf46rgcpa645yhrvxqmwznm6din"
+   "commit": "070abb16620653fb343980fb85a13c4d55e1070b",
+   "sha256": "0pcr471snnmhycvvgczs1gbil45w6lf1bdmg7w19vh2a0dq4pqi9"
   },
   "stable": {
    "version": [
@@ -30367,28 +30382,28 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20210701,
-    1024
+    20210715,
+    1552
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "a24168ffe3711890b5dcd41041a51146bbd67497",
-   "sha256": "1pz046fw06lgc7gjrfr0a895j867mm96k8h5dw3k0p64rh1xh1sa"
+   "commit": "3bd5e90accbb3a12d924bb7b4220221493675591",
+   "sha256": "1nikhz4l01zi884dwyjfsaralc1pd6y70fvd36i4qn477xinsvk4"
   },
   "stable": {
    "version": [
     0,
     0,
-    5
+    6
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "a615e4a7f642e0c3acd8628111624355380aa18f",
-   "sha256": "0dxrwcf5dnww0a9mvwjkcgm8ry3y282v9l85jh0645zk71nz1in3"
+   "commit": "d97e0ff4afa67bd19443245d4f663de29b043a6b",
+   "sha256": "0ssb3n1i67b6zp2j8djaalkr33x4c7zalw6vl6p5kqxkh8vy8cdf"
   }
  },
  {
@@ -31502,15 +31517,15 @@
   "repo": "hlissner/evil-snipe",
   "unstable": {
    "version": [
-    20210609,
-    509
+    20210713,
+    1456
    ],
    "deps": [
     "cl-lib",
     "evil"
    ],
-   "commit": "a9b9b39a7915e66b7d5da9cecfaf002c72d08196",
-   "sha256": "01ikzxvm878k0xwj10h3ww02459g3jiz4fjsm481jw1jjvnxg5b2"
+   "commit": "1a28d718c835a21591a170af78a03a366cd60c0d",
+   "sha256": "1dm73xmlhznh9yc22ifb238yyad09011nryc91n6glla347896p0"
   },
   "stable": {
    "version": [
@@ -31693,8 +31708,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "f20d442ff006aa5a6dc48ac654906b48b95107fd",
-   "sha256": "0bl854036zpjg5p5asamvlnl9lf46rgcpa645yhrvxqmwznm6din"
+   "commit": "070abb16620653fb343980fb85a13c4d55e1070b",
+   "sha256": "0pcr471snnmhycvvgczs1gbil45w6lf1bdmg7w19vh2a0dq4pqi9"
   },
   "stable": {
    "version": [
@@ -32398,11 +32413,11 @@
   "repo": "magnars/expand-region.el",
   "unstable": {
    "version": [
-    20210624,
-    1015
+    20210708,
+    1952
    ],
-   "commit": "519e92eabc470fe1792d8d4a37c98e76cf195840",
-   "sha256": "0rh5li9i6nz81mbji87dnv5ly58rl5lphlvjx4m0hb7dlqpw0db2"
+   "commit": "95a773bd8f557cbd43d3b2dab2fa4417ec5927ab",
+   "sha256": "05zdh71zkp2n740dcixanw9cziw93rkix2bb24vw9phkj271m0d7"
   },
   "stable": {
    "version": [
@@ -32916,14 +32931,14 @@
   "url": "https://git.sr.ht/~pkal/face-shift",
   "unstable": {
    "version": [
-    20190818,
-    1551
+    20210707,
+    1127
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "8c62d7a27a0e3092942742362ed73e17e254e904",
-   "sha256": "028b3j7rp4z78285r8w4db8dx9j6zlqp8aw4y0pvd4ifqbs5wh05"
+   "commit": "0170ab2993211eb0f514f7d1ce14e8194a11f6b2",
+   "sha256": "0zj9h3nmswpc7q02a76rrzw3ypjwn1lwq5mkm6s28q0xrdpmrgq3"
   },
   "stable": {
    "version": [
@@ -33463,11 +33478,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20210624,
-    1431
+    20210713,
+    2129
    ],
-   "commit": "f37a3de72c6cbf37f82d4b2f37d9009af5058099",
-   "sha256": "1qnmcysrl2zxiid4v1h1hq1nax3a7sxs2dmag54sfifm149lf7f3"
+   "commit": "0f83112e70c1cd13a8b98e9e75b2291fcdf3d57f",
+   "sha256": "1n1f9bn8447aq3666q9lj7idzj9nwkmknfzybk3is98m03cjki3z"
   },
   "stable": {
    "version": [
@@ -33509,8 +33524,8 @@
     "f",
     "s"
    ],
-   "commit": "164fb15d70adbc186eb2d987f5c5143aa7336659",
-   "sha256": "0i6r2mlpahrnszr9vk476iqvc1c8cpp6wn6fhlnz6vw4dybpw5p5"
+   "commit": "142a7a5ecd79b4a3db7ce3dfdd0d87ceeedab468",
+   "sha256": "1lmfnc5nljghqapciaqrvmj177v3m1ybndf7mjj74d6n41gphwcj"
   },
   "stable": {
    "version": [
@@ -33678,11 +33693,11 @@
   "repo": "jcs-elpa/fill-page",
   "unstable": {
    "version": [
-    20201105,
-    452
+    20210707,
+    354
    ],
-   "commit": "95f82f93848ca608d4c4d9ec7386d94745cbc691",
-   "sha256": "10kgaq1da5zgz2dzagw2fc5hlh4ik5z6vyfw0lqd7bqpjfg62kgr"
+   "commit": "cad66696f334f70adf2b8bdf9910852c017dbdd0",
+   "sha256": "0jg7gppjf39qzwb44n1q7bikhqvxs5hr4yd403v7apf75z0hpc3m"
   },
   "stable": {
    "version": [
@@ -33957,11 +33972,11 @@
   "repo": "jming422/fira-code-mode",
   "unstable": {
    "version": [
-    20210621,
-    1933
+    20210702,
+    1631
    ],
-   "commit": "85e0eba018bca70040faea19996b43ce8e543cad",
-   "sha256": "1mv0gphbp976ncfif2jbfrmkayh0lp5cjqmiimhw1inw7ps18k5r"
+   "commit": "eaff81f867d9c84e25891368f3d0cac7513984e8",
+   "sha256": "0gc77fkc6jczb52f5hil3h0hv74f7cxbijc8mjprh7zzgb09b6za"
   }
  },
  {
@@ -34178,19 +34193,19 @@
   "repo": "jonnay/fix-muscle-memory",
   "unstable": {
    "version": [
-    20160823,
-    439
+    20210702,
+    1755
    ],
-   "commit": "a123e04f8a1d2982cbf930efb909cad9522ac884",
-   "sha256": "0mm6dl7017x5l43jf89w4nn5hcyi4fm160d2rcqx5w6dwb6f0v27"
+   "commit": "b8d4b8025d758762f4459c70c3a7a209ead865ed",
+   "sha256": "0g3rg7bg256ymkby33nd5yhaf24216ghhkwvcz1vl54yzyfv8w2x"
   },
   "stable": {
    "version": [
     0,
-    93
+    94
    ],
-   "commit": "df687aea23c6eac4b751f993893c2fd56e5a8a3b",
-   "sha256": "02nl4vz6fnbjc7w1lk1y9z0qw5bsxr407ww0b2wqw6h8spmcpcrc"
+   "commit": "b8d4b8025d758762f4459c70c3a7a209ead865ed",
+   "sha256": "0g3rg7bg256ymkby33nd5yhaf24216ghhkwvcz1vl54yzyfv8w2x"
   }
  },
  {
@@ -34331,19 +34346,19 @@
   "repo": "Asalle/flatbuffers-mode",
   "unstable": {
    "version": [
-    20200822,
-    957
+    20210710,
+    1004
    ],
-   "commit": "c0e9dc220db5f08410f40becf03531938484cb6c",
-   "sha256": "0dahs0q004pgalxrll1f8995q1ws358fk87a1jkm3fazl97p7gx4"
+   "commit": "8e7783db45a64c9456130fd0c108ac12d45a7789",
+   "sha256": "1g446s8xhgcrkqhl08d6l68gga6n3c3hdk4z3bazglfwycynhpp9"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
-   "commit": "1b563b450e5353797083bcb03ab02f456e9a7361",
-   "sha256": "17g7y2nzhdwzck63miks4kn2w1nlari0qkc5v6lc4ksiaacispfb"
+   "commit": "8e7783db45a64c9456130fd0c108ac12d45a7789",
+   "sha256": "1g446s8xhgcrkqhl08d6l68gga6n3c3hdk4z3bazglfwycynhpp9"
   }
  },
  {
@@ -34701,14 +34716,14 @@
   "repo": "defaultxr/fluxus-mode",
   "unstable": {
    "version": [
-    20191001,
-    1716
+    20210715,
+    58
    ],
    "deps": [
     "osc"
    ],
-   "commit": "3d05fa15f141ac3e936f908097bb7eb6295cc367",
-   "sha256": "0axjlvhv3xwg16zkpskqp9kvb1x513jl329pmrjzazn5mdh2m8cw"
+   "commit": "a14578640c578a4fd09cb7e25da1e87d637719ae",
+   "sha256": "1k7jiagsbydr3vqb2r47dh3hp3g94vpfwpc3ds9lv6shv3h669d5"
   }
  },
  {
@@ -34800,8 +34815,8 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20210321,
-    852
+    20210708,
+    1337
    ],
    "deps": [
     "dash",
@@ -34809,8 +34824,8 @@
     "pkg-info",
     "seq"
    ],
-   "commit": "f8c679fff349850c80541a31de50009c3c15d4c9",
-   "sha256": "0v0zyq7zn89j036sp8ijxwpb0n435sf444ki618y7mv77k2qflxx"
+   "commit": "21d52264aa80bfa4ede94c59e37a20fb6d033b0c",
+   "sha256": "1k2fqiy0aw30za8d8bhia996ab168j61m8h1s9zi7d5y32q1csnh"
   },
   "stable": {
    "version": [
@@ -35768,14 +35783,14 @@
   "url": "https://git.umaneti.net/flycheck-grammalecte/",
   "unstable": {
    "version": [
-    20210627,
-    1018
+    20210705,
+    1656
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "8f13de89134e9708b2a24a040a0335a7302632f9",
-   "sha256": "1acwvndq604gl5n3985mj5v70vcl3d12vh6bzs5nz5xyr8c848z7"
+   "commit": "061ce63d217b7cd165c487d81331843dea5bc11c",
+   "sha256": "088g4vi01xanjm5dyzlw483h8w3dyijjccla37zfa55cg0nksdd3"
   },
   "stable": {
    "version": [
@@ -35804,8 +35819,8 @@
     "flycheck",
     "grammarly"
    ],
-   "commit": "8321fc98a0809cad17e37ca924d364423c37b8c0",
-   "sha256": "1pga651wnvw3czqshn731nx0cdaf157v7v1c5n7kh95lc2r3jmn3"
+   "commit": "abab9e6fadccd6e239f3f7efd91b155c9d5cd716",
+   "sha256": "1y6v3d4xnlfqcvl5hc4b0y6san1mnf2mx6hcvlbxdphhf12hp560"
   },
   "stable": {
    "version": [
@@ -36224,14 +36239,14 @@
   "repo": "emacs-languagetool/flycheck-languagetool",
   "unstable": {
    "version": [
-    20210629,
-    536
+    20210715,
+    946
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "6ade9d7f294cee7e41d0bce9dddb139c49985501",
-   "sha256": "1yq2n7bknw7by1cn53xn7kz8a3qj1w7szsjysaj93mhxb154g9qz"
+   "commit": "c4a1dd0b23b8b25ba706eed48ae7d3e97bf4f349",
+   "sha256": "1zcp9brh9cygga0yflw4saf7bf503ll1l4nmhf79h039xm7p3rcz"
   },
   "stable": {
    "version": [
@@ -36583,28 +36598,28 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20210617,
-    2237
+    20210714,
+    1805
    ],
    "deps": [
     "flycheck",
     "phpstan"
    ],
-   "commit": "56617fa87c9bec037d4e4a0a143b7d70a989c082",
-   "sha256": "02k4pmmxq3h8mi0dsjh0s0002gjkpg6g9pxsnxgalwb6rakfirbh"
+   "commit": "0869b152f82a76138daa53e953285936b9d558bd",
+   "sha256": "1xm5i658pf1lb4bfpy6zy5msanhia8r9j7v7rx72amkksja3hwnj"
   },
   "stable": {
    "version": [
     0,
-    5,
+    6,
     0
    ],
    "deps": [
     "flycheck",
     "phpstan"
    ],
-   "commit": "bf9e82a63f2ccb12af02c9e79a83e7989eeb7cb1",
-   "sha256": "15kv5xv6lcfgf048wr2zsnpvrplbxypy3wq56zvrzbq18hwprqg1"
+   "commit": "0869b152f82a76138daa53e953285936b9d558bd",
+   "sha256": "1xm5i658pf1lb4bfpy6zy5msanhia8r9j7v7rx72amkksja3hwnj"
   }
  },
  {
@@ -37728,8 +37743,8 @@
    "deps": [
     "grammarly"
    ],
-   "commit": "bc7c7e74013816ea06463ff85627bdc08ad60d9a",
-   "sha256": "0yj0mqyg0c87kvxz21y0wmfx97lwvym6qm3sdppgkff5fwppyj91"
+   "commit": "06ba82495614f1dfaffb8894f57789156586448c",
+   "sha256": "1lc3nv7km5m19l673agh9rxv9afllf7sz4sv0brgp1sbmks1il3b"
   },
   "stable": {
    "version": [
@@ -37981,8 +37996,8 @@
    "deps": [
     "s"
    ],
-   "commit": "5e44d7ba7153d20a01428bff98c1949a7a0eb753",
-   "sha256": "19149wr4plng3n1bpfd49ja1phd3sbyrxa6vk47qh8xc7x1ra309"
+   "commit": "5c93f538978f2d272e5210b27f5255ee87b6b61f",
+   "sha256": "1awd69ns238ia27k2njlx65gkyscxzayyyx777rbmy6g259bndzq"
   },
   "stable": {
    "version": [
@@ -38186,26 +38201,26 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20210617,
-    2223
+    20210714,
+    1805
    ],
    "deps": [
     "phpstan"
    ],
-   "commit": "56617fa87c9bec037d4e4a0a143b7d70a989c082",
-   "sha256": "02k4pmmxq3h8mi0dsjh0s0002gjkpg6g9pxsnxgalwb6rakfirbh"
+   "commit": "0869b152f82a76138daa53e953285936b9d558bd",
+   "sha256": "1xm5i658pf1lb4bfpy6zy5msanhia8r9j7v7rx72amkksja3hwnj"
   },
   "stable": {
    "version": [
     0,
-    5,
+    6,
     0
    ],
    "deps": [
     "phpstan"
    ],
-   "commit": "bf9e82a63f2ccb12af02c9e79a83e7989eeb7cb1",
-   "sha256": "15kv5xv6lcfgf048wr2zsnpvrplbxypy3wq56zvrzbq18hwprqg1"
+   "commit": "0869b152f82a76138daa53e953285936b9d558bd",
+   "sha256": "1xm5i658pf1lb4bfpy6zy5msanhia8r9j7v7rx72amkksja3hwnj"
   }
  },
  {
@@ -39121,8 +39136,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20210628,
-    736
+    20210716,
+    1447
    ],
    "deps": [
     "closql",
@@ -39135,8 +39150,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "84ef3a7bad5879a2dd179a94655ac0da28be3898",
-   "sha256": "0mp1jwc0ms6d15l3vw0zg35l68q58bk5bj8w5znjvwjh3akybfpm"
+   "commit": "49da45ac4515d7442ebd606f4ad4922a3e1439ff",
+   "sha256": "1vqhxckmkfbkvpnsigdb1625b5n0fpry2hxkympqnxspcccnijks"
   },
   "stable": {
    "version": [
@@ -39190,15 +39205,15 @@
   "repo": "lassik/emacs-format-all-the-code",
   "unstable": {
    "version": [
-    20210619,
-    533
+    20210708,
+    1728
    ],
    "deps": [
     "inheritenv",
     "language-id"
    ],
-   "commit": "6a3463a723e08a37bae85a7585700ab314ae86ea",
-   "sha256": "10aa5jh4ba4bhghwb8mi6my1dazbvxlylk3gcxji47qj0z78fajh"
+   "commit": "d60a763eaf716d17bf6b8dbff1cc8f54337bfeab",
+   "sha256": "12gvyr73ab6x4p5iadxdi61d3hwwfbxd9wm6vkja92glyqs2vvbf"
   },
   "stable": {
    "version": [
@@ -39341,8 +39356,8 @@
    "deps": [
     "seq"
    ],
-   "commit": "91f4ad083fa620e6e6202460decc3280bd8e4e71",
-   "sha256": "0xlg5b0sa4qbv68sza23fr5khv36860jbhzfbcqcw1d420xllryx"
+   "commit": "ede8a254fe1bfb125b52ea71252b863cf80eee18",
+   "sha256": "0s2qlnx5lq5ni53r0i4fja6qfxxbg6apq5madgkiyz5d1bay551g"
   },
   "stable": {
    "version": [
@@ -39959,8 +39974,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "b989a860d1d6191bb9c5911ac77ed0931424eaeb",
-   "sha256": "1w0hyfspi3kahj2lk1bzj3ny3r8bb0cj4yfjizzbfc1pz9dlkpkp"
+   "commit": "5b1c814d84714b0c94c5a7b4aeb3f44d2a4d5998",
+   "sha256": "1sw7abwli4hjwbyqmkc8vfg4sgil59gkygvk3f4p6gdihnfqynwp"
   },
   "stable": {
    "version": [
@@ -40698,8 +40713,8 @@
   "repo": "emacs-geiser/gauche",
   "unstable": {
    "version": [
-    20200802,
-    1300
+    20200801,
+    2337
    ],
    "deps": [
     "geiser"
@@ -41652,30 +41667,30 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210701,
-    1554
+    20210702,
+    822
    ],
    "deps": [
     "dash",
     "transient",
     "with-editor"
    ],
-   "commit": "2ae376e4923e02355828350b81cdc1b0f8fa72ff",
-   "sha256": "1h07rg0fvr7av69bcks1n63digafq145mlsaddyv6xixxqjp0vbg"
+   "commit": "bf9cc19a3287f6a3cc5c1836312f0d18b38b6e45",
+   "sha256": "0zjcvhjp4c01ibb1hshpqkib7fvjkmvh9xf06qfsm5ybdc04xik5"
   },
   "stable": {
    "version": [
     3,
-    0,
-    0
+    1,
+    1
    ],
    "deps": [
     "dash",
     "transient",
     "with-editor"
    ],
-   "commit": "c3bbc9b9425f3370690cabb11bd35b9040773fdc",
-   "sha256": "0dbp3gx43ipxv8zg9m0hfhksz85rnkikaq35rx705qqz6xq6xq9m"
+   "commit": "143d95cced1ee793106d16da3a182dcc2dd01e88",
+   "sha256": "0sn4iiicmqfqmvi7zwii6qdp35k09kqn36rpalv0w1i4jcm6j9kk"
   }
  },
  {
@@ -41755,11 +41770,11 @@
   "repo": "emacsorphanage/git-gutter",
   "unstable": {
    "version": [
-    20210511,
-    427
+    20210703,
+    1007
    ],
-   "commit": "d050abdd7f5a46c9cfbec2953d2fca90095e2857",
-   "sha256": "1bx44spbhags7d2jjfcvanian36vkw1cw186zy7vl2nqwf9hfa95"
+   "commit": "35aa068bc2bd6ad8b0070d9f3948d30b76c2e939",
+   "sha256": "020hnz41hwwr7kr2d1cs8vhlzn2i8p1hvd8v9z79v7a54f7573b9"
   },
   "stable": {
    "version": [
@@ -42833,16 +42848,16 @@
   "url": "https://git.launchpad.net/global-tags.el",
   "unstable": {
    "version": [
-    20210225,
-    1553
+    20210707,
+    1954
    ],
    "deps": [
     "async",
     "ht",
     "project"
    ],
-   "commit": "344d084ec5ff6c99b31c5ea57e5352c85b57ae26",
-   "sha256": "0x8m3srxhy0bdl6wqvi7m3q9jai73m5bavij1jwqhr3pc2caxzxm"
+   "commit": "06db25d91cc8bfb5e24e02adc04de1226c7e742d",
+   "sha256": "1q30cbqq0h1gfwlcbnx9s930li7w7a0y8sx2ivbvvyyc2j5gsk4j"
   },
   "stable": {
    "version": [
@@ -43979,8 +43994,8 @@
     20210102,
     515
    ],
-   "commit": "fcbd45f78b85500f66f323bd19994941832c28d1",
-   "sha256": "1akrm884nbqjf4l5667cfdxn8xawb2fkri40hv7k8w0pl9cjbamx"
+   "commit": "1d7d647bb53a49fce03486eba90e97ccf35cf85a",
+   "sha256": "14ysgyg1cqn83ly6fkwpq7ysibz9pgwcmn9x6lzk38ynkwdwjyz2"
   },
   "stable": {
    "version": [
@@ -44161,20 +44176,20 @@
   "repo": "io12/good-scroll.el",
   "unstable": {
    "version": [
-    20210613,
-    206
+    20210712,
+    1206
    ],
-   "commit": "26a1b958bbf2c45d86f033e58b74edd196302f23",
-   "sha256": "0g4fzji614aqy3kw9iivlmw5v8igql0lkrzvgffrd01jn57dzlwp"
+   "commit": "fac87dd390ad2aabe48afaef950f7a2d9b3ce283",
+   "sha256": "0kmiv013aqc4ayap39xlx7swrx2m8m12dzpvy2fa035aaj42ylvr"
   },
   "stable": {
    "version": [
-    1,
-    1,
-    4
+    2,
+    0,
+    0
    ],
-   "commit": "4ca86e18c8f64fd7a2d088a591ac11773d6b06a7",
-   "sha256": "0bq229nnwp8cy33gizp75wi3x11wn46p73v1581srm2f1zmkapsj"
+   "commit": "fac87dd390ad2aabe48afaef950f7a2d9b3ce283",
+   "sha256": "0kmiv013aqc4ayap39xlx7swrx2m8m12dzpvy2fa035aaj42ylvr"
   }
  },
  {
@@ -44203,8 +44218,8 @@
     20180130,
     1736
    ],
-   "commit": "9c8784ded344f6a35d1e1550385002f613a0c788",
-   "sha256": "1n1pk876yicv9hvwmja3hs6i7s25nv626p3gxsp9278yb933ml2m"
+   "commit": "4044bbd5ca4434b8cecd23a4da8ae173c1e0d58e",
+   "sha256": "0nym4c4j0awxzpj2qkds1fxppc7jzzazwj0j8qx6vr5yfp7iry51"
   }
  },
  {
@@ -44446,8 +44461,8 @@
     20210323,
     332
    ],
-   "commit": "6ab5128c028aac3ae070ba8df041b8039487253a",
-   "sha256": "0d8dihhl7cn3afwhn09drymm7c5hsf8v2m6rvpq5z7nkskkjw80v"
+   "commit": "1ed2df72f495784a2eccbe61de5f1b01b854fbea",
+   "sha256": "0hr6yhsr2x745i1q9sywvgr8xwvnpc05lr3zi84gci0frlab92d9"
   },
   "stable": {
    "version": [
@@ -44533,8 +44548,8 @@
     20210323,
     422
    ],
-   "commit": "c83688ea95b4308145555fea50e953a26d67b1b2",
-   "sha256": "0hi4jikr5hk4v28790mw1rj1myvr1pwldy7wh3n8bajhqdhbr59v"
+   "commit": "4cef6cab89eab5906330412efee6a3d9564f6e14",
+   "sha256": "02hywgvy9d0mhan595jgc2x6vqy428hi9ha9zybiz1hl2394xila"
   },
   "stable": {
    "version": [
@@ -44563,8 +44578,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "93851bd6e14df055d86661de494119e6bacb2192",
-   "sha256": "0bb5zbyr0xsf4p3440n5x2f3h10ya76vwr3jq10j0ff0x4fxs6iy"
+   "commit": "7822b34eb5d359ddae2f93d356c78c5ea05784d5",
+   "sha256": "0qkznd0a6cc32mwnmsa28lr8zji2nsi87kzcn467hq542zr61nz6"
   },
   "stable": {
    "version": [
@@ -44798,8 +44813,8 @@
     "s",
     "websocket"
    ],
-   "commit": "175e68d7ce9fd4c44d1eb808954cf0ba66b59599",
-   "sha256": "1ylynb295p5c26ayb8kdxqfbj9z61vinnd6bdlwsynr1wncbwyy4"
+   "commit": "46e802631a136cf356f5563005c9f9f5dedd09ed",
+   "sha256": "01vw411ngj325q1irhkx3fmf7g0mh99yrc72cxz3275mnc0dpdpj"
   },
   "stable": {
    "version": [
@@ -45211,8 +45226,8 @@
     20210609,
     1305
    ],
-   "commit": "0ef2a3566f76e1c03ec64ac64cbb916530e40e32",
-   "sha256": "1p15b41bdzg8819hnq6js62486mwdqcwxns5mnqb21bn6m7pizpm"
+   "commit": "c0ca78990395245e5f742166047b04eeff63cf6a",
+   "sha256": "1pyi6l08j19d30dk66ign0gpjh9wv1l42jnbsapb5migghas558z"
   },
   "stable": {
    "version": [
@@ -46475,8 +46490,8 @@
     20210108,
     1835
    ],
-   "commit": "fb3f3c9514e652f8955a67baeae13de264996860",
-   "sha256": "05kaxcazbr51chcmlx0fscwk32blj3lzndkr0qpbwfrn8n6mcmrg"
+   "commit": "6057c05154464bfb88d2ba119cdc8d4c7e767541",
+   "sha256": "0z1lpsvmkcxs3gcxkmi1vjgfa7wdfa42cp2i9rl2i17jq34j37yb"
   },
   "stable": {
    "version": [
@@ -46615,16 +46630,16 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210701,
-    637
+    20210714,
+    1600
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "e74f450eaa4f197f1fa63a819193bc1c65984042",
-   "sha256": "1xl9wn520gnpyyryf7iij8y1x5ak61zcira6g480sqvv2ympmhkd"
+   "commit": "60db46905443c87f324440202bd0735d57c5c201",
+   "sha256": "10rkyy63vqqf9s4i8rs409d22iwhxrhz3qikagmfyvvr1n6czcnp"
   },
   "stable": {
    "version": [
@@ -46718,14 +46733,14 @@
   "repo": "emacsorphanage/helm-ag",
   "unstable": {
    "version": [
-    20210305,
-    334
+    20210702,
+    845
    ],
    "deps": [
     "helm"
    ],
-   "commit": "51e164b4bb1a9826fe8b39c0d02b4064c9352b9f",
-   "sha256": "0371s2y06pipjn0ka8c1a0r6g8migz5sbm8hqqilng1cr1dm3x7a"
+   "commit": "7cfed5d3e861717466ae6d3f76c759548a9fad04",
+   "sha256": "0j1l9ifssd2xmdiif0c922dsdii143kjp8ifygqigb9m4wbsz8ax"
   },
   "stable": {
    "version": [
@@ -47079,15 +47094,15 @@
   "repo": "alphapapa/bufler.el",
   "unstable": {
    "version": [
-    20201216,
-    826
+    20210708,
+    2217
    ],
    "deps": [
     "bufler",
     "helm"
    ],
-   "commit": "097f4349920215bdd829fceabc1afdbba172c32a",
-   "sha256": "1a4y3p7cwygw09b9f9j9m821aiyjiji55mrm83pvv0xzc9rhwd3h"
+   "commit": "d466eac6c4b2ee25c765e7f31e44beb38dd44e4b",
+   "sha256": "00gyqpm0g437z71vbfd4kmih23vh6909dvygng133vxzly9k4f24"
   },
   "stable": {
    "version": [
@@ -47523,14 +47538,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210701,
-    608
+    20210714,
+    1600
    ],
    "deps": [
     "async"
    ],
-   "commit": "e74f450eaa4f197f1fa63a819193bc1c65984042",
-   "sha256": "1xl9wn520gnpyyryf7iij8y1x5ak61zcira6g480sqvv2ympmhkd"
+   "commit": "60db46905443c87f324440202bd0735d57c5c201",
+   "sha256": "10rkyy63vqqf9s4i8rs409d22iwhxrhz3qikagmfyvvr1n6czcnp"
   },
   "stable": {
    "version": [
@@ -48068,8 +48083,8 @@
    "deps": [
     "helm"
    ],
-   "commit": "59adbf2d3c67b174a354f0dd64f647b4391ab8d0",
-   "sha256": "1x2ds29k4wwv406j49nzjkh43scahmrshx4lssqrkc9cay7210nx"
+   "commit": "5d6366adc14c51570374320fa827b0772833a61e",
+   "sha256": "0nrkghnsn83ah0jqbv7fx2i90p1z37lfmh6kwgjkr2aq4ggrcklj"
   },
   "stable": {
    "version": [
@@ -48333,8 +48348,8 @@
     "flx",
     "helm"
    ],
-   "commit": "72d618f95d6531854a60322d88b242825016f8e6",
-   "sha256": "0bpnspq7c3akny8blsp75br11g6fh425v9hxfpwyk8iqs5zwvlb7"
+   "commit": "9d57e4802aacfc50efe4804e45ace16f6931635c",
+   "sha256": "1l2vjksmgp7djxfwp6lyg9vqbsx2snc8h3wnf9pf020p3h4ccy9v"
   },
   "stable": {
    "version": [
@@ -49115,8 +49130,8 @@
   "repo": "julienXX/helm-lobste.rs",
   "unstable": {
    "version": [
-    20150213,
-    1546
+    20150211,
+    2214
    ],
    "deps": [
     "cl-lib",
@@ -49612,8 +49627,8 @@
     "org-ql",
     "s"
    ],
-   "commit": "8342656b2d9af4bb6af9daa0a8b037d3693bd940",
-   "sha256": "0alrs2dsd5k4xjrs2zs7hcr5fbfrr3rdq705s04943ic4kzvhrc9"
+   "commit": "94f9e6f3031b32cf5e2149beca7074807235dcb0",
+   "sha256": "022arhyyn8hbb1hzjkv4gl3dr8lz1gv0x4h70x0970bsbqlsa27w"
   },
   "stable": {
    "version": [
@@ -50500,8 +50515,8 @@
     "s",
     "searcher"
    ],
-   "commit": "181f60cb8505aec05393a9dbf414733d19f76d2a",
-   "sha256": "06bnnbay56ngiddkvvwmy3fv4v2gjss8gm7gjcp2064m9njgw5mx"
+   "commit": "76a8de11e39da5c7a94066bcf3d515cdd23c6f63",
+   "sha256": "1698j6x0vbxfdpdknrzwihr4pwpl1914i3azarmngkh8wnhma26s"
   },
   "stable": {
    "version": [
@@ -50798,14 +50813,14 @@
   "repo": "jamesnvc/helm-switch-shell",
   "unstable": {
    "version": [
-    20210106,
-    1810
+    20210713,
+    1440
    ],
    "deps": [
     "helm"
    ],
-   "commit": "9de26ca41e94c095c978ed920009de0280f5c4ec",
-   "sha256": "190bmn04g4nlcrpnsm465vyp0zcd2ryh13bc14f7w1vrmnw6ll1j"
+   "commit": "8d7ba1d99ff12a8f1d6ce3b9684ae8aebf494cf3",
+   "sha256": "04d7hz7gpbcy4vnmwi605n51angn4xbx6kqqqdb8nqvzh4f0y5g1"
   }
  },
  {
@@ -52117,8 +52132,8 @@
     20200203,
     1927
    ],
-   "commit": "ac1bea7d99dd6965c72fabeb72d5fdc38c5380a4",
-   "sha256": "13pray3iapy6vbd1y1y7fqcnjpsvgfz2z7j1a1awzd8ifp12g9cp"
+   "commit": "852cb4e72c0f78c8dbb2c972bdcb4e7b0108ff4c",
+   "sha256": "031624grhvv5ix3gvnd8lzpws80lb5r272yggl1k57rsayyv55ix"
   }
  },
  {
@@ -52346,16 +52361,16 @@
   "repo": "narendraj9/hledger-mode",
   "unstable": {
    "version": [
-    20201212,
-    2121
+    20210706,
+    1225
    ],
    "deps": [
     "async",
     "htmlize",
     "popup"
    ],
-   "commit": "f1deebb0cbe9ca040856d3cc99942335250d9566",
-   "sha256": "0hnmia3c052php3i2g1sbsp402fgi17yv6as044ck617p7avz971"
+   "commit": "9ac07ff0adbce6a402c17e789b1750f9da0d22f4",
+   "sha256": "0x3dgws8nh7q8x7zzjwbm5k9n7gi7qqd3ww7y51fbx6p6ii3jpp4"
   }
  },
  {
@@ -52740,16 +52755,16 @@
   "repo": "thanhvg/emacs-howdoyou",
   "unstable": {
    "version": [
-    20210217,
-    1723
+    20210707,
+    1513
    ],
    "deps": [
     "org",
     "promise",
     "request"
    ],
-   "commit": "27e9e015b930175896c07536c25e379a4e1997af",
-   "sha256": "14f3fqz8sjmjh7si5gk31fh7bnvc9p1rfd9p2l39zvasvk1sxki0"
+   "commit": "4943a4ef8d242952ade64903a05c13094de2fbf0",
+   "sha256": "1fgg1jcnihx3akp7r0fvwdx71ldl2apbw6xa591f6r5slvh179gn"
   }
  },
  {
@@ -52942,8 +52957,8 @@
     20200929,
     559
    ],
-   "commit": "8cb33f9513d79e44a602927f35d5a3bb0dccbb92",
-   "sha256": "0x72qh6pmaw3dfnx296flbvbm1sxgljz4997jkjwiss2pr7qsgx0"
+   "commit": "97f885a550bed05f2fbdd933718313e6645a6ea1",
+   "sha256": "0b8wz43k64c2ca4kqjlp9zx97hafwmnjc38pa7lyip9yhhnhkkf5"
   },
   "stable": {
    "version": [
@@ -53056,6 +53071,30 @@
    ],
    "commit": "d2de8a676544deed1a5e084631a7799e487dbe55",
    "sha256": "0dd257988bdar9hl2711ch5qshx9jc11fqxcvbrd7rc1va5cshs9"
+  }
+ },
+ {
+  "ename": "huecycle",
+  "commit": "0c73a3a204ffe41f7370ef5d72a02a9e1844ce24",
+  "sha256": "0h4hfy9bw30sij5r3wgpz4sqwh343bwhd207p85kp0v10vnlk62x",
+  "fetcher": "github",
+  "repo": "pnor/huecycle",
+  "unstable": {
+   "version": [
+    20210706,
+    205
+   ],
+   "commit": "c343b2085dea11b820d4da6c6183e1102ec08698",
+   "sha256": "1bdhm9j2dammw5dzr8gh4wg5pkl7c706jqdwd43my7zsn2ipar24"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "c343b2085dea11b820d4da6c6183e1102ec08698",
+   "sha256": "1bdhm9j2dammw5dzr8gh4wg5pkl7c706jqdwd43my7zsn2ipar24"
   }
  },
  {
@@ -54775,8 +54814,8 @@
    "deps": [
     "impatient-mode"
    ],
-   "commit": "60ae30d07b857c074e2918680805cb37249de0ad",
-   "sha256": "0brj34ijgsgkbawp097wjwiaka2b082aypl5pal0298mpk97zxq0"
+   "commit": "bcb636dbef4630c5ae654642c6a637cceb588cac",
+   "sha256": "1nnmx7f256cll04wxwip3a1pll3rayiqx4ynirrm1ld97q8hdc3v"
   },
   "stable": {
    "version": [
@@ -54892,8 +54931,8 @@
     20210508,
     309
    ],
-   "commit": "044291cf063a86927dae50dffdb2b0e2e3f9199b",
-   "sha256": "0hiwq5nzh42f5ynjlhq9vlcgq8pmgcgbi9w5c5gczdl0s7cxv6l7"
+   "commit": "bfacd60a4be68a89d150f0bf2a9fb8714591f6f5",
+   "sha256": "1dxdzvg6bpz0wgj2amqy7q9xl8xi7clsw10d9c86gbq87b9js681"
   },
   "stable": {
    "version": [
@@ -55452,11 +55491,14 @@
   "repo": "emacs-jp/init-loader",
   "unstable": {
    "version": [
-    20200520,
-    2345
+    20210703,
+    902
    ],
-   "commit": "10b8d7b12acbd1036e68dfb59f460714baedaa33",
-   "sha256": "1w7sq9famd4xbh5jk974zzpn6cf1nh2vmbvjvd4fwpjhmnnibqsm"
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "ecab5a66b40227c4173992adfa5cfeae09f1657e",
+   "sha256": "0fkxv7i7jdlj0z5n4hfm8897pfy6jxmk8znpfr9564ay90cp445h"
   },
   "stable": {
    "version": [
@@ -55546,11 +55588,11 @@
   "repo": "ideasman42/emacs-inkpot-theme",
   "unstable": {
    "version": [
-    20210427,
-    1337
+    20210716,
+    58
    ],
-   "commit": "7c3a0a76fa00db41a4d3d990cc98a1c6b088df3d",
-   "sha256": "17x0afwfcr4k0nmliqajswmvaiglk1xl33r3j215w214xp6dqrp2"
+   "commit": "c3683aa99c738eb46cf310ba23162dbb315a5ac5",
+   "sha256": "14k3n5kn9z2lqdhm00qy0hz8synnv28i17gn518ps4cyk298dmby"
   }
  },
  {
@@ -55665,11 +55707,11 @@
   "url": "https://git.sr.ht/~pkal/insert-kaomoji",
   "unstable": {
    "version": [
-    20210618,
-    2249
+    20210707,
+    1126
    ],
-   "commit": "25b74d527cef00f6a49985161a8caaf62faa887c",
-   "sha256": "1qqxw67fbpix290jjrfai6z33fsyzb3zy1nwzk6mjss151586f5n"
+   "commit": "e818845a99d418e04c1685f06fe25116916f6168",
+   "sha256": "0acyzysz04sd3rahymw6x3a8zy57sy84d36zp6prd62y4w0sw361"
   },
   "stable": {
    "version": [
@@ -55854,8 +55896,8 @@
   "repo": "dcjohnson/inverse-acme-theme",
   "unstable": {
    "version": [
-    20210204,
-    1640
+    20170615,
+    1337
    ],
    "deps": [
     "autothemer",
@@ -56136,14 +56178,14 @@
   "repo": "jcs-elpa/isearch-project",
   "unstable": {
    "version": [
-    20200907,
-    1453
+    20210715,
+    1041
    ],
    "deps": [
     "f"
    ],
-   "commit": "1077b395e1c34a734120faf1f3a7feae6dc4d9c5",
-   "sha256": "1zdlk6s0j0825wy2blpxhsg5pxaybk5adxxpjvm6jj9r612xyn73"
+   "commit": "796e4e9a2508120ae430f522115c7d174d912276",
+   "sha256": "0wlh2ph87qa3i3n7j2mvih428ih65gqj0bzqwqw123cfflcz6xy2"
   },
   "stable": {
    "version": [
@@ -56378,8 +56420,8 @@
     20210602,
     1349
    ],
-   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
-   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
+   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
+   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
   },
   "stable": {
    "version": [
@@ -56406,8 +56448,8 @@
     "avy",
     "ivy"
    ],
-   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
-   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
+   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
+   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
   },
   "stable": {
    "version": [
@@ -56509,16 +56551,16 @@
   "repo": "jixiuf/ivy-dired-history",
   "unstable": {
    "version": [
-    20210418,
-    1444
+    20210715,
+    48
    ],
    "deps": [
     "cl-lib",
     "counsel",
     "ivy"
    ],
-   "commit": "1ffa9b705c52a9d5b03c97150addb4f746c08380",
-   "sha256": "1li8vh94w1mkwqbh1f0i1mmv5advrbh1183vpjc2zbmmk02pynkf"
+   "commit": "dba848929cb063a5536cb442c70be1099e2f5baa",
+   "sha256": "1fkw82am49j49s0s3ql22hl9i2imypb0xkrmsgc7sr2hfsim56sd"
   },
   "stable": {
    "version": [
@@ -56653,8 +56695,8 @@
     "ivy",
     "s"
    ],
-   "commit": "b237ee8e9fd2fd1b52254ef84cd06a0bb6c10a24",
-   "sha256": "0bimn8j3md579sg7bypsynmjnq1mlmmslci1k98sc8kfnky8260c"
+   "commit": "3ad203f6166f82c7a09ab4ad065fd40136915fb8",
+   "sha256": "07mdv0cnrjys0lcxamwpg5xl0g7wb0mgnzbkqyaik559avp5kq5a"
   },
   "stable": {
    "version": [
@@ -56747,16 +56789,16 @@
   "repo": "PythonNut/historian.el",
   "unstable": {
    "version": [
-    20190111,
-    313
+    20210714,
+    56
    ],
    "deps": [
     "flx",
     "historian",
     "ivy"
    ],
-   "commit": "ac1bea7d99dd6965c72fabeb72d5fdc38c5380a4",
-   "sha256": "13pray3iapy6vbd1y1y7fqcnjpsvgfz2z7j1a1awzd8ifp12g9cp"
+   "commit": "852cb4e72c0f78c8dbb2c972bdcb4e7b0108ff4c",
+   "sha256": "031624grhvv5ix3gvnd8lzpws80lb5r272yggl1k57rsayyv55ix"
   }
  },
  {
@@ -56774,8 +56816,8 @@
     "hydra",
     "ivy"
    ],
-   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
-   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
+   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
+   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
   },
   "stable": {
    "version": [
@@ -57107,8 +57149,8 @@
     "s",
     "searcher"
    ],
-   "commit": "3a2f5073a0d5842a6b3c386e70cc484e3c4ea77b",
-   "sha256": "1bk8kaxqq1m76x1i4hy3jqcy05pr6dlzjd4dbyi8lrx9sxnfrnkk"
+   "commit": "84faba3cd87374f54d5e27344d4812737375fbaa",
+   "sha256": "1lxiamv0960j1sfs9afqbdkp7mjkdbi1nw1nh5w8q3m9a44c1h89"
   },
   "stable": {
    "version": [
@@ -58493,14 +58535,14 @@
   "repo": "mooz/js2-mode",
   "unstable": {
    "version": [
-    20210622,
-    102
+    20210712,
+    202
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4eaf98e3cc3789381a37a05cd70a248db9ac8c1b",
-   "sha256": "0mlp1pbph3790lvg5j6cdaffhb9ly8jdl00lmffs14840b8prkf3"
+   "commit": "6f313c9566d9c8453a91c5ccaa25760978cb9f6d",
+   "sha256": "09fxg0ljv2g9rv7n67km7q64w49fcl0gngm68m252nyvk2x28b08"
   },
   "stable": {
    "version": [
@@ -59014,8 +59056,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20210624,
-    547
+    20210715,
+    1359
    ],
    "deps": [
     "dash",
@@ -59024,8 +59066,8 @@
     "spinner",
     "vterm"
    ],
-   "commit": "47f1b125f8364a0aa8c072fdc7b4007aad5c0724",
-   "sha256": "12lqc5yysjzf0vypjcs2mnsv6frhwyfm950rcsbwkwz3lvfnrajn"
+   "commit": "a71a536fc1f194bc329e2c33eed5eab542c00cab",
+   "sha256": "0cnhv37m8hcl3lfbiivy3yk338x60q8fglm5nibhfr55ln52jjc4"
   },
   "stable": {
    "version": [
@@ -59714,11 +59756,11 @@
   "repo": "ifosch/keepass-mode",
   "unstable": {
    "version": [
-    20210110,
-    630
+    20210628,
+    729
    ],
-   "commit": "515343a7667b2bf4253309449f65a6eb94933df7",
-   "sha256": "0hrq521swki0l3m81wk9p7pkc5j99li441fb75h7107v6z0p102c"
+   "commit": "fd7d380b762c888f25435d0c241012cdabf6e288",
+   "sha256": "1623hqlyk7qlvb5kigkyiji98a2vp39y0v6smag2mnqa3r89jq7l"
   },
   "stable": {
    "version": [
@@ -60165,8 +60207,8 @@
     20210523,
     403
    ],
-   "commit": "8d2a5ec4a7fe766a62037b05f26a8f36fff45c06",
-   "sha256": "1rszkzpr22dy9yr54k2pz6p2j6lbgvy189f6ki8gmlsqzdyxmssk"
+   "commit": "075b05b6ed7fe1b9f4f22544bc26749243de6808",
+   "sha256": "01qwcr65qzz0ilzj9318hnz9hs3gdd722xpajmp8sa1520w9vhzm"
   },
   "stable": {
    "version": [
@@ -60748,16 +60790,16 @@
   "repo": "kubernetes-el/kubernetes-el",
   "unstable": {
    "version": [
-    20210630,
-    612
+    20210714,
+    1307
    ],
    "deps": [
     "dash",
-    "magit",
-    "magit-popup"
+    "magit-popup",
+    "magit-section"
    ],
-   "commit": "d8034e6ddd668d2f7d34b6aa7bd19e2a575b609f",
-   "sha256": "1hp760wqwzflpnqrha1qnrbilr3qynd1dma00jyrhq76hdb83xwv"
+   "commit": "ffdae05d4d0e83be5c6884326b69a8ca83f2ae2b",
+   "sha256": "1fjrl2w3gp5mbdg6mkw23h9zfn2h8rdmxgyw80p0jpm0b31yq1i0"
   },
   "stable": {
    "version": [
@@ -60789,8 +60831,8 @@
     "evil",
     "kubernetes"
    ],
-   "commit": "d8034e6ddd668d2f7d34b6aa7bd19e2a575b609f",
-   "sha256": "1hp760wqwzflpnqrha1qnrbilr3qynd1dma00jyrhq76hdb83xwv"
+   "commit": "ffdae05d4d0e83be5c6884326b69a8ca83f2ae2b",
+   "sha256": "1fjrl2w3gp5mbdg6mkw23h9zfn2h8rdmxgyw80p0jpm0b31yq1i0"
   },
   "stable": {
    "version": [
@@ -60910,14 +60952,14 @@
   "url": "https://git.sr.ht/~tarsius/l",
   "unstable": {
    "version": [
-    20210214,
-    1130
+    20210705,
+    2113
    ],
    "deps": [
     "seq"
    ],
-   "commit": "518203abc6cee13c73c2d91282354ed59f00f15e",
-   "sha256": "1s3fndzjhz0xvbhdb0y7raa7zqrpws1xm79blgfcxcrv2fbmbzan"
+   "commit": "02b1afad2c5649221abada2d938ef3736e020a96",
+   "sha256": "0idzyx6pxn8s78my9b4qjxz6561w6bzjvbp3yv267piyjgvwnzpc"
   },
   "stable": {
    "version": [
@@ -61050,8 +61092,8 @@
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "56f808edfd0983c0df2ed1c957c50c02af5faad3",
-   "sha256": "05fyx88wmyc4c6lcy5qphg6zhbfmlnpy7y23l00qfi5k9hmv99hm"
+   "commit": "138e6794122f8601e58731a365930bd7cf5791ea",
+   "sha256": "0zj3i612h0sih7lyy4zvzldcrgqmsqcvr4y42zv75r81s0l6gddz"
   }
  },
  {
@@ -61176,25 +61218,25 @@
   "repo": "lassik/emacs-language-id",
   "unstable": {
    "version": [
-    20210618,
-    1532
+    20210708,
+    1719
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7db7ba27d2abf8891d40dc952c22d3a3654d9bbc",
-   "sha256": "11wzyv6jdprppjqygszl30hkxydjlhk7fdvda6h37k6dlk1fh1wp"
+   "commit": "5ac941a38b193d680df6bb9e96b0508a33bb3133",
+   "sha256": "0vxvlvw6zmr2cn6vhci22yyn77n22pr2r4wmscm8j4693kdcqbdj"
   },
   "stable": {
    "version": [
     0,
-    13
+    14
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7db7ba27d2abf8891d40dc952c22d3a3654d9bbc",
-   "sha256": "11wzyv6jdprppjqygszl30hkxydjlhk7fdvda6h37k6dlk1fh1wp"
+   "commit": "5ac941a38b193d680df6bb9e96b0508a33bb3133",
+   "sha256": "0vxvlvw6zmr2cn6vhci22yyn77n22pr2r4wmscm8j4693kdcqbdj"
   }
  },
  {
@@ -61620,14 +61662,14 @@
   "repo": "conao3/leaf-keywords.el",
   "unstable": {
    "version": [
-    20210222,
-    1243
+    20210711,
+    156
    ],
    "deps": [
     "leaf"
    ],
-   "commit": "4146621f4ae80ef0c30160337119441c1f6334b6",
-   "sha256": "16iv1cvlky2gij1ndx2d6q8l35axm72bx52n6v5y3h21aibj197n"
+   "commit": "f46311f8e7e5ce0d5af928fea99111b3c86de7ce",
+   "sha256": "1qlg6n5yaagq97x3c2r58pcblk0gz4bysg3cgm5iq3sq9lpf3h2n"
   },
   "stable": {
    "version": [
@@ -61866,8 +61908,8 @@
     "log4e",
     "spinner"
    ],
-   "commit": "aeba19919e6d8f1c0529330572240143a2af38e0",
-   "sha256": "0yfghps19832w4sdjaglnbb9xn40fc5a6072lxbsw8gan9c2bjh7"
+   "commit": "7ef1dffd44be9bba6450953d25ff787e122afc69",
+   "sha256": "15gfyx53m02andalyicnvs7b3v59zq64r0jmmgkg6gy5za6c0hsd"
   },
   "stable": {
    "version": [
@@ -62211,8 +62253,8 @@
   "repo": "merrickluo/liberime",
   "unstable": {
    "version": [
-    20210526,
-    623
+    20200915,
+    542
    ],
    "commit": "4a6da0f6ab9b43651f3fcc73412e3480b9403caa",
    "sha256": "04ag7icqqdhz40fi91fx4bxx8j6vw2774gw1fbppbks3sasimyy0"
@@ -62336,8 +62378,8 @@
    "deps": [
     "request"
    ],
-   "commit": "ef80eff8b7be117f9c48bdc6d9a62e56b0a93554",
-   "sha256": "1z6qd4bcpwdpvi6w9yrkrnk2ypllhm6k4zjl8v1p8k0j93dbn3ny"
+   "commit": "bfd5ef11f26ba46c8e0894ea08ffec74cca72288",
+   "sha256": "1x02lwplyd41qaxy27np2fza818p0h62np6kd9sqqxkng4ahy97z"
   },
   "stable": {
    "version": [
@@ -62378,17 +62420,17 @@
     20210303,
     1751
    ],
-   "commit": "95538837d93c9d05e35ea85d6c25527fac715df7",
-   "sha256": "0p3v41vrsfjv866gjys2izmiyxl7vaiy7m93ra9kx45mrslyjcyg"
+   "commit": "4a785dbbf4f906584716bb14c92230beda5081ed",
+   "sha256": "0vkqp8ck21hhwfnfvmxfwrb3dnkqk4072n4jr7w6ivvhs555srdd"
   },
   "stable": {
    "version": [
     0,
-    19,
+    20,
     0
    ],
-   "commit": "0169d3ef40403c1bb41b5ce81c7ae2ec01a6ba1d",
-   "sha256": "0p3v41vrsfjv866gjys2izmiyxl7vaiy7m93ra9kx45mrslyjcyg"
+   "commit": "89c2f0ad779b8d15581a3607beb55855b0da8737",
+   "sha256": "0vkqp8ck21hhwfnfvmxfwrb3dnkqk4072n4jr7w6ivvhs555srdd"
   }
  },
  {
@@ -62399,15 +62441,15 @@
   "repo": "emacs-vs/line-reminder",
   "unstable": {
    "version": [
-    20210627,
-    2121
+    20210715,
+    839
    ],
    "deps": [
     "fringe-helper",
     "indicators"
    ],
-   "commit": "355cdcb6888fe6668e85a96dfe694d4bd050372e",
-   "sha256": "0hs5js38djfid0aqz0ygswqj26j3dpqjbaidghlfhdhcvifixsvw"
+   "commit": "38ca45f01b31d5de07a4a5e43ec54c4644718dcf",
+   "sha256": "12qcrsjb9j9w7nqr28ff1gnk4icl134pgjvm9ph5psf6a6qd9d78"
   },
   "stable": {
    "version": [
@@ -62539,14 +62581,14 @@
   "repo": "noctuid/link-hint.el",
   "unstable": {
    "version": [
-    20210410,
-    1506
+    20150922,
+    451
    ],
    "deps": [
     "avy"
    ],
-   "commit": "ae73db6a5948c8d109fc1d570760bcafa3f07175",
-   "sha256": "1rlbxlh9a0hnlaxpgfjvjjvmhnzwc84p9xiqi740xv82cd27wcnl"
+   "commit": "9fbf196d155016d9b8471a99318ed67a086cf257",
+   "sha256": "0v2g9gzf2v88ag59q1pf5vhd4qjnz3g4i6gzl27k6fi7pvlxdn39"
   }
  },
  {
@@ -62743,8 +62785,8 @@
   "repo": "abo-abo/lispy",
   "unstable": {
    "version": [
-    20210121,
-    926
+    20210702,
+    1206
    ],
    "deps": [
     "ace-window",
@@ -62753,8 +62795,8 @@
     "iedit",
     "zoutline"
    ],
-   "commit": "38a7df4cbb16cfe3d62dc8ea98b50e2d9a572e58",
-   "sha256": "1q3sgk8ffwajmh8l7c4p4fz36xw4fqds8yqblbi5kardaa8bs8cs"
+   "commit": "e9731aa95581951ab2cbfaed28f0ac7d71124ac0",
+   "sha256": "12vvh1z72bhvh4yhm0r7c3wl3iplf45qkdqk92xc0mp3zf9w6c5g"
   },
   "stable": {
    "version": [
@@ -62781,16 +62823,16 @@
   "repo": "noctuid/lispyville",
   "unstable": {
    "version": [
-    20200808,
-    2240
+    20210702,
+    2031
    ],
    "deps": [
     "cl-lib",
     "evil",
     "lispy"
    ],
-   "commit": "89316f01822b2135e52ca27fd308d207ef618052",
-   "sha256": "10k3hxxpx2v2k4dyad7j1bzmr1q7rzvv4y6c67pa9zcqyaw8m91v"
+   "commit": "9c14bed0359f659e246d345c706f895737c3d172",
+   "sha256": "1jlxcr9vikczhryw3xslfy6hzs2ikcf9khbwaw53ymwdxrmphcci"
   }
  },
  {
@@ -63165,10 +63207,10 @@
   "unstable": {
    "version": [
     20210701,
-    1735
+    1955
    ],
-   "commit": "96ca0e9058d8c1e533ce9aa1396e49f086362b06",
-   "sha256": "0bcilb7mcf9al3qs8i63idw97025b193sslrwkd7w8pphk2g9cqi"
+   "commit": "db1f98cc470972f92d72f40b78db4baff5768edd",
+   "sha256": "1wgqcb4m5nzkbxkvdx801h9d1wqswlqmqbar4282wabgnw78zwwy"
   },
   "stable": {
    "version": [
@@ -63740,14 +63782,14 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20210701,
-    216
+    20210710,
+    228
    ],
    "deps": [
     "map"
    ],
-   "commit": "27df47157a0a1753065172a346a2ffeb1778a99c",
-   "sha256": "0cwqyggc9hf5kwpypw0230p5fl3j8a6b2k3cgsrfk4i4lwkfnr5c"
+   "commit": "f3f81affc88e6cb9efbc5440b26e081cffddd311",
+   "sha256": "0ibag71yz92abhbxsry3sby7g5361n4y7qac5myav2rj4bcjsl0n"
   }
  },
  {
@@ -63758,15 +63800,15 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20210701,
-    216
+    20210705,
+    2006
    ],
    "deps": [
     "dash",
     "loopy"
    ],
-   "commit": "27df47157a0a1753065172a346a2ffeb1778a99c",
-   "sha256": "0cwqyggc9hf5kwpypw0230p5fl3j8a6b2k3cgsrfk4i4lwkfnr5c"
+   "commit": "f3f81affc88e6cb9efbc5440b26e081cffddd311",
+   "sha256": "0ibag71yz92abhbxsry3sby7g5361n4y7qac5myav2rj4bcjsl0n"
   }
  },
  {
@@ -63833,8 +63875,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20210608,
-    2101
+    20210715,
+    1659
    ],
    "deps": [
     "dap-mode",
@@ -63845,14 +63887,14 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "01d89d43f17a15c7ccad5a458250d5d6b0f70b09",
-   "sha256": "0vnzzfap7ndr26016n1c1q21ga2lgw9vb555mn4dql6ny191ri0r"
+   "commit": "8481da68a9df4061bc2cd884a3b73c14e8fb4bea",
+   "sha256": "1accwvgwjp6j82i26788g3k9zc4al9xjw700cpdgsxw7mn6lkw8n"
   },
   "stable": {
    "version": [
     1,
     19,
-    0
+    1
    ],
    "deps": [
     "dap-mode",
@@ -63863,8 +63905,8 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "49bb4d597e30c95d66a96739ea10c1c4f74ac649",
-   "sha256": "0kwzi6f3ig6lq95h2y9nddwkisml1fig290vn1sm7wkl3r9ci8bd"
+   "commit": "8481da68a9df4061bc2cd884a3b73c14e8fb4bea",
+   "sha256": "1accwvgwjp6j82i26788g3k9zc4al9xjw700cpdgsxw7mn6lkw8n"
   }
  },
  {
@@ -63926,8 +63968,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20210616,
-    1021
+    20210715,
+    918
    ],
    "deps": [
     "grammarly",
@@ -63936,8 +63978,8 @@
     "request",
     "s"
    ],
-   "commit": "57a698e69c0dacbcad30398c262cdc5711efba71",
-   "sha256": "17jhfzy7bk645402yi65dsw19rvyjqm5wfd8y73hcfniihdrnqzp"
+   "commit": "bb7fe5d70a3d21813858d93f70fe807beba99688",
+   "sha256": "143afkkfm7dvhlpl77j98hbm5fk2jsrrkxkx1dpn17mj74ijq0ix"
   },
   "stable": {
    "version": [
@@ -64034,8 +64076,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20210701,
-    725
+    20210710,
+    1757
    ],
    "deps": [
     "dap-mode",
@@ -64047,8 +64089,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "28c56ec59a8c1b197727f4d56cec724445661fd9",
-   "sha256": "0g544mxv362ypwg79kyvjmnr63ss5psp89dmmzbx0bfpk8z4ib0j"
+   "commit": "b66a075bcb1edf57b09a0e1c73c3a399596d4760",
+   "sha256": "1s47y8hd9mnvz858h3sbdbdgrv3d1kdxag8flm44jla4yhgish7g"
   },
   "stable": {
    "version": [
@@ -64165,8 +64207,8 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "0e4c96a625bd83930cac338eb7a998c024a15f38",
-   "sha256": "11gvqbp9j585g86ir610lb3fq87nbwr44j3xzifh4rga6cwdb6yj"
+   "commit": "d1da153dbc762c5262f6e2a10264cc9075ebb6fc",
+   "sha256": "06vb7dxmjdc86zmv1i4qckx1isv0kvp5h0av2b4cnaci76bjh3s3"
   },
   "stable": {
    "version": [
@@ -64189,14 +64231,15 @@
   "repo": "emacs-languagetool/lsp-ltex",
   "unstable": {
    "version": [
-    20210616,
-    1021
+    20210715,
+    942
    ],
    "deps": [
+    "f",
     "lsp-mode"
    ],
-   "commit": "cd6fa0b32118792e9f7bcbf4a26032bfff05d603",
-   "sha256": "16hn5wbfa4f958pyl47l4nvqx092ws16l99dcwijzk9xs4wrkipn"
+   "commit": "b9a930757c71f7eb30a0828a502a237bfd882b43",
+   "sha256": "1hsq4jjz79bb1wl8m65n2zmx10mr8zc7dmg5sp6z6sprgyb3vndh"
   },
   "stable": {
    "version": [
@@ -64263,8 +64306,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20210630,
-    2003
+    20210715,
+    1320
    ],
    "deps": [
     "dash",
@@ -64274,8 +64317,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "7b183d397f8bc17eceb4d156e24575a47a1d807f",
-   "sha256": "15br2gf55436jm5a3iygr8cp3vriiar85kmgmap88ws8z83qg17x"
+   "commit": "cd47168035c98c6ebf9177705b9b7da53fcc9f5f",
+   "sha256": "1q1isn2g09pdczqdvbk5hjirym6106ip1z6klg1m2d5b9d8vx0l2"
   },
   "stable": {
    "version": [
@@ -64600,16 +64643,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20210619,
-    905
+    20210708,
+    134
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "240a7de26400cf8b13312c3f9acf7ce653bdaa8a",
-   "sha256": "1zscdjlnkx43i4kw2qmlvji23xfpw7n5y4v99ld33205dg905fsy"
+   "commit": "1ee371765612b7aaa6046aabdc2f65bcfcb93b11",
+   "sha256": "051hc6310zzn9qpvd9k8cj7ibzsk1k19l2485c5wra0fvm2lfa6x"
   },
   "stable": {
    "version": [
@@ -65087,8 +65130,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210701,
-    1554
+    20210716,
+    1440
    ],
    "deps": [
     "dash",
@@ -65097,14 +65140,14 @@
     "transient",
     "with-editor"
    ],
-   "commit": "2ae376e4923e02355828350b81cdc1b0f8fa72ff",
-   "sha256": "1h07rg0fvr7av69bcks1n63digafq145mlsaddyv6xixxqjp0vbg"
+   "commit": "bf9cc19a3287f6a3cc5c1836312f0d18b38b6e45",
+   "sha256": "0zjcvhjp4c01ibb1hshpqkib7fvjkmvh9xf06qfsm5ybdc04xik5"
   },
   "stable": {
    "version": [
     3,
-    0,
-    0
+    1,
+    1
    ],
    "deps": [
     "dash",
@@ -65113,8 +65156,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "c3bbc9b9425f3370690cabb11bd35b9040773fdc",
-   "sha256": "0dbp3gx43ipxv8zg9m0hfhksz85rnkikaq35rx705qqz6xq6xq9m"
+   "commit": "143d95cced1ee793106d16da3a182dcc2dd01e88",
+   "sha256": "0sn4iiicmqfqmvi7zwii6qdp35k09kqn36rpalv0w1i4jcm6j9kk"
   }
  },
  {
@@ -65184,8 +65227,8 @@
     "magit",
     "xterm-color"
    ],
-   "commit": "1164a6c3e501e944f1a6a2e91f15374a193bb8d3",
-   "sha256": "1a24qpqdk00prprm5s4gwfi1hvdljp2808rg33qaaa1087zdavqj"
+   "commit": "56cdffd377279589aa0cb1df99455c098f1848cf",
+   "sha256": "19q04y61hkzxkqw2xi1g7m4bwaxpfwza7if6cm41g72kdb8r68vb"
   }
  },
  {
@@ -65437,28 +65480,28 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210701,
-    1551
+    20210702,
+    819
    ],
    "deps": [
     "libgit",
     "magit"
    ],
-   "commit": "2ae376e4923e02355828350b81cdc1b0f8fa72ff",
-   "sha256": "1h07rg0fvr7av69bcks1n63digafq145mlsaddyv6xixxqjp0vbg"
+   "commit": "bf9cc19a3287f6a3cc5c1836312f0d18b38b6e45",
+   "sha256": "0zjcvhjp4c01ibb1hshpqkib7fvjkmvh9xf06qfsm5ybdc04xik5"
   },
   "stable": {
    "version": [
     3,
-    0,
-    0
+    1,
+    1
    ],
    "deps": [
     "libgit",
     "magit"
    ],
-   "commit": "c3bbc9b9425f3370690cabb11bd35b9040773fdc",
-   "sha256": "0dbp3gx43ipxv8zg9m0hfhksz85rnkikaq35rx705qqz6xq6xq9m"
+   "commit": "143d95cced1ee793106d16da3a182dcc2dd01e88",
+   "sha256": "0sn4iiicmqfqmvi7zwii6qdp35k09kqn36rpalv0w1i4jcm6j9kk"
   }
  },
  {
@@ -65606,26 +65649,26 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210701,
-    1554
+    20210702,
+    822
    ],
    "deps": [
     "dash"
    ],
-   "commit": "2ae376e4923e02355828350b81cdc1b0f8fa72ff",
-   "sha256": "1h07rg0fvr7av69bcks1n63digafq145mlsaddyv6xixxqjp0vbg"
+   "commit": "bf9cc19a3287f6a3cc5c1836312f0d18b38b6e45",
+   "sha256": "0zjcvhjp4c01ibb1hshpqkib7fvjkmvh9xf06qfsm5ybdc04xik5"
   },
   "stable": {
    "version": [
     3,
-    0,
-    0
+    1,
+    1
    ],
    "deps": [
     "dash"
    ],
-   "commit": "c3bbc9b9425f3370690cabb11bd35b9040773fdc",
-   "sha256": "0dbp3gx43ipxv8zg9m0hfhksz85rnkikaq35rx705qqz6xq6xq9m"
+   "commit": "143d95cced1ee793106d16da3a182dcc2dd01e88",
+   "sha256": "0sn4iiicmqfqmvi7zwii6qdp35k09kqn36rpalv0w1i4jcm6j9kk"
   }
  },
  {
@@ -65903,8 +65946,8 @@
   "repo": "p3r7/magrant",
   "unstable": {
    "version": [
-    20210514,
-    1322
+    20210706,
+    1438
    ],
    "deps": [
     "dash",
@@ -65913,8 +65956,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "79661be21cc8e9faf1ac93adb1f86f9b7a8b110d",
-   "sha256": "00hl22bl9cbivwdilzqrz9kf3qcixbc15x263cv1nn9ppba4arhw"
+   "commit": "6309c001355126e3ade79493479b517925943d17",
+   "sha256": "0fg4hi65qdix0lpfw29ymy2naskn2af661pzg695f47xhknsir1r"
   }
  },
  {
@@ -66230,8 +66273,8 @@
    "deps": [
     "manage-minor-mode"
    ],
-   "commit": "d377094c4ff5e93321e12f53892113083148bdaf",
-   "sha256": "0dpljs8qmpvpb0y2cvcr71ashzrm2ypb8p6anay4sjmiphkb60p5"
+   "commit": "ae46a80e27dc42913620ad78d7a84ece12643bd7",
+   "sha256": "16ygsxk5raa6p767jp6g5hmgsghq0dpk102g526d770iim5s8nlb"
   },
   "stable": {
    "version": [
@@ -66407,11 +66450,11 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20210620,
-    1943
+    20210716,
+    1252
    ],
-   "commit": "9796fada769f44cb8e05914bd6be3fcc15d791e2",
-   "sha256": "0yn6dybvsdhr37hnadmbfqi7pf7scxr9z6a6ghsqbrghycddd0mc"
+   "commit": "b5893884abeb6a355233edf54e0f63d04bc32ce2",
+   "sha256": "0cjabw0ia9rnb3idmv9s6i4izgklxkiax8zn5xw1c6n8ls5iwbqj"
   },
   "stable": {
    "version": [
@@ -66527,11 +66570,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20210616,
-    122
+    20210710,
+    1646
    ],
-   "commit": "1c7d29d52986b2cb153b5f643167ea49417de469",
-   "sha256": "0jgfxvhx5z3hjzpdxikx75ikgc0w7ap442svqpyigf78rb32wsjl"
+   "commit": "359347b2bb15f8d7ef819692ac79759ccfe2c85d",
+   "sha256": "1naqcg0a5shzcg0rlqs6w5mlr7sn0b8b2hmhs07qawvpxln8j628"
   },
   "stable": {
    "version": [
@@ -66742,8 +66785,8 @@
     20200720,
     1034
    ],
-   "commit": "d8e83b837bacdd45d274be42fe2d172fd1cbbba2",
-   "sha256": "1iy8vg2wlrzb01nc6sx21ijg62ak94k2x2w6gy56krp7frakacrv"
+   "commit": "67d19ed3d74c335a6a0e4798c98841c940ec911f",
+   "sha256": "04dyb3nn5rdgic1m74sv9wzxkfxvszk3sj2fnixp41dj3pvwwdwb"
   },
   "stable": {
    "version": [
@@ -66927,11 +66970,11 @@
   "url": "https://git.code.sf.net/p/matlab-emacs/src",
   "unstable": {
    "version": [
-    20210504,
-    1439
+    20210716,
+    1247
    ],
-   "commit": "c5824936cc7c2d24aeaac40010669f4eec89a239",
-   "sha256": "0rccwkglyw9hnab5mzhrzfrldlvi9c8ivygdh54jzfjlzcgwddv9"
+   "commit": "3fbc97b3f29c72b01812739536ed416e3e07e3c1",
+   "sha256": "0fhsp1g8mlh4ias1xgx0yjvh0g1khdy91pl474b2g0ffrml5ab73"
   }
  },
  {
@@ -67468,11 +67511,11 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20210623,
-    1512
+    20210707,
+    901
    ],
-   "commit": "a69ef83f2894c7e019c9b487b9646f7a63456471",
-   "sha256": "1v0pc3yglbgdpmviz45h1zcnc2kkz35jbvdzkrks122736nz1dli"
+   "commit": "7c4c0a7018109b2b1bcbc3f6c1486961b223e658",
+   "sha256": "13cissjjkhfab7sgmwwmdcl3d5kn3qd2d6w9nmcw0yb8c59r1c0l"
   },
   "stable": {
    "version": [
@@ -67500,8 +67543,8 @@
     "auto-complete",
     "merlin"
    ],
-   "commit": "a69ef83f2894c7e019c9b487b9646f7a63456471",
-   "sha256": "1v0pc3yglbgdpmviz45h1zcnc2kkz35jbvdzkrks122736nz1dli"
+   "commit": "7c4c0a7018109b2b1bcbc3f6c1486961b223e658",
+   "sha256": "13cissjjkhfab7sgmwwmdcl3d5kn3qd2d6w9nmcw0yb8c59r1c0l"
   },
   "stable": {
    "version": [
@@ -67533,8 +67576,8 @@
     "company",
     "merlin"
    ],
-   "commit": "a69ef83f2894c7e019c9b487b9646f7a63456471",
-   "sha256": "1v0pc3yglbgdpmviz45h1zcnc2kkz35jbvdzkrks122736nz1dli"
+   "commit": "7c4c0a7018109b2b1bcbc3f6c1486961b223e658",
+   "sha256": "13cissjjkhfab7sgmwwmdcl3d5kn3qd2d6w9nmcw0yb8c59r1c0l"
   },
   "stable": {
    "version": [
@@ -67595,8 +67638,8 @@
     "iedit",
     "merlin"
    ],
-   "commit": "a69ef83f2894c7e019c9b487b9646f7a63456471",
-   "sha256": "1v0pc3yglbgdpmviz45h1zcnc2kkz35jbvdzkrks122736nz1dli"
+   "commit": "7c4c0a7018109b2b1bcbc3f6c1486961b223e658",
+   "sha256": "13cissjjkhfab7sgmwwmdcl3d5kn3qd2d6w9nmcw0yb8c59r1c0l"
   },
   "stable": {
    "version": [
@@ -67692,11 +67735,11 @@
   "repo": "myTerminal/meta-presenter",
   "unstable": {
    "version": [
-    20190414,
-    1720
+    20210714,
+    1658
    ],
-   "commit": "704a2e0f2a3e6bb72578e00eccb772dfcf0670fc",
-   "sha256": "1hka4c87zdgqjawlmsfd7wi6rbc03qfp996ydrj84kz8saq7gf89"
+   "commit": "4ab48dacea245b223a0ffd2723ece746bd61c0af",
+   "sha256": "0na573lsgvzpfyam7bsc63lnsrd2acp9djbg3kpng999f2mlrx1r"
   },
   "stable": {
    "version": [
@@ -67931,11 +67974,11 @@
   "repo": "purpleidea/mgmt",
   "unstable": {
    "version": [
-    20210131,
-    2152
+    20190324,
+    1908
    ],
-   "commit": "48fa796ab1669dc275b8c99238fff6c83ad2fcc6",
-   "sha256": "0rn7ahpj2kjkmy7gq4fj0n99af70xxxykyjqsza1nnizxfgmrpwj"
+   "commit": "6a7d904fae5014aabae8c91add220485108d485b",
+   "sha256": "0r0msrnbz9177cv1mlacsyd35k945nk2qaqm1f8ymgxa99zy124i"
   },
   "stable": {
    "version": [
@@ -68138,11 +68181,11 @@
   "repo": "muffinmad/emacs-mini-frame",
   "unstable": {
    "version": [
-    20210212,
-    2041
+    20210710,
+    1941
    ],
-   "commit": "41afb3d79cd269726e955ef0896dc077562de0f5",
-   "sha256": "0yghz9pdjsm9v6lbjckm6c5h9ak7iylx8sqgyjwl6nihkpvv4jyp"
+   "commit": "b07faabfec1b5ba545dc1cb961545cc1e9d78db0",
+   "sha256": "0b7znsgvycfx2brk782mi0n8i779n1r7pqwfq7s256rgi4fcyzap"
   }
  },
  {
@@ -68523,8 +68566,8 @@
     20210601,
     2158
    ],
-   "commit": "d912fec98698c4f72a5f408d5a3f80e95327817d",
-   "sha256": "0gby38fd5vvfbm3pl2cvp6jsfjqi17xgh1m8vv9z9s6zang4knsy"
+   "commit": "5ad0fd71634ac9dc6f97f653bc748f9fb58d80e4",
+   "sha256": "0fxk860dv8xqd5rfp4bw1pspm58c71mhac2xp2cxi1i2jrg272dn"
   },
   "stable": {
    "version": [
@@ -68928,15 +68971,15 @@
   "repo": "damon-kwok/modern-sh",
   "unstable": {
    "version": [
-    20200904,
-    1838
+    20210716,
+    148
    ],
    "deps": [
     "eval-in-repl",
     "hydra"
    ],
-   "commit": "05430398a5070245c4358e6a1b7e49a154da174e",
-   "sha256": "05k5ak09rw8zrn5k7zjc54ckv4jrp9fs3s3r3ja5cil45irgcmhv"
+   "commit": "8b11b67ac738cfd95babbcc7543467fd9190fc7e",
+   "sha256": "1y0y2fwyi1qi5k3nypdv51rfyf06f2q2c6ki5yz6bl82lhd0vb1l"
   }
  },
  {
@@ -68986,20 +69029,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20210630,
-    1252
+    20210716,
+    431
    ],
-   "commit": "9b1d1594efa5d7389300b93c78f1b1dd389f9c27",
-   "sha256": "1m4wmcjhd7hck3rdg9anynlxzr9lnswkdzwypgwfwmabnvsyqvrm"
+   "commit": "9521dcec6c012d3776e3d05692720dd24922218b",
+   "sha256": "1m5ifpql8p0w4qk79n2n8wyrq1s7ys0yc8y0a09w1yyxjk6ay12k"
   },
   "stable": {
    "version": [
     1,
-    4,
+    5,
     0
    ],
-   "commit": "15c973f716378084a937e777f86182741fd9b697",
-   "sha256": "0p9yzj70kx3s740dl7k3vwwkr1g9zxsirwl83n1nvswc4csgv20j"
+   "commit": "b6fb7cda01a665f9369f2c6a29f3bf26c8cc8019",
+   "sha256": "1m5ifpql8p0w4qk79n2n8wyrq1s7ys0yc8y0a09w1yyxjk6ay12k"
   }
  },
  {
@@ -69692,8 +69735,8 @@
     20210306,
     1053
    ],
-   "commit": "171aebaf3a1fb76d1a460d12c7199bc6fbcec473",
-   "sha256": "06dw5blx8r6wzkwwwbi7p3fxs4flgsf2vlkz8vv9gar4cg9w7wy7"
+   "commit": "515b4f47c7f43816fce82cdf555107614e9e7edd",
+   "sha256": "1q39iy7g4f11nzhlsa1j8shrvhmg3ip2h43rxawhmypfwd95vzk1"
   },
   "stable": {
    "version": [
@@ -69819,8 +69862,8 @@
   "repo": "mpdel/mpdel",
   "unstable": {
    "version": [
-    20210107,
-    1303
+    20201026,
+    1123
    ],
    "deps": [
     "libmpdel",
@@ -70244,16 +70287,16 @@
   "repo": "lordpretzel/mu4e-views",
   "unstable": {
    "version": [
-    20210601,
-    1402
+    20210709,
+    150
    ],
    "deps": [
     "esxml",
     "ht",
     "xwidgets-reuse"
    ],
-   "commit": "c7f2398612218407e72b174f02b26cf2916eba22",
-   "sha256": "0irvzwfrrqzk8pcq1m3w9s21v2y0h6f5jrvsv88knz0ki1bdkbai"
+   "commit": "9fbe402dc5931ba9cafec581ac3e6d86e9a9f2da",
+   "sha256": "0a73izknp2nkzklkhf9wyxy38fnw4f1jyimdcnh14m1v5bcw2wal"
   },
   "stable": {
    "version": [
@@ -70419,8 +70462,8 @@
   "repo": "sagarjha/multi-run",
   "unstable": {
    "version": [
-    20210108,
-    336
+    20190507,
+    2349
    ],
    "deps": [
     "window-layout"
@@ -70477,8 +70520,8 @@
     "project",
     "vterm"
    ],
-   "commit": "8f385a0aa1ad7a279acc9276913955ef165e7ac7",
-   "sha256": "0anipknf7bfzygjkynq81ndspnfsqwx7l1i7chkfgfygqyq5486y"
+   "commit": "934397efd2e78a6b83d2b06ef4e4c281c0ae3c65",
+   "sha256": "0cz3zs9xd2zbyb9g9r4r893kl9nqk8i9l0zy66s500iy5522vcnh"
   }
  },
  {
@@ -70591,26 +70634,26 @@
   "repo": "zevlg/multitran.el",
   "unstable": {
    "version": [
-    20200201,
-    55
+    20210701,
+    2153
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "475e2a92795dbed1aa3b1c5eba2c6c779cac4508",
-   "sha256": "0nl4cm1nx7lmb2gd76jw8v0hqdfjjcwy0xskpi0brd8z6dp1m5n3"
+   "commit": "c34536186088f29d4e85631825e7c6d557a8d0fa",
+   "sha256": "0iqkgs3rrkhbj2mind4aa4qv7bf7vflnkdysd39b50jbwd7rv4fx"
   },
   "stable": {
    "version": [
     0,
     4,
-    10
+    11
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "258b1232af6680396b6c0912597ed52e583326f4",
-   "sha256": "08b9a0pb38swgvg2v97pm4g2zda0xagdgq42znwhkmhzjiskh2g1"
+   "commit": "c34536186088f29d4e85631825e7c6d557a8d0fa",
+   "sha256": "0iqkgs3rrkhbj2mind4aa4qv7bf7vflnkdysd39b50jbwd7rv4fx"
   }
  },
  {
@@ -71351,11 +71394,11 @@
   "repo": "rolandwalker/nav-flash",
   "unstable": {
    "version": [
-    20210510,
-    2035
+    20210711,
+    217
    ],
-   "commit": "d76314802273153c2c38156250d75f95ca352482",
-   "sha256": "006ghb4xrpp82wlshqmpsj0yh5vq8il6wl5v8f1cyy1vd21yl285"
+   "commit": "55786c9582410a5637b5635fea022aae564205cd",
+   "sha256": "0pj92h241k17hvlx7x0nx2hnjg6vyz65sa4ghyqhwa7mdn0c12pi"
   },
   "stable": {
    "version": [
@@ -72114,11 +72157,14 @@
   "repo": "NixOS/nix-mode",
   "unstable": {
    "version": [
-    20210629,
-    2024
+    20210706,
+    2217
    ],
-   "commit": "d27820b0408b3e9067c264e25c009bd5cd9dfcd1",
-   "sha256": "0hrhzm703k86a4wlx0hwnivklniziy2xbrs1q0mvijmsvks60f57"
+   "deps": [
+    "f"
+   ],
+   "commit": "3cca5b6527a69c4701394f424726282a1462ede3",
+   "sha256": "1cf88v8hbcn2kcyh4bv74yhpp7jf4r80zf3pzfw6cqvrgx19px2k"
   },
   "stable": {
    "version": [
@@ -72349,18 +72395,19 @@
   "repo": "dickmao/nnreddit",
   "unstable": {
    "version": [
-    20201130,
-    39
+    20210708,
+    43
    ],
    "deps": [
     "anaphora",
     "dash",
     "json-rpc",
     "request",
+    "s",
     "virtualenvwrapper"
    ],
-   "commit": "cf6bc58bff8bb8e2e3c4d681d2657b561573b2dc",
-   "sha256": "1cgw4vmffp08csf48gghfsm73h8yaai4k2kpgf213d6zqbxz9w5z"
+   "commit": "60bf11fdba8ff56b6b4b21f5f0c04953834d8a14",
+   "sha256": "1b6i4kwjb81s7x56g7xmkynryw8xzrpbbkfy03597ka0v0n8i717"
   }
  },
  {
@@ -72604,8 +72651,8 @@
   "repo": "esessoms/nofrils-theme",
   "unstable": {
    "version": [
-    20180620,
-    1248
+    20180227,
+    2153
    ],
    "commit": "98ad7bfaff1d85b33dc162645670285b067c6f92",
    "sha256": "0f8s7mhcs1ym4an8d4dabfvhin30xs2d0c5gv875hsgz8p3asgxs"
@@ -72711,11 +72758,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20210627,
-    1741
+    20210713,
+    1255
    ],
-   "commit": "1768b0c416ce1034a5726ff0037e5a605cb45ab6",
-   "sha256": "0cynllvnhiibxa9a06xg9qzybvsl802l7lcc2jwzhja05l2wrdps"
+   "commit": "d8a5fba4fe1efd7d0d652ead6d55371bc4078a9d",
+   "sha256": "138wxhawdp8nllpvmrgll4nvn5by3hsp0zy4gywf6nalr0d1wdld"
   },
   "stable": {
    "version": [
@@ -72895,8 +72942,8 @@
   "repo": "shaneikennedy/npm.el",
   "unstable": {
    "version": [
-    20210601,
-    1122
+    20200812,
+    1850
    ],
    "deps": [
     "jest",
@@ -73459,8 +73506,8 @@
    "deps": [
     "axiom-environment"
    ],
-   "commit": "ac8228a702290732ba12c5d13b38576a57afb0d6",
-   "sha256": "1nrlgrckvh2fiwis9bmr95h2bpxfkz1nknxdz61380f2caqwwhw7"
+   "commit": "7d72e6319b98b334f74b78f3d4151e92fb7dcbad",
+   "sha256": "1hwcndb1x3i51l0kvzk4mj6sil8h10mxmazic9zvwjhia9qz9hz3"
   }
  },
  {
@@ -74532,17 +74579,17 @@
     20210617,
     1726
    ],
-   "commit": "a54914c8f4bc5e2d57aac5ed15f1192c2f53abbc",
-   "sha256": "0625kwk1k8c4j92w4v5160zxcqxa2bf7kdmkii26m25fzw1az1d1"
+   "commit": "ba67af28ddca8718ef8816b2b0dc1e5b2f5e9591",
+   "sha256": "0dp4pkznz9yvqx9gxwbid1z2b8ajkr8i27zay9ghx69624hz3i4z"
   },
   "stable": {
    "version": [
     0,
-    18,
+    19,
     0
    ],
-   "commit": "3697f0f92854a681fd1156fe4f6fb97d060da1d8",
-   "sha256": "0n6363km8xr81pvyk453n6h2mb0256c5yxw3p1li4dn83f3lwxr1"
+   "commit": "ba67af28ddca8718ef8816b2b0dc1e5b2f5e9591",
+   "sha256": "0dp4pkznz9yvqx9gxwbid1z2b8ajkr8i27zay9ghx69624hz3i4z"
   }
  },
  {
@@ -75666,14 +75713,14 @@
   "repo": "awth13/org-appear",
   "unstable": {
    "version": [
-    20210627,
-    612
+    20210709,
+    949
    ],
    "deps": [
     "org"
    ],
-   "commit": "12056f697fce51958e7baf837d250341bd86194e",
-   "sha256": "0p3h2inqqf9ighr9sig1spbni9mq0k4iy8w10w5bpjd3xm37qx80"
+   "commit": "148aa124901ae598f69320e3dcada6325cdc2cf0",
+   "sha256": "0scj53w5kk62k294s7pfr15wqiiwvlprxhnmkrjmfx2gwyb1yh9i"
   }
  },
  {
@@ -75898,14 +75945,14 @@
   "repo": "Kungsgeten/org-brain",
   "unstable": {
    "version": [
-    20210515,
-    1814
+    20210706,
+    1519
    ],
    "deps": [
     "org"
    ],
-   "commit": "a9ca42cb8d1325a4e928716384a0bdb53ea2ad41",
-   "sha256": "0gp00wbp56g58fz6x4w70lhhwyy3ffxj8hhf5qfrz1wg264n23jy"
+   "commit": "46ca9f766322cff31279ecdf02251ff24a0e9431",
+   "sha256": "0bj08f5mg9v0xm2awbv1fxv98jj9scvqss6fmw0lzix6s3112z25"
   }
  },
  {
@@ -76454,8 +76501,8 @@
    "deps": [
     "web-server"
    ],
-   "commit": "b4f97edf4150870b84d7ee8508088c0d375eaa83",
-   "sha256": "124fq9k7qmjvn5hp9i2b4xmrm9z18zhbc9j1rv68wpdqf0kqxkcd"
+   "commit": "6e4d328afac1195fa7f831c6d41ae966b5d75a16",
+   "sha256": "0igx916wk9xc74h6zm8dz3h5007izrp2jdm4pdm2r4bcp1ybnk05"
   }
  },
  {
@@ -76587,26 +76634,20 @@
   "repo": "io12/org-fragtog",
   "unstable": {
    "version": [
-    20210514,
-    1608
+    20210713,
+    551
    ],
-   "deps": [
-    "org"
-   ],
-   "commit": "bed49744ed27ff205539a14fd51e2977852c49e5",
-   "sha256": "0cw8903nw0mrn9kppwlypsb6h9m54zrb6y969yj0gnkza6gqy36c"
+   "commit": "479e0a1c3610dfe918d89a5f5a92c8aec37f131d",
+   "sha256": "02g4a5lsmalc5mcybimx7ils43w3ac6269n9kzcnw59bj0i5kkcj"
   },
   "stable": {
    "version": [
     0,
     3,
-    2
+    3
    ],
-   "deps": [
-    "org"
-   ],
-   "commit": "bed49744ed27ff205539a14fd51e2977852c49e5",
-   "sha256": "0cw8903nw0mrn9kppwlypsb6h9m54zrb6y969yj0gnkza6gqy36c"
+   "commit": "479e0a1c3610dfe918d89a5f5a92c8aec37f131d",
+   "sha256": "02g4a5lsmalc5mcybimx7ils43w3ac6269n9kzcnw59bj0i5kkcj"
   }
  },
  {
@@ -76786,15 +76827,15 @@
   "repo": "marcIhm/org-id-cleanup",
   "unstable": {
    "version": [
-    20210326,
-    1711
+    20210714,
+    1604
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "2cb87624238281b438cda67ed375c56403524489",
-   "sha256": "1xmbrrp1zyvij18v3rqmini6w9i6v7dl4fp103ph6wznav8x0jbl"
+   "commit": "416c95fc9ad8551f1d9544f2504c866daac5477e",
+   "sha256": "189zzfi5a1qsjm8ayq5v58s5iagibv2vk6rb6zda4p0hrmnfz2ky"
   },
   "stable": {
    "version": [
@@ -76842,30 +76883,30 @@
   "repo": "marcIhm/org-index",
   "unstable": {
    "version": [
-    20210630,
-    1503
+    20210709,
+    1801
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "ddb1b95ac139676e4aa8a0b787e57feba34cc7cb",
-   "sha256": "0l563j9m8zcmsn8vqv3qchk4yqrfbigk5k4iqcw8p7cbix57sjah"
+   "commit": "4abf3a90503d1837782a35759066ffa7ec7dea55",
+   "sha256": "0409n80whcpkgcmhqrywgcj5d6fhqv67dyw4spg54hv9dn1p47zd"
   },
   "stable": {
    "version": [
     7,
-    2,
-    1
+    3,
+    0
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "1ee39e4f8616199ad8e5cb6b2d6b410e75857ecd",
-   "sha256": "06mf8s68mw6fcdpvdddcvy2x8z6zyisfvgh4sdrpz2z5j03v7qd7"
+   "commit": "4abf3a90503d1837782a35759066ffa7ec7dea55",
+   "sha256": "0409n80whcpkgcmhqrywgcj5d6fhqv67dyw4spg54hv9dn1p47zd"
   }
  },
  {
@@ -76959,14 +77000,14 @@
   "repo": "bastibe/org-journal",
   "unstable": {
    "version": [
-    20210326,
-    1207
+    20210714,
+    911
    ],
    "deps": [
     "org"
    ],
-   "commit": "5f253a880e1919ef4b98f0d91f271a8b522eaae5",
-   "sha256": "1cirbb5x29qnf59qkcfsjw467xx02vl4f17iqd4qqxwaarwkyq30"
+   "commit": "6c3a2fdb6c85253a32992a29edb976407bad4d77",
+   "sha256": "0rxrsqj3a8qchjhm9kb37zd9h1h1lcqfg2gwsgab74rfyfgf9ryd"
   },
   "stable": {
    "version": [
@@ -77078,14 +77119,14 @@
   "repo": "stardiviner/org-link-beautify",
   "unstable": {
    "version": [
-    20210628,
-    1124
+    20210704,
+    2214
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "f78924c06c9f3902bab8e390d91402516d2bb502",
-   "sha256": "1v847kpc3fh4sxi1rw8pp6xlb89r6z224831xkd82gys74ya0724"
+   "commit": "40d40c1e6187ec9c13292beb3f7f319f189264d8",
+   "sha256": "0253i9hvq9yki97jmdrvbv82xbgdrq76l73frq6xbbzzhw6615m6"
   }
  },
  {
@@ -77156,14 +77197,14 @@
   "repo": "dfeich/org-listcruncher",
   "unstable": {
    "version": [
-    20210503,
-    802
+    20210706,
+    1741
    ],
    "deps": [
     "seq"
    ],
-   "commit": "50c06445a837c6677da035f72dbe0f973d9e10a7",
-   "sha256": "1nw5wd781a5nh5csvsr6ycjpji66k8vkvw8z1sfa0p8xsbln9rk9"
+   "commit": "075e0e6d36eb50406a608bc8a2f0dd359ec63938",
+   "sha256": "133smvw9iaxg0p3y5wl0rc4fwwgbxgw6hxngpmar8qf4grwy4w27"
   }
  },
  {
@@ -77686,16 +77727,16 @@
   "repo": "org-pivotal/org-pivotal",
   "unstable": {
    "version": [
-    20210701,
-    342
+    20210705,
+    408
    ],
    "deps": [
     "a",
     "dash",
     "request"
    ],
-   "commit": "f55b9773b2f4a502e636688bc1caa21ee0396abe",
-   "sha256": "1ipxr8s384pljlz9rzpdhmrsa7q7jzk27dblrrapgbgi52h3n5np"
+   "commit": "6403cefb8440567fc593a8d267536138cd6165e2",
+   "sha256": "0a95gnvgfvj3f9xy5hl4d7367j8sfysf5ghnz6hxiz6ilhngfnz7"
   }
  },
  {
@@ -77911,8 +77952,8 @@
   "repo": "alphapapa/org-ql",
   "unstable": {
    "version": [
-    20210624,
-    1314
+    20210713,
+    233
    ],
    "deps": [
     "dash",
@@ -77926,8 +77967,8 @@
     "transient",
     "ts"
    ],
-   "commit": "8342656b2d9af4bb6af9daa0a8b037d3693bd940",
-   "sha256": "0alrs2dsd5k4xjrs2zs7hcr5fbfrr3rdq705s04943ic4kzvhrc9"
+   "commit": "94f9e6f3031b32cf5e2149beca7074807235dcb0",
+   "sha256": "022arhyyn8hbb1hzjkv4gl3dr8lz1gv0x4h70x0970bsbqlsa27w"
   },
   "stable": {
    "version": [
@@ -78846,8 +78887,8 @@
   "repo": "arbox/org-sync",
   "unstable": {
    "version": [
-    20181204,
-    23
+    20181203,
+    2242
    ],
    "deps": [
     "cl-lib",
@@ -79693,8 +79734,8 @@
   "repo": "jcs-elpa/organize-imports-java",
   "unstable": {
    "version": [
-    20210121,
-    606
+    20210715,
+    1155
    ],
    "deps": [
     "dash",
@@ -79702,8 +79743,8 @@
     "ht",
     "s"
    ],
-   "commit": "50c11af264505b026aed77d6b67a132f7d4f7e6b",
-   "sha256": "0q5qz7bm8k17v9mzixb4fbdcn9czcskkrrlnk38sgj390d2pyc7c"
+   "commit": "cd931a01adb23dd473ca1abd22f45ac0a5661cac",
+   "sha256": "0cmr4dq90kvmscsm2jvvpdijbmqh0skra79cybcj4pdzafx79c8c"
   },
   "stable": {
    "version": [
@@ -79903,8 +79944,8 @@
     20201129,
     604
    ],
-   "commit": "649fd0cdcb831dcd840c66ee324005165ce970ca",
-   "sha256": "1iarfqdxryj5p43hsch2jgqslrpyfkza9x9fpshmbpwjkbf1548x"
+   "commit": "5bd7ee9d9e23ce37fd004054071026ff51445654",
+   "sha256": "1qblj2m7bhykm58i63r5ywvpz6hr0vyzx7fa0s6rwlkjzbdn77g6"
   },
   "stable": {
    "version": [
@@ -80174,14 +80215,14 @@
   "repo": "xuchunyang/osx-dictionary.el",
   "unstable": {
    "version": [
-    20210309,
-    115
+    20210703,
+    1152
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4d4cc19fdd4ac8408bd5acc7694e7a7096b1e3b3",
-   "sha256": "1zmng3qx7i4wkz1vrxw0vw3kyirnb8a0pn46zq6zhzj33ybn9582"
+   "commit": "1a4479d9f44ef1e6e5f7643c172c32f6fe6cce21",
+   "sha256": "1714bh7gx1limy8zs1sbxyr9an7gj7viq8sf4cr6wnxz44v237fb"
   },
   "stable": {
    "version": [
@@ -80645,6 +80686,24 @@
    ],
    "commit": "3c52a7b11c8275fdb2e4cf98f68f2a48ad09a3ae",
    "sha256": "1lxvcbpzpzs3vkgg4pif3k89ddmj5mamk2q18wc3gx0czs6v301d"
+  }
+ },
+ {
+  "ename": "ox-750words",
+  "commit": "d05562f905715abfc139c224fa2fbbb796208318",
+  "sha256": "1cnzzfxvmg7d24lzp5n8i20c4yh2z1vpqhpciqy13qx9c3lqd4ri",
+  "fetcher": "github",
+  "repo": "zzamboni/750words-client",
+  "unstable": {
+   "version": [
+    20210701,
+    1950
+   ],
+   "deps": [
+    "750words"
+   ],
+   "commit": "0fed7621c04debad64ea6455455494d4e6eb03fa",
+   "sha256": "1qglbfdc6526aqsba93ngw1a6hp19lqx1wlxzzy9yvggbb02mii2"
   }
  },
  {
@@ -81214,14 +81273,14 @@
   "repo": "yjwen/org-reveal",
   "unstable": {
    "version": [
-    20210515,
-    1007
+    20210705,
+    2321
    ],
    "deps": [
     "org"
    ],
-   "commit": "826b01beb434d38e415d3001908baf5994c6d669",
-   "sha256": "0q8ygsd2r2yg1k5z9j7bbq2hl43hjjdpws0k4rsx19l786ssg7yq"
+   "commit": "014561540bdc5dc6fe68671cadcc3793a65f6b54",
+   "sha256": "1hha8f9vb6pmszpz0xx4lj2imm2nh81mgrvsblvbm92k4qvmk6z4"
   }
  },
  {
@@ -81472,6 +81531,39 @@
   }
  },
  {
+  "ename": "ox-yaow",
+  "commit": "cf9aa32de6b3daaa1f209fad6412cf057c43e4fd",
+  "sha256": "16ajjq2if5jlc58a19nh8q9vgnp1d9zsqgzadkphc8g7g0ca3yaf",
+  "fetcher": "github",
+  "repo": "LaurenceWarne/ox-yaow.el",
+  "unstable": {
+   "version": [
+    20210706,
+    1059
+   ],
+   "deps": [
+    "dash",
+    "f",
+    "s"
+   ],
+   "commit": "c7eca0130c35b3a8adcade637a35d1474368f4e9",
+   "sha256": "1k8vr1z9h6qywl037fh5p7ji0k78zm18r4qg996jghdk9sfxasfx"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "dash",
+    "f",
+    "s"
+   ],
+   "commit": "83f9e903f2853e9dc6367fa0a49015428d061dea",
+   "sha256": "1ab8n6k5pwsy54mm9fnfv64007fi884vjfxhbl5yvvg16a2pm7qa"
+  }
+ },
+ {
   "ename": "ox-zenn",
   "commit": "30a54915cf91b47230ddf66ad2e5e17c36fb5e7d",
   "sha256": "1lsvq5av234dbm88bw4jlj1vxmm3jd8hnzf8vv7q675qcxgpnz5j",
@@ -81618,14 +81710,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20210616,
-    2110
+    20210707,
+    1424
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "95e021756ee5c5255a63cce8351178e298c68363",
-   "sha256": "05qm6a0dy2iszrlwkiw5x2v0h5whk7d4qn7qjlf5qpns5fl0fwg2"
+   "commit": "eea82edcbcc95e9cd35e33243d77adeb88ec7edc",
+   "sha256": "018pihaz1msmizhfjqwsp4d1aa9idiri4nrf6ifkpp6v6j8k7mva"
   },
   "stable": {
    "version": [
@@ -82442,8 +82534,8 @@
    "deps": [
     "s"
    ],
-   "commit": "f910af3b1d98b88a0f41794bbe7fd57411e9b909",
-   "sha256": "02miw5sf4bbwmz58ya98ijjhqx92vamyzw8c5v2k6id3pxaypng4"
+   "commit": "0c4c92283baa951469e75f632fdd08f0cb9fe6af",
+   "sha256": "1g34wkb3ca6wgjkgmzbhaak95bpdh1k49p5m00ajhg1rqicxwdzw"
   },
   "stable": {
    "version": [
@@ -83640,14 +83732,14 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20210610,
-    548
+    20210709,
+    2353
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "68b13cef8435cae581850415cdda17e245dd0eae",
-   "sha256": "1iwqg1y47lp54qn9cjr3w9pca294mn92qlil3a4lr8xi57jbi3iz"
+   "commit": "b55aec612db791a1720232df0e2df0d3597d850b",
+   "sha256": "01bh8cs54mnikzrbhxc03588mrx8wsn2vqgb12j47g4lmg93759w"
   },
   "stable": {
    "version": [
@@ -84099,11 +84191,11 @@
   "repo": "emacs-php/php-mode",
   "unstable": {
    "version": [
-    20210519,
-    1728
+    20210714,
+    1700
    ],
-   "commit": "cbf27232649c39e3749eefd23f962750bd249a49",
-   "sha256": "0r20y2hrgy1gmnx6izzvmvjh4axwb4x4pgcxn4bjmpzypand5xfp"
+   "commit": "4b0e9f84d063c476b211ec89b2a17bddac138911",
+   "sha256": "0jw2c8fmj0m39xms301diid7l1wkhcpxh6mw2mrdla8as31vgygv"
   },
   "stable": {
    "version": [
@@ -84196,15 +84288,15 @@
   "repo": "mallt/php-scratch",
   "unstable": {
    "version": [
-    20201108,
-    750
+    20210706,
+    459
    ],
    "deps": [
     "php-mode",
     "s"
    ],
-   "commit": "a9db3986144fff424c93228a613f54734ef993a8",
-   "sha256": "01fkpcxmv98wklzf8vbs6l3kljdmwzclv5m73czzbgk5s3rwc8vb"
+   "commit": "b6bfd279da8a8ac7fc30459485956f3fd5d02573",
+   "sha256": "084ms50pw90jaqyll0rd3if1kb0i8hfrdrg72vss44cg83rq58vj"
   }
  },
  {
@@ -84249,26 +84341,26 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20210617,
-    2234
+    20210714,
+    1805
    ],
    "deps": [
     "php-mode"
    ],
-   "commit": "56617fa87c9bec037d4e4a0a143b7d70a989c082",
-   "sha256": "02k4pmmxq3h8mi0dsjh0s0002gjkpg6g9pxsnxgalwb6rakfirbh"
+   "commit": "0869b152f82a76138daa53e953285936b9d558bd",
+   "sha256": "1xm5i658pf1lb4bfpy6zy5msanhia8r9j7v7rx72amkksja3hwnj"
   },
   "stable": {
    "version": [
     0,
-    5,
+    6,
     0
    ],
    "deps": [
     "php-mode"
    ],
-   "commit": "bf9e82a63f2ccb12af02c9e79a83e7989eeb7cb1",
-   "sha256": "15kv5xv6lcfgf048wr2zsnpvrplbxypy3wq56zvrzbq18hwprqg1"
+   "commit": "0869b152f82a76138daa53e953285936b9d558bd",
+   "sha256": "1xm5i658pf1lb4bfpy6zy5msanhia8r9j7v7rx72amkksja3hwnj"
   }
  },
  {
@@ -86711,14 +86803,14 @@
   "unstable": {
    "version": [
     20210606,
-    1152
+    1150
    ],
    "deps": [
     "iter2",
     "nvm"
    ],
-   "commit": "e38d21a885e234af9ea6b03f499c487175570571",
-   "sha256": "1c7n43xi1sjprqn0xhd1hfdr39ipqiw1r8w76qbm3xx04h9bccy8"
+   "commit": "85c9349de2730b71c5796e342d67efee34faa9ed",
+   "sha256": "06gcqnd6wwcxqij4gx06y16kcqsh5znhs7hi5kwhzrbvqvqvrki8"
   },
   "stable": {
    "version": [
@@ -87122,11 +87214,11 @@
   "repo": "jcs-elpa/project-abbrev",
   "unstable": {
    "version": [
-    20200724,
-    901
+    20210715,
+    1213
    ],
-   "commit": "7b5749eae33eda576da3293dc386794c1248bb48",
-   "sha256": "0fvfp5hy93ggqspbnishzp0x0j1652ayismb8bpzkf6vra8vjrdw"
+   "commit": "e8c22beb14aff6d5661337feb6cebd7af3a3d454",
+   "sha256": "09zp7896ndmksk7mywdwhrh4bq951vj5lqjls7ncihifwlgcxa7w"
   },
   "stable": {
    "version": [
@@ -87810,8 +87902,8 @@
     20200619,
     1742
    ],
-   "commit": "4b77b733699f9c39b517a124da737c018b1164e2",
-   "sha256": "1mfvmpwxayrzp07vl72djv162vlf0xg29mxh030lqf7jc9h11gxq"
+   "commit": "b90ec9c242b303e90811deebaa2e3e684b63de91",
+   "sha256": "11n9ybjxfc8x58fwp2f67nc6mg4qkj8m9c7ldjlp77m01k0qrij1"
   },
   "stable": {
    "version": [
@@ -88657,6 +88749,40 @@
   }
  },
  {
+  "ename": "pygn-mode",
+  "commit": "a6a83906ba07f4a0cd906e8345de036a7cdcc6e5",
+  "sha256": "0w7rrq02rjkm4bbk08fz0r5yaxzbgxrgglhbg2qz7arzvgq4l715",
+  "fetcher": "github",
+  "repo": "dwcoates/pygn-mode",
+  "unstable": {
+   "version": [
+    20210714,
+    1304
+   ],
+   "deps": [
+    "ivy",
+    "nav-flash",
+    "uci-mode"
+   ],
+   "commit": "321c14c195cd2f8a31b9bf99dd318a552fbbcd6d",
+   "sha256": "1sz8riry4c4lf5n0nsd3msw5kch3ifwg5psrf4y866b0wlya7yk2"
+  },
+  "stable": {
+   "version": [
+    0,
+    5,
+    1
+   ],
+   "deps": [
+    "ivy",
+    "nav-flash",
+    "uci-mode"
+   ],
+   "commit": "cd06faecb40774fafa69d91085206810d686367a",
+   "sha256": "15hs87ly3gr8qcdfpsyyf8wadyhhij72kkj33hdqbbq9b74yr6qq"
+  }
+ },
+ {
   "ename": "pyim",
   "commit": "151a0af91a58e27f724854d85d5dd9668229fe8d",
   "sha256": "1ly4xhfr3irlrwvv20j3kyz98g7barridi9n8jppc0brh2dlv98j",
@@ -88664,15 +88790,15 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20210623,
-    415
+    20210714,
+    231
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "70d488f9233a578f0c7f8906aa83a1a690ec10fa",
-   "sha256": "14zczmikgsxqf3klx17n1imgpqhj3gjmz4hs95lkxs3a50qbqh7z"
+   "commit": "ebd3175c4c5e7845c52dddf71a806826a80df89d",
+   "sha256": "0p52a4bp4gmgwfpai8cwq3frp0fyhp9ma5a0idxdiamr8xjiwjz0"
   },
   "stable": {
    "version": [
@@ -88834,8 +88960,8 @@
     20210411,
     1931
    ],
-   "commit": "6f066733e23a61d83580cd1898e6b8afab8fafea",
-   "sha256": "1m7365k7a624mp33v5x23knkcahpa9gvb3sbr8idqlk8n8k3f6mk"
+   "commit": "6c29598ce446dc441a8095b83c82390249df3693",
+   "sha256": "0l5dg9snp4p6x3nlyl0civ50kdl1q6zr0hmx9hcp2c72hm22dqi5"
   },
   "stable": {
    "version": [
@@ -89759,15 +89885,15 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20210629,
-    2000
+    20210715,
+    2107
    ],
    "deps": [
     "faceup",
     "pos-tip"
    ],
-   "commit": "4f8eafe2a016e2e78872e4006939ee82397e57a0",
-   "sha256": "0fa9kipg1ihfr16ljsfgxd6z8a5fj31npfxhqv7q9ysi4nq479c0"
+   "commit": "c7aca6f1b4c34a48314bc7812c2d7edc849e3dba",
+   "sha256": "1pcxicz7kg6s9j9gsdb8pba3j3n5522gclc5qq95ch2q3i5phg91"
   }
  },
  {
@@ -89832,11 +89958,11 @@
   "repo": "istib/rainbow-blocks",
   "unstable": {
    "version": [
-    20210412,
-    1937
+    20210715,
+    1518
    ],
-   "commit": "ae5c11cd3dc64039c5e65c9f1804aceba5b3b209",
-   "sha256": "17ar9k2352h6cnvcknq945lna3illln87r1vf4ll1aa798azizpb"
+   "commit": "83c4d6e77a1e25d3d2d124a4e90d5b084f3e15a5",
+   "sha256": "1v583d6mh69cz1adl295pd7axlqk3m1qs94558n84d1sh7syxcdg"
   },
   "stable": {
    "version": [
@@ -90716,7 +90842,7 @@
   "unstable": {
    "version": [
     20210513,
-    2237
+    1453
    ],
    "deps": [
     "load-relative",
@@ -92013,8 +92139,8 @@
     "f",
     "s"
    ],
-   "commit": "f62be2d11c8a9182cf84f0efe7ed054cc304262d",
-   "sha256": "0ksw9s96mmb1qlypz9mc9br9139ha5jmahi42x4i8qppcn6zs5ja"
+   "commit": "eaf177324482d0eadf0e97a892a156c2d503f245",
+   "sha256": "18krcfbjvm9g67846dn3q7a2y4z3figirk3pvdsdb0fv425j11zr"
   },
   "stable": {
    "version": [
@@ -93400,8 +93526,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "bbf129cd128105de51b6c242b2551094b8d8987d",
-   "sha256": "09dnlvi8kf683n6q3yp4gy9d4idiyg4x6rcij8d90cvygh8i30wd"
+   "commit": "6ca73bb3cce4d1db3c4f91efb83b63227eb712d1",
+   "sha256": "12arrvvp3idq11a4ham77zxqp2d1026qz89ywgd3i9k1cbj852wi"
   }
  },
  {
@@ -93708,8 +93834,8 @@
   "repo": "djcb/sauron",
   "unstable": {
    "version": [
-    20201015,
-    836
+    20201011,
+    905
    ],
    "commit": "5daade4836da5b1b2ab26d84128d6c38328a5d52",
    "sha256": "0fkq8knq023zm538ls4zxghlkn9zf4rfccpmmgfcpad6bdm00cpc"
@@ -93871,8 +93997,8 @@
     20200830,
     301
    ],
-   "commit": "32c5c18e1cac173b79fc37b85dca51f4e8d57e45",
-   "sha256": "1vzg370393yfw1msgdyq2bwv3rc765z30vsrxssm0zifjqimkab6"
+   "commit": "cff035686cc9505d114115646e4d98edac307512",
+   "sha256": "0w5bzlsbs5zdk3h8ij019yj7861ggg0a4wcqwq7dm7rwf1bshsl2"
   }
  },
  {
@@ -94371,8 +94497,8 @@
   "repo": "t-e-r-m/sculpture-themes",
   "unstable": {
    "version": [
-    20210530,
-    624
+    20210524,
+    354
    ],
    "commit": "1da2b3501f3732b4a58d28b502e356226a43a96f",
    "sha256": "198rjkyv876h7mbs73h8dq4lx5xhl66p7xrpvb23v0vk4vw0q5vz"
@@ -94452,8 +94578,8 @@
     "dash",
     "f"
    ],
-   "commit": "447b6f0c3b4429e70a474a325151913100bc6417",
-   "sha256": "1w0l0r4n0w99523klia1pfyh0y3jvskhk2wrwzdx09mad0bdfj1b"
+   "commit": "46eefd5b3f4a6f24b2f88c8aa18cce0abb32edb1",
+   "sha256": "0fi04v84gp74xr84sh7blbc5s93xxb6apsrdh8zlc9dvwkkh5gza"
   },
   "stable": {
    "version": [
@@ -94690,11 +94816,11 @@
   "repo": "raxod502/selectrum",
   "unstable": {
    "version": [
-    20210530,
-    245
+    20210707,
+    1827
    ],
-   "commit": "a19bbe94de492bf504399c093cfc5695eb630fa8",
-   "sha256": "0jhc0qn3q7npsixj1b1cmplxdvpy30745h32y0ybyydahqc3yc30"
+   "commit": "48ea51aa5b6959ea2a134e36cd21f727047b0677",
+   "sha256": "0lini8hdih1qakf3hg981diw9gmzxjkd6rnjq3lddyqg6dvj9hhw"
   },
   "stable": {
    "version": [
@@ -95732,11 +95858,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210621,
-    534
+    20210714,
+    111
    ],
-   "commit": "70b985b1d00c8703acb1ebf16875616903470f45",
-   "sha256": "0djvaxbxjic4m8nqmj1gs0h77gf0fik00ia7ayfha3fc7fabiif9"
+   "commit": "ccdd3681b9e7d8b6a758f2aa61a0ae8eab21240b",
+   "sha256": "1ynl1kwnhp5xqvmi8p37lprshk96xi8q78rsjmd9f8pkb8ayqbf3"
   }
  },
  {
@@ -95808,11 +95934,11 @@
   "repo": "jcs-elpa/show-eol",
   "unstable": {
    "version": [
-    20200921,
-    1201
+    20210715,
+    1227
    ],
-   "commit": "02fdb5b2832889afd6cad5c517da9b1e4611c766",
-   "sha256": "0yy97yzc8v1h0vjpm6zbrdwy8sd931mscrbrq1svvv2y227s4ffl"
+   "commit": "28dc1d6faf21efbc49436b4458821a2d46e38ffe",
+   "sha256": "002vyik2nyqcvrf6d0qfbxc9bs95bc74crmyn9havlr50bw52wlc"
   },
   "stable": {
    "version": [
@@ -96161,11 +96287,11 @@
   "repo": "rnkn/side-notes",
   "unstable": {
    "version": [
-    20210502,
-    935
+    20210709,
+    1403
    ],
-   "commit": "ca73cec33880322c5bbab407825d502d87f4cf0f",
-   "sha256": "1qnrk8kib4rndgbljqxq7cmskgxwcc9d8wdbdr3mgkgbg08xv5gq"
+   "commit": "41fe8544661a772f764a0924e04080f258053955",
+   "sha256": "14xm2a465mgdbp47hwb1dpxw4w5vl0rdlc4m5bxd5z1l4s06nc32"
   },
   "stable": {
    "version": [
@@ -96736,8 +96862,8 @@
   "repo": "yuya373/emacs-slack",
   "unstable": {
    "version": [
-    20200830,
-    1021
+    20210712,
+    628
    ],
    "deps": [
     "alert",
@@ -96747,8 +96873,8 @@
     "request",
     "websocket"
    ],
-   "commit": "1f6a40faec0d8d9c9de51c444508d05a3e995ccd",
-   "sha256": "19lan9nd8qfw2ws7mx814vrin04c892yn5c8g3nad7lpnzszgr1r"
+   "commit": "ae1d742a0193fba38698931055708a28cc382bcf",
+   "sha256": "0292z0pzvwg85pr1g3xsglp9rkna6k7b0frbm5r43yr91sr0vv3f"
   }
  },
  {
@@ -96809,15 +96935,15 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20210614,
-    1523
+    20210709,
+    2051
    ],
    "deps": [
     "cl-lib",
     "macrostep"
    ],
-   "commit": "98a656d96b177edce57b552a2fa9d139cdce8c9a",
-   "sha256": "133p6yj5vdw6i4j2v8ac2g9ayrwxlvvimh2qs5fmxi8vklvn7h3a"
+   "commit": "68f5623f13c9a0d3d47ce70cf56928e00483d9d6",
+   "sha256": "1hybxng81ra3zqj07xp5vpzd5mx15sfvqa4wydg1kxi9ics6m9i6"
   },
   "stable": {
    "version": [
@@ -97052,8 +97178,8 @@
     20210629,
     2009
    ],
-   "commit": "954e5dad72fb5712dfa968222e2b46dfdf9a476c",
-   "sha256": "06m2vwxga1rys98z97abajqq89k2dlfrrab21hhgqwc0zmdmb9fv"
+   "commit": "41f4d650485217aa1f2afa7c159418f103a09231",
+   "sha256": "0cq1a19d1przjizp7d4vjl8khp09j6jcwavhrpja1saqhwavhv7c"
   },
   "stable": {
    "version": [
@@ -98069,15 +98195,15 @@
   "repo": "SpringHan/sniem",
   "unstable": {
    "version": [
-    20210605,
-    1242
+    20210708,
+    1128
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "54005eb19dfab02f38074e696fa8d247b59a2ad8",
-   "sha256": "18ynqkf98rjyzl48l5399g49x9gdmsj0wyc4jp7mly7xrv51zblx"
+   "commit": "1b3071974b55c7f2046bd20a052b8fc795d2c940",
+   "sha256": "16k64k4mzjaiyq264crcpnmccj7aza2zlr9jg6l7ggjssly3fw5c"
   }
  },
  {
@@ -98253,26 +98379,26 @@
   "repo": "hlissner/emacs-solaire-mode",
   "unstable": {
    "version": [
-    20210601,
-    1921
+    20210711,
+    2145
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "2298fd806d28daf511eb7836b23775e7df1f65e2",
-   "sha256": "1jfl0nhnv3ljagdlpsi2d7mhcrm8rww8crnhzad5zimzwc48nlcq"
+   "commit": "030964f7c62696c8cfb29125df6e7649d2bf9aeb",
+   "sha256": "01c1lkr21y0cd6gixzd38mql89k70jn049jr0xhazgz16cnw1g7j"
   },
   "stable": {
    "version": [
     2,
     0,
-    0
+    2
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "59efa9c52ec407161f741e67071813c3c1901680",
-   "sha256": "0aigavrqfi2dy4q5vrfs48n5k7839gqnafq7mp14cmcbrzcwadrd"
+   "commit": "030964f7c62696c8cfb29125df6e7649d2bf9aeb",
+   "sha256": "01c1lkr21y0cd6gixzd38mql89k70jn049jr0xhazgz16cnw1g7j"
   }
  },
  {
@@ -98283,14 +98409,14 @@
   "repo": "bbatsov/solarized-emacs",
   "unstable": {
    "version": [
-    20210519,
-    925
+    20210112,
+    1050
    ],
    "deps": [
     "dash"
    ],
-   "commit": "e626b1889d8c945806e959e451f08633d948f8a7",
-   "sha256": "1nz04q681slnzcqzc6lcckmv72h017616l1j7q4aalf2dqkn529z"
+   "commit": "8271679a627148c96ad894f960cec9b1abfb1e6c",
+   "sha256": "1xrya65z54si9cf64whllq7vhw5dnafal9q2m4jf62jvxmbjdfsi"
   },
   "stable": {
    "version": [
@@ -98847,11 +98973,11 @@
   "repo": "nashamri/spacemacs-theme",
   "unstable": {
    "version": [
-    20210618,
-    2001
+    20210706,
+    1210
    ],
-   "commit": "f98150e8e254e6bf94dee2de3e8baaf02e2aae80",
-   "sha256": "02jm3v3bnbc45rd4fl9kkln0pn49ix2igm254yz33cg0ykgkj2nf"
+   "commit": "dfe06629f8211ccd9933fc0d457019401ecbe594",
+   "sha256": "1apa6bp3lxs6jia37k079yd3qx79wclzh02bf66xpsqkwc2xg5fr"
   }
  },
  {
@@ -99009,11 +99135,11 @@
   "repo": "brailcom/speechd-el",
   "unstable": {
    "version": [
-    20210619,
-    1753
+    20210702,
+    1954
    ],
-   "commit": "bd21335668ac7ea4d8c992490b4a710053434e74",
-   "sha256": "1jlb1mfigcqxvm1aibf803xypmbj3x1145nmf2q0v2aaipd6s912"
+   "commit": "7f3d3d3545078df2f4a37094c618993145c731d2",
+   "sha256": "126chadfvsfpwa196811s2i8zr4cs1g413ssy52apn2fpzrb3vmp"
   }
  },
  {
@@ -99803,11 +99929,11 @@
   "repo": "jhgorrell/ssh-config-mode-el",
   "unstable": {
    "version": [
-    20210517,
-    1925
+    20210714,
+    951
    ],
-   "commit": "ff9a15ec150baef21d7d8c6f79c5602e56825391",
-   "sha256": "1nvsxj616lgciysmvzpwfpq7dv0alkv2ma4gi9b4j3vjwm0rzbry"
+   "commit": "1c8f8779f20479e55f9d3d1151f1f68c1dff56f2",
+   "sha256": "0vcs6bz3qzw06c7bs253m9q2l43k8nppzdv7hqbybcdh4fakp8xw"
   }
  },
  {
@@ -100114,8 +100240,8 @@
     20200606,
     1308
    ],
-   "commit": "097c527a40797e1b3f3a954cfc5e04987fbb61a9",
-   "sha256": "0yidmzdkrw66hga7nna337jk8rkml6plhr1mzfsyfazpb9da0zsj"
+   "commit": "ba12f620074b5a6e6615e2963bdc79fbba6060eb",
+   "sha256": "1gjmzm8lx8fas9phkbvy3rz9dyzqgdjs2ddd3l9biqqggwka0pa0"
   },
   "stable": {
    "version": [
@@ -100279,20 +100405,20 @@
   "repo": "akicho8/string-inflection",
   "unstable": {
    "version": [
-    20200927,
-    747
+    20210712,
+    755
    ],
-   "commit": "c4a519be102cb99dd86be3ee8c387f008d097635",
-   "sha256": "0f3nkfdpngax4zfw75jca2wywwh31ha6ywddh4125lbxi3y6m7s9"
+   "commit": "bf60b0c943cc0934aa188ada7c1c16053517df07",
+   "sha256": "077qxldhya397ka96786w0876bwa77x0il3zwixa9pcbqmqsg8qd"
   },
   "stable": {
    "version": [
     1,
     0,
-    12
+    13
    ],
-   "commit": "c4a519be102cb99dd86be3ee8c387f008d097635",
-   "sha256": "0f3nkfdpngax4zfw75jca2wywwh31ha6ywddh4125lbxi3y6m7s9"
+   "commit": "96a9baf4936df43b9f46804629384b79238691c3",
+   "sha256": "1v8h05m7iwxqp7lypdngib2620z0x23zc715vxqpqys79djwh9yh"
   }
  },
  {
@@ -100604,14 +100730,14 @@
   "repo": "nflath/sudo-edit",
   "unstable": {
    "version": [
-    20210108,
-    420
+    20210706,
+    534
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a7ae1713bb659988bb1465a13b837fbc2d699504",
-   "sha256": "1hncxbg5lvywzkwvdmzvrz71midy4samjq2vvxxhz90z1y5l8l29"
+   "commit": "23b78a39053088839f281bc0c3134203d7e04e50",
+   "sha256": "1c8rrrxq8i287a7r1qwrqhfyrl84jfcpnjxiqczwjmc95r510yyz"
   },
   "stable": {
    "version": [
@@ -101227,8 +101353,8 @@
    "deps": [
     "ivy"
    ],
-   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
-   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
+   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
+   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
   },
   "stable": {
    "version": [
@@ -101438,14 +101564,14 @@
   "url": "https://tildegit.org/contrapunctus/sxiv",
   "unstable": {
    "version": [
-    20210514,
-    918
+    20210713,
+    1845
    ],
    "deps": [
     "dash"
    ],
-   "commit": "a531a7596e307a218beb8ff77893eeae61284f6e",
-   "sha256": "0gimq172pp143jckfhhyw319n3vpjvlkadm0vhypycas9i89mcg0"
+   "commit": "14057b156dd57610edf101403e653be874a342bb",
+   "sha256": "14wh7fw45w5cfdqibrcfzahsf4cwbi97xp16jd773ynkcf049cjs"
   },
   "stable": {
    "version": [
@@ -101805,15 +101931,15 @@
   "repo": "vapniks/syslog-mode",
   "unstable": {
    "version": [
-    20190913,
-    2040
+    20210714,
+    1932
    ],
    "deps": [
     "hide-lines",
     "ov"
    ],
-   "commit": "18f441bf57dd70cdd48a71f1f4566ab35facdb35",
-   "sha256": "1xl6immya0i5xjpls3vqdqj9rr5jxp5srny8l9j4qxf8kp75byqa"
+   "commit": "ff1ab94c0f65e9891656d78d84f71614e0b9a597",
+   "sha256": "1x0xlbiisq8wngxhznkhxavhrhbc1w5p5w1qgfxib16fr09aqyc5"
   },
   "stable": {
    "version": [
@@ -102434,15 +102560,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20210701,
-    1035
+    20210711,
+    1323
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "a4054e9517d68109212f9d69342a49d4d65dd56f",
-   "sha256": "010b2rkpr8cib1c6s1ysg5wllrsg4rxc7h7cxqrjq1978bi499cw"
+   "commit": "377531fc19063b490b842e779df9b07195e8c496",
+   "sha256": "0gmjfw6kz5cflvj3zmyhw9qad850ckvq14k5vys62603yvm53qgw"
   },
   "stable": {
    "version": [
@@ -103382,14 +103508,14 @@
   "repo": "myTerminal/theme-looper",
   "unstable": {
    "version": [
-    20201107,
-    4
+    20210714,
+    1807
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "6bc170097f1dfb7ea4db91544c5ab653279e15cd",
-   "sha256": "0amm2jw86nyjzrga93n7jhz7p603mid46y41dsw2x8wz2rbh06r2"
+   "commit": "bb711c4bb992d7a129dd434a41a356cdaf8c387d",
+   "sha256": "09i7w2s594ksyi7a9bwpcycn4j7is19jh9kznrk39ar2kc3m118h"
   },
   "stable": {
    "version": [
@@ -103525,18 +103651,18 @@
     20200212,
     1903
    ],
-   "commit": "6c2a7567772f3954006c77a8bdc041df83802a00",
-   "sha256": "0g1j346s8jhw830byzjvgsjg6a03kza19xsghza1bzncwqjbv1n5"
+   "commit": "b157feff61c3bdefb138753af7636dae5a7b3c08",
+   "sha256": "1dnspcmni98xhcz21604238lskdqn6b4kpv2zllvq58si59q32mw"
   },
   "stable": {
    "version": [
     2021,
-    6,
-    28,
+    7,
+    12,
     0
    ],
-   "commit": "32036a5505970a5a8c905543ebc6de1b20a662d8",
-   "sha256": "0nc9d88ydm5x4nynyxq4rqbp63ypjd1mwf18vancwigv7jxc62an"
+   "commit": "faeb22efa9ed948e6096e37e65e6d121c83e329a",
+   "sha256": "1adaqcdzzrrff0186276pdmlqixkv47qfgyxap3by9zdiqwysd50"
   }
  },
  {
@@ -103592,20 +103718,20 @@
    "deps": [
     "haskell-mode"
    ],
-   "commit": "60a1c271b39dac22783a4f892446f08d3faeb025",
-   "sha256": "18spz3lvb3df0rr2cqxkqa6rfzrpwwryh4gkzp68znbbfl655l8d"
+   "commit": "95c065a410c20cbeefeaabc3084b2b09d09564c2",
+   "sha256": "02xbzwj1bf0n4lvg1rycmxsbvwi0p0h9a5fqx755kshwx5hngkx3"
   },
   "stable": {
    "version": [
     1,
     7,
-    7
+    8
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "b7399a878622173bf9fdc076ec72a8353e1b924c",
-   "sha256": "1qbywv182gzbdk27bzah273mb8brmqrpxcgv1pmdy10fc7fv2z0f"
+   "commit": "95c065a410c20cbeefeaabc3084b2b09d09564c2",
+   "sha256": "02xbzwj1bf0n4lvg1rycmxsbvwi0p0h9a5fqx755kshwx5hngkx3"
   }
  },
  {
@@ -103841,11 +103967,11 @@
   "repo": "aimebertrand/timu-spacegrey-theme",
   "unstable": {
    "version": [
-    20210621,
-    1857
+    20210710,
+    1950
    ],
-   "commit": "80d29c0f29925775fb00e90669a153d94eae01db",
-   "sha256": "1hdxis28ngrl0d1gafckah7srad4rnpmn4dh5dxd0a5vph63cxhw"
+   "commit": "e0629d59adc92112f51b5f9300e06e714349488d",
+   "sha256": "104zffdf0jlfqh6rlzl7a7ji5gs11pacy63ab4rjs2kx08p3z0y9"
   }
  },
  {
@@ -104004,11 +104130,11 @@
   "repo": "dalanicolai/toc-mode",
   "unstable": {
    "version": [
-    20201028,
-    1141
+    20210714,
+    725
    ],
-   "commit": "36fe728f387ab2087e4096cb4734a8642dd7f880",
-   "sha256": "1v3h1aw8p98rhy3mx8nngwl0v0pzk6pabr9mmah20cdgz1j8ax0s"
+   "commit": "977bec00d8d448ad2a5e2e4c17b9c9ba3e194ec2",
+   "sha256": "1yshkvsa5g6gxn9agf4z5ks5bd43l4akdcblxfgqkpshp25y5plv"
   }
  },
  {
@@ -104483,11 +104609,11 @@
   "repo": "jorgenschaefer/circe",
   "unstable": {
    "version": [
-    20210528,
-    754
+    20210713,
+    1609
    ],
-   "commit": "d6f1fa18646f6ed2a1c0f06a4888130bd694ff19",
-   "sha256": "1l6v02aa072jvhq4b9dpkprqs14py0d4jm3xvihm05lvrbf9v6c6"
+   "commit": "07d6d82cba864b1e38d3bd46654f2e1928a997c2",
+   "sha256": "04h60s6ig43sj144s7dlip1saf9kdwvzlfys8qwwx48003rbs0dp"
   },
   "stable": {
    "version": [
@@ -104590,20 +104716,20 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20210701,
-    1116
+    20210712,
+    1626
    ],
-   "commit": "51e833e5152e9fdcdc1dbbf34ad2d4905bde1f69",
-   "sha256": "10k9dzs8y6i0rfckclxm5n3maylmh95993n5dvrs8rbmlcpmihvy"
+   "commit": "e90481000f071e9a26a1cc0f40d347f7d3e2201e",
+   "sha256": "1sw9248cxr3x2hy2rhyzbwik08nvlkglxgig3rbqshc8spnid5h3"
   },
   "stable": {
    "version": [
     0,
     3,
-    5
+    6
    ],
-   "commit": "b711543401dafc159943d8a703cf30fabdc78e1f",
-   "sha256": "0wzfnzv2304a737zwp163aajjhm8i3ix9v7palgg1r3jskvbghmw"
+   "commit": "51e833e5152e9fdcdc1dbbf34ad2d4905bde1f69",
+   "sha256": "10k9dzs8y6i0rfckclxm5n3maylmh95993n5dvrs8rbmlcpmihvy"
   }
  },
  {
@@ -104651,14 +104777,14 @@
   "repo": "holomorph/transmission",
   "unstable": {
    "version": [
-    20210218,
-    2015
+    20210705,
+    2152
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "b5c1d391b4be469a07536e901e54a8680387025f",
-   "sha256": "1z3gzax6i9cwipmi64hg3h98haimlb0xsz4zm1ggqwwq1zd5csvp"
+   "commit": "a03a6f5c7b133e0a37896b6d993dd6d6d4532cc2",
+   "sha256": "1znpl4ps0ah6lmrlyha6wbkbvnx90qkvksp5xp87apfb61zqzqwz"
   },
   "stable": {
    "version": [
@@ -104723,8 +104849,8 @@
     20200910,
     1636
    ],
-   "commit": "20694aae145edd6ad496a395ef1a53ab37a59521",
-   "sha256": "01afsgkzn5y4ld5m1gmvai8pgdy73kmllivmz18a2q9fdrgaa6xb"
+   "commit": "d2651b913a6ec615e6285712833566a79dca7247",
+   "sha256": "0pw401npbahlii6x37c6mi66ghd16mv04d6y0d1nirflvg4nfl8a"
   },
   "stable": {
    "version": [
@@ -104964,8 +105090,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210606,
-    1918
+    20210713,
+    2032
    ],
    "deps": [
     "ace-window",
@@ -104977,8 +105103,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "2655a8976d56719add893cec45a18e018626842d",
-   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
+   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
+   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
   },
   "stable": {
    "version": [
@@ -105014,8 +105140,8 @@
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "2655a8976d56719add893cec45a18e018626842d",
-   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
+   "commit": "a6f9e9f1cea3502b3ead082fd208c4011a55add0",
+   "sha256": "1g004yj613x6qr06gaffb6rp2n47ximb1w8776l0s6w8d40msyyg"
   }
  },
  {
@@ -105033,8 +105159,8 @@
     "evil",
     "treemacs"
    ],
-   "commit": "2655a8976d56719add893cec45a18e018626842d",
-   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
+   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
+   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
   },
   "stable": {
    "version": [
@@ -105063,8 +105189,8 @@
    "deps": [
     "treemacs"
    ],
-   "commit": "2655a8976d56719add893cec45a18e018626842d",
-   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
+   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
+   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
   },
   "stable": {
    "version": [
@@ -105095,8 +105221,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "2655a8976d56719add893cec45a18e018626842d",
-   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
+   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
+   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
   },
   "stable": {
    "version": [
@@ -105128,8 +105254,8 @@
     "persp-mode",
     "treemacs"
    ],
-   "commit": "2655a8976d56719add893cec45a18e018626842d",
-   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
+   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
+   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
   },
   "stable": {
    "version": [
@@ -105161,8 +105287,8 @@
     "perspective",
     "treemacs"
    ],
-   "commit": "2655a8976d56719add893cec45a18e018626842d",
-   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
+   "commit": "a6f9e9f1cea3502b3ead082fd208c4011a55add0",
+   "sha256": "1g004yj613x6qr06gaffb6rp2n47ximb1w8776l0s6w8d40msyyg"
   }
  },
  {
@@ -105180,8 +105306,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "2655a8976d56719add893cec45a18e018626842d",
-   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
+   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
+   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
   },
   "stable": {
    "version": [
@@ -105389,15 +105515,15 @@
   "repo": "alphapapa/ts.el",
   "unstable": {
    "version": [
-    20201212,
-    1041
+    20210705,
+    341
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "b7ca357a0ed57694e0b25ec1b1ca12e24a4ce541",
-   "sha256": "12p4k8x1p0h94xcdis7m0vkzf41k5k3ijkaj838ywb7i74myfdxb"
+   "commit": "b6814e7e688781a586a775ef3504b9252af65b93",
+   "sha256": "1bf39qx8k7nn1dj1fp6j47zr1lp28ccrj6ciz7z3dk040rlxnv11"
   },
   "stable": {
    "version": [
@@ -105518,14 +105644,14 @@
   "repo": "ocaml/tuareg",
   "unstable": {
    "version": [
-    20210628,
-    1257
+    20210709,
+    321
    ],
    "deps": [
     "caml"
    ],
-   "commit": "2e8482e23f45f0e6246a8d075a3b8696c5f49070",
-   "sha256": "04wblkb0jqzq67p1d96i284wfqv3ddffrwz3i3wf537wyi8bmn4k"
+   "commit": "b59c422759506402f990b089dbaa91c0578e2c2e",
+   "sha256": "1maqyhy82ayfiv95ng4bpgxrvjkkz331pw4ld1x99jpwqljpwqzc"
   },
   "stable": {
    "version": [
@@ -106159,8 +106285,8 @@
     20200719,
     618
    ],
-   "commit": "d4edb2cc110f1679ebc82cb52a4242cbc74636db",
-   "sha256": "0agn2j0qd516kxqx1bh6ajpandi8vz7zas966nw88yhv8m8hlzb2"
+   "commit": "741ab716ada8e71a94a9dae3daa4236298d29bd7",
+   "sha256": "1ibjwmvx4p7kchxlnfpqxj4p3k99nwxwhzk4m2b1yyswpiad2k0z"
   },
   "stable": {
    "version": [
@@ -107033,8 +107159,8 @@
    "deps": [
     "exec-path-from-shell"
    ],
-   "commit": "43499194224483b27628fdf99f6f9ff6e731d844",
-   "sha256": "1j6vkg0z7m8yzrgy0innq7r2d5pchbqs3y5gf51qdzsfqdmff3ys"
+   "commit": "31d8bbec16eff342bd4c02b0cb12ea31dd31bf19",
+   "sha256": "0388kwc65hpbimd53br2x9z9dvxw20wnny09kldw5nnlvzvzrba1"
   },
   "stable": {
    "version": [
@@ -107063,8 +107189,8 @@
    "deps": [
     "s"
    ],
-   "commit": "408c01423d7036463891d83e4a21227250ed2a14",
-   "sha256": "1jz7x93c14f2nm8iqc30kzfjbn5bcdvxxnfljvwj77mwgir2ali8"
+   "commit": "aa6e271e8efc3a93caaaa740245d126d24e778ab",
+   "sha256": "0a8qb7wyi5pkg7g0x7imzzxryz55dr8msiila9j9skq6jlmn84hl"
   },
   "stable": {
    "version": [
@@ -107823,8 +107949,8 @@
   "repo": "koral/veri-kompass",
   "unstable": {
    "version": [
-    20200213,
-    934
+    20181103,
+    1246
    ],
    "deps": [
     "cl-lib",
@@ -108504,8 +108630,8 @@
     20210627,
     2121
    ],
-   "commit": "bda27d3a7f11fee0550055b0552c2633c167dd96",
-   "sha256": "1y8ycsm4d72v86prg87dffis5q853k2w0fvx5vz732jryzp18lda"
+   "commit": "28398f1059f88e7e242f39cfa0ff8213cdaefc42",
+   "sha256": "0ln5idsmj7x0b769g7bj9wk0bjr826kq4bryw206dxxnz06s3wcs"
   },
   "stable": {
    "version": [
@@ -108527,8 +108653,8 @@
     20210627,
     2121
    ],
-   "commit": "a8bff6913f603a30bd98bef882ace01476c440bf",
-   "sha256": "1rshwvfggjb7amgxcl31xhll28kfbgh14aw33khlp32gq6p3vqyh"
+   "commit": "500d35f051fca07459abd163d5692c853a49329f",
+   "sha256": "1k5akiim0c0qiv10np5yzdndz8p499qhzhhrp1i8dz36gbp5x8ll"
   },
   "stable": {
    "version": [
@@ -108707,8 +108833,8 @@
   "repo": "mihaiolteanu/vuiet",
   "unstable": {
    "version": [
-    20210323,
-    911
+    20210715,
+    907
    ],
    "deps": [
     "bind-key",
@@ -108717,8 +108843,8 @@
     "s",
     "versuri"
    ],
-   "commit": "43b9364042922950f612ac57d8c526921a01b291",
-   "sha256": "14432mnm5lvccb9x3fymzi53kxfh2if92c5q14llz6pbbif8x3vh"
+   "commit": "b327a5224ab45f6689ce635878301e54ca753b3b",
+   "sha256": "1sq2nmmw8ga4jhkgb3a0mkps7v8ma1jrrz8c1vbypfn1b3amvj3b"
   },
   "stable": {
    "version": [
@@ -108840,8 +108966,8 @@
     20210615,
     103
    ],
-   "commit": "70b985b1d00c8703acb1ebf16875616903470f45",
-   "sha256": "0djvaxbxjic4m8nqmj1gs0h77gf0fik00ia7ayfha3fc7fabiif9"
+   "commit": "ccdd3681b9e7d8b6a758f2aa61a0ae8eab21240b",
+   "sha256": "1ynl1kwnhp5xqvmi8p37lprshk96xi8q78rsjmd9f8pkb8ayqbf3"
   }
  },
  {
@@ -109401,14 +109527,14 @@
   "repo": "eschulte/emacs-web-server",
   "unstable": {
    "version": [
-    20210209,
-    58
+    20210708,
+    2242
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3aa5084bcb733aa77997b9210b4437903f6f29ce",
-   "sha256": "1cg27byi1g0s3yfzdkji4xzc15ci5kqb2j0mj5dfdms4db12dir4"
+   "commit": "6357a1c2d1718778503f7ee0909585094117525b",
+   "sha256": "1dp4ajfd4ikqdr2lkmjijw431d3hi07izaw54fn5zw8mp9dk225y"
   }
  },
  {
@@ -109845,11 +109971,11 @@
   "repo": "justbur/emacs-which-key",
   "unstable": {
    "version": [
-    20210630,
-    1217
+    20210712,
+    1852
    ],
-   "commit": "27d9fec33abb989b030f7677ccf5f799287d6472",
-   "sha256": "1vdvp3iavh57mwhmgxwalrha7h7hgxsfnkxbrspl9x9cx7fx98f3"
+   "commit": "55fcce0c6143044535bc6825a68f42ca83f58f00",
+   "sha256": "0bap1k6rzaqvqp7njzikw8clhky1fj78mdcx4zah1y57vhszavcw"
   },
   "stable": {
    "version": [
@@ -110178,15 +110304,15 @@
   "repo": "progfolio/wikinforg",
   "unstable": {
    "version": [
-    20210615,
-    2334
+    20210711,
+    302
    ],
    "deps": [
     "org",
     "wikinfo"
    ],
-   "commit": "7df42a260fb93cb743a08e67ea92d77f62dec72b",
-   "sha256": "05qqs4b0gmnwjl6d29xns93p2lyh1x2xzl0qpydbnxjirwp2bamx"
+   "commit": "31cf4a52990caa3f928b847ec25a5412836552bd",
+   "sha256": "0l13yi9iwi68n95wmxkjrf0zsmvxadpmxc7zm8x7v8kk5p7scnil"
   }
  },
  {
@@ -110894,11 +111020,11 @@
   "repo": "istib/wordsmith-mode",
   "unstable": {
    "version": [
-    20171025,
-    1430
+    20210715,
+    1517
    ],
-   "commit": "589a97412138145bea70e0450eeddeb7f138d538",
-   "sha256": "1zm4grysjpynibldvic75awhcmmnjmlkkvslw8bvirmi58qwvwzj"
+   "commit": "5d40ceaa2b8d41ab3634ca377ceb6a74deeb2287",
+   "sha256": "132l0i94nwrm676bpxw0wnr1drqwmapwv92mf4iyb209fr4hc2w2"
   },
   "stable": {
    "version": [
@@ -110918,8 +111044,8 @@
   "repo": "abo-abo/worf",
   "unstable": {
    "version": [
-    20210504,
-    1132
+    20210702,
+    1200
    ],
    "deps": [
     "ace-link",
@@ -110927,8 +111053,8 @@
     "swiper",
     "zoutline"
    ],
-   "commit": "c99ef5478183d0ab56b0abe943206491c802e003",
-   "sha256": "1qbs5dvqcip7y77f8sdyr7zw64vgxlybj4isi7x841j4z7kh5m11"
+   "commit": "28d381e2603a79340a94a410acbbb8a6b3e237d8",
+   "sha256": "15567bns5kag47d58xapr4z0gfj5py3a8lwfpjlhmzccmarjr7x8"
   },
   "stable": {
    "version": [
@@ -111392,11 +111518,11 @@
   "repo": "xahlee/xah-fly-keys",
   "unstable": {
    "version": [
-    20210701,
-    145
+    20210715,
+    2014
    ],
-   "commit": "6465e77d57a30a0a82ca4f4756593207b2ada510",
-   "sha256": "1bzlpwxkjmzgypagdp9qj4jf6crm3yhjnr98ipr1f49dl8178j6s"
+   "commit": "95c54a896c1e4af797f0af7cf9de85426c8e11eb",
+   "sha256": "137xv47cij7a0zws8xdw140cwlsnywapyb9y51dqpmn08s1ff2l2"
   }
  },
  {
@@ -111422,11 +111548,11 @@
   "repo": "xahlee/lookup-word-on-internet",
   "unstable": {
    "version": [
-    20200420,
-    1528
+    20210708,
+    2203
    ],
-   "commit": "c97a43dc0cebbfc519d0cce5b547dcc5e22b2085",
-   "sha256": "1qkazkisgw5c9xzxqm6xzm124r1v4d4dcyazvw66nz5j2zl1i5qd"
+   "commit": "53044a43db3c803fb3e32003c3106403ecfb8e4b",
+   "sha256": "09x8lrx4sdnx2sr0nkkn19hi7x6hi3gs0ad31xmjx1qgd7bw7as9"
   }
  },
  {
@@ -112453,8 +112579,8 @@
     20210625,
     803
    ],
-   "commit": "0ddf70ec214e2b1fade0594ec44c55adb48c06da",
-   "sha256": "1mkk07j3bayzprimiq95blbyj7idl01p6jv43hh226r427c89bcs"
+   "commit": "0d7556d0936e0223003208003470a2fa28f72150",
+   "sha256": "12lz73grpvnjgki93q9aywa5p6ddw67a73dcaryv186j3maq442w"
   },
   "stable": {
    "version": [
@@ -112813,11 +112939,11 @@
   "repo": "ryuslash/yoshi-theme",
   "unstable": {
    "version": [
-    20210623,
-    544
+    20210713,
+    455
    ],
-   "commit": "4aa2a0d0c3e3b7c408d680df8cc5ede53c18e923",
-   "sha256": "0psb3ff0f0wia7vmxqhframl8vnyzk6xx3dmv1g1j7b0njk259ij"
+   "commit": "06a6bcfc58d1f1cd8815c674c9fcbbf193bba0a9",
+   "sha256": "0mp68h924hfj86rya0kvk16w82lvllmiryz8ry70ngcfmwdh930v"
   },
   "stable": {
    "version": [
@@ -113221,15 +113347,15 @@
   "repo": "EFLS/zetteldeft",
   "unstable": {
    "version": [
-    20210602,
-    841
+    20210713,
+    1855
    ],
    "deps": [
     "ace-window",
     "deft"
    ],
-   "commit": "b71f24d382887aeefde9c47fb6aa521d0ebeb806",
-   "sha256": "09wy2gllacry2n0cp52fakaa36lnd1mnbb26zysdjxh0429siy4a"
+   "commit": "7dbf608d17786a69019867fd6b2b7d6c6edf849f",
+   "sha256": "1lq80ck08bydl98ka6j4qd6m5iqd1l8cx0y8pa2wq94vj71l65vl"
   },
   "stable": {
    "version": [
@@ -113662,8 +113788,8 @@
   "repo": "egh/zotxt-emacs",
   "unstable": {
    "version": [
-    20210222,
-    347
+    20210129,
+    413
    ],
    "deps": [
     "deferred",
@@ -113708,6 +113834,30 @@
    ],
    "commit": "63756846f8540b6faf89d885438186e4fe1c7d8a",
    "sha256": "1w0zh6vs7klgivq5r030a82mcfg1zwic4x3fimyiqyg5n8p67hyx"
+  }
+ },
+ {
+  "ename": "zoxide",
+  "commit": "77de3ff55aa7feffef7e389b4dc9a0844f82da55",
+  "sha256": "055f229a9kck8bbfwxksdi2b5v2aawjz2p8f6dar247ii1ix0jd6",
+  "fetcher": "gitlab",
+  "repo": "Vonfry/zoxide.el",
+  "unstable": {
+   "version": [
+    20210705,
+    448
+   ],
+   "commit": "f68d7cf9c8c813bdc1ec75f880e0dd1b64112f7c",
+   "sha256": "030vyh9v89ij1db1riqpzxxfgs50x0lx3isnhzbfj2dy3acmmc7s"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "f68d7cf9c8c813bdc1ec75f880e0dd1b64112f7c",
+   "sha256": "030vyh9v89ij1db1riqpzxxfgs50x0lx3isnhzbfj2dy3acmmc7s"
   }
  },
  {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -198,11 +198,11 @@
   "repo": "ymarco/auto-activating-snippets",
   "unstable": {
    "version": [
-    20210417,
-    1134
+    20210605,
+    1143
    ],
-   "commit": "3076cefea0f6ae9d7757f13c27b5602e007b58ec",
-   "sha256": "1psy6qpqxh6dm2ix7pwqdcq0rbiy6hyd830g76jk4wvj4spm5rpf"
+   "commit": "118ed7fc948b6d91eea727df35a1639521bf5fdb",
+   "sha256": "0qnsyvvb0knarvd4lvnzazf8y756iwx435zswym5lwsw5v847l8d"
   },
   "stable": {
    "version": [
@@ -1036,15 +1036,15 @@
    "version": [
     2,
     4,
-    0
+    1
    ],
    "deps": [
     "ac-php-core",
     "auto-complete",
     "yasnippet"
    ],
-   "commit": "33ed12bb2ec627a8a05360885f071e4a88fff399",
-   "sha256": "1ffayysbqh7vq65vhbmqg9yp03fqfnwj3drwyinr5ia81acp37nz"
+   "commit": "9770c95bf2df93d9cb0f200723b03b3d9a480640",
+   "sha256": "188z1i209z61nwfcgffgp90rdcsnl75izxpqv4x1vbaay5fvg33f"
   }
  },
  {
@@ -1073,7 +1073,7 @@
    "version": [
     2,
     4,
-    0
+    1
    ],
    "deps": [
     "dash",
@@ -1083,8 +1083,8 @@
     "s",
     "xcscope"
    ],
-   "commit": "33ed12bb2ec627a8a05360885f071e4a88fff399",
-   "sha256": "1ffayysbqh7vq65vhbmqg9yp03fqfnwj3drwyinr5ia81acp37nz"
+   "commit": "9770c95bf2df93d9cb0f200723b03b3d9a480640",
+   "sha256": "188z1i209z61nwfcgffgp90rdcsnl75izxpqv4x1vbaay5fvg33f"
   }
  },
  {
@@ -1597,10 +1597,10 @@
  },
  {
   "ename": "acme-theme",
-  "commit": "0bf14d91ff89556671b175d5f7e71066f27cb73d",
-  "sha256": "0zsrqvhly3si2qkvc4rhki89r2z185l684wf7j9kx32fgaaqanac",
+  "commit": "1b9a64eee8e5b3f75f873654fd6102fc4aaf5e10",
+  "sha256": "09079yjzc9dk052r5fjq9sxps2yld6rl36k6f58xj2rvghzdsbwc",
   "fetcher": "github",
-  "repo": "ianpan870102/acme-emacs-theme",
+  "repo": "ianyepan/acme-emacs-theme",
   "unstable": {
    "version": [
     20210430,
@@ -1856,6 +1856,24 @@
   }
  },
  {
+  "ename": "affe",
+  "commit": "84b0a313d4246b6e0c0541300a62c4ed37a71cbf",
+  "sha256": "1x0w6zl8ivv2lbj3qncqmvgh09p8q5zljhqxylsi3kc13xkv9d0p",
+  "fetcher": "github",
+  "repo": "minad/affe",
+  "unstable": {
+   "version": [
+    20210603,
+    1139
+   ],
+   "deps": [
+    "consult"
+   ],
+   "commit": "dee51350e1d7d3cfbfb12069dea9246454a3df31",
+   "sha256": "1dpzwwbkwxmkh430hk3w9p6z1rwns5znzbar071h95gi7phyhm2x"
+  }
+ },
+ {
   "ename": "afternoon-theme",
   "commit": "583256b7fa48501c8bfad305d76d2e16b6441539",
   "sha256": "13xgdw8px58sxpl7nyhkcdxwqdpp13i8wghvlb3l4471plw3vqgj",
@@ -1918,18 +1936,23 @@
     "annotation",
     "eri"
    ],
-   "commit": "ed6730a1717a0e3ddc25a75de0c2e109371391c7",
-   "sha256": "0zlx4xh5c5d88zfbbwd79qb56mrvd3fhgqd7r64p6gx9gfa6kbi5"
+   "commit": "044843c5281a7bdb9479317793a75c8c0fcfadd9",
+   "sha256": "04lirb2p1h46c1l84ysdnr2jxvzsdw1zv6jhm7h8ybgzmaa65b6m"
   },
   "stable": {
    "version": [
     2,
     6,
     1,
-    3
+    3,
+    20210605
    ],
-   "commit": "e5486b79cc78689e3fd07b6c924d0085063915ea",
-   "sha256": "1zl7c0rb5rg867a431apxlzj2flg3hjidamqa5prc1bzpmfaywyz"
+   "deps": [
+    "annotation",
+    "eri"
+   ],
+   "commit": "ab805592a0ae7066fbd5fa5f47e933194fce878f",
+   "sha256": "19ld12x4is0nx52i05zv20js0zysx3bljbdn2nr65vy11dq2cyyp"
   }
  },
  {
@@ -2287,6 +2310,32 @@
   }
  },
  {
+  "ename": "alectryon",
+  "commit": "4f7b6099b9167840602515f10ab02e70defbee1e",
+  "sha256": "0q1dsnrjak49dlmwkns79n996ip6zsdsv4k2ifgd9r8fd9yxki22",
+  "fetcher": "github",
+  "repo": "cpitclaudel/alectryon",
+  "unstable": {
+   "version": [
+    20210518,
+    1550
+   ],
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "df5664e71c1026af4aaf69e6b227d427a728e7c6",
+   "sha256": "1czy3sbwm6lfrgdbj0y12q4n70w6zg8g3y27iz1zr4y20hhcp2zk"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "55fc849cdb7a05bbaab6f9359386d8830bdcfb87",
+   "sha256": "0v5jfmqcvridh8z7y8i5hklybfxicgmbnambi21ml34px3p9fldc"
+  }
+ },
+ {
   "ename": "alert",
   "commit": "113953825ac4ff98d90a5375eb48d8b7bfa224e7",
   "sha256": "0x3cvczq09jvshz435jw2fjm69457x2wxdvvbbjq46nfnybhi118",
@@ -2378,23 +2427,20 @@
   "repo": "domtronn/all-the-icons.el",
   "unstable": {
    "version": [
-    20210513,
-    1918
+    20210603,
+    1604
    ],
-   "commit": "be99987eda1ba3fdc490984b207849689599b858",
-   "sha256": "0a0yva34hrz7d1zq9p6bn69ywc2zpi6zpwb2s5g1lbh23cihvi1g"
+   "commit": "facbde4a7be292bf9490932cbe403b443273f45d",
+   "sha256": "0lwgvgnqf7vihglm0c5bwsxbl4x7f641289cji5s7jwy2dbsqk7g"
   },
   "stable": {
    "version": [
-    4,
+    5,
     0,
-    1
+    0
    ],
-   "deps": [
-    "memoize"
-   ],
-   "commit": "d363bb3e73909be013fcf35e1458bb654ec5bbaa",
-   "sha256": "0yh7gnv9xfqn8q4rzaa6wpyn9575vyfxy7d3afly2mqsb367fgm5"
+   "commit": "facbde4a7be292bf9490932cbe403b443273f45d",
+   "sha256": "0lwgvgnqf7vihglm0c5bwsxbl4x7f641289cji5s7jwy2dbsqk7g"
   }
  },
  {
@@ -2504,8 +2550,21 @@
   "repo": "seagle0128/all-the-icons-ivy-rich",
   "unstable": {
    "version": [
-    20210505,
-    840
+    20210605,
+    1700
+   ],
+   "deps": [
+    "all-the-icons",
+    "ivy-rich"
+   ],
+   "commit": "e0eba9cb8f8c85c0b63434f6117f9fa232d8a890",
+   "sha256": "05a53s7v1vy688gwnn01p3flqlhznp2m0k1mg8ax4hjygyc05l8q"
+  },
+  "stable": {
+   "version": [
+    1,
+    5,
+    1
    ],
    "deps": [
     "all-the-icons",
@@ -2513,19 +2572,6 @@
    ],
    "commit": "0138c7e7f3b7a6c09665e45a6dd2168359efd47c",
    "sha256": "0nbbkasbklxf62rx9mc5w37r014vdbbg3vm5dy03hxzvq3y1yrpn"
-  },
-  "stable": {
-   "version": [
-    1,
-    5,
-    0
-   ],
-   "deps": [
-    "all-the-icons",
-    "ivy-rich"
-   ],
-   "commit": "7f8249ac92321a81d3db11e56888e569988b51d5",
-   "sha256": "1fwih9qidv0wkqrcsngcainw8b5bxcbk15g5a0p5dpl6hqcxj3rz"
   }
  },
  {
@@ -3146,18 +3192,19 @@
     20200914,
     644
    ],
-   "commit": "ed6730a1717a0e3ddc25a75de0c2e109371391c7",
-   "sha256": "0zlx4xh5c5d88zfbbwd79qb56mrvd3fhgqd7r64p6gx9gfa6kbi5"
+   "commit": "044843c5281a7bdb9479317793a75c8c0fcfadd9",
+   "sha256": "04lirb2p1h46c1l84ysdnr2jxvzsdw1zv6jhm7h8ybgzmaa65b6m"
   },
   "stable": {
    "version": [
     2,
     6,
     1,
-    3
+    3,
+    20210605
    ],
-   "commit": "e5486b79cc78689e3fd07b6c924d0085063915ea",
-   "sha256": "1zl7c0rb5rg867a431apxlzj2flg3hjidamqa5prc1bzpmfaywyz"
+   "commit": "ab805592a0ae7066fbd5fa5f47e933194fce878f",
+   "sha256": "19ld12x4is0nx52i05zv20js0zysx3bljbdn2nr65vy11dq2cyyp"
   }
  },
  {
@@ -3790,14 +3837,14 @@
   "repo": "stardiviner/arduino-mode",
   "unstable": {
    "version": [
-    20210216,
-    926
+    20210527,
+    1341
    ],
    "deps": [
     "spinner"
    ],
-   "commit": "969b49ef6c954a067b3cbca43a4cdc1c04b1a62a",
-   "sha256": "0cjygkddlla2ygiyn506mwqjfn52lqpwfbv1fbwcqljvfspc65am"
+   "commit": "d7c87812c205bc01c8c8a7ab02f201b6138c7e57",
+   "sha256": "08hjyxz187hc07d0g8s7z7d3pa2z9f8lwdzramki95gm27q08n4y"
   }
  },
  {
@@ -4414,6 +4461,38 @@
   }
  },
  {
+  "ename": "auth-source-keytar",
+  "commit": "4ba6f96ca2e20dcd75cf239370243bd8e484f851",
+  "sha256": "1wizylkfzsbkavqr7m88vnwgrikj8hd6v01x06k1c5kpwdggvyqv",
+  "fetcher": "github",
+  "repo": "emacs-grammarly/auth-source-keytar",
+  "unstable": {
+   "version": [
+    20210516,
+    556
+   ],
+   "deps": [
+    "keytar",
+    "s"
+   ],
+   "commit": "9ecdd6226b50a1a04675b65589e6cc36fd3aea2c",
+   "sha256": "04vr0i4y9i96vm1pliac8snnvlwqzafy7xrq39wpvhvd99qr4845"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    3
+   ],
+   "deps": [
+    "keytar",
+    "s"
+   ],
+   "commit": "6edf8ec86d74f1e9853da23052291cc28d2df8bc",
+   "sha256": "0vj2rfm516w9b4l0jwj6m9z1liqmddfmschsz2hc9i0zg1y312l5"
+  }
+ },
+ {
   "ename": "auth-source-kwallet",
   "commit": "047cc780e55a0f574afaf7fa0d94c31ed86cb57f",
   "sha256": "1fz63fdfw3cm8k59nxnbsaiylbs0nn5f250fwwfh51bknrqj3vin",
@@ -4421,11 +4500,20 @@
   "repo": "vaartis/auth-source-kwallet",
   "unstable": {
    "version": [
-    20210421,
-    1504
+    20210605,
+    1032
    ],
-   "commit": "c2abee6ada13d7332725bd700ad76da8aebea530",
-   "sha256": "1w43mlfslvmqabnm76j0bhkdsb4a2iwwidhm83qqrjpj08cq3ldj"
+   "commit": "053ed5e964acaf6f16a1708c36d812eeb7c1817d",
+   "sha256": "0jqn49wqhg3qh6m76zc65z37kaw562laifjjj8lhi9g3f86sldsp"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    1
+   ],
+   "commit": "1309cfcd00264a2bb8e0d1b435d4d03e3e02f314",
+   "sha256": "182wks10k0z1h24lkqx2rrs78f33rzarcq4s0r69cc6w67vj0fra"
   }
  },
  {
@@ -5094,14 +5182,14 @@
   "repo": "ncaq/auto-sudoedit",
   "unstable": {
    "version": [
-    20210502,
-    1103
+    20210522,
+    612
    ],
    "deps": [
     "f"
    ],
-   "commit": "54a7f295e6b1eecbcc86741aaf5d72e404b43bce",
-   "sha256": "1rhdvrj2rjbvl7vkb0wcp6krqxcaigl7jk9z8yvhx6s4cm2qli6q"
+   "commit": "0dec9e632f1f3208f0da2f94b57efa1aae9ce2ab",
+   "sha256": "1isk9106lpdh45l41n2v8q8m9vcfb4biy9dv87rkks58nysrxy3z"
   },
   "stable": {
    "version": [
@@ -5390,11 +5478,11 @@
   "repo": "avkoval/avk-emacs-themes",
   "unstable": {
    "version": [
-    20210507,
-    1127
+    20210521,
+    1051
    ],
-   "commit": "2da6de854b07f696da0cbc9e6961b3d228295f5e",
-   "sha256": "14rqaf6gaxabz92s9cv9fm7pjhc2vm154yjyvj3phaj188nn298x"
+   "commit": "7b9b6517873c4d4d73e6e34ca56c54062db60759",
+   "sha256": "0vah74474x9wby36hxi7jpmlr3q1zra33lkidvxf4xh9nsliqnqn"
   }
  },
  {
@@ -5442,8 +5530,8 @@
     "avy",
     "embark"
    ],
-   "commit": "a21e510bc63c8ddc98b2bb3e6fff38e9d7f41ca9",
-   "sha256": "13c8l2dafqn3xm0lgrn4agy2i7ycz8dxwvxdcdrbba1gdb8ivm2n"
+   "commit": "ef609bf15368a68c4eb3c46fd8cc1bb623b6b83e",
+   "sha256": "0ddh7zqgaq07534l6m3wjvbcj23a01h3x7scd4pl5rj6wyxqwv76"
   },
   "stable": {
    "version": [
@@ -5929,30 +6017,6 @@
   }
  },
  {
-  "ename": "bang",
-  "commit": "d9830cce42339243091f4463490954a8a955c65f",
-  "sha256": "1dx1130095ij09ix20jyqradkjw9gpdfpw0d9f3krrx6xjqfn2sk",
-  "fetcher": "git",
-  "url": "https://git.sr.ht/~zge/bang",
-  "unstable": {
-   "version": [
-    20210405,
-    1640
-   ],
-   "commit": "b5252a77aed6d1c533367fde0f11d6901bf23d96",
-   "sha256": "1m0wmcm1akdk19vf132y1g6wjdx9kgschf66qgggd97gl50za5ab"
-  },
-  "stable": {
-   "version": [
-    1,
-    0,
-    3
-   ],
-   "commit": "e02338331463461a85144c0ce6b9b877bd3a7567",
-   "sha256": "1rvgmkl950zrakczk9libws29c9l2hklw49m3xb4swa14kz1r639"
-  }
- },
- {
   "ename": "banner-comment",
   "commit": "4bb69f15cb6be38a86abf4d15450a29c9a819068",
   "sha256": "0i5nkfdwfr9mcir2ijdhw563azmr5p7hyl6rfy1r04fzs8j7w2pc",
@@ -6192,26 +6256,26 @@
   "repo": "jasonmj/battery-notifier",
   "unstable": {
    "version": [
-    20210517,
-    1247
+    20210521,
+    1238
    ],
    "deps": [
     "alert"
    ],
-   "commit": "d348b2b72cb19905e7831f40e6d94f873e1da6b9",
-   "sha256": "0amkrvb0i20jjclh091zkr2m5q92x6yjx8w68x8hzaa2qkabdbzf"
+   "commit": "ae2043db954e131d9de7347ab1a6107fd07e8893",
+   "sha256": "1w2cymf9yd3siijplb6vrcxwqhqsqii8bnxki7vqb1s16v7ciczz"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
    "deps": [
     "alert"
    ],
-   "commit": "d348b2b72cb19905e7831f40e6d94f873e1da6b9",
-   "sha256": "0amkrvb0i20jjclh091zkr2m5q92x6yjx8w68x8hzaa2qkabdbzf"
+   "commit": "ae2043db954e131d9de7347ab1a6107fd07e8893",
+   "sha256": "1w2cymf9yd3siijplb6vrcxwqhqsqii8bnxki7vqb1s16v7ciczz"
   }
  },
  {
@@ -6246,11 +6310,11 @@
   "repo": "bazelbuild/emacs-bazel-mode",
   "unstable": {
    "version": [
-    20210516,
-    1724
+    20210605,
+    906
    ],
-   "commit": "56113b72d2016e9827e84a579abc700884590074",
-   "sha256": "1qck0qwzcjl90xsp5m1pi8x9jr8alwa4cm4yy45d5m5s3lhfd88b"
+   "commit": "667554f76696a3cbb50c4c01b121c1aef882195a",
+   "sha256": "169x8d52hkb30w2c4ww7lpipdin5406nm2i95fbbxs1sz1068b8r"
   }
  },
  {
@@ -6923,8 +6987,8 @@
     "a",
     "pdf-tools"
    ],
-   "commit": "7bb01664b45fc08b7d013c91073cf3ce0d313984",
-   "sha256": "1hknnkidmd5w81i30xjj2q3x93mygqq7pk7kwfssnzrn8lih6a9b"
+   "commit": "246120647e28a27506ca0894ba98e371086881fd",
+   "sha256": "15gqzj4h0w33w38i8ihl74iy7aqxlds97gm93r72z69pm2l1d7dm"
   }
  },
  {
@@ -6972,14 +7036,14 @@
   "repo": "bdarcus/bibtex-actions",
   "unstable": {
    "version": [
-    20210511,
-    12
+    20210607,
+    1230
    ],
    "deps": [
     "bibtex-completion"
    ],
-   "commit": "d994b7e34e39adcc069685220c7c3cb7516625b9",
-   "sha256": "1jxdfyf68d1gc240kzvllzlk7wzhsdg4m50r8g6m6a9xnyzi68ad"
+   "commit": "07a3c64b12673b722a21c932eb85c595dea0c863",
+   "sha256": "0afnb0aa3msnvg2p4pjdcliccsfhaa7pp7bx76h3sfvv4648kki5"
   },
   "stable": {
    "version": [
@@ -7290,11 +7354,19 @@
   "repo": "Wilfred/bison-mode",
   "unstable": {
    "version": [
-    20200226,
-    47
+    20210527,
+    717
    ],
-   "commit": "675df47193accaf30ca44e142523b2b3bb122979",
-   "sha256": "08yg51pzpry5gy29fdbrrb7s5j5c5fxsrhgy0ncp0vl082fs1bv9"
+   "commit": "4f2e20394a475931409618c1635e9c9f1cf07d9c",
+   "sha256": "0rh4kjfapgnvv6yc3ps0n8y9nbrpdi5gs541j2axvqx97hhv8an9"
+  },
+  "stable": {
+   "version": [
+    0,
+    3
+   ],
+   "commit": "1193903e36adf6770b673c3936ac0fbdac609b95",
+   "sha256": "0v1vqc22nfhq2c09j0xiyd0yplimf1gy3m5zlgl33dijhh6wxv8n"
   }
  },
  {
@@ -7891,29 +7963,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20210519,
-    937
+    20210530,
+    1158
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "91668945db55e6c96940be1b49a868bd815b5e51",
-   "sha256": "1r2faskha94z55vs7kxj8pfdgw2yd0b3jl1h5higw9wjdwjwdzhb"
+   "commit": "e2263534e16ed8bbc935ee466f6ad2acbe9c603e",
+   "sha256": "169sdgi476hnxxv0s9qfi8cply9q7gb8i1hli4i74ynlrhc9wfq7"
   },
   "stable": {
    "version": [
     3,
-    1,
-    2
+    2,
+    0
    ],
    "deps": [
-    "dash",
     "epkg",
     "magit"
    ],
-   "commit": "3f9fc2281e9ae873873998782c98c57c5ebb0555",
-   "sha256": "1k889m4095lm97lphcwcrsl53vhgas7iha594mmk8cs7sm5csjy1"
+   "commit": "e2263534e16ed8bbc935ee466f6ad2acbe9c603e",
+   "sha256": "169sdgi476hnxxv0s9qfi8cply9q7gb8i1hli4i74ynlrhc9wfq7"
   }
  },
  {
@@ -8153,16 +8224,16 @@
   "repo": "rmuslimov/browse-at-remote",
   "unstable": {
    "version": [
-    20210405,
-    430
+    20210603,
+    802
    ],
    "deps": [
     "cl-lib",
     "f",
     "s"
    ],
-   "commit": "e02ad2189c87da33f80bf4967a968772ce3e4431",
-   "sha256": "0vn53zlwmhi4d6i81840i9pmrs8w4j6az2p0b4hw99xvk68grfiz"
+   "commit": "cef26f2c063f2473af42d0e126c8613fe2f709e4",
+   "sha256": "094gbvpf9vy95ij7li9vb17nyhi1grh9mbv1csydb9y157baw03v"
   },
   "stable": {
    "version": [
@@ -8399,6 +8470,21 @@
   }
  },
  {
+  "ename": "buffer-env",
+  "commit": "40651886215933432e77c680aea22bdee932fa9c",
+  "sha256": "18ab7jwr1w16vlgrgxsnb3dfvkfy9vs3szl9k9npckgzyar97y5m",
+  "fetcher": "github",
+  "repo": "astoff/buffer-env",
+  "unstable": {
+   "version": [
+    20210520,
+    1616
+   ],
+   "commit": "32c1cfdf06dfa7bdbd79aba8066064212672e755",
+   "sha256": "1mbrsakg7mbrr4szi7ha5hcfr88i79p5bn59dh7v6ywa357brmky"
+  }
+ },
+ {
   "ename": "buffer-flip",
   "commit": "3924870cac1392a7eaeeda34b92614c26c674d63",
   "sha256": "0ka9ynj528yp1p31hbhm89627v6dpwspybly806n92vxavxrn098",
@@ -8474,6 +8560,39 @@
    ],
    "commit": "9bf3ff940011c7af3fdd172fa3ea2511c7a8a190",
    "sha256": "0xdks4jfqyhkh34y48iq3gz8swp0f526kwnaai5mhgvazvs4za8c"
+  }
+ },
+ {
+  "ename": "buffer-ring",
+  "commit": "f6a145814144e6386efa9f96b43cf81d59a1091f",
+  "sha256": "0ch8pgiq1d90d06zxa5xvkvy18nwxlp7mfaymd6ldq20vgks07x9",
+  "fetcher": "github",
+  "repo": "countvajhula/buffer-ring",
+  "unstable": {
+   "version": [
+    20210529,
+    2059
+   ],
+   "deps": [
+    "dynaring",
+    "ht",
+    "s"
+   ],
+   "commit": "30572b4d8fff519c4996078a5ad743583fb22b0e",
+   "sha256": "1xg6kbjj4fccsr5awnh3ba9x33qznnala3kmnfwpmj94rd72whiy"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
+   ],
+   "deps": [
+    "dynaring",
+    "ht",
+    "s"
+   ],
+   "commit": "30572b4d8fff519c4996078a5ad743583fb22b0e",
+   "sha256": "1xg6kbjj4fccsr5awnh3ba9x33qznnala3kmnfwpmj94rd72whiy"
   }
  },
  {
@@ -9076,6 +9195,21 @@
   }
  },
  {
+  "ename": "c-eval",
+  "commit": "0a62a92eb2142d0a08a18a966ee99fa62d1392af",
+  "sha256": "13rgaisjy6x3szknlp3f5ama3y9l5yhlx3q17kjzdv7bs56kzcbq",
+  "fetcher": "github",
+  "repo": "lassik/emacs-c-eval",
+  "unstable": {
+   "version": [
+    20210603,
+    1716
+   ],
+   "commit": "f79be8354a3c01fddbf38b731aa8934421cef22f",
+   "sha256": "1qpi5j2h9q4khp3kbk4ybsg4mp2cp5kws5fz7bjpxz4iz0s8mbx7"
+  }
+ },
+ {
   "ename": "c0-mode",
   "commit": "268115452d9c22a6f2627cec1eb122b47e85b88c",
   "sha256": "0s3h4b3lpz4jsk222yyfdxh780dvykhaqgyv6r3ambz95vrmmpl4",
@@ -9446,21 +9580,21 @@
   "repo": "chenyanming/calibredb.el",
   "unstable": {
    "version": [
-    20210321,
-    944
+    20210603,
+    323
    ],
    "deps": [
     "dash",
     "s",
     "transient"
    ],
-   "commit": "a3b04c0c37b1e8ceff2472e21a3579e64e944528",
-   "sha256": "04fzskx066v5091467da3plsxkqx3acbaqmk282k8cdaxsnr4ifd"
+   "commit": "cb93563d0ec9e0c653210bc574f9546d1e7db437",
+   "sha256": "10dymcd17ili5r6ydiz7bj0q81y5fh0s1d64m4acfa8xfsi7zx55"
   },
   "stable": {
    "version": [
     2,
-    8,
+    10,
     0
    ],
    "deps": [
@@ -9468,8 +9602,8 @@
     "s",
     "transient"
    ],
-   "commit": "a62d7de582b16490b1af5add7b24a67022be531b",
-   "sha256": "19gc05k2p1l8wlkrqij9cw6d61hzknd6a9n64kzlpi87cpbav3lv"
+   "commit": "933140a3227ee61cfccf3cf0c567b5c9e64f1ded",
+   "sha256": "0s26a2fy1xldd0q57avds7zn0h7lkis2hjh9zmm1qhwn8409hys9"
   }
  },
  {
@@ -9674,6 +9808,21 @@
   }
  },
  {
+  "ename": "cargo-mode",
+  "commit": "48a13236086dad5b88834a27465bd77b1ee499b6",
+  "sha256": "1cpxhgxsnf6lmw8z2g1vxczs7pi9mk1xx1776726hajj4g8cx4p1",
+  "fetcher": "github",
+  "repo": "ayrat555/cargo-mode",
+  "unstable": {
+   "version": [
+    20210605,
+    1003
+   ],
+   "commit": "b98ea60ddec30eac174012671ee09e125748a193",
+   "sha256": "03vdinqm1hlbcflvks54ff9hqnjdzxih5bxnkm363s7mpr070d0d"
+  }
+ },
+ {
   "ename": "caroline-theme",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "178nxcz73lmvnjcr6x6as25d8m5knc21jpr66b4rg0rmlmhchkal",
@@ -9745,8 +9894,8 @@
   "repo": "cask/cask",
   "unstable": {
    "version": [
-    20210424,
-    125
+    20210528,
+    1605
    ],
    "deps": [
     "ansi",
@@ -9757,8 +9906,8 @@
     "s",
     "shut-up"
    ],
-   "commit": "81edfa78428fd2d9689507fd4d3b13c24cd99323",
-   "sha256": "071biqz1fv3rzjbn9xprpazk65xfl78hzhf2gdvz944pks3rhdfi"
+   "commit": "daee4bec9c7d96a165366f7edeaa4616837bf432",
+   "sha256": "062hsgb4315wvydygvygjywi4wp8xri3h0gj4n5dmy884578hhjl"
   },
   "stable": {
    "version": [
@@ -9955,8 +10104,8 @@
     20210501,
     820
    ],
-   "commit": "7a7e1ecaf7f4f68058f1b8831d0b7b839d228614",
-   "sha256": "0gcgbr28j88a73p5ng4f20qp0fx288na9hi4fnj32grqyrl6f1pq"
+   "commit": "ce0517127586e26f95f94f45d22a832f40a28321",
+   "sha256": "1qx99sigzmj4fc5wcaqs6wnyzsrzcqg73czn5aknxqkzd1whsk3a"
   }
  },
  {
@@ -10004,8 +10153,8 @@
     20200904,
     1431
    ],
-   "commit": "7a7e1ecaf7f4f68058f1b8831d0b7b839d228614",
-   "sha256": "0gcgbr28j88a73p5ng4f20qp0fx288na9hi4fnj32grqyrl6f1pq"
+   "commit": "ce0517127586e26f95f94f45d22a832f40a28321",
+   "sha256": "1qx99sigzmj4fc5wcaqs6wnyzsrzcqg73czn5aknxqkzd1whsk3a"
   }
  },
  {
@@ -10274,8 +10423,8 @@
     20171115,
     2108
    ],
-   "commit": "0c6f3539677300e591c8a2877270776ee2ab1be2",
-   "sha256": "038r1zw52ip12r6iddhjy458gaapl5g9vfrz4hqw23r4cp5zgxgn"
+   "commit": "35b67c8380bb284c9c59914d967ee157a62311b8",
+   "sha256": "1579n0m13l7ghw5g4b0iffrcvgsh5pk3abk29rrskq736i0h007s"
   },
   "stable": {
    "version": [
@@ -10393,16 +10542,16 @@
   "repo": "Alexander-Miller/cfrs",
   "unstable": {
    "version": [
-    20210217,
-    1848
+    20210529,
+    1123
    ],
    "deps": [
     "dash",
     "posframe",
     "s"
    ],
-   "commit": "7c42f2c82c7ae689f3ef291b066688c58ab96298",
-   "sha256": "1x8y4cc1cgln4qv6yzhsiqgnziilg5fh07bvg9ygcjmdhvnhsvcm"
+   "commit": "e16a01012545d378150432fa10684a2a7d1cc2d1",
+   "sha256": "1pj0l0jqgx3bixklllppgm6pwyfd0dc1ik5cs9x1azb1qdgf8kjs"
   },
   "stable": {
    "version": [
@@ -10579,11 +10728,11 @@
   "repo": "davep/cheat-sh.el",
   "unstable": {
    "version": [
-    20200226,
-    1021
+    20210607,
+    1307
    ],
-   "commit": "52293c366044e44c8f6b648a312433345e4718ad",
-   "sha256": "098b70gvyr74ygzbpyfvpn2zzlij47bzvqqj89igh10s4lxj0lzb"
+   "commit": "33bae22feae8d3375739c6bdef08d0dcdf47ee42",
+   "sha256": "0blyhgdk0li5slkhlj689jdal6d1qr4g2acz8i0jm4kvgysjilb5"
   },
   "stable": {
    "version": [
@@ -10717,11 +10866,11 @@
   "repo": "sergiruiztrepat/chembalance",
   "unstable": {
    "version": [
-    20210504,
-    1505
+    20210601,
+    1653
    ],
-   "commit": "80c8fd4c806366a4b75a27a656420e9e36316543",
-   "sha256": "0sshmw5ajfiff05000yhp4m3fyfdbhcqrm5crcqqw0cinvrfancn"
+   "commit": "ae36c823ca151f1dc6144ec96b2f5e98181c0dbb",
+   "sha256": "1n01h4lwfcm0skf0pgh7p87bmk4x3r6qsr5jcgm1ldafsx35x60g"
   }
  },
  {
@@ -10906,32 +11055,30 @@
   "url": "https://tildegit.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
-    20210507,
-    923
+    20210603,
+    1656
    ],
    "deps": [
     "dash",
-    "literate-elisp",
     "seq",
     "ts"
    ],
-   "commit": "ceb455288a74df6ff7cd45968f37f0f4d3919f28",
-   "sha256": "0366fwm7xwcja9qyx87zh0f78xfhjv5f40ybcfgk8zldbhz0zn6a"
+   "commit": "5c5b7fc5e72e2322af2cac14745c7adaab1d56cf",
+   "sha256": "104n79hj8649h90g8kh3i4rfyk1alq0skpjv8jjpbz0cybhp7n53"
   },
   "stable": {
    "version": [
     0,
-    7,
+    8,
     1
    ],
    "deps": [
     "dash",
-    "literate-elisp",
     "seq",
     "ts"
    ],
-   "commit": "ceb455288a74df6ff7cd45968f37f0f4d3919f28",
-   "sha256": "0366fwm7xwcja9qyx87zh0f78xfhjv5f40ybcfgk8zldbhz0zn6a"
+   "commit": "e9164ecca1e2f43676e5a071aca7644177866deb",
+   "sha256": "0fp0p1sv7jpam2vbgkv2yg7lsdlxa02213ka06cn8rb54lw7k702"
   }
  },
  {
@@ -10974,26 +11121,26 @@
   "url": "https://tildegit.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
-    20210514,
-    827
+    20210603,
+    1656
    ],
    "deps": [
     "chronometrist"
    ],
-   "commit": "ceb455288a74df6ff7cd45968f37f0f4d3919f28",
-   "sha256": "0366fwm7xwcja9qyx87zh0f78xfhjv5f40ybcfgk8zldbhz0zn6a"
+   "commit": "5c5b7fc5e72e2322af2cac14745c7adaab1d56cf",
+   "sha256": "104n79hj8649h90g8kh3i4rfyk1alq0skpjv8jjpbz0cybhp7n53"
   },
   "stable": {
    "version": [
     0,
-    7,
+    8,
     1
    ],
    "deps": [
     "chronometrist"
    ],
-   "commit": "ceb455288a74df6ff7cd45968f37f0f4d3919f28",
-   "sha256": "0366fwm7xwcja9qyx87zh0f78xfhjv5f40ybcfgk8zldbhz0zn6a"
+   "commit": "e9164ecca1e2f43676e5a071aca7644177866deb",
+   "sha256": "0fp0p1sv7jpam2vbgkv2yg7lsdlxa02213ka06cn8rb54lw7k702"
   }
  },
  {
@@ -11052,8 +11199,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20210518,
-    1038
+    20210524,
+    832
    ],
    "deps": [
     "clojure-mode",
@@ -11064,14 +11211,13 @@
     "sesman",
     "spinner"
    ],
-   "commit": "eccfcea186c3560527fbfc98491b3ab9a3f1e16f",
-   "sha256": "09k5bhvq7ksjpkjr7fzrvfr6cf1wd3fh2m8bfb8y25hbg2nnyisk"
+   "commit": "8f51546c0efb36226c4bae7d65465b0e0aa8c06f",
+   "sha256": "0bn1k34a0dr85c0jj3cb3w8afbhb5iy7whdddkfpa5fkrhc77acf"
   },
   "stable": {
    "version": [
     1,
     1,
-    0,
     1
    ],
    "deps": [
@@ -11083,8 +11229,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "45f6125301fbbe69333dc450804ce8ecdd611539",
-   "sha256": "1kf4056bga3cr40mm812m21r9mi0r30gn9v3jil3q6yhb5bm1gcl"
+   "commit": "8b3dabeefa8a3352d7a30a9fd9027c05a4c4f6e2",
+   "sha256": "0psd8zrhs5w1cfmksd5sjgy9xzfs9i9zp55g97rp7zp6y5als0lx"
   }
  },
  {
@@ -11257,14 +11403,14 @@
   "repo": "jorgenschaefer/circe",
   "unstable": {
    "version": [
-    20210508,
-    1616
+    20210601,
+    801
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "2798a75d625677402b01f138ebac6eb53337d9d6",
-   "sha256": "0r7k7cxs6gfam1rdy04vdq3q796v32wv5q9gq67sxfji8x1vbkn7"
+   "commit": "c0b2f997b3b73640d635ee84627bb8cf36c9adfe",
+   "sha256": "1kjfch0fhq67iivad56s071c8qlsssdsdg83h5v9iz2x4jipm0wa"
   },
   "stable": {
    "version": [
@@ -12191,26 +12337,26 @@
   "repo": "emacscollective/closql",
   "unstable": {
    "version": [
-    20200704,
-    2124
+    20210530,
+    1136
    ],
    "deps": [
     "emacsql-sqlite"
    ],
-   "commit": "1d5e9cbb69bc2992eaafa1bc084343efbd3e0c4c",
-   "sha256": "1s3pb8zn3ypc2pvkp7g7wvml02m06lk9d7c29pq1yqn9f5sisrcg"
+   "commit": "1b0e5bfef95de49bf669c54a15571386f10f4705",
+   "sha256": "01l4w3wc7rm7mca8pbkyz0yrks4z8i00ppy5c4bmrnn6akf7h9ih"
   },
   "stable": {
    "version": [
     1,
     0,
-    4
+    5
    ],
    "deps": [
     "emacsql-sqlite"
    ],
-   "commit": "c864c1fadfea4a05fff29cb60891b7a32ac88c78",
-   "sha256": "06j0sc6dx8f34wc8i7dzkp8jwvwnrpnl8i93vpc1qw0ih0jwa2zh"
+   "commit": "1b0e5bfef95de49bf669c54a15571386f10f4705",
+   "sha256": "01l4w3wc7rm7mca8pbkyz0yrks4z8i00ppy5c4bmrnn6akf7h9ih"
   }
  },
  {
@@ -12337,8 +12483,8 @@
   "repo": "atilaneves/cmake-ide",
   "unstable": {
    "version": [
-    20210512,
-    630
+    20210603,
+    1522
    ],
    "deps": [
     "cl-lib",
@@ -12346,8 +12492,8 @@
     "s",
     "seq"
    ],
-   "commit": "89b03795a02dcbfb14046c97230e82736a02f874",
-   "sha256": "027j4dcvjvvnjh6aln8brmi8xny787n0y2ycrajx043zjmh6x0cg"
+   "commit": "9b1100bd8d65b961b7478f9c011f0f6eb8cfcdd9",
+   "sha256": "1lr9cz856hqb3qz5fq6qqc2a55mfgdrh451np5m2bf2ljw0d67nh"
   },
   "stable": {
    "version": [
@@ -12374,17 +12520,17 @@
     20210104,
     1831
    ],
-   "commit": "d98a7cdb25611ed6f1e856fd4c4ff980225b89cd",
-   "sha256": "0hq8w46c0ldckh11cb61bzhqccjfhh11hadkmdahv8605q8y31nk"
+   "commit": "05d8a586fa4eb6256b8b80a0f7f084e8c5d3c8e6",
+   "sha256": "11vxpkf8y9n0kxyfgkbyrq76b0g4xjl2rriyj2d59s3xlx27gqjp"
   },
   "stable": {
    "version": [
     3,
     20,
-    2
+    3
    ],
-   "commit": "1ad4501ae97fb6c6deab096ff0ac7e03d554e26d",
-   "sha256": "0zr4zbbd1zng0v3mj8kql0ci2w18p4izjfq7hh6g5adq6l7ckfhm"
+   "commit": "13d112ea03f2b068da1f7ac3239a42a6cff94eda",
+   "sha256": "1rn9gzjcg1km9pbyipkfgzq8jvsmwwa2zkmra5yksfwq2094apnh"
   }
  },
  {
@@ -12536,11 +12682,11 @@
   "repo": "astoff/code-cells.el",
   "unstable": {
    "version": [
-    20210111,
-    744
+    20210529,
+    1452
    ],
-   "commit": "d03621b1033cc33054e30169517c57d020c13050",
-   "sha256": "0c2agyg28lqsmkkjcnhx8wdn531lh0zsy37q939wf231lpl4asvj"
+   "commit": "2e40770d7963dcbb52ac45dcd83c0537fda5e188",
+   "sha256": "1m6csmg7y99ihw6nhknnr6wqamf5y5j931gfbsrhbar2hh8wjx5m"
   }
  },
  {
@@ -12756,14 +12902,14 @@
   "repo": "ankurdave/color-identifiers-mode",
   "unstable": {
    "version": [
-    20201216,
-    2223
+    20210607,
+    1842
    ],
    "deps": [
     "dash"
    ],
-   "commit": "ca52e957254a07411c06716d2155968375943a12",
-   "sha256": "01g1x652gckzhihgiqx7jx58fd0ilv0yialfh3f8l1fsqw6cggqc"
+   "commit": "fa42b60f9e84995a8109a49798c0b4c618fc1ed3",
+   "sha256": "12ybgh8yzi62lw0c7yakgvfdx45sr11szyqdlf58n2pbkz9sxkmv"
   },
   "stable": {
    "version": [
@@ -12899,11 +13045,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20210107,
-    2111
+    20210528,
+    2344
    ],
-   "commit": "1445a556af9da3681ae0e7e7242352e9fe39fe73",
-   "sha256": "1d6wxzw1wf378jzvlzfsdq5gqq2i196lr8dszj4df472vsiw1hqi"
+   "commit": "c1a1091e39ecd69822e1494d8b6f0bbcb21eb9b1",
+   "sha256": "01afmfisii9cyri198s2g9rivkisfn6d3g40nyi0sgsx14jbyddz"
   },
   "stable": {
    "version": [
@@ -13343,11 +13489,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20210516,
-    211
+    20210606,
+    135
    ],
-   "commit": "5618f28d62cbbdcccdaee1b455fc6e9d1c8bff31",
-   "sha256": "00aiardy1k0fpjhx73mpyx4921zncx6avydvzh8rcn5w0p0zzx8p"
+   "commit": "e0f8c9ad754bdc2c02318f4baf433886c7aa83e3",
+   "sha256": "1wqwcggjzmqihdgs3bm23fbv2cxpbh9cjvnzgdj01vbgh4ccqkfh"
   },
   "stable": {
    "version": [
@@ -13626,26 +13772,26 @@
   "repo": "redguardtoo/company-ctags",
   "unstable": {
    "version": [
-    20201121,
-    1116
+    20210528,
+    1311
    ],
    "deps": [
     "company"
    ],
-   "commit": "b089a1e645cd14971c93397549b237ef63495adf",
-   "sha256": "045na4qi4n4w8vibjnxqd308ksgazx9ziy5x7ir7b4cklvkifvml"
+   "commit": "26f0a906a646b4885984e068a2046c3a1d0578eb",
+   "sha256": "0ix5zjwfjj4cbx61qy9d0rfbsmk5kgvm9r2v2r76qa39wx3dys82"
   },
   "stable": {
    "version": [
     0,
     0,
-    4
+    5
    ],
    "deps": [
     "company"
    ],
-   "commit": "ba4d2577fbbe5ad7bb978838e3e3177f8a56e8f8",
-   "sha256": "0cy48my9d02v7wa40dw5x6djyjjacddj9p0pgdvr1rg70lqxii45"
+   "commit": "26f0a906a646b4885984e068a2046c3a1d0578eb",
+   "sha256": "0ix5zjwfjj4cbx61qy9d0rfbsmk5kgvm9r2v2r76qa39wx3dys82"
   }
  },
  {
@@ -14017,15 +14163,15 @@
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "cl-lib",
     "company",
     "irony"
    ],
-   "commit": "52aca45bcd0f2cb0648fcafa2bbb4f8ad4b2fee7",
-   "sha256": "1qgyam2vyjw90kpxns5cd6bq3qiqjhzpwrlvmi18vyb69qcgqd8a"
+   "commit": "9ca8f35ef268c0b0cffd49efa687685b373f09fe",
+   "sha256": "1d3jw0d4zymznri86a5iixyxnw16jzkkrbhrh657ys73189c1c73"
   }
  },
  {
@@ -14235,8 +14381,8 @@
     "maxima",
     "seq"
    ],
-   "commit": "f92eafd716ae6e36665bbf027309477c2efa336d",
-   "sha256": "10a72c4v0v5c1npxq1fmglxjiczpf1x87jpd6523x337h054zgs0"
+   "commit": "74e10d5dedb16f74efc28299c98dd7db9a4392d6",
+   "sha256": "1r04mbn33y515b9fwr2x9rcbkvriz753dc0rasb8ca59klp1p5cv"
   },
   "stable": {
    "version": [
@@ -14378,6 +14524,25 @@
   }
  },
  {
+  "ename": "company-org-block",
+  "commit": "564ba95530adedd74f24d329672de7df9cf7afd9",
+  "sha256": "1l29mz5y6ldrd9kcs7fxjd7chm1gbfbs9mcv3xsfgbcyhicqmrjf",
+  "fetcher": "github",
+  "repo": "xenodium/company-org-block",
+  "unstable": {
+   "version": [
+    20210607,
+    1202
+   ],
+   "deps": [
+    "company",
+    "org"
+   ],
+   "commit": "e2742dea77b356ee11a1200263d48eed79f5fe43",
+   "sha256": "194kjkpaca7k60hxs96mah416fdn5mfbsa4wgrpc3cprlrbyp8jr"
+  }
+ },
+ {
   "ename": "company-php",
   "commit": "ac283f1b65c3ba6278e9d3236e5a19734e42b123",
   "sha256": "1gnhklfkg17vxfx7fw65lr4nr07jx71y84mhs9zszwcr9p840hh5",
@@ -14400,15 +14565,15 @@
    "version": [
     2,
     4,
-    0
+    1
    ],
    "deps": [
     "ac-php-core",
     "cl-lib",
     "company"
    ],
-   "commit": "33ed12bb2ec627a8a05360885f071e4a88fff399",
-   "sha256": "1ffayysbqh7vq65vhbmqg9yp03fqfnwj3drwyinr5ia81acp37nz"
+   "commit": "9770c95bf2df93d9cb0f200723b03b3d9a480640",
+   "sha256": "188z1i209z61nwfcgffgp90rdcsnl75izxpqv4x1vbaay5fvg33f"
   }
  },
  {
@@ -15532,56 +15697,88 @@
  },
  {
   "ename": "consult",
-  "commit": "a0f3b8b11eb8f9adf182ab62fcb276b52bc26f19",
-  "sha256": "17zriam6hgz19ms78c9zh0hvb4b6h5hinrinbmbb2jcwi4cykxs3",
+  "commit": "5a141c728f28e53b9f92ccbbff07c2af1dde3706",
+  "sha256": "02z6h0x346230ayncsb8phks9mmjdq5mj9ja68380hl6gkic3407",
   "fetcher": "github",
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20210520,
-    1824
+    20210606,
+    1237
    ],
-   "commit": "556ff4eb31eb1d00a2afdda6664d03b698264e3c",
-   "sha256": "0ss5idc0v5rn0hrbb07m8hdpcmggh46my8cciky98b9hdq3gch2v"
+   "commit": "ae905501bcdb8fdda0d10a0846d575fd2a38e6d7",
+   "sha256": "1jz4j27irxknfbcxsn8phhhaiwyc2z9gnyrj03ah1v57i0i9g79c"
   },
   "stable": {
    "version": [
     0,
-    7
+    8
    ],
-   "commit": "7480f020e57036ef14c2fda1d83c830583b2a53b",
-   "sha256": "1kzwybp87srckd1238drdcn9h7jyyqz9pzcwvw3ld8bgyyrwsxkj"
+   "commit": "e538f168d9d16c926d92c19d6131298962b778a9",
+   "sha256": "1460818fb6y086vgn1mzmrwhpa5jswlwi4v71zr86cg6y7yg4248"
   }
  },
  {
   "ename": "consult-flycheck",
-  "commit": "1a1fbbfebeb88dab2d032e994ec21c976f059d22",
-  "sha256": "0gf7nb2zylmm53xszd53qp7byvlppd2j9lh61p8syanjssqy4j67",
+  "commit": "5a141c728f28e53b9f92ccbbff07c2af1dde3706",
+  "sha256": "1cwbm7qsni8ycasx2v20yd1749lmlhf98kz28i1p8m0yqkjc3my0",
   "fetcher": "github",
-  "repo": "minad/consult",
+  "repo": "minad/consult-flycheck",
   "unstable": {
    "version": [
-    20210429,
-    1158
+    20210530,
+    202
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "556ff4eb31eb1d00a2afdda6664d03b698264e3c",
-   "sha256": "0ss5idc0v5rn0hrbb07m8hdpcmggh46my8cciky98b9hdq3gch2v"
+   "commit": "92b259e6a8ebe6439f67d3d7ffa44b7e64b76478",
+   "sha256": "15lihfdjdp5ynmq0g8wkq8dhb2jdlvfcqbb2ap588igi5vax3glz"
   },
   "stable": {
    "version": [
     0,
-    7
+    8
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "7480f020e57036ef14c2fda1d83c830583b2a53b",
-   "sha256": "1kzwybp87srckd1238drdcn9h7jyyqz9pzcwvw3ld8bgyyrwsxkj"
+   "commit": "92b259e6a8ebe6439f67d3d7ffa44b7e64b76478",
+   "sha256": "15lihfdjdp5ynmq0g8wkq8dhb2jdlvfcqbb2ap588igi5vax3glz"
+  }
+ },
+ {
+  "ename": "consult-ghq",
+  "commit": "513921c684fbab5ff57e47c509a89b15d7d3a5ce",
+  "sha256": "091018x5y28lbffjrb75a5r2cvprlhz0jdj371nlyvrpsdgdfs4f",
+  "fetcher": "github",
+  "repo": "tomoya/consult-ghq",
+  "unstable": {
+   "version": [
+    20210606,
+    2047
+   ],
+   "deps": [
+    "affe",
+    "consult"
+   ],
+   "commit": "c8619d66bd8f8728e43ed15096078b89eb4d2083",
+   "sha256": "1zrxigf7bnx6l9lv2xvnn3ba6c9dndijw1vlnli56cv215i0r4f6"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    4
+   ],
+   "deps": [
+    "affe",
+    "consult"
+   ],
+   "commit": "c8619d66bd8f8728e43ed15096078b89eb4d2083",
+   "sha256": "1zrxigf7bnx6l9lv2xvnn3ba6c9dndijw1vlnli56cv215i0r4f6"
   }
  },
  {
@@ -15674,16 +15871,15 @@
   "url": "https://codeberg.org/jao/espotify",
   "unstable": {
    "version": [
-    20210411,
-    1305
+    20210605,
+    1502
    ],
    "deps": [
     "consult",
-    "espotify",
-    "marginalia"
+    "espotify"
    ],
-   "commit": "22b81067ebcaef2cea633f967a4b55454af9326a",
-   "sha256": "0b93a8km80r1c3gbinnsigkkq8yc127jwrqj8s8z130b79ch91hn"
+   "commit": "3d62a3319ab03a810030058d3fb368b28dfd82d5",
+   "sha256": "0hj3nczmqmgiwsvh664rs34j63wl325x6nar21p1a84h5ximpkxq"
   }
  },
  {
@@ -16006,8 +16202,8 @@
     "ivy",
     "swiper"
    ],
-   "commit": "7c5d49f84f0919bbf00c53a9db48630adf8b2fbe",
-   "sha256": "1rji3p7a2f4ag4785h1k1f2ng9vi2lh8ifyh3m3j0yjihwq36m92"
+   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
+   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
   },
   "stable": {
    "version": [
@@ -16231,14 +16427,14 @@
   "repo": "CsBigDataHub/counsel-fd",
   "unstable": {
    "version": [
-    20200902,
-    2147
+    20210606,
+    1724
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "533d70f229abc73b013668bd03f7486effa1e369",
-   "sha256": "0iz0blxbi0zcilyg4a5aqzggy1b0rdygw5q45szp9hbzzqdb5wfg"
+   "commit": "e9513a3c7f6cdbdf038f951e828e631c0455e7d4",
+   "sha256": "005l1is12jq35nn1ap87a7p74qin26zpgbk599619lh9vai157ww"
   }
  },
  {
@@ -16858,6 +17054,33 @@
    ],
    "commit": "32fa3f4e461da92700523b1b20e7b28974c19a26",
    "sha256": "01q1l8ajw6lpp1bb4yp8r70d86hcl4hy0mz7x1hzqsvb7flhppp0"
+  }
+ },
+ {
+  "ename": "create-link",
+  "commit": "80b967b973240c5124957180819aeacac66271bb",
+  "sha256": "0ypj1sd9jabr5mmrpwibsahrchxs28kp4xv1yjk5pqwyz0r08a8b",
+  "fetcher": "github",
+  "repo": "kijimaD/create-link",
+  "unstable": {
+   "version": [
+    20210601,
+    1327
+   ],
+   "commit": "771a405e262c98b802e2c5302306aed802d8233e",
+   "sha256": "0kcv3jjygjvz75irjdddgakw8b0ckm5gqasrb2341zgqms7l9rfr"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "request",
+    "w3m"
+   ],
+   "commit": "fbc4e8eeec845f7d1610c52b81c0c7a4e961b991",
+   "sha256": "0h1ih1jsywhxhy91yjkz9464j79ma3mp73lxnfww71rwfd0wamyj"
   }
  },
  {
@@ -17827,8 +18050,8 @@
     20190111,
     2150
    ],
-   "commit": "940d80dcd5cbc8d55a0f9348d1a2472e9b8b7121",
-   "sha256": "00mhmfpp4vgfcvm6s7zbzxb0ayra1ghqvdhhqj6mzly15an85b40"
+   "commit": "7b018126aefb100a4f00aeba121688e8a168ee22",
+   "sha256": "0wxjnxic06kkdjlsd0r0afpms26rhdyskv2f4nj7gabiz1m341gm"
   },
   "stable": {
    "version": [
@@ -18048,8 +18271,8 @@
     "posframe",
     "s"
    ],
-   "commit": "434784654e26daa7a8512ed57907829a043592d3",
-   "sha256": "172z5qr7hwjsl9bhqzsgpgxslfxvrxvjlahwwfircrq1xqicvzlj"
+   "commit": "cc395e066755c7513d4862f5639f3d162b3bd30f",
+   "sha256": "0nmpldvkhgi668zpn5wym6rfvsdnib9ny2snzwsrrfgqa70lmky6"
   },
   "stable": {
    "version": [
@@ -18266,8 +18489,8 @@
   "repo": "bradyt/dart-server",
   "unstable": {
    "version": [
-    20190817,
-    1254
+    20210501,
+    1445
    ],
    "deps": [
     "cl-lib",
@@ -18275,8 +18498,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "aba838e8ee2f30309f366e8a91c17616549003ce",
-   "sha256": "0lwss1s1n2kfy0i8nwwfmz5fnw137zkhjs6zv81piniad6hrmn1l"
+   "commit": "75562baf9a89b7e314bc2f795f6ecdc5d1f2cc8c",
+   "sha256": "06v4gbckfgdl7hbppgv15ynsxq37qqdw1h8yzicwjqgylma0if1y"
   },
   "stable": {
    "version": [
@@ -18302,11 +18525,11 @@
   "repo": "magnars/dash.el",
   "unstable": {
    "version": [
-    20210330,
-    1544
+    20210602,
+    1928
    ],
-   "commit": "b9286a84975874b10493f1cb4ea051c501f51273",
-   "sha256": "13qmv5h2fvy1aqcc3xg7am3phpraw4jliz6qjcx0fjfshndkh5xl"
+   "commit": "aab346ed9d8f0f7ea033029c9688810353052e7e",
+   "sha256": "0vq8sgbil17llimaar4j5ar07g17q8ir3a7hfpmv9572ah1zqpw9"
   },
   "stable": {
    "version": [
@@ -18381,8 +18604,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "b9286a84975874b10493f1cb4ea051c501f51273",
-   "sha256": "13qmv5h2fvy1aqcc3xg7am3phpraw4jliz6qjcx0fjfshndkh5xl"
+   "commit": "aab346ed9d8f0f7ea033029c9688810353052e7e",
+   "sha256": "0vq8sgbil17llimaar4j5ar07g17q8ir3a7hfpmv9572ah1zqpw9"
   },
   "stable": {
    "version": [
@@ -18744,15 +18967,15 @@
   "repo": "skk-dev/ddskk",
   "unstable": {
    "version": [
-    20210112,
-    2013
+    20210522,
+    348
    ],
    "deps": [
     "ccc",
     "cdb"
    ],
-   "commit": "7a7e1ecaf7f4f68058f1b8831d0b7b839d228614",
-   "sha256": "0gcgbr28j88a73p5ng4f20qp0fx288na9hi4fnj32grqyrl6f1pq"
+   "commit": "ce0517127586e26f95f94f45d22a832f40a28321",
+   "sha256": "1qx99sigzmj4fc5wcaqs6wnyzsrzcqg73czn5aknxqkzd1whsk3a"
   }
  },
  {
@@ -19406,17 +19629,32 @@
  },
  {
   "ename": "devdocs",
-  "commit": "35763febad20f29320d459394f810668db6c3353",
-  "sha256": "14vab71fy5i1ccmzgfdg37lfs1ix3qwhcyk9lvbahcmwnbnimlzm",
+  "commit": "19d1adfa91593cc32a3ce94d47f4c32102408488",
+  "sha256": "1hizgj4fn3m986ri6zhx0a2dp0qkvm24farb4gcwf19p3ii70470",
   "fetcher": "github",
-  "repo": "xuchunyang/DevDocs.el",
+  "repo": "astoff/devdocs.el",
   "unstable": {
    "version": [
-    20170731,
-    850
+    20210606,
+    933
    ],
-   "commit": "a2d51e824f0cc48a9dd611cc740bc8b86143e611",
-   "sha256": "0nzh7pgvj4cs5d29lrrmbas29xdslgqzsqjmpapzqzbnrgprnbx8"
+   "commit": "07fc164a680d02de2a7af983adb5e726cbfd7fc0",
+   "sha256": "1ldd4h9r7wiqgynxwlqf6hg5m2whzaczlhxmbch7i60rd72wwvrj"
+  }
+ },
+ {
+  "ename": "devdocs-browser",
+  "commit": "6c13d0ea72261c4835b5f1983a1f3ee1e066f743",
+  "sha256": "0gqvjn0arrxdc7lbqrpak9l83ampsbdlbzmi1fk02i431yv89rpc",
+  "fetcher": "github",
+  "repo": "blahgeek/emacs-devdocs-browser",
+  "unstable": {
+   "version": [
+    20210601,
+    1447
+   ],
+   "commit": "d3702670eb361715e41440eb699523b3f4c60bee",
+   "sha256": "1mv0d67y6m1wi779lc0mnpylqiw3cnaj0rkj199fxh91nkc6vk27"
   }
  },
  {
@@ -19460,11 +19698,11 @@
   "repo": "redguardtoo/dianyou",
   "unstable": {
    "version": [
-    20191120,
-    39
+    20210525,
+    1517
    ],
-   "commit": "da7443a680bd8db75884355314e9352cd8c68d05",
-   "sha256": "099iiwp52rfnxgwhiaxdaridhcjdp3qchmskxmb1j5dz757c6w1c"
+   "commit": "f77d9e76be5d8022fa6ee5426144f13f38dd09f2",
+   "sha256": "08pwp1pv8c3klingl0qpymdh9ybqrjj47rdd191vhah2ahn5bs1g"
   },
   "stable": {
    "version": [
@@ -19629,14 +19867,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20210518,
-    1621
+    20210523,
+    11
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4f23c36da5bf102fcf6e7435fa79041feb7f1fbe",
-   "sha256": "1hpba4zznhkz2m9254h42ljccfd0kdz9lv1sjb4baq60f08lp5sj"
+   "commit": "d4340608c2d6d8b81aad8e690d0265799aba16f3",
+   "sha256": "1haqmaaj6ajqqfdni6gn3nmqaif8jqrpdnr84m3zjddsdw5zlcsk"
   },
   "stable": {
    "version": [
@@ -19699,8 +19937,8 @@
    "deps": [
     "transient"
    ],
-   "commit": "fdb37bb696aaec6cb2bcece3760866760e68edc4",
-   "sha256": "1ig7hk9vhlym91gzk4s6h2a6aj425nln29m6f2hpq9jh3qicgh9i"
+   "commit": "96861493f95fe88118942bbe64954142250d6c24",
+   "sha256": "13dda1883pkji4nf44mx9xiys6rgirw12si9fnazsviiqycjaf1b"
   },
   "stable": {
    "version": [
@@ -20021,8 +20259,8 @@
    "deps": [
     "treeview"
    ],
-   "commit": "1f88a9ddda0b431c79564f91d470e8e308ed3c32",
-   "sha256": "1pxkxlpbbm4si5z8gx7lbqaw2qvf6h3qc1qxsp6s47h10nrpi9kk"
+   "commit": "53dc9dae71d1be3a7a925332a53e72d2bd05366b",
+   "sha256": "0hgcargxbl58f4im57c1zqwnfxl52lfv78s8l69njjggvdki0hz1"
   }
  },
  {
@@ -20748,15 +20986,27 @@
   "repo": "ShuguangSun/dired-view-data",
   "unstable": {
    "version": [
-    20210510,
-    931
+    20210529,
+    600
    ],
    "deps": [
     "ess",
     "ess-view-data"
    ],
-   "commit": "80a5f254fc9e0a8f022e429a53c3d8b1da26c4b8",
-   "sha256": "04jj3jpgvnvrn7r1z5y7ilh1hah2d6rb91m17ll45i20sakhp2xc"
+   "commit": "c865c34536d9c3140ce647f03c8b7498b46e935c",
+   "sha256": "0xca6kjr9qf7w9hz63hfai2hl055cdp5gm8nldr1xjv5gk42765h"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "ess",
+    "ess-view-data"
+   ],
+   "commit": "c865c34536d9c3140ce647f03c8b7498b46e935c",
+   "sha256": "0xca6kjr9qf7w9hz63hfai2hl055cdp5gm8nldr1xjv5gk42765h"
   }
  },
  {
@@ -20767,14 +21017,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20210520,
-    748
+    20210603,
+    2349
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "1cd91779b99e3920f8c19ddb3bb84410284108c2",
-   "sha256": "1264ycfvy9cl71qgd8n7xp1xl0ngzdwq2agic5faf6jmqyg77ax7"
+   "commit": "43159042ca788be74c387cc59ba3fffc57079993",
+   "sha256": "01r6sk2zlj3mf39vczaybhpzzmv379vvi85mc4gygif24m102sg3"
   },
   "stable": {
    "version": [
@@ -21730,14 +21980,14 @@
   "repo": "emacs-pe/docker-tramp.el",
   "unstable": {
    "version": [
-    20170207,
-    325
+    20210526,
+    748
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "8e2b671eff7a81af43b76d9dfcf94ddaa8333a23",
-   "sha256": "1lgjvrss25d4hwgygr1amsbkh1l4kgpsdjpxxpyfgil1542haan1"
+   "commit": "aaee11cedf7b4c31700f24a1fd88dcef9c2a7c3d",
+   "sha256": "120sxrifn82hhrqhqdy0dhnni353vwzkkd5x7inqg1wpzsxjwhzl"
   },
   "stable": {
    "version": [
@@ -21826,8 +22076,8 @@
    "deps": [
     "s"
    ],
-   "commit": "c14485468439056bcfc6a0862fe35fa8d787d34a",
-   "sha256": "198vqmhyasilxgz2lwn7y3a0g885ws3pyhvvj80wy7n4ml8mfdr4"
+   "commit": "f6dcb378bb69c23d58978d5bc1e37c4ae160d278",
+   "sha256": "055b24cskxp0wy74synnnsmfnzbavmazyackq0qfnfbkqryrzfml"
   },
   "stable": {
    "version": [
@@ -21969,16 +22219,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20210517,
-    411
+    20210606,
+    1532
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "3b393766f447f6ee9622161a86ae90766b42a395",
-   "sha256": "14c4fsgsvlvxw1g1d9lk244bpz0snk3gir8ndd5zrb14b2nllwzb"
+   "commit": "1660910b758251608c17e1a0e27ff862e345daab",
+   "sha256": "1apbh9kp1qk3klx65imbhmxxnf8ax0hzzcdwj4n6qpm7s6bk1gc3"
   },
   "stable": {
    "version": [
@@ -22022,14 +22272,14 @@
   "repo": "hlissner/emacs-doom-themes",
   "unstable": {
    "version": [
-    20210507,
-    620
+    20210604,
+    1922
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4d24728f11853b5bd231687ac3f7a95108688313",
-   "sha256": "0kws2305asszwjcc28zsbb6xwg25pxwabm5vml9jqk9w5f3ajl33"
+   "commit": "b2c0ea0f0778a6ea85b87e1b87916572e98e1fe7",
+   "sha256": "1rjhmjsszms4rlqq368f717ds4kmdjblkgd2ww830d7sy5h5rb6n"
   },
   "stable": {
    "version": [
@@ -22172,11 +22422,11 @@
   "repo": "gustavopuche/doxy-graph-mode",
   "unstable": {
    "version": [
-    20200807,
-    646
+    20210604,
+    723
    ],
-   "commit": "2685c28e7a725614c23345195c3b85e505be2a1b",
-   "sha256": "0a4kil5v88wkki3r4jjc9ackv2z7ik0qgn4bdv75baskig8f8qjy"
+   "commit": "88af6ef4bc9c8918b66c7774f0a115b2addc310e",
+   "sha256": "0adis4gprh7gzi1nm274gqgzr794fsq4zfjfwz3nh96agc8h8g7j"
   }
  },
  {
@@ -22686,8 +22936,8 @@
     20210213,
     757
    ],
-   "commit": "03435a3608a703bac5b65bfa84c97d91dcc28a4f",
-   "sha256": "0ll1mc0vb81wkna70awgnw06q8xkjp0n2nmk997pjq8sm6d7prgm"
+   "commit": "ac3a66e0f7d3577b27cc5d5f2399163bfbe11828",
+   "sha256": "1grll7h2hv906bik224qn9fldmq4lhnlfcif1lg4grr3f4nhl1wc"
   },
   "stable": {
    "version": [
@@ -22911,11 +23161,20 @@
   "repo": "countvajhula/dynaring",
   "unstable": {
    "version": [
-    20210513,
-    429
+    20210603,
+    2331
    ],
-   "commit": "2919e28d324f63a5ceb83adedd40ed41cb091911",
-   "sha256": "01n8afwpx0cq010b4j4w15kjk9cg9civffmz32wgiihmhpkkc0bq"
+   "commit": "d3cc361b70b5dc4542624ced9c326523939ca021",
+   "sha256": "02mz2dfqfycw64z2906f9dvl5x6qb53xbhkn3hf5205hcg58w5zh"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "commit": "d640a557e3e7197cebb56365ad3552ffda39b838",
+   "sha256": "1fd17xryl2pkdlalc9jgwdkgl2mgks83wh5s8wilvwb21y8g306l"
   }
  },
  {
@@ -23333,26 +23592,26 @@
   "repo": "knu/easy-kill-extras.el",
   "unstable": {
    "version": [
-    20180920,
-    1334
+    20210529,
+    945
    ],
    "deps": [
     "easy-kill"
    ],
-   "commit": "b8ce8350cc86e0229f195082557970cd51def960",
-   "sha256": "1f8db92zzk8g8yyj0g334mdbgqmzrs8xamm1d24jai1289hm29xa"
+   "commit": "74e9d0fcafc38d5f24e6209671a552bc1ba5a867",
+   "sha256": "0yxfsp4zzzw9v4swgslsr4v35hs04sczskfyfdvw8wk0aahxcwrx"
   },
   "stable": {
    "version": [
     0,
     9,
-    6
+    10
    ],
    "deps": [
     "easy-kill"
    ],
-   "commit": "b8ce8350cc86e0229f195082557970cd51def960",
-   "sha256": "1f8db92zzk8g8yyj0g334mdbgqmzrs8xamm1d24jai1289hm29xa"
+   "commit": "74e9d0fcafc38d5f24e6209671a552bc1ba5a867",
+   "sha256": "0yxfsp4zzzw9v4swgslsr4v35hs04sczskfyfdvw8wk0aahxcwrx"
   }
  },
  {
@@ -23419,14 +23678,14 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20210505,
-    1914
+    20210607,
+    2206
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "0ed8c3cb1ccc130e9d4060d19e478474cdf3d6e0",
-   "sha256": "1i37hsgywhcrmsj0cmvs67hzknhx56wrs868k4rrs9cwgc2yf6j1"
+   "commit": "7e49d7e1eaeca755c0086a81967673eb5b45d175",
+   "sha256": "0n6p460nmy6h6sc29j1nmhb6zcbbk7qczab6pz96hyxp1cj9g5gy"
   },
   "stable": {
    "version": [
@@ -24267,8 +24526,8 @@
   "repo": "joaotavora/eglot",
   "unstable": {
    "version": [
-    20210516,
-    1044
+    20210526,
+    1751
    ],
    "deps": [
     "eldoc",
@@ -24277,8 +24536,8 @@
     "project",
     "xref"
    ],
-   "commit": "1ac06d0bcc247fb19df6eceb57e2ea3d534806ec",
-   "sha256": "1arvfga8yhzr14bkfykivcrpzj94ai50rqjvz743wlm5xw295j45"
+   "commit": "e498cb171bb07ec36880a2494aafc8acb1cc34ca",
+   "sha256": "1q2rg6kk16h0wv70p2x1rg5cjmn0w0gc3phriwdd7iwn842dsrb7"
   },
   "stable": {
    "version": [
@@ -24428,8 +24687,8 @@
   "repo": "millejoh/emacs-ipython-notebook",
   "unstable": {
    "version": [
-    20210505,
-    2237
+    20210522,
+    1036
    ],
    "deps": [
     "anaphora",
@@ -24440,8 +24699,8 @@
     "websocket",
     "with-editor"
    ],
-   "commit": "a9903b3b6df26eb5603aa38960c6bd9d826cecb8",
-   "sha256": "0di5275avxmd014zhwj420zapwdy0a00lkrl8j362f636kwp9lir"
+   "commit": "09af85821e4fce64675d5287fe9f3a6847d1c5d2",
+   "sha256": "12b8idh2mpd37nrc8ricr4s4hz4wgnp7cy1298qcpxl00xx99dqw"
   },
   "stable": {
    "version": [
@@ -24604,11 +24863,11 @@
   "repo": "dimitri/el-get",
   "unstable": {
    "version": [
-    20200912,
-    1653
+    20210606,
+    911
    ],
-   "commit": "d76ac84ae9670de7bf7725b362cafe86688771f9",
-   "sha256": "18x4qj75bh45b0dirp3jpw1zqni8xfqqh1q13q6b5ncy1nhvm4gl"
+   "commit": "52df810e538243d07f2a317ad36e351b440a75e0",
+   "sha256": "0s9107bss982v4njwkfyi4gismg402xcrqkq9c2hrwhyr6pny4w0"
   },
   "stable": {
    "version": [
@@ -24908,11 +25167,11 @@
   "repo": "Mstrodl/elcord",
   "unstable": {
    "version": [
-    20210513,
-    1531
+    20210524,
+    1611
    ],
-   "commit": "78a1d616f6a4fe8033e425eeff19b1f21955dbd2",
-   "sha256": "0j5j6j2wlan73z7xpa3yhji2sgb6m1gayc9pwmxxkwqvjpngyc45"
+   "commit": "afe8f31e2b9f78d13b22a695b7cf9c373656b85e",
+   "sha256": "09yk4xvsdd5mvrzx4kdfyi2bkbdykjg80hcxvjamh967s6vinzjb"
   }
  },
  {
@@ -24957,11 +25216,11 @@
   "repo": "doublep/eldev",
   "unstable": {
    "version": [
-    20210516,
-    2029
+    20210530,
+    1641
    ],
-   "commit": "006d2474a58ba7cb63911d5a9b8b9febba6593c7",
-   "sha256": "093r3dqbi7r3b35744pjbxcb39r1pk2qlqgf0j4kqmgby1xhjcjs"
+   "commit": "e9af76aa8fd9ce5b7010b7322a73341828cfe690",
+   "sha256": "1wryp568bl5p0s78va2pgh9aiskhphmva20zmk1jg0qjxim58grv"
   },
   "stable": {
    "version": [
@@ -25255,11 +25514,11 @@
   "repo": "skeeto/elfeed",
   "unstable": {
    "version": [
-    20210309,
-    2323
+    20210606,
+    1130
    ],
-   "commit": "e29c8b91450bd42d90041231f769c4e5fe5070da",
-   "sha256": "12m4q8zfmn6g0kz2v3vmch4kbmivxshj9xk58j2f3f3c8fvk6567"
+   "commit": "243add9e74003cd5718f33482b7bb8b4fe140fb5",
+   "sha256": "1lw8g9narlygqd7ypgbyvm4n12qxigzywglsjw6yjcry70p00kl3"
   },
   "stable": {
    "version": [
@@ -25374,26 +25633,26 @@
   "repo": "sp1ff/elfeed-score",
   "unstable": {
    "version": [
-    20210429,
-    1337
+    20210605,
+    2212
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "8c694d0feb33dca66d9a8d88f9aaa6e7ded472ea",
-   "sha256": "0lcpj2vp947kbfk6fq7xz7j71mcpjs9086pqh690w4mzv1253gra"
+   "commit": "dd4a0ceded6200fe2367a2de7b0e45d7fb5b4909",
+   "sha256": "17hf6b5db4d0cm1996z4sl00y4c8gl3rga97xxp2bmwbhdr7kaxw"
   },
   "stable": {
    "version": [
     0,
     7,
-    8
+    9
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "8c694d0feb33dca66d9a8d88f9aaa6e7ded472ea",
-   "sha256": "0lcpj2vp947kbfk6fq7xz7j71mcpjs9086pqh690w4mzv1253gra"
+   "commit": "dd4a0ceded6200fe2367a2de7b0e45d7fb5b4909",
+   "sha256": "17hf6b5db4d0cm1996z4sl00y4c8gl3rga97xxp2bmwbhdr7kaxw"
   }
  },
  {
@@ -25411,8 +25670,8 @@
     "elfeed",
     "simple-httpd"
    ],
-   "commit": "e29c8b91450bd42d90041231f769c4e5fe5070da",
-   "sha256": "12m4q8zfmn6g0kz2v3vmch4kbmivxshj9xk58j2f3f3c8fvk6567"
+   "commit": "243add9e74003cd5718f33482b7bb8b4fe140fb5",
+   "sha256": "1lw8g9narlygqd7ypgbyvm4n12qxigzywglsjw6yjcry70p00kl3"
   },
   "stable": {
    "version": [
@@ -25436,11 +25695,11 @@
   "repo": "lassik/elforth",
   "unstable": {
    "version": [
-    20210506,
-    454
+    20210522,
+    928
    ],
-   "commit": "f01437c1461b03de6d7f2f5748beb996a9fa497c",
-   "sha256": "00904bawhskz88z8hicrhiq5lx92q0bilz5nawymqrbmwq54a17q"
+   "commit": "2d8540434a28e7edaa04a992c3c362832b2fd61e",
+   "sha256": "0p4d6blqa3g6mpbn00vqysshga4i93l2s6i7nm2ckg4zrrn27pl5"
   }
  },
  {
@@ -25803,8 +26062,8 @@
   "repo": "jcollard/elm-mode",
   "unstable": {
    "version": [
-    20210224,
-    2314
+    20210525,
+    152
    ],
    "deps": [
     "dash",
@@ -25812,8 +26071,8 @@
     "reformatter",
     "s"
    ],
-   "commit": "e9fcf9cc2779cf7f5ae7ee4be339164b26755c69",
-   "sha256": "05g3r5hc6slaca8g7n6i6bk9lpq9jsb2kv2q5v8nbz96abqg56zm"
+   "commit": "f2e2d0053f3272d9fc0c2e16c8d17d97724cf524",
+   "sha256": "1gaddxw63d5fna43d7kc3px9sbd2knbjga0lx2zz0lsbcjr54pzr"
   },
   "stable": {
    "version": [
@@ -26487,11 +26746,11 @@
   "stable": {
    "version": [
     1,
-    3,
-    2
+    4,
+    0
    ],
-   "commit": "f9f810ffcd3cce7ed15848c72ce299609ec09414",
-   "sha256": "1p3zpg4p4a1cn13sg3hsa33gs1bdra1mlmxkagx883p3808i5qha"
+   "commit": "53d257db92fb72ade8ea1b91dc6839c21563119e",
+   "sha256": "1qccz8z0410xhygrfy62h1j3553avdcb7m61ps6b6y74nz615l1r"
   }
  },
  {
@@ -26799,11 +27058,11 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210520,
-    1753
+    20210607,
+    1506
    ],
-   "commit": "a21e510bc63c8ddc98b2bb3e6fff38e9d7f41ca9",
-   "sha256": "13c8l2dafqn3xm0lgrn4agy2i7ycz8dxwvxdcdrbba1gdb8ivm2n"
+   "commit": "ef609bf15368a68c4eb3c46fd8cc1bb623b6b83e",
+   "sha256": "0ddh7zqgaq07534l6m3wjvbcj23a01h3x7scd4pl5rj6wyxqwv76"
   },
   "stable": {
    "version": [
@@ -26822,15 +27081,15 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210517,
-    1319
+    20210525,
+    1515
    ],
    "deps": [
     "consult",
     "embark"
    ],
-   "commit": "a21e510bc63c8ddc98b2bb3e6fff38e9d7f41ca9",
-   "sha256": "13c8l2dafqn3xm0lgrn4agy2i7ycz8dxwvxdcdrbba1gdb8ivm2n"
+   "commit": "ef609bf15368a68c4eb3c46fd8cc1bb623b6b83e",
+   "sha256": "0ddh7zqgaq07534l6m3wjvbcj23a01h3x7scd4pl5rj6wyxqwv76"
   },
   "stable": {
    "version": [
@@ -26997,16 +27256,16 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20210514,
-    2034
+    20210607,
+    1450
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "06ef243c5a7b60de92ba5503bb385191e35fe21c",
-   "sha256": "1lrrbkvazalqlbiykhf9qvzxx53z05yjpzf7p0wlzkhhhmp87pm7"
+   "commit": "c360a8934c1e07ddab4e12d28800d362d254ccbd",
+   "sha256": "02aikwki7932dldhnsq8ndca59spbc4g2kjfal3sw16lklfw0sfa"
   },
   "stable": {
    "version": [
@@ -27747,27 +28006,26 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20210227,
-    1459
+    20210530,
+    1147
    ],
    "deps": [
     "closql"
    ],
-   "commit": "245157564b9bd1575480044c8b24007b2090dacb",
-   "sha256": "1bdbwbrrz4brkmg50808vsj70d5yaxb1a71n014nx1a09wnw1hmj"
+   "commit": "8ee60b65bff02ef606d489b83e2def9922e9623d",
+   "sha256": "03zsysj78w43q902wi9dhck64q9va247avr6fhdw8ynf2lvb78d3"
   },
   "stable": {
    "version": [
     3,
-    2,
-    2
+    3,
+    0
    ],
    "deps": [
-    "closql",
-    "dash"
+    "closql"
    ],
-   "commit": "ca211c5225aa550374d77629dd9b87e2b0b0d992",
-   "sha256": "1pxz611qb3m33r6343h0xhwqvvhjl131zyc2klplzgb23rkm8lk0"
+   "commit": "8ee60b65bff02ef606d489b83e2def9922e9623d",
+   "sha256": "03zsysj78w43q902wi9dhck64q9va247avr6fhdw8ynf2lvb78d3"
   }
  },
  {
@@ -28004,11 +28262,11 @@
   "repo": "kidd/erc-image.el",
   "unstable": {
    "version": [
-    20180522,
-    1424
+    20210604,
+    753
    ],
-   "commit": "82fb3871f02e24b1e880770b9a3d187aab43d0f0",
-   "sha256": "1q8mkf612fb4fjp8h4kbr107wn083iqfdgv8f80pcmil8y33dw9i"
+   "commit": "883084f0801d46a5ccf183e51ae9a734755bbb97",
+   "sha256": "081c8pjmpwnmqah7dbpkj20bk7ln57g4n7c1zxzdlsz80pxnfay4"
   }
  },
  {
@@ -28385,18 +28643,19 @@
     20200914,
     644
    ],
-   "commit": "ed6730a1717a0e3ddc25a75de0c2e109371391c7",
-   "sha256": "0zlx4xh5c5d88zfbbwd79qb56mrvd3fhgqd7r64p6gx9gfa6kbi5"
+   "commit": "044843c5281a7bdb9479317793a75c8c0fcfadd9",
+   "sha256": "04lirb2p1h46c1l84ysdnr2jxvzsdw1zv6jhm7h8ybgzmaa65b6m"
   },
   "stable": {
    "version": [
     2,
     6,
     1,
-    3
+    3,
+    20210605
    ],
-   "commit": "e5486b79cc78689e3fd07b6c924d0085063915ea",
-   "sha256": "1zl7c0rb5rg867a431apxlzj2flg3hjidamqa5prc1bzpmfaywyz"
+   "commit": "ab805592a0ae7066fbd5fa5f47e933194fce878f",
+   "sha256": "19ld12x4is0nx52i05zv20js0zysx3bljbdn2nr65vy11dq2cyyp"
   }
  },
  {
@@ -28410,17 +28669,17 @@
     20210315,
     1640
    ],
-   "commit": "7d21e4b2ec7e6a5dc4a51f235a4a5b7d11f27f9b",
-   "sha256": "1k0qi9blvhayzbzr60g55lh8k7sgn9xbpnn6cb8i4km3470ihnwl"
+   "commit": "a8969ec16a91c0e1ac56a438d81069d288662518",
+   "sha256": "0wp6sf8rw73waws47av68d4sdd28qix74n53c4fpdc4c2xq3j3h6"
   },
   "stable": {
    "version": [
     24,
     0,
-    1
+    2
    ],
-   "commit": "ae4f8649c0ed90abf177124a5c974abf89dd70e3",
-   "sha256": "1j2y3m1k75c62gvhvj5f2jw3sijii1z8bjnk547w4ak4ldl60kfg"
+   "commit": "82f97b9d3d639ed87175aeed75747eb6594170ab",
+   "sha256": "065kc9p30jam23grpm7dwxjf76n6g1hzdrq9q1irr3qmw1rr0240"
   }
  },
  {
@@ -29159,8 +29418,8 @@
     20210405,
     1808
    ],
-   "commit": "22b81067ebcaef2cea633f967a4b55454af9326a",
-   "sha256": "0b93a8km80r1c3gbinnsigkkq8yc127jwrqj8s8z130b79ch91hn"
+   "commit": "3d62a3319ab03a810030058d3fb368b28dfd82d5",
+   "sha256": "0hj3nczmqmgiwsvh664rs34j63wl325x6nar21p1a84h5ximpkxq"
   }
  },
  {
@@ -29338,8 +29597,8 @@
    "deps": [
     "ess"
    ],
-   "commit": "554bdc7d6c7fafc5b8a886690970b5145276a3f5",
-   "sha256": "0v4cj8d44a52h3r8k4yhr84xalfwrkwpdn3c5m44x7xp36s6zgbn"
+   "commit": "f6731eb26dc0fc5b7ca1fa881a5f9100f8fcf494",
+   "sha256": "0pvjk5a5v03qnasqsja30bywb4c481x9agf1rfcwbqsva7p97wiy"
   },
   "stable": {
    "version": [
@@ -29440,26 +29699,27 @@
   "repo": "ShuguangSun/ess-view-data",
   "unstable": {
    "version": [
-    20210326,
-    1431
+    20210603,
+    1412
    ],
    "deps": [
     "csv-mode",
     "ess"
    ],
-   "commit": "283251e8ac19ac0c0f89a4b0f0eb38482167e52b",
-   "sha256": "0kp94y27csj08868rbiwdfzgjx9q71j7d0whpqhsh27qhc189crq"
+   "commit": "845412ba57efab1a28fbaf0dcdbe76bdab03f828",
+   "sha256": "0m5wmxi4zq3xy9jsg7d2318iyn9g6fpzqiraq0810fbmrdl4dda4"
   },
   "stable": {
    "version": [
     1,
-    2
+    3
    ],
    "deps": [
+    "csv-mode",
     "ess"
    ],
-   "commit": "99ddbceaa54941a5e8438eadb0210fd16470e581",
-   "sha256": "1crbrzphs49ghkx3rv952wbdv483rwfblryv8bx8lgpxv5gkar9w"
+   "commit": "845412ba57efab1a28fbaf0dcdbe76bdab03f828",
+   "sha256": "0m5wmxi4zq3xy9jsg7d2318iyn9g6fpzqiraq0810fbmrdl4dda4"
   }
  },
  {
@@ -29866,15 +30126,15 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20210515,
-    1807
+    20210527,
+    2107
    ],
    "deps": [
     "cl-lib",
     "goto-chg"
    ],
-   "commit": "f0fdfef7703c814f9bb1bb2858d3cadc79fdcbdd",
-   "sha256": "1d3lnfyp7n1digldamddmxwlycm7xk5ljn5i9ngw59b936050lp6"
+   "commit": "ad47644eea5e351269f5bead18e713768d96f207",
+   "sha256": "1bcdrvrrjq9r75cfrxziq84slrjm8gbbhbm72hqjfzka6zcnr39g"
   },
   "stable": {
    "version": [
@@ -30068,15 +30328,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20210519,
-    524
+    20210607,
+    1954
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "d576c49e04da7cb9f773edaebdf540151883be4a",
-   "sha256": "05fig8a05rdd2cjq5pzqb9v51lwibyiflny2rfw226wn5m6f75af"
+   "commit": "86b02f84a8df0ddd6216cb85d49bedd6ee2ab747",
+   "sha256": "0vh0wdzz9idfinbfd3mynlp88lgq5j9wk8c3pc5a1is6g3jpj938"
   },
   "stable": {
    "version": [
@@ -30769,11 +31029,11 @@
   "repo": "redguardtoo/evil-nerd-commenter",
   "unstable": {
    "version": [
-    20210512,
-    1346
+    20210528,
+    1009
    ],
-   "commit": "9e7e96971900a2840fe2f7e8d6774c92fed2ccba",
-   "sha256": "04wyz472g4dlyyj7415s8wp4djaizrh7ncngqx8bl6zanksqyv56"
+   "commit": "c0f49e4e87300720b8e8a8296d92b8386956c7a2",
+   "sha256": "0ci3hjzgwayz9nvmwg5vbmvn80cz0lsppghi511cbr3cdf8xkkv4"
   },
   "stable": {
    "version": [
@@ -30808,14 +31068,14 @@
   "repo": "juliapath/evil-numbers",
   "unstable": {
    "version": [
-    20210520,
-    1300
+    20210605,
+    431
    ],
    "deps": [
     "evil"
    ],
-   "commit": "d7a3e6ddec9d69978318901cf75b911085969fc0",
-   "sha256": "12jk8l5k8lbvvg2yapfbpq31dzl4icsmr16imz32bpr7b7vvar65"
+   "commit": "cd23a7b458d73dc49434a3cf90d3d0caceb5811d",
+   "sha256": "1naxciaq1ci1ajs4if45wjy5qf8bgkxazyvl1kywrj299wi2qdv9"
   },
   "stable": {
    "version": [
@@ -31203,15 +31463,15 @@
   "repo": "hlissner/evil-snipe",
   "unstable": {
    "version": [
-    20200531,
-    1008
+    20210607,
+    420
    ],
    "deps": [
     "cl-lib",
     "evil"
    ],
-   "commit": "6dcac7f2516c6137a2de532fc2c052f242559ee3",
-   "sha256": "1faimkch2s08kbrwh3j77y0n5inrjr7vphy0xdl402bv0d20h8nq"
+   "commit": "9bd7345476174dfc6eeaa700a505e45b155ddb83",
+   "sha256": "1p7v9pnbyc4mhpkvmyl9vr825grqnfyl0h203sbnb1vnw15bbnbp"
   },
   "stable": {
    "version": [
@@ -31303,8 +31563,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "346d4d85fcf1f9517e9c4991c1efe68b4130f93a",
-   "sha256": "1gfgmr4909m36gknprcam6q4rkcqfbi6w43ky7x6jnlmgb6mxggg"
+   "commit": "4706987bc01a552343848da49b4951bd54374643",
+   "sha256": "0v2v58pchr5icdpvg4k6vblxhgjk09wi7f54hs1dj0f6rgvpxmx5"
   },
   "stable": {
    "version": [
@@ -31394,8 +31654,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "f0fdfef7703c814f9bb1bb2858d3cadc79fdcbdd",
-   "sha256": "1d3lnfyp7n1digldamddmxwlycm7xk5ljn5i9ngw59b936050lp6"
+   "commit": "ad47644eea5e351269f5bead18e713768d96f207",
+   "sha256": "1bcdrvrrjq9r75cfrxziq84slrjm8gbbhbm72hqjfzka6zcnr39g"
   },
   "stable": {
    "version": [
@@ -32337,11 +32597,11 @@
   "repo": "ieure/exwm-mff",
   "unstable": {
    "version": [
-    20201003,
-    1651
+    20210603,
+    1723
    ],
-   "commit": "0d428aca46b8c251dc04d412832e6e7b6e910872",
-   "sha256": "0g4jvnygcn91kzay0dvahkmf7813cizfc3lhyx1mvi6riz9li3l7"
+   "commit": "89206f2e3189f589c27c56bd2b6203e906ee7100",
+   "sha256": "0ipmapyd4jmpnk34wk9kfbvqnl04x74yg2pmj298wqa61ylw1n9j"
   },
   "stable": {
    "version": [
@@ -32462,8 +32722,20 @@
   "repo": "Wilfred/ez-query-replace.el",
   "unstable": {
    "version": [
-    20170814,
-    1321
+    20210525,
+    2222
+   ],
+   "deps": [
+    "dash",
+    "s"
+   ],
+   "commit": "3202cf4644ed3b6549284c3816b90bb230970a5b",
+   "sha256": "1xsvwf7g7c3v4p59svmahhn9pkr6zgp6vyr6dyvfy24mgaqw4jzv"
+  },
+  "stable": {
+   "version": [
+    0,
+    4
    ],
    "deps": [
     "dash",
@@ -32677,19 +32949,19 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20210427,
-    2150
+    20210602,
+    1952
    ],
-   "commit": "7b994f27c798a6cd528af25bccbba28e27e6adcf",
-   "sha256": "0m826s1hll6gjr7y665kix7rnyghdrwi7rga57s158vgg0j345wy"
+   "commit": "45f2faef92ee23738b86f4f8d0a433ad729a5ca8",
+   "sha256": "0slvrgw508388il24wlx9g0bf32anpk6rbhmb2r99anq2vhn4b4g"
   },
   "stable": {
    "version": [
     2,
-    19
+    20
    ],
-   "commit": "7b994f27c798a6cd528af25bccbba28e27e6adcf",
-   "sha256": "0m826s1hll6gjr7y665kix7rnyghdrwi7rga57s158vgg0j345wy"
+   "commit": "45f2faef92ee23738b86f4f8d0a433ad729a5ca8",
+   "sha256": "0slvrgw508388il24wlx9g0bf32anpk6rbhmb2r99anq2vhn4b4g"
   }
  },
  {
@@ -33030,11 +33302,11 @@
   "repo": "yqrashawn/fd-dired",
   "unstable": {
    "version": [
-    20210311,
-    321
+    20210605,
+    1057
    ],
-   "commit": "7d18938751d047eef18bfb5975195419f0d1e2d3",
-   "sha256": "0182hg9iayz371lv4flls3gwsvn7bad027h5bn7lizvxxmgg3c6s"
+   "commit": "c223aee30af7dc7f52fb20045226ed9f49f4ec49",
+   "sha256": "14dzn3ggq8vb6qb5babngrpgsb29k6y8ficgzwwd9wfd5npynrpa"
   },
   "stable": {
    "version": [
@@ -33473,8 +33745,8 @@
     20210426,
     835
    ],
-   "commit": "af56f75afc240d8121c8944a614a272be811830c",
-   "sha256": "151c9hvsb5bnprn7kf3g23igazkw9l7xvzizikifizfabay9wi2h"
+   "commit": "904225a3f89bbd3b44ea097a282ec6ca7945f7f1",
+   "sha256": "0bf3qnzhv7z71f4h9l0cq6mllkfmc81655qwbzakw3gqqmn8kyr3"
   },
   "stable": {
    "version": [
@@ -34188,15 +34460,15 @@
   "repo": "wanderlust/flim",
   "unstable": {
    "version": [
-    20210324,
-    1102
+    20210529,
+    1253
    ],
    "deps": [
     "apel",
     "oauth2"
    ],
-   "commit": "ddf5b6eceb73d7dbf6ff3a2d5281a2957cc2b836",
-   "sha256": "1pf7jg0psirjm2s84hcmjxkhd5s8vlgprn1miykxks2yxkvk01xf"
+   "commit": "02735dede6603987e8309a76d0bc7a9ff9a5a227",
+   "sha256": "1jy2wsm1xc6iaxa449wwz14ky4yiaxd8g05ry59r9pf60cpxxy1h"
   }
  },
  {
@@ -34583,14 +34855,14 @@
   "repo": "leotaku/flycheck-aspell",
   "unstable": {
    "version": [
-    20210411,
-    2342
+    20210605,
+    1713
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "74fa2837fd667235121a12eba43aa1675a58c0ec",
-   "sha256": "0kgib5igj4ngr589v57k3pwk5v8an33v9mdw5g8kxlsiw7ibr3xk"
+   "commit": "8c45988a12e7c149b17d7edb84e6dfc33bb7b288",
+   "sha256": "1lsfz3yi3i1mqmq6p9x6fx26wrlqihsaz3yk5g50yv6jqvfr1g79"
   }
  },
  {
@@ -37083,8 +37355,8 @@
     20210411,
     2342
    ],
-   "commit": "74fa2837fd667235121a12eba43aa1675a58c0ec",
-   "sha256": "0kgib5igj4ngr589v57k3pwk5v8an33v9mdw5g8kxlsiw7ibr3xk"
+   "commit": "8c45988a12e7c149b17d7edb84e6dfc33bb7b288",
+   "sha256": "1lsfz3yi3i1mqmq6p9x6fx26wrlqihsaz3yk5g50yv6jqvfr1g79"
   }
  },
  {
@@ -38173,8 +38445,8 @@
     20210124,
     1143
    ],
-   "commit": "94a2be0ef4515473101f823fccca71aa456bf84e",
-   "sha256": "1kw47ghvy7i87i6qrzijg64b43vsh4d7gn9r4g73jgdbqdmiqbyb"
+   "commit": "404233604439117301562deadc952fe82cb02120",
+   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
   },
   "stable": {
    "version": [
@@ -38201,8 +38473,8 @@
     "avy-menu",
     "flyspell-correct"
    ],
-   "commit": "94a2be0ef4515473101f823fccca71aa456bf84e",
-   "sha256": "1kw47ghvy7i87i6qrzijg64b43vsh4d7gn9r4g73jgdbqdmiqbyb"
+   "commit": "404233604439117301562deadc952fe82cb02120",
+   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
   },
   "stable": {
    "version": [
@@ -38233,8 +38505,8 @@
     "flyspell-correct",
     "helm"
    ],
-   "commit": "94a2be0ef4515473101f823fccca71aa456bf84e",
-   "sha256": "1kw47ghvy7i87i6qrzijg64b43vsh4d7gn9r4g73jgdbqdmiqbyb"
+   "commit": "404233604439117301562deadc952fe82cb02120",
+   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
   },
   "stable": {
    "version": [
@@ -38265,8 +38537,8 @@
     "flyspell-correct",
     "ivy"
    ],
-   "commit": "94a2be0ef4515473101f823fccca71aa456bf84e",
-   "sha256": "1kw47ghvy7i87i6qrzijg64b43vsh4d7gn9r4g73jgdbqdmiqbyb"
+   "commit": "404233604439117301562deadc952fe82cb02120",
+   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
   },
   "stable": {
    "version": [
@@ -38297,8 +38569,8 @@
     "flyspell-correct",
     "popup"
    ],
-   "commit": "94a2be0ef4515473101f823fccca71aa456bf84e",
-   "sha256": "1kw47ghvy7i87i6qrzijg64b43vsh4d7gn9r4g73jgdbqdmiqbyb"
+   "commit": "404233604439117301562deadc952fe82cb02120",
+   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
   },
   "stable": {
    "version": [
@@ -38692,8 +38964,8 @@
     20191004,
     1850
    ],
-   "commit": "7bb01664b45fc08b7d013c91073cf3ce0d313984",
-   "sha256": "1hknnkidmd5w81i30xjj2q3x93mygqq7pk7kwfssnzrn8lih6a9b"
+   "commit": "246120647e28a27506ca0894ba98e371086881fd",
+   "sha256": "15gqzj4h0w33w38i8ihl74iy7aqxlds97gm93r72z69pm2l1d7dm"
   }
  },
  {
@@ -38764,14 +39036,14 @@
  },
  {
   "ename": "forge",
-  "commit": "58c5ca46286712b2aa43e07bb5dcbc8b5eb321e8",
-  "sha256": "1ykpjgbi2yak9ww54wnm1gxj9zff2ggldg9msg3219r8frzjcnjv",
+  "commit": "6cee0395aa57874032cb75c9f3f71e62bd139235",
+  "sha256": "0a1yvdxx43zq9ivwmg34wyybkw4vhgzd2c54cchsbrbr972x9522",
   "fetcher": "github",
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20210507,
-    1554
+    20210525,
+    1345
    ],
    "deps": [
     "closql",
@@ -38783,13 +39055,13 @@
     "markdown-mode",
     "transient"
    ],
-   "commit": "37aa4e4b82a99246b3551daee6104dc1d192174a",
-   "sha256": "01z6mnl68lwm0nj0mbvns6xacfydadwcmjzfy3vnmj7hkcd9nynd"
+   "commit": "551e51511e25505d14e05699a1707fd57e394a9a",
+   "sha256": "139pndj9l9aifnvv2ak5zwf5gzwhp3m6dfpw1avf4vkh1zywzwa0"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
@@ -38797,14 +39069,13 @@
     "dash",
     "emacsql-sqlite",
     "ghub",
-    "graphql",
     "let-alist",
     "magit",
-    "magit-popup",
-    "markdown-mode"
+    "markdown-mode",
+    "transient"
    ],
-   "commit": "f5fc99935e2059ddede9766ce4bb96d99dcd203b",
-   "sha256": "0jipyqj3r4gkdwpcy0m5ij7x510r2admi8fbzwfysqyrwahs60nv"
+   "commit": "551e51511e25505d14e05699a1707fd57e394a9a",
+   "sha256": "139pndj9l9aifnvv2ak5zwf5gzwhp3m6dfpw1avf4vkh1zywzwa0"
   }
  },
  {
@@ -38839,15 +39110,15 @@
   "repo": "lassik/emacs-format-all-the-code",
   "unstable": {
    "version": [
-    20210413,
-    802
+    20210604,
+    1107
    ],
    "deps": [
     "inheritenv",
     "language-id"
    ],
-   "commit": "eb5906c7070b667432194da3991daf21f24b516a",
-   "sha256": "02i9qijkwzwjcl52ivzhcjamsiygdxn62gdkb9v511036vv4dqff"
+   "commit": "82f68e5d1f0641d7a050db02ab2c0a7d3888f358",
+   "sha256": "0761qmkza4sbl1k0vj4q18zm9p148h7131dq46wwajyxbmrxlxja"
   },
   "stable": {
    "version": [
@@ -38978,20 +39249,20 @@
  },
  {
   "ename": "fountain-mode",
-  "commit": "12589d1eb14bfc87d2e6f2a5ff8f5fb66b574a56",
-  "sha256": "1i55gcjy8ycr1ww2fh1a2j0bchx1bsfs0zd6v4cv5zdgy7vw6840",
+  "commit": "27cc1d093ce12b559a4266184fb9077c9810d542",
+  "sha256": "1jmb5xm0d1wffw3gj0idv114dzs845n41312dvghv7bblbxyd7bj",
   "fetcher": "github",
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20210516,
-    1556
+    20210523,
+    1327
    ],
    "deps": [
     "seq"
    ],
-   "commit": "faccbe3e1f02ed75745999a7f6f11a0fb855936a",
-   "sha256": "0jdszkbzwh3w3r1sf09h3g65q5b1gnwwd502423lgq80gabf3ni9"
+   "commit": "77f3ce6b646868210f91b6a80fcaaa77297ed341",
+   "sha256": "1f0mzrn237kv2p5bz58km4b7a46shzm1v7n4a6ksyfd3n7cqas85"
   },
   "stable": {
    "version": [
@@ -39602,14 +39873,14 @@
   "repo": "factor/factor",
   "unstable": {
    "version": [
-    20210506,
-    1352
+    20210602,
+    1531
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a456d86694067c04dcdff3e48d654ceed2c72465",
-   "sha256": "0vijg7ybg128p2zx1fr4fzgyrf3p5vbhssf8j1l9y7bkdq8i7smp"
+   "commit": "b989a860d1d6191bb9c5911ac77ed0931424eaeb",
+   "sha256": "1w0hyfspi3kahj2lk1bzj3ny3r8bb0cj4yfjizzbfc1pz9dlkpkp"
   },
   "stable": {
    "version": [
@@ -40092,11 +40363,11 @@
   "repo": "wavexx/gcode-mode.el",
   "unstable": {
    "version": [
-    20201218,
-    2109
+    20210522,
+    1025
    ],
-   "commit": "a1e2c6cbf4e364991ab2209d5cd5a3b698d459d9",
-   "sha256": "0x6aqh415gbn9x7qyb74zmw5v1ghi7y0lknlbdccxx3j62fmmv8w"
+   "commit": "1f83845af4102efc5e5856b55bd5ad165b2f0cdd",
+   "sha256": "0lrsnl08npknif66chs3spy6pnblx3mbxxw1dii8a7zcj2s0ripv"
   }
  },
  {
@@ -40518,11 +40789,11 @@
   "url": "https://git.carcosa.net/jmcbray/gemini.el.git",
   "unstable": {
    "version": [
-    20200813,
-    1424
+    20210226,
+    1419
    ],
-   "commit": "d114bacfb12f9e66821254ff0a1fb85443700b24",
-   "sha256": "0m7jricw40h4r30kcg60dl2ybgrdbiglnb55lz3n70bc5nsx8dcd"
+   "commit": "0a227125a4112266c06ed7247de039090314b525",
+   "sha256": "0fiix0ssaannim5kxpckhd5z6fssij3igv1dg9y7143dzxf274zz"
   },
   "stable": {
    "version": [
@@ -40667,8 +40938,8 @@
   "repo": "thisch/gerrit.el",
   "unstable": {
    "version": [
-    20210329,
-    817
+    20210530,
+    402
    ],
    "deps": [
     "dash",
@@ -40676,8 +40947,8 @@
     "magit",
     "s"
    ],
-   "commit": "6a90e7233dccc2f997af2cd5c896c8d72d3c3a76",
-   "sha256": "1nmgngxgzbp1l4av6vb6fgl2nbizsffv51qnki8yaycl1f3cmrg9"
+   "commit": "f1bdc47ab2bb29c2a0a385aaa9a5f0f6d543ffb5",
+   "sha256": "1qcw5kzcw9g41hqg0gnq3k6i4ygfgrlghadmfzdnf7dbk93ngl4g"
   }
  },
  {
@@ -40935,28 +41206,28 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20210427,
-    1239
+    20210531,
+    2006
    ],
    "deps": [
     "let-alist",
     "treepy"
    ],
-   "commit": "d6e6b0666104f3896d05d2b03d08d84d9dca096f",
-   "sha256": "04ifyn8pkhg6lhlikxfgj6fcnz33mgr6x24y72754szc105irb0s"
+   "commit": "e9a819c9c997b8e752eeb4a3fcd1a7b55ab8da47",
+   "sha256": "1c92q4hrax9gfrw35qi3slr7man006v5vqzp6hi2an5haw2cz4x2"
   },
   "stable": {
    "version": [
     3,
     5,
-    2
+    3
    ],
    "deps": [
     "let-alist",
     "treepy"
    ],
-   "commit": "d6e6b0666104f3896d05d2b03d08d84d9dca096f",
-   "sha256": "04ifyn8pkhg6lhlikxfgj6fcnz33mgr6x24y72754szc105irb0s"
+   "commit": "ae59388adbba32fa00e39f3323fe69367739ee6f",
+   "sha256": "1sn7rzfkm75vj3whhisrjk1s34lz6hc08hmf4nnznbdvyimnd013"
   }
  },
  {
@@ -41021,11 +41292,11 @@
   "repo": "csrhodes/gift-mode",
   "unstable": {
    "version": [
-    20180530,
-    1235
+    20210528,
+    1459
    ],
-   "commit": "b0441ae6e02f343be3b611a2d4b40495ecd932f0",
-   "sha256": "0dwpmvjsczcdzwhjvpfxrkfha513538z8wq3gr3l1zc1kdggx2bk"
+   "commit": "c93354e8fe1173b22f398f17b127875807f15b87",
+   "sha256": "1d974s7i2hi8yxdng2l02pfn2vkv65jzk5lm9p6if2myf5xbwis5"
   }
  },
  {
@@ -41301,29 +41572,30 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210512,
-    1949
+    20210525,
+    844
    ],
    "deps": [
     "dash",
     "transient",
     "with-editor"
    ],
-   "commit": "9d76233597aaad1c9ab188bde83c3b66d9bd3d0a",
-   "sha256": "1kmnvrgy71bk6z47w90vrmfl37j7q069vcdx9dcs4fpjaq2rbapw"
+   "commit": "4a8646a30df99bbafc95d4f21a0b2bf0a6f6566f",
+   "sha256": "0y3wzvyaxn5zybjak77r1cngaqqm462s3d4f1cwmzvrnpv99f3r9"
   },
   "stable": {
    "version": [
-    2,
-    90,
-    1
+    3,
+    0,
+    0
    ],
    "deps": [
     "dash",
+    "transient",
     "with-editor"
    ],
-   "commit": "791901b2f1d26fa0a383147fe77948a9abc753da",
-   "sha256": "1kw94sdczswsyzn1zlk5s5aplpdv4qd7qcqc5zfxsmsfwm3jacl4"
+   "commit": "c3bbc9b9425f3370690cabb11bd35b9040773fdc",
+   "sha256": "0dbp3gx43ipxv8zg9m0hfhksz85rnkikaq35rx705qqz6xq6xq9m"
   }
  },
  {
@@ -41528,8 +41800,8 @@
     "f",
     "hydra"
    ],
-   "commit": "24360718c1666a246a39aadc8a251faa8578cc66",
-   "sha256": "129xv2ddgdkc9ipkxvwprkwp245x1zq2r75liv31x8x4g4i4305i"
+   "commit": "5b1191f79f1845d7144bd2a49ad25c49866456aa",
+   "sha256": "06ybkpaqicx3q5hdjz99v3isj1jhrpmg55wf054dzx6wpjy8na21"
   },
   "stable": {
    "version": [
@@ -41704,14 +41976,14 @@
   "repo": "pidu/git-timemachine",
   "unstable": {
    "version": [
-    20200603,
-    701
+    20210528,
+    908
    ],
    "deps": [
     "transient"
    ],
-   "commit": "8d675750e921a047707fcdc36d84f8439b19a907",
-   "sha256": "1ppids836gdk5j8cli8wkzkjb85f4s1s550v5xpxyyq75rj1bnsr"
+   "commit": "3381797bcbf906b18dff654a2361032d2d01b4a3",
+   "sha256": "05pyjhi26charkjy0mhvigd72rvb4s1s8imycfynf0fmjy7f7n7x"
   },
   "stable": {
    "version": [
@@ -41794,20 +42066,20 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20210426,
-    2132
+    20210528,
+    1854
    ],
-   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
-   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
+   "commit": "433e1c57a63c88855fc41a942e29d7bc8c9c16c7",
+   "sha256": "0br3nwr2mjywysqn83npf45qpqii3xqzdggg5fd47r9vqqj6mc55"
   },
   "stable": {
    "version": [
     1,
     3,
-    0
+    1
    ],
-   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
-   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
+   "commit": "433e1c57a63c88855fc41a942e29d7bc8c9c16c7",
+   "sha256": "0br3nwr2mjywysqn83npf45qpqii3xqzdggg5fd47r9vqqj6mc55"
   }
  },
  {
@@ -41842,20 +42114,20 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20210426,
-    2132
+    20210528,
+    1856
    ],
-   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
-   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
+   "commit": "433e1c57a63c88855fc41a942e29d7bc8c9c16c7",
+   "sha256": "0br3nwr2mjywysqn83npf45qpqii3xqzdggg5fd47r9vqqj6mc55"
   },
   "stable": {
    "version": [
     1,
     3,
-    0
+    1
    ],
-   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
-   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
+   "commit": "433e1c57a63c88855fc41a942e29d7bc8c9c16c7",
+   "sha256": "0br3nwr2mjywysqn83npf45qpqii3xqzdggg5fd47r9vqqj6mc55"
   }
  },
  {
@@ -42130,20 +42402,20 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20210426,
-    2132
+    20210528,
+    1856
    ],
-   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
-   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
+   "commit": "433e1c57a63c88855fc41a942e29d7bc8c9c16c7",
+   "sha256": "0br3nwr2mjywysqn83npf45qpqii3xqzdggg5fd47r9vqqj6mc55"
   },
   "stable": {
    "version": [
     1,
     3,
-    0
+    1
    ],
-   "commit": "7678ead3cdbb1692c9728b9730c016283ed97af1",
-   "sha256": "0m8qfjj5hzxwyyi34sbk11qz5fix6z80hiki0v0a838sq4f586b6"
+   "commit": "433e1c57a63c88855fc41a942e29d7bc8c9c16c7",
+   "sha256": "0br3nwr2mjywysqn83npf45qpqii3xqzdggg5fd47r9vqqj6mc55"
   }
  },
  {
@@ -42292,14 +42564,14 @@
   "repo": "TxGVNN/gitlab-pipeline",
   "unstable": {
    "version": [
-    20210430,
-    151
+    20210601,
+    1339
    ],
    "deps": [
     "ghub"
    ],
-   "commit": "0a07b64e402fa1e25423f8f6ed38b35ff09159d9",
-   "sha256": "1611nday1mxkkjjwcz62bvl8863vlkl4bq4vf3wj6p237m4ai3ks"
+   "commit": "2404f9cf0a064aabea975adada250895c385e057",
+   "sha256": "00i6q4pggaq97xgvi2ifanh0lx8nq5gbi4r2gy596635x26a55zq"
   },
   "stable": {
    "version": [
@@ -42732,11 +43004,11 @@
   "repo": "emacsorphanage/gnuplot",
   "unstable": {
    "version": [
-    20210104,
-    1052
+    20210526,
+    1848
    ],
-   "commit": "116cad8e09024223f97e81b0a4503cef20de9bf5",
-   "sha256": "09y177sq24gs7wwjihw59g0m4n1rv2ws9890ynxjxawv823r0fxm"
+   "commit": "07a80272b86c081b40602ec0b080571f3269749d",
+   "sha256": "1d50b5vwnzca16g7hs2i0357lx9x5rvivdb5hdi0ngf6sb8d1afk"
   },
   "stable": {
    "version": [
@@ -42857,11 +43129,11 @@
   "repo": "unhammer/gnus-recent",
   "unstable": {
    "version": [
-    20210115,
-    1107
+    20210604,
+    720
    ],
-   "commit": "52f05e7431b5ce5487e8a990eb2ad01cade973bc",
-   "sha256": "178b8l2f5ykrq1yllg9rmn1vsyp3aqslrga1gxx1rc4grx22x31z"
+   "commit": "09b9e96f8e0ab006d9cfe8f5ab000ce7e50ef4de",
+   "sha256": "0qsnfiqcivy7czg2j7kdsifz7p5nid1zvw6zdnaihghzdxa1w1ia"
   },
   "stable": {
    "version": [
@@ -43029,30 +43301,6 @@
    ],
    "commit": "eef10fdde96a12528a6da32f51bf638b2863a3b1",
    "sha256": "03snnra31b5j6iy94gql240vhkynbjql9b4b5j8bsqp9inmbsia3"
-  }
- },
- {
-  "ename": "go-capf",
-  "commit": "be3dc9ae83c9d11a4f04f79775b17c5a2b86e96d",
-  "sha256": "0k6s65bf8iwkpr93agw9hqaxfckqi43lanffdic6j4vjrk4inlwz",
-  "fetcher": "git",
-  "url": "https://git.sr.ht/~zge/go-capf",
-  "unstable": {
-   "version": [
-    20200814,
-    1046
-   ],
-   "commit": "acc353135f390245453f0d90f5846f67b0a84952",
-   "sha256": "1hb8glprzpm94bsyx2mnv9w6b825y451agpqh2ry8ngydbc1llhi"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    0
-   ],
-   "commit": "de3b668b83a73da5ce189c536a58aa1d4f5d492c",
-   "sha256": "1y1dscqyd2jx5irj5pcy7sspzzp0nsy2j4zaqhln2snffpqa3hmf"
   }
  },
  {
@@ -43610,11 +43858,11 @@
   "repo": "lorniu/go-translate",
   "unstable": {
    "version": [
-    20201203,
-    203
+    20210527,
+    1257
    ],
-   "commit": "ea63d0ad9816aa1c478c66bd1ff9978e8330d3cb",
-   "sha256": "0v3w3ffls9h4vpalmkvswsrdcny3z1g7p9gdp75lw6pc9xkmkgnz"
+   "commit": "7a9b7978057bf747ed06fa6c9d2f30047714aa05",
+   "sha256": "1wydx9ak09dfmvqvvkdd5zdzablj8rhisk3im1f41a4hgiba80hr"
   },
   "stable": {
    "version": [
@@ -43833,20 +44081,20 @@
   "repo": "io12/good-scroll.el",
   "unstable": {
    "version": [
-    20210520,
-    431
+    20210607,
+    339
    ],
-   "commit": "60fd0a7a5d663150728027bfc4e7adb33970d277",
-   "sha256": "19apz49ba2cmlf449yc55s3150nrqhv5lajmw1rx36w0vbjkbyyn"
+   "commit": "b4233500bbbdb64758283ba8a4b7cef5a85181a2",
+   "sha256": "05k03bycwpgs9wf9rh4rxfp38lhzr46c8zpvkd5qr6zwb1nnvr00"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     1
    ],
-   "commit": "c72aa45b69025c2ee2c62eeccdaf15117cffe10d",
-   "sha256": "02lcw836dkj0dlv5g2pgx68i6a93lazsy7vln46dm5dckficr9bs"
+   "commit": "61aa3b57d572e6a46a1415b66dbc4b80c33bfb73",
+   "sha256": "0zprygv94rp1hdq7qxcmp3ns04j6l28y9w5hp087mhfbr1v5y54m"
   }
  },
  {
@@ -44235,13 +44483,13 @@
     "magit-popup",
     "s"
    ],
-   "commit": "13851af3d26288ec5760970b5b3ae3fd298d014d",
-   "sha256": "1ngl263wx18x3gw92i1rjffl6siacrvwbznmgv3793na96cvzs0f"
+   "commit": "da0ae769e70e1af16865c3fadb25e9132d089dc6",
+   "sha256": "09kdlz6h31yasi1rv7759m40zb12vj6llv70pqh9swrpii2nmdzp"
   },
   "stable": {
    "version": [
     0,
-    25,
+    26,
     0
    ],
    "deps": [
@@ -44250,8 +44498,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "bb0307eb84ae981cfca7fc8d680821a2c2be3c6d",
-   "sha256": "0jwfk4kqz8jzxlhdihb0wvyiza1zfwcwr2p9frk0cw50p6fjqbs6"
+   "commit": "34586b6650fb19689755570628a558ca9ea7946a",
+   "sha256": "0a7bnw01j4fbhga5x00v5bbk38j2q7mg7ablz6kswlmarqwr4fm6"
   }
  },
  {
@@ -44607,6 +44855,38 @@
    ],
    "commit": "672dd9ebd7e67d8089388b0c484cd650e76565f3",
    "sha256": "0sp0skc1rnhi39szfbq1i99pdgd3bhn4c15cff05iqhjy2d4hniw"
+  }
+ },
+ {
+  "ename": "graphql-doc",
+  "commit": "54bd4ea32fb912c51735243fa8f609890516fad9",
+  "sha256": "1szibk2ragp0pbbzw6bw1jmbpdbc6llj4cmd20wz8lvjwp3p1qss",
+  "fetcher": "github",
+  "repo": "ifitzpatrick/graphql-doc.el",
+  "unstable": {
+   "version": [
+    20210530,
+    221
+   ],
+   "deps": [
+    "promise",
+    "request"
+   ],
+   "commit": "a60a646413fce528ecf42be3ee111b3f92d9f95b",
+   "sha256": "168yqaygyvrw05kip10azdcjsczahrsflg43vl6ki7ii6x595b5s"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "deps": [
+    "promise",
+    "request"
+   ],
+   "commit": "1623cdd887846057200579cfddc0fa1815d1af9c",
+   "sha256": "0nqx88ng72vvz1vl7hj1m77ncf9i0d4l3n1bab0kp90fmrgxa69p"
   }
  },
  {
@@ -45040,14 +45320,14 @@
   "repo": "greduan/emacs-theme-gruvbox",
   "unstable": {
    "version": [
-    20210105,
-    1136
+    20210606,
+    1419
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "0013c68458ae62fe1dc4bbbb23f6a54a9d41e398",
-   "sha256": "197r166c4pj0kc2v65rip93pcmmnm4li2jvagvajblang1svr2v0"
+   "commit": "c2ae5e3fff39f78f23109d90fdf36b3b189df511",
+   "sha256": "1vx3grgnnb5mamig3cd882pvcbqpni3kglrjawgdc96wwiv1krbg"
   },
   "stable": {
    "version": [
@@ -46255,16 +46535,16 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210520,
-    1523
+    20210607,
+    1026
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "2b60812516a0560ba5b2501771b53273a56c6488",
-   "sha256": "0z3axb0ql8cgzgqa5wa90y35vdwmq8qxlpzv3sw9ypmcgl652fy6"
+   "commit": "a92156303021e0ec91a904e16a994d8e1ccd78f7",
+   "sha256": "1lxmp0a7wk7wqb6qcy1zn9sr47vakgxzn0j8yyvdv1vps4hz9wk0"
   },
   "stable": {
    "version": [
@@ -47163,14 +47443,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210519,
-    1827
+    20210606,
+    1857
    ],
    "deps": [
     "async"
    ],
-   "commit": "2b60812516a0560ba5b2501771b53273a56c6488",
-   "sha256": "0z3axb0ql8cgzgqa5wa90y35vdwmq8qxlpzv3sw9ypmcgl652fy6"
+   "commit": "a92156303021e0ec91a904e16a994d8e1ccd78f7",
+   "sha256": "1lxmp0a7wk7wqb6qcy1zn9sr47vakgxzn0j8yyvdv1vps4hz9wk0"
   },
   "stable": {
    "version": [
@@ -48248,14 +48528,14 @@
   "url": "https://framagit.org/steckerhalter/helm-google.git",
   "unstable": {
    "version": [
-    20180606,
-    520
+    20210527,
+    900
    ],
    "deps": [
     "helm"
    ],
-   "commit": "48e91a73d5f48c39d7a219022a24440cff548e1a",
-   "sha256": "05xj6bkr330glh56n8c63297zqh1cmlhxlyxpr04srjraifyzba1"
+   "commit": "27834161391c350ef790062391cb7eab1d59fb62",
+   "sha256": "1rb1pmzr6szg8jjm43dndnk99v4i5zb1wp24rs9w8zmhygdn8jf4"
   }
  },
  {
@@ -50768,14 +51048,14 @@
   "repo": "emacs-helm/helm-wikipedia",
   "unstable": {
    "version": [
-    20200630,
-    504
+    20210525,
+    717
    ],
    "deps": [
     "helm"
    ],
-   "commit": "a6c8b1d1ab5dc0a69cb44bb5f3eb6792ef091147",
-   "sha256": "1him1sqdl15qfjqrkgmnhligwqc6a9liiqndssa1law3bd36c2jb"
+   "commit": "c242c74efaeda2ffbafd281ee6bceae1a42507bb",
+   "sha256": "17210p61q6g1rx8a3gacbrv69c4n92h5ajh28yw5ya23c275dnkb"
   }
  },
  {
@@ -52739,11 +53019,11 @@
   "repo": "humanoid-colors/emacs-humanoid-themes",
   "unstable": {
    "version": [
-    20210520,
-    2212
+    20210525,
+    2259
    ],
-   "commit": "09ec7a3da848f24d232578fc7e4ac5ff4a7736c7",
-   "sha256": "0kbvb71y2780ghy8pc4i8s0rf8kd58xfngbsqpjhl4ard2qvh9sp"
+   "commit": "9b4587417f2583c503f84f3b1e994d7934e57bdd",
+   "sha256": "1dpanfa8qpy9l2i2pw5w95lqsw06944qbcz8c9fgpj2s3nchhkpi"
   }
  },
  {
@@ -52857,11 +53137,11 @@
   "repo": "Riyyi/emacs-hybrid-reverse",
   "unstable": {
    "version": [
-    20210325,
-    2311
+    20210527,
+    2324
    ],
-   "commit": "81e6651203ef666af4ddc63dc726cfb1443fe16b",
-   "sha256": "0m7k91kwhy8v602li3rfzmcb4qb443w2iv8qh38ncsl0l6bsc982"
+   "commit": "4cad8a17f6c9d98a628d78fe358d589b03172b57",
+   "sha256": "0xwl0fycygzwsrv4vrph6q6hy0550j3z1ir9ahfc7fjl091k192x"
   }
  },
  {
@@ -52996,14 +53276,14 @@
   "repo": "ieure/hyperspace-el",
   "unstable": {
    "version": [
-    20190908,
-    550
+    20210603,
+    1825
    ],
    "deps": [
     "s"
    ],
-   "commit": "a7ea085baf4a51cac0513cb57216677722938781",
-   "sha256": "004bdas6339af8zzb2agc27vb86wwbxxinp1n4fhswnlb2llr18c"
+   "commit": "c4c363c140250ba6b775516082063878975a6154",
+   "sha256": "13nvp7hzynrddws3x7f7p4529arn3m7km7ma4226mc7mbpfbjgi1"
   },
   "stable": {
    "version": [
@@ -53311,11 +53591,11 @@
   "repo": "oantolin/icomplete-vertical",
   "unstable": {
    "version": [
-    20210520,
-    2058
+    20210603,
+    1343
    ],
-   "commit": "99f7cf94f362d18b2f2716b431b9fcc64345c05b",
-   "sha256": "08ppnakyzxqx7cwr08rmgj2m5bh4w5ssqxxdz10gx8majgqrr6li"
+   "commit": "3bee30b374226deecde8a5cbbc6ca8471c303348",
+   "sha256": "1c7riqgm5fi13kb2k7qfykr0zsx3hkwyzgcxh4kqnd1y5w54pgs2"
   },
   "stable": {
    "version": [
@@ -53334,27 +53614,27 @@
   "repo": "plandes/icsql",
   "unstable": {
    "version": [
-    20210304,
-    1843
+    20210605,
+    1658
    ],
    "deps": [
     "buffer-manage",
     "choice-program"
    ],
-   "commit": "759a63d373681e09d71e0f5522d063a811d7127e",
-   "sha256": "191cwfjrcv2yvgh0f6n0f2s64w6r2v19vvc41x4g1x48szzrzbg2"
+   "commit": "bc7c5f27f9d804613759a1d1357166f9ccecbe0e",
+   "sha256": "1g3wy9jjlag4ma610kdqnb0f2sy1032m5q419ankh5fv0gfxlwbl"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
    "deps": [
     "buffer-manage",
     "choice-program"
    ],
-   "commit": "bc600ecb6e6134e98dfb67f10301bde5a4e07adf",
-   "sha256": "0j27iiwgzysd9ymb4nc0m1300sqz0gqmri7ky9zfgv2g5gpjs4w0"
+   "commit": "bc7c5f27f9d804613759a1d1357166f9ccecbe0e",
+   "sha256": "1g3wy9jjlag4ma610kdqnb0f2sy1032m5q419ankh5fv0gfxlwbl"
   }
  },
  {
@@ -53544,29 +53824,27 @@
   "repo": "DarwinAwardWinner/ido-completing-read-plus",
   "unstable": {
    "version": [
-    20210402,
-    53
+    20210529,
+    1318
    ],
    "deps": [
-    "cl-lib",
     "memoize",
     "seq"
    ],
-   "commit": "ba997f0cad2797453d0ecf1c754a45a53da140da",
-   "sha256": "01lrafc2gam4msgmwrwn375sfmwg7lj30hq2cjv0gsaxv669l0mk"
+   "commit": "49e7967ea8c0ab0a206b40d70fc19be115083fa1",
+   "sha256": "0amjz5l586w6qbhjr32gzcbg2d94k904h5is0030zgy2qswphnfn"
   },
   "stable": {
    "version": [
     4,
-    13
+    14
    ],
    "deps": [
-    "cl-lib",
     "memoize",
-    "s"
+    "seq"
    ],
-   "commit": "41b42779e22c064192b95e4de855ff7ebad45af6",
-   "sha256": "088b50iajgj602wsm1280gn5pqirycazndhs27r1li5d84fm1nvj"
+   "commit": "c97f0d0c314fe4b49a3c1e58144e97c72926172c",
+   "sha256": "05s2a7ncw53w6713cqsr6n20ax2g99h4hr1qsp400l05vzp1m531"
   }
  },
  {
@@ -53918,11 +54196,11 @@
   "repo": "victorhge/iedit",
   "unstable": {
    "version": [
-    20210402,
-    854
+    20210606,
+    1026
    ],
-   "commit": "ff68c2065316aa5fb72662428f8d5812ec8da83a",
-   "sha256": "1c5qxms26q2pd5g7p8zayqbbgypjix5ayk074kk07a4km4wx31h8"
+   "commit": "94650d77719a554cdcebfc6e26a731de87e14483",
+   "sha256": "029z9j3anb948mbmh6ai8asxgfim8193ymm41c7crqzga9p4ivc7"
   },
   "stable": {
    "version": [
@@ -54838,11 +55116,11 @@
   "repo": "nonsequitur/inf-ruby",
   "unstable": {
    "version": [
-    20210427,
-    1755
+    20210607,
+    2336
    ],
-   "commit": "92d5d122fa172bc49b5ec9ee1891aa9c84805c92",
-   "sha256": "1dn8wml7jwf3dx2nbkjpf2v6k88apiin8wqmz4yix5d2k3x2qm46"
+   "commit": "03dd9c9d4e3f94f5519a786804d3ef9d3a09ef9f",
+   "sha256": "1xjaqh3m32lbc6avccv5clz1q2ra4pcl58wwlzkg0yhkxn7r750i"
   },
   "stable": {
    "version": [
@@ -55116,11 +55394,11 @@
   "repo": "zonuexe/init-open-recentf.el",
   "unstable": {
    "version": [
-    20200321,
-    737
+    20210528,
+    1902
    ],
-   "commit": "369304d6adb6875948c4534419c4f303ac23c4f6",
-   "sha256": "1i41xcjj0kdhn7m29jb5gq2j2cyxn424y4lwx6s3fjj1ckx808ii"
+   "commit": "c019ea85a9c589815b0af60153858d09bcef130e",
+   "sha256": "12jwz0ssfxz1z55fb7v978xz8pwnclnqnzq5pqggzb06zkfxx7iv"
   },
   "stable": {
    "version": [
@@ -55706,15 +55984,15 @@
   "stable": {
    "version": [
     1,
-    4,
+    5,
     0
    ],
    "deps": [
     "cl-lib",
     "json"
    ],
-   "commit": "e630c497f973fa4d1f0fd0e0fd87fb9d18666986",
-   "sha256": "0n2nfcq58md1p2xdhq1smh8v7lsyj0ci7ma5xyd6bkg5rvhsh10i"
+   "commit": "b9c64abf81e73860e39ecd82dfa00cca90b53d99",
+   "sha256": "1ilvfqn7hzrjjy2zrv08dbdnmgksdgsmrdcvx05s8704430ag0pb"
   }
  },
  {
@@ -56016,11 +56294,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210518,
-    1815
+    20210602,
+    1349
    ],
-   "commit": "7c5d49f84f0919bbf00c53a9db48630adf8b2fbe",
-   "sha256": "1rji3p7a2f4ag4785h1k1f2ng9vi2lh8ifyh3m3j0yjihwq36m92"
+   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
+   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
   },
   "stable": {
    "version": [
@@ -56047,8 +56325,8 @@
     "avy",
     "ivy"
    ],
-   "commit": "7c5d49f84f0919bbf00c53a9db48630adf8b2fbe",
-   "sha256": "1rji3p7a2f4ag4785h1k1f2ng9vi2lh8ifyh3m3j0yjihwq36m92"
+   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
+   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
   },
   "stable": {
    "version": [
@@ -56415,8 +56693,8 @@
     "hydra",
     "ivy"
    ],
-   "commit": "7c5d49f84f0919bbf00c53a9db48630adf8b2fbe",
-   "sha256": "1rji3p7a2f4ag4785h1k1f2ng9vi2lh8ifyh3m3j0yjihwq36m92"
+   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
+   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
   },
   "stable": {
    "version": [
@@ -56782,8 +57060,8 @@
     "espotify",
     "ivy"
    ],
-   "commit": "22b81067ebcaef2cea633f967a4b55454af9326a",
-   "sha256": "0b93a8km80r1c3gbinnsigkkq8yc127jwrqj8s8z130b79ch91hn"
+   "commit": "3d62a3319ab03a810030058d3fb368b28dfd82d5",
+   "sha256": "0hj3nczmqmgiwsvh664rs34j63wl325x6nar21p1a84h5ximpkxq"
   }
  },
  {
@@ -57621,17 +57899,17 @@
  },
  {
   "ename": "jetbrains-darcula-theme",
-  "commit": "f4b9f64cae9ab15388352e0d93f34f7e73dbe201",
-  "sha256": "1d31aw9nmgj7m5hvj0qq290v1cfn12ljlvnc6f25g7003a68fv9z",
+  "commit": "e13051402c177efee0e9e3296f20beb1ec4a63fb",
+  "sha256": "0wfg2477mixndwhj9i1b6j9gl2avh9cyzapxdi0qpw862qk6g0fv",
   "fetcher": "github",
-  "repo": "ianpan870102/jetbrains-darcula-emacs-theme",
+  "repo": "ianyepan/jetbrains-darcula-emacs-theme",
   "unstable": {
    "version": [
-    20200927,
-    1317
+    20210602,
+    1430
    ],
-   "commit": "b9b3c39743be5aeba17d4d8e5d379613451ddec6",
-   "sha256": "1j3dxj4cr26vir226zb84zn0jsjwnhz02xb60a69jv4k1wcl6bq9"
+   "commit": "f57c359044ff1fa90db62a60b6691ff8d65c82f3",
+   "sha256": "17wd6yzhjdw5j3bpn6bnga5nkwdnqgk8nprqiavsir4ghkzw2h46"
   },
   "stable": {
    "version": [
@@ -58358,11 +58636,11 @@
   "url": "https://gitea.petton.fr/nico/json-process-client.git",
   "unstable": {
    "version": [
-    20190827,
-    1858
+    20210525,
+    733
    ],
-   "commit": "422606a7bf08d13646e3db4f6c2bddb69bd61dec",
-   "sha256": "16fyb0gwm4llwbmg12m4r9r8h540hcvhrsnlly6cry60h9p8dpc1"
+   "commit": "373b2cc7e3d26dc00594e0b2c1bb66815aad2826",
+   "sha256": "0f6vimdzg28j1jsr31ma0wf6y18jamv8znn4fwvf7pdd51hdn36x"
   },
   "stable": {
    "version": [
@@ -58499,26 +58777,26 @@
   "repo": "tminor/jsonnet-mode",
   "unstable": {
    "version": [
-    20210407,
-    2013
+    20210527,
+    1557
    ],
    "deps": [
     "dash"
    ],
-   "commit": "9bb6f86dfe6418ccccb929e8a03fb4bb24a9ac0e",
-   "sha256": "1rx7kr4pdhrmpcm5rm0h9kawk7czgdy1w5z3w4a2jw0v442bhx44"
+   "commit": "54a89b0aaba7a68782008c5e1ab00d5ec757316a",
+   "sha256": "14nxfa91yg2243v4d5kvynp2645x3811ispmhmpgil3x9qbl9jg9"
   },
   "stable": {
    "version": [
     0,
     1,
-    2
+    3
    ],
    "deps": [
     "dash"
    ],
-   "commit": "e93a1f55e5f9bc2b34b025c6f7a60a6f159268d1",
-   "sha256": "0vi7415n90d1z2ww1hld0gdp6v7z4rd6f70h476dp2x4hydk293i"
+   "commit": "54a89b0aaba7a68782008c5e1ab00d5ec757316a",
+   "sha256": "14nxfa91yg2243v4d5kvynp2645x3811ispmhmpgil3x9qbl9jg9"
   }
  },
  {
@@ -59147,14 +59425,14 @@
   "repo": "chenyanming/kana",
   "unstable": {
    "version": [
-    20201012,
-    1415
+    20210531,
+    1427
    ],
    "deps": [
     "dash"
    ],
-   "commit": "b93cdbf72a1c818d1a48530ef20c5dec64d7945e",
-   "sha256": "1ikpwghvqjf3bc60xmils2prx99lm1x326mw4gic8n7z9kasqizd"
+   "commit": "d3d550aad67ef8625b3860598bf3622f5b2a7d32",
+   "sha256": "0d5qnqhvnxw5009mq34jnnc19r01y4kz0ypnv1mby80g8jz2gl62"
   }
  },
  {
@@ -59229,15 +59507,15 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20210507,
-    1241
+    20210605,
+    1117
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "4e46cc6c843d95427139f824f448f779be80fbc7",
-   "sha256": "1q3wa0i8ng2b0gsmpi9cvdr1h0ffs1pys95pgnxnsdw2cvlh4v6m"
+   "commit": "7eb08e47bc5f227c72c318ff327c689ab54a7620",
+   "sha256": "181vnz6ancqhb13w9890pbplnw6lzbzcx3xkg4li9fk10lab72zk"
   },
   "stable": {
    "version": [
@@ -59571,20 +59849,20 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20210123,
-    1149
+    20210521,
+    828
    ],
-   "commit": "a3a0798349adf3e33277091fa8dee63173b68edf",
-   "sha256": "08n4lfd6zb0qwpaw48q7p1mi6rn5rzja02113fphz7ra2kapbpva"
+   "commit": "a12ef1fb480b56c34c92f48fc7f7aa8a1d7c4c4b",
+   "sha256": "0093v1c5nl2bh1lvccqq6fzpgjald3yypp87dsim982aywl2vlv1"
   },
   "stable": {
    "version": [
     1,
-    0,
-    4
+    1,
+    0
    ],
-   "commit": "16d9961d15536054632be1eff75fd0fb1a4420f8",
-   "sha256": "1g9arjdhdpvsw47ny9gi5k758ya37yza4mr0rhbf02yvrqyfsrgr"
+   "commit": "a12ef1fb480b56c34c92f48fc7f7aa8a1d7c4c4b",
+   "sha256": "0093v1c5nl2bh1lvccqq6fzpgjald3yypp87dsim982aywl2vlv1"
   }
  },
  {
@@ -59793,6 +60071,30 @@
    ],
    "commit": "cd682a7c4a8d64d6bae6a005db5045232e5e7b95",
    "sha256": "191i2b2xx6180sly0dd6b1z6npsrzjqhxrbak9wm6yblx7alsgn2"
+  }
+ },
+ {
+  "ename": "keytar",
+  "commit": "4ba6f96ca2e20dcd75cf239370243bd8e484f851",
+  "sha256": "1bm0kxrbkkk3c4zljf9azfm22msknkvrcns1j1r2hczjqdviay28",
+  "fetcher": "github",
+  "repo": "emacs-grammarly/keytar",
+  "unstable": {
+   "version": [
+    20210523,
+    403
+   ],
+   "commit": "8d2a5ec4a7fe766a62037b05f26a8f36fff45c06",
+   "sha256": "1rszkzpr22dy9yr54k2pz6p2j6lbgvy189f6ki8gmlsqzdyxmssk"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    2
+   ],
+   "commit": "17972320ef140bd56e551842d89f5d8c2d979f83",
+   "sha256": "06r84kcg7ig1xky01sa3kyw4iam5wzag4qpp2rm3q9rad246pjr0"
   }
  },
  {
@@ -60014,8 +60316,8 @@
     20210318,
     2106
    ],
-   "commit": "28bfe768d8066b9b42d5e9081ba7318ae7ca5fbe",
-   "sha256": "13lsva3lk9wrwp03flvgh9fcazw99var1b25v1gv75yfhj0m9hyy"
+   "commit": "3894a454ee03ede25e920759e6ac2df040ff3431",
+   "sha256": "1crqrmzxhm21psv5mkbzn3h2syrgszx50i4kd4n92f56dq7s8i4b"
   },
   "stable": {
    "version": [
@@ -60365,16 +60667,16 @@
   "repo": "chrisbarrett/kubernetes-el",
   "unstable": {
    "version": [
-    20210519,
-    642
+    20210604,
+    909
    ],
    "deps": [
     "dash",
     "magit",
     "magit-popup"
    ],
-   "commit": "d95e52547952743ebee1394223d2b202291deec0",
-   "sha256": "1c0lwdi1yin40q71vlfgf3iw0r1777whzlx79x9hnbgqavkq3xyw"
+   "commit": "93d7b4d1b079b3cf1fbe3949154b6a1bc06904ef",
+   "sha256": "0xz35j38ph1l870zrdd0r2xycxq65pbq1a1hi270q4mikpai85gb"
   },
   "stable": {
    "version": [
@@ -60406,8 +60708,8 @@
     "evil",
     "kubernetes"
    ],
-   "commit": "d95e52547952743ebee1394223d2b202291deec0",
-   "sha256": "1c0lwdi1yin40q71vlfgf3iw0r1777whzlx79x9hnbgqavkq3xyw"
+   "commit": "93d7b4d1b079b3cf1fbe3949154b6a1bc06904ef",
+   "sha256": "0xz35j38ph1l870zrdd0r2xycxq65pbq1a1hi270q4mikpai85gb"
   },
   "stable": {
    "version": [
@@ -60557,16 +60859,16 @@
   "repo": "tecosaur/LaTeX-auto-activating-snippets",
   "unstable": {
    "version": [
-    20210508,
-    1224
+    20210607,
+    1851
    ],
    "deps": [
     "aas",
     "auctex",
     "yasnippet"
    ],
-   "commit": "635e974cb692973856a4d26093876f5ad2285d3a",
-   "sha256": "0c3fz2v3zyq6s1gzz2013yafdhg46lffr4w8hwhxmgpsci6vf3hd"
+   "commit": "9d6f4448347fcf48d0fed51eba16423c9254c212",
+   "sha256": "0kfivjdjhlrbrn1z6i51y36s6f4qj386iy1jpcbvv33xa0lh5ksi"
   },
   "stable": {
    "version": [
@@ -60667,8 +60969,8 @@
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "4d12e7dd4c26bc5dd7594fc519bdbcf36b02e2ed",
-   "sha256": "18my5kh5wga049ygdg4ri8qh5lvf1c6v174fy3h3z972w4apk21n"
+   "commit": "63796ccadcc9147c5badd9a87f626611f63e3c4c",
+   "sha256": "1iwgi7jm20qwxlfa7klkz5zmdfxa14psly6xsl29i37j9p6146sb"
   }
  },
  {
@@ -60747,6 +61049,24 @@
    ],
    "commit": "0fe79567244ca719448c55a89082505596a2359a",
    "sha256": "1pkfazn6qy6n4rg1rvw7b79b7nsp7xqdadhpah4xjvqxd6apqasz"
+  }
+ },
+ {
+  "ename": "langtool-ignore-fonts",
+  "commit": "9792610d9325ce5f0cc7d07a621755d8fadd90c3",
+  "sha256": "1vivb57kyd3gnigf8j1xhnpn3d6jxcs5rb3699qyc18w1zk4y154",
+  "fetcher": "github",
+  "repo": "cjl8zf/langtool-ignore-fonts",
+  "unstable": {
+   "version": [
+    20210526,
+    2340
+   ],
+   "deps": [
+    "langtool"
+   ],
+   "commit": "c3291c85b733b9047653cbb1f525655394610bdb",
+   "sha256": "1pmpnpbl1xanprmikawcy9v4441q3381mmyp1v0mgf0dyzg871m6"
   }
  },
  {
@@ -61156,11 +61476,11 @@
   "repo": "conao3/leaf.el",
   "unstable": {
    "version": [
-    20210316,
-    1822
+    20210603,
+    1518
    ],
-   "commit": "ab5cc26b56a6a53a3338ebfde17b746522c2c14c",
-   "sha256": "1ds545sh8hg2vg5l7fm4v6z31lzax14ivdni3a37278jfx82xxrx"
+   "commit": "af0d4d8daaa323c34502d3cbea85ec8f70b06c00",
+   "sha256": "0p4smpfld1ky07cy5qn8kqpbqw5ymrn8valkpx4c519lj6pb9rn6"
   },
   "stable": {
    "version": [
@@ -61371,11 +61691,11 @@
   "repo": "pfitaxel/learn-ocaml.el",
   "unstable": {
    "version": [
-    20210209,
-    4
+    20210527,
+    1449
    ],
-   "commit": "ac7e2887baebedd51afbadc9e4c6f7b59351b0bb",
-   "sha256": "0v6nw2yqy8lhwssq2myx91jjlsg8d97f60yhrpjk3qc62037q60b"
+   "commit": "b8ba2a0bf56b751f077f13137a1904d66061a4d0",
+   "sha256": "0cc9s00flbih3kkbkan7xfqlv5qq9j4cz52ljj4xyxbf51r2lh0z"
   }
  },
  {
@@ -61653,11 +61973,11 @@
   "repo": "fniessen/emacs-leuven-theme",
   "unstable": {
    "version": [
-    20210507,
-    1556
+    20210602,
+    709
    ],
-   "commit": "7a2a8c49fd17c43c276dbe0aa941fd676a54a5cf",
-   "sha256": "02i7d8lzalwv6xaja82gn48qkf9ks0xvnaqzl9qwxiw980545z0y"
+   "commit": "b8b5076d643046008ea1496559acdd4ddfdb649a",
+   "sha256": "16rfyjk0cp487ra6v5c1cmf106ixipr9b71zfp0bwm35wa2mvdic"
   },
   "stable": {
    "version": [
@@ -61726,19 +62046,19 @@
   "repo": "rvirding/lfe",
   "unstable": {
    "version": [
-    20201007,
-    2214
+    20210603,
+    1241
    ],
-   "commit": "f762e9310390edb7a5a49d8d9dc22693fbcde973",
-   "sha256": "022bnn3ksaaihi3cnc7ib15ry2kydp4rjh1v25vym7vmfxlw9akz"
+   "commit": "1feb8af64c977946b6184b7d63b436c49dbeb52d",
+   "sha256": "0vxpkvp8fsi52zb2sqqd9xfdndyxb59hqg8qkpdfsdwszxngfij5"
   },
   "stable": {
    "version": [
-    1,
-    3
+    2,
+    0
    ],
-   "commit": "d8337516ab09edd4b281a27ac85684b81cdeb8bd",
-   "sha256": "0pgwi0h0d34353m39jin8dxw4yykgfcg90k6pc4qkjyrg40hh4l6"
+   "commit": "76eaf432f768b45393e404c1bd1861a08c19de3b",
+   "sha256": "0vxpkvp8fsi52zb2sqqd9xfdndyxb59hqg8qkpdfsdwszxngfij5"
   }
  },
  {
@@ -61809,11 +62129,11 @@
   "repo": "merrickluo/liberime",
   "unstable": {
    "version": [
-    20201106,
-    858
+    20210526,
+    623
    ],
-   "commit": "8d4d1d4f2924dc560bce1d79680df36dcc086d49",
-   "sha256": "0gk2y14lsfc9nw31xhrxqvlf834l8kyjnsqi7rhfk2sl6j1p669v"
+   "commit": "4a6da0f6ab9b43651f3fcc73412e3480b9403caa",
+   "sha256": "04ag7icqqdhz40fi91fx4bxx8j6vw2774gw1fbppbks3sasimyy0"
   },
   "stable": {
    "version": [
@@ -61976,17 +62296,17 @@
     20210303,
     1751
    ],
-   "commit": "868a001dc06cd75342b30da53936ab2ed286872e",
-   "sha256": "0z2415smaclx4rip10hm8jmn7byswl4y41iijbl1ga78mhvd227l"
+   "commit": "be7ff92e4dfb06ed51baaa10157d9a1ee1cd666a",
+   "sha256": "067i605hk3qy01106l90bbl91ivr3zqv2yqr41jf5pfysafykx4x"
   },
   "stable": {
    "version": [
     0,
-    16,
-    1
+    17,
+    0
    ],
-   "commit": "79105db651ff2f920193e2a715caf2c40b2379ca",
-   "sha256": "0z2415smaclx4rip10hm8jmn7byswl4y41iijbl1ga78mhvd227l"
+   "commit": "ec97fdf14ce7a65398ecc2755654db46a3ef3b14",
+   "sha256": "067i605hk3qy01106l90bbl91ivr3zqv2yqr41jf5pfysafykx4x"
   }
  },
  {
@@ -61997,27 +62317,28 @@
   "repo": "jcs-elpa/line-reminder",
   "unstable": {
    "version": [
-    20210426,
-    1859
+    20210531,
+    743
    ],
    "deps": [
     "fringe-helper",
     "indicators"
    ],
-   "commit": "8c9f824b1dc67c8489afef05b06d9525b29dab00",
-   "sha256": "0qr7qvcl6rlsagim3y71im24z85l3f7cvj39r0g77mnhm733z9m3"
+   "commit": "1856034d0ed8ce41a29a1ea051184ee7c2f3e276",
+   "sha256": "0ni73ybrg21l63hs51pixkxf77bl288hzji03bm8v1hzsm72vxxs"
   },
   "stable": {
    "version": [
     0,
-    4,
-    5
+    5,
+    0
    ],
    "deps": [
+    "fringe-helper",
     "indicators"
    ],
-   "commit": "bc488bbdba2172629183891758cfa9466a64182f",
-   "sha256": "1993rwd9bgr1lqxgxzwp6h2r57ljsbjh5r08f57jaalanjp4iq55"
+   "commit": "4d73b84a84227b01b7fbc6f717f6c380682cde2f",
+   "sha256": "0qkgmg60jfcwfsc693x9c066vgbclgqwzkqbmjrc32kcs57zhvni"
   }
  },
  {
@@ -62031,8 +62352,8 @@
     20180219,
     1024
    ],
-   "commit": "a49afb9c168eaf8aaaf94f0c631b7b74db9a1d82",
-   "sha256": "0213ppx15rdb5cxg7w8978880fzv3dh2m9p6idkmlfj7bndfd411"
+   "commit": "68e59d0fff1eb76c7b1a72c438f344c251115e81",
+   "sha256": "1ipqf3qfgzcrrp6xwgxb6wkk8a6ii5jx5im5gfhghdhy45z2m3ii"
   },
   "stable": {
    "version": [
@@ -62299,11 +62620,11 @@
   "repo": "lispunion/emacs-lisp-local",
   "unstable": {
    "version": [
-    20210307,
-    1545
+    20210605,
+    1347
    ],
-   "commit": "3a3237a5c25db9526dfbe1b3ac1e7125f8f459b0",
-   "sha256": "1nm2kmilhk2hm9nfd1f6drhlpwkpk31s1072y8im16ci7i13lig4"
+   "commit": "22e221c9330d2b5dc07e8b2caa34c83ac7c20b0d",
+   "sha256": "10dflrabhn974k9lr4jvib5vs7v45hj9skryc4wjc09wzz5qphpk"
   },
   "stable": {
    "version": [
@@ -62334,8 +62655,8 @@
  },
  {
   "ename": "lispy",
-  "commit": "29a704fede83b02e19c2ad213485f0f651931753",
-  "sha256": "1c8gz46ab5f07dljv2chr0i5lini81wl3zx4zw8xjysb4a5dp05v",
+  "commit": "45a02d8edf65ccf5929b8508294588507adaaf83",
+  "sha256": "0s0rjfy344pyxnbgmkbil38vy32iwkw3n50j30pl3ivnqm1wa3rz",
   "fetcher": "github",
   "repo": "abo-abo/lispy",
   "unstable": {
@@ -62617,14 +62938,14 @@
   "repo": "sulami/literate-calc-mode.el",
   "unstable": {
    "version": [
-    20210324,
-    1547
+    20210528,
+    815
    ],
    "deps": [
     "s"
    ],
-   "commit": "211eec1e8b03503a53fa3eb4528375f36972f759",
-   "sha256": "1kawczbjdvjzyz3fflp1ij0vi9qcrl0yhrv7knx9j1zh187jp7z7"
+   "commit": "29bb40a7150b6cfe1a96948ae1f36e9c107eb759",
+   "sha256": "1dznafcfwmd52jakkzzk3dhji55aal7hsfkglr3051fz8pkz7xfx"
   }
  },
  {
@@ -62664,11 +62985,11 @@
   "repo": "jingtaozf/literate-elisp",
   "unstable": {
    "version": [
-    20210424,
-    918
+    20210605,
+    1238
    ],
-   "commit": "3e00b497711ac78f0ac26669e35f375451f6711a",
-   "sha256": "0gpg60xr86qx2ib5q9ig5pi9lmhk5vjsb7fh5g6kifvsch31cry3"
+   "commit": "41f0946037b50323901ce708c1af82e59a334433",
+   "sha256": "1hjb1f835xq5jgq4s0dpr85vs5cap001lxv9n02l198gb2qppq6k"
   },
   "stable": {
    "version": [
@@ -62764,8 +63085,8 @@
     20210413,
     205
    ],
-   "commit": "a37f6b2394dcc2a848a055399dd45b052c9b707d",
-   "sha256": "0sbwva6asklx78wn1xcmxpr1758zwxncsl2gqn5x8f480bbafjbh"
+   "commit": "c191b149f93ed473f3900e506cfc762d53145237",
+   "sha256": "0likjz2q0pbs3cbqczdfhh6k0c1j8y6j32cxkcpjm9wakp1vzxq2"
   },
   "stable": {
    "version": [
@@ -62875,26 +63196,26 @@
   "url": "https://git.sr.ht/~tarsius/llama",
   "unstable": {
    "version": [
-    20210201,
-    837
+    20210525,
+    2005
    ],
    "deps": [
     "seq"
    ],
-   "commit": "f2f1476e88153b167bf4ce755f7455fcb3f98458",
-   "sha256": "0qnzbamf763h8fwjsn7i47a1amb8nixl25zw58jh4hhl470czi2f"
+   "commit": "2694b2aeb1c87bb2ad8b0f611ca438c30f5eaeae",
+   "sha256": "1xihy4xnvxvwwzy50z7msm9fkplsyy2kvi6zzlpgs8bad6aamg5f"
   },
   "stable": {
    "version": [
     0,
     1,
-    0
+    1
    ],
    "deps": [
     "seq"
    ],
-   "commit": "2027ce79165bf40314ad838c282920c53b5d7eae",
-   "sha256": "1jnll9xaxfwwvs0xjpdz8y6xlrsckm3a8ri5ml8k3fp81yby9as5"
+   "commit": "2694b2aeb1c87bb2ad8b0f611ca438c30f5eaeae",
+   "sha256": "1xihy4xnvxvwwzy50z7msm9fkplsyy2kvi6zzlpgs8bad6aamg5f"
   }
  },
  {
@@ -63330,6 +63651,40 @@
   }
  },
  {
+  "ename": "loopy",
+  "commit": "7f4e68f6feb5d0082580cc28f6184a6091e7c117",
+  "sha256": "1w4416vjbbba80bhcalpvr9ram1ijk3y9687525p3wicrfylx9s3",
+  "fetcher": "github",
+  "repo": "okamsn/loopy",
+  "unstable": {
+   "version": [
+    20210601,
+    133
+   ],
+   "commit": "50494b545b9a909fc6570216230beda1ebeedf36",
+   "sha256": "0wag0hhpak0i1k2bmzz896jkpadrmacj1m0bbb3y7rrl9sw1dcqg"
+  }
+ },
+ {
+  "ename": "loopy-dash",
+  "commit": "7f4e68f6feb5d0082580cc28f6184a6091e7c117",
+  "sha256": "0hk4c415wp4dqx1xjs246p8hqn15iamj8xiig2cla1f24zd7kd28",
+  "fetcher": "github",
+  "repo": "okamsn/loopy",
+  "unstable": {
+   "version": [
+    20210601,
+    129
+   ],
+   "deps": [
+    "dash",
+    "loopy"
+   ],
+   "commit": "50494b545b9a909fc6570216230beda1ebeedf36",
+   "sha256": "0wag0hhpak0i1k2bmzz896jkpadrmacj1m0bbb3y7rrl9sw1dcqg"
+  }
+ },
+ {
   "ename": "lorem-ipsum",
   "commit": "0c09f9b82430992d119d9148314c758f067832cd",
   "sha256": "0p62yifbrknjn8z0613wy2aaknj44liyrgbknhpa0qn0d4fcrp4h",
@@ -63393,8 +63748,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20210506,
-    34
+    20210601,
+    420
    ],
    "deps": [
     "dap-mode",
@@ -63405,14 +63760,14 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "96949d1c1cb5c63eb17ebbd43a125abead79149f",
-   "sha256": "0yqfb57pa2ks4y3v07asy2x7rvzlfcn7aj45x77dcqcssipnddps"
+   "commit": "7ef909a1c9e0e1c924b43637899e0d53b0d1b00f",
+   "sha256": "1vsfs0jpk7fdfb3zmpxs3f7fy0s7d9b8jha5p7y6g0afhxz4iqn1"
   },
   "stable": {
    "version": [
     1,
     18,
-    3
+    5
    ],
    "deps": [
     "dap-mode",
@@ -63423,8 +63778,8 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "96949d1c1cb5c63eb17ebbd43a125abead79149f",
-   "sha256": "0yqfb57pa2ks4y3v07asy2x7rvzlfcn7aj45x77dcqcssipnddps"
+   "commit": "90a06dfc23750c3861628256a4af4e3b00b2e23d",
+   "sha256": "1cabxsz7gbjywhsqjqp32vdgycg2mq21mdxvwbfcs6k0cf319dwh"
   }
  },
  {
@@ -63435,15 +63790,15 @@
   "repo": "emacs-lsp/lsp-docker",
   "unstable": {
    "version": [
-    20210404,
-    1717
+    20210529,
+    621
    ],
    "deps": [
     "dash",
     "lsp-mode"
    ],
-   "commit": "1909466ee7f7f4aeef624acd10c710afe685ef8a",
-   "sha256": "0y5w97c37wj67mvwk23l4rq3i80fw82r758dsma6ly32h5xlsq8b"
+   "commit": "fa304ea402ac492e97bee14496a41afa8508cc5e",
+   "sha256": "0y0z4ind08jj93qsxgvi5zqa5f8lnamg8fv2dvkgipx1qvq25r4c"
   }
  },
  {
@@ -63486,8 +63841,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20210418,
-    1806
+    20210523,
+    403
    ],
    "deps": [
     "grammarly",
@@ -63496,8 +63851,8 @@
     "request",
     "s"
    ],
-   "commit": "aff219380a7d192a37c8c25823b6bfc816bae825",
-   "sha256": "0ghqmay00r7lfmqx57r5kkldkgr4r20fb5xqh3i440wjdw8m3i3p"
+   "commit": "f34f0d50a91a82ab9c49e2cf5ddcb42a98cc2ede",
+   "sha256": "1hqilkbxa63gkl6sc8km6j0m4lxindf184c1zl91h4sfh4kg67zb"
   },
   "stable": {
    "version": [
@@ -63657,14 +64012,14 @@
   "repo": "fredcamps/lsp-jedi",
   "unstable": {
    "version": [
-    20210419,
-    2007
+    20210602,
+    1925
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "a6a6dcfbab69caee0b88dbe4244772e0bea5531a",
-   "sha256": "0l2dawi7avzb9i1wfff4kdfbz9s7vp4443y7x3va0jrsn3v33485"
+   "commit": "ab265f7fb26f4fa0385158a9f9d3649b606d2e23",
+   "sha256": "013vmhcxz7648jxxhk69rr0v5br2839517l72fwzk770l02mc6si"
   },
   "stable": {
    "version": [
@@ -63687,28 +64042,28 @@
   "repo": "non-Jedi/lsp-julia",
   "unstable": {
    "version": [
-    20210329,
-    1551
+    20210530,
+    2152
    ],
    "deps": [
     "julia-mode",
     "lsp-mode"
    ],
-   "commit": "81f7de5b9fe8e8e0e1e3a3ccc677f052edad140d",
-   "sha256": "1hwkx5ssix2si7jpsbfcg1i65v3z265l39158qjm31cxf8pk52dw"
+   "commit": "d4a7a27d6ac7c6831b4f493dd89f82fa0c75bdf5",
+   "sha256": "1rkf2ibjilf023fv68ql4bray8bdnl2biq5zmn1qk5pdp988iq4j"
   },
   "stable": {
    "version": [
     0,
-    4,
+    5,
     0
    ],
    "deps": [
     "julia-mode",
     "lsp-mode"
    ],
-   "commit": "81f7de5b9fe8e8e0e1e3a3ccc677f052edad140d",
-   "sha256": "1hwkx5ssix2si7jpsbfcg1i65v3z265l39158qjm31cxf8pk52dw"
+   "commit": "d4a7a27d6ac7c6831b4f493dd89f82fa0c75bdf5",
+   "sha256": "1rkf2ibjilf023fv68ql4bray8bdnl2biq5zmn1qk5pdp988iq4j"
   }
  },
  {
@@ -63719,26 +64074,56 @@
   "repo": "ROCKTAKEY/lsp-latex",
   "unstable": {
    "version": [
-    20210110,
-    1914
+    20210607,
+    1206
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "5fc536f24dc659f998bc673129d9e7c4b20d297c",
-   "sha256": "1k34zpg6f3i1pb68zh6fc7azd4hmbclnjpad1893q2zhqwxqdwz8"
+   "commit": "a5de6b7166935af4a1e05d254fc1a44600518066",
+   "sha256": "0i5mbz7mwnax7jwv9c1bkwp5jwqrvwvh51fgwkmnz0kpjxhzfpsm"
   },
   "stable": {
    "version": [
-    1,
-    3,
+    2,
+    0,
     0
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "969846d5d0c9a9d1fc8deae30a0f664607f06e72",
-   "sha256": "1dz9yib9g7a5b1yipxjc6mqq9ffkpkm2icpj6xzanfdnc1ymj7c9"
+   "commit": "1c60c2d331baf778bd8a3ac9d5688516398ae323",
+   "sha256": "1nm03yn02ja867d9ba3n980v86kcd5varzng1lhzv7fr7akv5j13"
+  }
+ },
+ {
+  "ename": "lsp-ltex",
+  "commit": "47faf55fd4876b28258173b7012eb413ab69a1be",
+  "sha256": "063yy68sy05gzcfp5bsk0mjh7g9x76r1c0qx0i8zw3r2a50g6llq",
+  "fetcher": "github",
+  "repo": "emacs-languagetool/lsp-ltex",
+  "unstable": {
+   "version": [
+    20210405,
+    1702
+   ],
+   "deps": [
+    "lsp-mode"
+   ],
+   "commit": "0fd8baec7e5f92d74b8b80d02c926d32332d86bd",
+   "sha256": "04jx5bknns1fyany1x8wzs6yx9qxzwrwj8m1iardxy8la3jp6ncd"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "lsp-mode"
+   ],
+   "commit": "5546970c7949d498947e4b6a281707feb2aee928",
+   "sha256": "0s7v43jmpbjjxvfp9s51kc5d9mk3kf5mwvc4iwbvrzpi0ar4vfdy"
   }
  },
  {
@@ -63749,8 +64134,8 @@
   "repo": "emacs-lsp/lsp-metals",
   "unstable": {
    "version": [
-    20210426,
-    739
+    20210529,
+    752
    ],
    "deps": [
     "dap-mode",
@@ -63762,8 +64147,8 @@
     "scala-mode",
     "treemacs"
    ],
-   "commit": "5aea52dfe08b8f5936ea3982be6c25339f652eba",
-   "sha256": "0ca5xq1l3lscx36pcdnpy2axgyikjrl18naqr140kr1y500sy37s"
+   "commit": "4c11fe47ef3c71a2fc7cd67a055ea0bc5883a0c6",
+   "sha256": "16laslmvsamvcn58gsi6hfs53p12q0nz7zx993ipa2xhy6n04hcg"
   },
   "stable": {
    "version": [
@@ -63793,8 +64178,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20210520,
-    1557
+    20210605,
+    1854
    ],
    "deps": [
     "dash",
@@ -63804,8 +64189,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "98284ed3ee58277b956579586b1ab3d4e2ff581d",
-   "sha256": "0841f90fzazdzs17b1v8dal3cz0w3a77hi8dbszsl96fgyy1gz0a"
+   "commit": "7b75d6bf01bed9ccb108cf1406d0e2af29d7e39b",
+   "sha256": "1lbb3bpizibpnw77bgdf8j2303gwh2133n8s518frmz6gcb7kz8s"
   },
   "stable": {
    "version": [
@@ -63961,8 +64346,8 @@
     "ht",
     "lsp-mode"
    ],
-   "commit": "e986eeb15d1b3bf0f8c59be71684eac0d3894de5",
-   "sha256": "05y3rhhcm7i230if0n17yqdn0jz4mz3g98h5wgg6s3bdn3kjlckn"
+   "commit": "71a79760938d2132923fbff58dc25301892b1654",
+   "sha256": "0si9qca8lml2hd8zj420dmks4cwzfidq14h3xfczhvrshhsc0mny"
   }
  },
  {
@@ -63979,8 +64364,8 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "5856c08d6393c10951f39b993a8d7bf2d506b44f",
-   "sha256": "0m55i7w1am55c7p35il3i06d4za8z5qamfwb8nki5zhiacw26bkw"
+   "commit": "4eb78c43046fceb53a66ccd24c85601bdb87ed17",
+   "sha256": "10d949gb3v7flnkb5khk11dcmfnlr4h02yfj8g3b0ihr1zr7c958"
   },
   "stable": {
    "version": [
@@ -64062,8 +64447,8 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "aafa9878a3df2f08e5a9c846d91fd53350ce3c99",
-   "sha256": "1la4mfaykd6vi7d0nw45a2ia8zwr8xflqhc4a9rmdl8biyrp47kj"
+   "commit": "ae4aa8705cc3a27ed86f1e7ee04d5c8f0522d8c0",
+   "sha256": "0q3dji9qy0aj7ai43xjcpb4hy6kvscrpr8r5cb9137g34zc0pd9x"
   }
  },
  {
@@ -64074,14 +64459,14 @@
   "repo": "merrickluo/lsp-tailwindcss",
   "unstable": {
    "version": [
-    20210508,
-    454
+    20210605,
+    315
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "7156fcd0d8beea0536c2830399631cd189ee4038",
-   "sha256": "0lvsdnn48z379cj553vwng6hsp9mnmy03qgxbnnamw5d0lkvfp9i"
+   "commit": "77ebadcb7decd953c069b421a7ab18188295e4b6",
+   "sha256": "0s34djc945zbzykazrd7k8gizbfws3xp8rjdbnplg4996k1c71n1"
   }
  },
  {
@@ -64102,8 +64487,8 @@
     "lsp-mode",
     "treemacs"
    ],
-   "commit": "b07868740d6f7d364e496048cee00bce10a6ab33",
-   "sha256": "1g8qkk6g67myz8rjvwa7iysrj0xpf0kcwrcdvf4dkc3rgh3kzm2v"
+   "commit": "f360d54fa68a00baec228d9582bc67c1a327d757",
+   "sha256": "0wbni6njz98c23pns4wxg4mq26zrvpyxh0qcz0a4l46zdn1962vm"
   },
   "stable": {
    "version": [
@@ -64130,16 +64515,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20210520,
-    1518
+    20210604,
+    1158
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "bd94da9348d9b4e814fdb55dae061826f48ffde9",
-   "sha256": "0y97i8yyvkyf7alfs27jkij6kjg9l47spxkdzm11abkb14z5gpr5"
+   "commit": "c4ffa7abf6706d591300c608c51d2b72178848ad",
+   "sha256": "1qr7is4k5w6dcfkcvg7crna6r26lqmb02v08i3yggq09qd01c08g"
   },
   "stable": {
    "version": [
@@ -64234,6 +64619,21 @@
    ],
    "commit": "8ece9b1379a73e7dc0b6e682dd5a573f88a5cb32",
    "sha256": "09zvn5fgjy27rmxziylvl83zdqmwa1jjndxmxhgsyh9mklisz32p"
+  }
+ },
+ {
+  "ename": "lux-mode",
+  "commit": "ca88d6e55ea272698f26e6d8ff66a3e57b7689ee",
+  "sha256": "0n0964gr5cac6k0zwfi9slyh2gsccmp7kipvjarvsj5nhx8khxb2",
+  "fetcher": "github",
+  "repo": "hawk/lux",
+  "unstable": {
+   "version": [
+    20210607,
+    1130
+   ],
+   "commit": "b5391e8dc088d95d8f131f49982d5c7cbaa23677",
+   "sha256": "08bfjg51ydznfk8w7hwznzyybl42mqa5l0pvb4xapqcq2na3d3yf"
   }
  },
  {
@@ -64596,40 +64996,40 @@
  },
  {
   "ename": "magit",
-  "commit": "15a5916ec8e9062e41b1dd7d4f5535a86c2170a3",
-  "sha256": "1bcv0yv5l51j3xyli9rq3zqjkf0b9w7yd0kykfmy1dp1hx39qf8r",
+  "commit": "4158066a2c75cf0bff128bd2dc1073472c32b1f4",
+  "sha256": "1hrh90qd47s6q6grr6rp2y7kfqq8bzhdfpyq2saihrric91s1rqz",
   "fetcher": "github",
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210519,
-    2015
+    20210531,
+    1524
    ],
    "deps": [
     "dash",
     "git-commit",
+    "magit-section",
     "transient",
     "with-editor"
    ],
-   "commit": "9d76233597aaad1c9ab188bde83c3b66d9bd3d0a",
-   "sha256": "1kmnvrgy71bk6z47w90vrmfl37j7q069vcdx9dcs4fpjaq2rbapw"
+   "commit": "4a8646a30df99bbafc95d4f21a0b2bf0a6f6566f",
+   "sha256": "0y3wzvyaxn5zybjak77r1cngaqqm462s3d4f1cwmzvrnpv99f3r9"
   },
   "stable": {
    "version": [
-    2,
-    90,
-    1
+    3,
+    0,
+    0
    ],
    "deps": [
-    "async",
     "dash",
-    "ghub",
     "git-commit",
-    "magit-popup",
+    "magit-section",
+    "transient",
     "with-editor"
    ],
-   "commit": "791901b2f1d26fa0a383147fe77948a9abc753da",
-   "sha256": "1kw94sdczswsyzn1zlk5s5aplpdv4qd7qcqc5zfxsmsfwm3jacl4"
+   "commit": "c3bbc9b9425f3370690cabb11bd35b9040773fdc",
+   "sha256": "0dbp3gx43ipxv8zg9m0hfhksz85rnkikaq35rx705qqz6xq6xq9m"
   }
  },
  {
@@ -64640,28 +65040,28 @@
   "repo": "magit/magit-annex",
   "unstable": {
    "version": [
-    20210512,
-    405
+    20210525,
+    2331
    ],
    "deps": [
     "cl-lib",
     "magit"
    ],
-   "commit": "d48fc38da0ed8c79a02591c5393aaef55498a988",
-   "sha256": "0qsnrwji66b0bwrgp1kj3b2mqq5vwphcs95mzk2y7xr75fwnvcbw"
+   "commit": "17e5e60b59eac3cf5938c1b22c29458c0d694b0a",
+   "sha256": "0ak4chfn95p2vj3y0wiyimj609a4jfzrfpsc1kn0is1jv3dlkl6c"
   },
   "stable": {
    "version": [
     1,
-    7,
-    1
+    8,
+    0
    ],
    "deps": [
     "cl-lib",
     "magit"
    ],
-   "commit": "21cb2927d672cc6bf631d8373a361b1766ccf004",
-   "sha256": "07r0d2i1hws63wfv1jys63r3lmrl4ywwi76gi7srwhzhqdr1af0n"
+   "commit": "17e5e60b59eac3cf5938c1b22c29458c0d694b0a",
+   "sha256": "0ak4chfn95p2vj3y0wiyimj609a4jfzrfpsc1kn0is1jv3dlkl6c"
   }
  },
  {
@@ -64890,26 +65290,26 @@
   "repo": "magit/magit-imerge",
   "unstable": {
    "version": [
-    20210512,
-    408
+    20210525,
+    2326
    ],
    "deps": [
     "magit"
    ],
-   "commit": "04633693d1e902d54d19d404e96201637714361d",
-   "sha256": "1knm30fzh7lri89gl8scimb5gf3rzbnr7x033zzn12v9w8i3dchy"
+   "commit": "cf3b4646aa0205e8d7f47e45165fe6403d6440f5",
+   "sha256": "1j96vg9kc03vxxq4r5a7v4di88pvbb5i01n8js06lgs9qzl097k7"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "magit"
    ],
-   "commit": "5b45efa65317886640c339d1c71d2b9e00e98b77",
-   "sha256": "02597aq00fq7b9284kq7s55ddrjb6xhh1l280gq3czi75658d3db"
+   "commit": "cf3b4646aa0205e8d7f47e45165fe6403d6440f5",
+   "sha256": "1j96vg9kc03vxxq4r5a7v4di88pvbb5i01n8js06lgs9qzl097k7"
   }
  },
  {
@@ -64952,15 +65352,28 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210124,
-    1829
+    20210525,
+    814
    ],
    "deps": [
     "libgit",
     "magit"
    ],
-   "commit": "9d76233597aaad1c9ab188bde83c3b66d9bd3d0a",
-   "sha256": "1kmnvrgy71bk6z47w90vrmfl37j7q069vcdx9dcs4fpjaq2rbapw"
+   "commit": "4a8646a30df99bbafc95d4f21a0b2bf0a6f6566f",
+   "sha256": "0y3wzvyaxn5zybjak77r1cngaqqm462s3d4f1cwmzvrnpv99f3r9"
+  },
+  "stable": {
+   "version": [
+    3,
+    0,
+    0
+   ],
+   "deps": [
+    "libgit",
+    "magit"
+   ],
+   "commit": "c3bbc9b9425f3370690cabb11bd35b9040773fdc",
+   "sha256": "0dbp3gx43ipxv8zg9m0hfhksz85rnkikaq35rx705qqz6xq6xq9m"
   }
  },
  {
@@ -65022,14 +65435,14 @@
   "repo": "dickmao/magit-patch-changelog",
   "unstable": {
    "version": [
-    20200217,
-    1202
+    20210607,
+    1635
    ],
    "deps": [
     "magit"
    ],
-   "commit": "876c780bdb676b6ece64861704e199b94f33cf71",
-   "sha256": "0wkjh9s67vs90lysdx3gjyrax9mlbzfvs563pzr6ab3l4p5pgnsw"
+   "commit": "5cd99a6336ad4b60e9e8ce766b8a9c0395289775",
+   "sha256": "17s5268kcqhgd141fvjqnn2wrny7v03yz940k2whr383l1253k6v"
   }
  },
  {
@@ -65108,23 +65521,26 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210224,
-    1417
+    20210525,
+    844
    ],
    "deps": [
     "dash"
    ],
-   "commit": "9d76233597aaad1c9ab188bde83c3b66d9bd3d0a",
-   "sha256": "1kmnvrgy71bk6z47w90vrmfl37j7q069vcdx9dcs4fpjaq2rbapw"
+   "commit": "4a8646a30df99bbafc95d4f21a0b2bf0a6f6566f",
+   "sha256": "0y3wzvyaxn5zybjak77r1cngaqqm462s3d4f1cwmzvrnpv99f3r9"
   },
   "stable": {
    "version": [
-    2,
-    90,
-    1
+    3,
+    0,
+    0
    ],
-   "commit": "791901b2f1d26fa0a383147fe77948a9abc753da",
-   "sha256": "1kw94sdczswsyzn1zlk5s5aplpdv4qd7qcqc5zfxsmsfwm3jacl4"
+   "deps": [
+    "dash"
+   ],
+   "commit": "c3bbc9b9425f3370690cabb11bd35b9040773fdc",
+   "sha256": "0dbp3gx43ipxv8zg9m0hfhksz85rnkikaq35rx705qqz6xq6xq9m"
   }
  },
  {
@@ -65191,26 +65607,26 @@
   "repo": "magit/magit-tbdiff",
   "unstable": {
    "version": [
-    20210512,
-    407
+    20210525,
+    2329
    ],
    "deps": [
     "magit"
    ],
-   "commit": "d8609cb28d0411edf40031c1a551d64f383fac51",
-   "sha256": "1l3wqrv3338w7lgmpqpqqmc3wwh0dhl76nmfqlp8xjf44r3is2v7"
+   "commit": "fef1b7772fe192c434089b67644ff93765e384d4",
+   "sha256": "1g5nsg6zb3jrm7w1ssawv109ai2l7dpnd1dqrjsry2dnx1mxd212"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "magit"
    ],
-   "commit": "4273bfab1d2b620d68d890fbaaa78c56cf210059",
-   "sha256": "0d1cn0nshxnvgjvl9j7wsai75pvsxmrmkdj57xdpyggwxgcpl1m4"
+   "commit": "fef1b7772fe192c434089b67644ff93765e384d4",
+   "sha256": "1g5nsg6zb3jrm7w1ssawv109ai2l7dpnd1dqrjsry2dnx1mxd212"
   }
  },
  {
@@ -65906,19 +66322,19 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20210518,
-    1405
+    20210605,
+    1213
    ],
-   "commit": "624028c69b55deb3387452b9eeabe9cb963bd2a4",
-   "sha256": "1z9s6n0d03l7cpz7x50jjcqdpyhjy4ifc3wqsv3snv54rz68gpwq"
+   "commit": "4c6272ffc4836de052c8b06f681b0e700cb01602",
+   "sha256": "0l4sl4w4yq3hkpvvw7w1mh046f95bkg1c3av07kwk9cm038rwhvg"
   },
   "stable": {
    "version": [
     0,
-    5
+    6
    ],
-   "commit": "5126ba6244e13e3e2cf608e7f3955377bcbd8c04",
-   "sha256": "07vfidgq9am07zz2ydhdifmp4jmgs9jn5l1nfqiyp16sd1br6czj"
+   "commit": "ca9a5e35913569d66d34193a87d8511b2bb9d2b2",
+   "sha256": "1lisns2vghmqlg8wiv6jy15cfgnc8j83khz0vfnmrjwgcmjw3bbz"
   }
  },
  {
@@ -66026,11 +66442,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20210504,
-    249
+    20210530,
+    1825
    ],
-   "commit": "9977753eebe3f5cca7ab85b18a7c719fdb0b7654",
-   "sha256": "0aaj4bdl7cks06kx0jbhw0rvcwl2g68wyniy344fz2dzwwmp7acf"
+   "commit": "58f2d22526ac1e4abd4ee1afff8624d2dd3123d3",
+   "sha256": "1k17zpx05yafxfsw89dlkymqc5xajzv28qby12kdhwwlsbarqvd0"
   },
   "stable": {
    "version": [
@@ -66509,15 +66925,15 @@
   "repo": "sasanidas/maxima",
   "unstable": {
    "version": [
-    20210520,
-    2021
+    20210526,
+    1525
    ],
    "deps": [
     "s",
     "test-simple"
    ],
-   "commit": "f92eafd716ae6e36665bbf027309477c2efa336d",
-   "sha256": "10a72c4v0v5c1npxq1fmglxjiczpf1x87jpd6523x337h054zgs0"
+   "commit": "74e10d5dedb16f74efc28299c98dd7db9a4392d6",
+   "sha256": "1r04mbn33y515b9fwr2x9rcbkvriz753dc0rasb8ca59klp1p5cv"
   },
   "stable": {
    "version": [
@@ -66947,16 +67363,16 @@
   "repo": "DogLooksGood/meow",
   "unstable": {
    "version": [
-    20210511,
-    314
+    20210606,
+    1056
    ],
    "deps": [
     "cl-lib",
     "dash",
     "s"
    ],
-   "commit": "bfe4a67b6f3ea14dcc9140e16731f45afb64faf0",
-   "sha256": "13w54vpv5y4mxvrzc36f6vciq5sjxxmfj7k0d81svpjywz9cd12r"
+   "commit": "1cf2508f8e95311aa9ca405f899c3596cf8c2bc7",
+   "sha256": "12xzq9sxczjppqpx75bny2dp647m3f9ww6zf9a22rgmmspzkk5cx"
   }
  },
  {
@@ -67307,8 +67723,8 @@
     20210422,
     326
    ],
-   "commit": "c1b386f3522054f063f4ac60730397ed1f724478",
-   "sha256": "0d0s9hxjvv39n1rik894yh7d20aw120r6cadyp4hqw4n24j8cs5q"
+   "commit": "543813e0acceb55653d876302a5d5741879fb717",
+   "sha256": "1w0pfz5dbhqglb5w3c2g4ww2c32nbsir8gqnsh69pa43h9q1msz1"
   },
   "stable": {
    "version": [
@@ -67384,11 +67800,11 @@
   "repo": "sggutier/mexican-holidays",
   "unstable": {
    "version": [
-    20200622,
-    132
+    20210604,
+    1421
    ],
-   "commit": "5b5dd6e71505e8938bac9e9733b30bd394631923",
-   "sha256": "04d4148nq3lmrpkxvzzkn88j30iv2l2466ps035x7v8hc83wxnjw"
+   "commit": "8e28907ea69f2c0ed9aad9f3b99664ca147379d0",
+   "sha256": "0mly44x0nq26pw8v98k3nnlc8ca1mn20jcqj5k5gzdbp6k49lkxa"
   }
  },
  {
@@ -67399,8 +67815,8 @@
   "repo": "danielsz/meyvn-el",
   "unstable": {
    "version": [
-    20210130,
-    2016
+    20210606,
+    1501
    ],
    "deps": [
     "cider",
@@ -67410,8 +67826,8 @@
     "projectile",
     "s"
    ],
-   "commit": "a49731f39020b7c7626ba12e4c7b2f1c17a69341",
-   "sha256": "13m1qym94qvy197ngd8lyn8nzfsbxbr5ss29mkbvaidhi13jdrwa"
+   "commit": "ddba1d60d6729bbeeefd0f76dac4e6c20e848f67",
+   "sha256": "1c454baagnvbg79yia5vwk51n0fp031rz0xhgawk70lrfjbc8256"
   },
   "stable": {
    "version": [
@@ -67821,14 +68237,11 @@
   "repo": "tarsius/minions",
   "unstable": {
    "version": [
-    20201204,
-    1051
+    20210603,
+    2150
    ],
-   "deps": [
-    "dash"
-   ],
-   "commit": "4a81446e13f5bfb514e593d0e1c5253a60113301",
-   "sha256": "19gwv9dn6g3jv12qq1h4fal2adsawrszyfkd62x99rlfa81ixg6d"
+   "commit": "aed285155dc8f073d766e752520ec599e77ce8b7",
+   "sha256": "1qxszcx9n1yfc9j9ihvrdwb57n19w03600z3v4z2ybxap1y0nq3v"
   },
   "stable": {
    "version": [
@@ -67965,11 +68378,11 @@
   "repo": "ayrat555/mix.el",
   "unstable": {
    "version": [
-    20210105,
-    1821
+    20210605,
+    1015
    ],
-   "commit": "39a7d3e35769086c0008389b3975dd90b91b657c",
-   "sha256": "0f74wb9f1j47qc0xhhn23i8nrsyznhngwvdrg62ixdzdz9z0z5hh"
+   "commit": "bfe61ed4e7dd8cfc0bb2603fbac3eb44b32438bf",
+   "sha256": "0wfjgkz08zsdl24b71x7ync05qnnh46grs8ahdn8s9j35q9kxqvf"
   }
  },
  {
@@ -68012,6 +68425,30 @@
    ],
    "commit": "8e23de82719af6c5b53b52b3308a02b3a1fb872e",
    "sha256": "1d08i2cfn1q446nyyji0hi9vlw7bzkpxhn6653jz2k77vd2y0wmk"
+  }
+ },
+ {
+  "ename": "mlscroll",
+  "commit": "7f37b0e3fb8ee6770ea9320ce759bf8cf2ba2292",
+  "sha256": "1a0n6jxx0a71yjrdlly0bckly5pkz5mlqg5x9cmvq687mqv7mhkc",
+  "fetcher": "github",
+  "repo": "jdtsmith/mlscroll",
+  "unstable": {
+   "version": [
+    20210601,
+    2158
+   ],
+   "commit": "db502020ffe6bc65576b93527a20c0bf3df562da",
+   "sha256": "0gw6xw38x8h72gbvhmddgzijs4xvkrgs6c7v552db56hrlsj9lhp"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "commit": "5811cb564727f74eb0c8b8b075e6dc982e6ac5f6",
+   "sha256": "1wj71kz9zdp1rb2lmxrfrrwjg7wb4yjgsaqmhv2l4hyq97pzr0nm"
   }
  },
  {
@@ -68320,20 +68757,20 @@
   "repo": "tarsius/mode-line-debug",
   "unstable": {
    "version": [
-    20201118,
-    1530
+    20210525,
+    2014
    ],
-   "commit": "1848f94fe7bb7a0a11e976d1d64922a5b69a5cfc",
-   "sha256": "1jlcrymj1ssfrnz017916bm32918wkypzz0m57xixmng06x375g2"
+   "commit": "41184eb66a3205abcc32a885780004207df86dbd",
+   "sha256": "0qnrvddbka8klmihfaydpkwrigrjmbabxnm0vkybdqwzx619hwyi"
   },
   "stable": {
    "version": [
     1,
-    3,
-    0
+    4,
+    1
    ],
-   "commit": "6d2c9c14f6a3835f4d54091ea241fd436da18ef0",
-   "sha256": "0y5bkbl6achfdpk4pjyan2hy8y45mvhrzwkf1mz5j4lwr476g18l"
+   "commit": "41184eb66a3205abcc32a885780004207df86dbd",
+   "sha256": "0qnrvddbka8klmihfaydpkwrigrjmbabxnm0vkybdqwzx619hwyi"
   }
  },
  {
@@ -68455,20 +68892,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20210520,
-    1651
+    20210607,
+    917
    ],
-   "commit": "334a472a1d132bb748b8c9cb607dffe596144251",
-   "sha256": "0f7q05n4nd1rj2g0gzj06aav3ilv699czadbgj5g1jsjxq5g1i7g"
+   "commit": "a2c8796fcbcbdd332165e02476c6de5799996d31",
+   "sha256": "0p9yzj70kx3s740dl7k3vwwkr1g9zxsirwl83n1nvswc4csgv20j"
   },
   "stable": {
    "version": [
     1,
-    3,
+    4,
     0
    ],
-   "commit": "69248a97c9da98de786891215ab6baafcc44a55d",
-   "sha256": "0d3i07g8sxg30llzx519ph3qp4bx0vk0xy80sxhy5vra2l30ihlj"
+   "commit": "15c973f716378084a937e777f86182741fd9b697",
+   "sha256": "0p9yzj70kx3s740dl7k3vwwkr1g9zxsirwl83n1nvswc4csgv20j"
   }
  },
  {
@@ -68802,20 +69239,20 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20210114,
-    850
+    20210522,
+    1100
    ],
-   "commit": "2a29baa0cb6e364c5acbbf590a6d7c936c4378ae",
-   "sha256": "0l6cgr2969flhkdkiycqppvblpsn0qkdp19r406jpqbc1ql394lj"
+   "commit": "392c77174ace6c57921f237f41eaa4c3a83ac303",
+   "sha256": "0b4kg4dxy4ywwin96vz6x3rpvgr718y5rgrdarmwym9wv1qz0a0c"
   },
   "stable": {
    "version": [
     0,
     5,
-    4
+    5
    ],
-   "commit": "f6bebfe6fe51b728ebd013b7084becad23cabad3",
-   "sha256": "0n8p864yj5m3n7f9qiq9hy24dwfvv0a0wchx2818rppff6vfq3hf"
+   "commit": "392c77174ace6c57921f237f41eaa4c3a83ac303",
+   "sha256": "0b4kg4dxy4ywwin96vz6x3rpvgr718y5rgrdarmwym9wv1qz0a0c"
   }
  },
  {
@@ -69161,8 +69598,8 @@
     20210306,
     1053
    ],
-   "commit": "3b3068e924e17f8820a35899f105f2ef838d0535",
-   "sha256": "0bsxy0v7mm153wxwhwbm039fbfhr9l0xa5sgz9l7gdzkwsxmcbna"
+   "commit": "d031469630c70188c20598c0f3a3c3c46c6c7a14",
+   "sha256": "13mbkpzfdy136y5w6ns73qy1fsxwqzsvnnfcid2x7rrrqbxrcm5r"
   },
   "stable": {
    "version": [
@@ -69713,15 +70150,16 @@
   "repo": "lordpretzel/mu4e-views",
   "unstable": {
    "version": [
-    20210228,
-    1556
+    20210601,
+    1402
    ],
    "deps": [
+    "esxml",
     "ht",
     "xwidgets-reuse"
    ],
-   "commit": "1a0ceeb874e2a56b3ebe06c8375221031bb90a5c",
-   "sha256": "0v7d899pvpwvvp9x0yaskhjf1c6bjmqajk2mclfkykadrh89z61j"
+   "commit": "c7f2398612218407e72b174f02b26cf2916eba22",
+   "sha256": "0irvzwfrrqzk8pcq1m3w9s21v2y0h6f5jrvsv88knz0ki1bdkbai"
   },
   "stable": {
    "version": [
@@ -69818,14 +70256,14 @@
   "repo": "ReanGD/emacs-multi-compile",
   "unstable": {
    "version": [
-    20200913,
-    8
+    20210604,
+    140
    ],
    "deps": [
     "dash"
    ],
-   "commit": "508b524aa880e0ca6695f0d5543ee7659f2dea7c",
-   "sha256": "0g5ja8ra6kyfpvkavy9diiwjasc4v2z80yi98kahi5nckfp90kvc"
+   "commit": "948ee25878c509d0f9ba8715b209eae79143b76e",
+   "sha256": "0lgp64pgblidm4jyr3wlv5xq2x81znzi0xvqm8h0f8af9jzl2b38"
   }
  },
  {
@@ -70211,8 +70649,8 @@
     20181002,
     1617
    ],
-   "commit": "ffa40235b7dabb6c6c165f64f32a963cde8031f0",
-   "sha256": "0ximk0aan7jqn5x7fk4pj35bxhi6zaspvyxrmac9kxaiz8znwffr"
+   "commit": "223723d9ceeb2878b884e83abb8ca74ad2e42081",
+   "sha256": "1sl7kfg5w73cw9mv4x1m497dg27h42zgx2ywl4s8fmx2k9f2pq1q"
   }
  },
  {
@@ -71197,6 +71635,20 @@
    ],
    "commit": "a968a923aad07ab15fb35deb79ac95581a427b4c",
    "sha256": "1mb55bbsb32gxms488pjw9fsqiic2qfmwkhm3pwcgy194723vcaa"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "deps": [
+    "company",
+    "f",
+    "markdown-mode",
+    "s"
+   ],
+   "commit": "3f86d26fb2006e82c673a5bf122594820a4842d8",
+   "sha256": "0xsljyirv7iwfclxzlj8h274pps02ni3bdwwlpjcmffz8v1fh3l5"
   }
  },
  {
@@ -71469,8 +71921,8 @@
     20181024,
     1439
    ],
-   "commit": "c573f6b8b23593f46a08616b76325d3ce0175002",
-   "sha256": "05kicpy4higgdhxbsn7a15cgv85xbwwaf5nzy7pxjk4yg4wvpd7v"
+   "commit": "8fa4d05fea5140f80ff5f4629d19c6ce0d6f5cca",
+   "sha256": "0dn53fjq4dl8szpjqxn91md0xvr4sa458j1p0w8vgskc0iibzn4c"
   },
   "stable": {
    "version": [
@@ -71568,11 +72020,11 @@
   "repo": "NixOS/nix-mode",
   "unstable": {
    "version": [
-    20210124,
-    204
+    20210523,
+    326
    ],
-   "commit": "0023fc5b100ec0c939ffe699d1a7d1afcf1f417a",
-   "sha256": "1fjf16dah95i3vlxk63rlixskgq18kn69fyg6dgpiw7pm98kjviy"
+   "commit": "e4844f7a711c8d7dceb82b6b841a1e8485e12586",
+   "sha256": "0g05qa926xkayd79n2zi9ypd4m5245jjxwv2vp4hqn2cl76pnpak"
   },
   "stable": {
    "version": [
@@ -71860,14 +72312,14 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20210124,
-    1559
+    20210605,
+    1753
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "57357e15643158b4e0d9b3b4f70a82f5fc73178a",
-   "sha256": "1kbbbx1agzcxc5n1b6cavdx3wjxz6mgi9rafja8mk8cyaaiz0rkd"
+   "commit": "a6c8e0575766eb573a7add103836d578bd205962",
+   "sha256": "1r8rarcp0q0rl19kc6q7lll0djkvf3iw17rrsjswsq3z9fyq8iyr"
   },
   "stable": {
    "version": [
@@ -71905,16 +72357,15 @@
   "repo": "thomp/noaa",
   "unstable": {
    "version": [
-    20190202,
-    1634
+    20210606,
+    2050
    ],
    "deps": [
-    "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "ebc6a4a1cc56c01d2bb882e4a40934a6a1f4e9ca",
-   "sha256": "04zhhz8v6bx627g1vhvd0s8bl5g3d6a1mfgf7pb13627npsvbrdx"
+   "commit": "e2a4870fd5f8e37956d9317b74317d99f17b87ad",
+   "sha256": "1djlfvnmzcjva1s4pjhr4hhmqmd30mm48933lpgy3pnwp7gq910x"
   }
  },
  {
@@ -72166,11 +72617,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20210515,
-    1210
+    20210605,
+    1839
    ],
-   "commit": "ff07183a02a480b36e70284289607c1315ac3db7",
-   "sha256": "10mx3vj7aqa646r0f308f7rr67v9zss6x5z4dpibmx5bhl5zz8r4"
+   "commit": "6f0f83660e222cfdd05b05ad134763a7ab26f097",
+   "sha256": "0rs37inh95c1r91mjjwf1kssmxq8mliblzvdjypijps13fxk7m60"
   },
   "stable": {
    "version": [
@@ -72350,15 +72801,15 @@
   "repo": "shaneikennedy/npm.el",
   "unstable": {
    "version": [
-    20200812,
-    1850
+    20210601,
+    1122
    ],
    "deps": [
     "jest",
     "transient"
    ],
-   "commit": "26d5cf79dfd1a2a74a66c44de129483d26354345",
-   "sha256": "0akjjb5xqpzg784qi6hbjfjm335mixqszzrxwz69ggl50iy9s6rk"
+   "commit": "d14d654c025d8f75f678503c98cd8682e69341cd",
+   "sha256": "0a54s7l01z5s5vasysxfysnzc2smn6r5pq01a6a3vqyaq3hz4khi"
   },
   "stable": {
    "version": [
@@ -72670,28 +73121,27 @@
   "repo": "douglasdavis/numpydoc.el",
   "unstable": {
    "version": [
-    20210510,
-    1558
+    20210523,
+    1746
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "01c067e1b83175cb3f03c2061528393166173012",
-   "sha256": "1wla0drxbk7kqxpam4yrmlz2ajrqv6sz66jg11795k7wh16ab21s"
+   "commit": "dcbc06429084e209f081a8c6318b46c1c9ff7309",
+   "sha256": "0bggm5ssxpj49km8q8z9hj351garl1xydz1dya7r0yvz12y6wn5g"
   },
   "stable": {
    "version": [
     0,
-    3,
-    0
+    4
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "01c067e1b83175cb3f03c2061528393166173012",
-   "sha256": "1wla0drxbk7kqxpam4yrmlz2ajrqv6sz66jg11795k7wh16ab21s"
+   "commit": "b8efad7723a0c1d5738d74c7ce56ea962726a74f",
+   "sha256": "11y73fwn4ca6pll5vb1p04l08z48kj2ldks3qavqj4pamdcm698d"
   }
  },
  {
@@ -73546,14 +73996,14 @@
   "repo": "Lompik/ob-nim",
   "unstable": {
    "version": [
-    20170809,
-    1830
+    20210601,
+    1807
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "bf1642cb93f0a898804dc13fd9408d2964403bd2",
-   "sha256": "1xgi863wn1pvlsajmldd706k1dk7d7pa6b9nbgsh34kzchvhd75s"
+   "commit": "6fd060a3ecd38be37e4ec2261cd65760a3c35a91",
+   "sha256": "12sinii7i917v1f3czvmc0rrwk3ksr1ls7wv4yvv9f8jdkzr0msm"
   }
  },
  {
@@ -73966,11 +74416,11 @@
   "repo": "ocaml-ppx/ocamlformat",
   "unstable": {
    "version": [
-    20201204,
-    945
+    20210601,
+    901
    ],
-   "commit": "a948866021f86461d3b6259b6cdc3506d31d3011",
-   "sha256": "1790c3hymn91nr03y1ragq703cj18877r8g233f27i0cz6gnbbqh"
+   "commit": "be14af363e9338e86173c2d96732f59b3c76e73e",
+   "sha256": "10q2xd4mqdi9h6dbjfx5081l8sc025rgkxsz9hwm93yrb5xw1rwd"
   },
   "stable": {
    "version": [
@@ -74163,26 +74613,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20210512,
-    1429
+    20210521,
+    1311
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "fbadeea46739954649c8eb6dd61f74eb1ba2bf8b",
-   "sha256": "0qsqj7yb608bgzyicn9zpqxvranbs94xapbssxp7y64ng1ad68d2"
+   "commit": "fe1feb913bf69b1e854053e3f07026c14c6c91dc",
+   "sha256": "0w4x18srwhznd4xicr2sk7m3lhzgw6pyza7skar5i4n7y30q38xp"
   },
   "stable": {
    "version": [
     3,
     20,
-    0
+    1
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "fbadeea46739954649c8eb6dd61f74eb1ba2bf8b",
-   "sha256": "0qsqj7yb608bgzyicn9zpqxvranbs94xapbssxp7y64ng1ad68d2"
+   "commit": "fe1feb913bf69b1e854053e3f07026c14c6c91dc",
+   "sha256": "0w4x18srwhznd4xicr2sk7m3lhzgw6pyza7skar5i4n7y30q38xp"
   }
  },
  {
@@ -74878,11 +75328,11 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20210518,
-    1413
+    20210603,
+    1335
    ],
-   "commit": "9637d7fd59f76a5b6d37470b1543ab827a0f9b8d",
-   "sha256": "0741jyin11dwf52srgjgw4xk581p16bwslzrq7qsnx4h4fnagarg"
+   "commit": "e85084e733d6eb50893974fc5fd569b944a5010c",
+   "sha256": "1lmjmp0iwp8n9nrqvygav7y2fxxwqpv4kk2wy2gg4bi056arbx5a"
   },
   "stable": {
    "version": [
@@ -75041,15 +75491,26 @@
   "repo": "eyeinsky/org-anki",
   "unstable": {
    "version": [
-    20201220,
-    2144
+    20210603,
+    1352
    ],
    "deps": [
-    "ox-slimhtml",
     "request"
    ],
-   "commit": "efa9e3aa2d768c00440f745192aba6672b28d086",
-   "sha256": "009n23gcgyfylp4q6igj67r606syq2r43s86g12xkl3vmc14929b"
+   "commit": "03c1ca90a7f2583074f020619c7cb92a783fb375",
+   "sha256": "1pwgs9xm6i0cqhrwpl60y3xbd0k64nr48kfa83x3yk9x38i6ddp0"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    2
+   ],
+   "deps": [
+    "request"
+   ],
+   "commit": "03c1ca90a7f2583074f020619c7cb92a783fb375",
+   "sha256": "1pwgs9xm6i0cqhrwpl60y3xbd0k64nr48kfa83x3yk9x38i6ddp0"
   }
  },
  {
@@ -75060,14 +75521,14 @@
   "repo": "awth13/org-appear",
   "unstable": {
    "version": [
-    20210516,
-    1936
+    20210605,
+    904
    ],
    "deps": [
     "org"
    ],
-   "commit": "9fcf2486e70362d9fbdd40f3eae26ee0c04f13a9",
-   "sha256": "0gfwhnz3ir0c7ah1v6ahg54a6vjyjmbybgg9w232jz3hhjsqyk9y"
+   "commit": "cf87546d6458d36492a89661a1e097e5596aa26a",
+   "sha256": "18p8s0syqhqpk21ylbk8np3srknhi4ckxfxn7i4jkscsy8282lcb"
   }
  },
  {
@@ -76004,6 +76465,21 @@
   }
  },
  {
+  "ename": "org-gamedb",
+  "commit": "ca995957e201a1df81839ac326807d789f05a5e1",
+  "sha256": "0r6m78spjfk8vpgki747al3klms1g9ql9b7spvirlqykaw9nmrb6",
+  "fetcher": "github",
+  "repo": "repelliuss/org-gamedb",
+  "unstable": {
+   "version": [
+    20210525,
+    2338
+   ],
+   "commit": "f283b6f6a7e8ad090405be57202caa3d3c424447",
+   "sha256": "1sxjxh4yrb7zf4k17sa2wyxsf70krl3mg1jp6qs8qn37gyn2x3d4"
+  }
+ },
+ {
   "ename": "org-gcal",
   "commit": "d97c701819ea8deaa8a9664db1f391200ee52c4f",
   "sha256": "014h67ba0cwi4i1llngypscyvyrm74ljh067i3iapx5a18q7xw5v",
@@ -76165,21 +76641,21 @@
   "repo": "marcIhm/org-id-cleanup",
   "unstable": {
    "version": [
-    20210320,
-    1023
+    20210326,
+    1711
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "0877bd57f95ad96a342505a6ecef0c15977f6bd6",
-   "sha256": "02q343sznbw1ma9zcxnpa7sy37s85ph9phpg479pfz5c51kji09h"
+   "commit": "2cb87624238281b438cda67ed375c56403524489",
+   "sha256": "1xmbrrp1zyvij18v3rqmini6w9i6v7dl4fp103ph6wznav8x0jbl"
   },
   "stable": {
    "version": [
     1,
     6,
-    0
+    1
    ],
    "deps": [
     "dash",
@@ -76221,8 +76697,22 @@
   "repo": "marcIhm/org-index",
   "unstable": {
    "version": [
-    20210517,
-    1508
+    20210602,
+    358
+   ],
+   "deps": [
+    "dash",
+    "org",
+    "s"
+   ],
+   "commit": "40716a4cfd36304b4a16977020b1e82870faec15",
+   "sha256": "1wncx69rqlvx9pnr5mlwn9i00nrfhi1icxv0zpc7z2kzf03wn930"
+  },
+  "stable": {
+   "version": [
+    7,
+    2,
+    1
    ],
    "deps": [
     "dash",
@@ -76231,20 +76721,6 @@
    ],
    "commit": "1ee39e4f8616199ad8e5cb6b2d6b410e75857ecd",
    "sha256": "06mf8s68mw6fcdpvdddcvy2x8z6zyisfvgh4sdrpz2z5j03v7qd7"
-  },
-  "stable": {
-   "version": [
-    7,
-    1,
-    7
-   ],
-   "deps": [
-    "dash",
-    "org",
-    "s"
-   ],
-   "commit": "47805bb8dc681872f3ad5dc74711938978d5c7f2",
-   "sha256": "0iiw798clq6hmml6fs60wwd38c4rzvxrdv4xr57innj06cja4dvy"
   }
  },
  {
@@ -76304,16 +76780,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20210514,
-    1352
+    20210527,
+    1629
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "21364700245acd2fe7a15f389db15370f0b67a02",
-   "sha256": "1h1fadjhvv2f6l4sk9b8mxpacxb82jnppbd6j4np4g4jcbc54ijx"
+   "commit": "a01f0453667f9baccf0b8a514e9c9f0a9fb9fb6e",
+   "sha256": "1gn2sflvcc4gvgci3m12d16mjrwxywrd8vvrs7s87k0cf7yl74vf"
   },
   "stable": {
    "version": [
@@ -76344,8 +76820,8 @@
    "deps": [
     "org"
    ],
-   "commit": "043bb9e26f75066dc1787cdc9265daca7a14dd4e",
-   "sha256": "0x4fvxdrllih2n643v3wgq0rl72dyhk11xqi2l1h718iaz4kqi5i"
+   "commit": "5f253a880e1919ef4b98f0d91f271a8b522eaae5",
+   "sha256": "1cirbb5x29qnf59qkcfsjw467xx02vl4f17iqd4qqxwaarwkyq30"
   },
   "stable": {
    "version": [
@@ -77612,15 +78088,15 @@
   "repo": "akirak/org-reverse-datetree",
   "unstable": {
    "version": [
-    20201128,
-    706
+    20210531,
+    1929
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "be24274dd62cd3c586cbea99c8f73db251bf319d",
-   "sha256": "1kjydjj2bwrvvckxh1c31gk1h09j876jg7rbyv0jb0kzfim79d2j"
+   "commit": "e7a7109e4c34811d471bf685b710234564a556f6",
+   "sha256": "10p35q5l9racfqp92xcqard7n75gpqw6l5zjgbybswnkzvdjzd8c"
   },
   "stable": {
    "version": [
@@ -77723,16 +78199,16 @@
   "repo": "org-roam/org-roam-bibtex",
   "unstable": {
    "version": [
-    20210507,
-    2051
+    20210602,
+    2113
    ],
    "deps": [
     "bibtex-completion",
     "org-ref",
     "org-roam"
    ],
-   "commit": "80a86980801ff233d7c12ae9efef589ffa53df67",
-   "sha256": "0sm4l32xscpq9hmilj0srqh7vij5x3602h1f0yh9wmckz9jq4f4w"
+   "commit": "f7b5be2ce0b43dd4d842484fc0ec37fdc8526907",
+   "sha256": "1cqx2izzchwd6yi0gmskdb0kiqjwk2m7rgk074bzzq0dzbpl180j"
   },
   "stable": {
    "version": [
@@ -77758,8 +78234,8 @@
   "repo": "org-roam/org-roam-server",
   "unstable": {
    "version": [
-    20210517,
-    1731
+    20210521,
+    1055
    ],
    "deps": [
     "dash",
@@ -77769,8 +78245,8 @@
     "s",
     "simple-httpd"
    ],
-   "commit": "ea4082f54af14cb692d6eb7f8f085971ebdca69d",
-   "sha256": "0dnnawh248mnjw7j0zwck0fxfhk828a9xbx5r1xizqmh50qv65mm"
+   "commit": "a0f82bf41e318d4ef606a26f54054262ed6c3441",
+   "sha256": "06j8wabbxay9h8ca4pbv5xgjygfzbb3kbk4icni3lrfj6izsp3i4"
   },
   "stable": {
    "version": [
@@ -77921,8 +78397,8 @@
     "org-super-agenda",
     "s"
    ],
-   "commit": "67fe1b5c6c879e14d34c34eec2190e9719046b6c",
-   "sha256": "00danbc1w5wd3gj0sdas26ip3lyxcsapq9ly4kbaprrxbf187b56"
+   "commit": "1b37069e47d1ea4745eacdf2dec2bdad756ee235",
+   "sha256": "0sf406dz4mkpaqaql3z8xs6jcksxasa5j7xkk79a9xnbanaxhzaq"
   },
   "stable": {
    "version": [
@@ -78106,11 +78582,11 @@
   "repo": "bastibe/org-static-blog",
   "unstable": {
    "version": [
-    20210329,
-    848
+    20210606,
+    1806
    ],
-   "commit": "c000cdff0cf3c10ac756bd7c5b5729965cfce876",
-   "sha256": "0vff4wh9vlkzix47kxqxabcl29glnxbmmpmppkp6cfk42zb6sw1g"
+   "commit": "0bd38b604405ba8e6ba00dd32ce4773eb02eb901",
+   "sha256": "1d9kdcdiz600swcy318hd56l751w2qyafdibnkzfkhjzw63c2hwh"
   },
   "stable": {
    "version": [
@@ -78331,15 +78807,15 @@
   "repo": "stardiviner/org-tag-beautify",
   "unstable": {
    "version": [
-    20210304,
-    1124
+    20210527,
+    1130
    ],
    "deps": [
     "all-the-icons",
     "org-pretty-tags"
    ],
-   "commit": "e655ced70140cbec8fe12f9207614ca2b3a6c37c",
-   "sha256": "0853avvi2qpr19ca6c9ix8ls7r2r5v5f38nzkr4lbindmmxl6kpv"
+   "commit": "20193bf9b07efba03fdd5ffb2852cd43fcd88051",
+   "sha256": "0diccvg4gx9djayihd1hp39q5n2s8cahck93s5r58vk0d4jlcyyk"
   }
  },
  {
@@ -78712,8 +79188,8 @@
     20210414,
     1844
    ],
-   "commit": "7bb01664b45fc08b7d013c91073cf3ce0d313984",
-   "sha256": "1hknnkidmd5w81i30xjj2q3x93mygqq7pk7kwfssnzrn8lih6a9b"
+   "commit": "246120647e28a27506ca0894ba98e371086881fd",
+   "sha256": "15gqzj4h0w33w38i8ihl74iy7aqxlds97gm93r72z69pm2l1d7dm"
   }
  },
  {
@@ -78850,7 +79326,7 @@
   "stable": {
    "version": [
     2,
-    4,
+    5,
     4
    ],
    "deps": [
@@ -78901,8 +79377,8 @@
     "metaweblog",
     "xml-rpc"
    ],
-   "commit": "c1b386f3522054f063f4ac60730397ed1f724478",
-   "sha256": "0d0s9hxjvv39n1rik894yh7d20aw120r6cadyp4hqw4n24j8cs5q"
+   "commit": "543813e0acceb55653d876302a5d5741879fb717",
+   "sha256": "1w0pfz5dbhqglb5w3c2g4ww2c32nbsir8gqnsh69pa43h9q1msz1"
   },
   "stable": {
    "version": [
@@ -79141,28 +79617,28 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20210512,
-    1945
+    20210525,
+    1956
    ],
    "deps": [
     "magit",
     "org"
    ],
-   "commit": "043db4f0957416652f872ca18289ef00b9474963",
-   "sha256": "1rybcybb4xb6wsfhh772mapggabn14i7ca2fl30qkzyc5qmhc3s9"
+   "commit": "26242895ef1642bf30c63683fb224fdba25e0853",
+   "sha256": "1xd58yqqsb79lgxkhxs4s50jq8f3639k6fhlza9hsy53apfczkal"
   },
   "stable": {
    "version": [
     1,
-    6,
-    3
+    7,
+    0
    ],
    "deps": [
     "magit",
     "org"
    ],
-   "commit": "ac9b1a42863a864fde9d225890ef5464bffdc646",
-   "sha256": "08amzcvw483dpfq5r34ysn84wzd538qk0jblc94vgcaidspx6481"
+   "commit": "26242895ef1642bf30c63683fb224fdba25e0853",
+   "sha256": "1xd58yqqsb79lgxkhxs4s50jq8f3639k6fhlza9hsy53apfczkal"
   }
  },
  {
@@ -79173,8 +79649,8 @@
   "repo": "magit/orgit-forge",
   "unstable": {
    "version": [
-    20210512,
-    2014
+    20210525,
+    1957
    ],
    "deps": [
     "forge",
@@ -79182,14 +79658,14 @@
     "org",
     "orgit"
    ],
-   "commit": "cfca04232337cb9ad62ffd9929d964ff6b8e8754",
-   "sha256": "1gvpccxxxhkddfjvgsbxrxqsvman0d6ndkimy9nsz8flzwb8g5gm"
+   "commit": "ea2a1cf9d337901b413e9df258b8e07af55c00f6",
+   "sha256": "07ia3b6bfilnpify93kq5g10xhh794v5pmc9cmmb312c3qyqi7b4"
   },
   "stable": {
    "version": [
     0,
     1,
-    0
+    1
    ],
    "deps": [
     "forge",
@@ -79197,8 +79673,8 @@
     "org",
     "orgit"
    ],
-   "commit": "63a19d1df1434e583aac1329ba4dcfa2ee59d7c1",
-   "sha256": "1vd7wnas53z0985if22sv0wpww2dp0g8b0z9hwlzdhlcrsjay5fz"
+   "commit": "ea2a1cf9d337901b413e9df258b8e07af55c00f6",
+   "sha256": "07ia3b6bfilnpify93kq5g10xhh794v5pmc9cmmb312c3qyqi7b4"
   }
  },
  {
@@ -79446,8 +79922,8 @@
     20210507,
     1619
    ],
-   "commit": "71216d56575da602ec713bf1bbe75c92606c1049",
-   "sha256": "1qfgfkww6v0glpnqdx3a6qixr63vbcvkby7ccw8qzpyb9bpar9g2"
+   "commit": "c0ba49bb01d037ce8800aa04db06f454ef043cb6",
+   "sha256": "07ck6slz0z484lywdymh719pfmxhvfsb1cvk2bdbrx4xq89sqwq6"
   },
   "stable": {
    "version": [
@@ -79755,20 +80231,20 @@
   "repo": "tarsius/outline-minor-faces",
   "unstable": {
    "version": [
-    20210214,
-    1715
+    20210530,
+    1259
    ],
-   "commit": "bb6db842e4fc2ed4d635001938ebafe93925f48c",
-   "sha256": "0h54wdsh6g0wmqf356s6br08hq29p6cdrsd14q9w6qaxhmfzbs7m"
+   "commit": "942bd43ea7099984e9ebccf48db70af345d4b6bf",
+   "sha256": "0xnzwb1ybhq38qgd3ml18565bbagfx6yzcfndc5d4ll7bzij6jbh"
   },
   "stable": {
    "version": [
     0,
     2,
-    3
+    4
    ],
-   "commit": "a34602b59063dd22ca6877466b85b2728f03c242",
-   "sha256": "1k3zfcmlwfby7yixjdxfynhys2kyhggg0n3d251a9frzrkyg6gxb"
+   "commit": "942bd43ea7099984e9ebccf48db70af345d4b6bf",
+   "sha256": "0xnzwb1ybhq38qgd3ml18565bbagfx6yzcfndc5d4ll7bzij6jbh"
   }
  },
  {
@@ -80059,8 +80535,8 @@
    "deps": [
     "org"
    ],
-   "commit": "a79dc519cd28c000ebca4254a4744ce2b9b82168",
-   "sha256": "1ffpslv58kzw9nhrfv2cp42vq0pdx5gm1bk20g6k697ijiz1r1jj"
+   "commit": "545d2e1547fdc48a5757152d19233effa11d9ee2",
+   "sha256": "1mv0x345rn85cyq0qm4kz22ymxbaa4r9lhnp7n2d2cp0cn23m9zv"
   },
   "stable": {
    "version": [
@@ -80098,15 +80574,15 @@
   "repo": "jkitchin/ox-clip",
   "unstable": {
    "version": [
-    20210323,
-    2145
+    20210528,
+    2059
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "2095537695135c7f1bc19db043925eb7d482907b",
-   "sha256": "0pingsmmdpw9g88rri7rkw8ajp1f982vx9rh97nfn51ppr94ihbw"
+   "commit": "05a14d56bbffe569d86f20b49ae31ed2ac7d1101",
+   "sha256": "14z5pghli7d3rkq3xmbjpssskx3zgwqwypb59wcprkyw8pl66rfp"
   }
  },
  {
@@ -80237,8 +80713,8 @@
    "deps": [
     "org"
    ],
-   "commit": "600a44cdd7caf0944c3b849d65e46580105f0375",
-   "sha256": "1jflz2a6hhdrnsnxdbh2y8ysw37za8d974513ak2w41w4k5k6xji"
+   "commit": "074c3abf0a6aa5d671da1a39a20137140ba41d24",
+   "sha256": "1a134x8pmgas5k1m769clk3yhrzdh4n0cwmh23bf22avk6n3bz8z"
   },
   "stable": {
    "version": [
@@ -80547,14 +81023,14 @@
   "repo": "0x60df/ox-qmd",
   "unstable": {
    "version": [
-    20201205,
-    721
+    20210529,
+    1012
    ],
    "deps": [
     "org"
    ],
-   "commit": "de78970b85dfd342b49f9956f350c6f7d0a13050",
-   "sha256": "1fggy2b6yklgm66zmyqcmib0aklilh99f51vxyifrhjlsrvinz1v"
+   "commit": "7e69c04626f8d35756f3b049bd7836fb751f7734",
+   "sha256": "14hdjkyyh4714vsc4amkdfhdda94gpaz7hy702ygmyfx0il1v92a"
   }
  },
  {
@@ -80565,14 +81041,14 @@
   "repo": "DarkBuffalo/ox-report",
   "unstable": {
    "version": [
-    20210430,
-    1212
+    20210604,
+    1436
    ],
    "deps": [
     "org-msg"
    ],
-   "commit": "1e730396b8b7aa5101b3e3f538d6d4c15514f415",
-   "sha256": "1firb26xnci1qprb4v4p3cp9vnmmp5bvsm3154gy0n2jr0hzvbjj"
+   "commit": "9354a9687f7175d26c854204878b2fe545c069b5",
+   "sha256": "15jqcwmcpcb8vczzd50jasz46db9667yqcmzd4v4ahnxhvvb2vfb"
   },
   "stable": {
    "version": [
@@ -81072,15 +81548,15 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20210511,
-    2055
+    20210528,
+    2348
    ],
    "deps": [
     "cl-lib",
     "let-alist"
    ],
-   "commit": "f910d9912997230e3a34429265ee95b7c0dbec8e",
-   "sha256": "0sd016in8sg5nazly0mr379j9y59b8mffsa2lpzkwqbj379rnzgl"
+   "commit": "10b6f3aab4f7c014ce339694255cf2c6dfd2bdea",
+   "sha256": "0ps3v3v4279rbma8fscrpm13dimv2d93hgbq3fqcq4j9kfd25jzq"
   },
   "stable": {
    "version": [
@@ -81103,14 +81579,14 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20210110,
-    2231
+    20210530,
+    319
    ],
    "deps": [
     "package-lint"
    ],
-   "commit": "f910d9912997230e3a34429265ee95b7c0dbec8e",
-   "sha256": "0sd016in8sg5nazly0mr379j9y59b8mffsa2lpzkwqbj379rnzgl"
+   "commit": "10b6f3aab4f7c014ce339694255cf2c6dfd2bdea",
+   "sha256": "0ps3v3v4279rbma8fscrpm13dimv2d93hgbq3fqcq4j9kfd25jzq"
   },
   "stable": {
    "version": [
@@ -81122,6 +81598,21 @@
    ],
    "commit": "cfe5aa2c8eeb2f6df38cf97a2315ac8f8ae41696",
    "sha256": "1cn713g90zyjfq225yvg14c1qshslpi4466m3w102l5g57p8xv44"
+  }
+ },
+ {
+  "ename": "package-loading-notifier",
+  "commit": "9d7c94da6374291527055e47dcbf55cc7a6edf39",
+  "sha256": "0ha47s60dkbi7n2a6ynnva6nh3fl7dyv7c7hkjr8d1lcc2jpdi8d",
+  "fetcher": "github",
+  "repo": "tttuuu888/package-loading-notifier",
+  "unstable": {
+   "version": [
+    20210603,
+    1138
+   ],
+   "commit": "8fd10303e19a2a1e8b5544ce8c34c8466af5d08a",
+   "sha256": "11d9mc9ca9bn9x3by8fqcan2c8wn85d8xnmkfvzxcmw7dz87kis2"
   }
  },
  {
@@ -81539,8 +82030,8 @@
     20200510,
     5
    ],
-   "commit": "7bb01664b45fc08b7d013c91073cf3ce0d313984",
-   "sha256": "1hknnkidmd5w81i30xjj2q3x93mygqq7pk7kwfssnzrn8lih6a9b"
+   "commit": "246120647e28a27506ca0894ba98e371086881fd",
+   "sha256": "15gqzj4h0w33w38i8ihl74iy7aqxlds97gm93r72z69pm2l1d7dm"
   }
  },
  {
@@ -82618,15 +83109,15 @@
   "repo": "vedang/pdf-tools",
   "unstable": {
    "version": [
-    20210511,
-    1739
+    20210531,
+    1613
    ],
    "deps": [
     "let-alist",
     "tablist"
    ],
-   "commit": "d262cf9e19d57c6567e06e51d109150c20753839",
-   "sha256": "0bls4kh7qv5wkjmxizj7rwn2kby0awg1fzkra3fkmg9xbvqzm7qh"
+   "commit": "5f77dae43eb8f71e52e10ba8cf994883f74c3fb7",
+   "sha256": "0hzqcnxi66d0c3dq7y3dn28f3yri4zcx46yylhy0xnm3f1yja0rm"
   },
   "stable": {
    "version": [
@@ -82956,6 +83447,24 @@
   }
  },
  {
+  "ename": "persp-mode-project-bridge",
+  "commit": "fa5d72aad13e1f7e1863deb5487a6ebc9eb09e1f",
+  "sha256": "0h7k03z91h7qx0kgdy5nam886730w9llmrbaajcz801892ddkn3a",
+  "fetcher": "github",
+  "repo": "CIAvash/persp-mode-project-bridge",
+  "unstable": {
+   "version": [
+    20210524,
+    656
+   ],
+   "deps": [
+    "persp-mode"
+   ],
+   "commit": "c8a2b76c4972c1e00648def5a9b59a2942bd462a",
+   "sha256": "1fzvz7f86azffyqrqx3jiwj54b739p2adb5yp9cilbfwkkqyff0v"
+  }
+ },
+ {
   "ename": "persp-mode-projectile-bridge",
   "commit": "2c049b0067b70577511114dc8abac0a00a9e0588",
   "sha256": "169mpikixa33ljmh2n9sm186yibrik3f5p8m1hcisnzdsc3wgxmp",
@@ -83017,14 +83526,14 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20210401,
-    1950
+    20210523,
+    2254
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "dd2a380ac71edf1321a6462f14668baf99879e80",
-   "sha256": "0l9i7ky25d9ii04w2brgxc8dk2rky50naba8lbfqi7hcc34z8pp6"
+   "commit": "b37c6756700a167742c8ab06fa5a850d9d94f4bd",
+   "sha256": "1ciab9xz4lbnnnx9407bagyf10dv6h9nalzm2wj6w6x7kckb4105"
   },
   "stable": {
    "version": [
@@ -83936,11 +84445,11 @@
   "repo": "EricCrosson/pine-script-mode",
   "unstable": {
    "version": [
-    20210514,
-    1232
+    20210605,
+    1527
    ],
-   "commit": "cb88aa6eb15c2bf52814b712e4b09ceb1e13ea25",
-   "sha256": "0vfrcy4vkbfa24f0a5n2q93vpbvqww4chbfyzpcrkwgclp07g53x"
+   "commit": "e465c0264958cbed0fb29dad2b30b9f18fbf1064",
+   "sha256": "0crc2q5mzflyz13zx0ghsf2kdmj67lcqb2vnnsw0z2sk7wafrz2i"
   },
   "stable": {
    "version": [
@@ -84218,10 +84727,10 @@
  },
  {
   "ename": "plain-theme",
-  "commit": "d4bd77883375b229e344384e42c3603ca096891c",
-  "sha256": "0igncivhnzzirglmz451czx69cwshjkigqvqddj0a77b1cwszfw8",
+  "commit": "d25eb506b358a3c89c950e66200ea52fe3ca9133",
+  "sha256": "16i60lp0af15sw4fbsj37yd4hs6i212smili9mjaqgiai7wxqv4f",
   "fetcher": "github",
-  "repo": "yegortimoshenko/plain-theme",
+  "repo": "abelianring/plain-theme",
   "unstable": {
    "version": [
     20171124,
@@ -85273,11 +85782,11 @@
   "repo": "polymode/polymode",
   "unstable": {
    "version": [
-    20210413,
-    2004
+    20210521,
+    1131
    ],
-   "commit": "b50ec54097d279bde6567ee3ba8a22471f466ec0",
-   "sha256": "0q2vjvz72m3nrnpck4hl059cjgcf2jdw2rl9h8fxyvbllyj0733f"
+   "commit": "7d1f822f0833b43326cc9253dc8a3e267ad4b376",
+   "sha256": "15gyqf9vs3yxls8l830ik5rdhvd0wiybqpi0yxnfpd6g9pcajm6w"
   },
   "stable": {
    "version": [
@@ -85476,11 +85985,11 @@
   "repo": "karthink/popper",
   "unstable": {
    "version": [
-    20210326,
-    2042
+    20210602,
+    847
    ],
-   "commit": "096078acea59df6109906641e9dd44893ed4f6a2",
-   "sha256": "1cvb40ad3zazfqjzwqgz4bnn9a2pl8yi52b0qfd56ccp32b24n91"
+   "commit": "2be084a77cc2bc79ea7dc23edada161f4ff6dfdb",
+   "sha256": "118sbcm6qavckxva81vamrs98dj38yv0qccqqj4p3a4q7brfi8cw"
   }
  },
  {
@@ -85736,11 +86245,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20210423,
-    220
+    20210604,
+    647
    ],
-   "commit": "739d8fd1081bdd0d20dee9e437d64df58747b871",
-   "sha256": "1hapg4dwrpa1ffkx8s3pialkh9zsh3r5jxk076c750k9rdwl3q4m"
+   "commit": "3257a52e3599bc1d5c9a4b646d36d7a49b0dd025",
+   "sha256": "13p7122100ywg6dc32wq0hvcn52x8djxq6vgcmdpdsdy7k4fkxwc"
   },
   "stable": {
    "version": [
@@ -85831,14 +86340,14 @@
   "repo": "milkypostman/powerline",
   "unstable": {
    "version": [
-    20210428,
-    1229
+    20210527,
+    1953
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "346de84be53cae3663b4e2512222c279933846d4",
-   "sha256": "00yy96a1rqcpbkvbn1hmb1pz5i7l0pwb2bqyxcc8qry7rkmvw7gy"
+   "commit": "cfba2aa9cfa190e7720900f01a946e1e78aac7e2",
+   "sha256": "1ljyp3a1dhak2h89yabjpf88037c7yhk4naxach1p86x3brwk68q"
   },
   "stable": {
    "version": [
@@ -86087,15 +86596,15 @@
   "repo": "jscheid/prettier.el",
   "unstable": {
    "version": [
-    20210313,
-    1047
+    20210606,
+    1152
    ],
    "deps": [
     "iter2",
     "nvm"
    ],
-   "commit": "5232b886bb6a4fb3848d63db1bcfcb30487a180f",
-   "sha256": "0sbka039sccqip36y98s1b5z6rd5w5q0jzl5kbdq4wmzi7j823ri"
+   "commit": "e38d21a885e234af9ea6b03f499c487175570571",
+   "sha256": "1c7n43xi1sjprqn0xhd1hfdr39ipqiw1r8w76qbm3xx04h9bccy8"
   },
   "stable": {
    "version": [
@@ -86652,26 +87161,26 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20210503,
-    738
+    20210607,
+    1513
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "35c6f9898272796694d04ab4fc4fbc85751e6b44",
-   "sha256": "0lxmd139aj42r1gyiw2hgr9riww7fdifngzmgy4k2946j3vr7ilc"
+   "commit": "155fdb44176347c9599357c7935993033260a930",
+   "sha256": "040g4frdjabpa8ddhag81dx3kphh5kp3iv34x4zsbkhb6gryd5zf"
   },
   "stable": {
    "version": [
     2,
-    3,
+    4,
     0
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "18f694931f0afe8b33e34731914e8bae81107b55",
-   "sha256": "0jgnj5il4ynbqgpvy41y6xwwdwnd8m7vsx2f8y8dlwnczr0a022r"
+   "commit": "bbb7b8d4c498e88046e4e6227990626f2b5dbe1b",
+   "sha256": "0w2s1mxbi8qqv0k34q0jj368n0p764rz72grdzzrmdlc96bbd03s"
   }
  },
  {
@@ -87063,11 +87572,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20210512,
-    556
+    20210607,
+    1422
    ],
-   "commit": "632297dd0ab35a42ed6eac163dcaca1e71fcd83b",
-   "sha256": "0gzggng9iq62qlyzx0v6f586qfqvwibpz7jp7ar8r3wz32h95vjm"
+   "commit": "bc86736abb728ec0d28abc90ef0adae21d29a66a",
+   "sha256": "00cga3n9nj2xa3ivb0fdkkdx3k11fp4879y188738631yd1x2lsa"
   },
   "stable": {
    "version": [
@@ -87170,17 +87679,17 @@
     20200619,
     1742
    ],
-   "commit": "96ccf402fe8e62649f2be48a05944d552701aa5f",
-   "sha256": "031rag0y1k2f0mxjsvblnhib6qh2sxqbq85bcv8bbvb18j6k7rp9"
+   "commit": "4644980d818ec9d987f74c74b1a1d45de9ab01fd",
+   "sha256": "1mzblak9s46wsfh3l1798k9pjwbddnz030y0cfx831lfpr20227b"
   },
   "stable": {
    "version": [
     3,
     17,
-    0
+    2
    ],
-   "commit": "652d99a8ee8aa6b801e11977951fbf444cfccc8f",
-   "sha256": "18w8v2djl5fjhivc09w6ilc5npgacdxqn962q6vl5awc50crkgs3"
+   "commit": "70db61a91bae270dca5db2f9837deea11118b148",
+   "sha256": "08a7rnflhklbabqm5yyz2nwyzzfbh24miiy3wsxphaanjz4xr6yi"
   }
  },
  {
@@ -87482,26 +87991,26 @@
   "repo": "hlissner/emacs-pug-mode",
   "unstable": {
    "version": [
-    20180513,
-    2126
+    20210503,
+    147
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "685fd3414d89736bf232f5d1a6bed9e0353b98fe",
-   "sha256": "06qy9bgizc68k57avrbcl2qd2kyb8s17gr6rvxdbjknk6i55dgp4"
+   "commit": "d08090485eb8c0488a7d2fbf63680dc0880c7d2f",
+   "sha256": "1f6bhdr1a72x94dlz2i1fwwln8crc2mbpc2iq23hvsbsfmj7xfzp"
   },
   "stable": {
    "version": [
     1,
     0,
-    7
+    8
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "96718f802dad3acd5a3f770b1452b81e39f77d92",
-   "sha256": "1jqj3qfc4686v09am869ls1k3jwy397646cql4a8dg7crjdpf023"
+   "commit": "d08090485eb8c0488a7d2fbf63680dc0880c7d2f",
+   "sha256": "1f6bhdr1a72x94dlz2i1fwwln8crc2mbpc2iq23hvsbsfmj7xfzp"
   }
  },
  {
@@ -88024,15 +88533,15 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20210513,
-    450
+    20210607,
+    427
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "924167a356ee4355e39461ea62c7dbd1eac45fc3",
-   "sha256": "01p8427w6a6kw5xbkyl8wgzj4xg6k7a3acisrp986c94zwi091ml"
+   "commit": "eaf331f67ad3d6ea5b63c92bcd0cfc0134466b53",
+   "sha256": "0prrkn2yaj6wm2hn17jgfxb1vz58mdm3ivmqsncrfhl1vdll73jm"
   },
   "stable": {
    "version": [
@@ -88194,17 +88703,17 @@
     20210411,
     1931
    ],
-   "commit": "55d3cb79d846d093dba5a351d87803ad5e9b05bf",
-   "sha256": "11ji3q2zm60454x6awgp3pvkxbfbvcm725zffmi837x675rqydg6"
+   "commit": "6c7bc2b576a705fcc7bc52494163e9a1a240ea80",
+   "sha256": "1m4swr0v998c6iq589mzx6glq7g2gc109469wcsjyi9j4cv7qgkr"
   },
   "stable": {
    "version": [
     2,
     8,
-    2
+    3
    ],
-   "commit": "091cb92314dc701f10390136da78fbbb362e892e",
-   "sha256": "13qiv3v8yc2b7sfvizlnx6xcam7yjicdkfjw00q50s5xqmali22p"
+   "commit": "735c958d3b36fb5d343b7bcb81b1055a430cb042",
+   "sha256": "1m8f8qv88bvqbviszwf0n4ch5dpyqa33067ampy706cpg7mwjvn0"
   }
  },
  {
@@ -88445,14 +88954,14 @@
   "repo": "wyuenho/emacs-python-isort",
   "unstable": {
    "version": [
-    20210509,
-    1532
+    20210603,
+    2153
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "4ba3dd75e7dd9f953d8b7c0b9c4c6d1b1c263047",
-   "sha256": "0lnl4byf93ibl2g353z9pzarvqwc1q732fz5gj11gv4yfp8p6xif"
+   "commit": "339814df22b87eebca02137e581f65d6283fce97",
+   "sha256": "094nqaf60cw3kch2hka5jbbrc5b6v3z6np98w3y6690yxwx7wmz4"
   },
   "stable": {
    "version": [
@@ -88475,11 +88984,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20210408,
-    800
+    20210601,
+    1845
    ],
-   "commit": "710ffadeb43136d400de0a4c9e4a94c8b7ff36f0",
-   "sha256": "1vym8nlpwv9ym7yixldjxp999b26a9pr4z0pka28fldxykfccwq0"
+   "commit": "198ba8e15e848825b2215e9fc363f06d8c173a28",
+   "sha256": "1z6vnbnqvn20gs131d0rjncr4nk11amahvmfaffkhiwmpsl1b3gv"
   },
   "stable": {
    "version": [
@@ -88630,11 +89139,11 @@
   "repo": "jorgenschaefer/pyvenv",
   "unstable": {
    "version": [
-    20201227,
-    1623
+    20210527,
+    829
    ],
-   "commit": "9b3678bc29192d2dba64df90fbdb17393ef8d877",
-   "sha256": "1pxinj6gc0mga0sl7y5ys3xsy94c33cbgahw418c36lhj8xxx21n"
+   "commit": "045ff9476dac26086a04538d9b7ba186aa8f0fd1",
+   "sha256": "1y5jqqqh0df75qydw3h7rx24pv5z628ci8ymdksn5khl1qp5041x"
   },
   "stable": {
    "version": [
@@ -89119,15 +89628,15 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20210517,
-    1613
+    20210604,
+    1431
    ],
    "deps": [
     "faceup",
     "pos-tip"
    ],
-   "commit": "abd59fd4538f09fb201957d87887e58e377f0255",
-   "sha256": "1vs4yxxca8r7n4cjgsfzljj0kb3b3h7nl5k4yqvc8r0q0rrhyn4d"
+   "commit": "4b46a818c08820e04d25df7fe830e80ea82e1126",
+   "sha256": "0kr1sd819rvyfw34g6sqcnygkllcx07ccc5zc773kn0ngiqd0zvn"
   }
  },
  {
@@ -89746,8 +90255,8 @@
    "deps": [
     "yasnippet"
    ],
-   "commit": "9d0a1bb90ac36c689cded48b661e81d4544fd719",
-   "sha256": "15vnybyvz18scladfqy1qj6vrwx1ac38ra8ymdg938aayvl57354"
+   "commit": "969c21734dab638057fe9e284f6a51edcc3407c9",
+   "sha256": "0sdh2qaa6fb11y3h8xy0f6frisan2bkxrk68r89bq875g21z8jfr"
   },
   "stable": {
    "version": [
@@ -89837,16 +90346,16 @@
   "repo": "realgud/realgud",
   "unstable": {
    "version": [
-    20210516,
-    1047
+    20210522,
+    2151
    ],
    "deps": [
     "load-relative",
     "loc-changes",
     "test-simple"
    ],
-   "commit": "cde79dd47f25617959c6cfa059e198a565b91f77",
-   "sha256": "1rpc0viymnm5jdrl16nmvsz0y8wnca03l0nhllwidyvazbf4x5zl"
+   "commit": "7a70b27614c488be274898d0141ec82feb3a8d5a",
+   "sha256": "116f94sslg1cd5cy5w25ygazdwrrlh85pfib7692a180vk6kz8g6"
   },
   "stable": {
    "version": [
@@ -90417,8 +90926,8 @@
   "repo": "thanhvg/emacs-reddigg",
   "unstable": {
    "version": [
-    20210301,
-    2307
+    20210603,
+    2305
    ],
    "deps": [
     "ht",
@@ -90426,8 +90935,8 @@
     "promise",
     "request"
    ],
-   "commit": "196200eeccc4e821c5200c2e04429aeaafe4d536",
-   "sha256": "06q6vb0gxq323zhrq3im7xadgxgb9b8h0bxqak8xfmcnny0mcjlr"
+   "commit": "1a6eaf3d1a5e44205399526c0f425281b8d9ccc3",
+   "sha256": "070zghnrh4ywndk6bz1vd750g2nxj4rd42gphymyz8x7kazqqh1j"
   }
  },
  {
@@ -91936,14 +92445,14 @@
   "repo": "dgutov/robe",
   "unstable": {
    "version": [
-    20210520,
-    1124
+    20210608,
+    17
    ],
    "deps": [
     "inf-ruby"
    ],
-   "commit": "c9cb1abcc4caca7aa89aa61e648d323117d49d88",
-   "sha256": "1yhwlz60wqw08z04fz0rybgbh6g609pbl9n857i1cvmrhm38k3f5"
+   "commit": "bcddba77ba11b46f94730708fff2215f4b620428",
+   "sha256": "04az3rk7h606pv2l16wf2bmad9nqb7nx6r7cwap90dvnfjn56a3y"
   },
   "stable": {
    "version": [
@@ -92593,11 +93102,11 @@
   "repo": "bard/emacs-run-command",
   "unstable": {
    "version": [
-    20210323,
-    1742
+    20210529,
+    1505
    ],
-   "commit": "92b70a1ed0aa9bdbed3915efe47b3ba92fe2cb74",
-   "sha256": "1jvclzlr9lhvb05zdnqw2l3y2m1nca2m5z8m1a7rmq9bk1wwl4pa"
+   "commit": "ce2d69feeffb9ef9815ef5b5e32f236763197a10",
+   "sha256": "132gsmgqnfzx8q0f4gchjzhm3wqm5frjrsb8q9cmqsa5y2g7qjmf"
   }
  },
  {
@@ -92608,11 +93117,11 @@
   "repo": "ideasman42/emacs-run-stuff",
   "unstable": {
    "version": [
-    20210308,
-    453
+    20210522,
+    243
    ],
-   "commit": "e5ee96c50c350cf860982b7b5deff1ed8d488c8a",
-   "sha256": "0g60kk49dbn331z06gpi3c8pqjsb780iwd07bl87bgbcxcpa2fg9"
+   "commit": "767eea8928b92da032aca7c8a429b1cced46781d",
+   "sha256": "0pdjhvma0hsd8slz240bavpyzvn9mdna7lsrd1ddw3nf8xjibczq"
   }
  },
  {
@@ -92796,11 +93305,11 @@
   "repo": "Kungsgeten/ryo-modal",
   "unstable": {
    "version": [
-    20210507,
-    646
+    20210523,
+    757
    ],
-   "commit": "b44321c6fbbfc53e211083dfa565525e79f596c6",
-   "sha256": "0gwf9a4cgpl3agggaj8x6r5hmq88wghzvyh69shc378n564n1cq5"
+   "commit": "ab6417d8e546f1836618ee72d074ec65431ebc80",
+   "sha256": "1yy0jr7n55qbraxif2zhgmyr31jd5sd62jyhd3cg327vl5ga1ajg"
   }
  },
  {
@@ -92811,11 +93320,11 @@
   "repo": "magnars/s.el",
   "unstable": {
    "version": [
-    20180406,
-    808
+    20210603,
+    736
    ],
-   "commit": "3a5166c81ac9e50eaccf5490c5c632f93452287e",
-   "sha256": "131z1g43xh6z20069s6lccm08srwhwgpbiwb7fp2h29pxp41g30z"
+   "commit": "e1710af8d058faca32529d1129deb5d57871385a",
+   "sha256": "1zm9zqa1479kn74a1hbs7jc8rli7vzz5hk8k2rqpi34yf569yjhj"
   },
   "stable": {
    "version": [
@@ -93231,8 +93740,8 @@
     20200830,
     301
    ],
-   "commit": "34389b16731dbde58e9597047e2111d587ce4fcf",
-   "sha256": "073g3132h64afzl0jcxl84n60ajb7p5y547rp4349c0zlsk3fwg0"
+   "commit": "393a5f2be890c1e90b3d5f331ce1bf34dad09742",
+   "sha256": "16y5njqb9v58fmsp9nn38wvzx71jgy0di2m8933a8dkirddi324v"
   }
  },
  {
@@ -93724,6 +94233,21 @@
   }
  },
  {
+  "ename": "sculpture-themes",
+  "commit": "408a269ccf0d938c3248880c5220b5b0b979f271",
+  "sha256": "1zyiki3raldp4wnhjsnfc5rzs6pycbagfp7qjjjxz1qgqig36wbw",
+  "fetcher": "github",
+  "repo": "t-e-r-m/sculpture-themes",
+  "unstable": {
+   "version": [
+    20210530,
+    624
+   ],
+   "commit": "1da2b3501f3732b4a58d28b502e356226a43a96f",
+   "sha256": "198rjkyv876h7mbs73h8dq4lx5xhl66p7xrpvb23v0vk4vw0q5vz"
+  }
+ },
+ {
   "ename": "sdcv",
   "commit": "173e233b2dacaaf54d92f3bcc06e54d068520dd4",
   "sha256": "1bj3b17sjd9fha686g6w191l4p8a1p8sb9br65xf54n6nd9bmv7a",
@@ -94035,11 +94559,11 @@
   "repo": "raxod502/selectrum",
   "unstable": {
    "version": [
-    20210520,
-    1825
+    20210530,
+    245
    ],
-   "commit": "a922b19f715ad6d046072a35a3df5ac5e4ed73d3",
-   "sha256": "1n5qf7lh4q0j9yxxxzfx5y2dlcdni3k7bwbf7d3gp5byl46as92z"
+   "commit": "a19bbe94de492bf504399c093cfc5695eb630fa8",
+   "sha256": "0jhc0qn3q7npsixj1b1cmplxdvpy30745h32y0ybyydahqc3yc30"
   },
   "stable": {
    "version": [
@@ -94123,15 +94647,15 @@
   "repo": "wanderlust/semi",
   "unstable": {
    "version": [
-    20210214,
-    853
+    20210529,
+    1313
    ],
    "deps": [
     "apel",
     "flim"
    ],
-   "commit": "20d75302509b5fba9849e74b61c1ce93e5819864",
-   "sha256": "14qy9k64fi8asd4ka9hv5v0aa7mkdnx6252n02gldg760janr7xl"
+   "commit": "95259568446f32c1af56dfc27e3614815322a1bf",
+   "sha256": "09xld1vpxdz1kvw039g7hk89p2d8pi95j9hgls6iviwzs6ni41yl"
   }
  },
  {
@@ -94243,15 +94767,15 @@
   "repo": "twlz0ne/separedit.el",
   "unstable": {
    "version": [
-    20210420,
-    1527
+    20210521,
+    1050
    ],
    "deps": [
     "dash",
     "edit-indirect"
    ],
-   "commit": "424b0f260a1bca20cd9359c42a0bc64a1a5e1928",
-   "sha256": "1i85mbnh6ijycsgxiknzvkimxag72cxg8asg3d1g4bakv3gp32rr"
+   "commit": "900fdc33b647e92d0f464872da1b12d724de7d43",
+   "sha256": "1ji8qjg3qsxprsqjp4hks999f0rfqnl3nyj08hr4vra5nqk6x4cg"
   },
   "stable": {
    "version": [
@@ -94722,14 +95246,14 @@
   "repo": "sebasmonia/sharper",
   "unstable": {
    "version": [
-    20210328,
-    1533
+    20210523,
+    1821
    ],
    "deps": [
     "transient"
    ],
-   "commit": "70ae6071478f3e451ed9318d67a5d024c01235e0",
-   "sha256": "1fw2qn88b84v0fkaigyyipyvvhhllkw1s1h6fgv2xl2h19i8r0gd"
+   "commit": "08277b6c30568adfbe438c9f2a1d6c3db4b7ebeb",
+   "sha256": "1n0nc3g57kl5d4zh0k0gis70kd05yb2pv7kw8akmdp9q7hxs6m93"
   }
  },
  {
@@ -94940,11 +95464,11 @@
   "repo": "deech/shen-elisp",
   "unstable": {
    "version": [
-    20180915,
-    2028
+    20210530,
+    349
    ],
-   "commit": "73b74c8d6e3a2ea34b667d177d9f130765bfe501",
-   "sha256": "1ym048cmkghx373fb7n5m6r73q5nfa62m10mqr4nzhsizgyzdbrn"
+   "commit": "dabb829d0d86f454ceb3b0846cdfc11af1f91cc7",
+   "sha256": "1h7v3bbljkw7lsxz4ijvw47c6fj070j0p268v4il2xh2mzw1nhjm"
   },
   "stable": {
    "version": [
@@ -95034,11 +95558,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210329,
-    149
+    20210606,
+    124
    ],
-   "commit": "2f95627b93dd49023b1d982329b4ccf8b7854109",
-   "sha256": "0l2dh75v1vmkh738iq5japh3fmqcinsb5s7qqirxlq54gznl7qm5"
+   "commit": "0e18a7e96c8e425ac7c2e69aa26fa6a1e8e6e51a",
+   "sha256": "1jxp447d8xnk4ixpni7rsph7fd3p58ydmi39yrx201hbqh15jxiz"
   }
  },
  {
@@ -95566,14 +96090,14 @@
   "repo": "vapniks/simple-call-tree",
   "unstable": {
    "version": [
-    20180224,
-    2056
+    20210608,
+    33
    ],
    "deps": [
     "anaphora"
    ],
-   "commit": "20059eb5549408def76aeb03d0d20839903dedef",
-   "sha256": "0gvhn2r7h6jz7a3i3a8gwlmghv1xfzj0sdib25kz645iylazji4h"
+   "commit": "d776c801d773e535d1647524e2c4f63b200d8ef1",
+   "sha256": "1jh1h09l4vkzj40l8nskkilbggfl889l3rhi8b70jm4yvmk9np62"
   }
  },
  {
@@ -96321,11 +96845,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20210303,
-    1148
+    20210604,
+    937
    ],
-   "commit": "5966d68727898fa6130fb6bb02208f70aa8d5ce3",
-   "sha256": "00yk9g0gi4gsa99n2gsq41mkwgvmih52mngmk4g8ajzxsv0pbwq0"
+   "commit": "c783ba6576b554f3fc15a70bf30d225f277d1863",
+   "sha256": "1lwghrqw81dr7mhx8i92nn4xhamnpqwdvmzx1lg1fzy7g5qx7fl6"
   },
   "stable": {
    "version": [
@@ -96773,11 +97297,11 @@
   "url": "https://git.genehack.net/genehack/smart-tab.git",
   "unstable": {
    "version": [
-    20200416,
-    2228
+    20210530,
+    1743
    ],
-   "commit": "67bf4f93f8afca61a3dc4f6c7a34b0b8ca9ede21",
-   "sha256": "1ws49lbafch1rb6g0j9k5h30c9shk3vvqhbjkf4qvhaqii94lgml"
+   "commit": "2f1b4073904805c8454ebc9bc967b23836a2d577",
+   "sha256": "0fflc9f3gwf1kl3rplfb4dr10j167l85z2hwy77b4gbjzd7lp502"
   }
  },
  {
@@ -96829,15 +97353,15 @@
   "repo": "Fuco1/smartparens",
   "unstable": {
    "version": [
-    20210330,
-    850
+    20210529,
+    1129
    ],
    "deps": [
     "cl-lib",
     "dash"
    ],
-   "commit": "25f4d6d1b732f4deabf922059d22a0a7dc04bd0a",
-   "sha256": "0jaa81fk6376fpxx6k4c9nsv0dhsyk23v9c5jbhkqj3zkf1dcj4x"
+   "commit": "911cc896a0f2eb8b5fbdd6fc8331523ad9889a3a",
+   "sha256": "12g7q86ncawikvxr87p7vda21pbfiwi3kr3rgkm7b1lx3zabwcai"
   },
   "stable": {
    "version": [
@@ -97013,6 +97537,25 @@
    ],
    "commit": "fbb381758adcb000a0c304be1b797f985f00e2de",
    "sha256": "07lzr1p58v95a4n6zad8y0dpj7chbxlcmb6s144pvcxx8kjwd4dr"
+  }
+ },
+ {
+  "ename": "smithers",
+  "commit": "147ae745350bd331d43c5a29e2cc4b56481c66a8",
+  "sha256": "07hv94qgkxxbanx0v7x7m18cy7f2jxraqyc83xycizlq4dx1k2vh",
+  "fetcher": "gitlab",
+  "repo": "mtekman/smithers.el",
+  "unstable": {
+   "version": [
+    20210531,
+    2232
+   ],
+   "deps": [
+    "dash",
+    "org"
+   ],
+   "commit": "db9ed12a8d2c131b6d37b4e7aff01b8e3cec81a6",
+   "sha256": "1rk1x096akhn5rip8vp2lf0yyyybqwq3w75vkmkg4dcb9cbrwz1q"
   }
  },
  {
@@ -97322,15 +97865,15 @@
   "repo": "SpringHan/sniem",
   "unstable": {
    "version": [
-    20210515,
-    1542
+    20210605,
+    1242
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "e42d88b1b1c121b0bcfa1869c3338d7b159172a3",
-   "sha256": "1cxgyd0pssx9n1kh0b5pi4pz0ws3rq8dyg0vfidih36vglg0dplx"
+   "commit": "54005eb19dfab02f38074e696fa8d247b59a2ad8",
+   "sha256": "18ynqkf98rjyzl48l5399g49x9gdmsj0wyc4jp7mly7xrv51zblx"
   }
  },
  {
@@ -97506,26 +98049,26 @@
   "repo": "hlissner/emacs-solaire-mode",
   "unstable": {
    "version": [
-    20210327,
-    2155
+    20210601,
+    1921
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "9d143db85428c5a7798e429f3b8abd2bf3f80747",
-   "sha256": "1g5cph02m07dxpmzd72xrzm56l62zdngis6xgz385zdfj67vi9a2"
+   "commit": "2298fd806d28daf511eb7836b23775e7df1f65e2",
+   "sha256": "1jfl0nhnv3ljagdlpsi2d7mhcrm8rww8crnhzad5zimzwc48nlcq"
   },
   "stable": {
    "version": [
-    1,
-    1,
-    2
+    2,
+    0,
+    0
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4ac324ccb0b751be80ce64449553462eafab4f32",
-   "sha256": "1klyzqrlsgx8q89zx1kn5z6wnpv1dmvbglldpv1y74hxhzi6ryps"
+   "commit": "59efa9c52ec407161f741e67071813c3c1901680",
+   "sha256": "0aigavrqfi2dy4q5vrfs48n5k7839gqnafq7mp14cmcbrzcwadrd"
   }
  },
  {
@@ -97751,35 +98294,6 @@
    ],
    "commit": "7b6e108f80237363faf7ec28b2c58dec270b8601",
    "sha256": "18cwii9h2planb9bgrih4hkz2cqinbl8wq5sal4b8kwnaq07bbw7"
-  }
- },
- {
-  "ename": "sos",
-  "commit": "e8acf595ef51c928b4b41a9fea171fbfd40c080d",
-  "sha256": "1sny4wa2746fi9p18js0y9fm2f9ix7yblqyqa36ibkfj4b50hvxi",
-  "fetcher": "github",
-  "repo": "emacsattic/sos",
-  "unstable": {
-   "version": [
-    20141215,
-    403
-   ],
-   "deps": [
-    "org"
-   ],
-   "commit": "1573adca912b88b5010d99a25c83a5b2313bd39c",
-   "sha256": "19jwnny0v6ppakpaaxv9qhr6353mksh9kxiz61kp4h12n6sfrb7p"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "deps": [
-    "org"
-   ],
-   "commit": "c3906ca6872f460c0bdd276410519308626313f1",
-   "sha256": "0b5w3vdr8llg3hqd22gnc6b6y089lq6vfk0ajkws6gfldz2gg2v1"
   }
  },
  {
@@ -98291,11 +98805,11 @@
   "repo": "brailcom/speechd-el",
   "unstable": {
    "version": [
-    20200706,
-    1236
+    20210607,
+    2032
    ],
-   "commit": "058f91b4d1b0350221218656202ea80cd6827d65",
-   "sha256": "0c9k68mnwm7hhd9mj6f3p8k83kmd67rgzcr27791mnjfkhipynvb"
+   "commit": "2ffae385139936a03e1d1a96993d3bf5f9509bbf",
+   "sha256": "1kwg74qy66kwhsl2pqn4cvkrqrfdvyyaz13h4h1bqpxckb1dc05z"
   }
  },
  {
@@ -98921,11 +99435,11 @@
   "repo": "srcery-colors/srcery-emacs",
   "unstable": {
    "version": [
-    20210201,
-    1444
+    20210601,
+    1247
    ],
-   "commit": "760dc6cb854383ab087d9b924de7273deddefe6a",
-   "sha256": "15anfzsfgddrlskppk068dzlz4zkg7xyk9727a7hwg4845126q6w"
+   "commit": "58dd21cd63e4a2eed15e0082c2547069363f107b",
+   "sha256": "128ri2g7jjgpacvaxhwwv4f2h3kdzf5vv3p01yqbs23m8mri8d9w"
   },
   "stable": {
    "version": [
@@ -98968,11 +99482,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20210504,
-    632
+    20210528,
+    2053
    ],
-   "commit": "ce69158f5efb3040a00e89ffef0d1931e5038f53",
-   "sha256": "1sfrp9iwrinx1q9hm6rdb1gayn4jhqsh00c3yzg83wbdw1vl8vpw"
+   "commit": "c4ff94490dd8124e633f907f94955b30b7a4d8d4",
+   "sha256": "065n3x1mzhjgkyvy5j3fgqa75npxqp1dq05xgac9pqgcr2j09mi6"
   },
   "stable": {
    "version": [
@@ -100503,14 +101017,14 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210509,
-    1535
+    20210521,
+    1319
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "7c5d49f84f0919bbf00c53a9db48630adf8b2fbe",
-   "sha256": "1rji3p7a2f4ag4785h1k1f2ng9vi2lh8ifyh3m3j0yjihwq36m92"
+   "commit": "040d458bce4a88f37359192061bcea5ebe87007c",
+   "sha256": "0lgpawrsvihksm9cx462qa1hsmxhhv1qp0h1f9m4wn1jrcrq7r24"
   },
   "stable": {
    "version": [
@@ -100840,8 +101354,8 @@
   "repo": "countvajhula/symex.el",
   "unstable": {
    "version": [
-    20210505,
-    11
+    20210528,
+    406
    ],
    "deps": [
     "evil",
@@ -100853,8 +101367,8 @@
     "seq",
     "undo-tree"
    ],
-   "commit": "5649ff2b7c0547e20adc7d32243f5b5ef99ddf54",
-   "sha256": "05vx9470prpqj54bq90alzgq7pnf1bap7wn5j21n02hrbp647jmv"
+   "commit": "1b6466e75295bbf7847253dfb6bf580b1c68eb9f",
+   "sha256": "1rbb7zl45x9xkf05601j05vq3f3hj0nh3rbv16a3n8d0ab5qnvhr"
   },
   "stable": {
    "version": [
@@ -101232,11 +101746,11 @@
   "repo": "fritzgrabo/tab-bar-echo-area",
   "unstable": {
    "version": [
-    20210519,
-    922
+    20210525,
+    2204
    ],
-   "commit": "97272ee04dbcf11341f18845c743e355ca514a87",
-   "sha256": "1kr4n7jzqps1zchhczrdqycvj6gfrb25g2rhjg78wifhd8rsj6wj"
+   "commit": "2196e76cb6f11e6ae0f35ac8259dfb755ea60336",
+   "sha256": "1xifgdwqpf0ccmdxhdr9zxzqsa769984xs4343v657171f53flz4"
   }
  },
  {
@@ -101247,14 +101761,14 @@
   "repo": "fritzgrabo/tab-bar-groups",
   "unstable": {
    "version": [
-    20210515,
-    2206
+    20210526,
+    2044
    ],
    "deps": [
     "s"
    ],
-   "commit": "dacbebb1c4afc7d8572b9801dc7efb156afbb968",
-   "sha256": "084i2sjzjchn9hylbg7hk5b06a8wac46n2w90fh41wqzdkpagk7r"
+   "commit": "63af8dced377a346b4559145b2e6e1767263f916",
+   "sha256": "16628wjk14h99z9i822xjv8fkxra6n65nafm3cr3ci86qd00j7a2"
   }
  },
  {
@@ -101573,20 +102087,20 @@
    "deps": [
     "cider"
    ],
-   "commit": "331e14b838a42adebbd325f80f60830fa0915d76",
-   "sha256": "1jpig982z0lbbnv2167q4lfv8dhhpg698gi6i7184lrjxr7dxqw7"
+   "commit": "82f343bac637e62f31152d72086c7facd4dfea27",
+   "sha256": "0bdai4gwz8nyc26gmb10z6pq6r2gw04iflzsc476xrp56d2abgbc"
   },
   "stable": {
    "version": [
     2,
-    0,
-    3
+    3,
+    0
    ],
    "deps": [
     "cider"
    ],
-   "commit": "ce85fd9bcd008031a605ea8913577f452b49e352",
-   "sha256": "06dm6gdh10jbmyjr0y96s06qi3k12phq522pviis68qm7v2ryr47"
+   "commit": "5da72b601cb9f052f35e88c41f1a18b326c03791",
+   "sha256": "1hhwyh4qkmhc303sf4qsarpczyqihh45z2xb96m2ra5zlqnklcpp"
   }
  },
  {
@@ -101716,15 +102230,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20210511,
-    1722
+    20210607,
+    1622
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "bc57c9e27a8c8c82d17cf2a2131e386494d49a1f",
-   "sha256": "0v9297syqz42fah5ng90a26b16wq1xvm4nh5cqphx4dgb31q2s08"
+   "commit": "0fcca201db99fbe93e8b0fd404dc00fd55cd658a",
+   "sha256": "0nqx5sddfa9442dgsssp022rfarznnq69gclj4h5kk726rkf9cid"
   },
   "stable": {
    "version": [
@@ -102173,11 +102687,11 @@
   "repo": "davidshepherd7/terminal-here",
   "unstable": {
    "version": [
-    20201230,
-    1219
+    20210605,
+    1453
    ],
-   "commit": "cb561b5feb37a03a1c35708c3eebf9b51b01f7a0",
-   "sha256": "02vmy0xbssqvs97f7ypmk50hiyb7qdsbrmmnlf3mlm55c2abk73s"
+   "commit": "e0e89344624fadf080f6770132ebdd7991355fdd",
+   "sha256": "11hvyvnbr6skw6czwk8gjw9v08azf8s2kafqh5jb1nlznfghcr11"
   },
   "stable": {
    "version": [
@@ -102807,18 +103321,18 @@
     20200212,
     1903
    ],
-   "commit": "9f15dc7bd57833ba9168551c85ede1d5e7036264",
-   "sha256": "05gg1634dkl1fbl9v8izln32ak188x4b4gxp4qaapm9dlpqp9rld"
+   "commit": "a67ce1533462256ff418027a3aa56516a1139d02",
+   "sha256": "0f20x4bklq32lcwa2ihnlnb6ri884xx7dyhg62yqz9y4w8filhhv"
   },
   "stable": {
    "version": [
     2021,
-    5,
-    17,
+    6,
+    7,
     0
    ],
-   "commit": "4c4030f0f99458ff151652d8c8c41f0655dfc2d9",
-   "sha256": "0wqff7q9xkr0h9xp8f9fj7zmqqpz55p11z20q49h6rfqbwyi95wh"
+   "commit": "ec71afa89573c92de4a2a2ab87a51bd9021f5819",
+   "sha256": "0h3b89nb8sshhc52fxsgpdiqr85mfg1rpzp69qmiiwx1yz0b66wi"
   }
  },
  {
@@ -103113,6 +103627,21 @@
    ],
    "commit": "66b21934b1eb8ee428c06dd64b3562ad44776a35",
    "sha256": "1jbmc356cqmjann2wdjnikyb0l136lpjka6bjim0rjhipdnw2acn"
+  }
+ },
+ {
+  "ename": "timu-spacegrey-theme",
+  "commit": "1bebe80350df731711bc526ca9fe942410211220",
+  "sha256": "1hl91gdj52zp8w4c6zp4bzkizj3x7ssr6wl465qq3fw1k5wp8l7n",
+  "fetcher": "gitlab",
+  "repo": "aimebertrand/timu-spacegrey-theme",
+  "unstable": {
+   "version": [
+    20210607,
+    1412
+   ],
+   "commit": "34a4499fac484c369774e356373b1f4994d65176",
+   "sha256": "11cjyiwi87rv9lj09810aazxgphdhpxpfhbhzr64176vqgmb8khr"
   }
  },
  {
@@ -103750,11 +104279,11 @@
   "repo": "jorgenschaefer/circe",
   "unstable": {
    "version": [
-    20201101,
-    1045
+    20210528,
+    754
    ],
-   "commit": "2798a75d625677402b01f138ebac6eb53337d9d6",
-   "sha256": "0r7k7cxs6gfam1rdy04vdq3q796v32wv5q9gq67sxfji8x1vbkn7"
+   "commit": "c0b2f997b3b73640d635ee84627bb8cf36c9adfe",
+   "sha256": "1kjfch0fhq67iivad56s071c8qlsssdsdg83h5v9iz2x4jipm0wa"
   },
   "stable": {
    "version": [
@@ -103809,11 +104338,11 @@
   "repo": "raghavgautam/tramp-hdfs",
   "unstable": {
    "version": [
-    20201001,
-    2022
+    20210526,
+    339
    ],
-   "commit": "822c7b8a5bfca97544817d04e8a4ff1ffbaf4267",
-   "sha256": "0kxxdpmr9h0kqsylh8aj8m5arwf4m5yrkcadjssa76drhdlhcirl"
+   "commit": "aa93bdbb3d5619c262ce53af1981edcd2a0705e5",
+   "sha256": "1ar1565qhw6wx76p5p7dyb5k0lplnfbf866x2mc6kn9vydmb29za"
   }
  },
  {
@@ -103857,20 +104386,20 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20210426,
-    2141
+    20210530,
+    2252
    ],
-   "commit": "6ceddc4d8c7a3c13d78c459213c796d2c19234c6",
-   "sha256": "0dhz5ca9i83vgi3pvkbvwanxbi1ibzwbmnhm8ymxdvzn508rlswl"
+   "commit": "a96818c93a10d9ef9bb14e5c0b9fdc1a808b13b9",
+   "sha256": "1mvccsfalnr4ybsgqazxcw62vfhigxg61y6v98k2fqncnmsbripa"
   },
   "stable": {
    "version": [
     0,
     3,
-    2
+    4
    ],
-   "commit": "162698aa9d40ecafefcb1af7bdf602954d766970",
-   "sha256": "1766hdqzg95k62nqhadfv502mpnjlx1l59ppqmc6r0las82dc6a8"
+   "commit": "b47e9d7d769437e279628d801a95c173c4ff26b4",
+   "sha256": "16z0j69sk7k51sd1vri3y2v0xjj0w7wpf5mmwnsxp8y6d3m0yjbv"
   }
  },
  {
@@ -104231,8 +104760,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210518,
-    2056
+    20210606,
+    1918
    ],
    "deps": [
     "ace-window",
@@ -104244,8 +104773,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "1a396fb66470736f3f76ae9342b20357426e371f",
-   "sha256": "044p01vjb8i5c2fk5b9ji064224vxmj8d9qy9ddbik2bizqd51k1"
+   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
+   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
   },
   "stable": {
    "version": [
@@ -104281,8 +104810,8 @@
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "1a396fb66470736f3f76ae9342b20357426e371f",
-   "sha256": "044p01vjb8i5c2fk5b9ji064224vxmj8d9qy9ddbik2bizqd51k1"
+   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
+   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
   }
  },
  {
@@ -104300,8 +104829,8 @@
     "evil",
     "treemacs"
    ],
-   "commit": "1a396fb66470736f3f76ae9342b20357426e371f",
-   "sha256": "044p01vjb8i5c2fk5b9ji064224vxmj8d9qy9ddbik2bizqd51k1"
+   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
+   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
   },
   "stable": {
    "version": [
@@ -104324,14 +104853,14 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210107,
-    1251
+    20210605,
+    1118
    ],
    "deps": [
     "treemacs"
    ],
-   "commit": "1a396fb66470736f3f76ae9342b20357426e371f",
-   "sha256": "044p01vjb8i5c2fk5b9ji064224vxmj8d9qy9ddbik2bizqd51k1"
+   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
+   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
   },
   "stable": {
    "version": [
@@ -104362,8 +104891,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "1a396fb66470736f3f76ae9342b20357426e371f",
-   "sha256": "044p01vjb8i5c2fk5b9ji064224vxmj8d9qy9ddbik2bizqd51k1"
+   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
+   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
   },
   "stable": {
    "version": [
@@ -104395,8 +104924,8 @@
     "persp-mode",
     "treemacs"
    ],
-   "commit": "1a396fb66470736f3f76ae9342b20357426e371f",
-   "sha256": "044p01vjb8i5c2fk5b9ji064224vxmj8d9qy9ddbik2bizqd51k1"
+   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
+   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
   },
   "stable": {
    "version": [
@@ -104428,8 +104957,8 @@
     "perspective",
     "treemacs"
    ],
-   "commit": "1a396fb66470736f3f76ae9342b20357426e371f",
-   "sha256": "044p01vjb8i5c2fk5b9ji064224vxmj8d9qy9ddbik2bizqd51k1"
+   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
+   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
   }
  },
  {
@@ -104447,8 +104976,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "1a396fb66470736f3f76ae9342b20357426e371f",
-   "sha256": "044p01vjb8i5c2fk5b9ji064224vxmj8d9qy9ddbik2bizqd51k1"
+   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
+   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
   },
   "stable": {
    "version": [
@@ -104548,10 +105077,10 @@
  },
  {
   "ename": "tron-legacy-theme",
-  "commit": "975e93e060f50a1fd00a6ba1566a9386271bdfd6",
-  "sha256": "08cfhnkb62121h6dksw9c0d38vxm38dfbfww7c8kj491is0w63f4",
+  "commit": "f217fe20e19e1c3e249857c4fdde7a7cfde76c36",
+  "sha256": "1xy6n2rdga2if1slkqs6xdl2h8kf8h92xb03a3k99gznmgxdzcxw",
   "fetcher": "github",
-  "repo": "ianpan870102/tron-legacy-emacs-theme",
+  "repo": "ianyepan/tron-legacy-emacs-theme",
   "unstable": {
    "version": [
     20210420,
@@ -104785,14 +105314,14 @@
   "repo": "ocaml/tuareg",
   "unstable": {
    "version": [
-    20210320,
-    1929
+    20210605,
+    1629
    ],
    "deps": [
     "caml"
    ],
-   "commit": "37a673020152ae0dbcaa250118b155d84e448f68",
-   "sha256": "0b9bnfwcnxkwjrdb4vm7y8wznqz4z990pv1s473gs97l7p04b1j9"
+   "commit": "24c1a1adbe51d93f681e72442fa73f885eb33776",
+   "sha256": "1cp6g117kfmwfqb7sq4y4jx8ggp29f4hz2kz5g3355s8zhjlld2y"
   },
   "stable": {
    "version": [
@@ -105343,28 +105872,28 @@
   "repo": "undercover-el/undercover.el",
   "unstable": {
    "version": [
-    20210123,
-    2157
+    20210602,
+    2119
    ],
    "deps": [
     "dash",
     "shut-up"
    ],
-   "commit": "c36a7366aa080558125fa651ed6a28d5df735b37",
-   "sha256": "0qji4738q0yx2n0xrpk12q2akx8rgsvpfgnnfxrnk8xiywjfrqwz"
+   "commit": "1d3587f1fad66a747688f36636b67b33b73447d3",
+   "sha256": "0qmvyy3xg5qi7ws8zcs934d6afsappr1a6pgfp796xpa9vdr4y6j"
   },
   "stable": {
    "version": [
     0,
     8,
-    0
+    1
    ],
    "deps": [
     "dash",
     "shut-up"
    ],
-   "commit": "0bc3583065e49647db47d8a595fec13cb517d12f",
-   "sha256": "19d3373fy635vbfwr1yhxirwqn68qzny9byv74smxws4ly04mr02"
+   "commit": "1d3587f1fad66a747688f36636b67b33b73447d3",
+   "sha256": "0qmvyy3xg5qi7ws8zcs934d6afsappr1a6pgfp796xpa9vdr4y6j"
   }
  },
  {
@@ -106345,14 +106874,14 @@
   "repo": "diml/utop",
   "unstable": {
    "version": [
-    20210404,
-    318
+    20210607,
+    1941
    ],
    "deps": [
     "tuareg"
    ],
-   "commit": "711c24661ce625070f8981fab9c6f31ce72b0a52",
-   "sha256": "0xwc14blqzrsyp7mzza0vavbp622a86bz9na8dks5zir2fgmmaxm"
+   "commit": "bac3946079a98df00f31656dc10c6c9f1a8bc422",
+   "sha256": "1wbmr0n384501i97x0akcfwcigklwqgwvhdwgxw6zxxn5wdg60b2"
   },
   "stable": {
    "version": [
@@ -107039,11 +107568,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20210429,
-    2113
+    20210525,
+    2135
    ],
-   "commit": "a6e46f436495fb54ba57832450995425ad8dbc26",
-   "sha256": "0zm3ks1j60vdm9fqspa06fcgcz5mmz1pz4fgr21q001bi3wg8vfq"
+   "commit": "9e3e8a1edd82f7d056d3744f9e40cf8a5bac4ecc",
+   "sha256": "1kjzglpyrf1vbsb5gjcwmi5b38fvn5rx95yc8fwbizgisx70abkc"
   },
   "stable": {
    "version": [
@@ -107658,11 +108187,11 @@
   "repo": "blak3mill3r/vmd-mode",
   "unstable": {
    "version": [
-    20200727,
-    701
+    20210524,
+    27
    ],
-   "commit": "31655a41caf006c3dd64d6e57f6c4488098f8bce",
-   "sha256": "1pnx977pm305kr0zakwy1wkdfpk09rilwx8rmai4459lyz0sa8j9"
+   "commit": "b2bdf2ab54f8fc37780e6b473e4ad69c0e9ff4a6",
+   "sha256": "0wraiy5v0h1j4i31fr1b83k613c01pajq2436f93r485c2529pzp"
   }
  },
  {
@@ -107796,17 +108325,17 @@
  },
  {
   "ename": "vscode-dark-plus-theme",
-  "commit": "0e7e489ea5cee3b1d2b6b5295cf95f3e1d9d6c60",
-  "sha256": "001xhi87dsh75sd0vg26v4w78rf1p8bhj1zhn3w7j255817xvcgd",
+  "commit": "f2397ff679c9f3b03bdead7b31a0dabc1e2f8d97",
+  "sha256": "0pwmv26cassw5d5h8p82i6jm8vd85m1ffb7i31w72w1s8x5y3j31",
   "fetcher": "github",
-  "repo": "ianpan870102/vscode-dark-plus-emacs-theme",
+  "repo": "ianyepan/vscode-dark-plus-emacs-theme",
   "unstable": {
    "version": [
-    20210430,
-    819
+    20210530,
+    629
    ],
-   "commit": "24c4cb28042b3b9cc8f4e5294d7597f986aa6fae",
-   "sha256": "0b85sm6n2ahyyj220k5mqd5ar3x8204p0cfxjyhlk2f989jvfm3i"
+   "commit": "961c8c1fdd7eb874d4e2ce386d5e6d1f318b5b72",
+   "sha256": "1dga7yhb5pnqj5d86pvzbabrq05xj1ppx6g0hinhm8z6m8h6y540"
   },
   "stable": {
    "version": [
@@ -107856,14 +108385,14 @@
   "repo": "jixiuf/vterm-toggle",
   "unstable": {
    "version": [
-    20210518,
-    1528
+    20210531,
+    1453
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "d726b54332b591ed05a89f1bd765960dd49d9a59",
-   "sha256": "03mcblwwfsa5d8k6xdfjzz5hp767j3p0ng3s113i2vylq4r27jav"
+   "commit": "afe60b814d9d045b968f4a464bbedb241b35392b",
+   "sha256": "007spqyc474k8fxi6l3s0jh8dg18d9b07wvz3lvbyrgdqwdw2a0p"
   }
  },
  {
@@ -108077,11 +108606,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210507,
-    231
+    20210606,
+    2300
    ],
-   "commit": "2f95627b93dd49023b1d982329b4ccf8b7854109",
-   "sha256": "0l2dh75v1vmkh738iq5japh3fmqcinsb5s7qqirxlq54gznl7qm5"
+   "commit": "0e18a7e96c8e425ac7c2e69aa26fa6a1e8e6e51a",
+   "sha256": "1jxp447d8xnk4ixpni7rsph7fd3p58ydmi39yrx201hbqh15jxiz"
   }
  },
  {
@@ -108725,14 +109254,14 @@
   "repo": "emacs-love/weblorg",
   "unstable": {
    "version": [
-    20210430,
-    2251
+    20210526,
+    129
    ],
    "deps": [
     "templatel"
    ],
-   "commit": "11ec801222eeb468878e6585efb55721592dbfe8",
-   "sha256": "01ipk5fwx5phsd6kr7kvdckhd19hly4szwlwl1a0jaxy0ab6iv54"
+   "commit": "ffea6a93f5d35fed8532f1187463a27eb46bff0a",
+   "sha256": "185crf3dgfqjq58s2bvdmvff5vmy73v4m4l2d17iwjyw3ifji5a8"
   },
   "stable": {
    "version": [
@@ -108911,11 +109440,11 @@
   "repo": "jstaursky/weyland-yutani-theme",
   "unstable": {
    "version": [
-    20210518,
-    1738
+    20210530,
+    1418
    ],
-   "commit": "7e9b8d930b22900030f76b1e109ce64eb275b793",
-   "sha256": "06qimv5pxyz6rqz7v5fjkji3ay2cxs7h9bqf2y2jxpy6zsdy851m"
+   "commit": "a56c56de048900409d271f91fd08a408fd9bf32e",
+   "sha256": "0nblkcz52qvfkf4q3yb7drv0rbpkqgzv3clwb6vkvwz13s29b6my"
   }
  },
  {
@@ -109085,11 +109614,11 @@
   "repo": "justbur/emacs-which-key",
   "unstable": {
    "version": [
-    20210407,
-    28
+    20210601,
+    252
    ],
-   "commit": "5fb30301cb3b4fca5a0e1ce8ec1ef59290b79199",
-   "sha256": "1wgygby4zwlbx6ry6asraaixl169qdz092zgk1brvg63w7f8vkkb"
+   "commit": "fc29864395fdaf688e2ef5111831663bad89a020",
+   "sha256": "1adv32z8dmpygbrk14l1pj2535c10ncv8znfzgi1s908ds20kad1"
   },
   "stable": {
    "version": [
@@ -109418,15 +109947,15 @@
   "repo": "progfolio/wikinforg",
   "unstable": {
    "version": [
-    20210126,
-    405
+    20210602,
+    1459
    ],
    "deps": [
     "org",
     "wikinfo"
    ],
-   "commit": "2eb31ab00e4c8ad53dc15234f29527b9f0f54d71",
-   "sha256": "0sghvnvbbv3d7kdvcv2dbbzbv38b3jjzbrhjv6fn5lynyr929vqr"
+   "commit": "3aecd23e68b9117a03c65fafa85a0805b58609d1",
+   "sha256": "0m1fj06x9r941k2842v2091xbff89wp704ifrcdgb6zbksx5d8i2"
   }
  },
  {
@@ -109837,23 +110366,20 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20210427,
-    1244
+    20210524,
+    1654
    ],
-   "commit": "86bdff68a106bc9d383fdab3bbf1ad4b703a52f0",
-   "sha256": "1rk8vza2g8gxybhjk10xj3pw9whc80cs9qv4avyv926g7dw60as9"
+   "commit": "5519b6a67ecd66865b4fdd5447425eee900c54f4",
+   "sha256": "1bmvkrfnjzrf0ch2mh75cv784mzs64i4f44l91xysapjqv46lfqn"
   },
   "stable": {
    "version": [
     3,
     0,
-    2
+    4
    ],
-   "deps": [
-    "async"
-   ],
-   "commit": "6735180e73e787b79535c245b162249b70dbf841",
-   "sha256": "0hw6i5r3adkm4988badi94825lywkrh3sddiff4z04kj1nj15d0k"
+   "commit": "5519b6a67ecd66865b4fdd5447425eee900c54f4",
+   "sha256": "1bmvkrfnjzrf0ch2mh75cv784mzs64i4f44l91xysapjqv46lfqn"
   }
  },
  {
@@ -109943,23 +110469,19 @@
   "repo": "DarwinAwardWinner/with-simulated-input",
   "unstable": {
    "version": [
-    20210514,
-    349
+    20210527,
+    2320
    ],
-   "commit": "c377a673c86cdedd5d48418caf8f1ce621aca767",
-   "sha256": "10ms0cqxvicjs9lsbiy8h0hphx2dikr6bf1npybqwi7g643f2jzk"
+   "commit": "0f43fe46d4ab098c18a90b9df18cb96bab8e4a35",
+   "sha256": "0im6a1nr75mgz13zjavwycd5zsm5ysz5flbsmka7i8bkn2js1fm1"
   },
   "stable": {
    "version": [
-    2,
-    4
+    3,
+    0
    ],
-   "deps": [
-    "s",
-    "seq"
-   ],
-   "commit": "3d881793521c5618cdb0968a85879e0e49da7fca",
-   "sha256": "12d3mhvzj74qwc4rdcb236jbqnf5lam8pk78j92kwbwjk1jaz2cf"
+   "commit": "ee4d2b75fd99bac3de40675b0a0e03529718f59f",
+   "sha256": "0n8h84whsh0aph8xhn9plprix9f6bysgvarz2anz7kwns19js6s4"
   }
  },
  {
@@ -111438,20 +111960,20 @@
   "repo": "zkry/yaml.el",
   "unstable": {
    "version": [
-    20210424,
-    2033
+    20210604,
+    1500
    ],
-   "commit": "d0abc17e3ddf42624d87fa6d2d3e1ba1dd175035",
-   "sha256": "19937d26gvj5ir1absb8rxyv35ac85xwvgb0nqcldmnqxqa2h66p"
+   "commit": "5b352258f50ec9d2e7ff8bd16323a24fb484b52b",
+   "sha256": "1zaj7w0jfzz7iwsnd8ql3pxgiw108dx0ggk2q5rqxdz5902hksqs"
   },
   "stable": {
    "version": [
     0,
-    2,
-    1
+    3,
+    2
    ],
-   "commit": "d8ac09e8cad7f67339e19c53e77da1cd0ff98d36",
-   "sha256": "0wkrvhb5yhb38sf7w1njxij1x0pfxp56hn97j2bk4w58dz94fxir"
+   "commit": "5b352258f50ec9d2e7ff8bd16323a24fb484b52b",
+   "sha256": "1zaj7w0jfzz7iwsnd8ql3pxgiw108dx0ggk2q5rqxdz5902hksqs"
   }
  },
  {
@@ -111462,26 +111984,26 @@
   "repo": "knu/yaml-imenu.el",
   "unstable": {
    "version": [
-    20201023,
-    1524
+    20210530,
+    251
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "fa37d9bf8a09af144980a42cc22891b1555a12ae",
-   "sha256": "08v2wxdcp5f43vl8976bn3lsiqkaph4driczgc0bw9p495fljb2p"
+   "commit": "01741205fb33d2ed511502d1cd65a711e07a3117",
+   "sha256": "1z8yzi322y8wnvci77xp7fb7x5l3z8zy1ng4zaa1z856va8x2971"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    3
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "fa37d9bf8a09af144980a42cc22891b1555a12ae",
-   "sha256": "08v2wxdcp5f43vl8976bn3lsiqkaph4driczgc0bw9p495fljb2p"
+   "commit": "01741205fb33d2ed511502d1cd65a711e07a3117",
+   "sha256": "1z8yzi322y8wnvci77xp7fb7x5l3z8zy1ng4zaa1z856va8x2971"
   }
  },
  {
@@ -112467,15 +112989,15 @@
   "repo": "EFLS/zetteldeft",
   "unstable": {
    "version": [
-    20210520,
-    724
+    20210602,
+    841
    ],
    "deps": [
     "ace-window",
     "deft"
    ],
-   "commit": "bf46e764ed799d08e27c84e2c79cc643cab61322",
-   "sha256": "0x930i82090nfypm2qm60fx50y2ixv2b9szzz1ab07bb42ikpic2"
+   "commit": "b71f24d382887aeefde9c47fb6aa521d0ebeb806",
+   "sha256": "09wy2gllacry2n0cp52fakaa36lnd1mnbb26zysdjxh0429siy4a"
   },
   "stable": {
    "version": [
@@ -112529,11 +113051,11 @@
   "repo": "ziglang/zig-mode",
   "unstable": {
    "version": [
-    20210412,
-    1428
+    20210605,
+    513
    ],
-   "commit": "2d0eb23e6b5c12b946f12c23803157605c90f02f",
-   "sha256": "0lpsqclk37nx8i9jfskbnvxrhvh6vaflgh63xijhv9ajx2iwpw0r"
+   "commit": "0babe7ec524f59d57c01e2fc66294d1afa01f5eb",
+   "sha256": "0balv7ggz10izjw7r6z9vx17qq88229jdzpsjas6z37gk61bfngk"
   }
  },
  {
@@ -112989,6 +113511,24 @@
    ],
    "commit": "406967322b7692492a5942d901335d626cace4d0",
    "sha256": "1nn6dvzcayh6nv6xn3siv09iixc5c3gy9c8y1fdwzq81yny9l2fr"
+  }
+ },
+ {
+  "ename": "zprint-format",
+  "commit": "54457e29def6ecfdf96f599e6a007f5ebee485b9",
+  "sha256": "1flb1i5byp6s8fj1vpgm5wc43f8hld7rg940m20a40ysr1x35szk",
+  "fetcher": "github",
+  "repo": "dpassen/zprint-format",
+  "unstable": {
+   "version": [
+    20210602,
+    146
+   ],
+   "deps": [
+    "reformatter"
+   ],
+   "commit": "6051a5709ea6182974d7239f26e04c9731e04447",
+   "sha256": "1in5cyrj0kn1fdfcw7iaxhsxx5hn3r3r0aiida8p9dvkx8kq540l"
   }
  },
  {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -25,26 +25,26 @@
  },
  {
   "ename": "0x0",
-  "commit": "a48b10b770038efc606fbbbedf79178d3b05186c",
-  "sha256": "1nkc5hfz77s37a1rp8m69f7zbk05jc1y1fcj0b46h9khyz6zbm01",
+  "commit": "982788433004ba644a372c50130613e3c56bba10",
+  "sha256": "0447s6jq57g0p5myb295930wyqk7q5qj00r8qi3l39670xsgbqdl",
   "fetcher": "git",
-  "url": "https://git.sr.ht/~zge/nullpointer-emacs",
+  "url": "https://git.sr.ht/~pkal/nullpointer-emacs",
   "unstable": {
    "version": [
-    20210512,
-    1001
+    20210628,
+    1207
    ],
-   "commit": "655846fd3ce772950d30167b4b9be6ce64502ae7",
-   "sha256": "0y4v72pmjjly2kxrrwks2z35qbc76109pnqpj637fpjr190c468l"
+   "commit": "a613afa08271a75551a4d2165b4ab872b131edc0",
+   "sha256": "1ngaq8ldyv9h0g5c83y4g5z1a19z4k90dha5y4g7v3lpzmqx4jgn"
   },
   "stable": {
    "version": [
     0,
     4,
-    2
+    3
    ],
-   "commit": "655846fd3ce772950d30167b4b9be6ce64502ae7",
-   "sha256": "0y4v72pmjjly2kxrrwks2z35qbc76109pnqpj637fpjr190c468l"
+   "commit": "ab3e213607e6349aecc0063332972ac40506edd9",
+   "sha256": "1aywyarjl8fghy5py05rd64sidhkla0xzks1596p1gwpk5pm7n0n"
   }
  },
  {
@@ -741,10 +741,10 @@
  },
  {
   "ename": "ac-html",
-  "commit": "3416586d4d782cdd61a56159c5f80a0ca9b3ddf4",
-  "sha256": "1vidmvylwwvraf8k63dvxv47ism49n6pp0f38l5rl4iaznhkdr84",
+  "commit": "28430d3db6e21cec8b138ef09320aeed711e58f9",
+  "sha256": "1fhrvww7sds90b4ka16sp79pjbjwrrl6ycp65pfc4b2cg1bq1w7m",
   "fetcher": "github",
-  "repo": "zhangkaiyulw/ac-html",
+  "repo": "victorteokw/ac-html",
   "unstable": {
    "version": [
     20151005,
@@ -1029,8 +1029,8 @@
     "auto-complete",
     "yasnippet"
    ],
-   "commit": "9770c95bf2df93d9cb0f200723b03b3d9a480640",
-   "sha256": "188z1i209z61nwfcgffgp90rdcsnl75izxpqv4x1vbaay5fvg33f"
+   "commit": "8a0dc9888de87ea3aace06628bff52ed32f3ca2b",
+   "sha256": "1xcsm72by6jiqr9y9fyk70nshsj5dj494faz9734m67fmxq45pfj"
   },
   "stable": {
    "version": [
@@ -1055,8 +1055,8 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20210218,
-    559
+    20210617,
+    949
    ],
    "deps": [
     "dash",
@@ -1066,8 +1066,8 @@
     "s",
     "xcscope"
    ],
-   "commit": "9770c95bf2df93d9cb0f200723b03b3d9a480640",
-   "sha256": "188z1i209z61nwfcgffgp90rdcsnl75izxpqv4x1vbaay5fvg33f"
+   "commit": "8a0dc9888de87ea3aace06628bff52ed32f3ca2b",
+   "sha256": "1xcsm72by6jiqr9y9fyk70nshsj5dj494faz9734m67fmxq45pfj"
   },
   "stable": {
    "version": [
@@ -1133,8 +1133,8 @@
     "auto-complete",
     "rtags"
    ],
-   "commit": "63f18acb21e664fd92fbc19465f0b5df085b5e93",
-   "sha256": "0wzyn9qzyly71yfwhlk5m94ygjnbk459pgbpgkhp9fqgchx12p1r"
+   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
+   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
   },
   "stable": {
    "version": [
@@ -1507,14 +1507,14 @@
   "repo": "mrkkrp/ace-popup-menu",
   "unstable": {
    "version": [
-    20210318,
-    1748
+    20210608,
+    839
    ],
    "deps": [
     "avy-menu"
    ],
-   "commit": "9a2056c53faba0bd7b7f44fb3faabf4d34b8497f",
-   "sha256": "0i7a708y9x4xdny3ccqwngn4la5vg0539c7qk87d163gl61mbk7k"
+   "commit": "594a305704be8ca0ef79a12b787bdb59bc6077c0",
+   "sha256": "1ykpb4l29iw5bxmip9cn6irgiak2hwb79kg1k5m32wc9p6b4kbjf"
   },
   "stable": {
    "version": [
@@ -1929,30 +1929,28 @@
   "repo": "agda/agda",
   "unstable": {
    "version": [
-    20210505,
-    1142
+    20210619,
+    545
    ],
    "deps": [
     "annotation",
     "eri"
    ],
-   "commit": "044843c5281a7bdb9479317793a75c8c0fcfadd9",
-   "sha256": "04lirb2p1h46c1l84ysdnr2jxvzsdw1zv6jhm7h8ybgzmaa65b6m"
+   "commit": "007a26fb5f7d9eb54db16484fb116d6e47c8cc5e",
+   "sha256": "1w9pra3qqmidsf5mvp0lmk9liw1ryaf8kjiawfgyyc6mzgw6nrvz"
   },
   "stable": {
    "version": [
     2,
     6,
-    1,
-    3,
-    20210605
+    2
    ],
    "deps": [
     "annotation",
     "eri"
    ],
-   "commit": "ab805592a0ae7066fbd5fa5f47e933194fce878f",
-   "sha256": "19ld12x4is0nx52i05zv20js0zysx3bljbdn2nr65vy11dq2cyyp"
+   "commit": "246a229faea2ef2fa53caf491ff8a2d72dd7510c",
+   "sha256": "1ccmryw6vs8d87d5zmjl0kr2kvyd1zxl73344fa7yzqgg2kw1da6"
   }
  },
  {
@@ -2323,8 +2321,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "df5664e71c1026af4aaf69e6b227d427a728e7c6",
-   "sha256": "1czy3sbwm6lfrgdbj0y12q4n70w6zg8g3y27iz1zr4y20hhcp2zk"
+   "commit": "bf859fdb80a46c6d0d9fd8f8540a8ae96d5c1016",
+   "sha256": "1bp3q84alqwkglifhwc5kcrb2dc22kjd3l0h9r0bh1klz70sjss4"
   },
   "stable": {
    "version": [
@@ -2451,14 +2449,25 @@
   "repo": "wyuenho/all-the-icons-dired",
   "unstable": {
    "version": [
-    20210422,
-    921
+    20210614,
+    1350
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "a294f45ec2c338e1255ae2dd98b19f3f143204e6",
-   "sha256": "1m3gqsgybx57qhdlswbn92cnsz9w10sqfzs2lnja63hzwzwxjg92"
+   "commit": "a758766878b6e8b9eaaf41d68599a2df99e37f48",
+   "sha256": "1shla7nyhml9m3g81p6yy8k4pdq289gb42900xzfp7zl4qvnm2vy"
+  },
+  "stable": {
+   "version": [
+    2,
+    0
+   ],
+   "deps": [
+    "all-the-icons"
+   ],
+   "commit": "a758766878b6e8b9eaaf41d68599a2df99e37f48",
+   "sha256": "1shla7nyhml9m3g81p6yy8k4pdq289gb42900xzfp7zl4qvnm2vy"
   }
  },
  {
@@ -2550,28 +2559,28 @@
   "repo": "seagle0128/all-the-icons-ivy-rich",
   "unstable": {
    "version": [
-    20210605,
-    1700
+    20210626,
+    1956
    ],
    "deps": [
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "e0eba9cb8f8c85c0b63434f6117f9fa232d8a890",
-   "sha256": "05a53s7v1vy688gwnn01p3flqlhznp2m0k1mg8ax4hjygyc05l8q"
+   "commit": "07b8c5271719afa6a4c598c2a19f4a096ca6efe8",
+   "sha256": "1blr46w08s9f3wrcarqds09is9akdsq8faghshby5fnk9s5srkq3"
   },
   "stable": {
    "version": [
     1,
-    5,
-    1
+    6,
+    2
    ],
    "deps": [
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "0138c7e7f3b7a6c09665e45a6dd2168359efd47c",
-   "sha256": "0nbbkasbklxf62rx9mc5w37r014vdbbg3vm5dy03hxzvq3y1yrpn"
+   "commit": "07b8c5271719afa6a4c598c2a19f4a096ca6efe8",
+   "sha256": "1blr46w08s9f3wrcarqds09is9akdsq8faghshby5fnk9s5srkq3"
   }
  },
  {
@@ -3150,11 +3159,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20210519,
-    1401
+    20210620,
+    751
    ],
-   "commit": "b22f594f3b813b12e442860344d2feb39d944b53",
-   "sha256": "1911j82vw8pp58byc41v2fhbjvr3l9rdjqa46gs757xssh0g8jal"
+   "commit": "9aba6305fef54f32b085a56ce2b843b3d8194ac2",
+   "sha256": "1n2pgvc4fw8r22ck2r3jmkrrh1vlwv1r35ljy5g3b95zjh11w7g4"
   },
   "stable": {
    "version": [
@@ -3192,19 +3201,17 @@
     20200914,
     644
    ],
-   "commit": "044843c5281a7bdb9479317793a75c8c0fcfadd9",
-   "sha256": "04lirb2p1h46c1l84ysdnr2jxvzsdw1zv6jhm7h8ybgzmaa65b6m"
+   "commit": "007a26fb5f7d9eb54db16484fb116d6e47c8cc5e",
+   "sha256": "1w9pra3qqmidsf5mvp0lmk9liw1ryaf8kjiawfgyyc6mzgw6nrvz"
   },
   "stable": {
    "version": [
     2,
     6,
-    1,
-    3,
-    20210605
+    2
    ],
-   "commit": "ab805592a0ae7066fbd5fa5f47e933194fce878f",
-   "sha256": "19ld12x4is0nx52i05zv20js0zysx3bljbdn2nr65vy11dq2cyyp"
+   "commit": "246a229faea2ef2fa53caf491ff8a2d72dd7510c",
+   "sha256": "1ccmryw6vs8d87d5zmjl0kr2kvyd1zxl73344fa7yzqgg2kw1da6"
   }
  },
  {
@@ -4517,30 +4524,6 @@
   }
  },
  {
-  "ename": "auth-source-pass",
-  "commit": "6e63342b442794ead4d8bed803b0924d9cd26dc4",
-  "sha256": "10l3kbffy08fh0krwvh4gn75k37criv2ma5hgkadvq1s2p5ps8r6",
-  "fetcher": "github",
-  "repo": "DamienCassou/auth-source-pass",
-  "unstable": {
-   "version": [
-    20210210,
-    1908
-   ],
-   "commit": "fa8b964494c1ef42035fad340ff5f29fcdbed21c",
-   "sha256": "0fn30iy1jy0kh09652a0fn7zg93cf3xvs2bz28lml7knj2hbqi2r"
-  },
-  "stable": {
-   "version": [
-    5,
-    0,
-    0
-   ],
-   "commit": "df074612114c3cc2fa1c3023f26ff182f9b1190a",
-   "sha256": "0qnqqdpbfr06nqw4hq7c1s7yh7zyrv4gqjj06v70cavjml7pagp6"
-  }
- },
- {
   "ename": "auth-source-xoauth2",
   "commit": "8ba0273c8aa2a50b9dc9b8312b860d94dfd808d5",
   "sha256": "0g06240ix4gzw3fb74jcadiq7nissi20i1vsbzhkx35j10mv7wn3",
@@ -4605,14 +4588,14 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20210518,
-    1020
+    20210615,
+    1457
    ],
    "deps": [
     "packed"
    ],
-   "commit": "3af0b02393ca4f207f1e454161f7bd8a747f3051",
-   "sha256": "1h2iv14ppj5pqbnb7z7xvw1jm3cmis10jpqnd6miax1s6jlm8z0r"
+   "commit": "0f3afc6b057f9c9a3b60966f36e34cb46008cf61",
+   "sha256": "0grb9y7v7ibbcjv1yhssnavz43cij16ys5c68my8mv12wg5ld86z"
   },
   "stable": {
    "version": [
@@ -4964,19 +4947,22 @@
   "repo": "jcs-elpa/auto-highlight-symbol",
   "unstable": {
    "version": [
-    20210108,
-    1841
+    20210629,
+    1535
    ],
-   "commit": "5ad84d0a12b175360b18504cd04e6bf7ab1cf5c8",
-   "sha256": "0dpsqzl6nn08kg9d42a6zpk7jq6621c0hzf28c1ary4vzcwm4j9v"
+   "deps": [
+    "ht"
+   ],
+   "commit": "45c472cf72df1d477550dcc07e556047b2fc5852",
+   "sha256": "1xbkcpidmzlbv3qs8r9i880pbkf7w78xagh85nvcrv965ra66k6c"
   },
   "stable": {
    "version": [
     1,
-    59
+    60
    ],
-   "commit": "0982390f19fee3c05856b9e4e40056dce4c4020d",
-   "sha256": "1vvk0vp61y63rjhfxk5ajs0m4p36pvbwb97sw66zdlrq5h33lmv9"
+   "commit": "d5125800b038d1275aabd14008ede75a3a858587",
+   "sha256": "1mi4mayfavkfm9fkg1j1wcv6kvb2cfgf5nr5kk15jhy7x1ajwphp"
   }
  },
  {
@@ -5111,11 +5097,11 @@
   "repo": "jcs-elpa/auto-rename-tag",
   "unstable": {
    "version": [
-    20210418,
-    1758
+    20210629,
+    1537
    ],
-   "commit": "8dbf13b344f6d5eba5c4876b18905d30b3118bb9",
-   "sha256": "1nlwg78d60w6xjpqhrc49nxxvjaxj07wb036rb5jsng9yb6r94m9"
+   "commit": "ac7b7183c5e84da110e2f4850c5d8bc5325d058a",
+   "sha256": "1hzh6ajccmkc2p5kcbl7vjh16rdh4nw3kmncw8ca32ij3l01rmb1"
   },
   "stable": {
    "version": [
@@ -5313,10 +5299,10 @@
  },
  {
   "ename": "autocrypt",
-  "commit": "c5aac210984709f020f96f3ca166185900accddf",
-  "sha256": "1y5p5n2p2qk638i1as3wbfz82r08jv4q91470xz9r1gkdnn1xyx8",
+  "commit": "982788433004ba644a372c50130613e3c56bba10",
+  "sha256": "0ngdxqski3q4mqsrw8h07mkm58kwrvpxvclgyhq2jypvcvlb7abg",
   "fetcher": "git",
-  "url": "https://git.sr.ht/~zge/autocrypt",
+  "url": "https://git.sr.ht/~pkal/autocrypt",
   "unstable": {
    "version": [
     20210412,
@@ -5325,8 +5311,8 @@
    "deps": [
     "cl-generic"
    ],
-   "commit": "5b55f8d37545e9c441788627c17e350d7edf4055",
-   "sha256": "0b06xnjkgwjpxl96mdi674pmvdaiwncifi1a30wxhl1dwr7kr084"
+   "commit": "1dc4e5983382093fc74c81d84a45cd2b53adfd90",
+   "sha256": "0r99h100v43i7wr2c1jqgyzixlc1y973swwfa9cfmnaxck3ibk93"
   }
  },
  {
@@ -5530,8 +5516,8 @@
     "avy",
     "embark"
    ],
-   "commit": "ef609bf15368a68c4eb3c46fd8cc1bb623b6b83e",
-   "sha256": "0ddh7zqgaq07534l6m3wjvbcj23a01h3x7scd4pl5rj6wyxqwv76"
+   "commit": "acbe1cba548832d295449da348719f69b9685c6f",
+   "sha256": "0c1zqfrn2va2m9z6rw3i2h6dwm2vc0asbha4d9r0gss4b7519pf2"
   },
   "stable": {
    "version": [
@@ -5771,19 +5757,19 @@
   "repo": "juergenhoetzel/babel",
   "unstable": {
    "version": [
-    20210520,
-    501
+    20210612,
+    640
    ],
-   "commit": "1f68c175e8a3223f37858167239051e9ab9e540c",
-   "sha256": "1b13pfxabfcl8p3j6bw6c5m2njzignab4p6fzxfmfpsvrq5yjzfz"
+   "commit": "946e69c61188bc41793402ac48466d8967ddb43d",
+   "sha256": "0drqcvkak677r2bc8jr0bp0qv3x2iw5cvlma6ir2blgm1d3q2bg3"
   },
   "stable": {
    "version": [
     1,
-    4
+    7
    ],
-   "commit": "65b55ad89017c9b3a1c8c241ac4b4541eabdaf5f",
-   "sha256": "0px1xggk6qyrwkma1p3d7b4z2id2gbrsxkliw3nwc1q4zndg1zr7"
+   "commit": "a6028ec6780f22b5b15c4458d968f7b49be3974b",
+   "sha256": "1vbhmrgcbrqj079g40w43xya4yc38ddhfn6wrd75s77qzmhrczll"
   }
  },
  {
@@ -6115,11 +6101,11 @@
   "repo": "szermatt/emacs-bash-completion",
   "unstable": {
    "version": [
-    20201011,
-    916
+    20210615,
+    1601
    ],
-   "commit": "65e54c6f9c0ffebf94f7c505694bd249b9b53d32",
-   "sha256": "0aj110pmx6f11flmyk8ryj4mghjay2wbix945wisrlydlnl9jmmc"
+   "commit": "d9c97b741db389ceb127b0f0180b2087cb24d0ef",
+   "sha256": "15m7gbwq1lmca2rlfb2ik86ibmvjnj58yajbp5d23xn03qqd6x6c"
   },
   "stable": {
    "version": [
@@ -6987,8 +6973,8 @@
     "a",
     "pdf-tools"
    ],
-   "commit": "246120647e28a27506ca0894ba98e371086881fd",
-   "sha256": "15gqzj4h0w33w38i8ihl74iy7aqxlds97gm93r72z69pm2l1d7dm"
+   "commit": "8a3b529d5ece261a8847298ea03ed35615cc9bfa",
+   "sha256": "16zalqjd2llwkp7v0218crgf3k34py8zx6lj6z7i3kbmxm9nb27q"
   }
  },
  {
@@ -7036,14 +7022,14 @@
   "repo": "bdarcus/bibtex-actions",
   "unstable": {
    "version": [
-    20210607,
-    1230
+    20210625,
+    1718
    ],
    "deps": [
     "bibtex-completion"
    ],
-   "commit": "07a3c64b12673b722a21c932eb85c595dea0c863",
-   "sha256": "0afnb0aa3msnvg2p4pjdcliccsfhaa7pp7bx76h3sfvv4648kki5"
+   "commit": "ee09acded11c160001e60c47de700e5fee6e9426",
+   "sha256": "0i4476gydsyandyb3r53hk8izx9jpmg03ny8f4glxcvlsm1ysvzf"
   },
   "stable": {
    "version": [
@@ -7119,11 +7105,11 @@
   "repo": "tarsius/bicycle",
   "unstable": {
    "version": [
-    20201028,
-    1854
+    20210615,
+    1459
    ],
-   "commit": "e3fbc0737bb5f891e4d57d048bbc1fe17401f17f",
-   "sha256": "1jgrnd3yxaqgd3rxls41xxzfaq9hkmjk9wbdg06ak9h5xw4fi17j"
+   "commit": "2f0d6fbe0e363a0ed1f878316d1c0d7c1d6e1082",
+   "sha256": "1zlbz5kkqz4r3a2d5y563s1isbs1328kjjrfmn69gwd6w2zi5pii"
   },
   "stable": {
    "version": [
@@ -7490,8 +7476,8 @@
     20200404,
     1550
    ],
-   "commit": "d99ab1aad84e4bd2bd4a499877764c213cce50ff",
-   "sha256": "0ay49ars61vr43n4bd3k4n1w89ilmw7d8s53ifixgw0vvjkz74z1"
+   "commit": "8f7cd388abccdf25baeca99c07ef2dfe264e8f2f",
+   "sha256": "16c4scmc7csb34c237m04fc2w252lvqiwjcz65bjmf077g1ipd7q"
   },
   "stable": {
    "version": [
@@ -7963,15 +7949,15 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20210530,
-    1158
+    20210618,
+    2112
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "e2263534e16ed8bbc935ee466f6ad2acbe9c603e",
-   "sha256": "169sdgi476hnxxv0s9qfi8cply9q7gb8i1hli4i74ynlrhc9wfq7"
+   "commit": "6ea061f30065493e206132ff3f7a2d8febb859d0",
+   "sha256": "0m7c512r789pbx2qgzx1zgbr2w4y6ma8l7zhvslji57hzhcvj10y"
   },
   "stable": {
    "version": [
@@ -8570,16 +8556,16 @@
   "repo": "countvajhula/buffer-ring",
   "unstable": {
    "version": [
-    20210529,
-    2059
+    20210624,
+    1642
    ],
    "deps": [
     "dynaring",
     "ht",
     "s"
    ],
-   "commit": "30572b4d8fff519c4996078a5ad743583fb22b0e",
-   "sha256": "1xg6kbjj4fccsr5awnh3ba9x33qznnala3kmnfwpmj94rd72whiy"
+   "commit": "4a226bc410ec7b5b0323879b03aad73be1b69728",
+   "sha256": "02l4wh4qykbk58cda8l3cyg4lpf5zjr0ss4927ac48nlxnawcrsa"
   },
   "stable": {
    "version": [
@@ -8925,14 +8911,14 @@
   "repo": "alphapapa/burly.el",
   "unstable": {
    "version": [
-    20201211,
-    58
+    20210621,
+    845
    ],
    "deps": [
     "map"
    ],
-   "commit": "291c2b34eee255f64c0fd889b67dc11a3b69ef12",
-   "sha256": "0a9k47xn9fhhw6rl73gri2ykzag5c68drfc7c4r0f1nqp61smkkv"
+   "commit": "c6d6aaeded0ef892af307652503de21db2a2a5b3",
+   "sha256": "1ic6qgmcj4l7a4775wwz45qwadj4ha4z3v2qlr4s54hzzldwc9w7"
   },
   "stable": {
    "version": [
@@ -9202,11 +9188,11 @@
   "repo": "lassik/emacs-c-eval",
   "unstable": {
    "version": [
-    20210603,
-    1716
+    20210611,
+    705
    ],
-   "commit": "f79be8354a3c01fddbf38b731aa8934421cef22f",
-   "sha256": "1qpi5j2h9q4khp3kbk4ybsg4mp2cp5kws5fz7bjpxz4iz0s8mbx7"
+   "commit": "fd129bfcb75475ac6820cc33862bd8efb8097fae",
+   "sha256": "1xfgjc0j8ck03278n014mvf768m68knyawrc3lmybr2gj04b4cz9"
   }
  },
  {
@@ -9426,20 +9412,20 @@
   "repo": "unhammer/calendar-norway.el",
   "unstable": {
    "version": [
-    20180906,
-    1502
+    20210608,
+    1136
    ],
-   "commit": "8d1fda8268caa74ba5e712c7675ed3c34e46e2d4",
-   "sha256": "011c8pz1g805a7c3djai39yasd2idfp4c2dcrvf7kbls27ayrl6d"
+   "commit": "4dd8c38ef30ad45931c8ae7bcdfd720c3fcffffc",
+   "sha256": "02xf57dincpn7km1f3c9dnq2qv6lk07m9z5hilm3nnns0wwzqdyw"
   },
   "stable": {
    "version": [
     0,
     9,
-    4
+    5
    ],
-   "commit": "8d1fda8268caa74ba5e712c7675ed3c34e46e2d4",
-   "sha256": "011c8pz1g805a7c3djai39yasd2idfp4c2dcrvf7kbls27ayrl6d"
+   "commit": "4dd8c38ef30ad45931c8ae7bcdfd720c3fcffffc",
+   "sha256": "02xf57dincpn7km1f3c9dnq2qv6lk07m9z5hilm3nnns0wwzqdyw"
   }
  },
  {
@@ -9785,14 +9771,14 @@
   "repo": "kwrooijen/cargo.el",
   "unstable": {
    "version": [
-    20210422,
-    657
+    20210615,
+    1543
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "0174599fd1c1b429042c7ca67c3d45f07441a43d",
-   "sha256": "0qm6cgzsr86s1rcvqpv8x5b3r1v7nq7z8il8ci4vlw9hk0wg65a2"
+   "commit": "1dd9771853b4327ed161232b65520c13ffe3c0c6",
+   "sha256": "12pwlww471s6n4vy367m3z8gscxpapi7q6sz5siyis9vjwz3ql2y"
   },
   "stable": {
    "version": [
@@ -9894,8 +9880,8 @@
   "repo": "cask/cask",
   "unstable": {
    "version": [
-    20210528,
-    1605
+    20210621,
+    1830
    ],
    "deps": [
     "ansi",
@@ -9906,8 +9892,8 @@
     "s",
     "shut-up"
    ],
-   "commit": "daee4bec9c7d96a165366f7edeaa4616837bf432",
-   "sha256": "062hsgb4315wvydygvygjywi4wp8xri3h0gj4n5dmy884578hhjl"
+   "commit": "9fbc15dfe8b0739082e7bbff65f226dfe74ac9dd",
+   "sha256": "16pc37b6qaaar8gb4b6rzx7bwdj1lamg34a0nlqw6bkp0wzv1d4v"
   },
   "stable": {
    "version": [
@@ -10165,11 +10151,11 @@
   "repo": "cdominik/cdlatex",
   "unstable": {
    "version": [
-    20201016,
-    1659
+    20210621,
+    654
    ],
-   "commit": "adf96bab0bbf28f65c882c0874f1c14fdb216bd8",
-   "sha256": "010sljis51q31l2irhmr4k3i80f6vnzxf8k09p6k7b91jcby3nf5"
+   "commit": "720f9145d88b3e54b5388742c8a1a2b963d74581",
+   "sha256": "1mgjw93b5mag1ivvxsm416nkvappi4rkddpjlpjcvqw7lwzgps3d"
   },
   "stable": {
    "version": [
@@ -10423,17 +10409,17 @@
     20171115,
     2108
    ],
-   "commit": "35b67c8380bb284c9c59914d967ee157a62311b8",
-   "sha256": "1579n0m13l7ghw5g4b0iffrcvgsh5pk3abk29rrskq736i0h007s"
+   "commit": "3a5929f70b2b258e4786f86383edee6db76bd5a7",
+   "sha256": "05a004z6lxafi9x16br3hhflv7dr1ndlgqrfsb88rjm17w6afpc3"
   },
   "stable": {
    "version": [
     3,
-    17,
+    18,
     0
    ],
-   "commit": "68302fb6a977b11238c91ad9a2b5cb52e6294561",
-   "sha256": "0y8knkrxhj8w2pvz3wjf36q4lpcbv89h2ha8ha1248mfgqmh3wjr"
+   "commit": "b2e902351f51f30b46836494ae9cc1b38b3c6cf5",
+   "sha256": "1lm791bv829p4yjy95lw673g1l9cihg0akan6qxyjg7x219l7dgy"
   }
  },
  {
@@ -10542,16 +10528,16 @@
   "repo": "Alexander-Miller/cfrs",
   "unstable": {
    "version": [
-    20210529,
-    1123
+    20210609,
+    1805
    ],
    "deps": [
     "dash",
     "posframe",
     "s"
    ],
-   "commit": "e16a01012545d378150432fa10684a2a7d1cc2d1",
-   "sha256": "1pj0l0jqgx3bixklllppgm6pwyfd0dc1ik5cs9x1azb1qdgf8kjs"
+   "commit": "2cb7f1cbf9292b0efe167ef372cfb5a7600564eb",
+   "sha256": "1y75mijqchkzhq185961clyl2idj22kz0a1gp69y29qhhfvs43yk"
   },
   "stable": {
    "version": [
@@ -11055,16 +11041,16 @@
   "url": "https://tildegit.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
-    20210603,
-    1656
+    20210622,
+    44
    ],
    "deps": [
     "dash",
     "seq",
     "ts"
    ],
-   "commit": "5c5b7fc5e72e2322af2cac14745c7adaab1d56cf",
-   "sha256": "104n79hj8649h90g8kh3i4rfyk1alq0skpjv8jjpbz0cybhp7n53"
+   "commit": "e7561cf0bb6cbe129edec7f3e15265c985e6e117",
+   "sha256": "1x8jb65pmzw3218skqmgn95bvl5wx02yghp5wmn1gd4xdhran2qc"
   },
   "stable": {
    "version": [
@@ -11121,14 +11107,14 @@
   "url": "https://tildegit.org/contrapunctus/chronometrist.git",
   "unstable": {
    "version": [
-    20210603,
-    1656
+    20210617,
+    1707
    ],
    "deps": [
     "chronometrist"
    ],
-   "commit": "5c5b7fc5e72e2322af2cac14745c7adaab1d56cf",
-   "sha256": "104n79hj8649h90g8kh3i4rfyk1alq0skpjv8jjpbz0cybhp7n53"
+   "commit": "e7561cf0bb6cbe129edec7f3e15265c985e6e117",
+   "sha256": "1x8jb65pmzw3218skqmgn95bvl5wx02yghp5wmn1gd4xdhran2qc"
   },
   "stable": {
    "version": [
@@ -11199,8 +11185,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20210524,
-    832
+    20210625,
+    1100
    ],
    "deps": [
     "clojure-mode",
@@ -11211,8 +11197,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "8f51546c0efb36226c4bae7d65465b0e0aa8c06f",
-   "sha256": "0bn1k34a0dr85c0jj3cb3w8afbhb5iy7whdddkfpa5fkrhc77acf"
+   "commit": "af140ced2286ff646471b067b94c2b18d42616df",
+   "sha256": "0nwh1pi31jrhxjxy7q92hpis5lf1k6f6l6k5vdb0y2lfsd7acqii"
   },
   "stable": {
    "version": [
@@ -11403,14 +11389,14 @@
   "repo": "jorgenschaefer/circe",
   "unstable": {
    "version": [
-    20210601,
-    801
+    20210614,
+    912
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "c0b2f997b3b73640d635ee84627bb8cf36c9adfe",
-   "sha256": "1kjfch0fhq67iivad56s071c8qlsssdsdg83h5v9iz2x4jipm0wa"
+   "commit": "d6f1fa18646f6ed2a1c0f06a4888130bd694ff19",
+   "sha256": "1l6v02aa072jvhq4b9dpkprqs14py0d4jm3xvihm05lvrbf9v6c6"
   },
   "stable": {
    "version": [
@@ -11552,6 +11538,21 @@
   }
  },
  {
+  "ename": "citre",
+  "commit": "a11fd12ba99427246c17c178ef9277fc2d2e2eed",
+  "sha256": "0nbyb0n0f1f11lnyv9wxy2d1vmz5vg5w18dln2vlwcjh2a6n3jz9",
+  "fetcher": "github",
+  "repo": "universal-ctags/citre",
+  "unstable": {
+   "version": [
+    20210701,
+    1448
+   ],
+   "commit": "01ed8539e8068f1e1ff658ab4b1931d9b7907809",
+   "sha256": "1ihxy871wqdpy3ri77kl1wwd21bnl484x343z9xvggl9z6dz8pw4"
+  }
+ },
+ {
   "ename": "cl-format",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "09jwy0fgaz2f04dvcdns6w859s6izvrkp8ib4lws3x8kx8z918fy",
@@ -11629,26 +11630,26 @@
  },
  {
   "ename": "clang-capf",
-  "commit": "c47e1fd9d5a4b85f08676742a9b36b74a2ac8fb6",
-  "sha256": "11qfh8c2kjcy715yyp0sywla74z92qn5j1z9wp4fv5p45w6b6112",
+  "commit": "982788433004ba644a372c50130613e3c56bba10",
+  "sha256": "0xng53wrvmmcl3pq1ap9ddnqrfwmhqwcwli7xnf7a5dqlx6dxj7h",
   "fetcher": "git",
-  "url": "https://git.sr.ht/~zge/clang-capf",
+  "url": "https://git.sr.ht/~pkal/clang-capf",
   "unstable": {
    "version": [
-    20201205,
-    1229
+    20210625,
+    1107
    ],
-   "commit": "6d0fcae75044d930e989903673b6ab22d0401418",
-   "sha256": "12kcb26vk0x20nkwsqw7fk2mlzd64dbh02wz7bpdr3r74iygsapf"
+   "commit": "e422f339395aac6d023954880d19bc76a0d1072d",
+   "sha256": "1gdd674m1vbl8acwsgx6qfmx1gr7h8a6yadzp1jjaandpmc9jlrf"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
-   "commit": "630ab057ed614d142ac08bb3a44a869a81cb591a",
-   "sha256": "0xrxk4b903ayymrngf2swk8d7ic8np1dy8zp9hg3wjlibsmagak0"
+   "commit": "e422f339395aac6d023954880d19bc76a0d1072d",
+   "sha256": "1gdd674m1vbl8acwsgx6qfmx1gr7h8a6yadzp1jjaandpmc9jlrf"
   }
  },
  {
@@ -11925,8 +11926,8 @@
   "repo": "clojure-emacs/clj-refactor.el",
   "unstable": {
    "version": [
-    20210518,
-    1305
+    20210628,
+    1154
    ],
    "deps": [
     "cider",
@@ -11939,8 +11940,8 @@
     "seq",
     "yasnippet"
    ],
-   "commit": "ae2f6344eaf66c872ebc4a87a389f34434ad7a3d",
-   "sha256": "064pnj9wyhfx02cczmp9ah00ng5v9ps7mhn6mbs6vldv9cfrsvr7"
+   "commit": "466822ff6f9da584f7cf72c868017b8840574dbd",
+   "sha256": "1jvmqb4sj3www6fq8srq13yjixp4ixx5i6b0xhiv2bi6r41m3ina"
   },
   "stable": {
    "version": [
@@ -12337,26 +12338,26 @@
   "repo": "emacscollective/closql",
   "unstable": {
    "version": [
-    20210530,
-    1136
+    20210616,
+    1951
    ],
    "deps": [
     "emacsql-sqlite"
    ],
-   "commit": "1b0e5bfef95de49bf669c54a15571386f10f4705",
-   "sha256": "01l4w3wc7rm7mca8pbkyz0yrks4z8i00ppy5c4bmrnn6akf7h9ih"
+   "commit": "e2687e7ff958a19e6e5d6552c4e0b7b33c424bab",
+   "sha256": "1ghqxnn39i032ibm5sbnv67r2dd2hgfnfpqbmb8wzg9wc6smnacq"
   },
   "stable": {
    "version": [
     1,
     0,
-    5
+    6
    ],
    "deps": [
     "emacsql-sqlite"
    ],
-   "commit": "1b0e5bfef95de49bf669c54a15571386f10f4705",
-   "sha256": "01l4w3wc7rm7mca8pbkyz0yrks4z8i00ppy5c4bmrnn6akf7h9ih"
+   "commit": "e2687e7ff958a19e6e5d6552c4e0b7b33c424bab",
+   "sha256": "1ghqxnn39i032ibm5sbnv67r2dd2hgfnfpqbmb8wzg9wc6smnacq"
   }
  },
  {
@@ -12483,8 +12484,8 @@
   "repo": "atilaneves/cmake-ide",
   "unstable": {
    "version": [
-    20210603,
-    1522
+    20210610,
+    1525
    ],
    "deps": [
     "cl-lib",
@@ -12492,8 +12493,8 @@
     "s",
     "seq"
    ],
-   "commit": "9b1100bd8d65b961b7478f9c011f0f6eb8cfcdd9",
-   "sha256": "1lr9cz856hqb3qz5fq6qqc2a55mfgdrh451np5m2bf2ljw0d67nh"
+   "commit": "28dc4ab5bd01d99553901b4efeb7234280928b18",
+   "sha256": "01xpknvj5mm2d3z6xzaw6cyb26hrzhvs44763ajvgw9l43mviwy3"
   },
   "stable": {
    "version": [
@@ -12520,17 +12521,19 @@
     20210104,
     1831
    ],
-   "commit": "05d8a586fa4eb6256b8b80a0f7f084e8c5d3c8e6",
-   "sha256": "11vxpkf8y9n0kxyfgkbyrq76b0g4xjl2rriyj2d59s3xlx27gqjp"
+   "commit": "bf6c9567920965f7b3aba37079cc1b51f31d969d",
+   "sha256": "1hk1qmvw9hmq8xarcnc3pspgsa2fkr8cra8g43i12b8011dz6hpb"
   },
   "stable": {
    "version": [
     3,
-    20,
-    3
+    21,
+    0,
+    -1,
+    2
    ],
-   "commit": "13d112ea03f2b068da1f7ac3239a42a6cff94eda",
-   "sha256": "1rn9gzjcg1km9pbyipkfgzq8jvsmwwa2zkmra5yksfwq2094apnh"
+   "commit": "e610e99ad34a545ac67f1977e78ea59a52fdcf79",
+   "sha256": "1jss6aavq89kmhdbjml6qamv9jm92xf74g1wz4dsr36wh0mypgfk"
   }
  },
  {
@@ -12682,11 +12685,11 @@
   "repo": "astoff/code-cells.el",
   "unstable": {
    "version": [
-    20210529,
-    1452
+    20210612,
+    755
    ],
-   "commit": "2e40770d7963dcbb52ac45dcd83c0537fda5e188",
-   "sha256": "1m6csmg7y99ihw6nhknnr6wqamf5y5j931gfbsrhbar2hh8wjx5m"
+   "commit": "1bd650391a6fe84eb267f2534a0750ea1b5549f4",
+   "sha256": "0r0gp0i0mkfw035qrhpbjw3vdlyiffc5b9zmsmq93wcqvn459154"
   }
  },
  {
@@ -13489,11 +13492,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20210606,
-    135
+    20210618,
+    2105
    ],
-   "commit": "e0f8c9ad754bdc2c02318f4baf433886c7aa83e3",
-   "sha256": "1wqwcggjzmqihdgs3bm23fbv2cxpbh9cjvnzgdj01vbgh4ccqkfh"
+   "commit": "1fd1b363eee68e4cdcf0e610005c0bdbf9940604",
+   "sha256": "00502ffyfx9zc6bs2pzn3zj3rj2zz8sdm1g046ijkgbya8wszkcm"
   },
   "stable": {
    "version": [
@@ -13772,26 +13775,26 @@
   "repo": "redguardtoo/company-ctags",
   "unstable": {
    "version": [
-    20210528,
-    1311
+    20210629,
+    1038
    ],
    "deps": [
     "company"
    ],
-   "commit": "26f0a906a646b4885984e068a2046c3a1d0578eb",
-   "sha256": "0ix5zjwfjj4cbx61qy9d0rfbsmk5kgvm9r2v2r76qa39wx3dys82"
+   "commit": "cf7bfdbfedc8ca4ee134c8d66e70eb6035185174",
+   "sha256": "0ysf3gd3fk74j203y2zg3rq41jx42wgk1y1fn2g5giawazi7ym2x"
   },
   "stable": {
    "version": [
     0,
     0,
-    5
+    6
    ],
    "deps": [
     "company"
    ],
-   "commit": "26f0a906a646b4885984e068a2046c3a1d0578eb",
-   "sha256": "0ix5zjwfjj4cbx61qy9d0rfbsmk5kgvm9r2v2r76qa39wx3dys82"
+   "commit": "cf7bfdbfedc8ca4ee134c8d66e70eb6035185174",
+   "sha256": "0ysf3gd3fk74j203y2zg3rq41jx42wgk1y1fn2g5giawazi7ym2x"
   }
  },
  {
@@ -14010,16 +14013,16 @@
   "repo": "jcs-elpa/company-fuzzy",
   "unstable": {
    "version": [
-    20210329,
-    1543
+    20210608,
+    1454
    ],
    "deps": [
     "company",
     "ht",
     "s"
    ],
-   "commit": "a90e45ee69bac18205418aea68d981c12835eb81",
-   "sha256": "0rm2nw5h74qhc5sqrwgw7l94x32kp35fw3xdpfpglr6bmqyqjbmz"
+   "commit": "b35c6fd89ad111c662916751cf8b3facc8acb1c0",
+   "sha256": "0h9ly6jpbkbcraxs8l0245vqld61jap1vw3cfrbp885jyyzpfb0v"
   },
   "stable": {
    "version": [
@@ -14531,15 +14534,15 @@
   "repo": "xenodium/company-org-block",
   "unstable": {
    "version": [
-    20210607,
-    1202
+    20210623,
+    731
    ],
    "deps": [
     "company",
     "org"
    ],
-   "commit": "e2742dea77b356ee11a1200263d48eed79f5fe43",
-   "sha256": "194kjkpaca7k60hxs96mah416fdn5mfbsa4wgrpc3cprlrbyp8jr"
+   "commit": "4fd9a9c673225196e211bb3ced411d0ef9ff2f88",
+   "sha256": "1nsgkamrq54vm88imdyhl4326fxl9hvkfp0prckgjcg2r37pkxar"
   }
  },
  {
@@ -14558,8 +14561,8 @@
     "cl-lib",
     "company"
    ],
-   "commit": "9770c95bf2df93d9cb0f200723b03b3d9a480640",
-   "sha256": "188z1i209z61nwfcgffgp90rdcsnl75izxpqv4x1vbaay5fvg33f"
+   "commit": "8a0dc9888de87ea3aace06628bff52ed32f3ca2b",
+   "sha256": "1xcsm72by6jiqr9y9fyk70nshsj5dj494faz9734m67fmxq45pfj"
   },
   "stable": {
    "version": [
@@ -14591,8 +14594,8 @@
     "company",
     "phpactor"
    ],
-   "commit": "debf66848c6099415c731b179dcd47e96db3b50b",
-   "sha256": "0i5g4gh5i5y8wsrqw89lwi2s2sn67pvvj2y6p7lnyv0i201v5bs8"
+   "commit": "272217fbb6b7e7f70615fc518d77c6d75f33a44f",
+   "sha256": "0hm96i9vdbkcq6mypjpl94dn3gzyk23iql5zzy2d221vmjhqvn7d"
   },
   "stable": {
    "version": [
@@ -14920,8 +14923,8 @@
     "company",
     "rtags"
    ],
-   "commit": "63f18acb21e664fd92fbc19465f0b5df085b5e93",
-   "sha256": "0wzyn9qzyly71yfwhlk5m94ygjnbk459pgbpgkhp9fqgchx12p1r"
+   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
+   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
   },
   "stable": {
    "version": [
@@ -14986,8 +14989,8 @@
     "company",
     "solidity-mode"
    ],
-   "commit": "383ac144727c716c65989c079ae76127e25144c3",
-   "sha256": "1q4b8623mygzp3qwy5bmb3hipzjfri9007x0ilq3i7k5bs34jz9r"
+   "commit": "5f6ef3156fadae5af6f381d674d20535529a20e4",
+   "sha256": "02rmc7naspjfl757k7zdfg9xd6nvfpsiqfcxkj6ywc7mnndpq2c0"
   },
   "stable": {
    "version": [
@@ -15703,19 +15706,19 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20210606,
-    1237
+    20210629,
+    1951
    ],
-   "commit": "ae905501bcdb8fdda0d10a0846d575fd2a38e6d7",
-   "sha256": "1jz4j27irxknfbcxsn8phhhaiwyc2z9gnyrj03ah1v57i0i9g79c"
+   "commit": "6ce9aa58e74da92e391cfe938bc3da4f47ab591e",
+   "sha256": "1ji5ilakwahipp23avzjpi5vfp5f17pm6m1prygk065zqdianrv9"
   },
   "stable": {
    "version": [
     0,
-    8
+    9
    ],
-   "commit": "e538f168d9d16c926d92c19d6131298962b778a9",
-   "sha256": "1460818fb6y086vgn1mzmrwhpa5jswlwi4v71zr86cg6y7yg4248"
+   "commit": "ee58941308d83a717728f056ea753e80f68cfbc0",
+   "sha256": "0iy6lrqbpi4lv7141rdawpn278rxinfxspwb81n04azyxrk28vlw"
   }
  },
  {
@@ -15789,29 +15792,29 @@
   "repo": "gagbo/consult-lsp",
   "unstable": {
    "version": [
-    20210428,
-    1515
+    20210630,
+    1151
    ],
    "deps": [
     "consult",
     "f",
     "lsp-mode"
    ],
-   "commit": "12989949cc21a1173206f688d56a1e798073a4c3",
-   "sha256": "0g3bpi53x6gr9631kzidbv4596bvdbxlr8y84ln40iwx5j8w6s7p"
+   "commit": "e8a50f2c94f40c86934ca2eaff007f9c00586272",
+   "sha256": "1xkkybfdzr1xqhvc2bamp253icm75dz7bkdz6bv8xj8688p8vrm9"
   },
   "stable": {
    "version": [
     0,
-    2
+    4
    ],
    "deps": [
     "consult",
     "f",
     "lsp-mode"
    ],
-   "commit": "c4c0426b58946578ac1806a60258d2b275d5b524",
-   "sha256": "11lrnv5ssiwwdvdib05nz070yc3w9lfcqikgnl3bq8gbcrm9zjf4"
+   "commit": "e4a0b9403477fe90741ac84d0d2ac3729122b363",
+   "sha256": "00rrc17axn7pmvzy1q95nf0w036cx7fhxwhimamh9cmijkdsf5w5"
   }
  },
  {
@@ -15822,15 +15825,15 @@
   "url": "https://codeberg.org/jao/consult-notmuch.git",
   "unstable": {
    "version": [
-    20210519,
-    57
+    20210701,
+    422
    ],
    "deps": [
     "consult",
     "notmuch"
    ],
-   "commit": "71aa3b8ee6cd3cd07313b74353ac29fdfde0e7b0",
-   "sha256": "1wfghhyv89fcnjznvjwriwdpksr3yijr5lg0xihc7vssz05c7qpr"
+   "commit": "9e65c421cf54ca12234acad727818fa0fe60fa3e",
+   "sha256": "19flyh3v1xm2zswzjkvjbijvpbq5r8isafza4fd0yicvqbjyklhx"
   },
   "stable": {
    "version": [
@@ -15853,14 +15856,14 @@
   "url": "https://codeberg.org/jao/consult-recoll.git",
   "unstable": {
    "version": [
-    20210411,
-    1300
+    20210620,
+    1955
    ],
    "deps": [
     "consult"
    ],
-   "commit": "9038cfa4222f428e28bdafa0aeb57362104a873d",
-   "sha256": "0sqwczfvplmlwkjmpd3l8i6gjsfw180kafyvkzdkdig4cwa39yks"
+   "commit": "7b54edb8ac011015ccb43c9d6193e455b4405425",
+   "sha256": "1qz0r36nv5d52g9i4g9lcrp9gh1kf16q8lgjwgxxqi0qrq2h99z0"
   }
  },
  {
@@ -15871,15 +15874,15 @@
   "url": "https://codeberg.org/jao/espotify",
   "unstable": {
    "version": [
-    20210605,
-    1502
+    20210620,
+    1953
    ],
    "deps": [
     "consult",
     "espotify"
    ],
-   "commit": "3d62a3319ab03a810030058d3fb368b28dfd82d5",
-   "sha256": "0hj3nczmqmgiwsvh664rs34j63wl325x6nar21p1a84h5ximpkxq"
+   "commit": "5bf63dacc5df8a74860e80dabd16afce68a24a36",
+   "sha256": "1vxg86wv6f96bva0d1xxhisk525chwhdl4nq77xhriflq65mcmi3"
   }
  },
  {
@@ -16397,14 +16400,14 @@
   "repo": "redguardtoo/counsel-etags",
   "unstable": {
    "version": [
-    20210410,
-    1256
+    20210608,
+    206
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "5d7ee6776ed5c314472e2af2797ebfdc725e6a70",
-   "sha256": "116yylad46sjfvadpl3lj3sb17ariswyp6k1ihh8ba5jn9f9hl5h"
+   "commit": "2c1f2161d36f70e0034e29abecfcb8878b30b6ac",
+   "sha256": "1hcsz773i67i82crzczm4csjkl9qj430m73lpvqkh7if543bs030"
   },
   "stable": {
    "version": [
@@ -16735,15 +16738,15 @@
   "repo": "mnewt/counsel-web",
   "unstable": {
    "version": [
-    20200313,
-    5
+    20210609,
+    2156
    ],
    "deps": [
     "counsel",
     "request"
    ],
-   "commit": "35c648b4cdd9f266ab54512a0fec2a3ca55d5bc6",
-   "sha256": "128vl9a5w8v2xzfi5xn9cqshxmcfq2pcmnkkqcxfmi401m2lm0bx"
+   "commit": "1359b3b204fcdac7a3d6664c7d540a88b5acecfd",
+   "sha256": "1y5dnhsx5q8jvrr5hjr8cp53nvdq25c9q9im61ym75nccl9lwp4v"
   }
  },
  {
@@ -17067,8 +17070,8 @@
     20210601,
     1327
    ],
-   "commit": "771a405e262c98b802e2c5302306aed802d8233e",
-   "sha256": "0kcv3jjygjvz75irjdddgakw8b0ckm5gqasrb2341zgqms7l9rfr"
+   "commit": "b2c24f42f2fae63433787150f77b397d69ce0e5b",
+   "sha256": "1c0smqhc87fzg7db20k92k938p8dkqiig59krwylkqgagsi7hbg4"
   },
   "stable": {
    "version": [
@@ -17238,11 +17241,11 @@
   "repo": "Boruch-Baum/emacs-crossword",
   "unstable": {
    "version": [
-    20210216,
-    1703
+    20210614,
+    633
    ],
-   "commit": "cb2e2a435ea9f4fa8c7517b4909af8b62bca8a3e",
-   "sha256": "18dk9623ff2kxfhbdnh4l68n5dfxqgrm6ilmv85dfj685kahd0d3"
+   "commit": "a8594b6e13f5e276aa9bc810ac74a8032bb1f678",
+   "sha256": "1in8y4fg79v0lx5k0bfhazppkhmb8x9xb0wrjpv3p877vy3687i9"
   },
   "stable": {
    "version": [
@@ -17372,16 +17375,16 @@
   "repo": "emacs-csharp/csharp-mode",
   "unstable": {
    "version": [
-    20210328,
-    2004
+    20210624,
+    1320
    ],
    "deps": [
     "tree-sitter",
     "tree-sitter-indent",
     "tree-sitter-langs"
    ],
-   "commit": "33e3042535e70a284389f8da1c495958fed8a826",
-   "sha256": "009qizx0cc97if0bdxrmw3l1slddwwhb21fq6npchg7dwswpnai4"
+   "commit": "093f0f21a9d04d79a380de145cbc42693ef8c76f",
+   "sha256": "1150s8zz9z6pmr9m8jny7g8qrhxdnpbk4nzrlyddhaf9hkw9nfi9"
   },
   "stable": {
    "version": [
@@ -18050,8 +18053,8 @@
     20190111,
     2150
    ],
-   "commit": "7b018126aefb100a4f00aeba121688e8a168ee22",
-   "sha256": "0wxjnxic06kkdjlsd0r0afpms26rhdyskv2f4nj7gabiz1m341gm"
+   "commit": "e7e5d1dc652755bd0ac0a45e4f970b1a2b137308",
+   "sha256": "0900w9ddx0i942spji7jg6ssv9d898isggzy9yjhirwn8fs0a2jb"
   },
   "stable": {
    "version": [
@@ -18525,11 +18528,11 @@
   "repo": "magnars/dash.el",
   "unstable": {
    "version": [
-    20210602,
-    1928
+    20210609,
+    1330
    ],
-   "commit": "aab346ed9d8f0f7ea033029c9688810353052e7e",
-   "sha256": "0vq8sgbil17llimaar4j5ar07g17q8ir3a7hfpmv9572ah1zqpw9"
+   "commit": "88d799595e8f1b4154637ce8a3f81b97b0520c1a",
+   "sha256": "0b68kivrvwwp51q7cizgdd5i69n7p322gzd305zb377aksl98rbj"
   },
   "stable": {
    "version": [
@@ -18604,8 +18607,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "aab346ed9d8f0f7ea033029c9688810353052e7e",
-   "sha256": "0vq8sgbil17llimaar4j5ar07g17q8ir3a7hfpmv9572ah1zqpw9"
+   "commit": "88d799595e8f1b4154637ce8a3f81b97b0520c1a",
+   "sha256": "0b68kivrvwwp51q7cizgdd5i69n7p322gzd305zb377aksl98rbj"
   },
   "stable": {
    "version": [
@@ -19635,11 +19638,11 @@
   "repo": "astoff/devdocs.el",
   "unstable": {
    "version": [
-    20210606,
-    933
+    20210625,
+    1617
    ],
-   "commit": "07fc164a680d02de2a7af983adb5e726cbfd7fc0",
-   "sha256": "1ldd4h9r7wiqgynxwlqf6hg5m2whzaczlhxmbch7i60rd72wwvrj"
+   "commit": "f7c57d1878d78f076e2a2ef1c97129dc8aa4da15",
+   "sha256": "0fgyv5g23by8gddaai6q7dwv0f87fam91avpd0fx8klckyz3i5ww"
   }
  },
  {
@@ -19650,11 +19653,11 @@
   "repo": "blahgeek/emacs-devdocs-browser",
   "unstable": {
    "version": [
-    20210601,
-    1447
+    20210629,
+    1601
    ],
-   "commit": "d3702670eb361715e41440eb699523b3f4c60bee",
-   "sha256": "1mv0d67y6m1wi779lc0mnpylqiw3cnaj0rkj199fxh91nkc6vk27"
+   "commit": "23e62096b98b9b509efc453d7fee0810acea4bf8",
+   "sha256": "0f6ld4m1x419677snbpd3qyx782zpj61rahphgc5nfj6aanvll0w"
   }
  },
  {
@@ -19759,10 +19762,10 @@
  },
  {
   "ename": "dictcc",
-  "commit": "5e867df96915a0c4f22fdccd4e2096878895bda6",
-  "sha256": "0x1y742hb3dm7xmh5810dlqki38kybw68rmg9adcchm2rn86jqlm",
+  "commit": "cdc15fbd060183e2b06f0c776075beddf7433f39",
+  "sha256": "023r50vwc3bbbyfmn05lyfpq78cmjr076i2rjd064izbrybififp",
   "fetcher": "github",
-  "repo": "cqql/dictcc.el",
+  "repo": "martenlienen/dictcc.el",
   "unstable": {
    "version": [
     20200421,
@@ -19867,14 +19870,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20210523,
-    11
+    20210615,
+    1539
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d4340608c2d6d8b81aad8e690d0265799aba16f3",
-   "sha256": "1haqmaaj6ajqqfdni6gn3nmqaif8jqrpdnr84m3zjddsdw5zlcsk"
+   "commit": "1077c734b3b6de02c80456035a4939b028cb4179",
+   "sha256": "18vk7rhysavm8j02kd4lw6j6zr2l13gyvrjxq7psy1flhvmkxknc"
   },
   "stable": {
    "version": [
@@ -19931,14 +19934,14 @@
   "repo": "ShuguangSun/diffpdf.el",
   "unstable": {
    "version": [
-    20210307,
-    932
+    20210626,
+    1447
    ],
    "deps": [
     "transient"
    ],
-   "commit": "96861493f95fe88118942bbe64954142250d6c24",
-   "sha256": "13dda1883pkji4nf44mx9xiys6rgirw12si9fnazsviiqycjaf1b"
+   "commit": "a5b203b549e373cb9b0ef3f00c0010bd34dd644a",
+   "sha256": "0bd09ljvlzffb02fgcvjjvysrj762a1wfvad0ywph4722dvnjfn0"
   },
   "stable": {
    "version": [
@@ -19963,8 +19966,8 @@
     20141014,
     2357
    ],
-   "commit": "e0aacd8b3d9f886f27222c1397f0655e849e0af7",
-   "sha256": "14ccak3cmv36pd085188lypal9gd3flyikcrxn0wi6hn60w2dgvr"
+   "commit": "53f2d001bd3a5cb80c6ada16b4e570afd1989a09",
+   "sha256": "0ivy5ydww69gnxws6y37hgvyyvs9gssvdljzs1h13pcycm05hdxb"
   }
  },
  {
@@ -20100,11 +20103,11 @@
   "repo": "tarsius/dim-autoload",
   "unstable": {
    "version": [
-    20200103,
-    1239
+    20210615,
+    1502
    ],
-   "commit": "c8dc02259d6c1aa25fb58742ae8b181f83b39a13",
-   "sha256": "0k9m57zrdpabb6b34j9xy3cmcpzni89wq71pzzwgdi47p1n4r4vd"
+   "commit": "77b6a5814ffb49e33679fd67b53b9f05042b6ebc",
+   "sha256": "1a1xhmsm1c4k3mkbbhzd7fmb8q60fhs0lrf39m261180kz0wnhrq"
   },
   "stable": {
    "version": [
@@ -20130,8 +20133,8 @@
    "deps": [
     "dylan"
    ],
-   "commit": "040c8ebc884305fd4ff980d21c68946fa74b095a",
-   "sha256": "1f99wn0lgknvnplp7nk2lylf17yak2hw53n9a0vkxng01xhf50d2"
+   "commit": "d85409dc3cba57a390ca85da95822f8078ecbfa2",
+   "sha256": "1cm4l2ycaw47mfgc6ms021zxkas1jajgwpnykqlkcwcbakbczxjl"
   }
  },
  {
@@ -20866,14 +20869,14 @@
   "repo": "jojojames/dired-sidebar",
   "unstable": {
    "version": [
-    20210411,
-    2315
+    20210608,
+    2340
    ],
    "deps": [
     "dired-subtree"
    ],
-   "commit": "79d8187da373b573a2d5385ca868553bb73e0005",
-   "sha256": "0b1f6ddhn8z4q790d370zhyqrn4mlqk7i6901sld52m14zigd72j"
+   "commit": "6be2dad2782e28dae2f50c0cbfd82042b2b6ba8d",
+   "sha256": "1lqnd64ga7g8dzzgfn2bw00y65hlvlgxnj3bk7j6qr5wzkz6qp52"
   },
   "stable": {
    "version": [
@@ -21017,14 +21020,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20210603,
-    2349
+    20210613,
+    1423
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "43159042ca788be74c387cc59ba3fffc57079993",
-   "sha256": "01r6sk2zlj3mf39vczaybhpzzmv379vvi85mc4gygif24m102sg3"
+   "commit": "5e13b7c088e2554b2aa406581520d53902c74016",
+   "sha256": "06vy5wgrv0sjdnsx31jg1c12wwzxpkgb2xz1djzi5pbhakidspv3"
   },
   "stable": {
    "version": [
@@ -21069,8 +21072,8 @@
     20160529,
     2017
    ],
-   "commit": "c08e163d9d6c62f7b07e94d54c96c2e364e67e0e",
-   "sha256": "1h2hnm8r3anfbk5x7d2dnv38bdllsbwaam6ivpbgzn12r23wrsr2"
+   "commit": "ad328a15c5deffc1021af9b3f19a745dcd8f4415",
+   "sha256": "1s6gwn3ksvk2wyslv7kwn0da3xgw1ayx6yaddhbxz0kg6ps2ran2"
   },
   "stable": {
    "version": [
@@ -21864,8 +21867,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20210516,
-    1958
+    20210624,
+    1359
    ],
    "deps": [
     "dash",
@@ -21875,8 +21878,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "bc2dc09edea167d4fdf022aa263bad71932bb0c4",
-   "sha256": "009qxd0q77pzq2xvm060zswy0amga9cdcc1h3zf2mhn2cw64ydic"
+   "commit": "9bcefbe54dbed4d364286fe65a87872e763ff7dc",
+   "sha256": "184dsvaa60b4j6w8s6146x81l5d2a6hkxjqp69gwiixpyjyvcj6n"
   },
   "stable": {
    "version": [
@@ -22076,8 +22079,8 @@
    "deps": [
     "s"
    ],
-   "commit": "f6dcb378bb69c23d58978d5bc1e37c4ae160d278",
-   "sha256": "055b24cskxp0wy74synnnsmfnzbavmazyackq0qfnfbkqryrzfml"
+   "commit": "32196031f60627e88a67b676d643ab51c251711f",
+   "sha256": "19bm4fr38hkh6mrbf0vgafwq2hfldkcn2b5flllvizq2qh86hq81"
   },
   "stable": {
    "version": [
@@ -22219,30 +22222,30 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20210606,
-    1532
+    20210627,
+    1731
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "1660910b758251608c17e1a0e27ff862e345daab",
-   "sha256": "1apbh9kp1qk3klx65imbhmxxnf8ax0hzzcdwj4n6qpm7s6bk1gc3"
+   "commit": "07d03c4626eaaf2cc9c346308add3700ad4a3a06",
+   "sha256": "0c9g5i9cyqcc934rz778zia24bls99i9hfl0s61354ncgw4qndfy"
   },
   "stable": {
    "version": [
     3,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "5cb0ff7a3878b218486fe7ef9b3c83cb226dd03e",
-   "sha256": "1dkgh87sv25mdlzdfihp6gp0asvwplx9yrn7nfsqzsfc3kpajkck"
+   "commit": "d514f43679513819b37333a64a44523f239150b6",
+   "sha256": "1gfkaxga919a1a19dhpbby95l8dixb1278g5d7iadjf2i3j0p3l0"
   }
  },
  {
@@ -22272,14 +22275,14 @@
   "repo": "hlissner/emacs-doom-themes",
   "unstable": {
    "version": [
-    20210604,
-    1922
+    20210701,
+    707
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b2c0ea0f0778a6ea85b87e1b87916572e98e1fe7",
-   "sha256": "1rjhmjsszms4rlqq368f717ds4kmdjblkgd2ww830d7sy5h5rb6n"
+   "commit": "bd5b9065dea54472519da67ccfcc3185bf5e35c3",
+   "sha256": "0g12rlkfg9ijgd2csrcmcqf6yrs33x9gfkw3g7azp74pvx3cvcmi"
   },
   "stable": {
    "version": [
@@ -22523,11 +22526,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20210518,
-    657
+    20210627,
+    1011
    ],
-   "commit": "aa72f3d5c4d49cc0fb581d2f4eac528cf0278a11",
-   "sha256": "1ay4i606rjcr55ky54sxyvh6ac4s4ilr1i3pykvavdgmrzy3ij89"
+   "commit": "99ef8ef438e8e11a4486a20c353508b5e20d010e",
+   "sha256": "0hrqbggmfizl7wcwjcnpgs7ykns6iqwai51mqv61k7m2m37slf6k"
   },
   "stable": {
    "version": [
@@ -22883,16 +22886,16 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20210303,
-    1714
+    20210622,
+    1720
    ],
    "deps": [
     "dash",
     "popup",
     "s"
    ],
-   "commit": "8f70acbe164553b225476fed55019ecddcf0bbd6",
-   "sha256": "08g417yf4byhhldvcbkmhrlm7iaylkv0cbcg1c701dyfngxn01y2"
+   "commit": "542e72d3feba986a12119f6def515ef1347cb4ca",
+   "sha256": "1x0g1n9x7qsiwqq8432li6yiww2kvdbk2wkqs3glw97grzrz89gc"
   },
   "stable": {
    "version": [
@@ -22936,17 +22939,17 @@
     20210213,
     757
    ],
-   "commit": "ac3a66e0f7d3577b27cc5d5f2399163bfbe11828",
-   "sha256": "1grll7h2hv906bik224qn9fldmq4lhnlfcif1lg4grr3f4nhl1wc"
+   "commit": "846b38c1efab4757240d131d2c45102930fc305c",
+   "sha256": "1vw500g9jfa4za1f0r90bzzb6ra9jyn52z1g4nwvqcnha1sixj7m"
   },
   "stable": {
    "version": [
     2,
-    8,
-    5
+    9,
+    0
    ],
-   "commit": "e84ba5230f6afacb12f022937138a752f1c301b6",
-   "sha256": "0a1jj6njzsfjgklsirs6a79079wg4jhy6n888vg3dgp44awwq5jn"
+   "commit": "641a95d2254ca7c51c97f07f2eed85b7a95db954",
+   "sha256": "01np4jy0f3czkpzkl38k9b4lsh41qk52ldaqxl98mgigyzhx4w0b"
   }
  },
  {
@@ -23058,11 +23061,11 @@
   "repo": "dylan-lang/dylan-emacs-support",
   "unstable": {
    "version": [
-    20210329,
-    604
+    20210613,
+    1431
    ],
-   "commit": "040c8ebc884305fd4ff980d21c68946fa74b095a",
-   "sha256": "1f99wn0lgknvnplp7nk2lylf17yak2hw53n9a0vkxng01xhf50d2"
+   "commit": "d85409dc3cba57a390ca85da95822f8078ecbfa2",
+   "sha256": "1cm4l2ycaw47mfgc6ms021zxkas1jajgwpnykqlkcwcbakbczxjl"
   }
  },
  {
@@ -23185,14 +23188,14 @@
   "repo": "ahyatt/emacs-dyncloze",
   "unstable": {
    "version": [
-    20210405,
-    212
+    20210613,
+    1956
    ],
    "deps": [
     "dash"
    ],
-   "commit": "38aac1a38017a707b4c539a7932cc8f6cd8f1a77",
-   "sha256": "05i0a1680a79xvawa93iip10ln6bkrnvzqh3a2lica4hfx0hsi0x"
+   "commit": "fe5baf6d324800779f80f5c6298a56e2dcb87598",
+   "sha256": "0c7bh3swwmfc1z834f79jakg1n6li5prd33r5k92id8kl18hb8fj"
   }
  },
  {
@@ -23449,8 +23452,8 @@
     20201112,
     820
    ],
-   "commit": "5f3cfac22a7e2508be47079860ab573f397c3cfa",
-   "sha256": "1p7x7wvzc1sragxpb7b6qnb9fv193mm3ydwf1kwi6rgnz29zql58"
+   "commit": "527df13dcfb11f7a059ca9e8e4d31ab79423d896",
+   "sha256": "0ylmd42z0lczliafwhw0ga80y7j1njdypzmfkmnblhlxyiwjxwxk"
   },
   "stable": {
    "version": [
@@ -24329,8 +24332,8 @@
   "repo": "sebastiw/edts",
   "unstable": {
    "version": [
-    20201110,
-    1827
+    20210630,
+    1626
    ],
    "deps": [
     "auto-complete",
@@ -24341,8 +24344,8 @@
     "popup",
     "s"
    ],
-   "commit": "648e8ac632bee8eaa92fc4e09a674ae453bae0a9",
-   "sha256": "1z7abw4s3k8ynx9i25blp0i51is0wdpsipx79l4wkpazhpsx8gb6"
+   "commit": "5564f5292eba339afa7760af9467c896ccd708da",
+   "sha256": "0dkpijsfprlckaggnzmarrbny2qn02927s0fh94dql2gqkvfxhd0"
   },
   "stable": {
    "version": [
@@ -24505,8 +24508,8 @@
     20200107,
     2333
    ],
-   "commit": "df4e47f7c8adfe90d9bf408459772a6cb4e71b70",
-   "sha256": "1n0dcrhwpl24whxzwhxf7qjlqlllzl5aahdq8h2zdgb6xz912k64"
+   "commit": "54fc2af0efdbb9e000667749bcfc9fda659304cf",
+   "sha256": "032iacivlg86fi3kwgsh0dsggx7kp8l9yvngb4ih7ilfd33mzrza"
   },
   "stable": {
    "version": [
@@ -24526,8 +24529,8 @@
   "repo": "joaotavora/eglot",
   "unstable": {
    "version": [
-    20210526,
-    1751
+    20210611,
+    2249
    ],
    "deps": [
     "eldoc",
@@ -24536,8 +24539,8 @@
     "project",
     "xref"
    ],
-   "commit": "e498cb171bb07ec36880a2494aafc8acb1cc34ca",
-   "sha256": "1q2rg6kk16h0wv70p2x1rg5cjmn0w0gc3phriwdd7iwn842dsrb7"
+   "commit": "5cc8df63d86a6c43134dd6e4e3ae26cfae14e66a",
+   "sha256": "0whplm1858d3mv4af6qk0jr5dk9ym1yzp4zsslrrfpyi54vy96yx"
   },
   "stable": {
    "version": [
@@ -24863,11 +24866,11 @@
   "repo": "dimitri/el-get",
   "unstable": {
    "version": [
-    20210606,
-    911
+    20210613,
+    1418
    ],
-   "commit": "52df810e538243d07f2a317ad36e351b440a75e0",
-   "sha256": "0s9107bss982v4njwkfyi4gismg402xcrqkq9c2hrwhyr6pny4w0"
+   "commit": "ec135b5353867ce3564a675e99024944b834395d",
+   "sha256": "1mpc4gnrpvqvhfvjvp4hqb4x6nzn1kfzgsqi4sdjgbfjqll2jzv0"
   },
   "stable": {
    "version": [
@@ -25170,8 +25173,8 @@
     20210524,
     1611
    ],
-   "commit": "afe8f31e2b9f78d13b22a695b7cf9c373656b85e",
-   "sha256": "09yk4xvsdd5mvrzx4kdfyi2bkbdykjg80hcxvjamh967s6vinzjb"
+   "commit": "64545671174f9ae307c0bd0aa9f1304d04236421",
+   "sha256": "10hjqva6xpilnsfsi8z7w3mjmii4hzf53cmccv1w3076ccvcpq62"
   }
  },
  {
@@ -25219,8 +25222,8 @@
     20210530,
     1641
    ],
-   "commit": "e9af76aa8fd9ce5b7010b7322a73341828cfe690",
-   "sha256": "1wryp568bl5p0s78va2pgh9aiskhphmva20zmk1jg0qjxim58grv"
+   "commit": "d51ce6152519b5cf32d0dcc40cad6787eb605997",
+   "sha256": "1nkc9fwg7fn8gvj4zg515320p7m2h3b1nyd6zzbp2v60qj7277jq"
   },
   "stable": {
    "version": [
@@ -25240,11 +25243,11 @@
   "repo": "casouri/eldoc-box",
   "unstable": {
    "version": [
-    20210402,
-    2039
+    20210608,
+    2202
    ],
-   "commit": "f66f8d0641a0025d65da1ec21141ea594d6883da",
-   "sha256": "1y9ns6kmhgzi176z251cymplqc9bdk0axhhcvh4mn21vi5igz4pz"
+   "commit": "13d207d40863a041b84c34f075668c7931db5a78",
+   "sha256": "1cvwp01w0adgxwlsispmir4wgs73cl62n5rh7ri6rw6g4fribq1m"
   },
   "stable": {
    "version": [
@@ -25302,15 +25305,15 @@
   "repo": "stardiviner/eldoc-overlay",
   "unstable": {
    "version": [
-    20200715,
-    1214
+    20210630,
+    1345
    ],
    "deps": [
     "inline-docs",
     "quick-peek"
    ],
-   "commit": "563ca285a510d1cbd5129cc3a8f8a3cdded065de",
-   "sha256": "1llh93rlvzsl9m2f7gprb5rbbf2ghysyn1balb8clb64hq98gjyb"
+   "commit": "3edbfb23836bdef253f4a5fd125952e55877d2b2",
+   "sha256": "1r2fjdra4bav16c108jzzjd2qhng7493i7l7znbasialf40j3cbs"
   }
  },
  {
@@ -25412,11 +25415,11 @@
   "repo": "xwl/electric-spacing",
   "unstable": {
    "version": [
-    20210430,
-    1714
+    20210625,
+    1722
    ],
-   "commit": "800e09af7b0cd5d78d22f857dbce10fb080637df",
-   "sha256": "0ykndvbbx8rvaxppmkngyrzp1x6fghj9xv55i847kpzx1c6gs4fc"
+   "commit": "1be87078a689d967cb2d6654659fb49427926d62",
+   "sha256": "06iws70cc58xs79wlv9wgqk6vk9grvv1jhcngjjwg0pdn080rksz"
   }
  },
  {
@@ -25528,6 +25531,44 @@
    ],
    "commit": "0ccd59aaace34546017a1a0d7c393749747d5bc6",
    "sha256": "1ghdvfn4f9y69r59i1ga9b3ib1r8sbqg6q1v5rz3f9paagfavrd1"
+  }
+ },
+ {
+  "ename": "elfeed-autotag",
+  "commit": "11425f3533d452f1f7f412b1dbe617be9dcbf225",
+  "sha256": "0p6avgi7pclcf1ml0k3lzwd92plgz28d8q82675gyjs8gfwkn5m7",
+  "fetcher": "github",
+  "repo": "paulelms/elfeed-autotag",
+  "unstable": {
+   "version": [
+    20210607,
+    637
+   ],
+   "deps": [
+    "dash",
+    "elfeed",
+    "elfeed-protocol",
+    "org",
+    "s"
+   ],
+   "commit": "bc62c37fb79b720ff8b6d67f04f2268841306dcd",
+   "sha256": "0vmvl3c465i2gkm9079hj7l3qxna37q3rrs498r8dby11c0dgcax"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    2
+   ],
+   "deps": [
+    "dash",
+    "elfeed",
+    "elfeed-protocol",
+    "org",
+    "s"
+   ],
+   "commit": "bc62c37fb79b720ff8b6d67f04f2268841306dcd",
+   "sha256": "0vmvl3c465i2gkm9079hj7l3qxna37q3rrs498r8dby11c0dgcax"
   }
  },
  {
@@ -25907,15 +25948,15 @@
   "repo": "Wilfred/elisp-refs",
   "unstable": {
    "version": [
-    20200815,
-    2357
+    20210615,
+    1624
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "b3634a4567c655a1cda51b217629849cba0ac6a7",
-   "sha256": "1zy629gavyrwx5gmpz7l1a86hbrxjrfqik398v3ja8vg8bj9d6nq"
+   "commit": "fdde21e34b1272783d566d8230b5ed2dc4749048",
+   "sha256": "15g3xp3w8lrshjf812c8v50y396zx7107fcyc59kljhsc257j62y"
   },
   "stable": {
    "version": [
@@ -26361,11 +26402,11 @@
   "repo": "redguardtoo/elpa-mirror",
   "unstable": {
    "version": [
-    20210509,
-    439
+    20210614,
+    302
    ],
-   "commit": "193dd942cd74f71d94067f48249427676ba7dec8",
-   "sha256": "0hwsy780x1kw1c9k1xrbrbip6l62fa41czal0nnqr9li0brig7d7"
+   "commit": "18209f7f4602e48204992e38c5d265eb1a68320a",
+   "sha256": "0507bydbplh515jm1y8w9fpv3mljxkj797ssackadx484n3v0yvv"
   },
   "stable": {
    "version": [
@@ -26424,8 +26465,8 @@
   "repo": "jorgenschaefer/elpy",
   "unstable": {
    "version": [
-    20210328,
-    1852
+    20210630,
+    2317
    ],
    "deps": [
     "company",
@@ -26434,8 +26475,8 @@
     "s",
     "yasnippet"
    ],
-   "commit": "2203597e1254eba345d6873daa40c7b9d144931c",
-   "sha256": "0rzqmcbrq7xdk748cwy5ikzbg7f13g57jf7rhxyfy6j5pwn8q7k7"
+   "commit": "4248dccef31e260813d93cafd083bfcd71efc92a",
+   "sha256": "16pkbg1fwsn0haz2x0ky9pmpgxj9syszsm5g58jra5r0dhyv99vz"
   },
   "stable": {
    "version": [
@@ -26737,11 +26778,11 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20210504,
-    1306
+    20210615,
+    1503
    ],
-   "commit": "53d257db92fb72ade8ea1b91dc6839c21563119e",
-   "sha256": "1qccz8z0410xhygrfy62h1j3553avdcb7m61ps6b6y74nz615l1r"
+   "commit": "ef6dfa8e598b2761d0a481526e98e254123a20f6",
+   "sha256": "0p7c2mnwz85klliy1af96knkdja6q9k9j11r0hfka7g4fak0qi6d"
   },
   "stable": {
    "version": [
@@ -26818,11 +26859,11 @@
   "repo": "skeeto/emacsql",
   "unstable": {
    "version": [
-    20200714,
-    28
+    20210615,
+    1539
    ],
-   "commit": "6d8cd9366284b5a27268ff4b783e2c34573d5b60",
-   "sha256": "04l1rzsmy9131h42y1v6vsfbby7v1gldwd5g600mqfjbbwcnbgsk"
+   "commit": "9dca5996168c4963eb67e61c7f17fdcb8228e314",
+   "sha256": "1gjwll970avjv0ah4m8w56ybi4l4bc4n8p29wq77za56m0g6jzrg"
   },
   "stable": {
    "version": [
@@ -26848,8 +26889,8 @@
    "deps": [
     "emacsql"
    ],
-   "commit": "6d8cd9366284b5a27268ff4b783e2c34573d5b60",
-   "sha256": "04l1rzsmy9131h42y1v6vsfbby7v1gldwd5g600mqfjbbwcnbgsk"
+   "commit": "9dca5996168c4963eb67e61c7f17fdcb8228e314",
+   "sha256": "1gjwll970avjv0ah4m8w56ybi4l4bc4n8p29wq77za56m0g6jzrg"
   },
   "stable": {
    "version": [
@@ -26878,8 +26919,8 @@
    "deps": [
     "emacsql"
    ],
-   "commit": "6d8cd9366284b5a27268ff4b783e2c34573d5b60",
-   "sha256": "04l1rzsmy9131h42y1v6vsfbby7v1gldwd5g600mqfjbbwcnbgsk"
+   "commit": "9dca5996168c4963eb67e61c7f17fdcb8228e314",
+   "sha256": "1gjwll970avjv0ah4m8w56ybi4l4bc4n8p29wq77za56m0g6jzrg"
   },
   "stable": {
    "version": [
@@ -26908,8 +26949,8 @@
    "deps": [
     "emacsql"
    ],
-   "commit": "6d8cd9366284b5a27268ff4b783e2c34573d5b60",
-   "sha256": "04l1rzsmy9131h42y1v6vsfbby7v1gldwd5g600mqfjbbwcnbgsk"
+   "commit": "9dca5996168c4963eb67e61c7f17fdcb8228e314",
+   "sha256": "1gjwll970avjv0ah4m8w56ybi4l4bc4n8p29wq77za56m0g6jzrg"
   },
   "stable": {
    "version": [
@@ -27058,11 +27099,11 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210607,
-    1506
+    20210615,
+    1833
    ],
-   "commit": "ef609bf15368a68c4eb3c46fd8cc1bb623b6b83e",
-   "sha256": "0ddh7zqgaq07534l6m3wjvbcj23a01h3x7scd4pl5rj6wyxqwv76"
+   "commit": "acbe1cba548832d295449da348719f69b9685c6f",
+   "sha256": "0c1zqfrn2va2m9z6rw3i2h6dwm2vc0asbha4d9r0gss4b7519pf2"
   },
   "stable": {
    "version": [
@@ -27088,8 +27129,8 @@
     "consult",
     "embark"
    ],
-   "commit": "ef609bf15368a68c4eb3c46fd8cc1bb623b6b83e",
-   "sha256": "0ddh7zqgaq07534l6m3wjvbcj23a01h3x7scd4pl5rj6wyxqwv76"
+   "commit": "acbe1cba548832d295449da348719f69b9685c6f",
+   "sha256": "0c1zqfrn2va2m9z6rw3i2h6dwm2vc0asbha4d9r0gss4b7519pf2"
   },
   "stable": {
    "version": [
@@ -27256,29 +27297,29 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20210607,
-    1450
+    20210619,
+    1246
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "c360a8934c1e07ddab4e12d28800d362d254ccbd",
-   "sha256": "02aikwki7932dldhnsq8ndca59spbc4g2kjfal3sw16lklfw0sfa"
+   "commit": "6e0aaaf4c5598826b24c3079b80bf8af000a77c6",
+   "sha256": "016y0w1gy8z1gdri54njas20l3kw99jg5bjyrmcbmgzjmb1jq0y8"
   },
   "stable": {
    "version": [
     7,
-    2
+    5
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "b0173b6b4c5b66a4706cb82c9b50a179bf159a0f",
-   "sha256": "1scppj8wkiml4dgsg4540hdd8mv9ghcp2r17b647az0ccxwp73qm"
+   "commit": "144c49ac2931b6e57e265cc6139b7c9718f1297e",
+   "sha256": "0j9qh781zr348qx49zvr59rdpmh4204fqx9sm3mfh3kg6kbc7v8x"
   }
  },
  {
@@ -28006,26 +28047,26 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20210530,
-    1147
+    20210616,
+    2229
    ],
    "deps": [
     "closql"
    ],
-   "commit": "8ee60b65bff02ef606d489b83e2def9922e9623d",
-   "sha256": "03zsysj78w43q902wi9dhck64q9va247avr6fhdw8ynf2lvb78d3"
+   "commit": "44b7b2519f84056ee94a6c4ce21fce146532174c",
+   "sha256": "0z9sz9ydfjzhawh4qip41h3vid1lslaf0h14hkjz9kx8fkrzib8a"
   },
   "stable": {
    "version": [
     3,
     3,
-    0
+    1
    ],
    "deps": [
     "closql"
    ],
-   "commit": "8ee60b65bff02ef606d489b83e2def9922e9623d",
-   "sha256": "03zsysj78w43q902wi9dhck64q9va247avr6fhdw8ynf2lvb78d3"
+   "commit": "44b7b2519f84056ee94a6c4ce21fce146532174c",
+   "sha256": "0z9sz9ydfjzhawh4qip41h3vid1lslaf0h14hkjz9kx8fkrzib8a"
   }
  },
  {
@@ -28158,10 +28199,10 @@
  },
  {
   "ename": "eradio",
-  "commit": "533c3f130d94335bf18907fefe2b5f1e047cdfbe",
-  "sha256": "0dxlsikgz1fbsypxxzczp6m4bbqh4kqv0f7w058z2sgzplybq3m4",
+  "commit": "99f67df1d87ecd1bb54b85fa1711dfba90dd00dc",
+  "sha256": "1w6igfsb8l4i2nq1h528wys61gwh784xzm99bw25rrjj17jdyxsn",
   "fetcher": "github",
-  "repo": "fossegrim/eradio",
+  "repo": "olavfosse/eradio",
   "unstable": {
    "version": [
     20210327,
@@ -28277,11 +28318,11 @@
   "repo": "alexmurray/erc-matterircd",
   "unstable": {
    "version": [
-    20201029,
-    2321
+    20210701,
+    32
    ],
-   "commit": "d46f55909f1c229fd84f409ef992a7a463719893",
-   "sha256": "19vwpl40nw3jgfmiwl1y4yna0ygjyzlqf5gs85g63f61d89gjlrs"
+   "commit": "6e9698310f5df5193bccb334839bca29e4bbfe30",
+   "sha256": "0cwq1ljgb0ga1b8f8gks9c4y8rqjfawpr4l0fi0p3y674a76z33f"
   }
  },
  {
@@ -28643,19 +28684,17 @@
     20200914,
     644
    ],
-   "commit": "044843c5281a7bdb9479317793a75c8c0fcfadd9",
-   "sha256": "04lirb2p1h46c1l84ysdnr2jxvzsdw1zv6jhm7h8ybgzmaa65b6m"
+   "commit": "007a26fb5f7d9eb54db16484fb116d6e47c8cc5e",
+   "sha256": "1w9pra3qqmidsf5mvp0lmk9liw1ryaf8kjiawfgyyc6mzgw6nrvz"
   },
   "stable": {
    "version": [
     2,
     6,
-    1,
-    3,
-    20210605
+    2
    ],
-   "commit": "ab805592a0ae7066fbd5fa5f47e933194fce878f",
-   "sha256": "19ld12x4is0nx52i05zv20js0zysx3bljbdn2nr65vy11dq2cyyp"
+   "commit": "246a229faea2ef2fa53caf491ff8a2d72dd7510c",
+   "sha256": "1ccmryw6vs8d87d5zmjl0kr2kvyd1zxl73344fa7yzqgg2kw1da6"
   }
  },
  {
@@ -28669,17 +28708,17 @@
     20210315,
     1640
    ],
-   "commit": "a8969ec16a91c0e1ac56a438d81069d288662518",
-   "sha256": "0wp6sf8rw73waws47av68d4sdd28qix74n53c4fpdc4c2xq3j3h6"
+   "commit": "3517ac9f6b48641b949e19971a1a2d022b7494a0",
+   "sha256": "1r9adb0x370c3cj93lgaag2ifkgi954gh5hnshkr3wz8bpqirvk1"
   },
   "stable": {
    "version": [
     24,
     0,
-    2
+    3
    ],
-   "commit": "82f97b9d3d639ed87175aeed75747eb6594170ab",
-   "sha256": "065kc9p30jam23grpm7dwxjf76n6g1hzdrq9q1irr3qmw1rr0240"
+   "commit": "0a887ba078f6faadea128b51a98e928dcb0e79a4",
+   "sha256": "0hirfg5y53gj5smf2rqxiadj02ad761hgq3yqcz4j1ldnm50hlr9"
   }
  },
  {
@@ -29418,8 +29457,8 @@
     20210405,
     1808
    ],
-   "commit": "3d62a3319ab03a810030058d3fb368b28dfd82d5",
-   "sha256": "0hj3nczmqmgiwsvh664rs34j63wl325x6nar21p1a84h5ximpkxq"
+   "commit": "5bf63dacc5df8a74860e80dabd16afce68a24a36",
+   "sha256": "1vxg86wv6f96bva0d1xxhisk525chwhdl4nq77xhriflq65mcmi3"
   }
  },
  {
@@ -29531,11 +29570,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20210520,
-    2146
+    20210616,
+    1806
    ],
-   "commit": "f62f460e3c55e5e7ad5941225e7884b0e1656131",
-   "sha256": "0i5i59pbga10s4yml5vi4fbbxmaqgf8fx4caj3mfgd8dkrkxblgp"
+   "commit": "a5df6aa81351385e9813b722afcacdba1648226d",
+   "sha256": "0di7s1k9lizvbr4n59qhn6ipc67klcyimlkdqw4if7nkfjif5bsn"
   },
   "stable": {
    "version": [
@@ -30126,15 +30165,15 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20210527,
-    2107
+    20210628,
+    1913
    ],
    "deps": [
     "cl-lib",
     "goto-chg"
    ],
-   "commit": "ad47644eea5e351269f5bead18e713768d96f207",
-   "sha256": "1bcdrvrrjq9r75cfrxziq84slrjm8gbbhbm72hqjfzka6zcnr39g"
+   "commit": "f20d442ff006aa5a6dc48ac654906b48b95107fd",
+   "sha256": "0bl854036zpjg5p5asamvlnl9lf46rgcpa645yhrvxqmwznm6din"
   },
   "stable": {
    "version": [
@@ -30328,15 +30367,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20210607,
-    1954
+    20210701,
+    1024
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "86b02f84a8df0ddd6216cb85d49bedd6ee2ab747",
-   "sha256": "0vh0wdzz9idfinbfd3mynlp88lgq5j9wk8c3pc5a1is6g3jpj938"
+   "commit": "a24168ffe3711890b5dcd41041a51146bbd67497",
+   "sha256": "1pz046fw06lgc7gjrfr0a895j867mm96k8h5dw3k0p64rh1xh1sa"
   },
   "stable": {
    "version": [
@@ -30894,26 +30933,26 @@
   "repo": "redguardtoo/evil-matchit",
   "unstable": {
    "version": [
-    20210325,
-    123
+    20210609,
+    1311
    ],
    "deps": [
     "evil"
    ],
-   "commit": "8c8c94bea899718f393ad041202a355e6f24ea19",
-   "sha256": "0vygxkvri6363wi3byjd2r23bjyvjkfy58n2kshslaq18z5vylzl"
+   "commit": "d7ad7f712b98aa64b7cc4fb16354b32666739c77",
+   "sha256": "1x7wpq0lgkp016yik6sc7b2abhixgcwk0mxx29dyycsjjkdlhp3a"
   },
   "stable": {
    "version": [
     2,
     3,
-    11
+    12
    ],
    "deps": [
     "evil"
    ],
-   "commit": "a0c5bd1fe89119b94ffb0a266d2969434e7ec4c1",
-   "sha256": "1990g1b6v0i7jaiv35bdssdn601rjifzg4fy9s3sxk0drqm1xiss"
+   "commit": "9cd0ddaacb3476221d37344715c759ed3cb538d7",
+   "sha256": "0l4ash907d91vccqdxjz1v5spd8f4va0vrdri6h9y1qc67mjlsph"
   }
  },
  {
@@ -31029,11 +31068,11 @@
   "repo": "redguardtoo/evil-nerd-commenter",
   "unstable": {
    "version": [
-    20210528,
-    1009
+    20210624,
+    1122
    ],
-   "commit": "c0f49e4e87300720b8e8a8296d92b8386956c7a2",
-   "sha256": "0ci3hjzgwayz9nvmwg5vbmvn80cz0lsppghi511cbr3cdf8xkkv4"
+   "commit": "118bebd02a489ddf5eee3ab6fb55b3ef37ebe6d4",
+   "sha256": "15phgj1x2k7i6wnhq3lbrjldrc7xr18z4sgsmklwwgr4blx9ql1s"
   },
   "stable": {
    "version": [
@@ -31463,15 +31502,15 @@
   "repo": "hlissner/evil-snipe",
   "unstable": {
    "version": [
-    20210607,
-    420
+    20210609,
+    509
    ],
    "deps": [
     "cl-lib",
     "evil"
    ],
-   "commit": "9bd7345476174dfc6eeaa700a505e45b155ddb83",
-   "sha256": "1p7v9pnbyc4mhpkvmyl9vr825grqnfyl0h203sbnb1vnw15bbnbp"
+   "commit": "a9b9b39a7915e66b7d5da9cecfaf002c72d08196",
+   "sha256": "01ikzxvm878k0xwj10h3ww02459g3jiz4fjsm481jw1jjvnxg5b2"
   },
   "stable": {
    "version": [
@@ -31557,14 +31596,14 @@
   "repo": "emacs-evil/evil-surround",
   "unstable": {
    "version": [
-    20200603,
-    2216
+    20210615,
+    2119
    ],
    "deps": [
     "evil"
    ],
-   "commit": "4706987bc01a552343848da49b4951bd54374643",
-   "sha256": "0v2v58pchr5icdpvg4k6vblxhgjk09wi7f54hs1dj0f6rgvpxmx5"
+   "commit": "3bd73794ee5a760118042584ef74e2b6fb2a1e06",
+   "sha256": "125yxpd2cmhwvcb0p9z5dc6ydk4w2a9vblkn9hayh6myj9jwjy9f"
   },
   "stable": {
    "version": [
@@ -31654,8 +31693,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "ad47644eea5e351269f5bead18e713768d96f207",
-   "sha256": "1bcdrvrrjq9r75cfrxziq84slrjm8gbbhbm72hqjfzka6zcnr39g"
+   "commit": "f20d442ff006aa5a6dc48ac654906b48b95107fd",
+   "sha256": "0bl854036zpjg5p5asamvlnl9lf46rgcpa645yhrvxqmwznm6din"
   },
   "stable": {
    "version": [
@@ -32308,8 +32347,8 @@
     20190520,
     1106
    ],
-   "commit": "e043df1bcef40cd5934a74c210e1e35d5eb0e5a6",
-   "sha256": "0am4g25mlmm1iqcm2kxzskrzhrm1f09cdwcqmvk4lidid5xcb6xc"
+   "commit": "fc6713e753380f3034d8df55b7af3a737ea52ab4",
+   "sha256": "17p8gcbm81qq1rgn3xdblmvyx3qn4sjpylna7pfpq32nkxjaajvc"
   },
   "stable": {
    "version": [
@@ -32338,10 +32377,10 @@
  },
  {
   "ename": "expand-line",
-  "commit": "3416586d4d782cdd61a56159c5f80a0ca9b3ddf4",
-  "sha256": "0bzz7zrpfdxhjxs7nzlmzjb9jfajhxkivzr5sm87mg3zx8b6gjyi",
+  "commit": "06f13c6ff35e0e710407b2138fcefaebf01b007a",
+  "sha256": "19vk9kp1pp5m9l6qwgnxalamqlcds66f3vc0psyymna1g7pinr1w",
   "fetcher": "github",
-  "repo": "zhangkaiyulw/expand-line",
+  "repo": "victorteokw/expand-line",
   "unstable": {
    "version": [
     20151006,
@@ -32359,11 +32398,11 @@
   "repo": "magnars/expand-region.el",
   "unstable": {
    "version": [
-    20200304,
-    1839
+    20210624,
+    1015
    ],
-   "commit": "4b8322774d9c1d8b64a0049d1dbbc1e7ce80c1a0",
-   "sha256": "1x6sbychbz91q7mnfn882ir9blfw98mjcrzby38z1xlx3c9phwyi"
+   "commit": "519e92eabc470fe1792d8d4a37c98e76cf195840",
+   "sha256": "0rh5li9i6nz81mbji87dnv5ly58rl5lphlvjx4m0hb7dlqpw0db2"
   },
   "stable": {
    "version": [
@@ -32775,15 +32814,15 @@
   "repo": "rejeep/f.el",
   "unstable": {
    "version": [
-    20191110,
-    1357
+    20210624,
+    1103
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "c4dbf8c8e83df834f5d6f72cd5649b9d8a8812ec",
-   "sha256": "132zj5yvx4llzsh6rs0jwj0b5cfl140v0m6rk0kckw3vfgfh0cln"
+   "commit": "50af874cd19042f17c8686813d52569b1025c76a",
+   "sha256": "0k6qp5vqyiql9f6i6z95iskjpv9wn6sd66wnf2x0jxbws4r2bjxy"
   },
   "stable": {
    "version": [
@@ -32871,10 +32910,10 @@
  },
  {
   "ename": "face-shift",
-  "commit": "e55d2d30525602726c3c63025f5fce671efac416",
-  "sha256": "1y0m6yv64q76x6i2r5npn97c2axsy2k7b3m58zxh8p7c5lpwjdpa",
+  "commit": "982788433004ba644a372c50130613e3c56bba10",
+  "sha256": "06962zrxnm7q9w8ddm6xwa2q1vbb8wi1z8sqmw0yksz6wra49d5w",
   "fetcher": "git",
-  "url": "https://git.sr.ht/~zge/face-shift",
+  "url": "https://git.sr.ht/~pkal/face-shift",
   "unstable": {
    "version": [
     20190818,
@@ -32883,8 +32922,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "8dd6fb5f6277d3a594654aeb3e6a7b7b5581656a",
-   "sha256": "003k8i18s782zf1g0c9wi8p9lyk0viz76dah8hd3y622hmx8sdlb"
+   "commit": "8c62d7a27a0e3092942742362ed73e17e254e904",
+   "sha256": "028b3j7rp4z78285r8w4db8dx9j6zlqp8aw4y0pvd4ifqbs5wh05"
   },
   "stable": {
    "version": [
@@ -32952,8 +32991,8 @@
     20210602,
     1952
    ],
-   "commit": "45f2faef92ee23738b86f4f8d0a433ad729a5ca8",
-   "sha256": "0slvrgw508388il24wlx9g0bf32anpk6rbhmb2r99anq2vhn4b4g"
+   "commit": "cb8803355e20812d84195b1b7c9b0578c3262e68",
+   "sha256": "0wx2k9262p712aasn3ha8si250yzhcqz513apna8lp5gri2rxsg8"
   },
   "stable": {
    "version": [
@@ -33424,20 +33463,20 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20210410,
-    1942
+    20210624,
+    1431
    ],
-   "commit": "59ab02344f569069b9899a3a5ffdca4a30093df4",
-   "sha256": "1vh6n2sg89g43sidymk22wjzjh71wgbajshhh7y3f6zf8xs94mmz"
+   "commit": "f37a3de72c6cbf37f82d4b2f37d9009af5058099",
+   "sha256": "1qnmcysrl2zxiid4v1h1hq1nax3a7sxs2dmag54sfifm149lf7f3"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
-   "commit": "ae4634bef12f66a1d4721ab74c5bf8dd29d710d2",
-   "sha256": "15b5zb66dzszpdiqkwgxqv434kqgpk1l065ic4lbj3y3krm2snbg"
+   "commit": "ea8564a2cc4f7e10b3fc13faf26a4f098b159f00",
+   "sha256": "1qnmcysrl2zxiid4v1h1hq1nax3a7sxs2dmag54sfifm149lf7f3"
   }
  },
  {
@@ -33574,15 +33613,15 @@
   "repo": "knpatel401/filetree",
   "unstable": {
    "version": [
-    20210514,
-    1614
+    20210629,
+    356
    ],
    "deps": [
     "dash",
     "helm"
    ],
-   "commit": "08c0ea22f304f9777cd96e9b86f7c6e5331e82d8",
-   "sha256": "1phqiisabqsfkmslajl012lc0bf5y0vkgrcjavbwzf52hj7kn982"
+   "commit": "f7dd8a310f5364f1e1549082ef231c3c27285e89",
+   "sha256": "1w1f924as6l0s9dkpjjk6bnkp29x52mf5pzzqxqsigp2r1z6k2lk"
   }
  },
  {
@@ -33768,8 +33807,8 @@
     20210427,
     1205
    ],
-   "commit": "3bf010d2be073d499de5ffdaa98f48bf8a3dd21e",
-   "sha256": "0zpckqcx4fbjni1f0c6wzi1356ab06j33himfgkhvyl1bn4w5jna"
+   "commit": "680ec93808176442a2c78b91b18bb4256d81d340",
+   "sha256": "1af30i3nsms1s2gwq3wx0xbmjxd95hipai63icw3jpwc3pmw3g2n"
   },
   "stable": {
    "version": [
@@ -33918,11 +33957,11 @@
   "repo": "jming422/fira-code-mode",
   "unstable": {
    "version": [
-    20201005,
-    1607
+    20210621,
+    1933
    ],
-   "commit": "a3a7a75d2b8b15404c37de186162a5f89ba447bf",
-   "sha256": "0az773s1g8c1sahyrci4zclzhyznr3kizmvxs65rpn0pcmcfq1m8"
+   "commit": "85e0eba018bca70040faea19996b43ce8e543cad",
+   "sha256": "1mv0gphbp976ncfif2jbfrmkayh0lp5cjqmiimhw1inw7ps18k5r"
   }
  },
  {
@@ -34855,14 +34894,14 @@
   "repo": "leotaku/flycheck-aspell",
   "unstable": {
    "version": [
-    20210605,
-    1713
+    20210618,
+    920
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "8c45988a12e7c149b17d7edb84e6dfc33bb7b288",
-   "sha256": "1lsfz3yi3i1mqmq6p9x6fx26wrlqihsaz3yk5g50yv6jqvfr1g79"
+   "commit": "3abe1a6184fefea3e427141131fba40afae3d356",
+   "sha256": "1g600caz7v7qm6fj67x0s064f4n5fr57bnd0m3sc43gn24rpjjdv"
   }
  },
  {
@@ -35723,31 +35762,31 @@
  },
  {
   "ename": "flycheck-grammalecte",
-  "commit": "2e7aee5074faedef4f2b989ffe05995b2f73bfbb",
-  "sha256": "031x2yh3wdklsm169h34sg0bzpl36nfms129zj4j0z99gw1kda3z",
+  "commit": "5f03c71c5482b4f3f6424e71dc19e7daec400db6",
+  "sha256": "0w55xmxxa28k776fl0kc08frsk1msq0ia40afa4gj8g6mi254qm3",
   "fetcher": "git",
   "url": "https://git.umaneti.net/flycheck-grammalecte/",
   "unstable": {
    "version": [
-    20210504,
-    1852
+    20210627,
+    1018
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "f488739aea2ef5c8d39bd28083dd72fdfee46e02",
-   "sha256": "18yiv09hzbclf9rjp61lxlia2m1qbvmwkiqxxs9jjpac28x7ypjf"
+   "commit": "8f13de89134e9708b2a24a040a0335a7302632f9",
+   "sha256": "1acwvndq604gl5n3985mj5v70vcl3d12vh6bzs5nz5xyr8c848z7"
   },
   "stable": {
    "version": [
-    1,
-    4
+    2,
+    0
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "f488739aea2ef5c8d39bd28083dd72fdfee46e02",
-   "sha256": "18yiv09hzbclf9rjp61lxlia2m1qbvmwkiqxxs9jjpac28x7ypjf"
+   "commit": "fab1b5071b7fe7a34869ffb8672abad38948c047",
+   "sha256": "040mb9djj4cxpjsjch9i30pi36a2z7grkhnsnfdi5qyh341p4pq0"
   }
  },
  {
@@ -36178,6 +36217,37 @@
   }
  },
  {
+  "ename": "flycheck-languagetool",
+  "commit": "06859c648c33d422a798ef98a564cb79783a9a3d",
+  "sha256": "0qnvvl9bfx7i0agfm3v7qrcjm86vfshpx97aa0ms8byw77hii5i7",
+  "fetcher": "github",
+  "repo": "emacs-languagetool/flycheck-languagetool",
+  "unstable": {
+   "version": [
+    20210629,
+    536
+   ],
+   "deps": [
+    "flycheck"
+   ],
+   "commit": "6ade9d7f294cee7e41d0bce9dddb139c49985501",
+   "sha256": "1yq2n7bknw7by1cn53xn7kz8a3qj1w7szsjysaj93mhxb154g9qz"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "deps": [
+    "flycheck",
+    "s"
+   ],
+   "commit": "5608a330e09222d05bf0354f1847f537168e22dd",
+   "sha256": "0v6gqhgwn2x6qd34380y5n1ql08anv02bs6qk7glq6a0ha8xkzfa"
+  }
+ },
+ {
   "ename": "flycheck-ledger",
   "commit": "dc715e6849aa5d6017e2478514c4a0d84c7ddbe5",
   "sha256": "0807pd2km4r60wgd6jakscbx63ab22d9kvf1cml0ad8wynsap7jl",
@@ -36513,15 +36583,15 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20201126,
-    603
+    20210617,
+    2237
    ],
    "deps": [
     "flycheck",
     "phpstan"
    ],
-   "commit": "6863a5278fc656cddb604b0c6e165f05d0171d0a",
-   "sha256": "05q1y6xshh5csr672jwplp2xmp87gvj9rc65ybpa687dkdmq8cdh"
+   "commit": "56617fa87c9bec037d4e4a0a143b7d70a989c082",
+   "sha256": "02k4pmmxq3h8mi0dsjh0s0002gjkpg6g9pxsnxgalwb6rakfirbh"
   },
   "stable": {
    "version": [
@@ -36900,8 +36970,8 @@
     "flycheck",
     "rtags"
    ],
-   "commit": "63f18acb21e664fd92fbc19465f0b5df085b5e93",
-   "sha256": "0wzyn9qzyly71yfwhlk5m94ygjnbk459pgbpgkhp9fqgchx12p1r"
+   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
+   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
   },
   "stable": {
    "version": [
@@ -37355,8 +37425,8 @@
     20210411,
     2342
    ],
-   "commit": "8c45988a12e7c149b17d7edb84e6dfc33bb7b288",
-   "sha256": "1lsfz3yi3i1mqmq6p9x6fx26wrlqihsaz3yk5g50yv6jqvfr1g79"
+   "commit": "3abe1a6184fefea3e427141131fba40afae3d356",
+   "sha256": "1g600caz7v7qm6fj67x0s064f4n5fr57bnd0m3sc43gn24rpjjdv"
   }
  },
  {
@@ -37898,6 +37968,36 @@
   }
  },
  {
+  "ename": "flymake-languagetool",
+  "commit": "3ead983cef03a4a25f78bac45d4a7cca5058880a",
+  "sha256": "07m3mps9vs2zk63ssgcwwmdbfln7qzqhnny4i90x6kd2g10vkmvc",
+  "fetcher": "github",
+  "repo": "emacs-languagetool/flymake-languagetool",
+  "unstable": {
+   "version": [
+    20210627,
+    434
+   ],
+   "deps": [
+    "s"
+   ],
+   "commit": "5e44d7ba7153d20a01428bff98c1949a7a0eb753",
+   "sha256": "19149wr4plng3n1bpfd49ja1phd3sbyrxa6vk47qh8xc7x1ra309"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "deps": [
+    "s"
+   ],
+   "commit": "f0f105ab11fd1de1379baef91fcd46e6c2464dca",
+   "sha256": "1sylnd4hybxnygcgxqw8p7mlp0r000n6f44y5fq3sv9518l5mflz"
+  }
+ },
+ {
   "ename": "flymake-less",
   "commit": "6d4eae8b7b7d81ebf4d85f38fc3a17b4bc918318",
   "sha256": "05k5daphxy94164c73ia7f4l1gv2cmlw8xzs8xnddg7ly22gjhi0",
@@ -38086,14 +38186,14 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20201122,
-    950
+    20210617,
+    2223
    ],
    "deps": [
     "phpstan"
    ],
-   "commit": "6863a5278fc656cddb604b0c6e165f05d0171d0a",
-   "sha256": "05q1y6xshh5csr672jwplp2xmp87gvj9rc65ybpa687dkdmq8cdh"
+   "commit": "56617fa87c9bec037d4e4a0a143b7d70a989c082",
+   "sha256": "02k4pmmxq3h8mi0dsjh0s0002gjkpg6g9pxsnxgalwb6rakfirbh"
   },
   "stable": {
    "version": [
@@ -38116,14 +38216,11 @@
   "repo": "manuel-uberti/flymake-proselint",
   "unstable": {
    "version": [
-    20200927,
-    640
+    20210621,
+    929
    ],
-   "deps": [
-    "flymake-quickdef"
-   ],
-   "commit": "b94950301139846002d2020bc630440ff834bf24",
-   "sha256": "1zlbw4mj0l9p72gw03jrqmaakh7550ha02r3rmxrlqs6gjzqsd1f"
+   "commit": "adf1ce7daf1380cb50f365a36548165fe4a32423",
+   "sha256": "1mmwq4b4idhbsygwjmn3fj67idixx4gaap9zfa0v4didahjsjsjh"
   }
  },
  {
@@ -38239,24 +38336,6 @@
    ],
    "commit": "e14e8e2abda223bd3920dbad0eefd5af5973ae6d",
    "sha256": "0d2vmpgr5c2cbpxcqm5x1ckfysbpwcbaa9frcnp2yfp8scvkvqj0"
-  }
- },
- {
-  "ename": "flymake-rust",
-  "commit": "7fabdb05de9b8ec18a3a566f99688b50443b6b44",
-  "sha256": "0fgpkz1d4y2ywizwwrhqdqncdmhdnbgf3mcv3hjpa82x44yb7j32",
-  "fetcher": "github",
-  "repo": "jxs/flymake-rust",
-  "unstable": {
-   "version": [
-    20170729,
-    2139
-   ],
-   "deps": [
-    "flymake-easy"
-   ],
-   "commit": "2f42d1f2dad73ec9de460eda6176e3ab25c446f0",
-   "sha256": "02fgkv9hxwrv8n5h6izb5jyjcpazlf86pjjj4zkv1ycpa6gyzzwn"
   }
  },
  {
@@ -38964,8 +39043,8 @@
     20191004,
     1850
    ],
-   "commit": "246120647e28a27506ca0894ba98e371086881fd",
-   "sha256": "15gqzj4h0w33w38i8ihl74iy7aqxlds97gm93r72z69pm2l1d7dm"
+   "commit": "8a3b529d5ece261a8847298ea03ed35615cc9bfa",
+   "sha256": "16zalqjd2llwkp7v0218crgf3k34py8zx6lj6z7i3kbmxm9nb27q"
   }
  },
  {
@@ -39042,8 +39121,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20210525,
-    1345
+    20210628,
+    736
    ],
    "deps": [
     "closql",
@@ -39053,16 +39132,17 @@
     "let-alist",
     "magit",
     "markdown-mode",
-    "transient"
+    "transient",
+    "yaml"
    ],
-   "commit": "551e51511e25505d14e05699a1707fd57e394a9a",
-   "sha256": "139pndj9l9aifnvv2ak5zwf5gzwhp3m6dfpw1avf4vkh1zywzwa0"
+   "commit": "84ef3a7bad5879a2dd179a94655ac0da28be3898",
+   "sha256": "0mp1jwc0ms6d15l3vw0zg35l68q58bk5bj8w5znjvwjh3akybfpm"
   },
   "stable": {
    "version": [
     0,
     2,
-    0
+    1
    ],
    "deps": [
     "closql",
@@ -39074,8 +39154,8 @@
     "markdown-mode",
     "transient"
    ],
-   "commit": "551e51511e25505d14e05699a1707fd57e394a9a",
-   "sha256": "139pndj9l9aifnvv2ak5zwf5gzwhp3m6dfpw1avf4vkh1zywzwa0"
+   "commit": "e7d0d759440492549db331f3c39c3cc62880118f",
+   "sha256": "0j28vc0q1h36pk0y2nidnlsc2y7n0vpfrd8civiv1zp8z0jwfyc9"
   }
  },
  {
@@ -39110,15 +39190,15 @@
   "repo": "lassik/emacs-format-all-the-code",
   "unstable": {
    "version": [
-    20210604,
-    1107
+    20210619,
+    533
    ],
    "deps": [
     "inheritenv",
     "language-id"
    ],
-   "commit": "82f68e5d1f0641d7a050db02ab2c0a7d3888f358",
-   "sha256": "0761qmkza4sbl1k0vj4q18zm9p148h7131dq46wwajyxbmrxlxja"
+   "commit": "6a3463a723e08a37bae85a7585700ab314ae86ea",
+   "sha256": "10aa5jh4ba4bhghwb8mi6my1dazbvxlylk3gcxji47qj0z78fajh"
   },
   "stable": {
    "version": [
@@ -39255,26 +39335,26 @@
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20210523,
-    1327
+    20210611,
+    1228
    ],
    "deps": [
     "seq"
    ],
-   "commit": "77f3ce6b646868210f91b6a80fcaaa77297ed341",
-   "sha256": "1f0mzrn237kv2p5bz58km4b7a46shzm1v7n4a6ksyfd3n7cqas85"
+   "commit": "91f4ad083fa620e6e6202460decc3280bd8e4e71",
+   "sha256": "0xlg5b0sa4qbv68sza23fr5khv36860jbhzfbcqcw1d420xllryx"
   },
   "stable": {
    "version": [
     3,
-    4,
-    1
+    5,
+    0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "707b8fdc9a0e1de1a911ca312c23c0c1672f3ec3",
-   "sha256": "14zhbcfqyp093kd1bxl7f2hf5l5995qmgpmnxfgw9qcc781crj73"
+   "commit": "91f4ad083fa620e6e6202460decc3280bd8e4e71",
+   "sha256": "0xlg5b0sa4qbv68sza23fr5khv36860jbhzfbcqcw1d420xllryx"
   }
  },
  {
@@ -40214,11 +40294,11 @@
   "repo": "bling/fzf.el",
   "unstable": {
    "version": [
-    20210508,
-    1516
+    20210619,
+    1421
    ],
-   "commit": "23c09c9c0417c7de67a8965d9b506d0cc7aea7a2",
-   "sha256": "0c4cz1kyanqswz5ww8aql96hqxg8p8lwwwygw061rq2ycmkl54nk"
+   "commit": "c975001725e4b7f58dd9379a64c170f07734af59",
+   "sha256": "01d303vbn7vvhl1g1wpmpy90h5vaj3yimzgmhnmswc2qc2s3cnhq"
   },
   "stable": {
    "version": [
@@ -40271,11 +40351,11 @@
   "repo": "ShiroTakeda/gams-mode",
   "unstable": {
    "version": [
-    20210227,
-    251
+    20210701,
+    36
    ],
-   "commit": "52e984d64c48f518222e0f6bd326236f78d7bf7a",
-   "sha256": "0fjdm2mlwibi6cz0r7cm4ylxzg7i8fljkwfhflb84xqcaknwr2sk"
+   "commit": "64e3544726b77f10becb58a51d61993fbba433af",
+   "sha256": "1sn893lnqfr13p1m2g36i6f0ikpibhp7q7ak5271fhpzjzh0fi1r"
   },
   "stable": {
    "version": [
@@ -40760,14 +40840,14 @@
   "repo": "emacs-geiser/stklos",
   "unstable": {
    "version": [
-    20210503,
-    944
+    20210626,
+    1440
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "0e3a0570354c03c0cfa25da82fb34ad2e81c1981",
-   "sha256": "1g31cibl88g1vjfvw4z80ywxpnxy5lijhs754qdcnx36maragh07"
+   "commit": "be482a03225720d7adb003c28e4515f6252e7ce2",
+   "sha256": "1dyzpr9i5pxi2p2hg3ndryh7x4y0r9bra88pd1l904vdfsxdxv5z"
   },
   "stable": {
    "version": [
@@ -40789,11 +40869,11 @@
   "url": "https://git.carcosa.net/jmcbray/gemini.el.git",
   "unstable": {
    "version": [
-    20210226,
-    1419
+    20210611,
+    1833
    ],
-   "commit": "0a227125a4112266c06ed7247de039090314b525",
-   "sha256": "0fiix0ssaannim5kxpckhd5z6fssij3igv1dg9y7143dzxf274zz"
+   "commit": "97e096ab2400bbe3c0f6d19fb49bd952f2f14e03",
+   "sha256": "1l092mhpv8dg00ln4yv040kmha7556klm5bqfdvc9ysjnfiwprkd"
   },
   "stable": {
    "version": [
@@ -40938,8 +41018,8 @@
   "repo": "thisch/gerrit.el",
   "unstable": {
    "version": [
-    20210530,
-    402
+    20210620,
+    334
    ],
    "deps": [
     "dash",
@@ -40947,8 +41027,8 @@
     "magit",
     "s"
    ],
-   "commit": "f1bdc47ab2bb29c2a0a385aaa9a5f0f6d543ffb5",
-   "sha256": "1qcw5kzcw9g41hqg0gnq3k6i4ygfgrlghadmfzdnf7dbk93ngl4g"
+   "commit": "ac555ccec74c48297bac0944a207e5b8aceac49e",
+   "sha256": "053gn6ja80810y4a2dayz3xy1bmzb7w06lvf87difa0nhm3mr54g"
   }
  },
  {
@@ -41206,15 +41286,15 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20210531,
-    2006
+    20210619,
+    1405
    ],
    "deps": [
     "let-alist",
     "treepy"
    ],
-   "commit": "e9a819c9c997b8e752eeb4a3fcd1a7b55ab8da47",
-   "sha256": "1c92q4hrax9gfrw35qi3slr7man006v5vqzp6hi2an5haw2cz4x2"
+   "commit": "865424d4faf66048bfb3752856ac0cf68e1c6efe",
+   "sha256": "0kqjxwkm3n6r9zg6pi015g9ix4pyz7b2rngcmmrindcjb5h292a4"
   },
   "stable": {
    "version": [
@@ -41272,8 +41352,8 @@
     20210401,
     656
    ],
-   "commit": "fa81e915c256271fa10b807a2935d5eaa4700dff",
-   "sha256": "1yf6yipvhhna29mzaan5vb3d5qvbrkp2awr5diyf381mvxgk8akh"
+   "commit": "8ab9c88a2b8cccd3c092e155f84b1b19930d0719",
+   "sha256": "1jiglrlhrph57p5kkm1qlqihwl6z7h9qh16qmmd5783ynksnbxp3"
   },
   "stable": {
    "version": [
@@ -41572,16 +41652,16 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210525,
-    844
+    20210701,
+    1554
    ],
    "deps": [
     "dash",
     "transient",
     "with-editor"
    ],
-   "commit": "4a8646a30df99bbafc95d4f21a0b2bf0a6f6566f",
-   "sha256": "0y3wzvyaxn5zybjak77r1cngaqqm462s3d4f1cwmzvrnpv99f3r9"
+   "commit": "2ae376e4923e02355828350b81cdc1b0f8fa72ff",
+   "sha256": "1h07rg0fvr7av69bcks1n63digafq145mlsaddyv6xixxqjp0vbg"
   },
   "stable": {
    "version": [
@@ -43004,11 +43084,11 @@
   "repo": "emacsorphanage/gnuplot",
   "unstable": {
    "version": [
-    20210526,
-    1848
+    20210609,
+    834
    ],
-   "commit": "07a80272b86c081b40602ec0b080571f3269749d",
-   "sha256": "1d50b5vwnzca16g7hs2i0357lx9x5rvivdb5hdi0ngf6sb8d1afk"
+   "commit": "7138b139d2dca9683f1a81325c643b2744aa1ea3",
+   "sha256": "1v30avyx5klccpxqi85l5467dbc2v7s1jk5xv7rzvhg27azr4jm2"
   },
   "stable": {
    "version": [
@@ -43574,14 +43654,14 @@
   "repo": "emacsorphanage/go-impl",
   "unstable": {
    "version": [
-    20170125,
-    1552
+    20210621,
+    743
    ],
    "deps": [
     "go-mode"
    ],
-   "commit": "69f0d0ef05771487e15abec500cd06befd171abf",
-   "sha256": "1rmik6g3l9q1bqavmqx1fhcadz4pwswgfnkbaxl6c5b6g2sl26iq"
+   "commit": "1eebba6ccd02d11a5a82ad4540a8d562797bc3b3",
+   "sha256": "1i48vawn2a76bdbvv02mw7c5ny7g8dxk6b6xw2y9z0iijmbr0dzl"
   },
   "stable": {
    "version": [
@@ -44081,20 +44161,20 @@
   "repo": "io12/good-scroll.el",
   "unstable": {
    "version": [
-    20210607,
-    339
+    20210613,
+    206
    ],
-   "commit": "b4233500bbbdb64758283ba8a4b7cef5a85181a2",
-   "sha256": "05k03bycwpgs9wf9rh4rxfp38lhzr46c8zpvkd5qr6zwb1nnvr00"
+   "commit": "26a1b958bbf2c45d86f033e58b74edd196302f23",
+   "sha256": "0g4fzji614aqy3kw9iivlmw5v8igql0lkrzvgffrd01jn57dzlwp"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    4
    ],
-   "commit": "61aa3b57d572e6a46a1415b66dbc4b80c33bfb73",
-   "sha256": "0zprygv94rp1hdq7qxcmp3ns04j6l28y9w5hp087mhfbr1v5y54m"
+   "commit": "4ca86e18c8f64fd7a2d088a591ac11773d6b06a7",
+   "sha256": "0bq229nnwp8cy33gizp75wi3x11wn46p73v1581srm2f1zmkapsj"
   }
  },
  {
@@ -44483,8 +44563,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "da0ae769e70e1af16865c3fadb25e9132d089dc6",
-   "sha256": "09kdlz6h31yasi1rv7759m40zb12vj6llv70pqh9swrpii2nmdzp"
+   "commit": "93851bd6e14df055d86661de494119e6bacb2192",
+   "sha256": "0bb5zbyr0xsf4p3440n5x2f3h10ya76vwr3jq10j0ff0x4fxs6iy"
   },
   "stable": {
    "version": [
@@ -45098,11 +45178,11 @@
   "repo": "ZungBang/emacs-grep-a-lot",
   "unstable": {
    "version": [
-    20131006,
-    1347
+    20210618,
+    1420
    ],
-   "commit": "9f9f645b9e308a0d887b66864ff97d0fca1ba4ad",
-   "sha256": "1f8262mrlinzgnn4m49hbj1hm3c1mvzza24py4b37sasn49546lw"
+   "commit": "223819dbea049bdeb5f97f9849fce139a5f16a75",
+   "sha256": "06rrbwb5ms2m3mhsg1l4hqnn7x379019kkdfm8gys5kxv4mfp22l"
   }
  },
  {
@@ -45128,20 +45208,20 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20210515,
-    1548
+    20210609,
+    1305
    ],
-   "commit": "02b7a8109fa1ae248e61c91da3bd8676f8d2e175",
-   "sha256": "0rd8nasnlc01wb4lkzpk3xrwj9lx2n4gsq7h4nc0irnbfy8phy1s"
+   "commit": "0ef2a3566f76e1c03ec64ac64cbb916530e40e32",
+   "sha256": "1p15b41bdzg8819hnq6js62486mwdqcwxns5mnqb21bn6m7pizpm"
   },
   "stable": {
    "version": [
     2,
-    2,
-    1
+    3,
+    0
    ],
-   "commit": "9615c4774727a719d38313a679d70f2a2c6aca68",
-   "sha256": "01imyi1l33ng78m6c5g4pma5gy4j7jy7dwmqwsqgwbws08qdbwgr"
+   "commit": "0ef2a3566f76e1c03ec64ac64cbb916530e40e32",
+   "sha256": "1p15b41bdzg8819hnq6js62486mwdqcwxns5mnqb21bn6m7pizpm"
   }
  },
  {
@@ -45264,11 +45344,11 @@
   "repo": "ROCKTAKEY/grugru",
   "unstable": {
    "version": [
-    20210127,
-    432
+    20210617,
+    1028
    ],
-   "commit": "4ac2bf3877e3af7d23ace3165b9c8ed536ff4832",
-   "sha256": "05nw45hgbygfvbymghsp425474d4nrgl8pjii8jwd1ym155bf13k"
+   "commit": "b1d873cb6186e08c6f7ec782df989b01e955fb4d",
+   "sha256": "1rsixglxvc5a25v1pbyz23bngql84nvjn8673lmkhdcqcvd3s1hg"
   },
   "stable": {
    "version": [
@@ -45494,14 +45574,14 @@
   "repo": "tmalsburg/guess-language.el",
   "unstable": {
    "version": [
-    20210308,
-    1514
+    20210623,
+    1505
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7e511d23ee4315a79081c53596398c471572fb0f",
-   "sha256": "03bm6j8d1v5z1gz1chlpp7s3jzi0lnq6nqdw8r7z1ik5si59dvj5"
+   "commit": "e6b78ed2a36bf5debd3d07ffd99a5a8ca60609d6",
+   "sha256": "0g0vdz42s6hns249lfxcha7l7ihqpyay3n5iijziwrbrrhqi6rx6"
   }
  },
  {
@@ -45576,8 +45656,8 @@
   "repo": "alezost/guix.el",
   "unstable": {
    "version": [
-    20210224,
-    1601
+    20210608,
+    1653
    ],
    "deps": [
     "bui",
@@ -45586,8 +45666,8 @@
     "geiser",
     "magit-popup"
    ],
-   "commit": "8ce6d219e87c5097abff9ce6f1f5a4293cdfcb31",
-   "sha256": "0awbd8x154c4dk4av7inpgd63n07xzng84vvc8qckmgljknc0j7k"
+   "commit": "c9aef52121b458297e70bb50f49f7276b4a8d759",
+   "sha256": "00xdxadbi9fxpfp60zah9190rcz3w08vl1blbhmaiy7c1hd2gi39"
   },
   "stable": {
    "version": [
@@ -46201,11 +46281,11 @@
   "repo": "haskell/haskell-mode",
   "unstable": {
    "version": [
-    20210507,
-    2243
+    20210622,
+    2049
    ],
-   "commit": "b35e8547b67f3d2c4d38ec7e7e516e3c0925352f",
-   "sha256": "1z6x28gv47vdi2a06p1w390a40ll1b1g2dhxhzpn998r6b1d8zxm"
+   "commit": "98ba3922360199d5260d47f417f096730ad057c5",
+   "sha256": "1k7zs7vlbpyhizv4ff1mhagz1mvazmm4bvq215z9f871hhf6l7ff"
   },
   "stable": {
    "version": [
@@ -46535,30 +46615,30 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210607,
-    1026
+    20210701,
+    637
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "a92156303021e0ec91a904e16a994d8e1ccd78f7",
-   "sha256": "1lxmp0a7wk7wqb6qcy1zn9sr47vakgxzn0j8yyvdv1vps4hz9wk0"
+   "commit": "e74f450eaa4f197f1fa63a819193bc1c65984042",
+   "sha256": "1xl9wn520gnpyyryf7iij8y1x5ak61zcira6g480sqvv2ympmhkd"
   },
   "stable": {
    "version": [
     3,
-    7,
-    1
+    8,
+    0
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "8b0b9953a71ba07c24fdfc4d26fab21fb66e4d1f",
-   "sha256": "0b8sfpvy02ijk9xi9b44762b718jqfq063wcg75dk3q452d27s1h"
+   "commit": "0714e27fe703a42fa52caf6daa0921d544a55402",
+   "sha256": "1xrpv0sqmlwn94bc31k2iav284i1hl95937541ihlkhqg6v2vwrv"
   }
  },
  {
@@ -47443,26 +47523,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210606,
-    1857
+    20210701,
+    608
    ],
    "deps": [
     "async"
    ],
-   "commit": "a92156303021e0ec91a904e16a994d8e1ccd78f7",
-   "sha256": "1lxmp0a7wk7wqb6qcy1zn9sr47vakgxzn0j8yyvdv1vps4hz9wk0"
+   "commit": "e74f450eaa4f197f1fa63a819193bc1c65984042",
+   "sha256": "1xl9wn520gnpyyryf7iij8y1x5ak61zcira6g480sqvv2ympmhkd"
   },
   "stable": {
    "version": [
     3,
-    7,
-    1
+    8,
+    0
    ],
    "deps": [
     "async"
    ],
-   "commit": "8b0b9953a71ba07c24fdfc4d26fab21fb66e4d1f",
-   "sha256": "0b8sfpvy02ijk9xi9b44762b718jqfq063wcg75dk3q452d27s1h"
+   "commit": "0714e27fe703a42fa52caf6daa0921d544a55402",
+   "sha256": "1xrpv0sqmlwn94bc31k2iav284i1hl95937541ihlkhqg6v2vwrv"
   }
  },
  {
@@ -49523,8 +49603,8 @@
   "repo": "alphapapa/org-ql",
   "unstable": {
    "version": [
-    20201123,
-    1102
+    20210608,
+    1556
    ],
    "deps": [
     "dash",
@@ -49532,16 +49612,17 @@
     "org-ql",
     "s"
    ],
-   "commit": "208e103ecc146db71d878df3bd09c6eb60c2797d",
-   "sha256": "09vdndp3935iy4flynbjpkvfax7vs1ppswl19wx4nn2rp7hdz8kp"
+   "commit": "8342656b2d9af4bb6af9daa0a8b037d3693bd940",
+   "sha256": "0alrs2dsd5k4xjrs2zs7hcr5fbfrr3rdq705s04943ic4kzvhrc9"
   },
   "stable": {
    "version": [
     0,
-    5
+    5,
+    2
    ],
-   "commit": "3924b023e0f1e8fa93cfa79bdd71f9f0c0fb4679",
-   "sha256": "14nsy2dbln3m5bpqzyfqycn18sb3qh407hjbkk1l0x2nqs3lrkqn"
+   "commit": "d3b0ef2f5194452d88bf23ec31ebfef822c47c24",
+   "sha256": "0b3xxnbhnrz0263fnrrdbs3gif4pjkfws4mxkfqqpg0fc8azp2rx"
   }
  },
  {
@@ -50284,8 +50365,8 @@
     "helm",
     "rtags"
    ],
-   "commit": "63f18acb21e664fd92fbc19465f0b5df085b5e93",
-   "sha256": "0wzyn9qzyly71yfwhlk5m94ygjnbk459pgbpgkhp9fqgchx12p1r"
+   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
+   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
   },
   "stable": {
    "version": [
@@ -50795,15 +50876,15 @@
   "repo": "emacs-helm/helm-system-packages",
   "unstable": {
    "version": [
-    20201114,
-    1019
+    20210628,
+    1727
    ],
    "deps": [
     "helm",
     "seq"
    ],
-   "commit": "c331c69de0a37d2bc4d6f882cc021a905e7e56f9",
-   "sha256": "13a8jpj4wwm0yjv8hnsizgjf8wi3r2ap87lyvw7g4c7snp2dydwa"
+   "commit": "a16bb1c3708416984106a98353700d456414b6a1",
+   "sha256": "09acgs1mjkqmm7n88x4hck2bp3jv5fifdkd406r8fh874vyfib38"
   },
   "stable": {
    "version": [
@@ -51560,11 +51641,11 @@
   "repo": "emacsmirror/highlight",
   "unstable": {
    "version": [
-    20190710,
-    1527
+    20210318,
+    2248
    ],
-   "commit": "9258a2b8362d737115cbd87618f947eadb140411",
-   "sha256": "0pbqzgbfkm8smi23j94hirxh2r1yc0ipyjbbv1y906br6bx5c1a8"
+   "commit": "28557cb8d99b96eb509aaec1334c7cdda162517f",
+   "sha256": "1klrc2w0wg9ajm973b7blkjcwscqni6nxaqkcmimava398lxss2l"
   }
  },
  {
@@ -51800,10 +51881,10 @@
    "version": [
     2,
     0,
-    2
+    3
    ],
-   "commit": "fdabfda5f6300f8dd4d2a62c49359605798cc001",
-   "sha256": "0x833ahd5m4rlqrgr7n5xj477vbs7mmp267in22hw0cxi9aan08q"
+   "commit": "891538de31524956136e1419e1206af0c8befe02",
+   "sha256": "08l5gb73ibs1mmfifnks5gxrcg8x8azw9g10jj2f8vn8viwwa7m0"
   }
  },
  {
@@ -52153,11 +52234,11 @@
   "repo": "ideasman42/emacs-hl-block-mode",
   "unstable": {
    "version": [
-    20210320,
-    1051
+    20210617,
+    1324
    ],
-   "commit": "717b4f743c633362a8b28c883c454c5ef3711722",
-   "sha256": "16b1hnxzfygn3pgck5d8m612iwn42bxsx0zhdqrzmjl9sjvvps4h"
+   "commit": "0ea43d320219ba4e6b7b1be36a5c1533ac3edb42",
+   "sha256": "1hg18rm7lqs45gvv1rb5d3vqh6g9nmyf2wd2sichl06a2cn48n16"
   }
  },
  {
@@ -52204,11 +52285,11 @@
   "repo": "ideasman42/emacs-hl-prog-extra",
   "unstable": {
    "version": [
-    20210422,
-    56
+    20210629,
+    602
    ],
-   "commit": "42dee82058e49a7eae5490af2b6b4147600e87ed",
-   "sha256": "1csvhvjzhq1w9384i9n78qv8x0c2y8mdqig6fa2k5qi84cgsh8zp"
+   "commit": "c251d0cd354565b859ddf7c61bdae32649c6a0f4",
+   "sha256": "0a8dkay7d31h2k4vsapwigf62wl77yk4r0wa86ly4p6vghbczj3w"
   }
  },
  {
@@ -52241,11 +52322,11 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20210504,
-    1406
+    20210615,
+    1505
    ],
-   "commit": "57378bd4511887a815725a7850e1ff2c6e9fda16",
-   "sha256": "0bdwdp8d0g7n0kv6l4h7alya3z6fsfi618dzw5x8f2az3r87yg8y"
+   "commit": "5ac0076cfeaea57f7c7a59d9d41a34c1bdc4b22e",
+   "sha256": "1h3h62rglgwir3jfy6wq9hkwlx6z28cs9dz8jv8xgpk1jsj89whw"
   },
   "stable": {
    "version": [
@@ -53137,11 +53218,11 @@
   "repo": "Riyyi/emacs-hybrid-reverse",
   "unstable": {
    "version": [
-    20210527,
-    2324
+    20210630,
+    1155
    ],
-   "commit": "4cad8a17f6c9d98a628d78fe358d589b03172b57",
-   "sha256": "0xwl0fycygzwsrv4vrph6q6hy0550j3z1ir9ahfc7fjl091k192x"
+   "commit": "e59c8392938235ca8d95306aa1c3f1591a43fb45",
+   "sha256": "0vrdd4w9v07g6092sva8br0n3dlf1n9gj8y56k13a1wn9hwi2wp3"
   }
  },
  {
@@ -53614,27 +53695,27 @@
   "repo": "plandes/icsql",
   "unstable": {
    "version": [
-    20210605,
-    1658
+    20210612,
+    1340
    ],
    "deps": [
     "buffer-manage",
     "choice-program"
    ],
-   "commit": "bc7c5f27f9d804613759a1d1357166f9ccecbe0e",
-   "sha256": "1g3wy9jjlag4ma610kdqnb0f2sy1032m5q419ankh5fv0gfxlwbl"
+   "commit": "4521e9d2debef7687bfd26a664479f0c46688a36",
+   "sha256": "0s65kilx1jrjhm80sc4fj3x0mr3x4m3vjllm6qxj8ml8sh3pkai3"
   },
   "stable": {
    "version": [
     0,
-    7
+    8
    ],
    "deps": [
     "buffer-manage",
     "choice-program"
    ],
-   "commit": "bc7c5f27f9d804613759a1d1357166f9ccecbe0e",
-   "sha256": "1g3wy9jjlag4ma610kdqnb0f2sy1032m5q419ankh5fv0gfxlwbl"
+   "commit": "4521e9d2debef7687bfd26a664479f0c46688a36",
+   "sha256": "0s65kilx1jrjhm80sc4fj3x0mr3x4m3vjllm6qxj8ml8sh3pkai3"
   }
  },
  {
@@ -54150,15 +54231,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20210223,
-    850
+    20210614,
+    1212
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "80aabd2566082aa67d17eccdd80e9f1fb10c9ec8",
-   "sha256": "1cmmasfmgnzhixhczigz1c2jzhr9yj4v6mwvgxs99vbg2k3p9rcq"
+   "commit": "f52ad0b4770403561b40f1d0499ecaca70da886c",
+   "sha256": "1ai5ha67650ryj7mdxx6b86hlm2v13h7kipisgvxj5dss3j9j7lv"
   },
   "stable": {
    "version": [
@@ -54196,11 +54277,11 @@
   "repo": "victorhge/iedit",
   "unstable": {
    "version": [
-    20210606,
-    1026
+    20210612,
+    546
    ],
-   "commit": "94650d77719a554cdcebfc6e26a731de87e14483",
-   "sha256": "029z9j3anb948mbmh6ai8asxgfim8193ymm41c7crqzga9p4ivc7"
+   "commit": "3247f3029a4e309c71a5b066fa4299d4cbb79fbc",
+   "sha256": "1w6apgfs4zgcqpcn3qgf0ncx46m6sz7vr4ln00s626ll0c4lhnys"
   },
   "stable": {
    "version": [
@@ -54403,11 +54484,11 @@
   "repo": "tarsius/imake",
   "unstable": {
    "version": [
-    20200103,
-    1238
+    20210615,
+    1506
    ],
-   "commit": "100d62c7095743fadddfad5b9e0740ee386ba4cf",
-   "sha256": "0wpfl74v7xnvsk3ribxkfyy4p5p9j2wskrcf0naavqpgm6fc6jvr"
+   "commit": "b61b1582abe8f7a389883f48b7e5243abb010a69",
+   "sha256": "19nbas7kpbxksd0vqbvf8awzpnrmy97yxd616kcxcp86qk34mlwr"
   },
   "stable": {
    "version": [
@@ -54910,16 +54991,16 @@
   "repo": "emacs-stuff/indent-tools",
   "unstable": {
    "version": [
-    20190606,
-    1642
+    20210622,
+    1207
    ],
    "deps": [
     "hydra",
     "s",
     "yafolding"
    ],
-   "commit": "c419874e6fb296ecdba94b2f4b73c9eecdd5329d",
-   "sha256": "1dwhn9ssirr7i08rfd97mih629cxc9jwnvncb74dxdbgn1bi2b9k"
+   "commit": "c731f05fa3950e2e8580ec61b88abbc705639830",
+   "sha256": "0jri2vxd5a4sx93xq6kjcc5zx9yrhv789x3lyq6r2p2422diw2jr"
   }
  },
  {
@@ -55077,11 +55158,11 @@
   "repo": "J3RN/inf-elixir",
   "unstable": {
    "version": [
-    20210315,
-    1723
+    20210629,
+    40
    ],
-   "commit": "b526ce852886d1863163e054fcbbcbb83c55b32a",
-   "sha256": "1kmv2j1g299wb8dqq43zk61jigkfl9rnqxbfnclzsqfdlnhvw6ii"
+   "commit": "ec87ecaab5a10e79034f77d553e7fefbf60b9f97",
+   "sha256": "1p6r0iwqcaf9bp123ccwafmzlf8hgwvap0cqwgy33cks6bhcbzb9"
   },
   "stable": {
    "version": [
@@ -55578,17 +55659,17 @@
  },
  {
   "ename": "insert-kaomoji",
-  "commit": "216fcef758036cf466fa5b52599394709eed48b3",
-  "sha256": "1ip61cigz6b6hsj8ahgb6fxf7yab24r0rjjl11i10ykq7sb49k00",
+  "commit": "982788433004ba644a372c50130613e3c56bba10",
+  "sha256": "0yaz5fsnxdrnv16sns8hgvf07fmfz8p8969619ywv844kv3p16q7",
   "fetcher": "git",
-  "url": "https://git.sr.ht/~zge/kaomoji",
+  "url": "https://git.sr.ht/~pkal/insert-kaomoji",
   "unstable": {
    "version": [
-    20200325,
-    2248
+    20210618,
+    2249
    ],
-   "commit": "d18423f78cc02ba866b1a1dfb0617476cd941c54",
-   "sha256": "0n6fjndwcp2qg8164420dlc3xsdzm6m0zwbvvwn5w03khbk788hr"
+   "commit": "25b74d527cef00f6a49985161a8caaf62faa887c",
+   "sha256": "1qqxw67fbpix290jjrfai6z33fsyzb3zy1nwzk6mjss151586f5n"
   },
   "stable": {
    "version": [
@@ -56862,15 +56943,15 @@
   "repo": "tumashu/ivy-posframe",
   "unstable": {
    "version": [
-    20210426,
-    2144
+    20210609,
+    1053
    ],
    "deps": [
     "ivy",
     "posframe"
    ],
-   "commit": "084cc59ea2cd62afaa51445ada3d00404749a541",
-   "sha256": "170z5akdwxzrn0b4cbk6v8a3dqz229b7pj9n0534y1a7ydvcyv9h"
+   "commit": "9c8382823392d5e64fb4879055e43ab4a029e62a",
+   "sha256": "1dqbgi12rd79jkrbyd59lrx9b5wi5a0k2xmf927c4mcqjfbvih2w"
   },
   "stable": {
    "version": [
@@ -56993,8 +57074,8 @@
     "ivy",
     "rtags"
    ],
-   "commit": "63f18acb21e664fd92fbc19465f0b5df085b5e93",
-   "sha256": "0wzyn9qzyly71yfwhlk5m94ygjnbk459pgbpgkhp9fqgchx12p1r"
+   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
+   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
   },
   "stable": {
    "version": [
@@ -57060,8 +57141,8 @@
     "espotify",
     "ivy"
    ],
-   "commit": "3d62a3319ab03a810030058d3fb368b28dfd82d5",
-   "sha256": "0hj3nczmqmgiwsvh664rs34j63wl325x6nar21p1a84h5ximpkxq"
+   "commit": "5bf63dacc5df8a74860e80dabd16afce68a24a36",
+   "sha256": "1vxg86wv6f96bva0d1xxhisk525chwhdl4nq77xhriflq65mcmi3"
   }
  },
  {
@@ -57858,11 +57939,11 @@
   "repo": "rymndhng/jest-test-mode",
   "unstable": {
    "version": [
-    20210228,
-    132
+    20210615,
+    41
    ],
-   "commit": "fb2bacab9475410c79e6e4ca344f093f7698466d",
-   "sha256": "0m3p75659krzcyc54ri0x8bwr1zxhkrfmyz8z7z5mjpydb8qb1v8"
+   "commit": "d7660096e7d49f9b2ebc8924c0f5b39c5ffa8c86",
+   "sha256": "1sw1cgykq9i6wdjjlqlw6jrdxnic615k96lbqyir84fizn55qcja"
   }
  },
  {
@@ -58412,14 +58493,14 @@
   "repo": "mooz/js2-mode",
   "unstable": {
    "version": [
-    20210414,
-    2241
+    20210622,
+    102
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b891edecedf30be6321e2f109fdfeb25b0edad27",
-   "sha256": "179vkwr57nibc148b961g1aim052v65qsva44imxibkm9h0n32w9"
+   "commit": "4eaf98e3cc3789381a37a05cd70a248db9ac8c1b",
+   "sha256": "0mlp1pbph3790lvg5j6cdaffhb9ly8jdl00lmffs14840b8prkf3"
   },
   "stable": {
    "version": [
@@ -58484,8 +58565,8 @@
    "deps": [
     "js2-mode"
    ],
-   "commit": "d970dd53dec76f9f72ade5b1f8717dea3d45bb3c",
-   "sha256": "0i46frhgmkw6qga1mki9bsrm6zncyca9fr81n1sadmgwfl1rxl28"
+   "commit": "ab01c290860ab0d8f43afcf1f7466fdced24e123",
+   "sha256": "12g1yah3k0k0p6nlrq8j9iq5l59zalknix60s1zj24bssac5y0zj"
   },
   "stable": {
    "version": [
@@ -58777,14 +58858,14 @@
   "repo": "tminor/jsonnet-mode",
   "unstable": {
    "version": [
-    20210527,
-    1557
+    20210627,
+    1451
    ],
    "deps": [
     "dash"
    ],
-   "commit": "54a89b0aaba7a68782008c5e1ab00d5ec757316a",
-   "sha256": "14nxfa91yg2243v4d5kvynp2645x3811ispmhmpgil3x9qbl9jg9"
+   "commit": "404ebe3ca964fde99b7a6d89d2840ce53376d80a",
+   "sha256": "1ddkljjmvbm35gdw6wnys2na19826wxxgydlikn52nvchvr5z5z9"
   },
   "stable": {
    "version": [
@@ -58820,10 +58901,10 @@
  },
  {
   "ename": "jst",
-  "commit": "3416586d4d782cdd61a56159c5f80a0ca9b3ddf4",
-  "sha256": "1kxf8ckhsh0sgc4xqkkyh7ghk17farqqz35ibvmyrkl9s19ydj1q",
+  "commit": "93d46615545045ea2a9456b8a28016ec933e43d4",
+  "sha256": "0zl20xy33cz1k0lcm2ymk0bi0w7ayndq0xqrw42fvd7gm1plbsd4",
   "fetcher": "github",
-  "repo": "zhangkaiyulw/jst-mode",
+  "repo": "victorteokw/jst-mode",
   "unstable": {
    "version": [
     20150604,
@@ -58933,8 +59014,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20210330,
-    1901
+    20210624,
+    547
    ],
    "deps": [
     "dash",
@@ -58943,8 +59024,8 @@
     "spinner",
     "vterm"
    ],
-   "commit": "03b4296ba7151963eb3c850f3314b02644101f51",
-   "sha256": "1jgs0pz8bzqg8116kyw3z7jwbf6karrl89ks028q091ylc00nm8b"
+   "commit": "47f1b125f8364a0aa8c072fdc7b4007aad5c0724",
+   "sha256": "12lqc5yysjzf0vypjcs2mnsv6frhwyfm950rcsbwkwz3lvfnrajn"
   },
   "stable": {
    "version": [
@@ -59216,26 +59297,26 @@
   "repo": "TxGVNN/emacs-k8s-mode",
   "unstable": {
    "version": [
-    20210414,
-    1543
+    20210618,
+    1540
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "14f08627d5bc320fee5bd9926e9aabe6956f514e",
-   "sha256": "1rfglmslhv3i71fgsqs8gjcnkff06lnp0b9s182rsnfz29dnzd1a"
+   "commit": "430e9d698f1411efe3f8f2bb4c8f8857e0321a8d",
+   "sha256": "0rpgsfxvbic7ni82cpqi7wya73ajbd2jfbjskklzlmhwn1j26a9v"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "9364cdbbae00055c4efa1eeb80503e0b0a215743",
-   "sha256": "1ap8nwlv9ha5a03gc10sva12sc6qzq1vig8hibg1igbsc1qmfkad"
+   "commit": "430e9d698f1411efe3f8f2bb4c8f8857e0321a8d",
+   "sha256": "0rpgsfxvbic7ni82cpqi7wya73ajbd2jfbjskklzlmhwn1j26a9v"
   }
  },
  {
@@ -59849,11 +59930,11 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20210521,
-    828
+    20210616,
+    826
    ],
-   "commit": "a12ef1fb480b56c34c92f48fc7f7aa8a1d7c4c4b",
-   "sha256": "0093v1c5nl2bh1lvccqq6fzpgjald3yypp87dsim982aywl2vlv1"
+   "commit": "04ba7519f34421c235bac458f0192c130f732f12",
+   "sha256": "09xr0h2ag3pzlz455gv5h915vn1dz56gqx61jx3n7fc4a794pqxw"
   },
   "stable": {
    "version": [
@@ -59920,14 +60001,14 @@
   "repo": "dacap/keyfreq",
   "unstable": {
    "version": [
-    20160516,
-    1416
+    20210630,
+    1318
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e5fe9d585ce882f1ba9afa5d894eaa82c79be4f4",
-   "sha256": "12m1jy8m8i39b809qbxx9g3r066jxhqwfyf5mqbd1lzlaw63b1i7"
+   "commit": "7bb36e910ae04ff1dce387e3ce73b669d299680b",
+   "sha256": "188055yg9fqw92p1wip7mx7nz5gz5jbwb6lgcjncxzs4i9v7w8kr"
   },
   "stable": {
    "version": [
@@ -60316,8 +60397,8 @@
     20210318,
     2106
    ],
-   "commit": "3894a454ee03ede25e920759e6ac2df040ff3431",
-   "sha256": "1crqrmzxhm21psv5mkbzn3h2syrgszx50i4kd4n92f56dq7s8i4b"
+   "commit": "143ba31a0a5c23d8c1a8d6fb1972d94cc1d7f31c",
+   "sha256": "1daisqp687p0bpjk8mj7c3sxq9clwi25byzbk7yx8l15rcr1bhr5"
   },
   "stable": {
    "version": [
@@ -60527,10 +60608,10 @@
  },
  {
   "ename": "kroman",
-  "commit": "6440f81aed1fcddcaf7afeedb74520e605211986",
-  "sha256": "0rcy3343pmlqzqzhmz2c3r0b44pn8fsyp39mvn9nmdnaxsn6q3k8",
+  "commit": "ff990cb7ff2c10c3d6c97b820c9eaad7c4e86b11",
+  "sha256": "0vg7wrm7h36gnhhyjpk6k2sq5x1rilzaqhjrhyk508f5jfzylzqz",
   "fetcher": "github",
-  "repo": "zhangkaiyulw/kroman-el",
+  "repo": "victorteokw/kroman-el",
   "unstable": {
    "version": [
     20150827,
@@ -60601,8 +60682,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20210326,
-    2053
+    20210623,
+    1316
    ],
    "deps": [
     "dash",
@@ -60610,8 +60691,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "91d1c8e97e4168fc49548c3449b4a60568c96790",
-   "sha256": "16s6iy3igb40r29x4bpb2x9763pf1fg5cygfdgabjq8xq36slmg8"
+   "commit": "801d4cc78cb59b3c39e9ea53d7f16ec3c9a6bb6b",
+   "sha256": "120pyq6njxvhjwjrsbrclxj9g4qsi9awm9pmvvy74z3qzxjkj7bl"
   },
   "stable": {
    "version": [
@@ -60643,8 +60724,8 @@
     "evil",
     "kubel"
    ],
-   "commit": "91d1c8e97e4168fc49548c3449b4a60568c96790",
-   "sha256": "16s6iy3igb40r29x4bpb2x9763pf1fg5cygfdgabjq8xq36slmg8"
+   "commit": "801d4cc78cb59b3c39e9ea53d7f16ec3c9a6bb6b",
+   "sha256": "120pyq6njxvhjwjrsbrclxj9g4qsi9awm9pmvvy74z3qzxjkj7bl"
   },
   "stable": {
    "version": [
@@ -60661,27 +60742,27 @@
  },
  {
   "ename": "kubernetes",
-  "commit": "16850227ea48f6f38102b9cdf80e0758766a24d2",
-  "sha256": "06357a8y3rpvid03r9vhmjgq97hmiah5g8gff32dij9424vidil9",
+  "commit": "870901c45fb35384953568a972aa36ad445e1ad9",
+  "sha256": "07x770fcnjg0545bml3jqmd9d9l1bw8i8i4imznqhwx3acm8grzy",
   "fetcher": "github",
-  "repo": "chrisbarrett/kubernetes-el",
+  "repo": "kubernetes-el/kubernetes-el",
   "unstable": {
    "version": [
-    20210604,
-    909
+    20210630,
+    612
    ],
    "deps": [
     "dash",
     "magit",
     "magit-popup"
    ],
-   "commit": "93d7b4d1b079b3cf1fbe3949154b6a1bc06904ef",
-   "sha256": "0xz35j38ph1l870zrdd0r2xycxq65pbq1a1hi270q4mikpai85gb"
+   "commit": "d8034e6ddd668d2f7d34b6aa7bd19e2a575b609f",
+   "sha256": "1hp760wqwzflpnqrha1qnrbilr3qynd1dma00jyrhq76hdb83xwv"
   },
   "stable": {
    "version": [
     0,
-    13,
+    15,
     0
    ],
    "deps": [
@@ -60689,40 +60770,40 @@
     "magit",
     "magit-popup"
    ],
-   "commit": "8ae9dc2340620c7d8efb2347723b25bde5a6fba0",
-   "sha256": "0di3vcq8c8j8avjlic7bhvbq4p27cvzyklm26wiq4rga88vjhyb0"
+   "commit": "ea81874f0490cea310b09c57718aa0e5c83d578b",
+   "sha256": "13kra8y8laqk949phxwlw5q0lmv4yc9knql12srdys1hyvhczwx3"
   }
  },
  {
   "ename": "kubernetes-evil",
-  "commit": "16850227ea48f6f38102b9cdf80e0758766a24d2",
-  "sha256": "12ygfs6g9aivf2ws3lxwjm5xnd2kidhli889icpygd5v7gnk9pg8",
+  "commit": "870901c45fb35384953568a972aa36ad445e1ad9",
+  "sha256": "163idbancjbm8jj8bprhrg7lqypz3g3qkfz7mas0b40iw6ip220h",
   "fetcher": "github",
-  "repo": "chrisbarrett/kubernetes-el",
+  "repo": "kubernetes-el/kubernetes-el",
   "unstable": {
    "version": [
-    20191108,
-    615
+    20210628,
+    2003
    ],
    "deps": [
     "evil",
     "kubernetes"
    ],
-   "commit": "93d7b4d1b079b3cf1fbe3949154b6a1bc06904ef",
-   "sha256": "0xz35j38ph1l870zrdd0r2xycxq65pbq1a1hi270q4mikpai85gb"
+   "commit": "d8034e6ddd668d2f7d34b6aa7bd19e2a575b609f",
+   "sha256": "1hp760wqwzflpnqrha1qnrbilr3qynd1dma00jyrhq76hdb83xwv"
   },
   "stable": {
    "version": [
     0,
-    13,
+    15,
     0
    ],
    "deps": [
     "evil",
     "kubernetes"
    ],
-   "commit": "8ae9dc2340620c7d8efb2347723b25bde5a6fba0",
-   "sha256": "0di3vcq8c8j8avjlic7bhvbq4p27cvzyklm26wiq4rga88vjhyb0"
+   "commit": "ea81874f0490cea310b09c57718aa0e5c83d578b",
+   "sha256": "13kra8y8laqk949phxwlw5q0lmv4yc9knql12srdys1hyvhczwx3"
   }
  },
  {
@@ -60969,8 +61050,8 @@
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "63796ccadcc9147c5badd9a87f626611f63e3c4c",
-   "sha256": "1iwgi7jm20qwxlfa7klkz5zmdfxa14psly6xsl29i37j9p6146sb"
+   "commit": "56f808edfd0983c0df2ed1c957c50c02af5faad3",
+   "sha256": "05fyx88wmyc4c6lcy5qphg6zhbfmlnpy7y23l00qfi5k9hmv99hm"
   }
  },
  {
@@ -61095,25 +61176,25 @@
   "repo": "lassik/emacs-language-id",
   "unstable": {
    "version": [
-    20210411,
-    1332
+    20210618,
+    1532
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "30a5bc267af7de167d0a835ead828016e6e7e14c",
-   "sha256": "1wkppwh72zs8b4jqdxqpf3gikh11la03nkj8nna9bg7k8n0a4vaq"
+   "commit": "7db7ba27d2abf8891d40dc952c22d3a3654d9bbc",
+   "sha256": "11wzyv6jdprppjqygszl30hkxydjlhk7fdvda6h37k6dlk1fh1wp"
   },
   "stable": {
    "version": [
     0,
-    12
+    13
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "2c99ce29b86fc635649f4e89723912dc1cc4f36c",
-   "sha256": "12fzzdc4jns440gb71iydsicni646gciaxv50p0wrfk9mbppidck"
+   "commit": "7db7ba27d2abf8891d40dc952c22d3a3654d9bbc",
+   "sha256": "11wzyv6jdprppjqygszl30hkxydjlhk7fdvda6h37k6dlk1fh1wp"
   }
  },
  {
@@ -61124,26 +61205,26 @@
   "repo": "PillFall/Emacs-LanguageTool.el",
   "unstable": {
    "version": [
-    20201111,
-    515
+    20210621,
+    453
    ],
    "deps": [
     "request"
    ],
-   "commit": "531ab81bf66c778616a326b93d4eedd509dd795e",
-   "sha256": "03mrlwic3ws54573abc8wpq4apffnmq4ncqlwsvs4nhg14yl2s59"
+   "commit": "feea3f9271ce920490a0d9dcd11e669e3eaad1d0",
+   "sha256": "0vxq945x1yn86kpw7qbb686vb3pzyk7wma8g0dbval2m4hsbrn26"
   },
   "stable": {
    "version": [
     0,
-    3,
-    0
+    4,
+    2
    ],
    "deps": [
     "request"
    ],
-   "commit": "531ab81bf66c778616a326b93d4eedd509dd795e",
-   "sha256": "03mrlwic3ws54573abc8wpq4apffnmq4ncqlwsvs4nhg14yl2s59"
+   "commit": "feea3f9271ce920490a0d9dcd11e669e3eaad1d0",
+   "sha256": "0vxq945x1yn86kpw7qbb686vb3pzyk7wma8g0dbval2m4hsbrn26"
   }
  },
  {
@@ -61364,11 +61445,11 @@
   "repo": "pekingduck/launchctl-el",
   "unstable": {
    "version": [
-    20210309,
-    1113
+    20210611,
+    2243
    ],
-   "commit": "86cbb8980de4641b552a792389cc2cb9b2718ee4",
-   "sha256": "08prmsx6ski5j1pnzr7v3hxvbdrb5by8x2dihwhz0wjgfsqj13mr"
+   "commit": "c9b7e93f5ec6fa504dfb03d60571cf3e5dc38e12",
+   "sha256": "0hbhbyl4qbc9b7hmkjpwclyfh4xnl5j51j18793wrh28xqpbkf0s"
   }
  },
  {
@@ -61476,11 +61557,11 @@
   "repo": "conao3/leaf.el",
   "unstable": {
    "version": [
-    20210603,
-    1518
+    20210611,
+    1550
    ],
-   "commit": "af0d4d8daaa323c34502d3cbea85ec8f70b06c00",
-   "sha256": "0p4smpfld1ky07cy5qn8kqpbqw5ymrn8valkpx4c519lj6pb9rn6"
+   "commit": "a4fd520f5c31f54e0797155866e0b35df277664e",
+   "sha256": "0xy1zjr32xpj4kkl3rxshcz5x2qvkn1ciq4v61p6a7vfr3qmkiz2"
   },
   "stable": {
    "version": [
@@ -61775,8 +61856,8 @@
   "repo": "kaiwk/leetcode.el",
   "unstable": {
    "version": [
-    20210121,
-    1600
+    20210620,
+    706
    ],
    "deps": [
     "aio",
@@ -61785,14 +61866,14 @@
     "log4e",
     "spinner"
    ],
-   "commit": "9c44791407c3f4f76d903ee43367547803ae9c32",
-   "sha256": "14nlmgbkb8vyb0r25sdg03lg2h38gj83vspp9v9vsqyiiirhnvnh"
+   "commit": "aeba19919e6d8f1c0529330572240143a2af38e0",
+   "sha256": "0yfghps19832w4sdjaglnbb9xn40fc5a6072lxbsw8gan9c2bjh7"
   },
   "stable": {
    "version": [
     0,
     1,
-    18
+    22
    ],
    "deps": [
     "aio",
@@ -61801,8 +61882,8 @@
     "log4e",
     "spinner"
    ],
-   "commit": "ef59344158ae4b7842ca2531ec77c439ed6e6997",
-   "sha256": "0sxrzr34x43dcxw9l3ib982rz4327fpwnjmj3hi17bc5gk6zzfq2"
+   "commit": "aeba19919e6d8f1c0529330572240143a2af38e0",
+   "sha256": "0yfghps19832w4sdjaglnbb9xn40fc5a6072lxbsw8gan9c2bjh7"
   }
  },
  {
@@ -62049,16 +62130,17 @@
     20210603,
     1241
    ],
-   "commit": "1feb8af64c977946b6184b7d63b436c49dbeb52d",
-   "sha256": "0vxpkvp8fsi52zb2sqqd9xfdndyxb59hqg8qkpdfsdwszxngfij5"
+   "commit": "8b73426766029eb541b69f49cc49b9dfa1c616be",
+   "sha256": "101mpzj38w6cng09aq5rq4ly4a0p9zgr8jmbvlkf12i8k03lsfsv"
   },
   "stable": {
    "version": [
     2,
-    0
+    0,
+    1
    ],
-   "commit": "76eaf432f768b45393e404c1bd1861a08c19de3b",
-   "sha256": "0vxpkvp8fsi52zb2sqqd9xfdndyxb59hqg8qkpdfsdwszxngfij5"
+   "commit": "c09b9aebaa659f5c2d0c152d8401fd6924144ce9",
+   "sha256": "0a5cfnk3021idvv4bv2lvnksjy9d0yyd13bnj793ks86j5f3hdv5"
   }
  },
  {
@@ -62153,11 +62235,11 @@
   "repo": "magit/libegit2",
   "unstable": {
    "version": [
-    20200515,
-    1759
+    20210620,
+    2017
    ],
-   "commit": "0ef8b13aef011a98b7da756e4f1ce3bb18e4d55a",
-   "sha256": "0pnjr3bg6y6354dfjjxfj0g51swzgl1fncpprah75x4k94rd369f"
+   "commit": "77bd28aeaa2a49962e8f714741f5a69b656a2183",
+   "sha256": "19sxrikxl0kbfnbl2rdjvj96l9abmqhi68jj5hglgpa8qp3flc24"
   }
  },
  {
@@ -62183,20 +62265,20 @@
   "repo": "mpdel/libmpdel",
   "unstable": {
    "version": [
-    20210107,
-    950
+    20210627,
+    755
    ],
-   "commit": "9162a4b350c978f94dde6f75d60bc6a17e1dc18e",
-   "sha256": "0w45g4pkjsggv5yqw0zsnwqvzljapfvhxzf0vhnrqc446ys9jzp3"
+   "commit": "e4ae63dd002fe07835c3c8a35b20b6e8347f8e84",
+   "sha256": "0pryjihv1766x86lqy2anpxwr159dndlzmqxxiiwhhz4skp5498w"
   },
   "stable": {
    "version": [
     1,
-    2,
+    3,
     0
    ],
-   "commit": "a9d67cea595bfeff73cf6281fa735df98dee9a45",
-   "sha256": "1nzs6g2mg3jhfhhfcxjhd9sbvwzhmr6j6mc80ln2nr4gzjqgaa4k"
+   "commit": "b49ab2fe497d61d7d00ed1ad0c3b5a1d6a65e5c4",
+   "sha256": "0krxhcay5s9s7i41q7ga5skj31vaz2qx3djcrlwajf203bl8j4m9"
   }
  },
  {
@@ -62296,36 +62378,36 @@
     20210303,
     1751
    ],
-   "commit": "be7ff92e4dfb06ed51baaa10157d9a1ee1cd666a",
-   "sha256": "067i605hk3qy01106l90bbl91ivr3zqv2yqr41jf5pfysafykx4x"
+   "commit": "95538837d93c9d05e35ea85d6c25527fac715df7",
+   "sha256": "0p3v41vrsfjv866gjys2izmiyxl7vaiy7m93ra9kx45mrslyjcyg"
   },
   "stable": {
    "version": [
     0,
-    17,
+    19,
     0
    ],
-   "commit": "ec97fdf14ce7a65398ecc2755654db46a3ef3b14",
-   "sha256": "067i605hk3qy01106l90bbl91ivr3zqv2yqr41jf5pfysafykx4x"
+   "commit": "0169d3ef40403c1bb41b5ce81c7ae2ec01a6ba1d",
+   "sha256": "0p3v41vrsfjv866gjys2izmiyxl7vaiy7m93ra9kx45mrslyjcyg"
   }
  },
  {
   "ename": "line-reminder",
-  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
-  "sha256": "1s3ibn7c1j6m7wdkb0z37apgfc0g8vhhrqcnmldf19zi3k13bm0x",
+  "commit": "eb151125750b06c2cf6fcc5d762c980fdc89b0dc",
+  "sha256": "1l7bf0lvncn645v7c3rr5gxd9jkz5jfyaps864mzwvmasbx6d3p4",
   "fetcher": "github",
-  "repo": "jcs-elpa/line-reminder",
+  "repo": "emacs-vs/line-reminder",
   "unstable": {
    "version": [
-    20210531,
-    743
+    20210627,
+    2121
    ],
    "deps": [
     "fringe-helper",
     "indicators"
    ],
-   "commit": "1856034d0ed8ce41a29a1ea051184ee7c2f3e276",
-   "sha256": "0ni73ybrg21l63hs51pixkxf77bl288hzji03bm8v1hzsm72vxxs"
+   "commit": "355cdcb6888fe6668e85a96dfe694d4bd050372e",
+   "sha256": "0hs5js38djfid0aqz0ygswqj26j3dpqjbaidghlfhdhcvifixsvw"
   },
   "stable": {
    "version": [
@@ -62352,8 +62434,8 @@
     20180219,
     1024
    ],
-   "commit": "68e59d0fff1eb76c7b1a72c438f344c251115e81",
-   "sha256": "1ipqf3qfgzcrrp6xwgxb6wkk8a6ii5jx5im5gfhghdhy45z2m3ii"
+   "commit": "a52bd2bce9d6fb73dc7fe1e867e3ea804b5abd07",
+   "sha256": "18fl0f3j6bfv85pjcf0fggd0k6l6gxwvi19jrp3slzf0mhrlxd8k"
   },
   "stable": {
    "version": [
@@ -62944,8 +63026,8 @@
    "deps": [
     "s"
    ],
-   "commit": "29bb40a7150b6cfe1a96948ae1f36e9c107eb759",
-   "sha256": "1dznafcfwmd52jakkzzk3dhji55aal7hsfkglr3051fz8pkz7xfx"
+   "commit": "18d523d5b6a8cecc3e93c550d2ceab2d1035de02",
+   "sha256": "1d8dlb2xsqk88lac7f9n0y8ridkn6gfl5pb6sr2n66v9mq75j6rq"
   }
  },
  {
@@ -62985,11 +63067,11 @@
   "repo": "jingtaozf/literate-elisp",
   "unstable": {
    "version": [
-    20210605,
-    1238
+    20210612,
+    1056
    ],
-   "commit": "41f0946037b50323901ce708c1af82e59a334433",
-   "sha256": "1hjb1f835xq5jgq4s0dpr85vs5cap001lxv9n02l198gb2qppq6k"
+   "commit": "1a6465d4190491ddf927698554b13352a7babb3a",
+   "sha256": "1nbzrxfrz209dgnlhkqq9bpf2h678laac2wsrrmf9flw65dpafv9"
   },
   "stable": {
    "version": [
@@ -63082,11 +63164,11 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20210413,
-    205
+    20210701,
+    1735
    ],
-   "commit": "c191b149f93ed473f3900e506cfc762d53145237",
-   "sha256": "0likjz2q0pbs3cbqczdfhh6k0c1j8y6j32cxkcpjm9wakp1vzxq2"
+   "commit": "96ca0e9058d8c1e533ce9aa1396e49f086362b06",
+   "sha256": "0bcilb7mcf9al3qs8i63idw97025b193sslrwkd7w8pphk2g9cqi"
   },
   "stable": {
    "version": [
@@ -63658,11 +63740,14 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20210601,
-    133
+    20210701,
+    216
    ],
-   "commit": "50494b545b9a909fc6570216230beda1ebeedf36",
-   "sha256": "0wag0hhpak0i1k2bmzz896jkpadrmacj1m0bbb3y7rrl9sw1dcqg"
+   "deps": [
+    "map"
+   ],
+   "commit": "27df47157a0a1753065172a346a2ffeb1778a99c",
+   "sha256": "0cwqyggc9hf5kwpypw0230p5fl3j8a6b2k3cgsrfk4i4lwkfnr5c"
   }
  },
  {
@@ -63673,15 +63758,15 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20210601,
-    129
+    20210701,
+    216
    ],
    "deps": [
     "dash",
     "loopy"
    ],
-   "commit": "50494b545b9a909fc6570216230beda1ebeedf36",
-   "sha256": "0wag0hhpak0i1k2bmzz896jkpadrmacj1m0bbb3y7rrl9sw1dcqg"
+   "commit": "27df47157a0a1753065172a346a2ffeb1778a99c",
+   "sha256": "0cwqyggc9hf5kwpypw0230p5fl3j8a6b2k3cgsrfk4i4lwkfnr5c"
   }
  },
  {
@@ -63748,8 +63833,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20210601,
-    420
+    20210608,
+    2101
    ],
    "deps": [
     "dap-mode",
@@ -63760,14 +63845,14 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "7ef909a1c9e0e1c924b43637899e0d53b0d1b00f",
-   "sha256": "1vsfs0jpk7fdfb3zmpxs3f7fy0s7d9b8jha5p7y6g0afhxz4iqn1"
+   "commit": "01d89d43f17a15c7ccad5a458250d5d6b0f70b09",
+   "sha256": "0vnzzfap7ndr26016n1c1q21ga2lgw9vb555mn4dql6ny191ri0r"
   },
   "stable": {
    "version": [
     1,
-    18,
-    5
+    19,
+    0
    ],
    "deps": [
     "dap-mode",
@@ -63778,8 +63863,8 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "90a06dfc23750c3861628256a4af4e3b00b2e23d",
-   "sha256": "1cabxsz7gbjywhsqjqp32vdgycg2mq21mdxvwbfcs6k0cf319dwh"
+   "commit": "49bb4d597e30c95d66a96739ea10c1c4f74ac649",
+   "sha256": "0kwzi6f3ig6lq95h2y9nddwkisml1fig290vn1sm7wkl3r9ci8bd"
   }
  },
  {
@@ -63797,8 +63882,8 @@
     "dash",
     "lsp-mode"
    ],
-   "commit": "fa304ea402ac492e97bee14496a41afa8508cc5e",
-   "sha256": "0y0z4ind08jj93qsxgvi5zqa5f8lnamg8fv2dvkgipx1qvq25r4c"
+   "commit": "49a6bab0b1ad88d220305dbe3a0a14d368f62354",
+   "sha256": "1i3gywik5m9j797c69ng70bs28qdww9662sjl6y232rw19rya93b"
   }
  },
  {
@@ -63841,8 +63926,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20210523,
-    403
+    20210616,
+    1021
    ],
    "deps": [
     "grammarly",
@@ -63851,8 +63936,8 @@
     "request",
     "s"
    ],
-   "commit": "f34f0d50a91a82ab9c49e2cf5ddcb42a98cc2ede",
-   "sha256": "1hqilkbxa63gkl6sc8km6j0m4lxindf184c1zl91h4sfh4kg67zb"
+   "commit": "57a698e69c0dacbcad30398c262cdc5711efba71",
+   "sha256": "17jhfzy7bk645402yi65dsw19rvyjqm5wfd8y73hcfniihdrnqzp"
   },
   "stable": {
    "version": [
@@ -63879,15 +63964,15 @@
   "repo": "emacs-lsp/lsp-haskell",
   "unstable": {
    "version": [
-    20210209,
-    2150
+    20210621,
+    1334
    ],
    "deps": [
     "haskell-mode",
     "lsp-mode"
    ],
-   "commit": "7efbef3d206989faa8b691a4230a3ed872542187",
-   "sha256": "15xp3gjj9zdvxbhcgw21108s9y99rfmih5sqlk7f0m9hw5mqw4zm"
+   "commit": "eb37ac4a6a43277263bbb17aed6a862a0992ae8e",
+   "sha256": "04pcwcw5bq6hs0zr553sf9isbslp4pbahbch0yb0l472ihlbcxwh"
   }
  },
  {
@@ -63949,8 +64034,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20210520,
-    1747
+    20210701,
+    725
    ],
    "deps": [
     "dap-mode",
@@ -63962,8 +64047,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "b6f14d8ae3cddcbacacf245aeef46e5407e5b401",
-   "sha256": "1xb051wgllmfm87bw4kiznfbsv54jqr9q02h2zy9np74n51q6jp7"
+   "commit": "28c56ec59a8c1b197727f4d56cec724445661fd9",
+   "sha256": "0g544mxv362ypwg79kyvjmnr63ss5psp89dmmzbx0bfpk8z4ib0j"
   },
   "stable": {
    "version": [
@@ -64074,14 +64159,14 @@
   "repo": "ROCKTAKEY/lsp-latex",
   "unstable": {
    "version": [
-    20210607,
-    1206
+    20210608,
+    1330
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "a5de6b7166935af4a1e05d254fc1a44600518066",
-   "sha256": "0i5mbz7mwnax7jwv9c1bkwp5jwqrvwvh51fgwkmnz0kpjxhzfpsm"
+   "commit": "0e4c96a625bd83930cac338eb7a998c024a15f38",
+   "sha256": "11gvqbp9j585g86ir610lb3fq87nbwr44j3xzifh4rga6cwdb6yj"
   },
   "stable": {
    "version": [
@@ -64104,14 +64189,14 @@
   "repo": "emacs-languagetool/lsp-ltex",
   "unstable": {
    "version": [
-    20210405,
-    1702
+    20210616,
+    1021
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "0fd8baec7e5f92d74b8b80d02c926d32332d86bd",
-   "sha256": "04jx5bknns1fyany1x8wzs6yx9qxzwrwj8m1iardxy8la3jp6ncd"
+   "commit": "cd6fa0b32118792e9f7bcbf4a26032bfff05d603",
+   "sha256": "16hn5wbfa4f958pyl47l4nvqx092ws16l99dcwijzk9xs4wrkipn"
   },
   "stable": {
    "version": [
@@ -64134,8 +64219,8 @@
   "repo": "emacs-lsp/lsp-metals",
   "unstable": {
    "version": [
-    20210529,
-    752
+    20210615,
+    1413
    ],
    "deps": [
     "dap-mode",
@@ -64147,8 +64232,8 @@
     "scala-mode",
     "treemacs"
    ],
-   "commit": "4c11fe47ef3c71a2fc7cd67a055ea0bc5883a0c6",
-   "sha256": "16laslmvsamvcn58gsi6hfs53p12q0nz7zx993ipa2xhy6n04hcg"
+   "commit": "9f82ebee48d32cd7bbc3e64b84d1ef5b0926195b",
+   "sha256": "1l4sxkmlif6dlh6j11fgy6z7hs4739jdcazm0y35cbhq9bspxsnx"
   },
   "stable": {
    "version": [
@@ -64178,8 +64263,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20210605,
-    1854
+    20210630,
+    2003
    ],
    "deps": [
     "dash",
@@ -64189,8 +64274,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "7b75d6bf01bed9ccb108cf1406d0e2af29d7e39b",
-   "sha256": "1lbb3bpizibpnw77bgdf8j2303gwh2133n8s518frmz6gcb7kz8s"
+   "commit": "7b183d397f8bc17eceb4d156e24575a47a1d807f",
+   "sha256": "15br2gf55436jm5a3iygr8cp3vriiar85kmgmap88ws8z83qg17x"
   },
   "stable": {
    "version": [
@@ -64477,8 +64562,8 @@
   "repo": "emacs-lsp/lsp-treemacs",
   "unstable": {
    "version": [
-    20210502,
-    1804
+    20210618,
+    1722
    ],
    "deps": [
     "dash",
@@ -64487,8 +64572,8 @@
     "lsp-mode",
     "treemacs"
    ],
-   "commit": "f360d54fa68a00baec228d9582bc67c1a327d757",
-   "sha256": "0wbni6njz98c23pns4wxg4mq26zrvpyxh0qcz0a4l46zdn1962vm"
+   "commit": "905cc74726438cf06d8ad7cabb2efae75aeb2359",
+   "sha256": "0kh8yn80x1fgpcvrgj9bqmlhpnkxqsy57w8m06gws8lhlnrh4yk9"
   },
   "stable": {
    "version": [
@@ -64515,16 +64600,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20210604,
-    1158
+    20210619,
+    905
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "c4ffa7abf6706d591300c608c51d2b72178848ad",
-   "sha256": "1qr7is4k5w6dcfkcvg7crna6r26lqmb02v08i3yggq09qd01c08g"
+   "commit": "240a7de26400cf8b13312c3f9acf7ce653bdaa8a",
+   "sha256": "1zscdjlnkx43i4kw2qmlvji23xfpw7n5y4v99ld33205dg905fsy"
   },
   "stable": {
    "version": [
@@ -64550,11 +64635,11 @@
   "repo": "immerrr/lua-mode",
   "unstable": {
    "version": [
-    20201110,
-    1250
+    20210619,
+    652
    ],
-   "commit": "2d9a468b94acd8480299d47449b53136060b7b23",
-   "sha256": "1586k3friamcyfg1xszhkh1vaddrfxji1mn7rd7s8id8f7sp8mnv"
+   "commit": "2bd9077dd0405efc9276f612e24a345698c539c4",
+   "sha256": "0ldk6v7c3xamyhq6zwp2l79iyxfan0qmlycsvj39z3fljaz953z0"
   },
   "stable": {
    "version": [
@@ -64632,8 +64717,8 @@
     20210607,
     1130
    ],
-   "commit": "b5391e8dc088d95d8f131f49982d5c7cbaa23677",
-   "sha256": "08bfjg51ydznfk8w7hwznzyybl42mqa5l0pvb4xapqcq2na3d3yf"
+   "commit": "d158bb78029705a6ee848f8e00c09ba1f3575564",
+   "sha256": "1dkx6xas7dg07pgk4h3f7cdr6hmccw00qv3fi8l2vj462nd7cr5w"
   }
  },
  {
@@ -65002,8 +65087,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210531,
-    1524
+    20210701,
+    1554
    ],
    "deps": [
     "dash",
@@ -65012,8 +65097,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "4a8646a30df99bbafc95d4f21a0b2bf0a6f6566f",
-   "sha256": "0y3wzvyaxn5zybjak77r1cngaqqm462s3d4f1cwmzvrnpv99f3r9"
+   "commit": "2ae376e4923e02355828350b81cdc1b0f8fa72ff",
+   "sha256": "1h07rg0fvr7av69bcks1n63digafq145mlsaddyv6xixxqjp0vbg"
   },
   "stable": {
    "version": [
@@ -65352,15 +65437,15 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210525,
-    814
+    20210701,
+    1551
    ],
    "deps": [
     "libgit",
     "magit"
    ],
-   "commit": "4a8646a30df99bbafc95d4f21a0b2bf0a6f6566f",
-   "sha256": "0y3wzvyaxn5zybjak77r1cngaqqm462s3d4f1cwmzvrnpv99f3r9"
+   "commit": "2ae376e4923e02355828350b81cdc1b0f8fa72ff",
+   "sha256": "1h07rg0fvr7av69bcks1n63digafq145mlsaddyv6xixxqjp0vbg"
   },
   "stable": {
    "version": [
@@ -65435,14 +65520,14 @@
   "repo": "dickmao/magit-patch-changelog",
   "unstable": {
    "version": [
-    20210607,
-    1635
+    20210616,
+    1302
    ],
    "deps": [
     "magit"
    ],
-   "commit": "5cd99a6336ad4b60e9e8ce766b8a9c0395289775",
-   "sha256": "17s5268kcqhgd141fvjqnn2wrny7v03yz940k2whr383l1253k6v"
+   "commit": "623d1a6a3bfa0f01bcaaffa13ad5ce5ae29cdb0a",
+   "sha256": "1dds83a6fcpakmhny5n3s4ibcvjba4p07pg8bpy37k32c704lw27"
   }
  },
  {
@@ -65521,14 +65606,14 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210525,
-    844
+    20210701,
+    1554
    ],
    "deps": [
     "dash"
    ],
-   "commit": "4a8646a30df99bbafc95d4f21a0b2bf0a6f6566f",
-   "sha256": "0y3wzvyaxn5zybjak77r1cngaqqm462s3d4f1cwmzvrnpv99f3r9"
+   "commit": "2ae376e4923e02355828350b81cdc1b0f8fa72ff",
+   "sha256": "1h07rg0fvr7av69bcks1n63digafq145mlsaddyv6xixxqjp0vbg"
   },
   "stable": {
    "version": [
@@ -66322,19 +66407,19 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20210605,
-    1213
+    20210620,
+    1943
    ],
-   "commit": "4c6272ffc4836de052c8b06f681b0e700cb01602",
-   "sha256": "0l4sl4w4yq3hkpvvw7w1mh046f95bkg1c3av07kwk9cm038rwhvg"
+   "commit": "9796fada769f44cb8e05914bd6be3fcc15d791e2",
+   "sha256": "0yn6dybvsdhr37hnadmbfqi7pf7scxr9z6a6ghsqbrghycddd0mc"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
-   "commit": "ca9a5e35913569d66d34193a87d8511b2bb9d2b2",
-   "sha256": "1lisns2vghmqlg8wiv6jy15cfgnc8j83khz0vfnmrjwgcmjw3bbz"
+   "commit": "9796fada769f44cb8e05914bd6be3fcc15d791e2",
+   "sha256": "0yn6dybvsdhr37hnadmbfqi7pf7scxr9z6a6ghsqbrghycddd0mc"
   }
  },
  {
@@ -66442,11 +66527,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20210530,
-    1825
+    20210616,
+    122
    ],
-   "commit": "58f2d22526ac1e4abd4ee1afff8624d2dd3123d3",
-   "sha256": "1k17zpx05yafxfsw89dlkymqc5xajzv28qby12kdhwwlsbarqvd0"
+   "commit": "1c7d29d52986b2cb153b5f643167ea49417de469",
+   "sha256": "0jgfxvhx5z3hjzpdxikx75ikgc0w7ap442svqpyigf78rb32wsjl"
   },
   "stable": {
    "version": [
@@ -66516,16 +66601,16 @@
   "repo": "ardumont/markdown-toc",
   "unstable": {
    "version": [
-    20210515,
-    902
+    20210629,
+    931
    ],
    "deps": [
     "dash",
     "markdown-mode",
     "s"
    ],
-   "commit": "86a4a2b092b0f23b9edb3ee0ab7da483b7f10a5b",
-   "sha256": "0n1fzla3dkscz70fy81fsbiyi2hj7swjy7zvxprhn36jjkb6b5hf"
+   "commit": "f78cba9b5761c91058fed3a781bd3fed7f996e1f",
+   "sha256": "12dddxa14ppa7gaayify67w4sc6ncbc68wdg4madfqj7s71lnm45"
   },
   "stable": {
    "version": [
@@ -67363,16 +67448,16 @@
   "repo": "DogLooksGood/meow",
   "unstable": {
    "version": [
-    20210606,
-    1056
+    20210622,
+    931
    ],
    "deps": [
     "cl-lib",
     "dash",
     "s"
    ],
-   "commit": "1cf2508f8e95311aa9ca405f899c3596cf8c2bc7",
-   "sha256": "12xzq9sxczjppqpx75bny2dp647m3f9ww6zf9a22rgmmspzkk5cx"
+   "commit": "174cb2fb5f1ae674a405667ed432cd6601f53656",
+   "sha256": "0ix0ph82j12v1x5bi9w643q0a9cik4yd02bmk5c919wnyfz1syy7"
   }
  },
  {
@@ -67383,11 +67468,11 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20210408,
-    1014
+    20210623,
+    1512
    ],
-   "commit": "7d929be2e9c1ae1a32e680591c5a224a96198e47",
-   "sha256": "0gpis7r2c7sppk4fx6alq9g2asva71xj05fjjq60zg87paimfdx4"
+   "commit": "a69ef83f2894c7e019c9b487b9646f7a63456471",
+   "sha256": "1v0pc3yglbgdpmviz45h1zcnc2kkz35jbvdzkrks122736nz1dli"
   },
   "stable": {
    "version": [
@@ -67408,15 +67493,15 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20210409,
-    1323
+    20210615,
+    1208
    ],
    "deps": [
     "auto-complete",
     "merlin"
    ],
-   "commit": "7d929be2e9c1ae1a32e680591c5a224a96198e47",
-   "sha256": "0gpis7r2c7sppk4fx6alq9g2asva71xj05fjjq60zg87paimfdx4"
+   "commit": "a69ef83f2894c7e019c9b487b9646f7a63456471",
+   "sha256": "1v0pc3yglbgdpmviz45h1zcnc2kkz35jbvdzkrks122736nz1dli"
   },
   "stable": {
    "version": [
@@ -67441,15 +67526,15 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20210409,
-    1323
+    20210615,
+    1208
    ],
    "deps": [
     "company",
     "merlin"
    ],
-   "commit": "7d929be2e9c1ae1a32e680591c5a224a96198e47",
-   "sha256": "0gpis7r2c7sppk4fx6alq9g2asva71xj05fjjq60zg87paimfdx4"
+   "commit": "a69ef83f2894c7e019c9b487b9646f7a63456471",
+   "sha256": "1v0pc3yglbgdpmviz45h1zcnc2kkz35jbvdzkrks122736nz1dli"
   },
   "stable": {
    "version": [
@@ -67503,15 +67588,15 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20210409,
-    1323
+    20210615,
+    1208
    ],
    "deps": [
     "iedit",
     "merlin"
    ],
-   "commit": "7d929be2e9c1ae1a32e680591c5a224a96198e47",
-   "sha256": "0gpis7r2c7sppk4fx6alq9g2asva71xj05fjjq60zg87paimfdx4"
+   "commit": "a69ef83f2894c7e019c9b487b9646f7a63456471",
+   "sha256": "1v0pc3yglbgdpmviz45h1zcnc2kkz35jbvdzkrks122736nz1dli"
   },
   "stable": {
    "version": [
@@ -67777,11 +67862,11 @@
   "repo": "kazu-yamamoto/Mew",
   "unstable": {
    "version": [
-    20210416,
-    33
+    20210625,
+    240
    ],
-   "commit": "380d6059fa9f102e736969d086749980820a9e0e",
-   "sha256": "03fxicfl7yvxj6ac636544km1khhmrjqi97r0smwqfxvlm2gs037"
+   "commit": "fc4bca6d95d8b8d5e169ecf1433d968c2eec299d",
+   "sha256": "0lcy73df204ww4kmbkfz5cbpmdwbsn7z47j5by89izn14dczllvq"
   },
   "stable": {
    "version": [
@@ -68237,11 +68322,11 @@
   "repo": "tarsius/minions",
   "unstable": {
    "version": [
-    20210603,
-    2150
+    20210615,
+    1510
    ],
-   "commit": "aed285155dc8f073d766e752520ec599e77ce8b7",
-   "sha256": "1qxszcx9n1yfc9j9ihvrdwb57n19w03600z3v4z2ybxap1y0nq3v"
+   "commit": "1be68e8571336672d6cbec86246d1bf7844976be",
+   "sha256": "0lg704kwc851spp69745np8hsk0h6rl2hvfpid0j412278ds1qi8"
   },
   "stable": {
    "version": [
@@ -68438,8 +68523,8 @@
     20210601,
     2158
    ],
-   "commit": "db502020ffe6bc65576b93527a20c0bf3df562da",
-   "sha256": "0gw6xw38x8h72gbvhmddgzijs4xvkrgs6c7v552db56hrlsj9lhp"
+   "commit": "d912fec98698c4f72a5f408d5a3f80e95327817d",
+   "sha256": "0gby38fd5vvfbm3pl2cvp6jsfjqi17xgh1m8vv9z9s6zang4knsy"
   },
   "stable": {
    "version": [
@@ -68877,11 +68962,20 @@
   "repo": "SidharthArya/modular-config.el",
   "unstable": {
    "version": [
-    20200824,
-    442
+    20210629,
+    2319
    ],
-   "commit": "c0a6d3dac1aa176deb8417c77dfeac06e9f18e1f",
-   "sha256": "1pky409m3mip42k6qw4sf28ja50lsw17318kwgcrkl0nrvnbs31j"
+   "commit": "222ed4aab718ebcc2944c6cca87ebc3370d5ac3c",
+   "sha256": "0bdh5akywlj3grwclkl4vk82iij2jlvinmcp3xbi973n7y9i4s49"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    3
+   ],
+   "commit": "222ed4aab718ebcc2944c6cca87ebc3370d5ac3c",
+   "sha256": "0bdh5akywlj3grwclkl4vk82iij2jlvinmcp3xbi973n7y9i4s49"
   }
  },
  {
@@ -68892,11 +68986,11 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20210607,
-    917
+    20210630,
+    1252
    ],
-   "commit": "a2c8796fcbcbdd332165e02476c6de5799996d31",
-   "sha256": "0p9yzj70kx3s740dl7k3vwwkr1g9zxsirwl83n1nvswc4csgv20j"
+   "commit": "9b1d1594efa5d7389300b93c78f1b1dd389f9c27",
+   "sha256": "1m4wmcjhd7hck3rdg9anynlxzr9lnswkdzwypgwfwmabnvsyqvrm"
   },
   "stable": {
    "version": [
@@ -69239,11 +69333,11 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20210522,
-    1100
+    20210615,
+    1511
    ],
-   "commit": "392c77174ace6c57921f237f41eaa4c3a83ac303",
-   "sha256": "0b4kg4dxy4ywwin96vz6x3rpvgr718y5rgrdarmwym9wv1qz0a0c"
+   "commit": "9d8b2f758098d19781c7c5cdaeda5785e41be039",
+   "sha256": "1z9pspjrpclxznc9d16lix1zc0yx520jx1nqjbxj3kcwfxzkbbl4"
   },
   "stable": {
    "version": [
@@ -69305,8 +69399,8 @@
   "repo": "ageldama/moonshot",
   "unstable": {
    "version": [
-    20200210,
-    2356
+    20210627,
+    2244
    ],
    "deps": [
     "cl-lib",
@@ -69318,8 +69412,8 @@
     "s",
     "seq"
    ],
-   "commit": "c9f363b1b5f2b92006e03116580540dadb7364ea",
-   "sha256": "0r6sn8f5la1sxw7af2h349p8p5ybmgpc7aisc96wjilp1zrmdh8v"
+   "commit": "ec37a12825888047a90d9ee8131aa4bea348edf7",
+   "sha256": "0vd9m2zs3rch361ykmf0l3fjsrk1rwlb7w1dc7zz3gwpb6nas845"
   }
  },
  {
@@ -69598,8 +69692,8 @@
     20210306,
     1053
    ],
-   "commit": "d031469630c70188c20598c0f3a3c3c46c6c7a14",
-   "sha256": "13mbkpzfdy136y5w6ns73qy1fsxwqzsvnnfcid2x7rrrqbxrcm5r"
+   "commit": "171aebaf3a1fb76d1a460d12c7199bc6fbcec473",
+   "sha256": "06dw5blx8r6wzkwwwbi7p3fxs4flgsf2vlkz8vv9gar4cg9w7wy7"
   },
   "stable": {
    "version": [
@@ -70256,14 +70350,14 @@
   "repo": "ReanGD/emacs-multi-compile",
   "unstable": {
    "version": [
-    20210604,
-    140
+    20210620,
+    48
    ],
    "deps": [
     "dash"
    ],
-   "commit": "948ee25878c509d0f9ba8715b209eae79143b76e",
-   "sha256": "0lgp64pgblidm4jyr3wlv5xq2x81znzi0xvqm8h0f8af9jzl2b38"
+   "commit": "65699ac6a2f787a07908466e1cbfe3333ace7532",
+   "sha256": "05h4rh5g8kqz8sl31r8800rkrcv9ir6jh6qr38qwj1zrcd77zk02"
   }
  },
  {
@@ -70828,14 +70922,14 @@
   "repo": "mallt/mysql-to-org-mode",
   "unstable": {
    "version": [
-    20200602,
-    2019
+    20210622,
+    447
    ],
    "deps": [
     "s"
    ],
-   "commit": "f3afc506f8b0d037238e49290de4b028c6ad9dd1",
-   "sha256": "19g21zvvamlhy1yrqhqbd1x3km6q2m650xsvl613rpcdqsk8l2ic"
+   "commit": "c5eefc71200f2e1d0d67a13ed897b3cdfa835117",
+   "sha256": "1ll7n8gxmzk7grlwh5igbxh7lvf7c08hi1xir2n0fj9wyzd432ny"
   },
   "stable": {
    "version": [
@@ -71921,8 +72015,8 @@
     20181024,
     1439
    ],
-   "commit": "8fa4d05fea5140f80ff5f4629d19c6ce0d6f5cca",
-   "sha256": "0dn53fjq4dl8szpjqxn91md0xvr4sa458j1p0w8vgskc0iibzn4c"
+   "commit": "c8f8f2a9e3016ab7a9ecb2e8b084cf441f3ae88e",
+   "sha256": "1nj7w0dgvhmqy5hkdn0idf468x7s2h2y5372j13w3x1fkdcnyln8"
   },
   "stable": {
    "version": [
@@ -72020,11 +72114,11 @@
   "repo": "NixOS/nix-mode",
   "unstable": {
    "version": [
-    20210523,
-    326
+    20210629,
+    2024
    ],
-   "commit": "e4844f7a711c8d7dceb82b6b841a1e8485e12586",
-   "sha256": "0g05qa926xkayd79n2zi9ypd4m5245jjxwv2vp4hqn2cl76pnpak"
+   "commit": "d27820b0408b3e9067c264e25c009bd5cd9dfcd1",
+   "sha256": "0hrhzm703k86a4wlx0hwnivklniziy2xbrs1q0mvijmsvks60f57"
   },
   "stable": {
    "version": [
@@ -72312,14 +72406,14 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20210605,
-    1753
+    20210619,
+    2158
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a6c8e0575766eb573a7add103836d578bd205962",
-   "sha256": "1r8rarcp0q0rl19kc6q7lll0djkvf3iw17rrsjswsq3z9fyq8iyr"
+   "commit": "b12a85a5afff7b5d60f889c1c2e8f5deab7fdbae",
+   "sha256": "193kyvj2f3zgb39shhcf2qk33rzbp8qp9mkc9p0cvnrc517h6y5r"
   },
   "stable": {
    "version": [
@@ -72617,20 +72711,20 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20210605,
-    1839
+    20210627,
+    1741
    ],
-   "commit": "6f0f83660e222cfdd05b05ad134763a7ab26f097",
-   "sha256": "0rs37inh95c1r91mjjwf1kssmxq8mliblzvdjypijps13fxk7m60"
+   "commit": "1768b0c416ce1034a5726ff0037e5a605cb45ab6",
+   "sha256": "0cynllvnhiibxa9a06xg9qzybvsl802l7lcc2jwzhja05l2wrdps"
   },
   "stable": {
    "version": [
     0,
     32,
-    1
+    2
    ],
-   "commit": "b580009e2bc69efb019983bf2f7dc5052c19545a",
-   "sha256": "06r0hdz8mxnzag74md62a9m6c2zm0fxn45n4n1c26j5cmrys7j16"
+   "commit": "af56f3bcdc8a644564a1182f58bd311907193a4a",
+   "sha256": "1f0xccc51z2fijj4cyx4pcxmam9pygq0z1rb4zrybz1vpsr7zrvk"
   }
  },
  {
@@ -72700,14 +72794,14 @@
   "url": "https://git.sr.ht/~tarsius/notmuch-maildir",
   "unstable": {
    "version": [
-    20210416,
-    1043
+    20210615,
+    1513
    ],
    "deps": [
     "notmuch"
    ],
-   "commit": "e34c470521e83c3100f0d6eb9e7402ae35e19321",
-   "sha256": "0pmikf1djkr07067nkgmdcxyn7l7ibswx6qlnai8v1v51f9h1g9q"
+   "commit": "fd0e2199da746906eca080d4ca5bca17068cdce5",
+   "sha256": "1fqnx6hhg0cqj82yjpl7llg6vvppc3y8q9k6g67mqr7z3712bw0x"
   },
   "stable": {
    "version": [
@@ -73121,15 +73215,15 @@
   "repo": "douglasdavis/numpydoc.el",
   "unstable": {
    "version": [
-    20210523,
-    1746
+    20210616,
+    1532
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "dcbc06429084e209f081a8c6318b46c1c9ff7309",
-   "sha256": "0bggm5ssxpj49km8q8z9hj351garl1xydz1dya7r0yvz12y6wn5g"
+   "commit": "9209d52ddf43eddc983763b77f6932be61982475",
+   "sha256": "1sx7jj9w20gxxsqx5wa9m6da0971qp8mgp76hpdc1crqrx1mj55b"
   },
   "stable": {
    "version": [
@@ -74199,6 +74293,25 @@
   }
  },
  {
+  "ename": "ob-swiftui",
+  "commit": "ed83f297fcccfc44be9d1a20f3b96071dd7b8a58",
+  "sha256": "0hxdacxqxqkjl6gi2j909vymjnnlpv8zsmlxw3r7g5i8f468d4qr",
+  "fetcher": "github",
+  "repo": "xenodium/ob-swiftui",
+  "unstable": {
+   "version": [
+    20210618,
+    856
+   ],
+   "deps": [
+    "org",
+    "swift-mode"
+   ],
+   "commit": "31cfe991eb171bb0d2f53cf621be1b9d91573ac3",
+   "sha256": "1l2n4ijf3sfgj05xzvnb1cd9k24ynh2cg36yj386bq7kadamympc"
+  }
+ },
+ {
   "ename": "ob-tmux",
   "commit": "a3f47fbfe745972e690e8028f893bb38ba30978d",
   "sha256": "12c0m2xxd75lbc98h7cwprmdn823mh2ii59pxr6fgnq7araqkz20",
@@ -74416,11 +74529,11 @@
   "repo": "ocaml-ppx/ocamlformat",
   "unstable": {
    "version": [
-    20210601,
-    901
+    20210617,
+    1726
    ],
-   "commit": "be14af363e9338e86173c2d96732f59b3c76e73e",
-   "sha256": "10q2xd4mqdi9h6dbjfx5081l8sc025rgkxsz9hwm93yrb5xw1rwd"
+   "commit": "a54914c8f4bc5e2d57aac5ed15f1192c2f53abbc",
+   "sha256": "0625kwk1k8c4j92w4v5160zxcqxa2bf7kdmkii26m25fzw1az1d1"
   },
   "stable": {
    "version": [
@@ -74613,26 +74726,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20210521,
-    1311
+    20210623,
+    653
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "fe1feb913bf69b1e854053e3f07026c14c6c91dc",
-   "sha256": "0w4x18srwhznd4xicr2sk7m3lhzgw6pyza7skar5i4n7y30q38xp"
+   "commit": "e828f86ee607de487cb60393b41c6919d0b66356",
+   "sha256": "0m3s68n31whryzwjz8iyd9mdzvdm2r9rh9cwlw8br5qh40jbl67b"
   },
   "stable": {
    "version": [
     3,
     20,
-    1
+    2
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "fe1feb913bf69b1e854053e3f07026c14c6c91dc",
-   "sha256": "0w4x18srwhznd4xicr2sk7m3lhzgw6pyza7skar5i4n7y30q38xp"
+   "commit": "26d6d8946ddd5f71954564f26e63f6b5f1e9c0aa",
+   "sha256": "0m3s68n31whryzwjz8iyd9mdzvdm2r9rh9cwlw8br5qh40jbl67b"
   }
  },
  {
@@ -74673,6 +74786,38 @@
    ],
    "commit": "2dd65324ac9833e07eaed5fb04acebafc6d5cbd2",
    "sha256": "00lxjl1i6kcvj9lym2m59xb5hrx2gcdpvsvq972d8iczp2jmcfxr"
+  }
+ },
+ {
+  "ename": "ol-notmuch",
+  "commit": "b6d136b1033d9afdea965ab07ba7c05e9ecf56e5",
+  "sha256": "1hsc5xj9mj3p1fz4svwqam5gxhcnfrpx5s97c4rzf8fq0cnf5pd1",
+  "fetcher": "git",
+  "url": "https://git.sr.ht/~tarsius/ol-notmuch",
+  "unstable": {
+   "version": [
+    20210530,
+    2054
+   ],
+   "deps": [
+    "notmuch",
+    "org"
+   ],
+   "commit": "126fb446d8fa9e54cf21103afaf506fd81273c02",
+   "sha256": "1pkb333m1rryhxf26p8661y7w9fnsaarn0qkzys1pyfj09q9rsmj"
+  },
+  "stable": {
+   "version": [
+    2,
+    0,
+    0
+   ],
+   "deps": [
+    "notmuch",
+    "org"
+   ],
+   "commit": "126fb446d8fa9e54cf21103afaf506fd81273c02",
+   "sha256": "1pkb333m1rryhxf26p8661y7w9fnsaarn0qkzys1pyfj09q9rsmj"
   }
  },
  {
@@ -75328,11 +75473,11 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20210603,
-    1335
+    20210613,
+    1723
    ],
-   "commit": "e85084e733d6eb50893974fc5fd569b944a5010c",
-   "sha256": "1lmjmp0iwp8n9nrqvygav7y2fxxwqpv4kk2wy2gg4bi056arbx5a"
+   "commit": "2646dad28c0819fbe9ee521d39efb9ae40e03982",
+   "sha256": "0vxfinsx69fqpcgbsv6g26klim3yasds3ha9v3xkk32y9sb783lr"
   },
   "stable": {
    "version": [
@@ -75491,26 +75636,26 @@
   "repo": "eyeinsky/org-anki",
   "unstable": {
    "version": [
-    20210603,
-    1352
+    20210628,
+    2141
    ],
    "deps": [
     "request"
    ],
-   "commit": "03c1ca90a7f2583074f020619c7cb92a783fb375",
-   "sha256": "1pwgs9xm6i0cqhrwpl60y3xbd0k64nr48kfa83x3yk9x38i6ddp0"
+   "commit": "8cc47ecef5d90d4f0f2bba669bbd89f88fda4be1",
+   "sha256": "11a44kfbpa2w54kqqc9mg3bzz0p0jrdjsz8l9sn11irl8xlgrm67"
   },
   "stable": {
    "version": [
     0,
     0,
-    2
+    3
    ],
    "deps": [
     "request"
    ],
-   "commit": "03c1ca90a7f2583074f020619c7cb92a783fb375",
-   "sha256": "1pwgs9xm6i0cqhrwpl60y3xbd0k64nr48kfa83x3yk9x38i6ddp0"
+   "commit": "8cc47ecef5d90d4f0f2bba669bbd89f88fda4be1",
+   "sha256": "11a44kfbpa2w54kqqc9mg3bzz0p0jrdjsz8l9sn11irl8xlgrm67"
   }
  },
  {
@@ -75521,14 +75666,14 @@
   "repo": "awth13/org-appear",
   "unstable": {
    "version": [
-    20210605,
-    904
+    20210627,
+    612
    ],
    "deps": [
     "org"
    ],
-   "commit": "cf87546d6458d36492a89661a1e097e5596aa26a",
-   "sha256": "18p8s0syqhqpk21ylbk8np3srknhi4ckxfxn7i4jkscsy8282lcb"
+   "commit": "12056f697fce51958e7baf837d250341bd86194e",
+   "sha256": "0p3h2inqqf9ighr9sig1spbni9mq0k4iy8w10w5bpjd3xm37qx80"
   }
  },
  {
@@ -76654,8 +76799,8 @@
   "stable": {
    "version": [
     1,
-    6,
-    1
+    7,
+    0
    ],
    "deps": [
     "dash",
@@ -76697,16 +76842,16 @@
   "repo": "marcIhm/org-index",
   "unstable": {
    "version": [
-    20210602,
-    358
+    20210630,
+    1503
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "40716a4cfd36304b4a16977020b1e82870faec15",
-   "sha256": "1wncx69rqlvx9pnr5mlwn9i00nrfhi1icxv0zpc7z2kzf03wn930"
+   "commit": "ddb1b95ac139676e4aa8a0b787e57feba34cc7cb",
+   "sha256": "0l563j9m8zcmsn8vqv3qchk4yqrfbigk5k4iqcw8p7cbix57sjah"
   },
   "stable": {
    "version": [
@@ -76780,16 +76925,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20210527,
-    1629
+    20210622,
+    130
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "a01f0453667f9baccf0b8a514e9c9f0a9fb9fb6e",
-   "sha256": "1gn2sflvcc4gvgci3m12d16mjrwxywrd8vvrs7s87k0cf7yl74vf"
+   "commit": "f4599dd5dfd7f97a22ca98502f809a8d14551c09",
+   "sha256": "0i8rqila62qamv3mxh66g678kbang3sxjbf3x70nmrx7fyy2m2jv"
   },
   "stable": {
    "version": [
@@ -76933,14 +77078,14 @@
   "repo": "stardiviner/org-link-beautify",
   "unstable": {
    "version": [
-    20210222,
-    227
+    20210628,
+    1124
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "4662b3a7b9244aa35aae2f469f87be4a44a6b1bb",
-   "sha256": "1wb00rm6zdlb8hrhph783wi8zjra8m09gi6m2nnfr37al3986g0s"
+   "commit": "f78924c06c9f3902bab8e390d91402516d2bb502",
+   "sha256": "1v847kpc3fh4sxi1rw8pp6xlb89r6z224831xkd82gys74ya0724"
   }
  },
  {
@@ -77111,30 +77256,30 @@
   "repo": "ndwarshuis/org-ml",
   "unstable": {
    "version": [
-    20210328,
-    1655
+    20210627,
+    1623
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "9d8c26d12c972a60b94bcc3b364d857db997cfa3",
-   "sha256": "102lrlf25i30xbpszr1mh6mkxd6wwgbwg32dafccxm4dmj3v9hqq"
+   "commit": "e14205312c54a1c97491c7f847d296b09f5f57b0",
+   "sha256": "030fsgdp8cg2h8mlxq6769l158pqcwnv4r3bl36lpjs950lv9pas"
   },
   "stable": {
    "version": [
     5,
-    6,
-    2
+    7,
+    0
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "5aeed6d0f7f878b20483975200df43b6fc7f32f9",
-   "sha256": "102lrlf25i30xbpszr1mh6mkxd6wwgbwg32dafccxm4dmj3v9hqq"
+   "commit": "e14205312c54a1c97491c7f847d296b09f5f57b0",
+   "sha256": "030fsgdp8cg2h8mlxq6769l158pqcwnv4r3bl36lpjs950lv9pas"
   }
  },
  {
@@ -77541,17 +77686,16 @@
   "repo": "org-pivotal/org-pivotal",
   "unstable": {
    "version": [
-    20200607,
-    1505
+    20210701,
+    342
    ],
    "deps": [
     "a",
     "dash",
-    "dash-functional",
     "request"
    ],
-   "commit": "125e70f9a682751e4ed7c3a350b2794af9600f47",
-   "sha256": "1w91wb6l3vsri015awig1kfs986zf49466x4ni0m24hcg00n2m7n"
+   "commit": "f55b9773b2f4a502e636688bc1caa21ee0396abe",
+   "sha256": "1ipxr8s384pljlz9rzpdhmrsa7q7jzk27dblrrapgbgi52h3n5np"
   }
  },
  {
@@ -77594,14 +77738,14 @@
   "repo": "rlister/org-present",
   "unstable": {
    "version": [
-    20200204,
-    1647
+    20210619,
+    1614
    ],
    "deps": [
     "org"
    ],
-   "commit": "9709ca2d04a59959354222ac4d3f8b750785739a",
-   "sha256": "08f8gh2zg4gr4d5ajlcnlj2lsp8nywni4mhw4w4nfa4dwyq7mxgv"
+   "commit": "5010b90fd09f484268f731b855d394deb8b5fc3d",
+   "sha256": "0k8l7qmxbxbzc4g0xh4ipssls78fky0cq2lg3864qdli820wzy5b"
   }
  },
  {
@@ -77655,14 +77799,14 @@
   "repo": "lujun9972/org-preview-html",
   "unstable": {
    "version": [
-    20180625,
-    619
+    20210623,
+    1523
    ],
    "deps": [
     "org"
    ],
-   "commit": "8ba7ecd7ac624f33b3e2395f477bbff4f1ec4efe",
-   "sha256": "1h46v0ckhfzv3fixcfxk7pkmh56c5lana8kpwiknm447q1wmlbx4"
+   "commit": "3fe7dd85b8a7dc4ead7495095a3abaad28e2f809",
+   "sha256": "1vih94z3k8qz2vkzvcqbxpipijsxyfn2kvimylfwjrfbkrmvigsp"
   }
  },
  {
@@ -77767,12 +77911,11 @@
   "repo": "alphapapa/org-ql",
   "unstable": {
    "version": [
-    20201213,
-    1358
+    20210624,
+    1314
    ],
    "deps": [
     "dash",
-    "dash-functional",
     "f",
     "map",
     "org",
@@ -77783,13 +77926,14 @@
     "transient",
     "ts"
    ],
-   "commit": "208e103ecc146db71d878df3bd09c6eb60c2797d",
-   "sha256": "09vdndp3935iy4flynbjpkvfax7vs1ppswl19wx4nn2rp7hdz8kp"
+   "commit": "8342656b2d9af4bb6af9daa0a8b037d3693bd940",
+   "sha256": "0alrs2dsd5k4xjrs2zs7hcr5fbfrr3rdq705s04943ic4kzvhrc9"
   },
   "stable": {
    "version": [
     0,
-    5
+    5,
+    2
    ],
    "deps": [
     "dash",
@@ -77804,8 +77948,8 @@
     "transient",
     "ts"
    ],
-   "commit": "3924b023e0f1e8fa93cfa79bdd71f9f0c0fb4679",
-   "sha256": "14nsy2dbln3m5bpqzyfqycn18sb3qh407hjbkk1l0x2nqs3lrkqn"
+   "commit": "d3b0ef2f5194452d88bf23ec31ebfef822c47c24",
+   "sha256": "0b3xxnbhnrz0263fnrrdbs3gif4pjkfws4mxkfqqpg0fc8azp2rx"
   }
  },
  {
@@ -77891,8 +78035,8 @@
     "htmlize",
     "org"
    ],
-   "commit": "4538c06fab9a7259aa1fb40e93a43dcfacef27c1",
-   "sha256": "1w6zvgfcyjqlxy4s13h7w66vv0fcid57s6vigzgnzi666w86fdyh"
+   "commit": "cf000894f6e5d0627151e2bec5b1a54a311ad53e",
+   "sha256": "1lfvhc4gly06rq5i2fgjydg4rsy7vgksa8hpydsvklr0ypvc1hcc"
   },
   "stable": {
    "version": [
@@ -78159,8 +78303,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20210513,
-    804
+    20210609,
+    1221
    ],
    "deps": [
     "dash",
@@ -78170,8 +78314,8 @@
     "org",
     "s"
    ],
-   "commit": "8ad141403065bebd5a72f0ef53cf5ef8f2034419",
-   "sha256": "126s444r0baylrmxw1z0lkbx7f40srk3wwk55li7is225qz2jlmb"
+   "commit": "756f6215b672e267f986a3d6e494f5309825b91a",
+   "sha256": "16rjqzj872y1240w15gawxcwj5gg1cds162wq1hswzplmx8wp9d1"
   },
   "stable": {
    "version": [
@@ -78207,8 +78351,8 @@
     "org-ref",
     "org-roam"
    ],
-   "commit": "f7b5be2ce0b43dd4d842484fc0ec37fdc8526907",
-   "sha256": "1cqx2izzchwd6yi0gmskdb0kiqjwk2m7rgk074bzzq0dzbpl180j"
+   "commit": "c9865196efe7cfdfcced0d47ea3e5b39bdddd162",
+   "sha256": "0c9y76r1bagz39m74kb2jcxqsc2q461407bbsib3f512sdf93lyg"
   },
   "stable": {
    "version": [
@@ -78371,11 +78515,11 @@
   "repo": "lordnik22/org-shoplist",
   "unstable": {
    "version": [
-    20210514,
-    1041
+    20210629,
+    2157
    ],
-   "commit": "1c534662719222e315d970e2fa871d222f80ea87",
-   "sha256": "1m6a37bw60xjkqaffzk1kjpcy76i5dd17925hzz2fbbhlxkac67x"
+   "commit": "71ea7643e66c97d21df49fb8b600578ca0464f83",
+   "sha256": "0pjcpry9hzma87f8isyi0q5si0i67g0gd8shj2y3qyizi9ns64a2"
   }
  },
  {
@@ -78582,11 +78726,11 @@
   "repo": "bastibe/org-static-blog",
   "unstable": {
    "version": [
-    20210606,
-    1806
+    20210616,
+    809
    ],
-   "commit": "0bd38b604405ba8e6ba00dd32ce4773eb02eb901",
-   "sha256": "1d9kdcdiz600swcy318hd56l751w2qyafdibnkzfkhjzw63c2hwh"
+   "commit": "4738a7bdb24cb4e1d1d5effc23f953e4c76e7713",
+   "sha256": "0kpa1rnpxfar8xkah29f9h6q26fgdxcb8gimsfqvrj145vama7pr"
   },
   "stable": {
    "version": [
@@ -79188,8 +79332,8 @@
     20210414,
     1844
    ],
-   "commit": "246120647e28a27506ca0894ba98e371086881fd",
-   "sha256": "15gqzj4h0w33w38i8ihl74iy7aqxlds97gm93r72z69pm2l1d7dm"
+   "commit": "8a3b529d5ece261a8847298ea03ed35615cc9bfa",
+   "sha256": "16zalqjd2llwkp7v0218crgf3k34py8zx6lj6z7i3kbmxm9nb27q"
   }
  },
  {
@@ -79617,15 +79761,15 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20210525,
-    1956
+    20210620,
+    1943
    ],
    "deps": [
     "magit",
     "org"
    ],
-   "commit": "26242895ef1642bf30c63683fb224fdba25e0853",
-   "sha256": "1xd58yqqsb79lgxkhxs4s50jq8f3639k6fhlza9hsy53apfczkal"
+   "commit": "f956d802f19ea495efa95af6c673588afeb3adc5",
+   "sha256": "0mbcr98xq3zim01dk1fbyc1vajnjwx90k62mygv343rhrd05v44m"
   },
   "stable": {
    "version": [
@@ -79649,8 +79793,8 @@
   "repo": "magit/orgit-forge",
   "unstable": {
    "version": [
-    20210525,
-    1957
+    20210615,
+    1516
    ],
    "deps": [
     "forge",
@@ -79658,8 +79802,8 @@
     "org",
     "orgit"
    ],
-   "commit": "ea2a1cf9d337901b413e9df258b8e07af55c00f6",
-   "sha256": "07ia3b6bfilnpify93kq5g10xhh794v5pmc9cmmb312c3qyqi7b4"
+   "commit": "365b75609a9454dccf5681eb6075ca53bd32af85",
+   "sha256": "1y7rywlqhsvkism9dmzlb3sijd8isp6qqhgba79aqgk9wz593rkv"
   },
   "stable": {
    "version": [
@@ -79759,8 +79903,8 @@
     20201129,
     604
    ],
-   "commit": "5aec071702c21dcc777e75b575d3875141688e46",
-   "sha256": "13405irnpwb1fgwv5d9mwywpbvb6d7smmi7nsd140l0i0m7anx1c"
+   "commit": "649fd0cdcb831dcd840c66ee324005165ce970ca",
+   "sha256": "1iarfqdxryj5p43hsch2jgqslrpyfkza9x9fpshmbpwjkbf1548x"
   },
   "stable": {
    "version": [
@@ -80713,8 +80857,8 @@
    "deps": [
     "org"
    ],
-   "commit": "074c3abf0a6aa5d671da1a39a20137140ba41d24",
-   "sha256": "1a134x8pmgas5k1m769clk3yhrzdh4n0cwmh23bf22avk6n3bz8z"
+   "commit": "290b5d6b659addf99cb96a316fb24caa90ad0e77",
+   "sha256": "04isqw4wfn5hq772sf0szq2rc3b8finhgjc5cna2sw7bhfgycywb"
   },
   "stable": {
    "version": [
@@ -81136,36 +81280,6 @@
   }
  },
  {
-  "ename": "ox-slimhtml",
-  "commit": "6fae8e3c4abd37a651d4cbdb337a74f1a7c7366a",
-  "sha256": "16jrw8n26iy69ibr29bp3pqp4lm66alihks37qipd2g5grqqfdnd",
-  "fetcher": "github",
-  "repo": "balddotcat/ox-slimhtml",
-  "unstable": {
-   "version": [
-    20210330,
-    1941
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "72cffc4292c82d5f3a24717ed386a953862485d8",
-   "sha256": "0p22dmyrcny82k0r1w84kcwi513xy03h848knzhm9zj7360dlkiw"
-  },
-  "stable": {
-   "version": [
-    0,
-    4,
-    5
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "a764ef64235845e4f5cfd73244d6cf1e7fee903b",
-   "sha256": "14h0kks7i2k53fwbsqb4giafacm58inppqpr5mbj904cy146g29f"
-  }
- },
- {
   "ename": "ox-spectacle",
   "commit": "f441e1b3ee30065f8a68c9b0b45d9db0cac8a289",
   "sha256": "1nf4765dihlcjbifhb9dinqin27ivqj2s8wzh1hj4vc3n8mdx5pr",
@@ -81504,14 +81618,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20210421,
-    1333
+    20210616,
+    2110
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b4eec13201093070a12f37396afce83eb6771df5",
-   "sha256": "1kr9iwsrpxbalhjz91pqplwkb44msdl2qv4rwsbapz8z8hs4xzji"
+   "commit": "95e021756ee5c5255a63cce8351178e298c68363",
+   "sha256": "05qm6a0dy2iszrlwkiw5x2v0h5whk7d4qn7qjlf5qpns5fl0fwg2"
   },
   "stable": {
    "version": [
@@ -81608,11 +81722,11 @@
   "repo": "tttuuu888/package-loading-notifier",
   "unstable": {
    "version": [
-    20210603,
-    1138
+    20210608,
+    1406
    ],
-   "commit": "8fd10303e19a2a1e8b5544ce8c34c8466af5d08a",
-   "sha256": "11d9mc9ca9bn9x3by8fqcan2c8wn85d8xnmkfvzxcmw7dz87kis2"
+   "commit": "1e30d097de8939c4aa380915d3ba3060a87ce3c6",
+   "sha256": "0wmf3pfjvxrv86mpvbkn5n4drc20yc12fwm4k6a613br0bs75gan"
   }
  },
  {
@@ -82030,8 +82144,8 @@
     20200510,
     5
    ],
-   "commit": "246120647e28a27506ca0894ba98e371086881fd",
-   "sha256": "15gqzj4h0w33w38i8ihl74iy7aqxlds97gm93r72z69pm2l1d7dm"
+   "commit": "8a3b529d5ece261a8847298ea03ed35615cc9bfa",
+   "sha256": "16zalqjd2llwkp7v0218crgf3k34py8zx6lj6z7i3kbmxm9nb27q"
   }
  },
  {
@@ -82584,22 +82698,22 @@
     "s",
     "with-editor"
    ],
-   "commit": "4e73cdc4c376ad61d2e4858bc87cf01eab0dd403",
-   "sha256": "0pvn8djsm8bvx2msrfvm12b778w9yl7sw517l2x0bdm48apz3ifx"
+   "commit": "3dd14690c7c81ac80e32e942cf5976732faf0fb3",
+   "sha256": "10015qvf98j4m26rprrvhbfj4dg4j5sg2c0ps7x94cjjxrph7kf6"
   },
   "stable": {
    "version": [
     1,
     7,
-    3
+    4
    ],
    "deps": [
-    "f",
+    "auth-source-pass",
     "s",
     "with-editor"
    ],
-   "commit": "74fdfb5022f317ad48d449e29543710bdad1afda",
-   "sha256": "0nixbsyckkp1qjszgac74m00vj10vc3vyw2wic1zgc2rx795k228"
+   "commit": "1078f2514d579178d5df7042c6a790e9c9b731ad",
+   "sha256": "17zp9pnb3i9sd2zn9qanngmsywrb7y495ngcqs6313pv3gb83v53"
   }
  },
  {
@@ -82932,11 +83046,11 @@
   "repo": "JonWaltman/pcmpl-args.el",
   "unstable": {
    "version": [
-    20190223,
-    1613
+    20210625,
+    2116
    ],
-   "commit": "0b8a05fc6e370fa9c466250659619f8d6b53d446",
-   "sha256": "1zhjpgnd8n95fv2z5d9360cx2vhw88yqz7gyc0qc563p6l3xmffg"
+   "commit": "e6957896b065e2fda80a8258dfebb86b49742c15",
+   "sha256": "0fx7v5b3v7y9qxr8n8pm6449rdf4ljc0fb6kp0vpdzfzc4yzgdni"
   }
  },
  {
@@ -83492,21 +83606,21 @@
   "repo": "bbatsov/persp-projectile",
   "unstable": {
    "version": [
-    20180616,
-    1944
+    20210618,
+    708
    ],
    "deps": [
     "cl-lib",
     "perspective",
     "projectile"
    ],
-   "commit": "533808b3e4f8f95a1e3ed9c55d9aa720277ebd5f",
-   "sha256": "17i1srw1k771i3a5wlydbyasyd9z39ryf48mxfs0dsbx1zjbj0pg"
+   "commit": "4e374d7650c7e041df5af5ac280a44d4a4ec705a",
+   "sha256": "0cpf1739cd6ylyaz7pspsmh1dsmvymdqfpypahca0nn169vdrzk9"
   },
   "stable": {
    "version": [
+    1,
     0,
-    2,
     0
    ],
    "deps": [
@@ -83514,8 +83628,8 @@
     "perspective",
     "projectile"
    ],
-   "commit": "7686633acf44402fa90429759cca6a155e4df2b9",
-   "sha256": "0rqyzsmg32sdr4k9i2lf3jfyr9bskkl7gfb5ndl16iip9py7403z"
+   "commit": "6e4c2e017d59d10d627cf95b2bb9f9fa2b22a3a3",
+   "sha256": "0566zm9gbac9b1niszl0jhwizxw2a0f8b4b2idvihpsi93iwa8vi"
   }
  },
  {
@@ -83526,14 +83640,14 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20210523,
-    2254
+    20210610,
+    548
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b37c6756700a167742c8ab06fa5a850d9d94f4bd",
-   "sha256": "1ciab9xz4lbnnnx9407bagyf10dv6h9nalzm2wj6w6x7kckb4105"
+   "commit": "68b13cef8435cae581850415cdda17e245dd0eae",
+   "sha256": "1iwqg1y47lp54qn9cjr3w9pca294mn92qlil3a4lr8xi57jbi3iz"
   },
   "stable": {
    "version": [
@@ -83988,8 +84102,8 @@
     20210519,
     1728
    ],
-   "commit": "9561a6c0a92a3d7c00e7e57972f42cb5be775898",
-   "sha256": "189imf8dvmsfhcy0p9f8a7l0z8dfdsnialk58f4p1l06p67s21df"
+   "commit": "cbf27232649c39e3749eefd23f962750bd249a49",
+   "sha256": "0r20y2hrgy1gmnx6izzvmvjh4axwb4x4pgcxn4bjmpzypand5xfp"
   },
   "stable": {
    "version": [
@@ -84101,8 +84215,8 @@
   "repo": "emacs-php/phpactor.el",
   "unstable": {
    "version": [
-    20210517,
-    1838
+    20210619,
+    1706
    ],
    "deps": [
     "async",
@@ -84110,8 +84224,8 @@
     "f",
     "php-runtime"
    ],
-   "commit": "debf66848c6099415c731b179dcd47e96db3b50b",
-   "sha256": "0i5g4gh5i5y8wsrqw89lwi2s2sn67pvvj2y6p7lnyv0i201v5bs8"
+   "commit": "272217fbb6b7e7f70615fc518d77c6d75f33a44f",
+   "sha256": "0hm96i9vdbkcq6mypjpl94dn3gzyk23iql5zzy2d221vmjhqvn7d"
   },
   "stable": {
    "version": [
@@ -84135,14 +84249,14 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20201122,
-    950
+    20210617,
+    2234
    ],
    "deps": [
     "php-mode"
    ],
-   "commit": "6863a5278fc656cddb604b0c6e165f05d0171d0a",
-   "sha256": "05q1y6xshh5csr672jwplp2xmp87gvj9rc65ybpa687dkdmq8cdh"
+   "commit": "56617fa87c9bec037d4e4a0a143b7d70a989c082",
+   "sha256": "02k4pmmxq3h8mi0dsjh0s0002gjkpg6g9pxsnxgalwb6rakfirbh"
   },
   "stable": {
    "version": [
@@ -84445,11 +84559,11 @@
   "repo": "EricCrosson/pine-script-mode",
   "unstable": {
    "version": [
-    20210605,
-    1527
+    20210629,
+    1257
    ],
-   "commit": "e465c0264958cbed0fb29dad2b30b9f18fbf1064",
-   "sha256": "0crc2q5mzflyz13zx0ghsf2kdmj67lcqb2vnnsw0z2sk7wafrz2i"
+   "commit": "c04309be9fb73012b4c5c839741b1abcfe0b8aa9",
+   "sha256": "1hahd9w5pww3nx1xvbci4pscpbzb0k5xv3yff896jg66di36fvwg"
   },
   "stable": {
    "version": [
@@ -84595,21 +84709,21 @@
  },
  {
   "ename": "pippel",
-  "commit": "6d1796688ed0d6957557d960ca28e450f9bcb6cf",
-  "sha256": "1li4h0dff1n7njy2lk3d50ndrlw84fphmdg16j0srkbgy7xz90yn",
+  "commit": "45459106a88b5bb8ce5afdef9a7cb95a0fb447bf",
+  "sha256": "1gn944k09r78lfn1nqg69fnwx91y9lvw1k2i9czk7yhx4zmyinpl",
   "fetcher": "github",
-  "repo": "brotzeit/pippel",
+  "repo": "arifer612/pippel",
   "unstable": {
    "version": [
-    20180710,
-    856
+    20210614,
+    1655
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "21a5200e8e5ccaa1911abb4ebf090b76ca839756",
-   "sha256": "1amqjm6kn1xda058kdwq3xgk7raz6y9iw0mzrac78sgf57qaczyb"
+   "commit": "2480fd376b8f69691b45b0141fca0d900a5ac64a",
+   "sha256": "190cd66bhvlmyxki7hl43s0h4rvflw9r36xm4ky3c1mhbkrfsz1p"
   }
  },
  {
@@ -85579,15 +85693,15 @@
   "repo": "polymode/poly-markdown",
   "unstable": {
    "version": [
-    20200316,
-    1315
+    20210625,
+    803
    ],
    "deps": [
     "markdown-mode",
     "polymode"
    ],
-   "commit": "1536cf0c32f71d5cd05c90f7905905e38006e95d",
-   "sha256": "1q4qq0ql08hxkdrd2aal03560k612my7bvnfpfij3g432hn0p7v6"
+   "commit": "e79d811d78da668556a694bb840bea3515b4c6f8",
+   "sha256": "02jpak60jl6nrz5zkkc0cw5i95vl4h6g31qvgb3qsidimav305n6"
   },
   "stable": {
    "version": [
@@ -85985,11 +86099,11 @@
   "repo": "karthink/popper",
   "unstable": {
    "version": [
-    20210602,
-    847
+    20210610,
+    1945
    ],
-   "commit": "2be084a77cc2bc79ea7dc23edada161f4ff6dfdb",
-   "sha256": "118sbcm6qavckxva81vamrs98dj38yv0qccqqj4p3a4q7brfi8cw"
+   "commit": "4c51182f5f5dd7a1ffa69fb994ef5ef6f9592686",
+   "sha256": "028wfdi240r8xdz7j77fv29brk5ck6yhhh1vj9p58m4f4ff8r9ik"
   }
  },
  {
@@ -86000,11 +86114,11 @@
   "repo": "auto-complete/popup-el",
   "unstable": {
    "version": [
-    20210317,
-    138
+    20210625,
+    400
    ],
-   "commit": "866a091b83369873b4d1c5d62a590fbb0a150bd0",
-   "sha256": "059x15zlc6c17yg5ahdca3bryr10nh9xbb61dv0gdc2wg2c0pzzi"
+   "commit": "cf899f8012f4189e76a009bebb589ff71631b1e9",
+   "sha256": "09nf95bin4dq50vapax8xndm0bay2cbsws4zvpb4hp3kk0gdzrl6"
   },
   "stable": {
    "version": [
@@ -86245,11 +86359,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20210604,
-    647
+    20210617,
+    42
    ],
-   "commit": "3257a52e3599bc1d5c9a4b646d36d7a49b0dd025",
-   "sha256": "13p7122100ywg6dc32wq0hvcn52x8djxq6vgcmdpdsdy7k4fkxwc"
+   "commit": "f97c4aff2c2c376ca62276d5597aa108546633a9",
+   "sha256": "18w06fdz63w2arwgbgbl9wghb9fin4cqpxnyajppyqk5lpnsn7iq"
   },
   "stable": {
    "version": [
@@ -86771,10 +86885,10 @@
  },
  {
   "ename": "private",
-  "commit": "6440f81aed1fcddcaf7afeedb74520e605211986",
-  "sha256": "1mvma2xgjy9vkh468x80xlri6qfr7d494la1j6r1clkjsn5kg7hr",
+  "commit": "e036ca25bced52cdacc4e56dcdea4282360aa5da",
+  "sha256": "1rq4vyfjr8b2fnwjnw28if9y9svvaxw1pwisys5p8rx0mff48cn3",
   "fetcher": "github",
-  "repo": "zhangkaiyulw/private",
+  "repo": "victorteokw/private",
   "unstable": {
    "version": [
     20150122,
@@ -87059,6 +87173,21 @@
   }
  },
  {
+  "ename": "project-mode-line-tag",
+  "commit": "9a739b3a77aaf0033161c6687e1e9c5592bb18bd",
+  "sha256": "0syr5lpn0xmvf54k65lif181y6kcvs96j8wykzzlmsf9zdkkdg20",
+  "fetcher": "github",
+  "repo": "fritzgrabo/project-mode-line-tag",
+  "unstable": {
+   "version": [
+    20210615,
+    1825
+   ],
+   "commit": "ed6adf9287d2aa526d85451623f1aa281cfa7e0a",
+   "sha256": "0xryvjsb2r4rj22wgjpixa31kg4sp7xww63hldnf7c1cvcc9g305"
+  }
+ },
+ {
   "ename": "project-persist",
   "commit": "bd81d1f8a30ed951ed94b9a4db13a2f7735ea878",
   "sha256": "0csjwj0qaw0hz2qrj8kxgxlixh2hi3aqib98vm19sr3f1b8qab24",
@@ -87143,14 +87272,14 @@
   "repo": "hying-caritas/project-shells",
   "unstable": {
    "version": [
-    20201026,
-    748
+    20210625,
+    647
    ],
    "deps": [
     "seq"
    ],
-   "commit": "382b3d48a797ea56383732ebf9cd219aeec676df",
-   "sha256": "04zsk6mwxkp71fbjq64k78nwx3gvgbp2fmm5f8ah2ap2g65j5kq3"
+   "commit": "900369828f1a213c60a2207a71d46bc43fd5405c",
+   "sha256": "1igs3dr3j9lw8lyww1wp69v5i9k2ifvblmsh862vx7l6rvy98f5h"
   }
  },
  {
@@ -87161,14 +87290,14 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20210607,
-    1513
+    20210701,
+    441
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "155fdb44176347c9599357c7935993033260a930",
-   "sha256": "040g4frdjabpa8ddhag81dx3kphh5kp3iv34x4zsbkhb6gryd5zf"
+   "commit": "da08a9103b5ba3b38ef031a9627a19436eb318b5",
+   "sha256": "08y36qvr20888jc2b5172qgah0xpp9bc3iwp38w8clfrjfd28g2s"
   },
   "stable": {
    "version": [
@@ -87241,34 +87370,36 @@
   "repo": "asok/projectile-rails",
   "unstable": {
    "version": [
-    20210325,
-    2120
+    20210625,
+    708
    ],
    "deps": [
+    "dash",
     "f",
     "inf-ruby",
     "inflections",
     "projectile",
     "rake"
    ],
-   "commit": "f1fe6e8eff485dc560e6ffe7f0b9c46a61509a58",
-   "sha256": "1b9wsn6mm1ajh81f6bmp3ajxch3j05bzslzxjakw93gjg69w74y1"
+   "commit": "6a18ada3566ab2cb795129e3dfca2a32cc413fb8",
+   "sha256": "1xr6ha5jkczpbdqpxf8s4qggvx4arwky6mfwaji2kjnkk0ajjyda"
   },
   "stable": {
    "version": [
     0,
-    21,
+    22,
     0
    ],
    "deps": [
+    "dash",
     "f",
     "inf-ruby",
     "inflections",
     "projectile",
     "rake"
    ],
-   "commit": "8d6b3734958f5dc7a620dc1b44754986d3726f3d",
-   "sha256": "03cj0cpmqyxcvqscnjcgcfz5k1ga6knr5jcb5prnv9hfjfqgk3pb"
+   "commit": "6a18ada3566ab2cb795129e3dfca2a32cc413fb8",
+   "sha256": "1xr6ha5jkczpbdqpxf8s4qggvx4arwky6mfwaji2kjnkk0ajjyda"
   }
  },
  {
@@ -87679,17 +87810,17 @@
     20200619,
     1742
    ],
-   "commit": "4644980d818ec9d987f74c74b1a1d45de9ab01fd",
-   "sha256": "1mzblak9s46wsfh3l1798k9pjwbddnz030y0cfx831lfpr20227b"
+   "commit": "4b77b733699f9c39b517a124da737c018b1164e2",
+   "sha256": "1mfvmpwxayrzp07vl72djv162vlf0xg29mxh030lqf7jc9h11gxq"
   },
   "stable": {
    "version": [
     3,
     17,
-    2
+    3
    ],
-   "commit": "70db61a91bae270dca5db2f9837deea11118b148",
-   "sha256": "08a7rnflhklbabqm5yyz2nwyzzfbh24miiy3wsxphaanjz4xr6yi"
+   "commit": "909a0f36a10075c4b4bc70fdee2c7e32dd612a72",
+   "sha256": "08644kaxhpjs38q5q4fp01yr0wakg1ijha4g3lzp2ifg7y3c465d"
   }
  },
  {
@@ -88533,15 +88664,15 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20210607,
-    427
+    20210623,
+    415
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "eaf331f67ad3d6ea5b63c92bcd0cfc0134466b53",
-   "sha256": "0prrkn2yaj6wm2hn17jgfxb1vz58mdm3ivmqsncrfhl1vdll73jm"
+   "commit": "70d488f9233a578f0c7f8906aa83a1a690ec10fa",
+   "sha256": "14zczmikgsxqf3klx17n1imgpqhj3gjmz4hs95lkxs3a50qbqh7z"
   },
   "stable": {
    "version": [
@@ -88588,14 +88719,14 @@
   "repo": "p1uxtar/pyim-cangjiedict",
   "unstable": {
    "version": [
-    20210507,
-    928
+    20210617,
+    934
    ],
    "deps": [
     "pyim"
    ],
-   "commit": "455e20e90044a1fcd6c4b45252745fa233e0107d",
-   "sha256": "0dv5l8cpccvc7jsc4qdijnz76dp2rznmcnkkn3w75xw46ai8chnk"
+   "commit": "d17e3d32a6480939b350a91a915ebe8e6efad819",
+   "sha256": "1bszpqsm15az0wvbgsk012manxnvigbk38qr5iqzkgd4d13yv5fs"
   }
  },
  {
@@ -88703,17 +88834,17 @@
     20210411,
     1931
    ],
-   "commit": "6c7bc2b576a705fcc7bc52494163e9a1a240ea80",
-   "sha256": "1m4swr0v998c6iq589mzx6glq7g2gc109469wcsjyi9j4cv7qgkr"
+   "commit": "6f066733e23a61d83580cd1898e6b8afab8fafea",
+   "sha256": "1m7365k7a624mp33v5x23knkcahpa9gvb3sbr8idqlk8n8k3f6mk"
   },
   "stable": {
    "version": [
     2,
-    8,
+    9,
     3
    ],
-   "commit": "735c958d3b36fb5d343b7bcb81b1055a430cb042",
-   "sha256": "1m8f8qv88bvqbviszwf0n4ch5dpyqa33067ampy706cpg7mwjvn0"
+   "commit": "aa688de05e469e33a20478144013946ccb752736",
+   "sha256": "0r2xp90bwwqnya3gq0q0gh2qdn7i9fcsq8ab890bnd0b44ivx0nk"
   }
  },
  {
@@ -88984,11 +89115,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20210601,
-    1845
+    20210620,
+    1854
    ],
-   "commit": "198ba8e15e848825b2215e9fc363f06d8c173a28",
-   "sha256": "1z6vnbnqvn20gs131d0rjncr4nk11amahvmfaffkhiwmpsl1b3gv"
+   "commit": "3f0be5ace492d2ddd8405f4b5186ef89caee762e",
+   "sha256": "17clkgs94dgq5nsjlwkr52m5s446ibfss3qc8a8m0zaz6j4f8l1m"
   },
   "stable": {
    "version": [
@@ -89162,11 +89293,11 @@
   "repo": "psaris/q-mode",
   "unstable": {
    "version": [
-    20210307,
-    2102
+    20210620,
+    1712
    ],
-   "commit": "a30a84afae9bb72bc601b213ae68821479b0bb03",
-   "sha256": "1q85vxvv76vmb9zhc91p2aqh333h1p48737spriv5sw9wvis0gdm"
+   "commit": "86d937854c45f6b2a102b42c1a991ba713532f9e",
+   "sha256": "1hbb0m5kjczyri6hbgkk1par53zfnsp7m133xqzfhg2sibrvbz2x"
   }
  },
  {
@@ -89628,15 +89759,15 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20210604,
-    1431
+    20210629,
+    2000
    ],
    "deps": [
     "faceup",
     "pos-tip"
    ],
-   "commit": "4b46a818c08820e04d25df7fe830e80ea82e1126",
-   "sha256": "0kr1sd819rvyfw34g6sqcnygkllcx07ccc5zc773kn0ngiqd0zvn"
+   "commit": "4f8eafe2a016e2e78872e4006939ee82397e57a0",
+   "sha256": "0fa9kipg1ihfr16ljsfgxd6z8a5fj31npfxhqv7q9ysi4nq479c0"
   }
  },
  {
@@ -90293,11 +90424,11 @@
   "repo": "pfchen/read-only-cfg",
   "unstable": {
    "version": [
-    20210517,
-    749
+    20210608,
+    1259
    ],
-   "commit": "c128c9412f768adf89ff5c4ad433cf0beab6656a",
-   "sha256": "11zj4ysmacvz82j1siqlcp30i05my20lscls8wkdjl75g9d2b12l"
+   "commit": "a02395b37a68b2e20e365c2e3752f966c71d4c02",
+   "sha256": "0jihqc16knvws5w2y5djdir4h52mpwk86nbjlap47lh2r18qk6q6"
   }
  },
  {
@@ -92023,11 +92154,11 @@
   "repo": "galdor/rfc-mode",
   "unstable": {
    "version": [
-    20210510,
-    1104
+    20210615,
+    1721
    ],
-   "commit": "b885d6bd2b3be69a2413c4dc5cc34344d821cba2",
-   "sha256": "0qqvab5n5y70mv9dq06xnqmpxy9pr994k3b83kw70pq43gb03nxd"
+   "commit": "3ef663203b157e7c5b2cd3c425ec8fbe7977a24c",
+   "sha256": "0lrmgvrj69rs49vjfwkm3w9z4y5mkndra1kdqmr9s7z9f1558is1"
   },
   "stable": {
    "version": [
@@ -92050,28 +92181,28 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20210305,
-    1621
+    20210625,
+    939
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "10e64887c224002572e1f1e19c74453cba606c3f",
-   "sha256": "1519lh5j5zki2dfzd1a1hl1d24nap99hv80647rvpr3mzbcsg29s"
+   "commit": "0fa6d33d2f3123aecd0b0dbc5fa3d884edf10a92",
+   "sha256": "17f11znjyfnxs5y0zafcx9aa055wkw3igzk9gy0cipnyp42yb4v7"
   },
   "stable": {
    "version": [
     2,
-    0,
-    3
+    1,
+    0
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "bb89400d4d5e4eb22917f7048256745ea566a844",
-   "sha256": "0d8habjr4nv0xbgsk7nj5zid5zywf00vbl5zcx7anda5w1cy2zvr"
+   "commit": "0fa6d33d2f3123aecd0b0dbc5fa3d884edf10a92",
+   "sha256": "17f11znjyfnxs5y0zafcx9aa055wkw3igzk9gy0cipnyp42yb4v7"
   }
  },
  {
@@ -92230,8 +92361,8 @@
   "repo": "DogLooksGood/emacs-rime",
   "unstable": {
    "version": [
-    20210207,
-    1432
+    20210628,
+    1648
    ],
    "deps": [
     "cl-lib",
@@ -92239,14 +92370,14 @@
     "popup",
     "posframe"
    ],
-   "commit": "519e6eb3b5e8e668c2835d27f54fcf5776242576",
-   "sha256": "1q0kzdy3nxswsriq4fxr00wmw43x737dd7pnkf9g6v8hd7gsqkzc"
+   "commit": "b93e761209211f8a6de1bb4b8f1d36651564a8d9",
+   "sha256": "0z0iwsqr92g8ykxb51gkawwxwzx0faw0027zgdi7c38ngjqld237"
   },
   "stable": {
    "version": [
     1,
     0,
-    4
+    5
    ],
    "deps": [
     "cl-lib",
@@ -92254,8 +92385,8 @@
     "popup",
     "posframe"
    ],
-   "commit": "ee7f951f0bc3b55034634019dd385706bc413dbb",
-   "sha256": "1a50cziwg7lpgh26yvwxs46jfyfq1m0l6igbg5g5m288mz4d3an9"
+   "commit": "b93e761209211f8a6de1bb4b8f1d36651564a8d9",
+   "sha256": "0z0iwsqr92g8ykxb51gkawwxwzx0faw0027zgdi7c38ngjqld237"
   }
  },
  {
@@ -92430,11 +92561,11 @@
   "repo": "jgkamat/rmsbolt",
   "unstable": {
    "version": [
-    20191218,
-    257
+    20210624,
+    417
    ],
-   "commit": "2bc1afe528b70b8aad4243a3b2b72bcf09a599e1",
-   "sha256": "0pg2q275qd83i8c1g0f1xlwvbqd40xm3gw2ahl80blyllsvz04j9"
+   "commit": "ff496660cc52a6dd33d358ef0acc6d4bb70cc340",
+   "sha256": "05i0101238yy1da6z543nr9x5gpvgdxrrdn3sw5dibcn6z62ml3p"
   }
  },
  {
@@ -92445,14 +92576,14 @@
   "repo": "dgutov/robe",
   "unstable": {
    "version": [
-    20210608,
-    17
+    20210626,
+    137
    ],
    "deps": [
     "inf-ruby"
    ],
-   "commit": "bcddba77ba11b46f94730708fff2215f4b620428",
-   "sha256": "04az3rk7h606pv2l16wf2bmad9nqb7nx6r7cwap90dvnfjn56a3y"
+   "commit": "e1304d123d729aa063671d0ca526b01e72f0f5ed",
+   "sha256": "1ghwjymcmmr99z060l1shm9sqbjxxdgq6b7ayn8s9mldcqm5pa3q"
   },
   "stable": {
    "version": [
@@ -92695,8 +92826,8 @@
     20210313,
     1541
    ],
-   "commit": "63f18acb21e664fd92fbc19465f0b5df085b5e93",
-   "sha256": "0wzyn9qzyly71yfwhlk5m94ygjnbk459pgbpgkhp9fqgchx12p1r"
+   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
+   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
   },
   "stable": {
    "version": [
@@ -92721,8 +92852,8 @@
    "deps": [
     "rtags"
    ],
-   "commit": "63f18acb21e664fd92fbc19465f0b5df085b5e93",
-   "sha256": "0wzyn9qzyly71yfwhlk5m94ygjnbk459pgbpgkhp9fqgchx12p1r"
+   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
+   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
   },
   "stable": {
    "version": [
@@ -93255,8 +93386,8 @@
   "repo": "brotzeit/rustic",
   "unstable": {
    "version": [
-    20210502,
-    1646
+    20210609,
+    1900
    ],
    "deps": [
     "dash",
@@ -93269,8 +93400,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "ed68fd3bb410869e1a4ce3943b5913ea88d9b509",
-   "sha256": "0896m5ajlq90pp7ds6iw7plqkffm6k01v3rfqfhb3qwd92nxgcf0"
+   "commit": "bbf129cd128105de51b6c242b2551094b8d8987d",
+   "sha256": "09dnlvi8kf683n6q3yp4gy9d4idiyg4x6rcij8d90cvygh8i30wd"
   }
  },
  {
@@ -93305,11 +93436,11 @@
   "repo": "Kungsgeten/ryo-modal",
   "unstable": {
    "version": [
-    20210523,
-    757
+    20210625,
+    2046
    ],
-   "commit": "ab6417d8e546f1836618ee72d074ec65431ebc80",
-   "sha256": "1yy0jr7n55qbraxif2zhgmyr31jd5sd62jyhd3cg327vl5ga1ajg"
+   "commit": "fc9e227127fa327183d39d28c3afdb2f395a51a2",
+   "sha256": "1j05dyg77fpdh7gl29bq48fdba7kwbhsq3ryn6b8vzhncapsqj99"
   }
  },
  {
@@ -93320,11 +93451,11 @@
   "repo": "magnars/s.el",
   "unstable": {
    "version": [
-    20210603,
-    736
+    20210616,
+    619
    ],
-   "commit": "e1710af8d058faca32529d1129deb5d57871385a",
-   "sha256": "1zm9zqa1479kn74a1hbs7jc8rli7vzz5hk8k2rqpi34yf569yjhj"
+   "commit": "08661efb075d1c6b4fa812184c1e5e90c08795a9",
+   "sha256": "02hcjnf8n0nzqysqi9g7kqykxmn8nwhsx1scrq6wj1iibc16nh0p"
   },
   "stable": {
    "version": [
@@ -93740,8 +93871,8 @@
     20200830,
     301
    ],
-   "commit": "393a5f2be890c1e90b3d5f331ce1bf34dad09742",
-   "sha256": "16y5njqb9v58fmsp9nn38wvzx71jgy0di2m8933a8dkirddi324v"
+   "commit": "32c5c18e1cac173b79fc37b85dca51f4e8d57e45",
+   "sha256": "1vzg370393yfw1msgdyq2bwv3rc765z30vsrxssm0zifjqimkab6"
   }
  },
  {
@@ -94084,10 +94215,10 @@
  },
  {
   "ename": "scratches",
-  "commit": "6440f81aed1fcddcaf7afeedb74520e605211986",
-  "sha256": "116bjy1m35h83r2c354i2xk1br87nmvd99kbzax0wgkkkcjff8c4",
+  "commit": "991ef46a458c9301283dd440d79448fb25374c98",
+  "sha256": "0gq5ar2v50sxddf0lccm75kl2fq3g4zacq8wd2hf9kp3cq7mylh9",
   "fetcher": "github",
-  "repo": "zhangkaiyulw/scratches",
+  "repo": "victorteokw/scratches",
   "unstable": {
    "version": [
     20151006,
@@ -94647,15 +94778,15 @@
   "repo": "wanderlust/semi",
   "unstable": {
    "version": [
-    20210529,
-    1313
+    20210613,
+    948
    ],
    "deps": [
     "apel",
     "flim"
    ],
-   "commit": "95259568446f32c1af56dfc27e3614815322a1bf",
-   "sha256": "09xld1vpxdz1kvw039g7hk89p2d8pi95j9hgls6iviwzs6ni41yl"
+   "commit": "509f6f0bc2f5d020c63e47d9ad89410dc20bcb6f",
+   "sha256": "0lnr5kyc59rs2p3lnhyr6cc126rh17szp68xpsx4brym3blb37yc"
   }
  },
  {
@@ -94767,15 +94898,15 @@
   "repo": "twlz0ne/separedit.el",
   "unstable": {
    "version": [
-    20210521,
-    1050
+    20210630,
+    1805
    ],
    "deps": [
     "dash",
     "edit-indirect"
    ],
-   "commit": "900fdc33b647e92d0f464872da1b12d724de7d43",
-   "sha256": "1ji8qjg3qsxprsqjp4hks999f0rfqnl3nyj08hr4vra5nqk6x4cg"
+   "commit": "4fbbd85c0f809593f6d26edf1388ff059f77e82f",
+   "sha256": "0jyz0cz1c6bimkd48iv09lgmzgbb63v5dybcgrjcmcg630c8yh87"
   },
   "stable": {
    "version": [
@@ -94834,6 +94965,25 @@
    ],
    "commit": "a48cbcbe273b33edd3ae56e68f44b4100fa3a48a",
    "sha256": "1f05amz22klvs2yqyw7n5bmivgdn5zc7vkv5x6bgc9b5k977lggj"
+  }
+ },
+ {
+  "ename": "seriestracker",
+  "commit": "9370b3c06f065ee50ed7e4ffcfd9d503b6e9563f",
+  "sha256": "03vg4y262yy0y3xh0imx4mh59z2lhzif5jxnad2w385khnyj1n21",
+  "fetcher": "github",
+  "repo": "MaximeWack/seriestracker",
+  "unstable": {
+   "version": [
+    20210629,
+    2303
+   ],
+   "deps": [
+    "dash",
+    "transient"
+   ],
+   "commit": "a5ce1bfd06ed90bba9947a9045659d13f3362a96",
+   "sha256": "0gjwp0h9ip58da1p8q9s9pjfh0g6pav4gam9s51xnx8mv0vbgb68"
   }
  },
  {
@@ -95279,11 +95429,11 @@
   "repo": "ieure/shell-here",
   "unstable": {
    "version": [
-    20191011,
-    1959
+    20210616,
+    2338
    ],
-   "commit": "88b80deb1337a97b403b20fc467fa2d579b3bfd5",
-   "sha256": "1x9zcxsc6cnh0h051377asbqhcx3mzcarrnj9zmyg6fcszgas5v1"
+   "commit": "a3679c52d31d1dc6ed29bcab087cb5455a992eda",
+   "sha256": "0w0mlggb5gnvm109qn50ric3lb9znxvfkzvc7xla2qnmaz037ppz"
   }
  },
  {
@@ -95399,6 +95549,30 @@
    ],
    "commit": "9820b0ad6f22c700759555aae8a454a7dc5a46b3",
    "sha256": "0wvaa5nrbblayjvzjyj6cd942ywg7xz5d8fqaffxcvwlcdihvm7q"
+  }
+ },
+ {
+  "ename": "shellcop",
+  "commit": "51f723347f56e150852bf82d163c04aa846a3d9c",
+  "sha256": "19281hh73m898187ksb0wl409iwgr49z6mqx3dr5ggajbs7jp4yn",
+  "fetcher": "github",
+  "repo": "redguardtoo/shellcop",
+  "unstable": {
+   "version": [
+    20210622,
+    721
+   ],
+   "commit": "7c025b10173ef380ea539dbbdcd7d60977119e24",
+   "sha256": "1rjiyz3sx387b8559k01j6149jw729zlk5s3ah2jaxj6p9cag418"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    6
+   ],
+   "commit": "7c025b10173ef380ea539dbbdcd7d60977119e24",
+   "sha256": "1rjiyz3sx387b8559k01j6149jw729zlk5s3ah2jaxj6p9cag418"
   }
  },
  {
@@ -95558,11 +95732,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210606,
-    124
+    20210621,
+    534
    ],
-   "commit": "0e18a7e96c8e425ac7c2e69aa26fa6a1e8e6e51a",
-   "sha256": "1jxp447d8xnk4ixpni7rsph7fd3p58ydmi39yrx201hbqh15jxiz"
+   "commit": "70b985b1d00c8703acb1ebf16875616903470f45",
+   "sha256": "0djvaxbxjic4m8nqmj1gs0h77gf0fik00ia7ayfha3fc7fabiif9"
   }
  },
  {
@@ -95950,6 +96124,36 @@
   }
  },
  {
+  "ename": "side-hustle",
+  "commit": "f75ebbbec4736474a745487cecebdd70a3edde21",
+  "sha256": "01avgnswjq4jflgxfkrcgc56il6v6qgxblv1zn70n2p31x7n8y63",
+  "fetcher": "github",
+  "repo": "rnkn/side-hustle",
+  "unstable": {
+   "version": [
+    20210627,
+    701
+   ],
+   "deps": [
+    "seq"
+   ],
+   "commit": "1f4cd5e7cfbabb00c6d87e913770f21e3d16c957",
+   "sha256": "0qcaqfsnw90prch3x1flccanys4bh72x2pdmf27nh5b3i9jbrbv2"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "deps": [
+    "seq"
+   ],
+   "commit": "786932352ce2f10214b801e872690e05b6102851",
+   "sha256": "09i5ds9ayid570x97glcy6cb8qdr5jc8riqfs7wl3hi4dif0z61a"
+  }
+ },
+ {
   "ename": "side-notes",
   "commit": "67d23bdaefb563d88b206a9ed822316f3d5be9a2",
   "sha256": "07hrrplgvp3fvl10fsmxifnim8wz34w7fhzzzkxpdj1zlwls6h83",
@@ -96090,14 +96294,14 @@
   "repo": "vapniks/simple-call-tree",
   "unstable": {
    "version": [
-    20210608,
-    33
+    20210625,
+    2001
    ],
    "deps": [
     "anaphora"
    ],
-   "commit": "d776c801d773e535d1647524e2c4f63b200d8ef1",
-   "sha256": "1jh1h09l4vkzj40l8nskkilbggfl889l3rhi8b70jm4yvmk9np62"
+   "commit": "26de24bcde0eae911a0185bb5a6b74b9864fcfc3",
+   "sha256": "0589ns2v6jxyd7adjkj34zlcnnxbfs6c7hm56yskbs2s4qkkf369"
   }
  },
  {
@@ -96605,15 +96809,15 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20210512,
-    1220
+    20210614,
+    1523
    ],
    "deps": [
     "cl-lib",
     "macrostep"
    ],
-   "commit": "bdda756a5667a537497a35f5a0fc5b7c28bf3bd3",
-   "sha256": "0xm3fdwla8axag1zpc7361mgyjpf1qg907l86w4v8ald8z4qcvl9"
+   "commit": "98a656d96b177edce57b552a2fa9d139cdce8c9a",
+   "sha256": "133p6yj5vdw6i4j2v8ac2g9ayrwxlvvimh2qs5fmxi8vklvn7h3a"
   },
   "stable": {
    "version": [
@@ -96845,11 +97049,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20210604,
-    937
+    20210629,
+    2009
    ],
-   "commit": "c783ba6576b554f3fc15a70bf30d225f277d1863",
-   "sha256": "1lwghrqw81dr7mhx8i92nn4xhamnpqwdvmzx1lg1fzy7g5qx7fl6"
+   "commit": "954e5dad72fb5712dfa968222e2b46dfdf9a476c",
+   "sha256": "06m2vwxga1rys98z97abajqq89k2dlfrrab21hhgqwc0zmdmb9fv"
   },
   "stable": {
    "version": [
@@ -97124,10 +97328,10 @@
  },
  {
   "ename": "smart-mark",
-  "commit": "6440f81aed1fcddcaf7afeedb74520e605211986",
-  "sha256": "0kx34983qqxkx2afql1daj155294dkbinw861lhx537614fq7wmn",
+  "commit": "debbf9d7069436641a4ea922c3e44dd8176cb072",
+  "sha256": "01crd7bv6r1iz414s8044qp3560n52f4pmbq0qniin2dya7si681",
   "fetcher": "github",
-  "repo": "zhangkaiyulw/smart-mark",
+  "repo": "victorteokw/smart-mark",
   "unstable": {
    "version": [
     20150912,
@@ -98118,8 +98322,8 @@
     "flycheck",
     "solidity-mode"
    ],
-   "commit": "383ac144727c716c65989c079ae76127e25144c3",
-   "sha256": "1q4b8623mygzp3qwy5bmb3hipzjfri9007x0ilq3i7k5bs34jz9r"
+   "commit": "5f6ef3156fadae5af6f381d674d20535529a20e4",
+   "sha256": "02rmc7naspjfl757k7zdfg9xd6nvfpsiqfcxkj6ywc7mnndpq2c0"
   },
   "stable": {
    "version": [
@@ -98143,11 +98347,11 @@
   "repo": "ethereum/emacs-solidity",
   "unstable": {
    "version": [
-    20210505,
-    1704
+    20210622,
+    931
    ],
-   "commit": "383ac144727c716c65989c079ae76127e25144c3",
-   "sha256": "1q4b8623mygzp3qwy5bmb3hipzjfri9007x0ilq3i7k5bs34jz9r"
+   "commit": "5f6ef3156fadae5af6f381d674d20535529a20e4",
+   "sha256": "02rmc7naspjfl757k7zdfg9xd6nvfpsiqfcxkj6ywc7mnndpq2c0"
   },
   "stable": {
    "version": [
@@ -98643,11 +98847,11 @@
   "repo": "nashamri/spacemacs-theme",
   "unstable": {
    "version": [
-    20210206,
-    1428
+    20210618,
+    2001
    ],
-   "commit": "c8c468580048e2464f012d171b2101bfb208e33d",
-   "sha256": "1rbv04smfyhm5qm3ghn9vsl0sm4lv20gkpw2zdzrf0l3nkb7dx45"
+   "commit": "f98150e8e254e6bf94dee2de3e8baaf02e2aae80",
+   "sha256": "02jm3v3bnbc45rd4fl9kkln0pn49ix2igm254yz33cg0ykgkj2nf"
   }
  },
  {
@@ -98718,14 +98922,14 @@
   "repo": "ljos/sparql-mode",
   "unstable": {
    "version": [
-    20200429,
-    1719
+    20210701,
+    1202
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e8c9345e2e2427282b3dc9cd1e297e3c76d34f7f",
-   "sha256": "1i799cq0dydq7jdhc1b2ridlsmmkk85286g9r6nj6kif3177l171"
+   "commit": "ceb370b3879841f8809cc3f9b1b87e898f10562f",
+   "sha256": "05vbsfyck0nxa0bsg7jjshjzh7719gx6z6i9i4ayxcfygh3wh6xz"
   },
   "stable": {
    "version": [
@@ -98763,11 +98967,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20210415,
-    1821
+    20210629,
+    1739
    ],
-   "commit": "86c223a2db529768fd815dc0635ed432c1a215e8",
-   "sha256": "1bz6186w83xmajnw489dc1la7b6gly9vrp40mh58gknk5fjdx86w"
+   "commit": "b915b063f9de2eff4b9a37c04559a3f2fbfdba84",
+   "sha256": "1skwcsv8cvjfsgncgd4hybkhjdf6clb65pnpqfh9jxc866aw9n39"
   }
  },
  {
@@ -98805,11 +99009,11 @@
   "repo": "brailcom/speechd-el",
   "unstable": {
    "version": [
-    20210607,
-    2032
+    20210619,
+    1753
    ],
-   "commit": "2ffae385139936a03e1d1a96993d3bf5f9509bbf",
-   "sha256": "1kwg74qy66kwhsl2pqn4cvkrqrfdvyyaz13h4h1bqpxckb1dc05z"
+   "commit": "bd21335668ac7ea4d8c992490b4a710053434e74",
+   "sha256": "1jlb1mfigcqxvm1aibf803xypmbj3x1145nmf2q0v2aaipd6s912"
   }
  },
  {
@@ -98894,11 +99098,11 @@
   "repo": "ideasman42/emacs-spell-fu",
   "unstable": {
    "version": [
-    20210415,
-    1326
+    20210617,
+    426
    ],
-   "commit": "fae15427a1027e5eafdff7e5627cd399f73dbc37",
-   "sha256": "05xarav1dw4315rh4qchvf6p9vsdyg09nm9rc6k657n4r8ip725c"
+   "commit": "1abcb5594e1bfe35716d29e64523e4cebdce737c",
+   "sha256": "0hk3cly374sgiwdf3crjj45afr8nv4jq4bda1vkdb9yqjla0xw8s"
   }
  },
  {
@@ -99482,11 +99686,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20210528,
-    2053
+    20210701,
+    23
    ],
-   "commit": "c4ff94490dd8124e633f907f94955b30b7a4d8d4",
-   "sha256": "065n3x1mzhjgkyvy5j3fgqa75npxqp1dq05xgac9pqgcr2j09mi6"
+   "commit": "a92d2a4f748f124910d406a9386979688f7f28a5",
+   "sha256": "1gfqskdng23dpacvmypyc2jsrw15hrrwq84qmlnwyibf0g0pjj1f"
   },
   "stable": {
    "version": [
@@ -99614,11 +99818,11 @@
   "repo": "cjohansson/emacs-ssh-deploy",
   "unstable": {
    "version": [
-    20201016,
-    1439
+    20210626,
+    2228
    ],
-   "commit": "fce4ea35f09ed5899c1a2dfa3527bc2dd5ca3ba5",
-   "sha256": "10banrq8p0v10237yy2f04i0vvpjdz0by9cp92ambw94c3l3ii8f"
+   "commit": "7c5fe8af2d62d8f6d32ebe2d3bfc53051a9432d1",
+   "sha256": "1ca1ai742g2901pni08clk37h1ls4n65pzxpsfzsxnr7i46yh989"
   },
   "stable": {
    "version": [
@@ -99910,8 +100114,8 @@
     20200606,
     1308
    ],
-   "commit": "311caea3f11330a42a37efe078305b4ce42e53ae",
-   "sha256": "1hfr36xb24y829pcd4maw206lyhrb3qwxxzj6gwh3a0nw8s1sr1m"
+   "commit": "097c527a40797e1b3f3a954cfc5e04987fbb61a9",
+   "sha256": "0yidmzdkrw66hga7nna337jk8rkml6plhr1mzfsyfazpb9da0zsj"
   },
   "stable": {
    "version": [
@@ -99960,11 +100164,11 @@
   "repo": "motform/stimmung-themes",
   "unstable": {
    "version": [
-    20210430,
-    839
+    20210610,
+    1256
    ],
-   "commit": "eac0f54da5ff116622a6448b68057b45c337f2de",
-   "sha256": "0b7glyq3z98vi7f79zg0phqm6ibc30lq2m4mwy22gg0941rr2zja"
+   "commit": "e69b7532ceb27126fb9516c9a8aff652b032088a",
+   "sha256": "1jcqcf34d55r1z786gpkj7jwap646izk498pn2dia7skiwwljx5b"
   }
  },
  {
@@ -100268,11 +100472,11 @@
   "repo": "PythonNut/su.el",
   "unstable": {
    "version": [
-    20210226,
-    42
+    20210626,
+    2025
    ],
-   "commit": "787f78989253f4568942a4cece5f135f005e135f",
-   "sha256": "1sr6lwjd2py0pncbx4qxa8wfxa3fnmfhxr944aid672hba2pdx7s"
+   "commit": "36db018de8423a6e380a49d4e602d376a0740f6d",
+   "sha256": "08vma290dxzjxyn4df2i1kjzm24myxvsll9cxky277asbb8ja74z"
   }
  },
  {
@@ -100933,26 +101137,26 @@
   "repo": "swift-emacs/swift-mode",
   "unstable": {
    "version": [
-    20210518,
-    728
+    20210613,
+    543
    ],
    "deps": [
     "seq"
    ],
-   "commit": "4a5f57722e06dad3bbbb1a496ef7d1b732ac7c46",
-   "sha256": "05x6xy29dym9pn8kssiwhn34c1vwxgsb9jnfq6n0ii5inlw0vx2g"
+   "commit": "1b47a09f1c0e15c543e0551e7f1e643f437e7711",
+   "sha256": "1f12rmsxzjz0ixrzvi37gj6kqkjp08mym0qvnxdmqiackagxp2rq"
   },
   "stable": {
    "version": [
     8,
-    2,
+    3,
     0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "fd3c824c3622aef4ad29983667f34ebad91e9f69",
-   "sha256": "1s60j7778n8vl53capi1bs5mbb1g2vwaaa4y7wdv6ajrlxh95a5x"
+   "commit": "1b47a09f1c0e15c543e0551e7f1e643f437e7711",
+   "sha256": "1f12rmsxzjz0ixrzvi37gj6kqkjp08mym0qvnxdmqiackagxp2rq"
   }
  },
  {
@@ -101354,8 +101558,8 @@
   "repo": "countvajhula/symex.el",
   "unstable": {
    "version": [
-    20210528,
-    406
+    20210630,
+    1816
    ],
    "deps": [
     "evil",
@@ -101367,8 +101571,8 @@
     "seq",
     "undo-tree"
    ],
-   "commit": "1b6466e75295bbf7847253dfb6bf580b1c68eb9f",
-   "sha256": "1rbb7zl45x9xkf05601j05vq3f3hj0nh3rbv16a3n8d0ab5qnvhr"
+   "commit": "740d80599c0a1ff0882e231e46c61ba16c83cd84",
+   "sha256": "1zfjdrm88c16czmi4i6rm87nafpyrjpjkj79cg44l9cizyv5198q"
   },
   "stable": {
    "version": [
@@ -101761,14 +101965,14 @@
   "repo": "fritzgrabo/tab-bar-groups",
   "unstable": {
    "version": [
-    20210526,
-    2044
+    20210615,
+    1915
    ],
    "deps": [
     "s"
    ],
-   "commit": "63af8dced377a346b4559145b2e6e1767263f916",
-   "sha256": "16628wjk14h99z9i822xjv8fkxra6n65nafm3cr3ci86qd00j7a2"
+   "commit": "a2e456097322d0b1cfdb7aa37c32a628bcca3bf0",
+   "sha256": "19ni9bl34hzmqsb9wiznbghw67m7g9zz3z5m3wgndn9zsj37ccka"
   }
  },
  {
@@ -101803,10 +102007,10 @@
  },
  {
   "ename": "tab-jump-out",
-  "commit": "6440f81aed1fcddcaf7afeedb74520e605211986",
-  "sha256": "1p2hkj0d9hbiwbf746l3rad8a5x6hk97b0ajl6q6cwbmy2qm3cca",
+  "commit": "f84b8d995a13b8d30d15b3bf9f671dd06fb8522b",
+  "sha256": "0yyncbgdbw8lgjaycmky7wxhhxaqydks25qf565n2xj87snc5l7n",
   "fetcher": "github",
-  "repo": "zhangkaiyulw/tab-jump-out",
+  "repo": "victorteokw/tab-jump-out",
   "unstable": {
    "version": [
     20151006,
@@ -101985,11 +102189,11 @@
   "repo": "tmalsburg/tango-plus-theme",
   "unstable": {
    "version": [
-    20210505,
-    1051
+    20210615,
+    1229
    ],
-   "commit": "f31d282a70b0eb24470935438af59de96ddace2e",
-   "sha256": "1f3kxc9l0f4r7fxhrz77lghn4847f3b7dk8j84sn6d5zr436by8n"
+   "commit": "6ad64d82c8bd8c559b9023cd70b1c2d0c18e9060",
+   "sha256": "0ig8ng5ycdf256phigh3fzalvd0ncvs54f7kfpq0gp43ky9sgvz0"
   }
  },
  {
@@ -102230,28 +102434,28 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20210607,
-    1622
+    20210701,
+    1035
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "0fcca201db99fbe93e8b0fd404dc00fd55cd658a",
-   "sha256": "0nqx5sddfa9442dgsssp022rfarznnq69gclj4h5kk726rkf9cid"
+   "commit": "a4054e9517d68109212f9d69342a49d4d65dd56f",
+   "sha256": "010b2rkpr8cib1c6s1ysg5wllrsg4rxc7h7cxqrjq1978bi499cw"
   },
   "stable": {
    "version": [
     0,
     7,
-    24
+    25
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "9187e6e3d903474645f3e64806bc62ef687ec205",
-   "sha256": "1ra04cp49zzx8vy8aswd00l46ixyc44sxh1s3nw880b4ywzxmc6j"
+   "commit": "f979ac79070c39a4c483c08df96080763287ce4e",
+   "sha256": "1fdvghwpmja94d65p02j7wa09lwjs3ah1kfb1v17b6l9qd5g80nc"
   }
  },
  {
@@ -102839,10 +103043,10 @@
    "version": [
     1,
     1,
-    0
+    1
    ],
-   "commit": "77181c75cbde5954542688659cd4f2352ed29fbe",
-   "sha256": "1bcwja7hm11hxd1nmf1z93hkzcvkkpxavvbivg6j336ygzr1r82g"
+   "commit": "5d35efbf2c1619d9385ef00ed74e9de1ea7cf32d",
+   "sha256": "11df5606hiqgglxi6xrrljwh70h2wgkib447ggvs2r3f2jayilr4"
   }
  },
  {
@@ -102853,15 +103057,15 @@
   "repo": "emacsorphanage/terraform-mode",
   "unstable": {
    "version": [
-    20201208,
-    1827
+    20210621,
+    1953
    ],
    "deps": [
     "dash",
     "hcl-mode"
    ],
-   "commit": "a9fa5bdaf58e9cae32ee44b7d0883f5600441b05",
-   "sha256": "12v8mldxpa32v63zg4y3c7dihbw4v5agy3kd9rpiyymf6z0pcad5"
+   "commit": "e560caaa9d9a11b0868adf6d9dcae5ebb5055730",
+   "sha256": "0r4zw6jwn5v1xzzbc1195jblhcg3ikbmz3wiwy462qzib56bj8d3"
   },
   "stable": {
    "version": [
@@ -103321,18 +103525,18 @@
     20200212,
     1903
    ],
-   "commit": "a67ce1533462256ff418027a3aa56516a1139d02",
-   "sha256": "0f20x4bklq32lcwa2ihnlnb6ri884xx7dyhg62yqz9y4w8filhhv"
+   "commit": "6c2a7567772f3954006c77a8bdc041df83802a00",
+   "sha256": "0g1j346s8jhw830byzjvgsjg6a03kza19xsghza1bzncwqjbv1n5"
   },
   "stable": {
    "version": [
     2021,
     6,
-    7,
+    28,
     0
    ],
-   "commit": "ec71afa89573c92de4a2a2ab87a51bd9021f5819",
-   "sha256": "0h3b89nb8sshhc52fxsgpdiqr85mfg1rpzp69qmiiwx1yz0b66wi"
+   "commit": "32036a5505970a5a8c905543ebc6de1b20a662d8",
+   "sha256": "0nc9d88ydm5x4nynyxq4rqbp63ypjd1mwf18vancwigv7jxc62an"
   }
  },
  {
@@ -103388,20 +103592,20 @@
    "deps": [
     "haskell-mode"
    ],
-   "commit": "cfc231660a642b2451f874824365931419ab45a0",
-   "sha256": "06wqsljigm7hvycvg4p5rilivr8g7im300jlnm1r463dc1d12kjh"
+   "commit": "60a1c271b39dac22783a4f892446f08d3faeb025",
+   "sha256": "18spz3lvb3df0rr2cqxkqa6rfzrpwwryh4gkzp68znbbfl655l8d"
   },
   "stable": {
    "version": [
     1,
     7,
-    4
+    7
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "652d7a4e374d3c171278e6bdfccfa41c7621d4d3",
-   "sha256": "11590ifnh9ynwcfv31f5m59wr6ckrm3xi2g40wvk4ddxslj4yxnh"
+   "commit": "b7399a878622173bf9fdc076ec72a8353e1b924c",
+   "sha256": "1qbywv182gzbdk27bzah273mb8brmqrpxcgv1pmdy10fc7fv2z0f"
   }
  },
  {
@@ -103637,11 +103841,11 @@
   "repo": "aimebertrand/timu-spacegrey-theme",
   "unstable": {
    "version": [
-    20210607,
-    1412
+    20210621,
+    1857
    ],
-   "commit": "34a4499fac484c369774e356373b1f4994d65176",
-   "sha256": "11cjyiwi87rv9lj09810aazxgphdhpxpfhbhzr64176vqgmb8khr"
+   "commit": "80d29c0f29925775fb00e90669a153d94eae01db",
+   "sha256": "1hdxis28ngrl0d1gafckah7srad4rnpmn4dh5dxd0a5vph63cxhw"
   }
  },
  {
@@ -104282,8 +104486,8 @@
     20210528,
     754
    ],
-   "commit": "c0b2f997b3b73640d635ee84627bb8cf36c9adfe",
-   "sha256": "1kjfch0fhq67iivad56s071c8qlsssdsdg83h5v9iz2x4jipm0wa"
+   "commit": "d6f1fa18646f6ed2a1c0f06a4888130bd694ff19",
+   "sha256": "1l6v02aa072jvhq4b9dpkprqs14py0d4jm3xvihm05lvrbf9v6c6"
   },
   "stable": {
    "version": [
@@ -104386,20 +104590,20 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20210530,
-    2252
+    20210701,
+    1116
    ],
-   "commit": "a96818c93a10d9ef9bb14e5c0b9fdc1a808b13b9",
-   "sha256": "1mvccsfalnr4ybsgqazxcw62vfhigxg61y6v98k2fqncnmsbripa"
+   "commit": "51e833e5152e9fdcdc1dbbf34ad2d4905bde1f69",
+   "sha256": "10k9dzs8y6i0rfckclxm5n3maylmh95993n5dvrs8rbmlcpmihvy"
   },
   "stable": {
    "version": [
     0,
     3,
-    4
+    5
    ],
-   "commit": "b47e9d7d769437e279628d801a95c173c4ff26b4",
-   "sha256": "16z0j69sk7k51sd1vri3y2v0xjj0w7wpf5mmwnsxp8y6d3m0yjbv"
+   "commit": "b711543401dafc159943d8a703cf30fabdc78e1f",
+   "sha256": "0wzfnzv2304a737zwp163aajjhm8i3ix9v7palgg1r3jskvbghmw"
   }
  },
  {
@@ -104773,8 +104977,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
-   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
+   "commit": "2655a8976d56719add893cec45a18e018626842d",
+   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
   },
   "stable": {
    "version": [
@@ -104810,8 +105014,8 @@
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
-   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
+   "commit": "2655a8976d56719add893cec45a18e018626842d",
+   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
   }
  },
  {
@@ -104829,8 +105033,8 @@
     "evil",
     "treemacs"
    ],
-   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
-   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
+   "commit": "2655a8976d56719add893cec45a18e018626842d",
+   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
   },
   "stable": {
    "version": [
@@ -104853,14 +105057,14 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210605,
-    1118
+    20210630,
+    1953
    ],
    "deps": [
     "treemacs"
    ],
-   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
-   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
+   "commit": "2655a8976d56719add893cec45a18e018626842d",
+   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
   },
   "stable": {
    "version": [
@@ -104891,8 +105095,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
-   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
+   "commit": "2655a8976d56719add893cec45a18e018626842d",
+   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
   },
   "stable": {
    "version": [
@@ -104924,8 +105128,8 @@
     "persp-mode",
     "treemacs"
    ],
-   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
-   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
+   "commit": "2655a8976d56719add893cec45a18e018626842d",
+   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
   },
   "stable": {
    "version": [
@@ -104957,8 +105161,8 @@
     "perspective",
     "treemacs"
    ],
-   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
-   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
+   "commit": "2655a8976d56719add893cec45a18e018626842d",
+   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
   }
  },
  {
@@ -104976,8 +105180,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "c2b0beaeb0383c3e6cbc453d6c42cdbc87c6da5e",
-   "sha256": "1plbkalmqi94ikb61yzbs07cr18my1s5p9fli4yd4qkw4mbwc3s4"
+   "commit": "2655a8976d56719add893cec45a18e018626842d",
+   "sha256": "060m6gwwvv82p7jry6viqzdf5fw6ljq4gbdkmqc5ilpkrcnmscv8"
   },
   "stable": {
    "version": [
@@ -105314,14 +105518,14 @@
   "repo": "ocaml/tuareg",
   "unstable": {
    "version": [
-    20210605,
-    1629
+    20210628,
+    1257
    ],
    "deps": [
     "caml"
    ],
-   "commit": "24c1a1adbe51d93f681e72442fa73f885eb33776",
-   "sha256": "1cp6g117kfmwfqb7sq4y4jx8ggp29f4hz2kz5g3355s8zhjlld2y"
+   "commit": "2e8482e23f45f0e6246a8d075a3b8696c5f49070",
+   "sha256": "04wblkb0jqzq67p1d96i284wfqv3ddffrwz3i3wf537wyi8bmn4k"
   },
   "stable": {
    "version": [
@@ -105738,6 +105942,30 @@
   }
  },
  {
+  "ename": "uci-mode",
+  "commit": "0779d9728de07e3115b48997f2623d1fc5c313c7",
+  "sha256": "0idk3flaq316ynf02226j4hww8rlb60ssikqkjh69n0r31ygg0q3",
+  "fetcher": "github",
+  "repo": "dwcoates/uci-mode",
+  "unstable": {
+   "version": [
+    20210626,
+    1956
+   ],
+   "commit": "2cdf4de5af96d56108a0a5716416ef3c8ac7bb7c",
+   "sha256": "133vrnbann0ibsm14h7ghdx8f9i92niazbw8r49srx2xx0jv3lk6"
+  },
+  "stable": {
+   "version": [
+    0,
+    5,
+    5
+   ],
+   "commit": "2cdf4de5af96d56108a0a5716416ef3c8ac7bb7c",
+   "sha256": "133vrnbann0ibsm14h7ghdx8f9i92niazbw8r49srx2xx0jv3lk6"
+  }
+ },
+ {
   "ename": "ucs-utils",
   "commit": "c9db386ab3910940addae6e925b2ac17e64e0f87",
   "sha256": "111fwg2cqqzpa79rcqxidppb12c8g12zszppph2ydfvkgkryb6z2",
@@ -105990,11 +106218,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20210418,
-    920
+    20210617,
+    1327
    ],
-   "commit": "243d93b4c7c1224e7067cd323f64d23dfdfe7c0e",
-   "sha256": "1gdx6kir0a0v7q2ai59miibch9hccqlnx2y88qswfpqr9pf7z6vm"
+   "commit": "579936966b41d2d6782f587509fef21477141374",
+   "sha256": "1sqjp84hi81q62pyx7py7zvmkwdywh106i6jqqnmgkv0ai9cb2ml"
   }
  },
  {
@@ -106224,11 +106452,11 @@
   "repo": "astoff/unicode-math-input.el",
   "unstable": {
    "version": [
-    20210110,
-    1431
+    20210612,
+    847
    ],
-   "commit": "b46fc1d4cc5ab5c2bca3de1e5e43c8f53f1d343b",
-   "sha256": "1g84ynppdv46lhsrl0bgvdvlkijhzns4knkldgmbdhsjafvnz8cw"
+   "commit": "2788d7824d23749a6e5b33f653c47471455da187",
+   "sha256": "1kqaqzlgf9gqxf3fzy41m606h7ridp5iik1w5a0dpq86ni23r77c"
   }
  },
  {
@@ -106880,17 +107108,20 @@
    "deps": [
     "tuareg"
    ],
-   "commit": "bac3946079a98df00f31656dc10c6c9f1a8bc422",
-   "sha256": "1wbmr0n384501i97x0akcfwcigklwqgwvhdwgxw6zxxn5wdg60b2"
+   "commit": "c87b8b2817eefd0cd53564618911386b89b587c5",
+   "sha256": "1zf4hg33sblzh2f65vk0292jg4jlwa8702kfwpsg1kcg4w6nsfdp"
   },
   "stable": {
    "version": [
     2,
-    7,
+    8,
     0
    ],
-   "commit": "a5ff52bbf608e1112b5c0d41a36e3267f39f4084",
-   "sha256": "125cv7kwvr1xj52yfb5qlra2li2hikbqnqvqdasn0rq3pkj7f02b"
+   "deps": [
+    "tuareg"
+   ],
+   "commit": "c87b8b2817eefd0cd53564618911386b89b587c5",
+   "sha256": "1zf4hg33sblzh2f65vk0292jg4jlwa8702kfwpsg1kcg4w6nsfdp"
   }
  },
  {
@@ -106939,15 +107170,15 @@
   "repo": "damon-kwok/v-mode",
   "unstable": {
    "version": [
-    20210425,
-    411
+    20210608,
+    629
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "96ca8dad3a3a402a44bf9066591fe27fa2e4fd9a",
-   "sha256": "08n577b8xr1pv2mdzqzdbkd5j0pih7zd4z4p5y5w4hq72mcid43q"
+   "commit": "3afbd72180417ada6aeeec861081495aca962124",
+   "sha256": "0is9hdh8w87l9x84ihhcd040z8m7cy2321q2rmbfmpffaaja90cl"
   }
  },
  {
@@ -107205,19 +107436,19 @@
   "repo": "muffinmad/emacs-vc-hgcmd",
   "unstable": {
    "version": [
-    20201211,
-    1339
+    20210608,
+    1030
    ],
-   "commit": "d23de9d10ff68b4c2302ab956f3ba3bb5d3858ee",
-   "sha256": "14c2brvw6vnf1h3lbpap4jh5d7mjnzxrbny4jk77832v09mj2ria"
+   "commit": "c00d792b34219a387832f8f9b4a689d7972f592a",
+   "sha256": "05gjyq4cpc79ipiyl3j263cw6mdbfxmh7wvsxsxavp21q588fb0y"
   },
   "stable": {
    "version": [
     1,
-    13
+    14
    ],
-   "commit": "d23de9d10ff68b4c2302ab956f3ba3bb5d3858ee",
-   "sha256": "14c2brvw6vnf1h3lbpap4jh5d7mjnzxrbny4jk77832v09mj2ria"
+   "commit": "12e102f8359095953e06ed17c7223cd6638e5cea",
+   "sha256": "1mm8lnwii53j32v54aahl8sf3ciwymrvc1rgy4nw2m7hcrnjsb78"
   }
  },
  {
@@ -107374,16 +107605,16 @@
   "repo": "justbur/emacs-vdiff-magit",
   "unstable": {
    "version": [
-    20190304,
-    1707
+    20210614,
+    1630
    ],
    "deps": [
     "magit",
     "transient",
     "vdiff"
    ],
-   "commit": "b100d126c69e5c26a61ae05aa1778bcc4302b597",
-   "sha256": "16cjmrzflf2i1w01973sl944xrfanakba8sb4dpwi79d92xp03xy"
+   "commit": "fa62a260411387702dd4cc4791075c737519001f",
+   "sha256": "04n47g3ffnh3bjq5575b6l046cpy7dixksfjy8pzsgh9ah1h37lz"
   },
   "stable": {
    "version": [
@@ -108264,17 +108495,17 @@
  },
  {
   "ename": "vs-dark-theme",
-  "commit": "60b9b00d18334f2d7b737e3cc6b3c733e1b163e4",
-  "sha256": "0didkb2zd9ac7h1ccwi9y1q5mcqpwxyws7nsk5g8rhrkygdf9lds",
+  "commit": "094a9cbc18882daa4f2efd3d72bb0a34e6bd9f63",
+  "sha256": "1rz2flacnh6h40k559l0r1vwcnx89w4j9ipp1ysnh8rzji3wl07k",
   "fetcher": "github",
-  "repo": "jcs-elpa/vs-dark-theme",
+  "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20210427,
-    727
+    20210627,
+    2121
    ],
-   "commit": "5a826e6ea3e9edd9241e3253ce97333955c8ae1a",
-   "sha256": "0q94crd6m6m000gjxwv92jz9rphmnr5wg7jzf6yig1hlhfqjgw9v"
+   "commit": "bda27d3a7f11fee0550055b0552c2633c167dd96",
+   "sha256": "1y8ycsm4d72v86prg87dffis5q853k2w0fvx5vz732jryzp18lda"
   },
   "stable": {
    "version": [
@@ -108287,17 +108518,17 @@
  },
  {
   "ename": "vs-light-theme",
-  "commit": "c997456be95ece85fdef87905e9e14fe308fd827",
-  "sha256": "02w5zyxf34r1lvk56s3xbkzpvinbwsyv1h685hg9vhn0yy0a23ns",
+  "commit": "a1258f6afe69d0a13c19246a8b8bd2e5b1a67b48",
+  "sha256": "14wbqim0bghxwp45qwjh7nc3gi91jaapakaq3x0ypyw8l6xxrbnm",
   "fetcher": "github",
-  "repo": "jcs-elpa/vs-light-theme",
+  "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20210427,
-    727
+    20210627,
+    2121
    ],
-   "commit": "e324120248c1d513a6516edff250d161f876aad9",
-   "sha256": "1jw9cbbvm76ijvcrkkn27r3n6qw14jxbirdc0bryv4k12yiwla9m"
+   "commit": "a8bff6913f603a30bd98bef882ace01476c440bf",
+   "sha256": "1rshwvfggjb7amgxcl31xhll28kfbgh14aw33khlp32gq6p3vqyh"
   },
   "stable": {
    "version": [
@@ -108334,8 +108565,8 @@
     20210530,
     629
    ],
-   "commit": "961c8c1fdd7eb874d4e2ce386d5e6d1f318b5b72",
-   "sha256": "1dga7yhb5pnqj5d86pvzbabrq05xj1ppx6g0hinhm8z6m8h6y540"
+   "commit": "bcae11818d74aa0de8e592b8349d90e512444758",
+   "sha256": "1rmdin9z68xkxqjhvhyklbby5mxs3qf4wx9c07945p4ps80w8z5g"
   },
   "stable": {
    "version": [
@@ -108370,11 +108601,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20210409,
-    1558
+    20210618,
+    1922
    ],
-   "commit": "2b1392cb2b14ec5bd0b7355197d5f353aa5d3983",
-   "sha256": "0cz0zfq5lannqq2ivmp6zv9r3fybkykx2vl4vn614rij23lylbwc"
+   "commit": "d9dfa624679afdd5db6ad25429ef86d3dd91401e",
+   "sha256": "07nk6bw70mi9r3kgs5b11pfwfvfa73xwdl3xgclv8l7k87yysd69"
   }
  },
  {
@@ -108385,14 +108616,14 @@
   "repo": "jixiuf/vterm-toggle",
   "unstable": {
    "version": [
-    20210531,
-    1453
+    20210629,
+    927
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "afe60b814d9d045b968f4a464bbedb241b35392b",
-   "sha256": "007spqyc474k8fxi6l3s0jh8dg18d9b07wvz3lvbyrgdqwdw2a0p"
+   "commit": "2258eb19e8bde75f79505c4306f3476bcedce56c",
+   "sha256": "0k5hmn2wnag6hirnk2ch3xviymbxha5pcb3p1j1lj2likbhwizw8"
   }
  },
  {
@@ -108606,11 +108837,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210606,
-    2300
+    20210615,
+    103
    ],
-   "commit": "0e18a7e96c8e425ac7c2e69aa26fa6a1e8e6e51a",
-   "sha256": "1jxp447d8xnk4ixpni7rsph7fd3p58ydmi39yrx201hbqh15jxiz"
+   "commit": "70b985b1d00c8703acb1ebf16875616903470f45",
+   "sha256": "0djvaxbxjic4m8nqmj1gs0h77gf0fik00ia7ayfha3fc7fabiif9"
   }
  },
  {
@@ -108831,16 +109062,16 @@
   "repo": "wanderlust/wanderlust",
   "unstable": {
    "version": [
-    20210312,
-    843
+    20210629,
+    1252
    ],
    "deps": [
     "apel",
     "flim",
     "semi"
    ],
-   "commit": "6e189fc944a9bbde76c5a6d9b6a38d57e85e6390",
-   "sha256": "0yphp7bqgmhd89hgqy8rg6kmkkzmhz3sjkzm9b1paic7fx9s0maj"
+   "commit": "769699d60aa033049804083b459ee562b82db77e",
+   "sha256": "0mgl28xsvc0421pysy6hh0hymr0li8iayaa330r41cbqsk3gz4nw"
   }
  },
  {
@@ -109614,20 +109845,20 @@
   "repo": "justbur/emacs-which-key",
   "unstable": {
    "version": [
-    20210601,
-    252
+    20210630,
+    1217
    ],
-   "commit": "fc29864395fdaf688e2ef5111831663bad89a020",
-   "sha256": "1adv32z8dmpygbrk14l1pj2535c10ncv8znfzgi1s908ds20kad1"
+   "commit": "27d9fec33abb989b030f7677ccf5f799287d6472",
+   "sha256": "1vdvp3iavh57mwhmgxwalrha7h7hgxsfnkxbrspl9x9cx7fx98f3"
   },
   "stable": {
    "version": [
     3,
     5,
-    2
+    3
    ],
-   "commit": "5fb30301cb3b4fca5a0e1ce8ec1ef59290b79199",
-   "sha256": "1wgygby4zwlbx6ry6asraaixl169qdz092zgk1brvg63w7f8vkkb"
+   "commit": "1f9c37d50f08995c8671822591c8babb893ccc6f",
+   "sha256": "144i3hkgm36wnfmqk5vq390snziy3zhwifbh6q6dzs99ic77d5g6"
   }
  },
  {
@@ -109638,15 +109869,15 @@
   "repo": "yanghaoxie/which-key-posframe",
   "unstable": {
    "version": [
-    20190427,
-    1103
+    20210615,
+    944
    ],
    "deps": [
     "posframe",
     "which-key"
    ],
-   "commit": "e7f28608c7fc9507e407c6b840dff09062df533a",
-   "sha256": "0954llm57gfy3lvq8s32mqdswbv20na0v28gi61kw7023f1wg7ri"
+   "commit": "90e85d74899fc23d95798048cc0bbdb4bab9c1b7",
+   "sha256": "173a04s00rydqpkrwdd9khwijbslkwmzqa557x6r1vpp0pdgaz0l"
   },
   "stable": {
    "version": [
@@ -109932,11 +110163,11 @@
   "repo": "progfolio/wikinfo",
   "unstable": {
    "version": [
-    20210121,
-    1642
+    20210630,
+    1730
    ],
-   "commit": "afa32f2b3c23e6d1565698faf9697fa445059bb9",
-   "sha256": "1wxdb34xsvqydr54w44b84hbins8ay1md49vphp6jqbj99q992dg"
+   "commit": "bd60451f661609b1b7bfb25662b8b68c0a842c8a",
+   "sha256": "07jplxs05bwac7i6ksxwl7pm30qk8mc3dvdx0pvim59l67vb61wh"
   }
  },
  {
@@ -109947,15 +110178,15 @@
   "repo": "progfolio/wikinforg",
   "unstable": {
    "version": [
-    20210602,
-    1459
+    20210615,
+    2334
    ],
    "deps": [
     "org",
     "wikinfo"
    ],
-   "commit": "3aecd23e68b9117a03c65fafa85a0805b58609d1",
-   "sha256": "0m1fj06x9r941k2842v2091xbff89wp704ifrcdgb6zbksx5d8i2"
+   "commit": "7df42a260fb93cb743a08e67ea92d77f62dec72b",
+   "sha256": "05qqs4b0gmnwjl6d29xns93p2lyh1x2xzl0qpydbnxjirwp2bamx"
   }
  },
  {
@@ -110125,27 +110356,28 @@
   "repo": "bmag/emacs-purpose",
   "unstable": {
    "version": [
-    20210423,
-    454
+    20210628,
+    715
    ],
    "deps": [
     "imenu-list",
     "let-alist"
    ],
-   "commit": "1a556294131a78b557f88bd28d42b43d5c6bd79a",
-   "sha256": "15v3225irmgg6zsv4h3zyqrbcgx9kbr6rzx5v5hgf9h16fgibi8j"
+   "commit": "bb462f12f836414425edac32ebd069b4fd5b98d4",
+   "sha256": "1cw513mh3gyl21qpmgwqjgpi8kwddmd4n69l4ax5a5pv3vvwrcx9"
   },
   "stable": {
    "version": [
     1,
-    8
+    8,
+    1
    ],
    "deps": [
     "imenu-list",
     "let-alist"
    ],
-   "commit": "8f84defbb4d80ecaada37a2bbde2c1d8699f98af",
-   "sha256": "1bq0s56wj6ibyh625zfnisy8yniz72dpg4mcgq55azsbnd4fblqq"
+   "commit": "bb462f12f836414425edac32ebd069b4fd5b98d4",
+   "sha256": "1cw513mh3gyl21qpmgwqjgpi8kwddmd4n69l4ax5a5pv3vvwrcx9"
   }
  },
  {
@@ -110979,8 +111211,8 @@
     20210316,
     156
    ],
-   "commit": "2e57f792edc371e7105ee388f878d52d5801f5de",
-   "sha256": "0qyx41yawaamfs8k3dr7b48kf09snlklja0pa1n8nw80q355w94p"
+   "commit": "986c9d96ff898d346b453422e8e312f7976e6089",
+   "sha256": "17wls9mn097kwpcg9f4dxa6is0yshxgmjh2z1pk1nwfd8mdpczvg"
   },
   "stable": {
    "version": [
@@ -111000,11 +111232,11 @@
   "repo": "ag91/writer-word-goals",
   "unstable": {
    "version": [
-    20210503,
-    656
+    20210614,
+    1527
    ],
-   "commit": "ef94f78b2c4e4fcf1a59d492637cbc84396cb032",
-   "sha256": "0xf2nvwvag21ds566r90rlf98hf80mz3zj2svhwmqrj6nm70p6z3"
+   "commit": "46c8a7c71275ced2c662c1222d4b85319f80dd83",
+   "sha256": "15qxs91inbpr9qk2xlaijargkvj9c6rmw0m4b05qrqni0cgb75dk"
   }
  },
  {
@@ -111115,11 +111347,11 @@
   "repo": "xahlee/xah-css-mode",
   "unstable": {
    "version": [
-    20201229,
-    837
+    20210627,
+    505
    ],
-   "commit": "5d9db23bbb982c28cbcf351957ef96ecd80e4c0b",
-   "sha256": "0f1dwl1nljxw94g6jkqv7rsyxnr9na0xxj447jhmsjyd3iry3g7n"
+   "commit": "62b7162198ca6659e025feb058e5662c55333ad4",
+   "sha256": "0xk5wa209pgc2sfz0j4dac57apy45si87628bqc21fnf877ga8qv"
   }
  },
  {
@@ -111130,11 +111362,11 @@
   "repo": "xahlee/xah-elisp-mode",
   "unstable": {
    "version": [
-    20210208,
-    2056
+    20210627,
+    508
    ],
-   "commit": "3ae341944297d59bf33f5580364af2858198781e",
-   "sha256": "09w44nmxdvc7pxyz959qj59dfqxplj22qqdal7206bb12r1l88zr"
+   "commit": "86ddb3ce73bb2a844a126e42386571ca8e884260",
+   "sha256": "1ks43xdfv287n3sy8n25widkwwx388pm3b8p4r2ld6qz200wqjdq"
   }
  },
  {
@@ -111145,11 +111377,11 @@
   "repo": "xahlee/xah-find",
   "unstable": {
    "version": [
-    20210111,
-    334
+    20210624,
+    327
    ],
-   "commit": "8948fa8f18023868731a1666f9893abc08f370e1",
-   "sha256": "1qk1scf085fc650km5hx2fp2chxj1a2hwp4bffxmp59mg78qpb71"
+   "commit": "16b8d62ddb1d5548fcd78a0371481434390ebd54",
+   "sha256": "10scxxxg84b38rjlmk0r486r7b1nvla57yq6v1h1ymlbp0addvby"
   }
  },
  {
@@ -111160,11 +111392,11 @@
   "repo": "xahlee/xah-fly-keys",
   "unstable": {
    "version": [
-    20210520,
-    540
+    20210701,
+    145
    ],
-   "commit": "3022cbf1e0b16c4fe632d03bd49832afac12510c",
-   "sha256": "0bv9r4kak8gjwcvws1vygdr9ppfyi9m34y5a5alm606y8qmzjxs6"
+   "commit": "6465e77d57a30a0a82ca4f4756593207b2ada510",
+   "sha256": "1bzlpwxkjmzgypagdp9qj4jf6crm3yhjnr98ipr1f49dl8178j6s"
   }
  },
  {
@@ -111356,8 +111588,8 @@
   "repo": "dandavison/xenops",
   "unstable": {
    "version": [
-    20210504,
-    1106
+    20210630,
+    740
    ],
    "deps": [
     "aio",
@@ -111367,8 +111599,8 @@
     "f",
     "s"
    ],
-   "commit": "4994ae4a660ee94d341ce1905c12b4cf39fee574",
-   "sha256": "0cqvz8bkpjc4fmdn10zq70q3bvixx25yn13ihxygsdi1mjmn30fh"
+   "commit": "95b0b37cf5bb6474f054056b0dad9402c700c5b7",
+   "sha256": "09xiabicada3ziyinlc9fczcdy2nr01fn3fqlq1vpjzb5882k63l"
   }
  },
  {
@@ -111670,10 +111902,10 @@
  },
  {
   "ename": "xresources-theme",
-  "commit": "35763febad20f29320d459394f810668db6c3353",
-  "sha256": "1vsbvg9w5g6y2qlb8ssn12ax31r7fbslfi9vcgvmjydcr8r1z0zs",
+  "commit": "8ff729d95709a9e0f458e54dbdab4724ca3c09f3",
+  "sha256": "0n359mjv4j6n002v5bimas77y1507x1797qj6l1kcdwym8pk0rvg",
   "fetcher": "github",
-  "repo": "cqql/xresources-theme",
+  "repo": "martenlienen/xresources-theme",
   "unstable": {
    "version": [
     20190108,
@@ -111960,20 +112192,20 @@
   "repo": "zkry/yaml.el",
   "unstable": {
    "version": [
-    20210604,
-    1500
+    20210625,
+    528
    ],
-   "commit": "5b352258f50ec9d2e7ff8bd16323a24fb484b52b",
-   "sha256": "1zaj7w0jfzz7iwsnd8ql3pxgiw108dx0ggk2q5rqxdz5902hksqs"
+   "commit": "69c699a15af342199d0dbbbe7676a85487781ae7",
+   "sha256": "1j1yqpnpn5k17jnrax56and4yss1bimxck3zigbgy5fpng89l8sb"
   },
   "stable": {
    "version": [
     0,
     3,
-    2
+    3
    ],
-   "commit": "5b352258f50ec9d2e7ff8bd16323a24fb484b52b",
-   "sha256": "1zaj7w0jfzz7iwsnd8ql3pxgiw108dx0ggk2q5rqxdz5902hksqs"
+   "commit": "9382bf5a3b1cad1c404bfd13fab8cf6688fe8442",
+   "sha256": "0xm6c4lk62ifwpc03wmn6602r1izfbk9kpyv3wg3p8ksxllvd0ns"
   }
  },
  {
@@ -112095,11 +112327,11 @@
   "repo": "Kungsgeten/yankpad",
   "unstable": {
    "version": [
-    20210205,
-    1318
+    20210625,
+    1951
    ],
-   "commit": "fb9cb7753af971701dcd96a51efb4d70e2b2a18f",
-   "sha256": "1xaal77cqics6fdm51j7pm12k61v0qxg68krgb7yi1fd90fm2iy3"
+   "commit": "6f5c7e5171030663ebda4f1f872c30d0e165b6b7",
+   "sha256": "08f5qn1dsikv9dkdvdrb8mmjb3himlnh9bcany2w4pj0apgcwn4d"
   },
   "stable": {
    "version": [
@@ -112218,11 +112450,11 @@
   "repo": "emacsorphanage/yascroll",
   "unstable": {
    "version": [
-    20210427,
-    645
+    20210625,
+    803
    ],
-   "commit": "bd20a61ab7cd610625137c051c7f15e7404b7829",
-   "sha256": "0mxl8qxj9vdr8cg9xkh2v901n8m1drk0wzf4di34vkgkmrlkigyg"
+   "commit": "0ddf70ec214e2b1fade0594ec44c55adb48c06da",
+   "sha256": "1mkk07j3bayzprimiq95blbyj7idl01p6jv43hh226r427c89bcs"
   },
   "stable": {
    "version": [
@@ -112348,11 +112580,11 @@
   "url": "https://www.yatex.org/hgrepos/yatex",
   "unstable": {
    "version": [
-    20200208,
-    931
+    20210630,
+    2200
    ],
-   "commit": "f4c2dca86202c2da5b4f0f6ec97c49dd1cb01e6c",
-   "sha256": "1dh4i2dj2cfg693bvwdi4frmi2892h4q25xdacdm63c7fmn3ap6l"
+   "commit": "d4831b3672f87affbb0f7f69135e7824d0bd325b",
+   "sha256": "0fga8zicxgmfw4px2zwfvwycl9hcqcwnf65izrbrj6rrljdbb3yv"
   }
  },
  {
@@ -112581,11 +112813,11 @@
   "repo": "ryuslash/yoshi-theme",
   "unstable": {
    "version": [
-    20210509,
-    520
+    20210623,
+    544
    ],
-   "commit": "9a26f361083ed1d0dd56e659fae913ffea51c739",
-   "sha256": "1da39wyb8zhpyvqxld19cna0jdjhpdiwsmac6ari7nw8i8dvbbhw"
+   "commit": "4aa2a0d0c3e3b7c408d680df8cc5ede53c18e923",
+   "sha256": "0psb3ff0f0wia7vmxqhframl8vnyzk6xx3dmv1g1j7b0njk259ij"
   },
   "stable": {
    "version": [
@@ -113121,14 +113353,14 @@
   "repo": "nnicandro/emacs-zmq",
   "unstable": {
    "version": [
-    20210424,
-    1943
+    20210613,
+    343
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "790033363cf0e78c616cfe117a2f681381e96f29",
-   "sha256": "0vssi5d02s7f9rhsgqnbh4ql2nvjcc4hsrmihwrk1ij50pn927yj"
+   "commit": "38dc6c4119aee57666caf8f97c8a3d7f678823e0",
+   "sha256": "0j7szww8fi2pyvln1bppyq8nly0vkbncz63kzqhi1zx7dfz127ry"
   },
   "stable": {
    "version": [

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -1148,8 +1148,8 @@
     "auto-complete",
     "rtags"
    ],
-   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
-   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
+   "commit": "3a057f127b931c683288f8731f05ba5e2aab4133",
+   "sha256": "1brf05grh0xdcjllaiixpjxmcg2j130gcrxkqm5v4ryb1w9fki7g"
   },
   "stable": {
    "version": [
@@ -1951,8 +1951,8 @@
     "annotation",
     "eri"
    ],
-   "commit": "3543ef3df19228012a1ac5be766cc38fd2f65f6a",
-   "sha256": "0wlqrl8ikqc7q61i2qzmwp6h0mrv9kn5229pbsrb1ris7gxgi13b"
+   "commit": "286bbef128cb3194f8bd63cd5e497bea621c709a",
+   "sha256": "1i176damqxg0nqawhgr22ypzysnbk44aii0r81pl6zbwsvdxkqn6"
   },
   "stable": {
    "version": [
@@ -2183,15 +2183,15 @@
   "repo": "alan-platform/AlanForEmacs",
   "unstable": {
    "version": [
-    20200723,
-    1405
+    20210721,
+    1343
    ],
    "deps": [
     "flycheck",
     "s"
    ],
-   "commit": "fc1fc0312b3e7f868f95b917a66719afb96f0c9a",
-   "sha256": "1cadc2v8mdlz5di7cwhc9qqhrkwgl3gxyw5v4il895r44rcdifgq"
+   "commit": "c1c4205d2cdf8bf69b22e62548568ed4a8529807",
+   "sha256": "023lzr112gjscmyqgfz5ib3a80s3bis72acsaxnk4jw32knjy4yl"
   },
   "stable": {
    "version": [
@@ -2293,7 +2293,7 @@
     0
    ],
    "commit": "97c20b1fd9ad3f138e1100e3a837d05108c4c564",
-   "sha256": "1wsvs756cbwbxlaxij352kman7196m39684m6sqnfb685cfrwzdj"
+   "sha256": "1x4apig2hrvvy6pjciklmz5afpq5l4rmfjahc2wvyzs79abh0icx"
   }
  },
  {
@@ -2327,14 +2327,14 @@
   "repo": "cpitclaudel/alectryon",
   "unstable": {
    "version": [
-    20210518,
-    1550
+    20210722,
+    1554
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "3fad996473200fa07b0381cd66179089d10fcc6f",
-   "sha256": "0qj4cjra1kyiw8h2qm024wgy9fy3xjwik7sr1mfkhk1gbndl8m3w"
+   "commit": "f3688475bba4c451fdfe52ad95fb25c7050ec9f9",
+   "sha256": "02h6xhnnbx27gq3xm2f2j3py5h94kcg8m8399j7dhski60ncn4b4"
   },
   "stable": {
    "version": [
@@ -2513,14 +2513,14 @@
   "repo": "seagle0128/all-the-icons-ibuffer",
   "unstable": {
    "version": [
-    20210325,
-    512
+    20210721,
+    651
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "f304d283cbb815cd28b86c1cbe74b706c0678e25",
-   "sha256": "1afjcv94p8za3ri9c324j1wdg4klpcaippby3r1avwnjy5l9qpav"
+   "commit": "a3cc2d96f619a2a6cf1cb6ad881ab6e509ac8fc3",
+   "sha256": "09l0y99lqi3p7h0ll3hm13zi6kp2pbya8rdpvqrx7jpkg3w5slfk"
   },
   "stable": {
    "version": [
@@ -2575,15 +2575,15 @@
   "repo": "seagle0128/all-the-icons-ivy-rich",
   "unstable": {
    "version": [
-    20210626,
-    1956
+    20210721,
+    653
    ],
    "deps": [
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "78ee2fb4eb43c970e12a91949f7efd26ca1834d5",
-   "sha256": "04pgr5xjk84kksck7f1y9gpvxxnsy803zq252hg1pzg1pl6bx3ga"
+   "commit": "b20df3e2c901a107441b6246b9d03fa3dc57f47f",
+   "sha256": "1hqf3jqpq0viygxnbkq7rsabpyygz2kr6nl6jrarm8wdczs55rpr"
   },
   "stable": {
    "version": [
@@ -3217,8 +3217,8 @@
     20200914,
     644
    ],
-   "commit": "3543ef3df19228012a1ac5be766cc38fd2f65f6a",
-   "sha256": "0wlqrl8ikqc7q61i2qzmwp6h0mrv9kn5229pbsrb1ris7gxgi13b"
+   "commit": "286bbef128cb3194f8bd63cd5e497bea621c709a",
+   "sha256": "1i176damqxg0nqawhgr22ypzysnbk44aii0r81pl6zbwsvdxkqn6"
   },
   "stable": {
    "version": [
@@ -5324,11 +5324,11 @@
   "url": "https://git.sr.ht/~pkal/autocrypt",
   "unstable": {
    "version": [
-    20210709,
-    1230
+    20210720,
+    1810
    ],
-   "commit": "32786dc552569c7cc9970628f580b0b7b8e0b03d",
-   "sha256": "0vs8kwgxvmbr1yy1f8jvxpixy4jfxpdk17mq0gfvlcmnqb560gdr"
+   "commit": "b2c8d431f89788d1e01d42c55e65612e6fc11b44",
+   "sha256": "05378j4pyxb9s8wpffmmrcn09inxjipiw1sy8jqgc5cslpd1jl3g"
   }
  },
  {
@@ -5532,8 +5532,8 @@
     "avy",
     "embark"
    ],
-   "commit": "acbe1cba548832d295449da348719f69b9685c6f",
-   "sha256": "0c1zqfrn2va2m9z6rw3i2h6dwm2vc0asbha4d9r0gss4b7519pf2"
+   "commit": "c0a3e5398c3303d9336d3614ff8e2ce543501eaf",
+   "sha256": "18g86ymca74jkkrpjqxcy289rna968qrk4gpn09k52zf83xaafha"
   },
   "stable": {
    "version": [
@@ -6187,7 +6187,7 @@
     "flycheck"
    ],
    "commit": "5bfd5f91b9f91e46158e0419c6bb5c350e7684a1",
-   "sha256": "0nb6dbk8aclkq7jki52y4lwgbxg61xh1598l08yfv2l1ykhgg0n0"
+   "sha256": "0mb85g7bydd0nv3hjzvqb3d01cs4hg5846ibcznaqhsqk93pgm2h"
   }
  },
  {
@@ -7044,8 +7044,8 @@
    "deps": [
     "bibtex-completion"
    ],
-   "commit": "f5b73bce4fcc31d55044d17949569b35dc50283b",
-   "sha256": "06wv37ck15i4m90lwksyc4zq9pwx4ljr90g8yqjmmracpgbm967y"
+   "commit": "6b9a075aebd85fee8a071ffbbada1158ecd470d4",
+   "sha256": "0ihpm7pnlx5acj7jmrqr9di92908mz7z3k1kg62k8vxj2q43a00c"
   },
   "stable": {
    "version": [
@@ -7067,8 +7067,8 @@
   "repo": "tmalsburg/helm-bibtex",
   "unstable": {
    "version": [
-    20210408,
-    1649
+    20210718,
+    1044
    ],
    "deps": [
     "biblio",
@@ -7078,8 +7078,8 @@
     "parsebib",
     "s"
    ],
-   "commit": "9f6ea920a49457d85096caa0e61f086a42b2908e",
-   "sha256": "0dqf2anmjlgcz7xn4q2pw8cfmhwdhdg4fm8q41vhrp60ymbc6dik"
+   "commit": "a0d32ab16748b7b0c43d6421f1b497b7caf8e590",
+   "sha256": "0a0mn41lvqjx8rdrfgff5fjs757nin30caap7ciapnvr18g9mh5h"
   },
   "stable": {
    "version": [
@@ -8701,17 +8701,18 @@
   "repo": "alphapapa/bufler.el",
   "unstable": {
    "version": [
-    20210716,
-    1006
+    20210722,
+    1703
    ],
    "deps": [
     "dash",
     "f",
     "magit-section",
+    "map",
     "pretty-hydra"
    ],
-   "commit": "d466eac6c4b2ee25c765e7f31e44beb38dd44e4b",
-   "sha256": "00gyqpm0g437z71vbfd4kmih23vh6909dvygng133vxzly9k4f24"
+   "commit": "b951e621bc4a4bb07babf8b32dc318d91ae261c9",
+   "sha256": "14d2mcx6ppjzkpv63m7iir0j2dn549gkxr30bxx8qvc1v7r7r6wn"
   },
   "stable": {
    "version": [
@@ -9749,6 +9750,30 @@
   }
  },
  {
+  "ename": "capnp-mode",
+  "commit": "7981e5108f449a52631699439724712cba1d2a40",
+  "sha256": "04idy13yzb5khzycsh394j8m4cchvnl7j75cw7ms1kdxzx6w2k4b",
+  "fetcher": "github",
+  "repo": "capnproto/capnproto",
+  "unstable": {
+   "version": [
+    20210707,
+    2310
+   ],
+   "commit": "583f07515b3be254ec150ce1dadabb48fdfa5bd3",
+   "sha256": "1nccl2v2fvpmsmvga1ghb9kb72v90bgdqhxb153086qx69s7vlcn"
+  },
+  "stable": {
+   "version": [
+    0,
+    8,
+    0
+   ],
+   "commit": "57a4ca5af5a7f55b768a9d9d6655250bffb1257f",
+   "sha256": "0z7p9687bdvhddgyb6b3j0c3bngynnyvc8z6yp4hhynvrlvsmy5d"
+  }
+ },
+ {
   "ename": "capture",
   "commit": "bdfe43be6c5f77845e82745534a1b1a9eb190466",
   "sha256": "1hxrvyq8my5886q7wj5w3mhyja7d6cf19gyclap492ci7kmrkdk2",
@@ -10424,8 +10449,8 @@
     20171115,
     2108
    ],
-   "commit": "d87317f360d64b5f68809a564d03436d2b07e96a",
-   "sha256": "1g2q4fg95wpg1d77zrk80923553w2sgsby3ylrrq92y11ks4yiq5"
+   "commit": "94d292543d4869c3c5b48bb4dd1e5d901ce6227e",
+   "sha256": "12pxnwgfr0ypf80hpgrqyb789wj41gv8cbzsr1jks7pinvpda65f"
   },
   "stable": {
    "version": [
@@ -10501,7 +10526,7 @@
     "yaml-mode"
    ],
    "commit": "f3462930067de8f79c3d2e8da14d1924f609d3ab",
-   "sha256": "15ndphxz1jy4wbk52f6l3hk67b29844ljmmxd8wmahmi6c8nh3si"
+   "sha256": "0ggq4q2c1xi26m4rlvjm8f51wlj7h351pp6m20k6l25856858vhi"
   }
  },
  {
@@ -11419,14 +11444,14 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20210713,
-    1609
+    20210717,
+    1041
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "07d6d82cba864b1e38d3bd46654f2e1928a997c2",
-   "sha256": "04h60s6ig43sj144s7dlip1saf9kdwvzlfys8qwwx48003rbs0dp"
+   "commit": "77e16de3b9fbaa0417b56a9acc70a9bca17c4ad0",
+   "sha256": "1ww04kfz4kkbhrbd78r4dpylhayb5hl72qcjv8wm0mhgfwmbb358"
   },
   "stable": {
    "version": [
@@ -11497,8 +11522,8 @@
   "repo": "andras-simonyi/citeproc-el",
   "unstable": {
    "version": [
-    20210709,
-    602
+    20210719,
+    918
    ],
    "deps": [
     "dash",
@@ -11508,8 +11533,8 @@
     "s",
     "string-inflection"
    ],
-   "commit": "dc118772ad4585c0511f4f8f25c81faf69952038",
-   "sha256": "0v8z6fhrsi9kszqcbrm1ggvin0jff744byaiw06d3id1hc428iq5"
+   "commit": "b46d3c3c6e5a00237f62084c64a25c4b4efabe1b",
+   "sha256": "0gyyxaiky82km9c897vvslnin7yll3yzjfz0fd5zg7lz4kmjilqk"
   },
   "stable": {
    "version": [
@@ -11575,11 +11600,11 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20210716,
-    403
+    20210722,
+    1158
    ],
-   "commit": "813e8c32a41f84ff099feddb5a4d5a51c5c200b5",
-   "sha256": "02482ln1458hb6z1x89b7294q4bwwdqi08h6m0mmvgd3vz2nwmqs"
+   "commit": "45e7f801744f471b43fdd96cfe734a4a3796bab6",
+   "sha256": "1sdj2nvgnbvsz2cvgzpr0axzm4gcb0sna0ps37mbxb0y356xyzfv"
   },
   "stable": {
    "version": [
@@ -12530,8 +12555,8 @@
     20210104,
     1831
    ],
-   "commit": "4e17e90988e9f23dece4c04f574d456309d7a50c",
-   "sha256": "1gqbgs8zxn9dcpxmbykz0mrqy6p229b0pdz3hnk0kncqkk004lx1"
+   "commit": "f7a3031b7defbc805a39a8b23dbefe10764d956b",
+   "sha256": "13036j6019viskahslw3vq28h5kn1xr6ap61l2hvgzpimriam012"
   },
   "stable": {
    "version": [
@@ -13499,11 +13524,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20210709,
-    1110
+    20210721,
+    2003
    ],
-   "commit": "d77184094b9a45b204813d824918e1ec2aac8504",
-   "sha256": "09f59ipp6c2b1xpnmk82ygxcfkfhh36h4g1c07dmxf7m3z1hwlgi"
+   "commit": "7b731e7d435d8782c5095f6f269704a5e21eccad",
+   "sha256": "1av9ln4nhkjqd6x6v43yjnzp07kx1qhzcxjni343x4npix6p41xm"
   },
   "stable": {
    "version": [
@@ -14406,7 +14431,7 @@
     "seq"
    ],
    "commit": "8d643a1776523ef1a6e0bff0bb0a390772fcc77d",
-   "sha256": "17m9x3yy0k63j59vx1sf25jcfb6b9yj0ggp2jiq1mih4b62rp97d"
+   "sha256": "1r04mbn33y515b9fwr2x9rcbkvriz753dc0rasb8ca59klp1p5cv"
   }
  },
  {
@@ -14651,7 +14676,7 @@
     "s"
    ],
    "commit": "0e6941e1832faafb2176238339667edd482acd95",
-   "sha256": "1ri022shrwiw10gdydm66c2xya1qxl449r5f8qadals7m4crczp2"
+   "sha256": "0xw475spfwq32nn5qz3gk22cggj1f5y245da9030vzi2jfb9vvid"
   }
  },
  {
@@ -14741,8 +14766,8 @@
     "company",
     "prescient"
    ],
-   "commit": "4a0f5405798cfcb98ea005078ef2e2d490e922c4",
-   "sha256": "04rz8mypgslb0la4wgj3na5c8p28s9lghq4nykcb28nhcxwfvz8n"
+   "commit": "54b19cf7121d9eb679c2ba26b3c26e82c8a90df9",
+   "sha256": "122j06gav4y6ghkjgwivlfqq1y4rl52sm8wskcq1gm3g7n36ds5h"
   },
   "stable": {
    "version": [
@@ -14930,8 +14955,8 @@
     "company",
     "rtags"
    ],
-   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
-   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
+   "commit": "3a057f127b931c683288f8731f05ba5e2aab4133",
+   "sha256": "1brf05grh0xdcjllaiixpjxmcg2j130gcrxkqm5v4ryb1w9fki7g"
   },
   "stable": {
    "version": [
@@ -14996,8 +15021,8 @@
     "company",
     "solidity-mode"
    ],
-   "commit": "5f6ef3156fadae5af6f381d674d20535529a20e4",
-   "sha256": "02rmc7naspjfl757k7zdfg9xd6nvfpsiqfcxkj6ywc7mnndpq2c0"
+   "commit": "6f7bd1641e5282ec5163188d8b8c2f6dfddc2e36",
+   "sha256": "0rkw21pic9nypv7vz06chyn9mjl560a4dayb84gj5w6v8gfznrcw"
   },
   "stable": {
    "version": [
@@ -15590,24 +15615,6 @@
   }
  },
  {
-  "ename": "confluence",
-  "commit": "30de78c9cf83de30093a5647976eeaf552d4b2cb",
-  "sha256": "0xa2g168mm31kh5h7smhx35cjsk1js88nzs19yakjljf56b1khlf",
-  "fetcher": "github",
-  "repo": "emacsorphanage/confluence",
-  "unstable": {
-   "version": [
-    20151021,
-    128
-   ],
-   "deps": [
-    "xml-rpc"
-   ],
-   "commit": "4518d270a07760644c4204985c83d234ece4738b",
-   "sha256": "1lrq23cxlp2vkyv7g56r06bp7chhw10kii3ymkydf24y4pyn1zpg"
-  }
- },
- {
   "ename": "conkeror-minor-mode",
   "commit": "1e6aed365c42987d64d0cd9a8a6178339b1b39e8",
   "sha256": "1ch108f20k7xbf79azsp31hh4wmw7iycsxddcszgxkbm7pj11933",
@@ -15713,11 +15720,11 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20210716,
-    1219
+    20210722,
+    1644
    ],
-   "commit": "5fb6248c8e12630ce1247985c67ea28ae4077e4f",
-   "sha256": "1cgk144alm3pbig9acm62q3r7479x69ig76q3z6agamdvf91ay29"
+   "commit": "d42ccdca5bbc4c437819cf4d29c7b8728ed090bc",
+   "sha256": "134flhq2rx2qjhfc5fspsijpdiv7a3z5mk0j1pwipfwfkid27nqk"
   },
   "stable": {
    "version": [
@@ -17451,6 +17458,14 @@
    ],
    "commit": "a7f0f4610c976a28c41b9b8299892f88b5d0336c",
    "sha256": "0j8m7rhkf98zqkg6zydcks6qs4msw6vz51nbqya23hka2wpz7f81"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "a7f0f4610c976a28c41b9b8299892f88b5d0336c",
+   "sha256": "0j8m7rhkf98zqkg6zydcks6qs4msw6vz51nbqya23hka2wpz7f81"
   }
  },
  {
@@ -18060,8 +18075,8 @@
     20190111,
     2150
    ],
-   "commit": "5bf5aa63d6b6742144071a2af896067c21b3752a",
-   "sha256": "1nnyca4bagdbpmzy64pqy95vxbj3dx7lfbapvs120zbpxj193p7a"
+   "commit": "e46e9dd7c37d8d7ad432a94fff5daafa7fa444e3",
+   "sha256": "0lbla1pbqk2gaprkwdyxg5x381nmxx1jcc9snls6crlsf8bbhrm4"
   },
   "stable": {
    "version": [
@@ -18268,8 +18283,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20210711,
-    1427
+    20210720,
+    448
    ],
    "deps": [
     "bui",
@@ -18281,8 +18296,8 @@
     "posframe",
     "s"
    ],
-   "commit": "685168efc72e61bca2a248155bace7ec633269a5",
-   "sha256": "1mwy92rj9jj4ziflhzpy774vrp5m7zwzy2x1iyj33mn2rmykwl2w"
+   "commit": "d472a6c937cf519434e718e873c195f5d1e80f19",
+   "sha256": "17az0rvcy84iahlfdn246marjn4kgrif4gnv0h1zf4sdznk2aijh"
   },
   "stable": {
    "version": [
@@ -18338,7 +18353,7 @@
     0
    ],
    "commit": "2ecd466ffa7a3157b9ddcd7545b6fb8ad308c976",
-   "sha256": "1h5lssnc1am54hkprnp61bsj5fnm8j556q2gbhljfjgrdwnqv8ky"
+   "sha256": "1y8rsc63nl4n43pvn283f1vcpqyjnv6xl60fwyscwrqaz19bsnl1"
   }
  },
  {
@@ -18638,11 +18653,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20210714,
-    305
+    20210718,
+    940
    ],
-   "commit": "09932ef488b47c6b645a081fee4a82be437f98d8",
-   "sha256": "1kfsc5f37i4k4j8rqmi70cd6yvwxhhq2q513gby8qj2bqsgiwkhb"
+   "commit": "67573ceb3db5bc7a5192311c6cac044cb29f61a7",
+   "sha256": "1ljcym1gwibldsp656a4h9x4hn36ywavqan7h8gk2grr5716cpx2"
   },
   "stable": {
    "version": [
@@ -18963,7 +18978,7 @@
     "ht"
    ],
    "commit": "5123477396a562fae350a89fbed79464cc498bc9",
-   "sha256": "0xd94cpqpv0yw70ajrvs69ygds62m40fk0m4s59zvdn5qs7ivj4k"
+   "sha256": "1bkiwg1wp3l904159gycdr83xkb3i0h2k0da7akzkwc957abvp8w"
   }
  },
  {
@@ -19848,7 +19863,7 @@
     0
    ],
    "commit": "6d0c4203eb192d73d89261b3a9bad52951e394af",
-   "sha256": "1rdmhsrlqn19a140i3099fp7f9wnlglp760rnrjp5p840wzfm74q"
+   "sha256": "0a89bp9vz8lzg5klhmzpfmc0mhqmx667ivr86ckkjhiwr2mmzq0s"
   }
  },
  {
@@ -20305,11 +20320,11 @@
   "repo": "HKey/dired-atool",
   "unstable": {
    "version": [
-    20210706,
-    1456
+    20210719,
+    404
    ],
-   "commit": "c01e0a79c952a29db17c262c9ce8a90632b04b3a",
-   "sha256": "1r44s3f29p70li6k6646xcby3ypz1ljgd4j1fhdd0x4d7a09zl0v"
+   "commit": "01416fd5961b901c50686c91cb59b3833adc831b",
+   "sha256": "0dx829jlxr84mylcr0l7wgbkbhajmb2yg2dcnyd1gi768fgh7jdj"
   },
   "stable": {
    "version": [
@@ -20569,7 +20584,7 @@
     5
    ],
    "commit": "dbace8d2250f84487d31b39050fcdc260fcde804",
-   "sha256": "1d9105ibaw858gqp19rx2m6xm3hl57vzsmdqir883cy46qpvwhki"
+   "sha256": "0r9qmr2l5kjwh1frp0k87nyaf13f7f9fjjf9yf9z92djqapfm9dd"
   }
  },
  {
@@ -20752,7 +20767,7 @@
     "hydra"
    ],
    "commit": "79e422be55c72bfe36d2ec8a838f19d1cc8d101a",
-   "sha256": "14hb3d76y4n8qvfl74v9hzgl6774bqdcmsa0npv3gs144fbx9prk"
+   "sha256": "01zdha3p7wsf98yayvwgpd4arcs7yhz62yk1nyq9n13hvmqg7dvk"
   }
  },
  {
@@ -22238,16 +22253,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20210706,
-    604
+    20210721,
+    1833
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "06606e0b8b3c19fbe56e25702e2a664deec593c3",
-   "sha256": "0akyzih955j2ijnrvfnajwpml5xb3v9pg9wbn4z8nkcw33hvxgk9"
+   "commit": "8cbb0457f3f35b3a1615eef176785aacdf5afe97",
+   "sha256": "1hxs2vdp0qvjcn32yrxxbqq3vgjb68fx0fqsqhh5x3cgvabcim0j"
   },
   "stable": {
    "version": [
@@ -22955,8 +22970,8 @@
     20210715,
     548
    ],
-   "commit": "48bd29decb847bd9357aceeca9ad1c916f199913",
-   "sha256": "02fy271d8s77l2g4rykgpnqvy4sq2ri88xz97ink00r1r12cdvk9"
+   "commit": "07dd21abc029f50c6a3a96f2867d31102366faba",
+   "sha256": "0pvbvzdljxq7mjfsx4fcm3782wdawx2mgzi4hy7kvw7z80n9zm7k"
   },
   "stable": {
    "version": [
@@ -24554,8 +24569,8 @@
   "repo": "joaotavora/eglot",
   "unstable": {
    "version": [
-    20210611,
-    2249
+    20210721,
+    2323
    ],
    "deps": [
     "eldoc",
@@ -24564,8 +24579,8 @@
     "project",
     "xref"
    ],
-   "commit": "5cc8df63d86a6c43134dd6e4e3ae26cfae14e66a",
-   "sha256": "0whplm1858d3mv4af6qk0jr5dk9ym1yzp4zsslrrfpyi54vy96yx"
+   "commit": "194b178ef41ccd3d937983f3829d44a546bb24d6",
+   "sha256": "12pmqq3l08p1vggbhccpg9bh0n78qrdmk5q30a1d4jrfkifcfbr0"
   },
   "stable": {
    "version": [
@@ -26441,11 +26456,11 @@
   "url": "https://thelambdalab.xyz/git/elpher.git",
   "unstable": {
    "version": [
-    20210716,
-    1445
+    20210720,
+    1520
    ],
-   "commit": "7e0919bd74952fb229862f1280e01817721b7fc2",
-   "sha256": "13fjp20hf4jv3325ipnjrzqvxa122sfhs44dgsr52g9mkhhc6kbm"
+   "commit": "3cddc8bdcb0a05ecd308c310bcd020f7288af4de",
+   "sha256": "12xcra3a5bsihcfqs014bcayw0wmv5f22gdk6dipfx1pjygz1x1k"
   },
   "stable": {
    "version": [
@@ -27031,7 +27046,7 @@
     0
    ],
    "commit": "f0add6820d250875f7d7c21aa5d813dc73dbcf96",
-   "sha256": "18bnw6yb41ki1xvkhi07v7fqx3var928majgd6613ra9nirnyqnj"
+   "sha256": "0zg52b3hl0rp9hjz04546kngssxs0l64dm01bwp9hapy7pichbci"
   }
  },
  {
@@ -27114,11 +27129,11 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210615,
-    1833
+    20210723,
+    47
    ],
-   "commit": "acbe1cba548832d295449da348719f69b9685c6f",
-   "sha256": "0c1zqfrn2va2m9z6rw3i2h6dwm2vc0asbha4d9r0gss4b7519pf2"
+   "commit": "c0a3e5398c3303d9336d3614ff8e2ce543501eaf",
+   "sha256": "18g86ymca74jkkrpjqxcy289rna968qrk4gpn09k52zf83xaafha"
   },
   "stable": {
    "version": [
@@ -27137,15 +27152,15 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210525,
-    1515
+    20210717,
+    1845
    ],
    "deps": [
     "consult",
     "embark"
    ],
-   "commit": "acbe1cba548832d295449da348719f69b9685c6f",
-   "sha256": "0c1zqfrn2va2m9z6rw3i2h6dwm2vc0asbha4d9r0gss4b7519pf2"
+   "commit": "c0a3e5398c3303d9336d3614ff8e2ce543501eaf",
+   "sha256": "18g86ymca74jkkrpjqxcy289rna968qrk4gpn09k52zf83xaafha"
   },
   "stable": {
    "version": [
@@ -28333,11 +28348,11 @@
   "repo": "alexmurray/erc-matterircd",
   "unstable": {
    "version": [
-    20210701,
-    32
+    20210720,
+    412
    ],
-   "commit": "6e9698310f5df5193bccb334839bca29e4bbfe30",
-   "sha256": "0cwq1ljgb0ga1b8f8gks9c4y8rqjfawpr4l0fi0p3y674a76z33f"
+   "commit": "caafa1a62a76c2132d8b0872d57684f877608408",
+   "sha256": "0cba6wawwjmidpv1mccmrn2cr5xkyyj44aildifvyqay7nhldp3d"
   }
  },
  {
@@ -28367,7 +28382,7 @@
     "switch-buffer-functions"
    ],
    "commit": "7539654e4a72edcc5bba07a101961e5bf0a9d449",
-   "sha256": "11zpqwh1mlfifbgnvhc63bvnhg340jgxssm3m43hr1sxsyb52lh6"
+   "sha256": "0pfnp7gw75hfhsy7jizp622s6yv61h3k2s0l2g33i801ar6abwm5"
   }
  },
  {
@@ -28699,8 +28714,8 @@
     20200914,
     644
    ],
-   "commit": "3543ef3df19228012a1ac5be766cc38fd2f65f6a",
-   "sha256": "0wlqrl8ikqc7q61i2qzmwp6h0mrv9kn5229pbsrb1ris7gxgi13b"
+   "commit": "286bbef128cb3194f8bd63cd5e497bea621c709a",
+   "sha256": "1i176damqxg0nqawhgr22ypzysnbk44aii0r81pl6zbwsvdxkqn6"
   },
   "stable": {
    "version": [
@@ -28723,17 +28738,17 @@
     20210315,
     1640
    ],
-   "commit": "81c6d94625a04f6550e77a068489ca6378cabfee",
-   "sha256": "1kkjyradh316xcqsh9pn4l1nvz1krn8cm3zch0vfp47dkkg54w1y"
+   "commit": "4adbbaa681d902cc342f20c4e153d0cb6d866238",
+   "sha256": "01nq7qdmdpasvay3jg9kmg8wamvf37pwqcc37sfc85h81qf2rvc4"
   },
   "stable": {
    "version": [
     24,
     0,
-    3
+    4
    ],
-   "commit": "0a887ba078f6faadea128b51a98e928dcb0e79a4",
-   "sha256": "0hirfg5y53gj5smf2rqxiadj02ad761hgq3yqcz4j1ldnm50hlr9"
+   "commit": "c07336b844645f80430505194c01ffd59672804f",
+   "sha256": "0wy4fbflsm5sc1jjs6vf8ad0621q1m3vmfazz6jrg1s9llsxgr9r"
   }
  },
  {
@@ -29815,15 +29830,15 @@
   "repo": "tali713/esxml",
   "unstable": {
    "version": [
-    20210323,
-    1102
+    20210722,
+    1345
    ],
    "deps": [
     "cl-lib",
     "kv"
    ],
-   "commit": "9f96449f6059cb75491dc812ddeb1b6200ec6740",
-   "sha256": "1xzxmgsg0j72sf1vjh9gjswz3c29js0kqhm7r3jrqrh3a5agdnml"
+   "commit": "701ccc285f3748d94c12f85636fecaa88858c178",
+   "sha256": "1ig5i3h5ldsdmxas4nvxrdbdmawgpa10kwq3mmzczp5qwp5a3vq8"
   },
   "stable": {
    "version": [
@@ -30180,15 +30195,15 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20210715,
-    1839
+    20210721,
+    658
    ],
    "deps": [
     "cl-lib",
     "goto-chg"
    ],
-   "commit": "070abb16620653fb343980fb85a13c4d55e1070b",
-   "sha256": "0pcr471snnmhycvvgczs1gbil45w6lf1bdmg7w19vh2a0dq4pqi9"
+   "commit": "5201f5cf5a4870e081d09bc3113a55cb94f3812f",
+   "sha256": "0i6b358vcsywx66fm5p4476rpy7bnl92zyjisb47kqlkznr3s25r"
   },
   "stable": {
    "version": [
@@ -30382,15 +30397,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20210715,
-    1552
+    20210721,
+    1454
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "3bd5e90accbb3a12d924bb7b4220221493675591",
-   "sha256": "1nikhz4l01zi884dwyjfsaralc1pd6y70fvd36i4qn477xinsvk4"
+   "commit": "8d10ad4ea59752595de37a8ddc44e8d3fb14fe89",
+   "sha256": "18qkc3mbc8sr56823bpdr319dg2k2l29chk7c6zr5ln5jls08q8a"
   },
   "stable": {
    "version": [
@@ -31083,20 +31098,20 @@
   "repo": "redguardtoo/evil-nerd-commenter",
   "unstable": {
    "version": [
-    20210624,
-    1122
+    20210719,
+    1305
    ],
-   "commit": "118bebd02a489ddf5eee3ab6fb55b3ef37ebe6d4",
-   "sha256": "15phgj1x2k7i6wnhq3lbrjldrc7xr18z4sgsmklwwgr4blx9ql1s"
+   "commit": "2133167e0699f44fe37830839362e2e6793bce88",
+   "sha256": "0qrqpwnny7v4l8abf93c7l6dz7wkk1b8i6wv0fdcq6b7jrq1ixh4"
   },
   "stable": {
    "version": [
     3,
     5,
-    4
+    5
    ],
-   "commit": "b8ac35fe019df5602c31912f65303a3d8ad0066c",
-   "sha256": "1vyl8lidhjph7k86n8q09mwqpasaxsmwb8vi5i2gcd6klds9hg0d"
+   "commit": "8b0d9654ecf8f3f1d88db6be8238aaf76afa8a94",
+   "sha256": "1qrlg4cxlsd4cf1z8j2662pfb9p6pnqpsyb74flja9cqv6g5ylp8"
   }
  },
  {
@@ -31708,8 +31723,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "070abb16620653fb343980fb85a13c4d55e1070b",
-   "sha256": "0pcr471snnmhycvvgczs1gbil45w6lf1bdmg7w19vh2a0dq4pqi9"
+   "commit": "5201f5cf5a4870e081d09bc3113a55cb94f3812f",
+   "sha256": "0i6b358vcsywx66fm5p4476rpy7bnl92zyjisb47kqlkznr3s25r"
   },
   "stable": {
    "version": [
@@ -33084,14 +33099,14 @@
   "repo": "jrosdahl/fancy-dabbrev",
   "unstable": {
    "version": [
-    20200129,
-    1933
+    20210720,
+    1833
    ],
    "deps": [
     "popup"
    ],
-   "commit": "158e1e54055cafe5da9122a59519e8b3ed1057cf",
-   "sha256": "06616lzvv6vdc2i37gy47zw3rb4yjml83vn5py2k30ck8gl4fhs2"
+   "commit": "1096582f68cda91fe9d9336756b7c044ab0d6096",
+   "sha256": "0qp1nqcni5a3m9iaqar07sii6mpcnnqxmaf5n2fpz1iaz6bwsxva"
   }
  },
  {
@@ -33478,11 +33493,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20210713,
-    2129
+    20210720,
+    1516
    ],
-   "commit": "0f83112e70c1cd13a8b98e9e75b2291fcdf3d57f",
-   "sha256": "1n1f9bn8447aq3666q9lj7idzj9nwkmknfzybk3is98m03cjki3z"
+   "commit": "12bdd8ee09ce2ba7c232df96fb199461d25a89c5",
+   "sha256": "13fyadml9wa30f4brdwfnby067q6bp2dl1y6x7hz0pzzlbk4sbs5"
   },
   "stable": {
    "version": [
@@ -33491,7 +33506,7 @@
     0
    ],
    "commit": "ea8564a2cc4f7e10b3fc13faf26a4f098b159f00",
-   "sha256": "1qnmcysrl2zxiid4v1h1hq1nax3a7sxs2dmag54sfifm149lf7f3"
+   "sha256": "03z3f60qsn6k9wg1km49ad4xlwp82114r5pzibnxly2n0vmmdsyb"
   }
  },
  {
@@ -33819,11 +33834,11 @@
   "repo": "redguardtoo/find-file-in-project",
   "unstable": {
    "version": [
-    20210427,
-    1205
+    20210720,
+    244
    ],
-   "commit": "680ec93808176442a2c78b91b18bb4256d81d340",
-   "sha256": "1af30i3nsms1s2gwq3wx0xbmjxd95hipai63icw3jpwc3pmw3g2n"
+   "commit": "cde02e549512742366a91ffb70c86c354117cfde",
+   "sha256": "1xkpyn5lh6nhsmnq50174lnir9c9xhwb9ihvj0lw721s57xq3aa0"
   },
   "stable": {
    "version": [
@@ -34158,7 +34173,7 @@
     4
    ],
    "commit": "ba63f0591c3be1644ee7ee972430c74b5d346579",
-   "sha256": "014vbzxz1jmm83a5mg4zsyxm8nw96n8s2l7h3myhrn880d9xnqgg"
+   "sha256": "1yjfvb2vn5pmrq5fw4sfx1lfkbnkwlc160izpvkrf9ww9xsas6al"
   }
  },
  {
@@ -35013,7 +35028,7 @@
     "flycheck"
    ],
    "commit": "b4ffad5cabea7e858c66dc824d545653b1cdcb70",
-   "sha256": "1la7qhczg9bgs1klinwj21mjywsg1nm3sxd5cyc09bxjzbflzzz6"
+   "sha256": "0ggq4q2c1xi26m4rlvjm8f51wlj7h351pp6m20k6l25856858vhi"
   }
  },
  {
@@ -35789,8 +35804,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "061ce63d217b7cd165c487d81331843dea5bc11c",
-   "sha256": "088g4vi01xanjm5dyzlw483h8w3dyijjccla37zfa55cg0nksdd3"
+   "commit": "59b37e09923290da1c8458e507da43f403f555d2",
+   "sha256": "1l0rq2g9dn90xr75cjz64cyai90m5cayr2b2fdrkkrz70g00pqlr"
   },
   "stable": {
    "version": [
@@ -36052,7 +36067,7 @@
     "flycheck"
    ],
    "commit": "54744a78d06373404933fedc3ca836916e83de51",
-   "sha256": "1zdvan6l2s97s7swnccq21z1ja8vl64l757j3hg50ipq8j5yy9dl"
+   "sha256": "1vvsswadiks9mpb49vz2q8z69wq0jalsvgalhn10k3pyz7p0abnd"
   }
  },
  {
@@ -36985,8 +37000,8 @@
     "flycheck",
     "rtags"
    ],
-   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
-   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
+   "commit": "3a057f127b931c683288f8731f05ba5e2aab4133",
+   "sha256": "1brf05grh0xdcjllaiixpjxmcg2j130gcrxkqm5v4ryb1w9fki7g"
   },
   "stable": {
    "version": [
@@ -38536,11 +38551,11 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20210124,
-    1143
+    20210723,
+    505
    ],
-   "commit": "404233604439117301562deadc952fe82cb02120",
-   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
+   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
+   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
   },
   "stable": {
    "version": [
@@ -38567,8 +38582,8 @@
     "avy-menu",
     "flyspell-correct"
    ],
-   "commit": "404233604439117301562deadc952fe82cb02120",
-   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
+   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
+   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
   },
   "stable": {
    "version": [
@@ -38599,8 +38614,8 @@
     "flyspell-correct",
     "helm"
    ],
-   "commit": "404233604439117301562deadc952fe82cb02120",
-   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
+   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
+   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
   },
   "stable": {
    "version": [
@@ -38631,8 +38646,8 @@
     "flyspell-correct",
     "ivy"
    ],
-   "commit": "404233604439117301562deadc952fe82cb02120",
-   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
+   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
+   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
   },
   "stable": {
    "version": [
@@ -38663,8 +38678,8 @@
     "flyspell-correct",
     "popup"
    ],
-   "commit": "404233604439117301562deadc952fe82cb02120",
-   "sha256": "131yv9524yl7bwn9pd86pfjwjphv66lakfa9d293m4pq9mmg87s6"
+   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
+   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
   },
   "stable": {
    "version": [
@@ -39350,14 +39365,14 @@
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20210611,
-    1228
+    20210717,
+    906
    ],
    "deps": [
     "seq"
    ],
-   "commit": "ede8a254fe1bfb125b52ea71252b863cf80eee18",
-   "sha256": "0s2qlnx5lq5ni53r0i4fja6qfxxbg6apq5madgkiyz5d1bay551g"
+   "commit": "d2e0cb8f328a1219a3830f82fd01e789cac398b2",
+   "sha256": "04a5mwlxq43mk132j7v4gx9jiss2pah38rgk0dsc6pn00xjf4j9q"
   },
   "stable": {
    "version": [
@@ -39974,8 +39989,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "5b1c814d84714b0c94c5a7b4aeb3f44d2a4d5998",
-   "sha256": "1sw7abwli4hjwbyqmkc8vfg4sgil59gkygvk3f4p6gdihnfqynwp"
+   "commit": "d9b6d549251d4a1a7cec2e83b11bda2ef7ff4ed2",
+   "sha256": "0246kl945g5v539h1hvwg06jsmj10a4q8rld3g6jix2iy1jmnfw7"
   },
   "stable": {
    "version": [
@@ -40586,7 +40601,7 @@
     16
    ],
    "commit": "803dfeb9414ed7b99c5d567170f32c97cafa1114",
-   "sha256": "16jqni4s2yxszhkbb83fkgflygbxzx01cmq2qq40p4ihbvwm0gb0"
+   "sha256": "0s02443pxi49c8hmkk3g489ngb5bl95inraq3jabb6dh7gyxgkag"
   }
  },
  {
@@ -40873,7 +40888,7 @@
     "geiser"
    ],
    "commit": "0e3a0570354c03c0cfa25da82fb34ad2e81c1981",
-   "sha256": "1g31cibl88g1vjfvw4z80ywxpnxy5lijhs754qdcnx36maragh07"
+   "sha256": "1dyzpr9i5pxi2p2hg3ndryh7x4y0r9bra88pd1l904vdfsxdxv5z"
   }
  },
  {
@@ -41367,8 +41382,8 @@
     20210401,
     656
    ],
-   "commit": "8ab9c88a2b8cccd3c092e155f84b1b19930d0719",
-   "sha256": "1jiglrlhrph57p5kkm1qlqihwl6z7h9qh16qmmd5783ynksnbxp3"
+   "commit": "5517a557a17d8016c9e26b0acb74197550f829b9",
+   "sha256": "0n0gd4k1c1s8xj7p1yg7irnkaxw9f91jmjp5www5hrwhi3mbmpb8"
   },
   "stable": {
    "version": [
@@ -41376,7 +41391,7 @@
     2
    ],
    "commit": "fa81e915c256271fa10b807a2935d5eaa4700dff",
-   "sha256": "1yf6yipvhhna29mzaan5vb3d5qvbrkp2awr5diyf381mvxgk8akh"
+   "sha256": "1jiglrlhrph57p5kkm1qlqihwl6z7h9qh16qmmd5783ynksnbxp3"
   }
  },
  {
@@ -41675,8 +41690,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "bf9cc19a3287f6a3cc5c1836312f0d18b38b6e45",
-   "sha256": "0zjcvhjp4c01ibb1hshpqkib7fvjkmvh9xf06qfsm5ybdc04xik5"
+   "commit": "0ea7868e368864da4604eaafa7dd332e70584cc8",
+   "sha256": "1np7rvp1la2l8gb8rkyjalgrhsk2zc9a9chdadx06769z16fbr2r"
   },
   "stable": {
    "version": [
@@ -41726,7 +41741,7 @@
     "s"
    ],
    "commit": "8a403005ea7f7611bb1bfd829eeefe5a4f10bb40",
-   "sha256": "0w5xl9r7sbhlwxzg391x50pnsjmjjakn761v3qg0lj6xhv23sdl5"
+   "sha256": "02hag6jd55mqf0n90p0hvihmqjvd0cdlpm5knsxk3cll7fp0kkkr"
   }
  },
  {
@@ -41949,7 +41964,7 @@
     0
    ],
    "commit": "ea49e2e005af977a08331f8caa8f64d102b3b932",
-   "sha256": "0prx0xbnhhp46c09nnzpz07jgr3s5ngrw8zjksf48abr8acwywfv"
+   "sha256": "05bkpg7xz8644np9imsj5ms821sbsb784ap5fjdnnn69kllz0d33"
   }
  },
  {
@@ -42089,7 +42104,7 @@
     "transient"
    ],
    "commit": "391eb61050de321101e631fcf373fc70ec6e7700",
-   "sha256": "1pz4l1xnq6s67w5yq9107vm8dg7rqf8n9dmbn90jys97c722g70n"
+   "sha256": "05pyjhi26charkjy0mhvigd72rvb4s1s8imycfynf0fmjy7f7n7x"
   }
  },
  {
@@ -42617,7 +42632,7 @@
     "yaml-mode"
    ],
    "commit": "2651e831aed84ee2512245952fac94901b086549",
-   "sha256": "16fb4r3vq8xkzl911v7gaky95w1agfxjlpaxpjmidwx48rbcar59"
+   "sha256": "0yd6s5vy5afkigm87xyh1nnwljplx1wdn5h02224ica0py48fzhd"
   }
  },
  {
@@ -42648,7 +42663,7 @@
     "gitlab-ci-mode"
    ],
    "commit": "30ea0eab74b24818f187242b079845785035e967",
-   "sha256": "0awv24znkxs0h8pkj4b5jwjajxkf1agam09m5glr8zn5g3xbj798"
+   "sha256": "1w1simnlffg56j79gal1qf1nlav9f8fmr2zfswfrmcv6cac6fhj9"
   }
  },
  {
@@ -42710,7 +42725,7 @@
     "helm"
    ],
    "commit": "5fe0a66642da6f4e7ba9e1e3a96572c7f1876e37",
-   "sha256": "1c5js19zyb1z61hapvbfcl5jhrjqij46cxldgqij6al0scw44dga"
+   "sha256": "1mxkcnjgazc1pyjbqqfnhc9phpyrgah960avm2fmi7m9n5v8cf0w"
   }
  },
  {
@@ -43171,7 +43186,7 @@
     "gnus"
    ],
    "commit": "210c70f0021ee78e724f1d8e00ca96e1e99928ca",
-   "sha256": "08j8x0iaz5s9q0b68d8h3153w0z6vak5l8qgw3dd1drz5p9xnvyw"
+   "sha256": "0h7w5wrkrd0jw8nmgbkzq8wam7ynvy7flhjg4frphzmimlhysli2"
   }
  },
  {
@@ -44218,8 +44233,8 @@
     20180130,
     1736
    ],
-   "commit": "4044bbd5ca4434b8cecd23a4da8ae173c1e0d58e",
-   "sha256": "0nym4c4j0awxzpj2qkds1fxppc7jzzazwj0j8qx6vr5yfp7iry51"
+   "commit": "d88a5b7b59948d23977942ee62037e8912ff68ce",
+   "sha256": "1k29za2g3b10jy3nlkg09h5jn8d25w9yghrmz8cvm8zghxkqi2m7"
   }
  },
  {
@@ -46000,7 +46015,7 @@
     5
    ],
    "commit": "fd37f013c2f2619a88d3ed5311a9d1308cc82614",
-   "sha256": "196ydb57h4mjagjaiflvb20my561i6mdc6v6694ibdik2yns2inm"
+   "sha256": "1nykpp8afa0c0wiax1qn8wf5hfjaixk5kn4yhcw40z00pb8i2z5f"
   }
  },
  {
@@ -46638,8 +46653,8 @@
     "helm-core",
     "popup"
    ],
-   "commit": "60db46905443c87f324440202bd0735d57c5c201",
-   "sha256": "10rkyy63vqqf9s4i8rs409d22iwhxrhz3qikagmfyvvr1n6czcnp"
+   "commit": "f6cf6078a745ec6ab313dbe98097e3bd5cef0a8c",
+   "sha256": "1h00ay4jjzkvkv5wh9cnd187c3ix8rixasl3wl6ilbilvx1pwv37"
   },
   "stable": {
    "version": [
@@ -46932,8 +46947,8 @@
     "cl-lib",
     "helm"
    ],
-   "commit": "9f6ea920a49457d85096caa0e61f086a42b2908e",
-   "sha256": "0dqf2anmjlgcz7xn4q2pw8cfmhwdhdg4fm8q41vhrp60ymbc6dik"
+   "commit": "a0d32ab16748b7b0c43d6421f1b497b7caf8e590",
+   "sha256": "0a0mn41lvqjx8rdrfgff5fjs757nin30caap7ciapnvr18g9mh5h"
   },
   "stable": {
    "version": [
@@ -47101,8 +47116,8 @@
     "bufler",
     "helm"
    ],
-   "commit": "d466eac6c4b2ee25c765e7f31e44beb38dd44e4b",
-   "sha256": "00gyqpm0g437z71vbfd4kmih23vh6909dvygng133vxzly9k4f24"
+   "commit": "b951e621bc4a4bb07babf8b32dc318d91ae261c9",
+   "sha256": "14d2mcx6ppjzkpv63m7iir0j2dn549gkxr30bxx8qvc1v7r7r6wn"
   },
   "stable": {
    "version": [
@@ -47538,14 +47553,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210714,
-    1600
+    20210716,
+    1933
    ],
    "deps": [
     "async"
    ],
-   "commit": "60db46905443c87f324440202bd0735d57c5c201",
-   "sha256": "10rkyy63vqqf9s4i8rs409d22iwhxrhz3qikagmfyvvr1n6czcnp"
+   "commit": "f6cf6078a745ec6ab313dbe98097e3bd5cef0a8c",
+   "sha256": "1h00ay4jjzkvkv5wh9cnd187c3ix8rixasl3wl6ilbilvx1pwv37"
   },
   "stable": {
    "version": [
@@ -50380,8 +50395,8 @@
     "helm",
     "rtags"
    ],
-   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
-   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
+   "commit": "3a057f127b931c683288f8731f05ba5e2aab4133",
+   "sha256": "1brf05grh0xdcjllaiixpjxmcg2j130gcrxkqm5v4ryb1w9fki7g"
   },
   "stable": {
    "version": [
@@ -53139,11 +53154,11 @@
   "repo": "humanoid-colors/emacs-humanoid-themes",
   "unstable": {
    "version": [
-    20210525,
-    2259
+    20210721,
+    2022
    ],
-   "commit": "9b4587417f2583c503f84f3b1e994d7934e57bdd",
-   "sha256": "1dpanfa8qpy9l2i2pw5w95lqsw06944qbcz8c9fgpj2s3nchhkpi"
+   "commit": "d140638360a3eb1bf8f17877bd888f898df63ec0",
+   "sha256": "1lybjbbcjsry20p6jzmkg2h7am7hcgfhjkdmby9pk4whnhk9l4lh"
   }
  },
  {
@@ -55197,11 +55212,11 @@
   "repo": "J3RN/inf-elixir",
   "unstable": {
    "version": [
-    20210629,
-    40
+    20210722,
+    1310
    ],
-   "commit": "ec87ecaab5a10e79034f77d553e7fefbf60b9f97",
-   "sha256": "1p6r0iwqcaf9bp123ccwafmzlf8hgwvap0cqwgy33cks6bhcbzb9"
+   "commit": "59b7126540bb848d3a38ccff71e85f3cc0cef39d",
+   "sha256": "1jdc4daydjzrmk07b8a45adrwjaifnwyn9gfi16yl7bn3wx6zcvq"
   },
   "stable": {
    "version": [
@@ -56481,8 +56496,8 @@
     "cl-lib",
     "swiper"
    ],
-   "commit": "9f6ea920a49457d85096caa0e61f086a42b2908e",
-   "sha256": "0dqf2anmjlgcz7xn4q2pw8cfmhwdhdg4fm8q41vhrp60ymbc6dik"
+   "commit": "a0d32ab16748b7b0c43d6421f1b497b7caf8e590",
+   "sha256": "0a0mn41lvqjx8rdrfgff5fjs757nin30caap7ciapnvr18g9mh5h"
   },
   "stable": {
    "version": [
@@ -57024,8 +57039,8 @@
     "ivy",
     "prescient"
    ],
-   "commit": "4a0f5405798cfcb98ea005078ef2e2d490e922c4",
-   "sha256": "04rz8mypgslb0la4wgj3na5c8p28s9lghq4nykcb28nhcxwfvz8n"
+   "commit": "54b19cf7121d9eb679c2ba26b3c26e82c8a90df9",
+   "sha256": "122j06gav4y6ghkjgwivlfqq1y4rl52sm8wskcq1gm3g7n36ds5h"
   },
   "stable": {
    "version": [
@@ -57116,8 +57131,8 @@
     "ivy",
     "rtags"
    ],
-   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
-   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
+   "commit": "3a057f127b931c683288f8731f05ba5e2aab4133",
+   "sha256": "1brf05grh0xdcjllaiixpjxmcg2j130gcrxkqm5v4ryb1w9fki7g"
   },
   "stable": {
    "version": [
@@ -59056,8 +59071,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20210715,
-    1359
+    20210722,
+    426
    ],
    "deps": [
     "dash",
@@ -59066,8 +59081,8 @@
     "spinner",
     "vterm"
    ],
-   "commit": "a71a536fc1f194bc329e2c33eed5eab542c00cab",
-   "sha256": "0cnhv37m8hcl3lfbiivy3yk338x60q8fglm5nibhfr55ln52jjc4"
+   "commit": "e4035da5322b9528b9751a0305a0feaa28e181fb",
+   "sha256": "1rpcsw7ddg7cs5mha7sn4j719rkvk04vwsri1y6d1c80y2fdlr10"
   },
   "stable": {
    "version": [
@@ -59828,11 +59843,11 @@
   "repo": "Boruch-Baum/emacs-key-assist",
   "unstable": {
    "version": [
-    20210415,
-    227
+    20210722,
+    758
    ],
-   "commit": "fae7ce265db3bcfd1c6153eb051afd8789e61a4b",
-   "sha256": "16gi43wgqqjqljnmjwap8lng1p4davv8prvpip034qw9v6vjmm2p"
+   "commit": "8e5cd089e0b2fedec57c55eeff74cdb6121441aa",
+   "sha256": "0lg8v6lsa62zhnlrz47hlda65ra6yfqijgz4jcl5vxcx2hgks8g8"
   },
   "stable": {
    "version": [
@@ -60460,26 +60475,28 @@
   "repo": "stardiviner/kiwix.el",
   "unstable": {
    "version": [
-    20210219,
-    51
+    20210723,
+    443
    ],
    "deps": [
+    "elquery",
     "request"
    ],
-   "commit": "0c5e1619f079df822686cf42af5859111b6afd44",
-   "sha256": "179wsr1ffsl4hm4vnb0zzbw338jni5pz8ndgkfq21jppgzk8mlna"
+   "commit": "c0c597d1e1653112f3e10c67dcc22d85beb2aed8",
+   "sha256": "1k056qzw3a4i4icyrl1a0dv971jnl5d096hawj5qhgwslplrhdpj"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
-    "cl-lib"
+    "elquery",
+    "request"
    ],
-   "commit": "c662f3dc5d924a4b64b7af4af28f15f27b7cea1e",
-   "sha256": "0i11sfnqvjqqb625cgfzibs6yszx891y4dy7fd6wzmdpclcyzr8z"
+   "commit": "e191c312e5c9343fd9601c45a8ccd017479ee475",
+   "sha256": "1lsbd2qjmpbk474n19s9mq2n1i5sdg6jrnbpja6vdmn3a28c5wj7"
   }
  },
  {
@@ -61247,26 +61264,26 @@
   "repo": "PillFall/Emacs-LanguageTool.el",
   "unstable": {
    "version": [
-    20210621,
-    453
+    20210722,
+    702
    ],
    "deps": [
     "request"
    ],
-   "commit": "feea3f9271ce920490a0d9dcd11e669e3eaad1d0",
-   "sha256": "0vxq945x1yn86kpw7qbb686vb3pzyk7wma8g0dbval2m4hsbrn26"
+   "commit": "d3665a97cc87577f434a7476e1194b43f35408a8",
+   "sha256": "0gpnczvdwrcvvd162mi9nf55b0vzbpfmbhan1bqzc84rbjw0bzql"
   },
   "stable": {
    "version": [
     0,
     4,
-    2
+    3
    ],
    "deps": [
     "request"
    ],
-   "commit": "feea3f9271ce920490a0d9dcd11e669e3eaad1d0",
-   "sha256": "0vxq945x1yn86kpw7qbb686vb3pzyk7wma8g0dbval2m4hsbrn26"
+   "commit": "d3665a97cc87577f434a7476e1194b43f35408a8",
+   "sha256": "0gpnczvdwrcvvd162mi9nf55b0vzbpfmbhan1bqzc84rbjw0bzql"
   }
  },
  {
@@ -62420,17 +62437,17 @@
     20210303,
     1751
    ],
-   "commit": "4a785dbbf4f906584716bb14c92230beda5081ed",
-   "sha256": "0vkqp8ck21hhwfnfvmxfwrb3dnkqk4072n4jr7w6ivvhs555srdd"
+   "commit": "3603e4473ce9f81c5d73ba623c1938e152d03723",
+   "sha256": "1s1wsz8w7i1p509dqvv0ykljlqlr56203k4lrc542vjdnj4ih4z4"
   },
   "stable": {
    "version": [
     0,
-    20,
+    21,
     0
    ],
-   "commit": "89c2f0ad779b8d15581a3607beb55855b0da8737",
-   "sha256": "0vkqp8ck21hhwfnfvmxfwrb3dnkqk4072n4jr7w6ivvhs555srdd"
+   "commit": "ec88b4d6b430338a1a44a04dca1642fdef15641f",
+   "sha256": "02n5yc0nqckfpfxkw8gxigg59769alxvk043c2d9bxgm79zxvhhy"
   }
  },
  {
@@ -63590,6 +63607,40 @@
   }
  },
  {
+  "ename": "logms",
+  "commit": "bd2169076b021407552523282ba1df0ae1aec311",
+  "sha256": "1jrqya88ii3l4p9044w8x9nbnfm7gpw9kq0ycsclwyap3n71fm0r",
+  "fetcher": "github",
+  "repo": "jcs-elpa/logms",
+  "unstable": {
+   "version": [
+    20210721,
+    349
+   ],
+   "deps": [
+    "f",
+    "ht",
+    "s"
+   ],
+   "commit": "497eb1fa71340a8d7758dd7c8115de05ab452129",
+   "sha256": "1c5psadb590wbcqab0bjdfdsfd3rninbahr42pbi8gvdg0ay9qws"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    1
+   ],
+   "deps": [
+    "f",
+    "ht",
+    "s"
+   ],
+   "commit": "68bab96a13d64efdf4f5951d931d0862e6861fb5",
+   "sha256": "137z22qyfz0d58iqb8w3lcz5cr2ddi0h2xdns90r979b68lhsj56"
+  }
+ },
+ {
   "ename": "lognav-mode",
   "commit": "a5b0dadc609d13737d56657c17a945f10e840222",
   "sha256": "1fg2j63f6yaf4011vla36p1p0pjixzisff4wj80vh634yqvwp4ys",
@@ -63924,8 +63975,8 @@
     "dash",
     "lsp-mode"
    ],
-   "commit": "49a6bab0b1ad88d220305dbe3a0a14d368f62354",
-   "sha256": "1i3gywik5m9j797c69ng70bs28qdww9662sjl6y232rw19rya93b"
+   "commit": "7039afe9507467e0b1c1fba485f26a7892463bc5",
+   "sha256": "1f0k76ic6cv6kdszy38jfi5wbv1i9qqp3gnn63j4p0f0xj0ppsgw"
   }
  },
  {
@@ -64306,8 +64357,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20210715,
-    1320
+    20210721,
+    511
    ],
    "deps": [
     "dash",
@@ -64317,8 +64368,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "cd47168035c98c6ebf9177705b9b7da53fcc9f5f",
-   "sha256": "1q1isn2g09pdczqdvbk5hjirym6106ip1z6klg1m2d5b9d8vx0l2"
+   "commit": "ac3b7e6efd1f8d4bb92aa4d89fc361fce3208c46",
+   "sha256": "1gx5y9j259q4iqnp7b58958wnpw8l3fdcs88zx38252givf814nx"
   },
   "stable": {
    "version": [
@@ -64474,8 +64525,8 @@
     "ht",
     "lsp-mode"
    ],
-   "commit": "71a79760938d2132923fbff58dc25301892b1654",
-   "sha256": "0si9qca8lml2hd8zj420dmks4cwzfidq14h3xfczhvrshhsc0mny"
+   "commit": "9a0637e59d2a08a66c49fe8cda708e995ec156ed",
+   "sha256": "1jcf4jzsw10z9068xm20r7qdspd9yxhswpm0jjsm9rcypi2vm78r"
   }
  },
  {
@@ -64492,8 +64543,8 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "4eb78c43046fceb53a66ccd24c85601bdb87ed17",
-   "sha256": "10d949gb3v7flnkb5khk11dcmfnlr4h02yfj8g3b0ihr1zr7c958"
+   "commit": "4f2ea975c3199c0e8e35c0b1e9778cf1ed6bd9c2",
+   "sha256": "1hmdayrmxw979vigx1z6mlpzb5dwblx5c1f2k3ysms5didznlmcf"
   },
   "stable": {
    "version": [
@@ -64643,16 +64694,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20210708,
-    134
+    20210718,
+    1626
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "1ee371765612b7aaa6046aabdc2f65bcfcb93b11",
-   "sha256": "051hc6310zzn9qpvd9k8cj7ibzsk1k19l2485c5wra0fvm2lfa6x"
+   "commit": "4283414de69312298d51b03e938d95d37d238391",
+   "sha256": "08wqbwxwapi91mj94mgqy02bjz512sj3nwv77b067xqchz5yv6q5"
   },
   "stable": {
    "version": [
@@ -65006,15 +65057,15 @@
   "repo": "nbfalcon/macrostep-geiser",
   "unstable": {
    "version": [
-    20210324,
-    2141
+    20210717,
+    801
    ],
    "deps": [
     "geiser",
     "macrostep"
    ],
-   "commit": "8600fca05fd12a2e0ffe63238ddbfcb37c285dac",
-   "sha256": "1912hxbb7mbra91vjw1fnzbb4fd9ri59lc1hcrw196c7a4hzgv0y"
+   "commit": "f6a2d5bb96ade4f23df557649af87ebd0cc45125",
+   "sha256": "0dykvwcvg8n24z3fkx6rv3l1mhzmca4cxj0gsvvqsg9wp0az1fc7"
   }
  },
  {
@@ -65130,8 +65181,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210716,
-    1440
+    20210721,
+    1556
    ],
    "deps": [
     "dash",
@@ -65140,8 +65191,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "bf9cc19a3287f6a3cc5c1836312f0d18b38b6e45",
-   "sha256": "0zjcvhjp4c01ibb1hshpqkib7fvjkmvh9xf06qfsm5ybdc04xik5"
+   "commit": "0ea7868e368864da4604eaafa7dd332e70584cc8",
+   "sha256": "1np7rvp1la2l8gb8rkyjalgrhsk2zc9a9chdadx06769z16fbr2r"
   },
   "stable": {
    "version": [
@@ -65487,8 +65538,8 @@
     "libgit",
     "magit"
    ],
-   "commit": "bf9cc19a3287f6a3cc5c1836312f0d18b38b6e45",
-   "sha256": "0zjcvhjp4c01ibb1hshpqkib7fvjkmvh9xf06qfsm5ybdc04xik5"
+   "commit": "0ea7868e368864da4604eaafa7dd332e70584cc8",
+   "sha256": "1np7rvp1la2l8gb8rkyjalgrhsk2zc9a9chdadx06769z16fbr2r"
   },
   "stable": {
    "version": [
@@ -65655,8 +65706,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "bf9cc19a3287f6a3cc5c1836312f0d18b38b6e45",
-   "sha256": "0zjcvhjp4c01ibb1hshpqkib7fvjkmvh9xf06qfsm5ybdc04xik5"
+   "commit": "0ea7868e368864da4604eaafa7dd332e70584cc8",
+   "sha256": "1np7rvp1la2l8gb8rkyjalgrhsk2zc9a9chdadx06769z16fbr2r"
   },
   "stable": {
    "version": [
@@ -66450,11 +66501,11 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20210716,
-    1252
+    20210721,
+    2100
    ],
-   "commit": "b5893884abeb6a355233edf54e0f63d04bc32ce2",
-   "sha256": "0cjabw0ia9rnb3idmv9s6i4izgklxkiax8zn5xw1c6n8ls5iwbqj"
+   "commit": "a3a8edbf25db4b1e167f1fdff6f60a065d0bf9cb",
+   "sha256": "0a4ra9fwyj5av4cjyj1y1y1z1kr6dnq39hhf51c072zqw3k3jar9"
   },
   "stable": {
    "version": [
@@ -66570,11 +66621,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20210710,
-    1646
+    20210722,
+    839
    ],
-   "commit": "359347b2bb15f8d7ef819692ac79759ccfe2c85d",
-   "sha256": "1naqcg0a5shzcg0rlqs6w5mlr7sn0b8b2hmhs07qawvpxln8j628"
+   "commit": "f3c4fd9230252503e3a9f2de6f5d469c4ac270ae",
+   "sha256": "08snhqw9kyg8vdaz7ibga0pf2j5cg1akjiphs88dgvxkph8m65nr"
   },
   "stable": {
    "version": [
@@ -67074,7 +67125,7 @@
     "test-simple"
    ],
    "commit": "8d643a1776523ef1a6e0bff0bb0a390772fcc77d",
-   "sha256": "17m9x3yy0k63j59vx1sf25jcfb6b9yj0ggp2jiq1mih4b62rp97d"
+   "sha256": "1r04mbn33y515b9fwr2x9rcbkvriz753dc0rasb8ca59klp1p5cv"
   }
  },
  {
@@ -67511,11 +67562,11 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20210707,
-    901
+    20210720,
+    950
    ],
-   "commit": "7c4c0a7018109b2b1bcbc3f6c1486961b223e658",
-   "sha256": "13cissjjkhfab7sgmwwmdcl3d5kn3qd2d6w9nmcw0yb8c59r1c0l"
+   "commit": "3442c5f32498d566b9cfbe0f503eb4304820ca78",
+   "sha256": "0hh5qb3327n4zmb41aggb7q9468ixsda17bkj73qnc8afhfm4m6x"
   },
   "stable": {
    "version": [
@@ -67543,8 +67594,8 @@
     "auto-complete",
     "merlin"
    ],
-   "commit": "7c4c0a7018109b2b1bcbc3f6c1486961b223e658",
-   "sha256": "13cissjjkhfab7sgmwwmdcl3d5kn3qd2d6w9nmcw0yb8c59r1c0l"
+   "commit": "3442c5f32498d566b9cfbe0f503eb4304820ca78",
+   "sha256": "0hh5qb3327n4zmb41aggb7q9468ixsda17bkj73qnc8afhfm4m6x"
   },
   "stable": {
    "version": [
@@ -67576,8 +67627,8 @@
     "company",
     "merlin"
    ],
-   "commit": "7c4c0a7018109b2b1bcbc3f6c1486961b223e658",
-   "sha256": "13cissjjkhfab7sgmwwmdcl3d5kn3qd2d6w9nmcw0yb8c59r1c0l"
+   "commit": "3442c5f32498d566b9cfbe0f503eb4304820ca78",
+   "sha256": "0hh5qb3327n4zmb41aggb7q9468ixsda17bkj73qnc8afhfm4m6x"
   },
   "stable": {
    "version": [
@@ -67638,8 +67689,8 @@
     "iedit",
     "merlin"
    ],
-   "commit": "7c4c0a7018109b2b1bcbc3f6c1486961b223e658",
-   "sha256": "13cissjjkhfab7sgmwwmdcl3d5kn3qd2d6w9nmcw0yb8c59r1c0l"
+   "commit": "3442c5f32498d566b9cfbe0f503eb4304820ca78",
+   "sha256": "0hh5qb3327n4zmb41aggb7q9468ixsda17bkj73qnc8afhfm4m6x"
   },
   "stable": {
    "version": [
@@ -68534,7 +68585,7 @@
     1
    ],
    "commit": "beb22e85f6073a930f7338a78bd186e3090abdd7",
-   "sha256": "1dhljrh44dsnixd8hbb11k6dgap8r8n7jknhfy2afdzq889fih74"
+   "sha256": "1yf21gm4ziplmgx8yn7jqq45mwfiindbrman7fc5b9ifq78x9ryn"
   }
  },
  {
@@ -69029,11 +69080,11 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20210716,
-    431
+    20210722,
+    1916
    ],
-   "commit": "9521dcec6c012d3776e3d05692720dd24922218b",
-   "sha256": "1m5ifpql8p0w4qk79n2n8wyrq1s7ys0yc8y0a09w1yyxjk6ay12k"
+   "commit": "fd61a0c67ceafa3aeb0aeebddb93955148376b7e",
+   "sha256": "0l9gfq4qapa5snskb747jydprb0xvn80rjc83da1vwh4j8s3gavz"
   },
   "stable": {
    "version": [
@@ -69042,7 +69093,7 @@
     0
    ],
    "commit": "b6fb7cda01a665f9369f2c6a29f3bf26c8cc8019",
-   "sha256": "1m5ifpql8p0w4qk79n2n8wyrq1s7ys0yc8y0a09w1yyxjk6ay12k"
+   "sha256": "1yz5yr3acc601xcms7vr2jbj4bq6dqz8n5ymyfyxldid0n5ykzy4"
   }
  },
  {
@@ -69735,8 +69786,8 @@
     20210306,
     1053
    ],
-   "commit": "515b4f47c7f43816fce82cdf555107614e9e7edd",
-   "sha256": "1q39iy7g4f11nzhlsa1j8shrvhmg3ip2h43rxawhmypfwd95vzk1"
+   "commit": "d08f2a8d96af3ff80aac0e5641d9d20281084038",
+   "sha256": "1dbpy2bw131g5d166dmw5m4zq7y6h3krm7k1lv33cnbss10kj2fl"
   },
   "stable": {
    "version": [
@@ -70334,8 +70385,8 @@
   "repo": "mihaiolteanu/mugur",
   "unstable": {
    "version": [
-    20210503,
-    1516
+    20210719,
+    722
    ],
    "deps": [
     "anaphora",
@@ -70343,8 +70394,8 @@
     "dash",
     "s"
    ],
-   "commit": "b84752c391c5fe515960f77c80d08f313df57f33",
-   "sha256": "0la8lqr3wgizmnwnpys9mwrj1qi0al0gx6kxhlfwf9jr5gbdg9np"
+   "commit": "63a0377ac1ad48171621c9f0c719b62ec9395d35",
+   "sha256": "180i7igzqv5l22vk6n96g196mnd50lgwcmjkmzwlwdxn4jsgvjbv"
   },
   "stable": {
    "version": [
@@ -72360,16 +72411,16 @@
   "repo": "dickmao/nnhackernews",
   "unstable": {
    "version": [
-    20210219,
-    1948
+    20210716,
+    1030
    ],
    "deps": [
     "anaphora",
     "dash",
     "request"
    ],
-   "commit": "b5a221b63c8b311d50807fdfab4ae6b965844f06",
-   "sha256": "1lq3rh52x0f059lxk0cczins2vggiwjs5m1drj7dkb8lmlxc41y4"
+   "commit": "50a6a7a58bc0316a9acc2b972380692f7438d9ed",
+   "sha256": "0q86wzl4va5xjj7czh6ldypwgb09gv8gp7kqi449bhx984a1yq7n"
   }
  },
  {
@@ -72664,7 +72715,7 @@
     0
    ],
    "commit": "7825f88cb881a84eaa5cd1689772819a18eb2943",
-   "sha256": "009did3i3i8yi0virq606l02w1mw0gdyiqablqg7m368gx0gfvh5"
+   "sha256": "0f8s7mhcs1ym4an8d4dabfvhin30xs2d0c5gv875hsgz8p3asgxs"
   }
  },
  {
@@ -72758,11 +72809,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20210713,
-    1255
+    20210719,
+    1132
    ],
-   "commit": "d8a5fba4fe1efd7d0d652ead6d55371bc4078a9d",
-   "sha256": "138wxhawdp8nllpvmrgll4nvn5by3hsp0zy4gywf6nalr0d1wdld"
+   "commit": "bed62eb8bee4aeca1fabfa5e302b515849f50b31",
+   "sha256": "00mixvwwhrmmr7wcscyzdhwhbnfiha0b0lcx1f3zk5xyshll2y9n"
   },
   "stable": {
    "version": [
@@ -73123,20 +73174,19 @@
   "repo": "joostkremers/nswbuff",
   "unstable": {
    "version": [
-    20210129,
-    850
+    20210721,
+    741
    ],
-   "commit": "2aa3a96abbc76f007923f3fbb19a5246e29ae500",
-   "sha256": "0lhl49cs0sdr7p22spxf83sixp1pzjiq11plmxc8i0lqv735b9sn"
+   "commit": "fa9dcf131697ea7af066e11a1edcc881c397e07f",
+   "sha256": "0bkx7mwy3zbb0ixawvn4cysxk3jjc7ahssvdprvw19ls9xx3wbsp"
   },
   "stable": {
    "version": [
     1,
-    2,
-    1
+    3
    ],
-   "commit": "71e241763ca0a4a1d1b432e172d46bed4f44dbe7",
-   "sha256": "1sswhr52rp8c4v4fv30sww1gadbdrlk3l35j8xmqfw6hbgzxb5dn"
+   "commit": "fa9dcf131697ea7af066e11a1edcc881c397e07f",
+   "sha256": "0bkx7mwy3zbb0ixawvn4cysxk3jjc7ahssvdprvw19ls9xx3wbsp"
   }
  },
  {
@@ -74179,14 +74229,14 @@
   "repo": "alf/ob-restclient.el",
   "unstable": {
    "version": [
-    20200316,
-    759
+    20210718,
+    2008
    ],
    "deps": [
     "restclient"
    ],
-   "commit": "0ebfc7c5ebf96d2fe1a476439831363a5a43b9b6",
-   "sha256": "0sc6rljlzm7g4v4l4ziqrr0ydbsyypbq0h19f9xafvnb2pn40j84"
+   "commit": "bfbc4d8e8a348c140f9328542daf5d979f0993e2",
+   "sha256": "0nq5w2gankvb7ix8rv33814j7qvhiawd9r15b9i6syn1i5k5pxhj"
   }
  },
  {
@@ -74579,8 +74629,8 @@
     20210617,
     1726
    ],
-   "commit": "ba67af28ddca8718ef8816b2b0dc1e5b2f5e9591",
-   "sha256": "0dp4pkznz9yvqx9gxwbid1z2b8ajkr8i27zay9ghx69624hz3i4z"
+   "commit": "121f3913f5dad7468b33d4a5ca19e7a687d2ecfc",
+   "sha256": "104jaqllwzcikk17iajgnjnnqchgivj210mhrx07qrk5vy5qwv5d"
   },
   "stable": {
    "version": [
@@ -75520,11 +75570,11 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20210613,
-    1723
+    20210721,
+    2059
    ],
-   "commit": "2646dad28c0819fbe9ee521d39efb9ae40e03982",
-   "sha256": "0vxfinsx69fqpcgbsv6g26klim3yasds3ha9v3xkk32y9sb783lr"
+   "commit": "1e84120a28525ccb47b602fc19b7afbeffbbe502",
+   "sha256": "13smhq5yh5awfqfn3739yw19dxdkqz5fbbczvv8kxf70skjxb9bk"
   },
   "stable": {
    "version": [
@@ -76399,7 +76449,7 @@
     "seq"
    ],
    "commit": "4c114489e682e514e79701045d541ab6f3dc3fb4",
-   "sha256": "13y302lyscdqrba1sfx60yf5ji2xi7fbsvjsjbw7hiz63kg6rccy"
+   "sha256": "079x6rcz50rpw0vdq5q2kjpixz95k9f3j9dwk91r5111vvr428w3"
   }
  },
  {
@@ -76966,16 +77016,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20210622,
-    130
+    20210719,
+    2242
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "f4599dd5dfd7f97a22ca98502f809a8d14551c09",
-   "sha256": "0i8rqila62qamv3mxh66g678kbang3sxjbf3x70nmrx7fyy2m2jv"
+   "commit": "2ea00944a7426012cda95cede99e49470f1383aa",
+   "sha256": "179h5j0k79hbbxz2n3x6hm1v2ws9qii6n8zx4800avbq1fgsh792"
   },
   "stable": {
    "version": [
@@ -77373,14 +77423,14 @@
   "repo": "jeremy-compostella/org-msg",
   "unstable": {
    "version": [
-    20210518,
-    2355
+    20210716,
+    2237
    ],
    "deps": [
     "htmlize"
    ],
-   "commit": "4c92c627b6cfb234fd257b714a5dbfc72d7af8d2",
-   "sha256": "0mln6324jb8p77pkbiaflmdj8h9m9wvmabgadhi6kh2jp4dhijql"
+   "commit": "7cedeeece58879e05d3a3bab8af1385006f234df",
+   "sha256": "0gw34smbw9v0f3xwjci7zsj8hbnqd54yzbph6az65r5634nqhiv2"
   }
  },
  {
@@ -77829,7 +77879,7 @@
     2
    ],
    "commit": "549fa6969660dcf0cf9bca5b7341d0cb48ec3b77",
-   "sha256": "12s74if74vw8q5awgrk0d1244ysfgb9kw3dxhypsccsbf413jmii"
+   "sha256": "0ksj6hssyr44qnvb32qj9lrq825ivvndhck9gzx4h7gbxmvq12a4"
   }
  },
  {
@@ -78090,7 +78140,7 @@
     "org"
    ],
    "commit": "4538c06fab9a7259aa1fb40e93a43dcfacef27c1",
-   "sha256": "1w6zvgfcyjqlxy4s13h7w66vv0fcid57s6vigzgnzi666w86fdyh"
+   "sha256": "1lfvhc4gly06rq5i2fgjydg4rsy7vgksa8hpydsvklr0ypvc1hcc"
   }
  },
  {
@@ -78122,7 +78172,7 @@
     "org-ref"
    ],
    "commit": "abcd622e4edaa5e4480bcd1e7e4953f67c90e036",
-   "sha256": "08ia6gn0x0yydl28dhghifyxz0mrn0asllqg4s449gaz729cxqkd"
+   "sha256": "1467vskijg2n8k7fa2jj2hz8xr2s04r8a89521wmz54cza21g5j4"
   }
  },
  {
@@ -78344,36 +78394,36 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20210609,
-    1221
+    20210721,
+    1746
    ],
    "deps": [
     "dash",
     "emacsql",
-    "emacsql-sqlite3",
+    "emacsql-sqlite",
     "f",
-    "org",
-    "s"
+    "magit-section",
+    "org"
    ],
-   "commit": "756f6215b672e267f986a3d6e494f5309825b91a",
-   "sha256": "16rjqzj872y1240w15gawxcwj5gg1cds162wq1hswzplmx8wp9d1"
+   "commit": "9c10a3c04c06d1658a63d44927e385e2d97854d6",
+   "sha256": "0kd7wkd6k37ahsgmcjcs0msp02x6vfkq8gdih210yp2w6vz10hhy"
   },
   "stable": {
    "version": [
-    1,
     2,
-    4
+    0,
+    0
    ],
    "deps": [
     "dash",
     "emacsql",
-    "emacsql-sqlite3",
+    "emacsql-sqlite",
     "f",
-    "org",
-    "s"
+    "magit-section",
+    "org"
    ],
-   "commit": "9065f6a999b98d4b495e3d8fa1fa4424eddd25a8",
-   "sha256": "10jrnjq65lpg1x8d7lqc537yai9m6pdnfbzwr87fcyv6f8yii8xn"
+   "commit": "3a78422a099261317d369be58947f4d4b3df1da3",
+   "sha256": "0mslrdgd41czay3w7znz4qsv1h0p3zqfsq6bkyxmxfyd2w5z82zf"
   }
  },
  {
@@ -78384,31 +78434,30 @@
   "repo": "org-roam/org-roam-bibtex",
   "unstable": {
    "version": [
-    20210602,
-    2113
+    20210720,
+    1306
    ],
    "deps": [
     "bibtex-completion",
     "org-ref",
     "org-roam"
    ],
-   "commit": "c9865196efe7cfdfcced0d47ea3e5b39bdddd162",
-   "sha256": "0c9y76r1bagz39m74kb2jcxqsc2q461407bbsib3f512sdf93lyg"
+   "commit": "13de4262d87debdbc43f8e2bd72b991b7284e705",
+   "sha256": "0iizd5vzxxl7fsm7k4y7dwisipsqwc3xqn33nk8r4c182mga3d9c"
   },
   "stable": {
    "version": [
     0,
     6,
-    0,
-    -1
+    0
    ],
    "deps": [
     "bibtex-completion",
     "org-ref",
     "org-roam"
    ],
-   "commit": "03b3a843fdbba428b29faa932661bc74fd66e29b",
-   "sha256": "17ds31cdq4prlknbjhhcjz17sim26yx8iws1scg4xcffxnb1s39r"
+   "commit": "eea7469fc32eddc9d74621b7ecc1f36832b7efd3",
+   "sha256": "04vc2w7x2lyamp0qa1y274smsf9x2qxr1igrpz9f4y5ha5332px5"
   }
  },
  {
@@ -79941,11 +79990,11 @@
   "repo": "tgbugs/orgstrap",
   "unstable": {
    "version": [
-    20201129,
-    604
+    20210722,
+    737
    ],
-   "commit": "5bd7ee9d9e23ce37fd004054071026ff51445654",
-   "sha256": "1qblj2m7bhykm58i63r5ywvpz6hr0vyzx7fa0s6rwlkjzbdn77g6"
+   "commit": "6f3ab471da576938d8200ce600fbb02dcb947f16",
+   "sha256": "1f8dspi9xizrxylff2zllwzz9lzrg3wr9cx0d5qzs74bs685vwwy"
   },
   "stable": {
    "version": [
@@ -80113,10 +80162,11 @@
   "stable": {
    "version": [
     1,
-    3
+    3,
+    2
    ],
-   "commit": "bcb858f607b0d833e1581e0630446ecc576eefd6",
-   "sha256": "1b6ms822j075fciijpwywzn675hbqqbaylz5iy3czlwypjg1slhh"
+   "commit": "c0ba49bb01d037ce8800aa04db06f454ef043cb6",
+   "sha256": "07ck6slz0z484lywdymh719pfmxhvfsb1cvk2bdbrx4xq89sqwq6"
   }
  },
  {
@@ -83138,11 +83188,11 @@
   "repo": "JonWaltman/pcmpl-args.el",
   "unstable": {
    "version": [
-    20210625,
-    2116
+    20210722,
+    329
    ],
-   "commit": "e6957896b065e2fda80a8258dfebb86b49742c15",
-   "sha256": "0fx7v5b3v7y9qxr8n8pm6449rdf4ljc0fb6kp0vpdzfzc4yzgdni"
+   "commit": "36139ba64f43a3d3f4090ef0118bcebfef7e20c9",
+   "sha256": "1isab23shk1gfk54z4ppbnnkrm527rzb9cvbqqa47s8gv9k7zbnm"
   }
  },
  {
@@ -84215,20 +84265,20 @@
   "repo": "vpxyz/php-quickhelp",
   "unstable": {
    "version": [
-    20201108,
-    1132
+    20210721,
+    1945
    ],
-   "commit": "e36fc61a7061044ab7984421997566b97776f722",
-   "sha256": "1zkql9zy35apidxrd29w479600nccbrzn350f0xjsq2wzmk64ci2"
+   "commit": "f22e6d31aad504094b441e2f635869fc97939ddf",
+   "sha256": "12dwjrflhbih1v75sxh0kp4w67i4xzccyxvy9601f94xnrha9s84"
   },
   "stable": {
    "version": [
     0,
     5,
-    1
+    3
    ],
-   "commit": "e36fc61a7061044ab7984421997566b97776f722",
-   "sha256": "1zkql9zy35apidxrd29w479600nccbrzn350f0xjsq2wzmk64ci2"
+   "commit": "f22e6d31aad504094b441e2f635869fc97939ddf",
+   "sha256": "12dwjrflhbih1v75sxh0kp4w67i4xzccyxvy9601f94xnrha9s84"
   }
  },
  {
@@ -86734,11 +86784,11 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20210425,
-    1720
+    20210723,
+    143
    ],
-   "commit": "4a0f5405798cfcb98ea005078ef2e2d490e922c4",
-   "sha256": "04rz8mypgslb0la4wgj3na5c8p28s9lghq4nykcb28nhcxwfvz8n"
+   "commit": "54b19cf7121d9eb679c2ba26b3c26e82c8a90df9",
+   "sha256": "122j06gav4y6ghkjgwivlfqq1y4rl52sm8wskcq1gm3g7n36ds5h"
   },
   "stable": {
    "version": [
@@ -86959,8 +87009,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "e746822cd7d8a0dcf56902d32fbadb3297690590",
-   "sha256": "09pskvha06picdlgclvwijng712s3xd5mr3kxxpp6gb02qsiy3yy"
+   "commit": "9e38442d95a49199e1a2e69aefbfe139ca9036ab",
+   "sha256": "1x42lfp3ay31lvdmjsvwqblci1bbwxhddq58fq1ip108lwqazl87"
   },
   "stable": {
    "version": [
@@ -87902,8 +87952,8 @@
     20200619,
     1742
    ],
-   "commit": "b90ec9c242b303e90811deebaa2e3e684b63de91",
-   "sha256": "11n9ybjxfc8x58fwp2f67nc6mg4qkj8m9c7ldjlp77m01k0qrij1"
+   "commit": "d662ec9c2e4f8ca21cb500b25cfe7430511014b2",
+   "sha256": "1n8ls2pm36imqg98yz20q9nyyxf4z0250mp4aigjcv3c66j8fp2a"
   },
   "stable": {
    "version": [
@@ -88203,7 +88253,7 @@
     "unidecode"
    ],
    "commit": "d781870e2f57e40110e07768289ab81d8554f122",
-   "sha256": "17d2v7q6sfafk8j1ish053xsmihi4f1hbk53fkkmhwan6sw9c4sc"
+   "sha256": "154lkpipi5wgcwx4j9w6h3zysciw7hblf03an2irr9xgdhs7xs7q"
   }
  },
  {
@@ -88271,7 +88321,7 @@
     8
    ],
    "commit": "708cae8e67dbae293c7c4be0ca5e49d76fac6714",
-   "sha256": "1v48i37iqrrwbyy3bscicfq66vbbml4sg0f0n950bnk0qagjx8py"
+   "sha256": "1bkkgs2agy00wivilljkj3a9fsb2ba935icjmhbk46zjc6yf3y6q"
   }
  },
  {
@@ -88756,16 +88806,16 @@
   "repo": "dwcoates/pygn-mode",
   "unstable": {
    "version": [
-    20210714,
-    1304
+    20210721,
+    1917
    ],
    "deps": [
     "ivy",
     "nav-flash",
     "uci-mode"
    ],
-   "commit": "321c14c195cd2f8a31b9bf99dd318a552fbbcd6d",
-   "sha256": "1sz8riry4c4lf5n0nsd3msw5kch3ifwg5psrf4y866b0wlya7yk2"
+   "commit": "30cce9c134f685d7f2db81aa879e683864a23b66",
+   "sha256": "0q4q5wziwy2nhv0yyx7k5jx6bccx9lxr4f97njb06j2nvz2x7k1v"
   },
   "stable": {
    "version": [
@@ -88790,15 +88840,15 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20210714,
-    231
+    20210720,
+    47
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "ebd3175c4c5e7845c52dddf71a806826a80df89d",
-   "sha256": "0p52a4bp4gmgwfpai8cwq3frp0fyhp9ma5a0idxdiamr8xjiwjz0"
+   "commit": "ace904840c676297138ed62abb4f1d05c837fd4c",
+   "sha256": "117h1zanyjlb566kzdx014xjzryvf6qvqa37zbyb821ajxjlpkk0"
   },
   "stable": {
    "version": [
@@ -88881,14 +88931,14 @@
   "repo": "tumashu/pyim-wbdict",
   "unstable": {
    "version": [
-    20210504,
-    1144
+    20210719,
+    38
    ],
    "deps": [
     "pyim"
    ],
-   "commit": "da51e226bca9be2ed6175298489be64e45492759",
-   "sha256": "0nl1yi3zf4pp7cksprmigm119dcp1d2477k4jdm10z7zfcq2p6r0"
+   "commit": "4812f93ee00196b8fee9f434aa5cd77fabcf90d1",
+   "sha256": "1wvzgyf3mq3wy0sdnx5jhscr5x28pgbvw8dmfyn18741xnsn26fb"
   },
   "stable": {
    "version": [
@@ -88960,17 +89010,17 @@
     20210411,
     1931
    ],
-   "commit": "6c29598ce446dc441a8095b83c82390249df3693",
-   "sha256": "0l5dg9snp4p6x3nlyl0civ50kdl1q6zr0hmx9hcp2c72hm22dqi5"
+   "commit": "a054796d7008f4531b482490f917bdef1454b8fd",
+   "sha256": "07zs0dzh500xs26ybyfz2z4wigc74l6wq3z1225gnblphhzl4jv9"
   },
   "stable": {
    "version": [
     2,
     9,
-    3
+    5
    ],
-   "commit": "aa688de05e469e33a20478144013946ccb752736",
-   "sha256": "0r2xp90bwwqnya3gq0q0gh2qdn7i9fcsq8ab890bnd0b44ivx0nk"
+   "commit": "ec8219e48f031f93377cc7d862a6f3bf80d76dbf",
+   "sha256": "1fixqimr8mq0mg5qs8wj4hbrzlw9925x72311is4s5r8phyjaabb"
   }
  },
  {
@@ -89254,7 +89304,7 @@
     0
    ],
    "commit": "906b0a107f7bcfe6e32bcfedb977e6f0f99fda59",
-   "sha256": "1vym8nlpwv9ym7yixldjxp999b26a9pr4z0pka28fldxykfccwq0"
+   "sha256": "17clkgs94dgq5nsjlwkr52m5s446ibfss3qc8a8m0zaz6j4f8l1m"
   }
  },
  {
@@ -89353,7 +89403,7 @@
     "python"
    ],
    "commit": "e606469aafec2e6beda8c589540b88a5a6f6f33f",
-   "sha256": "00i7cc4r7275l22k3708xi4hqw2j44yivdb1madzrpf314v3kabr"
+   "sha256": "0vyipfsppissa87pdnbksamdby0yl2q8nzawqivv6smn33jp6vsn"
   }
  },
  {
@@ -89424,29 +89474,6 @@
    ],
    "commit": "86d937854c45f6b2a102b42c1a991ba713532f9e",
    "sha256": "1hbb0m5kjczyri6hbgkk1par53zfnsp7m133xqzfhg2sibrvbz2x"
-  }
- },
- {
-  "ename": "ql",
-  "commit": "475bd8fd66c6d5b5c7e74aa2c4e094d313cc8303",
-  "sha256": "0wxjblqacs5nx2hyh7r6rlv1yngbhn6phn5rni4dw2dms98zj34z",
-  "fetcher": "github",
-  "repo": "ieure/ql-el",
-  "unstable": {
-   "version": [
-    20180418,
-    2020
-   ],
-   "commit": "d976414ba6aa576ad524b5ee5bfa620efd072258",
-   "sha256": "138h4ndnzpphsmi4b8yw53mxc3rnqrj1c3jp8njx5pkmiqkp1q00"
-  },
-  "stable": {
-   "version": [
-    1,
-    1
-   ],
-   "commit": "d976414ba6aa576ad524b5ee5bfa620efd072258",
-   "sha256": "138h4ndnzpphsmi4b8yw53mxc3rnqrj1c3jp8njx5pkmiqkp1q00"
   }
  },
  {
@@ -89885,15 +89912,15 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20210715,
-    2107
+    20210720,
+    2002
    ],
    "deps": [
     "faceup",
     "pos-tip"
    ],
-   "commit": "c7aca6f1b4c34a48314bc7812c2d7edc849e3dba",
-   "sha256": "1pcxicz7kg6s9j9gsdb8pba3j3n5522gclc5qq95ch2q3i5phg91"
+   "commit": "76ca5838cbc266c306aa54964410730f6fd93d88",
+   "sha256": "1q4cgsi659bk4p1avl6bpzfhlf314432mqjhj3hlyxhf4d3nza8m"
   }
  },
  {
@@ -90550,11 +90577,11 @@
   "repo": "pfchen/read-only-cfg",
   "unstable": {
    "version": [
-    20210608,
-    1259
+    20210717,
+    205
    ],
-   "commit": "a02395b37a68b2e20e365c2e3752f966c71d4c02",
-   "sha256": "0jihqc16knvws5w2y5djdir4h52mpwk86nbjlap47lh2r18qk6q6"
+   "commit": "a4e50d4fbf48970e98b2464e13f46e51a4c43c37",
+   "sha256": "1mbnyp2xknymfs2nrcw572plrwxgjacrysxaf5szr75vn2vh11nl"
   }
  },
  {
@@ -92452,7 +92479,7 @@
     0
    ],
    "commit": "c7c6b726806df7e8cb25a41b213a207850c91cb7",
-   "sha256": "0p044wg9d4i6f5x7bdshmisgwvw424y16lixac93q6v5bh3xmab5"
+   "sha256": "18rba101m9vmjl4mf3x0k7wvbgn6qmay9la745vzpr3lx1f4nn98"
   }
  },
  {
@@ -92646,7 +92673,7 @@
     "web-mode"
    ],
    "commit": "6cf58cf04fee933113857af07414b3f27c24b505",
-   "sha256": "0s3hs0w6hz8vx4172mfraiqfjhd1a9h1w61ra6fklc5fjf3y8pn8"
+   "sha256": "0b3gqs1lsk80shirsc41zajzjbg1sgzksmnfazffx88h612p7ygd"
   }
  },
  {
@@ -92829,7 +92856,7 @@
     4
    ],
    "commit": "71e475ab35555e0a1eca26d73acf1ced911e422e",
-   "sha256": "0x3mmf4gq4d0cqfqbkrrpwhayvmplacck0zc9nlzcn35y17jzpcz"
+   "sha256": "0y18i4ly61jyvxymvgjr99arhxfn5y5s659jnqf4gvyp3d671dkf"
   }
  },
  {
@@ -92952,8 +92979,8 @@
     20210313,
     1541
    ],
-   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
-   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
+   "commit": "3a057f127b931c683288f8731f05ba5e2aab4133",
+   "sha256": "1brf05grh0xdcjllaiixpjxmcg2j130gcrxkqm5v4ryb1w9fki7g"
   },
   "stable": {
    "version": [
@@ -93512,8 +93539,8 @@
   "repo": "brotzeit/rustic",
   "unstable": {
    "version": [
-    20210609,
-    1900
+    20210719,
+    1514
    ],
    "deps": [
     "dash",
@@ -93526,8 +93553,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "6ca73bb3cce4d1db3c4f91efb83b63227eb712d1",
-   "sha256": "12arrvvp3idq11a4ham77zxqp2d1026qz89ywgd3i9k1cbj852wi"
+   "commit": "26c2e09907135d5be9628c710bb0753c256b7242",
+   "sha256": "1bilqhln8m6qk5r3q8dvhhsql1c38dnf7m55kysja86bf6yb3s59"
   }
  },
  {
@@ -94642,7 +94669,7 @@
     "s"
    ],
    "commit": "91c56311b48a26aa6ef5a113b0a828e174059b0a",
-   "sha256": "1iyq8m75gzyx2ww919i4zl63gajsaczgwax214a1jgf8x91j590k"
+   "sha256": "10ikd6ksz5adpldyx9h8s3qnwc488rqixzwnd0rjjwqigmllj9lb"
   }
  },
  {
@@ -94819,8 +94846,8 @@
     20210707,
     1827
    ],
-   "commit": "48ea51aa5b6959ea2a134e36cd21f727047b0677",
-   "sha256": "0lini8hdih1qakf3hg981diw9gmzxjkd6rnjq3lddyqg6dvj9hhw"
+   "commit": "97693d0aea2c548197e9d1de3bdedf8e703775a4",
+   "sha256": "0d03sw0w2yhhmnpdn7xc0sm2n3lk11ffhkbz59kzdkcqqi7ppv04"
   },
   "stable": {
    "version": [
@@ -94846,8 +94873,8 @@
     "prescient",
     "selectrum"
    ],
-   "commit": "4a0f5405798cfcb98ea005078ef2e2d490e922c4",
-   "sha256": "04rz8mypgslb0la4wgj3na5c8p28s9lghq4nykcb28nhcxwfvz8n"
+   "commit": "54b19cf7121d9eb679c2ba26b3c26e82c8a90df9",
+   "sha256": "122j06gav4y6ghkjgwivlfqq1y4rl52sm8wskcq1gm3g7n36ds5h"
   },
   "stable": {
    "version": [
@@ -95858,11 +95885,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210714,
-    111
+    20210721,
+    148
    ],
-   "commit": "ccdd3681b9e7d8b6a758f2aa61a0ae8eab21240b",
-   "sha256": "1ynl1kwnhp5xqvmi8p37lprshk96xi8q78rsjmd9f8pkb8ayqbf3"
+   "commit": "635a71df74d755113f26a6c6d9ae48ccb485393d",
+   "sha256": "0llby9858sjfxrh6x5nklkm24lmk6d5xm6mw0y6d02pn6rinx0sx"
   }
  },
  {
@@ -96102,7 +96129,7 @@
     "s"
    ],
    "commit": "9b8cfb59a2dcee8b39b680ab9adad5ecb1f53c0b",
-   "sha256": "0kx0c4syd7k6ff9j463bib32pz4wq0rzjlg6b0yqnymlzfr1mbki"
+   "sha256": "1xnby24gpxij1z03wvx89s459jw0f8bwhgi80xvdq8gxhbbz2w7a"
   }
  },
  {
@@ -96716,11 +96743,11 @@
   "repo": "dawranliou/sketch-themes",
   "unstable": {
    "version": [
-    20210325,
-    1700
+    20210719,
+    2212
    ],
-   "commit": "407094c03e934043aa6d70369bf3e1bd841d1c91",
-   "sha256": "1glm8cxd91kq6910rrzgh3xaas67fylvgqxq2ld6gzcgmxzhv8yl"
+   "commit": "8c4b4ef49fbb059ad00ab9fb76f22c2cdd780e7c",
+   "sha256": "0lvjdcsx3gvg7lk22l5c8jmdqk9s38figlr5zcbbk7fgjpf4q0p2"
   },
   "stable": {
    "version": [
@@ -97175,11 +97202,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20210629,
-    2009
+    20210721,
+    1756
    ],
-   "commit": "41f4d650485217aa1f2afa7c159418f103a09231",
-   "sha256": "0cq1a19d1przjizp7d4vjl8khp09j6jcwavhrpja1saqhwavhv7c"
+   "commit": "e8f57c09cb4cc857887310e61eed7325500e9998",
+   "sha256": "1ipbi9h1p943mxzyc81wyrpyah41dhg33kmb3y9cy6avr2pkm1ry"
   },
   "stable": {
    "version": [
@@ -98448,8 +98475,8 @@
     "flycheck",
     "solidity-mode"
    ],
-   "commit": "5f6ef3156fadae5af6f381d674d20535529a20e4",
-   "sha256": "02rmc7naspjfl757k7zdfg9xd6nvfpsiqfcxkj6ywc7mnndpq2c0"
+   "commit": "6f7bd1641e5282ec5163188d8b8c2f6dfddc2e36",
+   "sha256": "0rkw21pic9nypv7vz06chyn9mjl560a4dayb84gj5w6v8gfznrcw"
   },
   "stable": {
    "version": [
@@ -98473,11 +98500,11 @@
   "repo": "ethereum/emacs-solidity",
   "unstable": {
    "version": [
-    20210622,
-    931
+    20210717,
+    844
    ],
-   "commit": "5f6ef3156fadae5af6f381d674d20535529a20e4",
-   "sha256": "02rmc7naspjfl757k7zdfg9xd6nvfpsiqfcxkj6ywc7mnndpq2c0"
+   "commit": "6f7bd1641e5282ec5163188d8b8c2f6dfddc2e36",
+   "sha256": "0rkw21pic9nypv7vz06chyn9mjl560a4dayb84gj5w6v8gfznrcw"
   },
   "stable": {
    "version": [
@@ -99812,11 +99839,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20210701,
-    23
+    20210721,
+    125
    ],
-   "commit": "a92d2a4f748f124910d406a9386979688f7f28a5",
-   "sha256": "1gfqskdng23dpacvmypyc2jsrw15hrrwq84qmlnwyibf0g0pjj1f"
+   "commit": "de1fdca07229e5d43c18cb3dc300397849eeab78",
+   "sha256": "0vdlcy211zx3fr8vcl6hm8xj8v3wkjj4y7pjcni9g87iijzf6gx2"
   },
   "stable": {
    "version": [
@@ -100240,8 +100267,8 @@
     20200606,
     1308
    ],
-   "commit": "ba12f620074b5a6e6615e2963bdc79fbba6060eb",
-   "sha256": "1gjmzm8lx8fas9phkbvy3rz9dyzqgdjs2ddd3l9biqqggwka0pa0"
+   "commit": "1b2058a91b7ed920952ea99b5140c60b8c7cdd1b",
+   "sha256": "1nk6mbxl416dpgwmpy52v161n2ag3gi6crrzvczx524879a9zvkf"
   },
   "stable": {
    "version": [
@@ -100249,7 +100276,7 @@
     1
    ],
    "commit": "68f949852ab7f0e8bb52c6a6fc2ece2a74ded824",
-   "sha256": "129mms7gd0kxqcg3gb2rp5f61420ldlhb0iwslkm7iv64kbxzww1"
+   "sha256": "09d69q9m4k4pwhl2k5r7d7lqd4cj0qf22cys94zjkrsyw5gggd36"
   }
  },
  {
@@ -100598,11 +100625,11 @@
   "repo": "PythonNut/su.el",
   "unstable": {
    "version": [
-    20210626,
-    2025
+    20210721,
+    1816
    ],
-   "commit": "36db018de8423a6e380a49d4e602d376a0740f6d",
-   "sha256": "08vma290dxzjxyn4df2i1kjzm24myxvsll9cxky277asbb8ja74z"
+   "commit": "1ecf7a7bbf9d88708eb2215e940753f8d6bccc92",
+   "sha256": "1994ypxz5zgrpdd5v61znf41c0dn4favab560wkgfnhhzrc1jgkf"
   }
  },
  {
@@ -101684,8 +101711,8 @@
   "repo": "countvajhula/symex.el",
   "unstable": {
    "version": [
-    20210630,
-    1816
+    20210720,
+    1708
    ],
    "deps": [
     "evil",
@@ -101697,8 +101724,8 @@
     "seq",
     "undo-tree"
    ],
-   "commit": "740d80599c0a1ff0882e231e46c61ba16c83cd84",
-   "sha256": "1zfjdrm88c16czmi4i6rm87nafpyrjpjkj79cg44l9cizyv5198q"
+   "commit": "acd0874024018a3352761ffef3ca88916370b195",
+   "sha256": "17fi4jzsfp2k1fp772b75ihjsg602qyc1vzc0k6vv0p05kiv8s2x"
   },
   "stable": {
    "version": [
@@ -101931,15 +101958,15 @@
   "repo": "vapniks/syslog-mode",
   "unstable": {
    "version": [
-    20210714,
-    1932
+    20210722,
+    1112
    ],
    "deps": [
     "hide-lines",
     "ov"
    ],
-   "commit": "ff1ab94c0f65e9891656d78d84f71614e0b9a597",
-   "sha256": "1x0xlbiisq8wngxhznkhxavhrhbc1w5p5w1qgfxib16fr09aqyc5"
+   "commit": "e18d74d8a12b943a3a64eb8c693981e55aea8e9a",
+   "sha256": "0snf3pjnhff0r7v4iwqqq3568h0a4ff7b2s3axssxk4rfg8bm3ks"
   },
   "stable": {
    "version": [
@@ -101975,7 +102002,7 @@
     11
    ],
    "commit": "3ad6d52072f0bd043dced40ba7bd422fd9c00a7b",
-   "sha256": "0pxkyys2lgn16rhf4mzqlh27vs9aw6g083z2vr2agr7bmbavd2fp"
+   "sha256": "0n4qr5qqy6hbc1hg4wi1d2ckdl870v5mf9xhv5m9vrlwaphvnnjr"
   }
  },
  {
@@ -103651,18 +103678,18 @@
     20200212,
     1903
    ],
-   "commit": "b157feff61c3bdefb138753af7636dae5a7b3c08",
-   "sha256": "1dnspcmni98xhcz21604238lskdqn6b4kpv2zllvq58si59q32mw"
+   "commit": "1486e47402a5fa7df9791bd01c7e703671de9de6",
+   "sha256": "098hf7w27223v0h7090w4s2gcw5ylnj6fdfw3c1ifhblglyrbq1n"
   },
   "stable": {
    "version": [
     2021,
     7,
-    12,
+    22,
     0
    ],
-   "commit": "faeb22efa9ed948e6096e37e65e6d121c83e329a",
-   "sha256": "1adaqcdzzrrff0186276pdmlqixkv47qfgyxap3by9zdiqwysd50"
+   "commit": "3a1532f0ee53c6746f50dbad17c248eeced05d21",
+   "sha256": "1nzx3bw472m3ajmhlwp217jyrxm31j9av4h6fw884icpnn3392s7"
   }
  },
  {
@@ -103718,8 +103745,8 @@
    "deps": [
     "haskell-mode"
    ],
-   "commit": "95c065a410c20cbeefeaabc3084b2b09d09564c2",
-   "sha256": "02xbzwj1bf0n4lvg1rycmxsbvwi0p0h9a5fqx755kshwx5hngkx3"
+   "commit": "531db05f9b15feadbc1a0df194a4f9dcd0d10c0a",
+   "sha256": "16m17q8kc0fxq1nc47ggxjjna04k27hch93q8pqilp00s7695597"
   },
   "stable": {
    "version": [
@@ -104612,8 +104639,8 @@
     20210713,
     1609
    ],
-   "commit": "07d6d82cba864b1e38d3bd46654f2e1928a997c2",
-   "sha256": "04h60s6ig43sj144s7dlip1saf9kdwvzlfys8qwwx48003rbs0dp"
+   "commit": "77e16de3b9fbaa0417b56a9acc70a9bca17c4ad0",
+   "sha256": "1ww04kfz4kkbhrbd78r4dpylhayb5hl72qcjv8wm0mhgfwmbb358"
   },
   "stable": {
    "version": [
@@ -104716,11 +104743,11 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20210712,
-    1626
+    20210721,
+    2104
    ],
-   "commit": "e90481000f071e9a26a1cc0f40d347f7d3e2201e",
-   "sha256": "1sw9248cxr3x2hy2rhyzbwik08nvlkglxgig3rbqshc8spnid5h3"
+   "commit": "769219b5f5757f1373a28e993f36b6a41c778651",
+   "sha256": "1s108ps8l563ywn4k5z64y67fgi3j0c7ln2zz9qi9xfih0lnz81b"
   },
   "stable": {
    "version": [
@@ -106271,7 +106298,7 @@
     0
    ],
    "commit": "c2f4870aff70efe70a8d1b089e56d3a2d6d048b9",
-   "sha256": "0i6jfr4l7mr8gpavmfblr5d41ck8aqzaf4iv1qk5fyzsb6yi0nla"
+   "sha256": "14ybav1f82m2gsxkciwlc0pm01ihqqaqq6arnjqvgxdnw0z6qniq"
   }
  },
  {
@@ -107081,7 +107108,7 @@
     "use-package"
    ],
    "commit": "f33c448ed43ecb003b60ff601ee7ef9b08cff947",
-   "sha256": "1wzn3h8k7aydj3hxxws64b0v4cr3b77cf7z128xh3v6xz2w62m4z"
+   "sha256": "1k1dwydqfgx2yvbipahwzk8kyj7v5ih6hkra8ladbn67x013f9rq"
   }
  },
  {
@@ -108131,7 +108158,7 @@
     "outshine"
    ],
    "commit": "5202db4c6a511a90a950a723293d11d55ec05264",
-   "sha256": "1ygx8g9cxyyhhpcqan1ca4g741s3dd141bcmp6jjqbjfn2gqraz6"
+   "sha256": "1qfjwsxi3w2gdl258jbk5d3z645gs6zccxx2iah54zbgql17pgj9"
   }
  },
  {
@@ -108688,11 +108715,11 @@
   "repo": "ianyepan/vscode-dark-plus-emacs-theme",
   "unstable": {
    "version": [
-    20210530,
-    629
+    20210720,
+    1218
    ],
-   "commit": "bcae11818d74aa0de8e592b8349d90e512444758",
-   "sha256": "1rmdin9z68xkxqjhvhyklbby5mxs3qf4wx9c07945p4ps80w8z5g"
+   "commit": "aadf603bccb51addfcbd1ee4f684f720d56df56f",
+   "sha256": "0zskaz2np8x6wz3zrkqw5bhmwzyq8llvqq5sbwjzlgdl2xph876f"
   },
   "stable": {
    "version": [
@@ -108870,30 +108897,30 @@
   "repo": "d12frosted/vulpea",
   "unstable": {
    "version": [
-    20210503,
-    624
+    20210718,
+    944
    ],
    "deps": [
     "org",
     "org-roam",
     "s"
    ],
-   "commit": "0f73528e603b1901cbe36eccd536a9113ef0439d",
-   "sha256": "030aglgmph8p9qi160ws6qv288mkwpyhhj0m946q72y7hmsc5xxp"
+   "commit": "ebbfc00978603c40222e260f06dbec9d781e3306",
+   "sha256": "1gx8h50r7mhm4p675an5a6hrm37zdcaw1lw2kpn7apr6kyi3c6q7"
   },
   "stable": {
    "version": [
     0,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "org",
     "org-roam",
     "s"
    ],
-   "commit": "c4f39b853c54cbfab48876812012e040b56838ee",
-   "sha256": "1dgmxbdvyb9vdha2swg4ahai6xvfvlr7d03y3c2c3db2jbr00aw5"
+   "commit": "16f61797090df570c182c8b3aefd6fe6c9768e93",
+   "sha256": "04i55w017d2i3sf49rs7jj4yzv51bppz6dlybk09cy5giwafv9cx"
   }
  },
  {
@@ -108966,8 +108993,8 @@
     20210615,
     103
    ],
-   "commit": "ccdd3681b9e7d8b6a758f2aa61a0ae8eab21240b",
-   "sha256": "1ynl1kwnhp5xqvmi8p37lprshk96xi8q78rsjmd9f8pkb8ayqbf3"
+   "commit": "635a71df74d755113f26a6c6d9ae48ccb485393d",
+   "sha256": "0llby9858sjfxrh6x5nklkm24lmk6d5xm6mw0y6d02pn6rinx0sx"
   }
  },
  {
@@ -109563,26 +109590,26 @@
   "repo": "pzel/weblio",
   "unstable": {
    "version": [
-    20210511,
-    2105
+    20210718,
+    1410
    ],
    "deps": [
     "request"
    ],
-   "commit": "ba0b745c3c11a93eaac826f74232f9eefbbae7a1",
-   "sha256": "00agkipgf6hc1bsrq460lydql8f04y42h4lh764k1fwg7x1a8pm2"
+   "commit": "2b4b0c206440b5c63960214feacfceb0c26231c7",
+   "sha256": "1iy1finnxqjbdivzyn7crpnha87mq1fmd98pkx2r8sk551nfw35s"
   },
   "stable": {
    "version": [
     0,
     3,
-    3
+    4
    ],
    "deps": [
     "request"
    ],
-   "commit": "ba0b745c3c11a93eaac826f74232f9eefbbae7a1",
-   "sha256": "00agkipgf6hc1bsrq460lydql8f04y42h4lh764k1fwg7x1a8pm2"
+   "commit": "2b4b0c206440b5c63960214feacfceb0c26231c7",
+   "sha256": "1iy1finnxqjbdivzyn7crpnha87mq1fmd98pkx2r8sk551nfw35s"
   }
  },
  {
@@ -109797,11 +109824,11 @@
   "repo": "jstaursky/weyland-yutani-theme",
   "unstable": {
    "version": [
-    20210530,
-    1418
+    20210717,
+    1858
    ],
-   "commit": "a56c56de048900409d271f91fd08a408fd9bf32e",
-   "sha256": "0nblkcz52qvfkf4q3yb7drv0rbpkqgzv3clwb6vkvwz13s29b6my"
+   "commit": "246410e1c03f7d8d8e76102f7c5e3cda83acb36b",
+   "sha256": "184n7k0i2m9syy7mkjxdzjm36iyfx4azchwz0aania4pqm8dz7jv"
   }
  },
  {
@@ -111097,8 +111124,8 @@
     20210511,
     1128
    ],
-   "commit": "f74a58f3cfb2e94cee4c4527b2f7aeb8fa5ab46c",
-   "sha256": "0m50xxi5nz08byxjdp5k20d075anv88lsdk1z2q66y2jqaqbxian"
+   "commit": "c310d1ba0e0238e5a22f2a584c966b8b5e7e6616",
+   "sha256": "0k7p39y0lwqr2021nq34asxc4sya4xv3w2nbxqkzjz0ddnyiw2qr"
   },
   "stable": {
    "version": [
@@ -111473,11 +111500,11 @@
   "repo": "xahlee/xah-css-mode",
   "unstable": {
    "version": [
-    20210627,
-    505
+    20210721,
+    2312
    ],
-   "commit": "62b7162198ca6659e025feb058e5662c55333ad4",
-   "sha256": "0xk5wa209pgc2sfz0j4dac57apy45si87628bqc21fnf877ga8qv"
+   "commit": "372f5bab99c06a3dbdec220ff5558046e1766476",
+   "sha256": "0gxd1sk8k8z9d0rrjpgdnh7by8yvwbh2awj4gm81c11k2ylbjcgl"
   }
  },
  {
@@ -111518,11 +111545,11 @@
   "repo": "xahlee/xah-fly-keys",
   "unstable": {
    "version": [
-    20210715,
-    2014
+    20210721,
+    1622
    ],
-   "commit": "95c54a896c1e4af797f0af7cf9de85426c8e11eb",
-   "sha256": "137xv47cij7a0zws8xdw140cwlsnywapyb9y51dqpmn08s1ff2l2"
+   "commit": "afacaeebc3225de13acf19378d7af832d6150871",
+   "sha256": "08q495fhvcm8n78smsvcz2svzjqjihmzrvp2allysvyy25ni4d5b"
   }
  },
  {
@@ -111691,11 +111718,11 @@
   "repo": "dkogan/xcscope.el",
   "unstable": {
    "version": [
-    20201025,
-    2002
+    20210719,
+    828
    ],
-   "commit": "8e441efab0757778fe3594ff68c378bf90f539f9",
-   "sha256": "0v3jypw0c9m8lbiyq9dv4b7jpqjb1lr0qx619dy9xa48rdj107rh"
+   "commit": "d228d7593d762e457340f678d14b663ef66d7cee",
+   "sha256": "0pr85ywp585imjzswm04647nb4iqqvg8jgmbcs5210qmr9kh0z8d"
   },
   "stable": {
    "version": [
@@ -111895,19 +111922,19 @@
   "repo": "ndw/xmlunicode",
   "unstable": {
    "version": [
-    20200823,
-    755
+    20210717,
+    1246
    ],
-   "commit": "0c2ee59888042d516f79a7b96526cbeae611c9bc",
-   "sha256": "026srs8nf6d5ksq30s3qy1jx4x65bdnyxz8p8nnsqlf81lbmhwq5"
+   "commit": "7e4c71c30f0d5214c45d4d4d48b149029ddb6b77",
+   "sha256": "0gc9fg95ihqz7lkn3vxc0qaslbxbj5jkhm2ddh41c3v9ym79mblp"
   },
   "stable": {
    "version": [
     1,
-    23
+    24
    ],
-   "commit": "0c2ee59888042d516f79a7b96526cbeae611c9bc",
-   "sha256": "026srs8nf6d5ksq30s3qy1jx4x65bdnyxz8p8nnsqlf81lbmhwq5"
+   "commit": "7e4c71c30f0d5214c45d4d4d48b149029ddb6b77",
+   "sha256": "0gc9fg95ihqz7lkn3vxc0qaslbxbj5jkhm2ddh41c3v9ym79mblp"
   }
  },
  {
@@ -113277,7 +113304,7 @@
     "pkg-info"
    ],
    "commit": "9adc5cf07a9117d25eaab41867ddde914c6d2f5a",
-   "sha256": "0g2vfscikz8qa0danvcickcjnz99yjm9jgk3sci094gmgwka3j2y"
+   "sha256": "1vl7nyfdpvh4ilxw1bckfkv59d6mxbb7m3z2fvrxs1gss06ks9va"
   }
  },
  {
@@ -113347,15 +113374,15 @@
   "repo": "EFLS/zetteldeft",
   "unstable": {
    "version": [
-    20210713,
-    1855
+    20210721,
+    2026
    ],
    "deps": [
     "ace-window",
     "deft"
    ],
-   "commit": "7dbf608d17786a69019867fd6b2b7d6c6edf849f",
-   "sha256": "1lq80ck08bydl98ka6j4qd6m5iqd1l8cx0y8pa2wq94vj71l65vl"
+   "commit": "f4d2e02e7b9d02799036d2dd864d45115f937fbd",
+   "sha256": "032wpg75jwh0nq9a36727f037vwaic05yqjmcc0lwz23czrkpsd5"
   },
   "stable": {
    "version": [
@@ -113809,7 +113836,7 @@
     "request"
    ],
    "commit": "98323098c37a444de49cfef44f1506e9386e8c5f",
-   "sha256": "1zr67h0w49rsi84mgf6jdili28h8782q6vjl8za0iq1hcx9zqxyf"
+   "sha256": "18hi6m2ngl9yz599q5bhifafi4vz1adc06bjl0bhb3rs62vbkwk2"
   }
  },
  {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -1600,8 +1600,8 @@
   "repo": "chumpage/ack-menu",
   "unstable": {
    "version": [
-    20130107,
-    640
+    20150504,
+    2022
    ],
    "deps": [
     "mag-menu"
@@ -1951,8 +1951,8 @@
     "annotation",
     "eri"
    ],
-   "commit": "286bbef128cb3194f8bd63cd5e497bea621c709a",
-   "sha256": "1i176damqxg0nqawhgr22ypzysnbk44aii0r81pl6zbwsvdxkqn6"
+   "commit": "c1c20b8d29838b4e0708b768d98e2edce933d15d",
+   "sha256": "1rscm80nrgr1c00vcp683rvc42wdll08jc3s2srvaxw3iadd03ln"
   },
   "stable": {
    "version": [
@@ -2182,16 +2182,16 @@
   "fetcher": "github",
   "repo": "alan-platform/AlanForEmacs",
   "unstable": {
-   "version": [
-    20210721,
-    1343
+  "version": [
+    20210728,
+    1427
    ],
    "deps": [
     "flycheck",
     "s"
    ],
-   "commit": "c1c4205d2cdf8bf69b22e62548568ed4a8529807",
-   "sha256": "023lzr112gjscmyqgfz5ib3a80s3bis72acsaxnk4jw32knjy4yl"
+   "commit": "6e2005441af34fe54872c00ed793f6084f25c3f8",
+   "sha256": "0fqbjklfglgiy838j37p0v0rcvzj48vps8zsn0bmnabnd5vsrc3b"
   },
   "stable": {
    "version": [
@@ -2333,8 +2333,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "f3688475bba4c451fdfe52ad95fb25c7050ec9f9",
-   "sha256": "02h6xhnnbx27gq3xm2f2j3py5h94kcg8m8399j7dhski60ncn4b4"
+   "commit": "8089607dc118827e832d4bd524b3c0f0f56e8cdd",
+   "sha256": "1im0k28skb9skxxfkh279j91xjfc4c7qnmwc8l6sgazhglj5rqs6"
   },
   "stable": {
    "version": [
@@ -2441,11 +2441,11 @@
   "repo": "domtronn/all-the-icons.el",
   "unstable": {
    "version": [
-    20210703,
-    2203
+    20210728,
+    2330
    ],
-   "commit": "9d97c074b08000eacefc03ebc5dadbdc33888cc2",
-   "sha256": "06ya21isl47cfs4fsl8k3qzh7d27gss0snxv7mmv8a0c7rgjyx7j"
+   "commit": "e01eeb40858f971e45c014726a14c75556d8cc8f",
+   "sha256": "0psyfmajz2rsi5asv07514zd7vlwzk42hff4dcbmycyf7s998ifn"
   },
   "stable": {
    "version": [
@@ -2513,14 +2513,14 @@
   "repo": "seagle0128/all-the-icons-ibuffer",
   "unstable": {
    "version": [
-    20210721,
-    651
+    20210727,
+    808
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "a3cc2d96f619a2a6cf1cb6ad881ab6e509ac8fc3",
-   "sha256": "09l0y99lqi3p7h0ll3hm13zi6kp2pbya8rdpvqrx7jpkg3w5slfk"
+   "commit": "c1c0606a793b71c8c1efc3c55dfcc22182214f24",
+   "sha256": "0p0icyj9084q7gm3bjknxgxd6g36sgy3b1kpxlm3fmh93j0v6l32"
   },
   "stable": {
    "version": [
@@ -2575,15 +2575,15 @@
   "repo": "seagle0128/all-the-icons-ivy-rich",
   "unstable": {
    "version": [
-    20210721,
-    653
+    20210727,
+    757
    ],
    "deps": [
     "all-the-icons",
     "ivy-rich"
    ],
-   "commit": "b20df3e2c901a107441b6246b9d03fa3dc57f47f",
-   "sha256": "1hqf3jqpq0viygxnbkq7rsabpyygz2kr6nl6jrarm8wdczs55rpr"
+   "commit": "2a4baba0343d1e4dcabc29e5ccca596fd032ac90",
+   "sha256": "1fy86vkn5j0v9brkfzfjrwr1zrp792i7pxywlrflahcbxd8v68pp"
   },
   "stable": {
    "version": [
@@ -3217,8 +3217,8 @@
     20200914,
     644
    ],
-   "commit": "286bbef128cb3194f8bd63cd5e497bea621c709a",
-   "sha256": "1i176damqxg0nqawhgr22ypzysnbk44aii0r81pl6zbwsvdxkqn6"
+   "commit": "c1c20b8d29838b4e0708b768d98e2edce933d15d",
+   "sha256": "1rscm80nrgr1c00vcp683rvc42wdll08jc3s2srvaxw3iadd03ln"
   },
   "stable": {
    "version": [
@@ -4102,7 +4102,7 @@
   "unstable": {
    "version": [
     20210501,
-    1536
+    1527
    ],
    "commit": "9a8cd0c3d5c120bfa03187c54dba6e33f6e3ca19",
    "sha256": "1s2gdilaf38m2dg6nm4kcz5n4n455a9127pl4cbz9lg7mp3l2pg5"
@@ -4604,14 +4604,14 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20210615,
-    1457
+    20210728,
+    2054
    ],
    "deps": [
     "packed"
    ],
-   "commit": "0f3afc6b057f9c9a3b60966f36e34cb46008cf61",
-   "sha256": "0grb9y7v7ibbcjv1yhssnavz43cij16ys5c68my8mv12wg5ld86z"
+   "commit": "504863340fa82cf8aca785ad1f2a541be598c3d6",
+   "sha256": "0d1z6k4gcx9yxvvsi9m3pz0nfbql1f2vs29ccjcdycaxlq04k7ls"
   },
   "stable": {
    "version": [
@@ -5532,8 +5532,8 @@
     "avy",
     "embark"
    ],
-   "commit": "c0a3e5398c3303d9336d3614ff8e2ce543501eaf",
-   "sha256": "18g86ymca74jkkrpjqxcy289rna968qrk4gpn09k52zf83xaafha"
+   "commit": "4f969299a4726058fae8773bd9c4fb7c58371c86",
+   "sha256": "1mfhqv66j45mqs90i5jywxw8cv5v1df42s4q5svx9f75jjwrn8l7"
   },
   "stable": {
    "version": [
@@ -7038,14 +7038,14 @@
   "repo": "bdarcus/bibtex-actions",
   "unstable": {
    "version": [
-    20210714,
-    1030
+    20210727,
+    1208
    ],
    "deps": [
     "bibtex-completion"
    ],
-   "commit": "6b9a075aebd85fee8a071ffbbada1158ecd470d4",
-   "sha256": "0ihpm7pnlx5acj7jmrqr9di92908mz7z3k1kg62k8vxj2q43a00c"
+   "commit": "a2569ef74b40ed6b6459ed1b1b19e12282b426d0",
+   "sha256": "02yvr60ri07igfq8c0v2a0hybqzkvnacqp34jv1y4dhd5igbhfdc"
   },
   "stable": {
    "version": [
@@ -7067,8 +7067,8 @@
   "repo": "tmalsburg/helm-bibtex",
   "unstable": {
    "version": [
-    20210718,
-    1044
+    20210725,
+    1459
    ],
    "deps": [
     "biblio",
@@ -7078,8 +7078,8 @@
     "parsebib",
     "s"
    ],
-   "commit": "a0d32ab16748b7b0c43d6421f1b497b7caf8e590",
-   "sha256": "0a0mn41lvqjx8rdrfgff5fjs757nin30caap7ciapnvr18g9mh5h"
+   "commit": "12079bb09f203dda5cc2dd003bd60a6ad490f762",
+   "sha256": "11y1yif6z26cc502s72p310z9m6130p5kyqb2py74r3x0k0nc61s"
   },
   "stable": {
    "version": [
@@ -8927,14 +8927,14 @@
   "repo": "alphapapa/burly.el",
   "unstable": {
    "version": [
-    20210709,
-    415
+    20210726,
+    125
    ],
    "deps": [
     "map"
    ],
-   "commit": "a67a026db0937b26c0b7a2fcf81bf44498ad2dd1",
-   "sha256": "0xck02i9l0yw7yzy6sgzg17k2hyqaj9lvafp7r229xzw8rdzl8cr"
+   "commit": "59fa9e92abdf1e730f8f3908d5a42852c10c5e2b",
+   "sha256": "1jbfsr28fhf945lhhbds89a9g5c8rbpmykwg8z5adp8ncfj6pw99"
   },
   "stable": {
    "version": [
@@ -9616,8 +9616,8 @@
   "repo": "beacoder/call-graph",
   "unstable": {
    "version": [
-    20210311,
-    830
+    20210728,
+    802
    ],
    "deps": [
     "anaconda-mode",
@@ -9626,8 +9626,8 @@
     "ivy",
     "tree-mode"
    ],
-   "commit": "3e5c510c51dd8b3491a32a1d67ad6268033348ee",
-   "sha256": "1jj8bj9a05dq0igxd2ddf0p9gc9sbffcn0wy3b26qlcspcvbpm1h"
+   "commit": "7a40f9ddb16a6ce9345e0bd632109b7e2048baa1",
+   "sha256": "18as7vq8cmhxkxgh0p8qlifyvza66n6xf9a2fi07wc4acp2gpn55"
   },
   "stable": {
    "version": [
@@ -9760,8 +9760,8 @@
     20210707,
     2310
    ],
-   "commit": "583f07515b3be254ec150ce1dadabb48fdfa5bd3",
-   "sha256": "1nccl2v2fvpmsmvga1ghb9kb72v90bgdqhxb153086qx69s7vlcn"
+   "commit": "c4c70235ebbfc1733789f07f084c2d071679feee",
+   "sha256": "063gfjlay5fdgd19q363np9p5s24hxrwvxbxahkjjfn40mnb6nqi"
   },
   "stable": {
    "version": [
@@ -10449,8 +10449,8 @@
     20171115,
     2108
    ],
-   "commit": "94d292543d4869c3c5b48bb4dd1e5d901ce6227e",
-   "sha256": "12pxnwgfr0ypf80hpgrqyb789wj41gv8cbzsr1jks7pinvpda65f"
+   "commit": "d33da533194106a0a30dc4a22f11acbd2846cfba",
+   "sha256": "0q89wmfa4pi2a3vs9qcy27dharxlqpxm9b4lpxbjzii9f08fad0x"
   },
   "stable": {
    "version": [
@@ -11240,8 +11240,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20210706,
-    1151
+    20210729,
+    521
    ],
    "deps": [
     "clojure-mode",
@@ -11252,8 +11252,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "fe8cf244fd3426261f9f630c981a6296afd433a4",
-   "sha256": "02xj7g6jnwd9vjr8jipqvwy89zadkzsak08pq8418hz2af26bvaf"
+   "commit": "52ad2bc4ebadf6692d9c2d5cfcae467e149beea6",
+   "sha256": "15vr53diq6q8sj9cnb3w8smxx6jlxp0ps4vjqk24yv1lgycfq0ng"
   },
   "stable": {
    "version": [
@@ -11522,8 +11522,8 @@
   "repo": "andras-simonyi/citeproc-el",
   "unstable": {
    "version": [
-    20210719,
-    918
+    20210727,
+    1320
    ],
    "deps": [
     "dash",
@@ -11533,8 +11533,8 @@
     "s",
     "string-inflection"
    ],
-   "commit": "b46d3c3c6e5a00237f62084c64a25c4b4efabe1b",
-   "sha256": "0gyyxaiky82km9c897vvslnin7yll3yzjfz0fd5zg7lz4kmjilqk"
+   "commit": "ad453630ced1fd1aa1f760b96da1cd702c77aaa9",
+   "sha256": "1v7k1psvj1n90y5nb8cflapfzn5hf75hxsfdmy4ppliw97b5bq9d"
   },
   "stable": {
    "version": [
@@ -11600,11 +11600,11 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20210722,
-    1158
+    20210728,
+    125
    ],
-   "commit": "45e7f801744f471b43fdd96cfe734a4a3796bab6",
-   "sha256": "1sdj2nvgnbvsz2cvgzpr0axzm4gcb0sna0ps37mbxb0y356xyzfv"
+   "commit": "5c5958e467e4da7a8578039643d5036b3395e3d6",
+   "sha256": "1fal5cbj1wbji4ail1b8k9bc3c8mps7m68j7lk2086x67l1il9di"
   },
   "stable": {
    "version": [
@@ -12225,8 +12225,8 @@
     20210706,
     1318
    ],
-   "commit": "3e426b3a479f479963f2c7d1147cc826ed1a0ee1",
-   "sha256": "16smnr1hlbv347wnzhncasz5ihy0sb4fcpx5dw9v8az5r3q8xpak"
+   "commit": "ba59133b8ebdd98fdd282d21514dc718d600568a",
+   "sha256": "0lynpgkrl7vn12zfdhknsv94i3myamzlqwi9wd8fh06q9i0a81cz"
   },
   "stable": {
    "version": [
@@ -12252,8 +12252,8 @@
    "deps": [
     "clojure-mode"
    ],
-   "commit": "3e426b3a479f479963f2c7d1147cc826ed1a0ee1",
-   "sha256": "16smnr1hlbv347wnzhncasz5ihy0sb4fcpx5dw9v8az5r3q8xpak"
+   "commit": "ba59133b8ebdd98fdd282d21514dc718d600568a",
+   "sha256": "0lynpgkrl7vn12zfdhknsv94i3myamzlqwi9wd8fh06q9i0a81cz"
   },
   "stable": {
    "version": [
@@ -12555,17 +12555,17 @@
     20210104,
     1831
    ],
-   "commit": "f7a3031b7defbc805a39a8b23dbefe10764d956b",
-   "sha256": "13036j6019viskahslw3vq28h5kn1xr6ap61l2hvgzpimriam012"
+   "commit": "9251205512c49bbdda5d82f48126dc5b8e79d70f",
+   "sha256": "0jkkb213w1zngask7n542rj8idjxvzbxy51pgydhas57m6xng4af"
   },
   "stable": {
    "version": [
     3,
     21,
-    0
+    1
    ],
-   "commit": "ff7a2e37bfff23ce1751a93b3eba179fbf32a9b6",
-   "sha256": "061cjj5mni91p6b0mpp6a2zrkrmw1hc3l4cci6lcqbx733y192fq"
+   "commit": "f7cf69e34a1607e8ea2b6d10fef6a6058377c24e",
+   "sha256": "18gwkb8p9086qg4acfbs74891nzh5wqs3id6iv5zqwc76kvcb4y7"
   }
  },
  {
@@ -13807,14 +13807,14 @@
   "repo": "redguardtoo/company-ctags",
   "unstable": {
    "version": [
-    20210629,
-    1038
+    20210723,
+    1322
    ],
    "deps": [
     "company"
    ],
-   "commit": "cf7bfdbfedc8ca4ee134c8d66e70eb6035185174",
-   "sha256": "0ysf3gd3fk74j203y2zg3rq41jx42wgk1y1fn2g5giawazi7ym2x"
+   "commit": "ff813c58e930d01fb55ee2f57fe810896a12c51b",
+   "sha256": "0v5a7aaqj1p2c6ci34v31r4jb1wd29rff7n779n3klaqjbkg3b6h"
   },
   "stable": {
    "version": [
@@ -13965,6 +13965,40 @@
    ],
    "commit": "4ba7dc60ba67f736e698a5fa0b754b866f36a646",
    "sha256": "1rhf2hr345953mkn52i58aiq8j16ps2ckapd5f7jxmhkcpzxxfhk"
+  }
+ },
+ {
+  "ename": "company-emojify",
+  "commit": "a83aa15fa8c6fa2e8fd22c8368be18714d97861f",
+  "sha256": "07rnpz30k38cmh20r1gf6zimch4y8kxyhrl5bk03x887hwkrwc4y",
+  "fetcher": "github",
+  "repo": "jcs-elpa/company-emojify",
+  "unstable": {
+   "version": [
+    20210718,
+    424
+   ],
+   "deps": [
+    "company",
+    "emojify",
+    "ht"
+   ],
+   "commit": "cebfff07a21f885f87a692ec4d5e7f84468c6565",
+   "sha256": "1ishjn1biv9irm3ih96b0larsz6jq81lxd7jjkh4nqjs1207gcij"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "company",
+    "emojify",
+    "ht"
+   ],
+   "commit": "015dc2cee7c9713794efd44d398a12eb62a94185",
+   "sha256": "0w1pvknlnbz9q9v9krq4cvfjmk1mzhcvyh61qqn5m9srgc3hdkg3"
   }
  },
  {
@@ -14766,8 +14800,8 @@
     "company",
     "prescient"
    ],
-   "commit": "54b19cf7121d9eb679c2ba26b3c26e82c8a90df9",
-   "sha256": "122j06gav4y6ghkjgwivlfqq1y4rl52sm8wskcq1gm3g7n36ds5h"
+   "commit": "027c2137a8d9e01a1d4c7b5e5d98da017dd2d48e",
+   "sha256": "04hwfqia53bk2fi7kw1pzwi5v0rgimr15kw6mmjlvcmwk0c1mghr"
   },
   "stable": {
    "version": [
@@ -15720,11 +15754,11 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20210722,
-    1644
+    20210729,
+    844
    ],
-   "commit": "d42ccdca5bbc4c437819cf4d29c7b8728ed090bc",
-   "sha256": "134flhq2rx2qjhfc5fspsijpdiv7a3z5mk0j1pwipfwfkid27nqk"
+   "commit": "ebed71d554a5eda6914de6519cd30b867e9dbc28",
+   "sha256": "1bk9h3yh4r7l0jsmas83sa0hvzsbj8zvracf081jdhi7vl27p9zq"
   },
   "stable": {
    "version": [
@@ -15839,15 +15873,15 @@
   "url": "https://codeberg.org/jao/consult-notmuch.git",
   "unstable": {
    "version": [
-    20210701,
-    422
+    20210725,
+    2113
    ],
    "deps": [
     "consult",
     "notmuch"
    ],
-   "commit": "9e65c421cf54ca12234acad727818fa0fe60fa3e",
-   "sha256": "19flyh3v1xm2zswzjkvjbijvpbq5r8isafza4fd0yicvqbjyklhx"
+   "commit": "62462df58ecd888ae8a3a8421078227acdfd36d1",
+   "sha256": "0z4ayx6xh9x9rqj1shm4kw4q1xw99xncisd0c4m9g5qbn4mq6yas"
   },
   "stable": {
    "version": [
@@ -16219,8 +16253,8 @@
     "ivy",
     "swiper"
    ],
-   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
-   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
+   "commit": "031d4d051da1d8fd20f0f46e8df66c426bf3174c",
+   "sha256": "16hsnh0l51vayr7a8h4y9h63pw0w5kzsdwhk90bypf2fpjgqdx94"
   },
   "stable": {
    "version": [
@@ -16414,26 +16448,26 @@
   "repo": "redguardtoo/counsel-etags",
   "unstable": {
    "version": [
-    20210608,
-    206
+    20210725,
+    821
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "2c1f2161d36f70e0034e29abecfcb8878b30b6ac",
-   "sha256": "1hcsz773i67i82crzczm4csjkl9qj430m73lpvqkh7if543bs030"
+   "commit": "84fff26b0f207131c2e6669bd7f510eac43973aa",
+   "sha256": "07445bbr68q1pnwpj5bwqmml9ky1gq67g24zswv8fylnzjkhy9wc"
   },
   "stable": {
    "version": [
     1,
     9,
-    16
+    17
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "894cd7e25a2f96e29b70897ab799e7dd9e4f85fd",
-   "sha256": "01si554r0s6m7ypx1m2n0z6j6q6yihifz76dha6q6v56ixdlv626"
+   "commit": "84fff26b0f207131c2e6669bd7f510eac43973aa",
+   "sha256": "07445bbr68q1pnwpj5bwqmml9ky1gq67g24zswv8fylnzjkhy9wc"
   }
  },
  {
@@ -17389,25 +17423,20 @@
   "repo": "emacs-csharp/csharp-mode",
   "unstable": {
    "version": [
-    20210624,
-    1320
+    20210727,
+    1254
    ],
-   "deps": [
-    "tree-sitter",
-    "tree-sitter-indent",
-    "tree-sitter-langs"
-   ],
-   "commit": "093f0f21a9d04d79a380de145cbc42693ef8c76f",
-   "sha256": "1150s8zz9z6pmr9m8jny7g8qrhxdnpbk4nzrlyddhaf9hkw9nfi9"
+   "commit": "27cd2e8da1f374fd9db121826bf78484b0e4079e",
+   "sha256": "1qrcxyn9n2xn4k2is8q8brvicncc9x78gq3sl8xw00smww3i3rdj"
   },
   "stable": {
    "version": [
     0,
-    11,
+    12,
     0
    ],
-   "commit": "84664285a6d215998da763dc5d286d4f941df81e",
-   "sha256": "0aq6ln92jr3hcrd1592n4s5cb079fly7qaj2hm510p9zckyfx230"
+   "commit": "69fe52b5908e1b29b2765d7e01cd6a8f0fc16332",
+   "sha256": "1x40xm9d5sbxbnyxl12ppkzlgxzyn0bjg2vmc139jpkazmmw7r7k"
   }
  },
  {
@@ -17643,11 +17672,11 @@
   "repo": "raxod502/ctrlf",
   "unstable": {
    "version": [
-    20210418,
-    2044
+    20210724,
+    126
    ],
-   "commit": "dbe83710d06bc39315f1455f6f21479f3747c0aa",
-   "sha256": "0nl7mh1i9pw039gd0ma6xrv499aw2vs3a1fm1bxz71hh13jmbd4c"
+   "commit": "b78e129a8a4fabfebba8cdd5ef51278d0d57e0f4",
+   "sha256": "0j3rsax644x8753hginn0cd8sm86wf521p1rjqspdhgpi4dv0cdq"
   },
   "stable": {
    "version": [
@@ -17895,6 +17924,21 @@
   }
  },
  {
+  "ename": "cursor-flash",
+  "commit": "6a269e5187fd244f67adb83b940eedcbd643a0c2",
+  "sha256": "0y7ngpxwid83rgw1fbmrp7xifkkvf04a9s6wdfd2l8jdyh0jvn65",
+  "fetcher": "github",
+  "repo": "Boruch-Baum/emacs-cursor-flash",
+  "unstable": {
+   "version": [
+    20210722,
+    445
+   ],
+   "commit": "6bb54a1e2e1bf9df80926718b1b8b9ee49080484",
+   "sha256": "1zav30zkf7ir5zwy9625wldg4kaf8bk3mn1py5sidihpn299319b"
+  }
+ },
+ {
   "ename": "cursor-test",
   "commit": "6439f7561cfab4f6f3beb132d2a65e94b3deba9e",
   "sha256": "1c1d5xq4alamlwyqxjx557aykz5dw87acp0lyglsrzzkdynbwlb1",
@@ -18075,8 +18119,8 @@
     20190111,
     2150
    ],
-   "commit": "e46e9dd7c37d8d7ad432a94fff5daafa7fa444e3",
-   "sha256": "0lbla1pbqk2gaprkwdyxg5x381nmxx1jcc9snls6crlsf8bbhrm4"
+   "commit": "0574dbceef7b8ee16a9cc94091c3629dfa23133d",
+   "sha256": "1gnwy0pdxwwwicp46w9g9mcsnz070wb7hjvrj33nilsv796m3kss"
   },
   "stable": {
    "version": [
@@ -18173,11 +18217,11 @@
   "repo": "cbowdon/daemons.el",
   "unstable": {
    "version": [
-    20200421,
-    912
+    20210728,
+    1514
    ],
-   "commit": "a26155d04cec399ffe25b88f71cbfa4ada784569",
-   "sha256": "0bvfcrr3blyz0861ysfw2qbfh1iq8nfdh1kw9wz4m7g6big27qgd"
+   "commit": "cbab674d995022c1c223bfccf13d8009c7c4e2ba",
+   "sha256": "0h08k9g746j1kg4138am3v7lv9w6fg7yrz2hzm7x737qmg852chn"
   },
   "stable": {
    "version": [
@@ -19075,8 +19119,8 @@
     20201011,
     1543
    ],
-   "commit": "4fd5547a54ee931f4a16adde1d3b52bf01ce045a",
-   "sha256": "07yar2b0h8d16j3q55cw2mdk88akvsab6z7bpkzavyqalgvd061b"
+   "commit": "6f09126b2e97b2e195145204caba11d0d4f871df",
+   "sha256": "0qrjy3zs2xjf54b7kcwxbds99il76zxlx219c5d1siq6bkv0z0k4"
   },
   "stable": {
    "version": [
@@ -19889,8 +19933,8 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20210615,
-    1539
+    20210716,
+    241
    ],
    "deps": [
     "cl-lib"
@@ -20287,14 +20331,14 @@
   "repo": "tilmanrassy/emacs-dir-treeview",
   "unstable": {
    "version": [
-    20201003,
-    2206
+    20210625,
+    2358
    ],
    "deps": [
     "treeview"
    ],
-   "commit": "53dc9dae71d1be3a7a925332a53e72d2bd05366b",
-   "sha256": "0hgcargxbl58f4im57c1zqwnfxl52lfv78s8l69njjggvdki0hz1"
+   "commit": "c48b0e12eb02ae046cf6dc97fe006db31ded3f2b",
+   "sha256": "07hhy41h1qx38rrf6f9b2r13chs3v4mzyplhpx1r6wjrj0nmh2pv"
   }
  },
  {
@@ -21020,15 +21064,15 @@
   "repo": "ShuguangSun/dired-view-data",
   "unstable": {
    "version": [
-    20210529,
-    600
+    20210724,
+    1015
    ],
    "deps": [
     "ess",
     "ess-view-data"
    ],
-   "commit": "c865c34536d9c3140ce647f03c8b7498b46e935c",
-   "sha256": "0xca6kjr9qf7w9hz63hfai2hl055cdp5gm8nldr1xjv5gk42765h"
+   "commit": "92dc267bcaac1b6258ad595488bf10b88882b5ae",
+   "sha256": "00zzcrhjkc3f0wfda3a843wk0ajkhyi8qi4jy0lax4myc0i8mpsk"
   },
   "stable": {
    "version": [
@@ -22014,14 +22058,14 @@
   "repo": "emacs-pe/docker-tramp.el",
   "unstable": {
    "version": [
-    20210526,
-    748
+    20210729,
+    508
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "aaee11cedf7b4c31700f24a1fd88dcef9c2a7c3d",
-   "sha256": "120sxrifn82hhrqhqdy0dhnni353vwzkkd5x7inqg1wpzsxjwhzl"
+   "commit": "7bfbb55417e7d2aac53adf92cb0e3fd329c495c1",
+   "sha256": "078hqc8rqw27v5li8dgmh9sspfrypha6h7hx4iagjwndb2llg2ix"
   },
   "stable": {
    "version": [
@@ -22306,14 +22350,14 @@
   "repo": "hlissner/emacs-doom-themes",
   "unstable": {
    "version": [
-    20210714,
-    1511
+    20210728,
+    2333
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b7995ac041f8dadb021cd2445e85d29c9bf718ae",
-   "sha256": "09hhplhb0832ja9nnsq3d4p6g0fdw2sp9kl2y4n2kk6zq909ar54"
+   "commit": "9e2680b9188ebd58c490598684bb7545ba01950d",
+   "sha256": "1yricwp9xndkqask5gg4frg5axmjn2g65z8bbazg9gixvsj4gbbq"
   },
   "stable": {
    "version": [
@@ -22510,8 +22554,8 @@
    "deps": [
     "debian-el"
    ],
-   "commit": "0f2a8257788a2f99e87326e52402f69e3f534903",
-   "sha256": "1hkabhnbiwygcx3blv3hc819m3bckkcngsf280pfg2y1xmd9n7b2"
+   "commit": "458f5230d02b15c94e94eca1af4eabaec30f45db",
+   "sha256": "0cdsi18vn3la9yaq4nbpvvhrblr36x0lc54wp7gv75rlg23fbl5a"
   },
   "stable": {
    "version": [
@@ -22970,8 +23014,8 @@
     20210715,
     548
    ],
-   "commit": "07dd21abc029f50c6a3a96f2867d31102366faba",
-   "sha256": "0pvbvzdljxq7mjfsx4fcm3782wdawx2mgzi4hy7kvw7z80n9zm7k"
+   "commit": "d1e683b1489ff830d61566876a94b1da35bc2aaa",
+   "sha256": "0yi88xd0h3mbggjhay66pz7j55hjvqln7cs0av2na9d5mf70asrb"
   },
   "stable": {
    "version": [
@@ -23543,15 +23587,15 @@
   "repo": "masasam/emacs-easy-hugo",
   "unstable": {
    "version": [
-    20210303,
-    2352
+    20210726,
+    2034
    ],
    "deps": [
     "popup",
     "request"
    ],
-   "commit": "b3c9ca2a4e1d90013a7d990056d56cdf2bdf8e40",
-   "sha256": "1g48c2142yqs8ir2872q0zdl46qprx2mhhhd9jvcscakm4xv3cdf"
+   "commit": "279d242d66dd48f7a59405167dff332a569f4c1d",
+   "sha256": "0cvzq29299lsh6rq4sxmz2fdsnapbv4iqrx2bnsvld9dpm01m6j6"
   },
   "stable": {
    "version": [
@@ -24730,8 +24774,8 @@
   "repo": "millejoh/emacs-ipython-notebook",
   "unstable": {
    "version": [
-    20210522,
-    1036
+    20210723,
+    1958
    ],
    "deps": [
     "anaphora",
@@ -24742,8 +24786,8 @@
     "websocket",
     "with-editor"
    ],
-   "commit": "09af85821e4fce64675d5287fe9f3a6847d1c5d2",
-   "sha256": "12b8idh2mpd37nrc8ricr4s4hz4wgnp7cy1298qcpxl00xx99dqw"
+   "commit": "983ee612f81c1f976bc1ebce2bfe574a825ba9ed",
+   "sha256": "1hfsbw5fgxbxma7smzmdc7qa4f9affrgs19xxk3dk0p659789lip"
   },
   "stable": {
    "version": [
@@ -24765,24 +24809,6 @@
    ],
    "commit": "42f8efc54bfb915248972490a4b438b8d5bda381",
    "sha256": "0jnqi8pq83s8q0dy2y1518yz8lsc0graqrqf8frss21fcj7ny22g"
-  }
- },
- {
-  "ename": "ein-mumamo",
-  "commit": "bd8fcf7f6332f94dc37697f9412c8043da8d4f76",
-  "sha256": "029sk90xz9fhv2s56f5hp0aks1d6ybz517009vv4892bbzkpjv1w",
-  "fetcher": "github",
-  "repo": "millejoh/ein-mumamo",
-  "unstable": {
-   "version": [
-    20150302,
-    28
-   ],
-   "deps": [
-    "ein"
-   ],
-   "commit": "028fefec499598add1a87b92ed991891f38f0c7b",
-   "sha256": "1w0b3giy9ca35pp2ni4afnqas64a2vriilab7jiw9anp3ryh6570"
   }
  },
  {
@@ -25619,14 +25645,14 @@
   "repo": "Manoj321/elfeed-dashboard",
   "unstable": {
    "version": [
-    20201218,
-    347
+    20210727,
+    603
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "9e8e212da9ea471bdc58bc0a1f5932833029bb38",
-   "sha256": "182kr8nqrnf1lpiqbl04qm6871yvk0z53dxxdjc2y9xnh6dvx460"
+   "commit": "b143f8453aed2053e8fc6f05cef6233797408546",
+   "sha256": "1yvr3fg5dx0z6h7jbv3fvn5ccw5grpcaj2ynp7zri5y388g160ql"
   }
  },
  {
@@ -26294,11 +26320,21 @@
   "repo": "jcaw/elnode",
   "unstable": {
    "version": [
-    20190608,
-    1623
+    20190702,
+    1509
    ],
-   "commit": "305c532b6e59f58c4afcfb76466dbfbdc4e58b9c",
-   "sha256": "1214216wrdhfw3lbf59vnddk28hi4g3s1ksdi5walksihd3gh7my"
+   "deps": [
+    "creole",
+    "dash",
+    "db",
+    "fakir",
+    "kv",
+    "noflet",
+    "s",
+    "web"
+   ],
+   "commit": "29ef0f51a65a24fca7fdcdb4140d2e4556e4bb29",
+   "sha256": "1bks7aakhvdab56gbsa44ca9kbilajisdd9bns485d9wr62d2lgj"
   }
  },
  {
@@ -26456,20 +26492,20 @@
   "url": "https://thelambdalab.xyz/git/elpher.git",
   "unstable": {
    "version": [
-    20210720,
-    1520
+    20210729,
+    1123
    ],
-   "commit": "3cddc8bdcb0a05ecd308c310bcd020f7288af4de",
-   "sha256": "12xcra3a5bsihcfqs014bcayw0wmv5f22gdk6dipfx1pjygz1x1k"
+   "commit": "2cdf02e99dbd2d7f765c08ad2f8477b4ea07d5f7",
+   "sha256": "19gsy0q8qddsm7mcf8ijkw2f92cqg7q32x7yhqblmmwbqa7zcsjf"
   },
   "stable": {
    "version": [
-    2,
-    10,
-    2
+    3,
+    1,
+    0
    ],
-   "commit": "1edbaec565d413a9c7d4c55e9356c38b2037e0f5",
-   "sha256": "0xqiisirpvw4ka9417pq4r73x937wl3qbf8cpn2i03akm8d58smd"
+   "commit": "8c20802c5f2262440dadbdca60b7901d09ca022f",
+   "sha256": "0a6qfm7x4nbfanjv33h1zgcwnywd77qbc4adya5kx8lndcn0669l"
   }
  },
  {
@@ -27129,11 +27165,11 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210723,
-    47
+    20210729,
+    1843
    ],
-   "commit": "c0a3e5398c3303d9336d3614ff8e2ce543501eaf",
-   "sha256": "18g86ymca74jkkrpjqxcy289rna968qrk4gpn09k52zf83xaafha"
+   "commit": "4f969299a4726058fae8773bd9c4fb7c58371c86",
+   "sha256": "1mfhqv66j45mqs90i5jywxw8cv5v1df42s4q5svx9f75jjwrn8l7"
   },
   "stable": {
    "version": [
@@ -27152,15 +27188,15 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20210717,
-    1845
+    20210729,
+    1543
    ],
    "deps": [
     "consult",
     "embark"
    ],
-   "commit": "c0a3e5398c3303d9336d3614ff8e2ce543501eaf",
-   "sha256": "18g86ymca74jkkrpjqxcy289rna968qrk4gpn09k52zf83xaafha"
+   "commit": "4f969299a4726058fae8773bd9c4fb7c58371c86",
+   "sha256": "1mfhqv66j45mqs90i5jywxw8cv5v1df42s4q5svx9f75jjwrn8l7"
   },
   "stable": {
    "version": [
@@ -27327,16 +27363,16 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20210619,
-    1246
+    20210726,
+    1926
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "6e0aaaf4c5598826b24c3079b80bf8af000a77c6",
-   "sha256": "016y0w1gy8z1gdri54njas20l3kw99jg5bjyrmcbmgzjmb1jq0y8"
+   "commit": "a0e26c1a143778f7378ec8a053725726e1e6aeef",
+   "sha256": "0j1jjwavdl3q33rn6zx9z3ka87d9fihd9s5bhrgw3x4fvgv8gikg"
   },
   "stable": {
    "version": [
@@ -27769,8 +27805,8 @@
   "repo": "rejeep/enclose.el",
   "unstable": {
    "version": [
-    20120618,
-    2019
+    20121008,
+    1614
    ],
    "commit": "2747653e84af39017f503064bc66ed1812a77259",
    "sha256": "0dz5xm05d7irh1j8iy08jk521p19cjai1kw68z2nngnyf1az7cim"
@@ -27910,7 +27946,7 @@
   "unstable": {
    "version": [
     20130407,
-    1236
+    1348
    ],
    "commit": "7fd2f48ef4ff32c8f013c634ea2dd6b1d1409f80",
    "sha256": "0v5p97dvzrk3j59yjc6iny71j3fdw9bb8737wnnzm098ff42dfmd"
@@ -28714,8 +28750,8 @@
     20200914,
     644
    ],
-   "commit": "286bbef128cb3194f8bd63cd5e497bea621c709a",
-   "sha256": "1i176damqxg0nqawhgr22ypzysnbk44aii0r81pl6zbwsvdxkqn6"
+   "commit": "c1c20b8d29838b4e0708b768d98e2edce933d15d",
+   "sha256": "1rscm80nrgr1c00vcp683rvc42wdll08jc3s2srvaxw3iadd03ln"
   },
   "stable": {
    "version": [
@@ -28738,8 +28774,8 @@
     20210315,
     1640
    ],
-   "commit": "4adbbaa681d902cc342f20c4e153d0cb6d866238",
-   "sha256": "01nq7qdmdpasvay3jg9kmg8wamvf37pwqcc37sfc85h81qf2rvc4"
+   "commit": "4a12f98146fb5f0484ae04b6bf1e469c3d882e12",
+   "sha256": "09rpzlvygp83drcwgbq75bxgi7m8xrap51mrgqc4rfgcmmmc3zk3"
   },
   "stable": {
    "version": [
@@ -28959,8 +28995,8 @@
   "repo": "dakrone/es-mode",
   "unstable": {
    "version": [
-    20201112,
-    2317
+    20201125,
+    2059
    ],
    "deps": [
     "cl-lib",
@@ -30195,15 +30231,15 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20210721,
-    658
+    20210726,
+    2220
    ],
    "deps": [
     "cl-lib",
     "goto-chg"
    ],
-   "commit": "5201f5cf5a4870e081d09bc3113a55cb94f3812f",
-   "sha256": "0i6b358vcsywx66fm5p4476rpy7bnl92zyjisb47kqlkznr3s25r"
+   "commit": "5c28294d830a5a79e9b9da2c32e7675d52d76720",
+   "sha256": "07va0zlaa9ykbjd6mrdpp2d428xpc1zf11vqsys0lfimcx2llxj6"
   },
   "stable": {
    "version": [
@@ -30963,26 +30999,26 @@
   "repo": "redguardtoo/evil-matchit",
   "unstable": {
    "version": [
-    20210609,
-    1311
+    20210727,
+    1106
    ],
    "deps": [
     "evil"
    ],
-   "commit": "d7ad7f712b98aa64b7cc4fb16354b32666739c77",
-   "sha256": "1x7wpq0lgkp016yik6sc7b2abhixgcwk0mxx29dyycsjjkdlhp3a"
+   "commit": "80dc731ab736545541546ca64187e850bf0e39c8",
+   "sha256": "1j1p4z6ps58nbsh55l9h30gxbkrzwzkjpq7zl50q6yfc84z7byzk"
   },
   "stable": {
    "version": [
     2,
     3,
-    12
+    13
    ],
    "deps": [
     "evil"
    ],
-   "commit": "9cd0ddaacb3476221d37344715c759ed3cb538d7",
-   "sha256": "0l4ash907d91vccqdxjz1v5spd8f4va0vrdri6h9y1qc67mjlsph"
+   "commit": "80dc731ab736545541546ca64187e850bf0e39c8",
+   "sha256": "1j1p4z6ps58nbsh55l9h30gxbkrzwzkjpq7zl50q6yfc84z7byzk"
   }
  },
  {
@@ -31723,8 +31759,8 @@
    "deps": [
     "evil"
    ],
-   "commit": "5201f5cf5a4870e081d09bc3113a55cb94f3812f",
-   "sha256": "0i6b358vcsywx66fm5p4476rpy7bnl92zyjisb47kqlkznr3s25r"
+   "commit": "5c28294d830a5a79e9b9da2c32e7675d52d76720",
+   "sha256": "07va0zlaa9ykbjd6mrdpp2d428xpc1zf11vqsys0lfimcx2llxj6"
   },
   "stable": {
    "version": [
@@ -31747,15 +31783,15 @@
   "repo": "iyefrat/evil-tex",
   "unstable": {
    "version": [
-    20210510,
-    1809
+    20210728,
+    2155
    ],
    "deps": [
     "auctex",
     "evil"
    ],
-   "commit": "87445d4d2339436179e792609bfbff0eaf056a9c",
-   "sha256": "014bwsnry6v07n9cv194gsiwny0jp6rxs5gl4dhqfwq9hbj74p84"
+   "commit": "9b3a560cc43cca73d2947747892f7d4f92c2c573",
+   "sha256": "0hain42prqaa08fc116a0qy12j8pbj4a8i589s6h87h4hhy8dj8d"
   },
   "stable": {
    "version": [
@@ -32791,15 +32827,15 @@
   "repo": "Wilfred/ez-query-replace.el",
   "unstable": {
    "version": [
-    20210525,
-    2222
+    20210724,
+    2247
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "3202cf4644ed3b6549284c3816b90bb230970a5b",
-   "sha256": "1xsvwf7g7c3v4p59svmahhn9pkr6zgp6vyr6dyvfy24mgaqw4jzv"
+   "commit": "2b68472f4007a73908c3b242e83ac5a7587967ff",
+   "sha256": "0zdgdqd9zi9fz6rn2z24jmpr83rzwbgxq0q38ynmskkd7n42a8ds"
   },
   "stable": {
    "version": [
@@ -32946,14 +32982,11 @@
   "url": "https://git.sr.ht/~pkal/face-shift",
   "unstable": {
    "version": [
-    20210707,
-    1127
+    20210725,
+    2146
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "0170ab2993211eb0f514f7d1ce14e8194a11f6b2",
-   "sha256": "0zj9h3nmswpc7q02a76rrzw3ypjwn1lwq5mkm6s28q0xrdpmrgq3"
+   "commit": "14dce79fc42116c49eb4c8a4ab7ca3c4bd7cbf6f",
+   "sha256": "0k10dskv9fzs1y05h7mq0z798kpwgkwwhh9dd9d7hdk70vkvlg66"
   },
   "stable": {
    "version": [
@@ -33105,8 +33138,8 @@
    "deps": [
     "popup"
    ],
-   "commit": "1096582f68cda91fe9d9336756b7c044ab0d6096",
-   "sha256": "0qp1nqcni5a3m9iaqar07sii6mpcnnqxmaf5n2fpz1iaz6bwsxva"
+   "commit": "eff6cba7b09611ce9ade56972f0ceccf227cf174",
+   "sha256": "0nzg2l9wxyqkhr4wj0mmcc4ydm1lx1smdcnsf1hs2yqh7bdgi02k"
   }
  },
  {
@@ -33371,11 +33404,11 @@
   "repo": "yqrashawn/fd-dired",
   "unstable": {
    "version": [
-    20210605,
-    1057
+    20210723,
+    549
    ],
-   "commit": "c223aee30af7dc7f52fb20045226ed9f49f4ec49",
-   "sha256": "14dzn3ggq8vb6qb5babngrpgsb29k6y8ficgzwwd9wfd5npynrpa"
+   "commit": "458464771bb220b6eb87ccfd4c985c436e57dc7e",
+   "sha256": "0253r4fbi9b8vk5akp1wz0krvik500jhy1hclwp1p0bwrq2irlml"
   },
   "stable": {
    "version": [
@@ -33493,11 +33526,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20210720,
-    1516
+    20210724,
+    2039
    ],
-   "commit": "12bdd8ee09ce2ba7c232df96fb199461d25a89c5",
-   "sha256": "13fyadml9wa30f4brdwfnby067q6bp2dl1y6x7hz0pzzlbk4sbs5"
+   "commit": "128702146298dad3f4d5409992e985fe670581d1",
+   "sha256": "12mvxziyrzgbmcg9kcqbscjld42ybl7km027m0kaln39awc0nb03"
   },
   "stable": {
    "version": [
@@ -33834,11 +33867,11 @@
   "repo": "redguardtoo/find-file-in-project",
   "unstable": {
    "version": [
-    20210720,
-    244
+    20210729,
+    5
    ],
-   "commit": "cde02e549512742366a91ffb70c86c354117cfde",
-   "sha256": "1xkpyn5lh6nhsmnq50174lnir9c9xhwb9ihvj0lw721s57xq3aa0"
+   "commit": "136018df39520433840d67acbbf92908ab115532",
+   "sha256": "0rgvk4r1iy4kncmxvgzlgb39dsjvvmihnqwrjgkmzdqfx9891m02"
   },
   "stable": {
    "version": [
@@ -38551,11 +38584,11 @@
   "repo": "d12frosted/flyspell-correct",
   "unstable": {
    "version": [
-    20210723,
-    505
+    20210724,
+    1042
    ],
-   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
-   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
+   "commit": "00357953a736e21d0a1c8d76f5605820990544fe",
+   "sha256": "1jf1jd0y6pn61czgsb9bccj3zxwjyglv0cgvyjjkadk1biaz0chj"
   },
   "stable": {
    "version": [
@@ -38582,8 +38615,8 @@
     "avy-menu",
     "flyspell-correct"
    ],
-   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
-   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
+   "commit": "00357953a736e21d0a1c8d76f5605820990544fe",
+   "sha256": "1jf1jd0y6pn61czgsb9bccj3zxwjyglv0cgvyjjkadk1biaz0chj"
   },
   "stable": {
    "version": [
@@ -38614,8 +38647,8 @@
     "flyspell-correct",
     "helm"
    ],
-   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
-   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
+   "commit": "00357953a736e21d0a1c8d76f5605820990544fe",
+   "sha256": "1jf1jd0y6pn61czgsb9bccj3zxwjyglv0cgvyjjkadk1biaz0chj"
   },
   "stable": {
    "version": [
@@ -38646,8 +38679,8 @@
     "flyspell-correct",
     "ivy"
    ],
-   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
-   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
+   "commit": "00357953a736e21d0a1c8d76f5605820990544fe",
+   "sha256": "1jf1jd0y6pn61czgsb9bccj3zxwjyglv0cgvyjjkadk1biaz0chj"
   },
   "stable": {
    "version": [
@@ -38678,8 +38711,8 @@
     "flyspell-correct",
     "popup"
    ],
-   "commit": "f9b57ea42938e272d9b7ac90d62c5496694ece00",
-   "sha256": "02vr4a0489l9kig9yypwx59dbaz44l2qi0akym1r5nsh4gmx9hsh"
+   "commit": "00357953a736e21d0a1c8d76f5605820990544fe",
+   "sha256": "1jf1jd0y6pn61czgsb9bccj3zxwjyglv0cgvyjjkadk1biaz0chj"
   },
   "stable": {
    "version": [
@@ -39151,8 +39184,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20210716,
-    1447
+    20210727,
+    1934
    ],
    "deps": [
     "closql",
@@ -39165,8 +39198,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "49da45ac4515d7442ebd606f4ad4922a3e1439ff",
-   "sha256": "1vqhxckmkfbkvpnsigdb1625b5n0fpry2hxkympqnxspcccnijks"
+   "commit": "34cbaa7b6a77ba2e4c6750f4f922d3e887c08c67",
+   "sha256": "1bpkzzkm3r0ylfk319k0dr03ikllhps65yir5i7ybwafddj8albp"
   },
   "stable": {
    "version": [
@@ -39526,11 +39559,11 @@
   "repo": "tarsius/frameshot",
   "unstable": {
    "version": [
-    20200103,
-    1238
+    20210728,
+    1258
    ],
-   "commit": "1b5974f0cc7c2a34e5f9fab6b25578dad7df3dbf",
-   "sha256": "1rcx0la0njg3ij0xgw7l1wl8nlvdd0bj40v51wvmdybyiba7cdx6"
+   "commit": "63d42d913468cd0d75dcccb99e5517057fa34e25",
+   "sha256": "0ar5dxyxz7nwmh1b1rdiiy76fm43q0pxcpj5959pc7gqxbf5c1rh"
   },
   "stable": {
    "version": [
@@ -39652,11 +39685,11 @@
   "repo": "rnkn/freeze-it",
   "unstable": {
    "version": [
-    20210201,
-    731
+    20210727,
+    1535
    ],
-   "commit": "d5dc811fc892d78e042394bb4a1342dea2480b5c",
-   "sha256": "0n1w3rycc5cpqvhw6d1dzkwjdy1xx7bps7d994l4hcpdfx5c25lx"
+   "commit": "151d264a0d0593b413b5a984b391023e905a190b",
+   "sha256": "04cv6p9df7h6w9h2ina3y3mmkp0y1rs6d9wmzari0cbm7q50hz4l"
   },
   "stable": {
    "version": [
@@ -39989,8 +40022,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "d9b6d549251d4a1a7cec2e83b11bda2ef7ff4ed2",
-   "sha256": "0246kl945g5v539h1hvwg06jsmj10a4q8rld3g6jix2iy1jmnfw7"
+   "commit": "7b451bb813d242dbc0cd6c29d071e0b320f2200e",
+   "sha256": "0wvbjc40f3bph7vhkixnrqa7k18f5jl81zdvdrr3fplkqnm3vxwj"
   },
   "stable": {
    "version": [
@@ -40728,8 +40761,8 @@
   "repo": "emacs-geiser/gauche",
   "unstable": {
    "version": [
-    20200801,
-    2337
+    20200802,
+    1300
    ],
    "deps": [
     "geiser"
@@ -41316,15 +41349,15 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20210619,
-    1405
+    20210727,
+    1414
    ],
    "deps": [
     "let-alist",
     "treepy"
    ],
-   "commit": "865424d4faf66048bfb3752856ac0cf68e1c6efe",
-   "sha256": "0kqjxwkm3n6r9zg6pi015g9ix4pyz7b2rngcmmrindcjb5h292a4"
+   "commit": "00a77b79c28e22db1b151c3f7857073ccbeff726",
+   "sha256": "0qrp2n53fhvwr5ndnmfzh841g88hzmcgz3i54hbcqq1gj6vwqd7f"
   },
   "stable": {
    "version": [
@@ -41690,8 +41723,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "0ea7868e368864da4604eaafa7dd332e70584cc8",
-   "sha256": "1np7rvp1la2l8gb8rkyjalgrhsk2zc9a9chdadx06769z16fbr2r"
+   "commit": "ad406cd28b4e08ddb6964c168c7c8dffb5debbc6",
+   "sha256": "10h3131a4zjnm90z73p6h8hh3iv8dgd4rd19vhrm05pbi1i6v7m8"
   },
   "stable": {
    "version": [
@@ -42343,11 +42376,11 @@
   "repo": "TxGVNN/github-explorer",
   "unstable": {
    "version": [
-    20210402,
-    1246
+    20210718,
+    824
    ],
-   "commit": "633b7371a6a00660422e195795c4b79f16bf29ae",
-   "sha256": "1wqnar0y6migb5n4hkz98r5bpxxx9m4qn15wg9cz213jpnykfkyy"
+   "commit": "98d759473ddfdddba0d82ff710aafc9ee6f0490b",
+   "sha256": "084scd1prj0i1ljz6l298a4yknqkj4rjl9yjvqmd605ac8ji3xh1"
   },
   "stable": {
    "version": [
@@ -44593,8 +44626,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "7822b34eb5d359ddae2f93d356c78c5ea05784d5",
-   "sha256": "0qkznd0a6cc32mwnmsa28lr8zji2nsi87kzcn467hq542zr61nz6"
+   "commit": "19e1a8188e003bae250ff6c40f61a31b638ce35d",
+   "sha256": "0iajd0qdcgh4vvl3f81z4r1pki9wkzy3hrywp1mmm5zhfncvhfis"
   },
   "stable": {
    "version": [
@@ -46645,16 +46678,16 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20210714,
-    1600
+    20210729,
+    1510
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "f6cf6078a745ec6ab313dbe98097e3bd5cef0a8c",
-   "sha256": "1h00ay4jjzkvkv5wh9cnd187c3ix8rixasl3wl6ilbilvx1pwv37"
+   "commit": "2c6839f32afc5056b1045f21a1b9771452dfa8f9",
+   "sha256": "0mj1nywzhrj6arw5gnqfk72d0q9im1b2xssp7i10agg2isyfrc98"
   },
   "stable": {
    "version": [
@@ -46939,16 +46972,16 @@
   "repo": "tmalsburg/helm-bibtex",
   "unstable": {
    "version": [
-    20201214,
-    2111
+    20210725,
+    1510
    ],
    "deps": [
     "bibtex-completion",
     "cl-lib",
     "helm"
    ],
-   "commit": "a0d32ab16748b7b0c43d6421f1b497b7caf8e590",
-   "sha256": "0a0mn41lvqjx8rdrfgff5fjs757nin30caap7ciapnvr18g9mh5h"
+   "commit": "12079bb09f203dda5cc2dd003bd60a6ad490f762",
+   "sha256": "11y1yif6z26cc502s72p310z9m6130p5kyqb2py74r3x0k0nc61s"
   },
   "stable": {
    "version": [
@@ -47559,8 +47592,8 @@
    "deps": [
     "async"
    ],
-   "commit": "f6cf6078a745ec6ab313dbe98097e3bd5cef0a8c",
-   "sha256": "1h00ay4jjzkvkv5wh9cnd187c3ix8rixasl3wl6ilbilvx1pwv37"
+   "commit": "2c6839f32afc5056b1045f21a1b9771452dfa8f9",
+   "sha256": "0mj1nywzhrj6arw5gnqfk72d0q9im1b2xssp7i10agg2isyfrc98"
   },
   "stable": {
    "version": [
@@ -48406,26 +48439,26 @@
   "repo": "masutaka/emacs-helm-ghq",
   "unstable": {
    "version": [
-    20190526,
-    1409
+    20210724,
+    744
    ],
    "deps": [
     "helm"
    ],
-   "commit": "d0d6aa0f407388e7012f0443df8ae657ece01779",
-   "sha256": "08884pk0d6xplsn1z9slaf4b9mmam6s9dg4dcxi1na1inpi6y082"
+   "commit": "7b47ac91e42762f2ecbbceeaadc05b86c9fe5f14",
+   "sha256": "0a4piipqnsj0rnwmqz3vj674ljmy1bl33qr9hv959pw5b3jzqfh0"
   },
   "stable": {
    "version": [
     1,
     8,
-    0
+    1
    ],
    "deps": [
     "helm"
    ],
-   "commit": "d0d6aa0f407388e7012f0443df8ae657ece01779",
-   "sha256": "08884pk0d6xplsn1z9slaf4b9mmam6s9dg4dcxi1na1inpi6y082"
+   "commit": "7b47ac91e42762f2ecbbceeaadc05b86c9fe5f14",
+   "sha256": "0a4piipqnsj0rnwmqz3vj674ljmy1bl33qr9hv959pw5b3jzqfh0"
   }
  },
  {
@@ -48734,26 +48767,26 @@
   "repo": "masutaka/emacs-helm-hatena-bookmark",
   "unstable": {
    "version": [
-    20190609,
-    1455
+    20210724,
+    732
    ],
    "deps": [
     "helm"
    ],
-   "commit": "10b8bfbd7fc4c3f503b2bc01f0c062dac128059e",
-   "sha256": "17f7y7bw15y3x30j7b3ymp3gpnszfvnf8hmlgc1mkwafxvzv06i1"
+   "commit": "a6a2b37370ac84ca2cae5ef65b2b144a010b1584",
+   "sha256": "0zwngldnh6ys9m7v0fc4nwk1bcrwqvip08114vn4dcv8kl3lnxvv"
   },
   "stable": {
    "version": [
     2,
     4,
-    3
+    4
    ],
    "deps": [
     "helm"
    ],
-   "commit": "10b8bfbd7fc4c3f503b2bc01f0c062dac128059e",
-   "sha256": "17f7y7bw15y3x30j7b3ymp3gpnszfvnf8hmlgc1mkwafxvzv06i1"
+   "commit": "a6a2b37370ac84ca2cae5ef65b2b144a010b1584",
+   "sha256": "0zwngldnh6ys9m7v0fc4nwk1bcrwqvip08114vn4dcv8kl3lnxvv"
   }
  },
  {
@@ -49145,8 +49178,8 @@
   "repo": "julienXX/helm-lobste.rs",
   "unstable": {
    "version": [
-    20150211,
-    2214
+    20150213,
+    1546
    ],
    "deps": [
     "cl-lib",
@@ -49164,14 +49197,14 @@
   "repo": "emacs-helm/helm-ls-git",
   "unstable": {
    "version": [
-    20210324,
-    1515
+    20210729,
+    911
    ],
    "deps": [
     "helm"
    ],
-   "commit": "48696448e52d266f5b2cb5ee1390071dab4d16e8",
-   "sha256": "1nhza9af2xfwq1idk4g69kr4wyyf9samk3vi40jvkfnwap4w3ip4"
+   "commit": "d861fb407d72470db41ac458447b92c6d9b00206",
+   "sha256": "13hxglh5w70w5y7x4r7rqpa7npj4lfrajjjic8vizn71752cndkg"
   },
   "stable": {
    "version": [
@@ -54285,15 +54318,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20210614,
-    1212
+    20210728,
+    846
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "f52ad0b4770403561b40f1d0499ecaca70da886c",
-   "sha256": "1ai5ha67650ryj7mdxx6b86hlm2v13h7kipisgvxj5dss3j9j7lv"
+   "commit": "be578820a7e14cb4264a63eac272800a3540a7f3",
+   "sha256": "174xlr36n8iv8gmapmfy55jgppmbck0m51yhni35674f50q8200y"
   },
   "stable": {
    "version": [
@@ -55152,26 +55185,26 @@
   "repo": "clojure-emacs/inf-clojure",
   "unstable": {
    "version": [
-    20210322,
-    1421
+    20210723,
+    718
    ],
    "deps": [
     "clojure-mode"
    ],
-   "commit": "a2cebf5362fe583538dda8dcf6348a8d73b462a2",
-   "sha256": "0sfn6x08i7sd2k6z4swpd8hxaab3ly0gfyapcaq768chi0grr0gw"
+   "commit": "c23c55e662c16ec94e684b2ec9611e78531921a8",
+   "sha256": "070h1j2axc40c3j8q6kji4avjpns65hj5kjb8a7pv5xiac9j50cy"
   },
   "stable": {
    "version": [
     3,
-    0,
+    1,
     0
    ],
    "deps": [
     "clojure-mode"
    ],
-   "commit": "2c8e46b584be71fe1a585c9072da86382710dc59",
-   "sha256": "13rk3g58vaizp67c1plhfc80vsshdvvsz81wsf3076xp35p05w9b"
+   "commit": "c23c55e662c16ec94e684b2ec9611e78531921a8",
+   "sha256": "070h1j2axc40c3j8q6kji4avjpns65hj5kjb8a7pv5xiac9j50cy"
   }
  },
  {
@@ -55911,8 +55944,8 @@
   "repo": "dcjohnson/inverse-acme-theme",
   "unstable": {
    "version": [
-    20170615,
-    1337
+    20210204,
+    1640
    ],
    "deps": [
     "autothemer",
@@ -56432,11 +56465,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20210602,
-    1349
+    20210727,
+    1907
    ],
-   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
-   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
+   "commit": "031d4d051da1d8fd20f0f46e8df66c426bf3174c",
+   "sha256": "16hsnh0l51vayr7a8h4y9h63pw0w5kzsdwhk90bypf2fpjgqdx94"
   },
   "stable": {
    "version": [
@@ -56463,8 +56496,8 @@
     "avy",
     "ivy"
    ],
-   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
-   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
+   "commit": "031d4d051da1d8fd20f0f46e8df66c426bf3174c",
+   "sha256": "16hsnh0l51vayr7a8h4y9h63pw0w5kzsdwhk90bypf2fpjgqdx94"
   },
   "stable": {
    "version": [
@@ -56496,8 +56529,8 @@
     "cl-lib",
     "swiper"
    ],
-   "commit": "a0d32ab16748b7b0c43d6421f1b497b7caf8e590",
-   "sha256": "0a0mn41lvqjx8rdrfgff5fjs757nin30caap7ciapnvr18g9mh5h"
+   "commit": "12079bb09f203dda5cc2dd003bd60a6ad490f762",
+   "sha256": "11y1yif6z26cc502s72p310z9m6130p5kyqb2py74r3x0k0nc61s"
   },
   "stable": {
    "version": [
@@ -56831,8 +56864,8 @@
     "hydra",
     "ivy"
    ],
-   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
-   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
+   "commit": "031d4d051da1d8fd20f0f46e8df66c426bf3174c",
+   "sha256": "16hsnh0l51vayr7a8h4y9h63pw0w5kzsdwhk90bypf2fpjgqdx94"
   },
   "stable": {
    "version": [
@@ -57039,8 +57072,8 @@
     "ivy",
     "prescient"
    ],
-   "commit": "54b19cf7121d9eb679c2ba26b3c26e82c8a90df9",
-   "sha256": "122j06gav4y6ghkjgwivlfqq1y4rl52sm8wskcq1gm3g7n36ds5h"
+   "commit": "027c2137a8d9e01a1d4c7b5e5d98da017dd2d48e",
+   "sha256": "04hwfqia53bk2fi7kw1pzwi5v0rgimr15kw6mmjlvcmwk0c1mghr"
   },
   "stable": {
    "version": [
@@ -58915,14 +58948,14 @@
   "repo": "tminor/jsonnet-mode",
   "unstable": {
    "version": [
-    20210627,
-    1451
+    20210726,
+    1251
    ],
    "deps": [
     "dash"
    ],
-   "commit": "404ebe3ca964fde99b7a6d89d2840ce53376d80a",
-   "sha256": "1ddkljjmvbm35gdw6wnys2na19826wxxgydlikn52nvchvr5z5z9"
+   "commit": "63c0f44fe7b5a333173235db7102ef8c2ae0b006",
+   "sha256": "1l7v5ibbl52ylbnz92ipw10ds8ahj3s2q4yxansnj8xy19kpjchz"
   },
   "stable": {
    "version": [
@@ -59071,8 +59104,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20210722,
-    426
+    20210728,
+    523
    ],
    "deps": [
     "dash",
@@ -59081,8 +59114,8 @@
     "spinner",
     "vterm"
    ],
-   "commit": "e4035da5322b9528b9751a0305a0feaa28e181fb",
-   "sha256": "1rpcsw7ddg7cs5mha7sn4j719rkvk04vwsri1y6d1c80y2fdlr10"
+   "commit": "7652679de3118c10659fdc492d67ec097e9ef46e",
+   "sha256": "1n41bvrrnqgj3qijdn4s7zac4xrfvyh759q99agycbsm1xdpkrvj"
   },
   "stable": {
    "version": [
@@ -59645,28 +59678,28 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20210605,
-    1117
+    20210727,
+    1225
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "7eb08e47bc5f227c72c318ff327c689ab54a7620",
-   "sha256": "181vnz6ancqhb13w9890pbplnw6lzbzcx3xkg4li9fk10lab72zk"
+   "commit": "1e6d02784a1c1e9f537b45aa487ee16885283b60",
+   "sha256": "1prs055mx64ck6dhwsj5xx0pk90mhw0vbinxwr2chn68zkzyvf6g"
   },
   "stable": {
    "version": [
     1,
     6,
-    4
+    5
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "c50bc11fdd42dc98ff806d1fc7cd94619c0ab7bb",
-   "sha256": "08ypmv43vjk1l409n894jxplnja6nicn2k3qwhwaf9qxhz0yxpjr"
+   "commit": "1e6d02784a1c1e9f537b45aa487ee16885283b60",
+   "sha256": "1prs055mx64ck6dhwsj5xx0pk90mhw0vbinxwr2chn68zkzyvf6g"
   }
  },
  {
@@ -59771,11 +59804,11 @@
   "repo": "ifosch/keepass-mode",
   "unstable": {
    "version": [
-    20210628,
-    729
+    20210110,
+    630
    ],
-   "commit": "fd7d380b762c888f25435d0c241012cdabf6e288",
-   "sha256": "1623hqlyk7qlvb5kigkyiji98a2vp39y0v6smag2mnqa3r89jq7l"
+   "commit": "515343a7667b2bf4253309449f65a6eb94933df7",
+   "sha256": "0hrq521swki0l3m81wk9p7pkc5j99li441fb75h7107v6z0p102c"
   },
   "stable": {
    "version": [
@@ -60454,8 +60487,8 @@
     20210318,
     2106
    ],
-   "commit": "143ba31a0a5c23d8c1a8d6fb1972d94cc1d7f31c",
-   "sha256": "1daisqp687p0bpjk8mj7c3sxq9clwi25byzbk7yx8l15rcr1bhr5"
+   "commit": "a55ad400a52e038f110df10d8f3c1e822b90f76c",
+   "sha256": "06kwhj190k7g5hqy9ibgphf1xrhkhzp36d0d3kqbqkdfc4jx7xaj"
   },
   "stable": {
    "version": [
@@ -60475,15 +60508,15 @@
   "repo": "stardiviner/kiwix.el",
   "unstable": {
    "version": [
-    20210723,
-    443
+    20210724,
+    1237
    ],
    "deps": [
     "elquery",
     "request"
    ],
-   "commit": "c0c597d1e1653112f3e10c67dcc22d85beb2aed8",
-   "sha256": "1k056qzw3a4i4icyrl1a0dv971jnl5d096hawj5qhgwslplrhdpj"
+   "commit": "71e770ce1e9994cf3e035cbcc7a2f26b1922323c",
+   "sha256": "0m6insjzl4hc00ank3i5f7y3mq734cbz085yfkm79vziy5j1i2bc"
   },
   "stable": {
    "version": [
@@ -61007,8 +61040,8 @@
     "auctex",
     "yasnippet"
    ],
-   "commit": "9d6f4448347fcf48d0fed51eba16423c9254c212",
-   "sha256": "0kfivjdjhlrbrn1z6i51y36s6f4qj386iy1jpcbvv33xa0lh5ksi"
+   "commit": "d6cd35d57ed9cd1728913ee75e42f575f090c3b9",
+   "sha256": "0i571idikvgryyar4sskl9k31jrn88cax7gm18mm6yfjq33ivk18"
   },
   "stable": {
    "version": [
@@ -61109,8 +61142,8 @@
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "138e6794122f8601e58731a365930bd7cf5791ea",
-   "sha256": "0zj3i612h0sih7lyy4zvzldcrgqmsqcvr4y42zv75r81s0l6gddz"
+   "commit": "4cf69db45aeeb01feb6b38c88b6aa2d01ae4da13",
+   "sha256": "1ihs24dqnbzj37y9zrwdwzwnr1xrxcs4qxm0z3d1bjalffai2x13"
   }
  },
  {
@@ -61983,8 +62016,8 @@
   "repo": "phillord/lentic",
   "unstable": {
    "version": [
-    20190102,
-    2124
+    20210727,
+    1247
    ],
    "deps": [
     "dash",
@@ -61992,8 +62025,8 @@
     "m-buffer",
     "s"
    ],
-   "commit": "e6d013bf570bb235817f6c8f0abdd31d3b456d53",
-   "sha256": "0ksmb5mvcpa699bw62fkhrx1i8adgrzsbc2fivfsimq54y25rdd7"
+   "commit": "36861bdf9c1d88492648da553f66529e3a879880",
+   "sha256": "0cj19czxmrxw1id1ym1ai3k7sv9shl3lz4fqj8qyg73j4kj1gbn0"
   },
   "stable": {
    "version": [
@@ -62167,15 +62200,30 @@
   "repo": "tecosaur/lexic",
   "unstable": {
    "version": [
-    20210318,
-    1315
+    20210729,
+    1808
+   ],
+   "commit": "25c8d839cf78332c15b5762024ccb5f7c90b7a11",
+   "sha256": "14x4a6dw9ywzl16f4blg7bmb0rvvik5jjldilshjdxf4zpvy80fd"
+  }
+ },
+ {
+  "ename": "lf",
+  "commit": "8073246c85cf632c01c14c48c453e1fd80d49569",
+  "sha256": "1rs5lik11xqpm624p6l02vdmf0zsmlz422s0d1wlz3f5hnchv7p2",
+  "fetcher": "github",
+  "repo": "alhassy/lf",
+  "unstable": {
+   "version": [
+    20210729,
+    229
    ],
    "deps": [
     "dash",
-    "visual-fill-column"
+    "s"
    ],
-   "commit": "4ded6be2ce3e8dadc5635a534827181a8c8ab602",
-   "sha256": "116qjizqa83zy6xas5cah58sf22ha05pps2004wfgng487ln9n59"
+   "commit": "54994d4db09d879c247db9aecdc0b6f27dcb7e6a",
+   "sha256": "0slv6ix6z0pnwr4rphpyy0fk0ff0bx0h6vqb8qjf85gnwz8l6dwr"
   }
  },
  {
@@ -62270,8 +62318,8 @@
   "repo": "merrickluo/liberime",
   "unstable": {
    "version": [
-    20200915,
-    542
+    20210526,
+    623
    ],
    "commit": "4a6da0f6ab9b43651f3fcc73412e3480b9403caa",
    "sha256": "04ag7icqqdhz40fi91fx4bxx8j6vw2774gw1fbppbks3sasimyy0"
@@ -62437,8 +62485,8 @@
     20210303,
     1751
    ],
-   "commit": "3603e4473ce9f81c5d73ba623c1938e152d03723",
-   "sha256": "1s1wsz8w7i1p509dqvv0ykljlqlr56203k4lrc542vjdnj4ih4z4"
+   "commit": "ec85691c073f0c3cb5a96d3716c70a93ff207faf",
+   "sha256": "0319awqqr6wv05wwqkhi3wwdj0rv76h3j92dml3mr9nna4lcdaqa"
   },
   "stable": {
    "version": [
@@ -62447,7 +62495,7 @@
     0
    ],
    "commit": "ec88b4d6b430338a1a44a04dca1642fdef15641f",
-   "sha256": "02n5yc0nqckfpfxkw8gxigg59769alxvk043c2d9bxgm79zxvhhy"
+   "sha256": "0319awqqr6wv05wwqkhi3wwdj0rv76h3j92dml3mr9nna4lcdaqa"
   }
  },
  {
@@ -62598,14 +62646,14 @@
   "repo": "noctuid/link-hint.el",
   "unstable": {
    "version": [
-    20150922,
-    451
+    20210727,
+    1302
    ],
    "deps": [
     "avy"
    ],
-   "commit": "9fbf196d155016d9b8471a99318ed67a086cf257",
-   "sha256": "0v2g9gzf2v88ag59q1pf5vhd4qjnz3g4i6gzl27k6fi7pvlxdn39"
+   "commit": "d3c5bacc9c697c4cf8b14616c4199210f9267068",
+   "sha256": "1d25lf556c9idr0slzakcks93rcw032bp1hbbcqffrljqzapxz4x"
   }
  },
  {
@@ -63226,8 +63274,8 @@
     20210701,
     1955
    ],
-   "commit": "db1f98cc470972f92d72f40b78db4baff5768edd",
-   "sha256": "1wgqcb4m5nzkbxkvdx801h9d1wqswlqmqbar4282wabgnw78zwwy"
+   "commit": "23e674f8572f3189fbe3917af6f22e6ec8708818",
+   "sha256": "1j25p0hmdfyfhlfrdn02q2ng6sgnaqvcjz1ll7rl0liq5acjvd2w"
   },
   "stable": {
    "version": [
@@ -63367,11 +63415,11 @@
   "url": "https://hg.serna.eu/emacs/lms",
   "unstable": {
    "version": [
-    20201214,
-    1852
+    20210724,
+    1250
    ],
-   "commit": "e6dae7465423a5304d0e38e92625383d07fe6f52",
-   "sha256": "1axxfh96pl2s0c301ak1gjh10k744wafnza3qx4sqaxcka5f6hc9"
+   "commit": "b4f56e17933d1d4098eeb04ef665a3f18479def9",
+   "sha256": "0fcz8hz26pwpwbl5dq4w3z6vmnjjjzwckv19zhwxj7bgv9dnm6wa"
   }
  },
  {
@@ -63833,14 +63881,14 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20210710,
-    228
+    20210729,
+    144
    ],
    "deps": [
     "map"
    ],
-   "commit": "f3f81affc88e6cb9efbc5440b26e081cffddd311",
-   "sha256": "0ibag71yz92abhbxsry3sby7g5361n4y7qac5myav2rj4bcjsl0n"
+   "commit": "b38817b9e161947ec6433c34952ac0af90ae88cd",
+   "sha256": "1dzvw3zy7caslx7jidm2vqn2a53pcnvzdli0ywam1yfaj26fv6b3"
   }
  },
  {
@@ -63858,8 +63906,8 @@
     "dash",
     "loopy"
    ],
-   "commit": "f3f81affc88e6cb9efbc5440b26e081cffddd311",
-   "sha256": "0ibag71yz92abhbxsry3sby7g5361n4y7qac5myav2rj4bcjsl0n"
+   "commit": "b38817b9e161947ec6433c34952ac0af90ae88cd",
+   "sha256": "1dzvw3zy7caslx7jidm2vqn2a53pcnvzdli0ywam1yfaj26fv6b3"
   }
  },
  {
@@ -63926,8 +63974,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20210715,
-    1659
+    20210728,
+    201
    ],
    "deps": [
     "dap-mode",
@@ -63938,8 +63986,8 @@
     "lsp-treemacs",
     "pkg-info"
    ],
-   "commit": "8481da68a9df4061bc2cd884a3b73c14e8fb4bea",
-   "sha256": "1accwvgwjp6j82i26788g3k9zc4al9xjw700cpdgsxw7mn6lkw8n"
+   "commit": "1237f6762a6c8c8f0618c850a3c9be13655118a3",
+   "sha256": "0bw940zv6alh4gsryyll4k607c5lpl8fzr8v6qd2v91kydsks848"
   },
   "stable": {
    "version": [
@@ -64127,8 +64175,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20210710,
-    1757
+    20210728,
+    1739
    ],
    "deps": [
     "dap-mode",
@@ -64140,8 +64188,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "b66a075bcb1edf57b09a0e1c73c3a399596d4760",
-   "sha256": "1s47y8hd9mnvz858h3sbdbdgrv3d1kdxag8flm44jla4yhgish7g"
+   "commit": "7ba9c459a484a9ef8d6a59e509c03d761fccde45",
+   "sha256": "1pi17qxqpaig8x2hpcdhwnvn3a8smgkkspc2a2gb9xwq9bcjglp5"
   },
   "stable": {
    "version": [
@@ -64357,8 +64405,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20210721,
-    511
+    20210729,
+    732
    ],
    "deps": [
     "dash",
@@ -64368,8 +64416,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "ac3b7e6efd1f8d4bb92aa4d89fc361fce3208c46",
-   "sha256": "1gx5y9j259q4iqnp7b58958wnpw8l3fdcs88zx38252givf814nx"
+   "commit": "f996db04e1159299c4fce2cbf3dc0cfa0e3966c4",
+   "sha256": "1w903yw2w4gwcz8ma1rpr2il8w76yh6gnifp3p2885r305xhsf5a"
   },
   "stable": {
    "version": [
@@ -65157,11 +65205,11 @@
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20200304,
-    1323
+    20210728,
+    1354
    ],
-   "commit": "e54f934952cde3f96d6a131968295d993b3cf624",
-   "sha256": "1yivbgbcy5qvs55dn5lx08mbkmsd4mriymas9jgh7rn6hl14x8hj"
+   "commit": "d221002128b7954fb5705c37b974223514a9c4f0",
+   "sha256": "0h04i2xif8iqlrp85kp3p34snzhfcgqcf65asd1qblh0qlhp37gn"
   },
   "stable": {
    "version": [
@@ -65181,8 +65229,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20210721,
-    1556
+    20210728,
+    2026
    ],
    "deps": [
     "dash",
@@ -65191,8 +65239,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "0ea7868e368864da4604eaafa7dd332e70584cc8",
-   "sha256": "1np7rvp1la2l8gb8rkyjalgrhsk2zc9a9chdadx06769z16fbr2r"
+   "commit": "ad406cd28b4e08ddb6964c168c7c8dffb5debbc6",
+   "sha256": "10h3131a4zjnm90z73p6h8hh3iv8dgd4rd19vhrm05pbi1i6v7m8"
   },
   "stable": {
    "version": [
@@ -65538,8 +65586,8 @@
     "libgit",
     "magit"
    ],
-   "commit": "0ea7868e368864da4604eaafa7dd332e70584cc8",
-   "sha256": "1np7rvp1la2l8gb8rkyjalgrhsk2zc9a9chdadx06769z16fbr2r"
+   "commit": "ad406cd28b4e08ddb6964c168c7c8dffb5debbc6",
+   "sha256": "10h3131a4zjnm90z73p6h8hh3iv8dgd4rd19vhrm05pbi1i6v7m8"
   },
   "stable": {
    "version": [
@@ -65706,8 +65754,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "0ea7868e368864da4604eaafa7dd332e70584cc8",
-   "sha256": "1np7rvp1la2l8gb8rkyjalgrhsk2zc9a9chdadx06769z16fbr2r"
+   "commit": "ad406cd28b4e08ddb6964c168c7c8dffb5debbc6",
+   "sha256": "10h3131a4zjnm90z73p6h8hh3iv8dgd4rd19vhrm05pbi1i6v7m8"
   },
   "stable": {
    "version": [
@@ -66501,11 +66549,11 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20210721,
-    2100
+    20210729,
+    1226
    ],
-   "commit": "a3a8edbf25db4b1e167f1fdff6f60a065d0bf9cb",
-   "sha256": "0a4ra9fwyj5av4cjyj1y1y1z1kr6dnq39hhf51c072zqw3k3jar9"
+   "commit": "a36af71f8ac530fbb24700494f5b2a75f2cc0111",
+   "sha256": "18xxglr557svzmh2j2n6lybxd9rkwmafxfw6zxd6qxn2b11ps0fh"
   },
   "stable": {
    "version": [
@@ -66621,11 +66669,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20210722,
-    839
+    20210728,
+    756
    ],
-   "commit": "f3c4fd9230252503e3a9f2de6f5d469c4ac270ae",
-   "sha256": "08snhqw9kyg8vdaz7ibga0pf2j5cg1akjiphs88dgvxkph8m65nr"
+   "commit": "8158bc8239c531756fbf6602f4b4dea8d52eb4cc",
+   "sha256": "1g58va0a4m8q82nr16l693wngbbdj3xw07a937a2x21y1pzrgiih"
   },
   "stable": {
    "version": [
@@ -66964,15 +67012,15 @@
   "repo": "matsievskiysv/math-preview",
   "unstable": {
    "version": [
-    20210219,
-    1431
+    20210729,
+    1842
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "08aa7c47ffc85c9cba1c9812e1c14250cc4192e4",
-   "sha256": "1z371v68aw92iaj5mbsk47mfr44scgkwazbf9i6gzygq84fdm6dh"
+   "commit": "b6f54d7a53d2ed5c71fc9ab6d65da63103c799bc",
+   "sha256": "0hzchn5m5r0iv0im43paxbpd00fyv4m1rv53asp1fg2h27zg7xfz"
   }
  },
  {
@@ -67565,18 +67613,19 @@
     20210720,
     950
    ],
-   "commit": "3442c5f32498d566b9cfbe0f503eb4304820ca78",
-   "sha256": "0hh5qb3327n4zmb41aggb7q9468ixsda17bkj73qnc8afhfm4m6x"
+   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
+   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
   },
   "stable": {
    "version": [
     4,
-    2,
+    3,
+    1,
     -4,
     412
    ],
-   "commit": "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c",
-   "sha256": "0dlrxss3i1z584l0dack8v3pf02bimx8bydqkj3bfiljqsi912v1"
+   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
+   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
   }
  },
  {
@@ -67594,13 +67643,14 @@
     "auto-complete",
     "merlin"
    ],
-   "commit": "3442c5f32498d566b9cfbe0f503eb4304820ca78",
-   "sha256": "0hh5qb3327n4zmb41aggb7q9468ixsda17bkj73qnc8afhfm4m6x"
+   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
+   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
   },
   "stable": {
    "version": [
     4,
-    2,
+    3,
+    1,
     -4,
     412
    ],
@@ -67608,8 +67658,8 @@
     "auto-complete",
     "merlin"
    ],
-   "commit": "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c",
-   "sha256": "0dlrxss3i1z584l0dack8v3pf02bimx8bydqkj3bfiljqsi912v1"
+   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
+   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
   }
  },
  {
@@ -67627,13 +67677,14 @@
     "company",
     "merlin"
    ],
-   "commit": "3442c5f32498d566b9cfbe0f503eb4304820ca78",
-   "sha256": "0hh5qb3327n4zmb41aggb7q9468ixsda17bkj73qnc8afhfm4m6x"
+   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
+   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
   },
   "stable": {
    "version": [
     4,
-    2,
+    3,
+    1,
     -4,
     412
    ],
@@ -67641,8 +67692,8 @@
     "company",
     "merlin"
    ],
-   "commit": "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c",
-   "sha256": "0dlrxss3i1z584l0dack8v3pf02bimx8bydqkj3bfiljqsi912v1"
+   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
+   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
   }
  },
  {
@@ -67689,13 +67740,14 @@
     "iedit",
     "merlin"
    ],
-   "commit": "3442c5f32498d566b9cfbe0f503eb4304820ca78",
-   "sha256": "0hh5qb3327n4zmb41aggb7q9468ixsda17bkj73qnc8afhfm4m6x"
+   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
+   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
   },
   "stable": {
    "version": [
     4,
-    2,
+    3,
+    1,
     -4,
     412
    ],
@@ -67703,8 +67755,8 @@
     "iedit",
     "merlin"
    ],
-   "commit": "fe7380bb13ff91f8ed5cfbfea6a6ca01ee1ef88c",
-   "sha256": "0dlrxss3i1z584l0dack8v3pf02bimx8bydqkj3bfiljqsi912v1"
+   "commit": "ba8ec63cf40b8999238c4639d111ca3bdb1e34cf",
+   "sha256": "1icd08irnj927d9hs5bzqjfdgc789829xy7032hs946ng44xkcg3"
   }
  },
  {
@@ -68262,14 +68314,14 @@
   "repo": "kiennq/emacs-mini-modeline",
   "unstable": {
    "version": [
-    20210312,
-    452
+    20210725,
+    900
    ],
    "deps": [
     "dash"
    ],
-   "commit": "3e67b8e59d46659df4b37dedf75485a366c93600",
-   "sha256": "1iqdbm90qj90a522qmssbqn5im0kxdw1kxq7z821ss3fag960xw8"
+   "commit": "fb2fc8661b4a32a40b3f5777ae1d69654c263ff0",
+   "sha256": "1bv06p6m5xygqcpwxngds2hral58h23jvp3di5dq3ac2hkf2m92l"
   },
   "stable": {
    "version": [
@@ -69056,20 +69108,20 @@
   "repo": "SidharthArya/modular-config.el",
   "unstable": {
    "version": [
-    20210629,
-    2319
+    20210726,
+    1614
    ],
-   "commit": "222ed4aab718ebcc2944c6cca87ebc3370d5ac3c",
-   "sha256": "0bdh5akywlj3grwclkl4vk82iij2jlvinmcp3xbi973n7y9i4s49"
+   "commit": "2bd77193fa3a7ec0541db284b4034821a8f59fea",
+   "sha256": "1bbycd4cr280vl643kvnzyml44mg63yh4i28bbszmj2yrkxy0frj"
   },
   "stable": {
    "version": [
     0,
     0,
-    3
+    5
    ],
-   "commit": "222ed4aab718ebcc2944c6cca87ebc3370d5ac3c",
-   "sha256": "0bdh5akywlj3grwclkl4vk82iij2jlvinmcp3xbi973n7y9i4s49"
+   "commit": "3c78fde6b7c53857c712408691427536d3c891bc",
+   "sha256": "057lhrlnyhl0hdp419lvl0fqpkkp3msmzn7gynvqmjig756dra7p"
   }
  },
  {
@@ -69080,11 +69132,11 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20210722,
-    1916
+    20210729,
+    950
    ],
-   "commit": "fd61a0c67ceafa3aeb0aeebddb93955148376b7e",
-   "sha256": "0l9gfq4qapa5snskb747jydprb0xvn80rjc83da1vwh4j8s3gavz"
+   "commit": "7447abafd82a1a7f9696ed5c193ae683609b5b82",
+   "sha256": "14wwfvc0gn3ciigslvbl8didxiif84ragwzwaya4wcchwjg5vzsj"
   },
   "stable": {
    "version": [
@@ -69427,11 +69479,11 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20210615,
-    1511
+    20210729,
+    1215
    ],
-   "commit": "9d8b2f758098d19781c7c5cdaeda5785e41be039",
-   "sha256": "1z9pspjrpclxznc9d16lix1zc0yx520jx1nqjbxj3kcwfxzkbbl4"
+   "commit": "9b679400ca885b8ff51bcfd75b87f79d66c0ee26",
+   "sha256": "14x3hd0z0nh0dyfi434vqywi7aawfxhlqj6sp7m17np56zq32yhi"
   },
   "stable": {
    "version": [
@@ -69786,8 +69838,8 @@
     20210306,
     1053
    ],
-   "commit": "d08f2a8d96af3ff80aac0e5641d9d20281084038",
-   "sha256": "1dbpy2bw131g5d166dmw5m4zq7y6h3krm7k1lv33cnbss10kj2fl"
+   "commit": "87f9ce226a32225cd3dfedde47a21fa16541ae88",
+   "sha256": "07364nxahcwn77l1xxr5gl9hqf0jc4q6gkzg0gs3wlwbbm9qdaic"
   },
   "stable": {
    "version": [
@@ -69913,8 +69965,8 @@
   "repo": "mpdel/mpdel",
   "unstable": {
    "version": [
-    20201026,
-    1123
+    20210107,
+    1303
    ],
    "deps": [
     "libmpdel",
@@ -70338,16 +70390,16 @@
   "repo": "lordpretzel/mu4e-views",
   "unstable": {
    "version": [
-    20210709,
-    150
+    20210729,
+    1158
    ],
    "deps": [
     "esxml",
     "ht",
     "xwidgets-reuse"
    ],
-   "commit": "9fbe402dc5931ba9cafec581ac3e6d86e9a9f2da",
-   "sha256": "0a73izknp2nkzklkhf9wyxy38fnw4f1jyimdcnh14m1v5bcw2wal"
+   "commit": "f3f454c7f92e8a9eecb5501af9ca81a547fd1841",
+   "sha256": "137r0kbd386954ydiwz6g9ff3j5289nqfzkvhp13rjjkrs668332"
   },
   "stable": {
    "version": [
@@ -70513,8 +70565,8 @@
   "repo": "sagarjha/multi-run",
   "unstable": {
    "version": [
-    20190507,
-    2349
+    20210108,
+    336
    ],
    "deps": [
     "window-layout"
@@ -70564,15 +70616,15 @@
   "repo": "suonlight/multi-vterm",
   "unstable": {
    "version": [
-    20201203,
-    1500
+    20210727,
+    1050
    ],
    "deps": [
     "project",
     "vterm"
    ],
-   "commit": "934397efd2e78a6b83d2b06ef4e4c281c0ae3c65",
-   "sha256": "0cz3zs9xd2zbyb9g9r4r893kl9nqk8i9l0zy66s500iy5522vcnh"
+   "commit": "a3df7218c1ecadef779e2c47815201052283f9ea",
+   "sha256": "0z6321994c4c8f5iya240pzvhirci9idlc110wjjwsm4pzdrrppj"
   }
  },
  {
@@ -72109,8 +72161,8 @@
     20181024,
     1439
    ],
-   "commit": "c8f8f2a9e3016ab7a9ecb2e8b084cf441f3ae88e",
-   "sha256": "1nj7w0dgvhmqy5hkdn0idf468x7s2h2y5372j13w3x1fkdcnyln8"
+   "commit": "d52a43d105040b92442e7c6657b50a2188b80ebd",
+   "sha256": "1pikcr0m533l03ffkwv9ak5w1zqcln3ar28km2052330mq93gpj4"
   },
   "stable": {
    "version": [
@@ -72411,16 +72463,16 @@
   "repo": "dickmao/nnhackernews",
   "unstable": {
    "version": [
-    20210716,
-    1030
+    20210729,
+    953
    ],
    "deps": [
     "anaphora",
     "dash",
     "request"
    ],
-   "commit": "50a6a7a58bc0316a9acc2b972380692f7438d9ed",
-   "sha256": "0q86wzl4va5xjj7czh6ldypwgb09gv8gp7kqi449bhx984a1yq7n"
+   "commit": "3a2fc7da6c6cfaba15fabcf1f3c9cf57b016c362",
+   "sha256": "1z91i6kl0bpsk87rl0ysfm8wifb3a196r82bxb6wlk6lkxlqr8jq"
   }
  },
  {
@@ -72702,8 +72754,8 @@
   "repo": "esessoms/nofrils-theme",
   "unstable": {
    "version": [
-    20180227,
-    2153
+    20180620,
+    1248
    ],
    "commit": "98ad7bfaff1d85b33dc162645670285b067c6f92",
    "sha256": "0f8s7mhcs1ym4an8d4dabfvhin30xs2d0c5gv875hsgz8p3asgxs"
@@ -72809,11 +72861,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20210719,
-    1132
+    20210725,
+    1815
    ],
-   "commit": "bed62eb8bee4aeca1fabfa5e302b515849f50b31",
-   "sha256": "00mixvwwhrmmr7wcscyzdhwhbnfiha0b0lcx1f3zk5xyshll2y9n"
+   "commit": "b649b0c871e7fbfcd15a24d51b071bad2680e5d2",
+   "sha256": "1jvibldc37whindnq64ghnj6iha1k3nvvj8bkv9s2fm90g7y4zy1"
   },
   "stable": {
    "version": [
@@ -72993,8 +73045,8 @@
   "repo": "shaneikennedy/npm.el",
   "unstable": {
    "version": [
-    20200812,
-    1850
+    20210601,
+    1122
    ],
    "deps": [
     "jest",
@@ -74629,8 +74681,8 @@
     20210617,
     1726
    ],
-   "commit": "121f3913f5dad7468b33d4a5ca19e7a687d2ecfc",
-   "sha256": "104jaqllwzcikk17iajgnjnnqchgivj210mhrx07qrk5vy5qwv5d"
+   "commit": "269984a50006efe282c693a6315962c92749296a",
+   "sha256": "19w93zpffybb4zb0h12rvyfh0857f1vf3hyr1r7rmgwyslfgp6gh"
   },
   "stable": {
    "version": [
@@ -75189,8 +75241,8 @@
   "repo": "OmniSharp/omnisharp-emacs",
   "unstable": {
    "version": [
-    20201220,
-    906
+    20210725,
+    1955
    ],
    "deps": [
     "auto-complete",
@@ -75202,8 +75254,8 @@
     "popup",
     "s"
    ],
-   "commit": "5fad6835bee15792774183164dd423ba18cf1e01",
-   "sha256": "1ww202j6bh8ycw2wfngy9rw1hv5qrjg66bgp2yj28j12ag1qxn2r"
+   "commit": "e276ff140666057c6d6848f9cfc84a82e3a7650c",
+   "sha256": "0aicn5s368s6ks4dq5b8xga0ifijd4lkqawzs0a4y58z8s922h69"
   },
   "stable": {
    "version": [
@@ -77016,16 +77068,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20210719,
-    2242
+    20210727,
+    519
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "2ea00944a7426012cda95cede99e49470f1383aa",
-   "sha256": "179h5j0k79hbbxz2n3x6hm1v2ws9qii6n8zx4800avbq1fgsh792"
+   "commit": "c8b05805f897b5325e12d94e4f10a287219db44d",
+   "sha256": "1vd49wxdj8r228xk9hpqig1f68m0iv5rsrj24ya4rdlf3z4671p4"
   },
   "stable": {
    "version": [
@@ -77169,14 +77221,14 @@
   "repo": "stardiviner/org-link-beautify",
   "unstable": {
    "version": [
-    20210704,
-    2214
+    20210724,
+    1406
    ],
    "deps": [
     "all-the-icons"
    ],
-   "commit": "40d40c1e6187ec9c13292beb3f7f319f189264d8",
-   "sha256": "0253i9hvq9yki97jmdrvbv82xbgdrq76l73frq6xbbzzhw6615m6"
+   "commit": "e34c314b84a0c2aef50772baa7c849f54323f598",
+   "sha256": "0bq1fl8qn3sf9wmqjj27ii42b95g501c16dbwziapvm3jhw3cz6h"
   }
  },
  {
@@ -77423,14 +77475,14 @@
   "repo": "jeremy-compostella/org-msg",
   "unstable": {
    "version": [
-    20210716,
-    2237
+    20210728,
+    2037
    ],
    "deps": [
     "htmlize"
    ],
-   "commit": "7cedeeece58879e05d3a3bab8af1385006f234df",
-   "sha256": "0gw34smbw9v0f3xwjci7zsj8hbnqd54yzbph6az65r5634nqhiv2"
+   "commit": "bb51a47513d1c4232aca8ca2c705ec57bd174b4b",
+   "sha256": "01xhhq0r36hkfhhacvwm7nwajvl7j8v3qbpn1xhi3vyy3zabhpzp"
   }
  },
  {
@@ -78251,8 +78303,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20210510,
-    1614
+    20210726,
+    1533
    ],
    "deps": [
     "bibtex-completion",
@@ -78267,8 +78319,8 @@
     "pdf-tools",
     "s"
    ],
-   "commit": "8aa2bb45268f660956151547533689d4ec30378d",
-   "sha256": "0ihjjmysldxx8n3q7mi06p5ydxknxy347c9lf3gnlgzcc776a49v"
+   "commit": "839ca73f3ae451efbf82859dcd17b63375cb8d76",
+   "sha256": "0zhzxmwlgwa0c27rfqpbpz7k477mm5ahhxyvmkvk6nafv5gdryc6"
   },
   "stable": {
    "version": [
@@ -78394,8 +78446,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20210721,
-    1746
+    20210729,
+    1527
    ],
    "deps": [
     "dash",
@@ -78405,8 +78457,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "9c10a3c04c06d1658a63d44927e385e2d97854d6",
-   "sha256": "0kd7wkd6k37ahsgmcjcs0msp02x6vfkq8gdih210yp2w6vz10hhy"
+   "commit": "127d6efa485c2d7846e1ec88954f4bf93623281f",
+   "sha256": "1663brqgysfkn5ja26jm6f4rf8zjdvrbbfkwi0xcfkac2sg2f4bq"
   },
   "stable": {
    "version": [
@@ -78434,16 +78486,16 @@
   "repo": "org-roam/org-roam-bibtex",
   "unstable": {
    "version": [
-    20210720,
-    1306
+    20210729,
+    1238
    ],
    "deps": [
     "bibtex-completion",
     "org-ref",
     "org-roam"
    ],
-   "commit": "13de4262d87debdbc43f8e2bd72b991b7284e705",
-   "sha256": "0iizd5vzxxl7fsm7k4y7dwisipsqwc3xqn33nk8r4c182mga3d9c"
+   "commit": "919ec8d837a7a3bd25232bdba17a0208efaefb2a",
+   "sha256": "0ir7516ngagf8mvy3qdir50bfigrqd2pl45c4g2y5cih5lvmfsn6"
   },
   "stable": {
    "version": [
@@ -78468,8 +78520,8 @@
   "repo": "org-roam/org-roam-server",
   "unstable": {
    "version": [
-    20210521,
-    1055
+    20210723,
+    1424
    ],
    "deps": [
     "dash",
@@ -78479,8 +78531,8 @@
     "s",
     "simple-httpd"
    ],
-   "commit": "a0f82bf41e318d4ef606a26f54054262ed6c3441",
-   "sha256": "06j8wabbxay9h8ca4pbv5xgjygfzbb3kbk4icni3lrfj6izsp3i4"
+   "commit": "35cd20280428470d37c1bff18d26cd49436ec3a2",
+   "sha256": "0xf229xkvzwaxwg2aqxgxpsi89aw3dp76ixhpkwyx6l52798nznf"
   },
   "stable": {
    "version": [
@@ -78879,8 +78931,8 @@
     "s",
     "ts"
    ],
-   "commit": "f5e80e4d0da6b2eeda9ba21e021838fa6a495376",
-   "sha256": "18q1af3hjjbsny9lxqjsq68qjzzpdjqgx7npg7pl7k3hzdjaj42f"
+   "commit": "a5557ea4f51571ee9def3cd9a1ab1c38f1a27af7",
+   "sha256": "1xbdkscg32pqpwzs50igdwkyi2k2mgi01wkqm7rc6bhrpgsk9gkw"
   },
   "stable": {
    "version": [
@@ -78936,8 +78988,8 @@
   "repo": "arbox/org-sync",
   "unstable": {
    "version": [
-    20181203,
-    2242
+    20181204,
+    23
    ],
    "deps": [
     "cl-lib",
@@ -79041,15 +79093,15 @@
   "repo": "stardiviner/org-tag-beautify",
   "unstable": {
    "version": [
-    20210527,
-    1130
+    20210729,
+    929
    ],
    "deps": [
     "all-the-icons",
     "org-pretty-tags"
    ],
-   "commit": "20193bf9b07efba03fdd5ffb2852cd43fcd88051",
-   "sha256": "0diccvg4gx9djayihd1hp39q5n2s8cahck93s5r58vk0d4jlcyyk"
+   "commit": "69e7dcb50278ff0d7b220cda9562d4fe7e4db0ec",
+   "sha256": "0wyqjzb2ph7092ghrnq0gxaf4r57mvcm0007kqpzqvknc3byd38d"
   }
  },
  {
@@ -80960,14 +81012,14 @@
   "repo": "kaushalmodi/ox-hugo",
   "unstable": {
    "version": [
-    20210518,
-    108
+    20210727,
+    117
    ],
    "deps": [
     "org"
    ],
-   "commit": "290b5d6b659addf99cb96a316fb24caa90ad0e77",
-   "sha256": "04isqw4wfn5hq772sf0szq2rc3b8finhgjc5cna2sw7bhfgycywb"
+   "commit": "8345ceb90ff1314d598c6b67ba6ee7616e2b0bc4",
+   "sha256": "09x5dr4kc9pxz8iw1ibl262164akr1m5gms5cws2q3zy04qjqfzl"
   },
   "stable": {
    "version": [
@@ -81760,14 +81812,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20210707,
-    1424
+    20210724,
+    1143
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "eea82edcbcc95e9cd35e33243d77adeb88ec7edc",
-   "sha256": "018pihaz1msmizhfjqwsp4d1aa9idiri4nrf6ifkpp6v6j8k7mva"
+   "commit": "01246e739da2eded6e007631861cada633302faa",
+   "sha256": "03w5yaivh2zc8c42zrfqmrlcc8lkmg3jjxa7sf223bwq1v9xypdj"
   },
   "stable": {
    "version": [
@@ -81864,11 +81916,11 @@
   "repo": "tttuuu888/package-loading-notifier",
   "unstable": {
    "version": [
-    20210608,
-    1406
+    20210724,
+    1700
    ],
-   "commit": "1e30d097de8939c4aa380915d3ba3060a87ce3c6",
-   "sha256": "0wmf3pfjvxrv86mpvbkn5n4drc20yc12fwm4k6a613br0bs75gan"
+   "commit": "895ab23f970f954349ccb6c89d397ad7d86087f8",
+   "sha256": "0maa3w06wx54f482z2k6d0vq8mr01j75nnbb7d0mjw15d6qi7pbk"
   }
  },
  {
@@ -82692,15 +82744,15 @@
   "repo": "clojure-emacs/parseedn",
   "unstable": {
    "version": [
-    20200419,
-    1124
+    20210729,
+    1657
    ],
    "deps": [
     "a",
     "parseclj"
    ],
-   "commit": "90cfe3df51b96f85e346f336c0a0ee6bf7fee508",
-   "sha256": "0fhmxj8qjhpqzmj07phf1njkjryc6d2qqqcl4f515b6hly1l41kz"
+   "commit": "7b9ca20b398ca0ca0e3005e84c16f23aab49b667",
+   "sha256": "0knv5m6w7v9zi94b6qi861r271l49pxzmwzp4nm595c33lxagqj2"
   },
   "stable": {
    "version": [
@@ -83188,11 +83240,11 @@
   "repo": "JonWaltman/pcmpl-args.el",
   "unstable": {
    "version": [
-    20210722,
-    329
+    20210729,
+    331
    ],
-   "commit": "36139ba64f43a3d3f4090ef0118bcebfef7e20c9",
-   "sha256": "1isab23shk1gfk54z4ppbnnkrm527rzb9cvbqqa47s8gv9k7zbnm"
+   "commit": "7d444d5793c779a863d5834572c1dae4d87a250b",
+   "sha256": "0mvpbv0y25qvk42yrhkawbimff92mbd8kgpcb8rb3lvdjv4mh0n0"
   }
  },
  {
@@ -84197,14 +84249,14 @@
   "repo": "OVYA/php-cs-fixer",
   "unstable": {
    "version": [
-    20201126,
-    1538
+    20210729,
+    1022
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "c5b5d8a4986b31bade5e2a57131469bf90630db8",
-   "sha256": "0v6nhyrkcb4nw1b0d30wlns0f82h5a8i7wf5jsb0wjlbqgxabx4b"
+   "commit": "cc9a3624dcdc72d748d91e3d7cdb8544a1d85a51",
+   "sha256": "1iiazmyzr6gxwsdpx687j0zp3s1zs0rk4kgv4hicl9mjda2f7dmz"
   },
   "stable": {
    "version": [
@@ -84265,20 +84317,20 @@
   "repo": "vpxyz/php-quickhelp",
   "unstable": {
    "version": [
-    20210721,
-    1945
+    20210725,
+    1413
    ],
-   "commit": "f22e6d31aad504094b441e2f635869fc97939ddf",
-   "sha256": "12dwjrflhbih1v75sxh0kp4w67i4xzccyxvy9601f94xnrha9s84"
+   "commit": "18678b9648a4227e612df773bac9ec46fc51b75d",
+   "sha256": "0x2n95sd85486irk04ig07lmilzc5v3448ys6p0kwn7357iir6wv"
   },
   "stable": {
    "version": [
     0,
     5,
-    3
+    4
    ],
-   "commit": "f22e6d31aad504094b441e2f635869fc97939ddf",
-   "sha256": "12dwjrflhbih1v75sxh0kp4w67i4xzccyxvy9601f94xnrha9s84"
+   "commit": "18678b9648a4227e612df773bac9ec46fc51b75d",
+   "sha256": "0x2n95sd85486irk04ig07lmilzc5v3448ys6p0kwn7357iir6wv"
   }
  },
  {
@@ -86784,11 +86836,11 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20210723,
-    143
+    20210724,
+    1756
    ],
-   "commit": "54b19cf7121d9eb679c2ba26b3c26e82c8a90df9",
-   "sha256": "122j06gav4y6ghkjgwivlfqq1y4rl52sm8wskcq1gm3g7n36ds5h"
+   "commit": "027c2137a8d9e01a1d4c7b5e5d98da017dd2d48e",
+   "sha256": "04hwfqia53bk2fi7kw1pzwi5v0rgimr15kw6mmjlvcmwk0c1mghr"
   },
   "stable": {
    "version": [
@@ -86853,14 +86905,14 @@
   "unstable": {
    "version": [
     20210606,
-    1150
+    1152
    ],
    "deps": [
     "iter2",
     "nvm"
    ],
-   "commit": "85c9349de2730b71c5796e342d67efee34faa9ed",
-   "sha256": "06gcqnd6wwcxqij4gx06y16kcqsh5znhs7hi5kwhzrbvqvqvrki8"
+   "commit": "e38d21a885e234af9ea6b03f499c487175570571",
+   "sha256": "1c7n43xi1sjprqn0xhd1hfdr39ipqiw1r8w76qbm3xx04h9bccy8"
   },
   "stable": {
    "version": [
@@ -87952,8 +88004,8 @@
     20200619,
     1742
    ],
-   "commit": "d662ec9c2e4f8ca21cb500b25cfe7430511014b2",
-   "sha256": "1n8ls2pm36imqg98yz20q9nyyxf4z0250mp4aigjcv3c66j8fp2a"
+   "commit": "53365065d9b8549a5c7b7ef1e7e0fd22926dbd07",
+   "sha256": "07r0mvflnhhnqc5igmv6r894nrv70a4j6sf9fzz23ka945ss5dgq"
   },
   "stable": {
    "version": [
@@ -88806,16 +88858,16 @@
   "repo": "dwcoates/pygn-mode",
   "unstable": {
    "version": [
-    20210721,
-    1917
+    20210724,
+    2207
    ],
    "deps": [
     "ivy",
     "nav-flash",
     "uci-mode"
    ],
-   "commit": "30cce9c134f685d7f2db81aa879e683864a23b66",
-   "sha256": "0q4q5wziwy2nhv0yyx7k5jx6bccx9lxr4f97njb06j2nvz2x7k1v"
+   "commit": "7298c3cd798853309bece115848e9d0400a7a627",
+   "sha256": "049aw0cs8kh4p2113v7f2cxcv9277zby02hxalg86bx0rdy8yaz5"
   },
   "stable": {
    "version": [
@@ -89010,17 +89062,17 @@
     20210411,
     1931
    ],
-   "commit": "a054796d7008f4531b482490f917bdef1454b8fd",
-   "sha256": "07zs0dzh500xs26ybyfz2z4wigc74l6wq3z1225gnblphhzl4jv9"
+   "commit": "ca3bc53fd8d628473fba25c7736d0abfac8e4a4a",
+   "sha256": "0yhkj2468si884x748v0a3jhzyg890fvxv02y5g5v8alpj19j1jj"
   },
   "stable": {
    "version": [
     2,
     9,
-    5
+    6
    ],
-   "commit": "ec8219e48f031f93377cc7d862a6f3bf80d76dbf",
-   "sha256": "1fixqimr8mq0mg5qs8wj4hbrzlw9925x72311is4s5r8phyjaabb"
+   "commit": "444f654e23de0772036c0e29c8e5745e48a8970c",
+   "sha256": "15yw69v1cj6zkndk60c2g0dgl0khh8bfm1lrwhjffpdjfc7nkc9a"
   }
  },
  {
@@ -89912,15 +89964,15 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20210720,
-    2002
+    20210727,
+    1545
    ],
    "deps": [
     "faceup",
     "pos-tip"
    ],
-   "commit": "76ca5838cbc266c306aa54964410730f6fd93d88",
-   "sha256": "1q4cgsi659bk4p1avl6bpzfhlf314432mqjhj3hlyxhf4d3nza8m"
+   "commit": "ef9a3fed943495ec2b0c8258f8e00307d6434b17",
+   "sha256": "0rkhkhpjpnp4h3c60ms9637737sfz6nfjlvlgvw0wfa51bvmzimd"
   }
  },
  {
@@ -90869,7 +90921,7 @@
   "unstable": {
    "version": [
     20210513,
-    1453
+    2237
    ],
    "deps": [
     "load-relative",
@@ -92514,8 +92566,8 @@
   "repo": "DogLooksGood/emacs-rime",
   "unstable": {
    "version": [
-    20210628,
-    1648
+    20210723,
+    1236
    ],
    "deps": [
     "cl-lib",
@@ -92523,8 +92575,8 @@
     "popup",
     "posframe"
    ],
-   "commit": "b93e761209211f8a6de1bb4b8f1d36651564a8d9",
-   "sha256": "0z0iwsqr92g8ykxb51gkawwxwzx0faw0027zgdi7c38ngjqld237"
+   "commit": "1d9bcc6dad4182e9b6a5839f8261b260e57be2fc",
+   "sha256": "157hndsslfxyi4n927y67shnk2xwhwz0idxwkdhcd4zl9jjzwpqr"
   },
   "stable": {
    "version": [
@@ -92999,14 +93051,14 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20200310,
-    1909
+    20210721,
+    2314
    ],
    "deps": [
     "rtags"
    ],
-   "commit": "65113e2a137baa9f85dc2157b893291470788dc4",
-   "sha256": "1qc4hy6r2sz59nb28xrrqiad91xbmsrr9jzhi4k915qgds6m029h"
+   "commit": "3a057f127b931c683288f8731f05ba5e2aab4133",
+   "sha256": "1brf05grh0xdcjllaiixpjxmcg2j130gcrxkqm5v4ryb1w9fki7g"
   },
   "stable": {
    "version": [
@@ -93861,8 +93913,8 @@
   "repo": "djcb/sauron",
   "unstable": {
    "version": [
-    20201011,
-    905
+    20201015,
+    836
    ],
    "commit": "5daade4836da5b1b2ab26d84128d6c38328a5d52",
    "sha256": "0fkq8knq023zm538ls4zxghlkn9zf4rfccpmmgfcpad6bdm00cpc"
@@ -94024,8 +94076,8 @@
     20200830,
     301
    ],
-   "commit": "cff035686cc9505d114115646e4d98edac307512",
-   "sha256": "0w5bzlsbs5zdk3h8ij019yj7861ggg0a4wcqwq7dm7rwf1bshsl2"
+   "commit": "bb54b9743aca98017746959e2cf0d9c9e0844110",
+   "sha256": "0yj3ivxbzgv2x96jsagnvn059hh7r65qpmz7gv76l8b6qnfr1i80"
   }
  },
  {
@@ -94524,8 +94576,8 @@
   "repo": "t-e-r-m/sculpture-themes",
   "unstable": {
    "version": [
-    20210524,
-    354
+    20210530,
+    624
    ],
    "commit": "1da2b3501f3732b4a58d28b502e356226a43a96f",
    "sha256": "198rjkyv876h7mbs73h8dq4lx5xhl66p7xrpvb23v0vk4vw0q5vz"
@@ -94866,15 +94918,15 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20210425,
-    1720
+    20210724,
+    1756
    ],
    "deps": [
     "prescient",
     "selectrum"
    ],
-   "commit": "54b19cf7121d9eb679c2ba26b3c26e82c8a90df9",
-   "sha256": "122j06gav4y6ghkjgwivlfqq1y4rl52sm8wskcq1gm3g7n36ds5h"
+   "commit": "027c2137a8d9e01a1d4c7b5e5d98da017dd2d48e",
+   "sha256": "04hwfqia53bk2fi7kw1pzwi5v0rgimr15kw6mmjlvcmwk0c1mghr"
   },
   "stable": {
    "version": [
@@ -95885,11 +95937,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210721,
-    148
+    20210725,
+    2353
    ],
-   "commit": "635a71df74d755113f26a6c6d9ae48ccb485393d",
-   "sha256": "0llby9858sjfxrh6x5nklkm24lmk6d5xm6mw0y6d02pn6rinx0sx"
+   "commit": "f0baf78897c95799a725d6f9092eef4a55a7f518",
+   "sha256": "1cb5c8fmdg5fzqcj9dsqxb0xah7kk5sl0crm9rq6l13zvvqn714a"
   }
  },
  {
@@ -96536,14 +96588,14 @@
   "repo": "andreas-roehler/simple-paren",
   "unstable": {
    "version": [
-    20210206,
-    2015
+    20210729,
+    611
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7b17fcc467e485dce5550be901d26223b8ad3f23",
-   "sha256": "1ksckai0hr2345vpjsahv0kzk8h52vrg2wki290v5aj64iy2nw76"
+   "commit": "9601e6b15f36d2e3a721043820a650413cbee42b",
+   "sha256": "1mclkg8frsljzcklfbbbnr72i9i990ag41n2iivbf1p27xbcp5cc"
   }
  },
  {
@@ -97202,11 +97254,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20210721,
-    1756
+    20210729,
+    1613
    ],
-   "commit": "e8f57c09cb4cc857887310e61eed7325500e9998",
-   "sha256": "1ipbi9h1p943mxzyc81wyrpyah41dhg33kmb3y9cy6avr2pkm1ry"
+   "commit": "540a8c5b9a04af0a6907e07cb070f1fed8a76f48",
+   "sha256": "13m15gcsqmagxmjvn28kd5rhh0ly7d4p4malhg5m7cbbms4svv68"
   },
   "stable": {
    "version": [
@@ -98436,14 +98488,14 @@
   "repo": "bbatsov/solarized-emacs",
   "unstable": {
    "version": [
-    20210112,
-    1050
+    20210724,
+    703
    ],
    "deps": [
     "dash"
    ],
-   "commit": "8271679a627148c96ad894f960cec9b1abfb1e6c",
-   "sha256": "1xrya65z54si9cf64whllq7vhw5dnafal9q2m4jf62jvxmbjdfsi"
+   "commit": "e281635dbaecb1715805a604f3404e7143a19356",
+   "sha256": "0a1sv5x49adj5s26khandc86y844vqk7241jc5qsli2dvdbxsqdg"
   },
   "stable": {
    "version": [
@@ -99839,11 +99891,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20210721,
-    125
+    20210727,
+    1800
    ],
-   "commit": "de1fdca07229e5d43c18cb3dc300397849eeab78",
-   "sha256": "0vdlcy211zx3fr8vcl6hm8xj8v3wkjj4y7pjcni9g87iijzf6gx2"
+   "commit": "70935753de73724f338700725462dec2cfda90f7",
+   "sha256": "1z1cvkbxpw28pgi6fzmkk1w6ha339pw09qy1hzppis8haijj0zxs"
   },
   "stable": {
    "version": [
@@ -99956,11 +100008,11 @@
   "repo": "jhgorrell/ssh-config-mode-el",
   "unstable": {
    "version": [
-    20210714,
+    20210724,
     951
    ],
-   "commit": "1c8f8779f20479e55f9d3d1151f1f68c1dff56f2",
-   "sha256": "0vcs6bz3qzw06c7bs253m9q2l43k8nppzdv7hqbybcdh4fakp8xw"
+   "commit": "2642659aa4cb882d95d84f780e8f8bf5e3a9114b",
+   "sha256": "1fivfpadw14cw9f78jpjhn7zl1b9sh3jhh7g8lh7f62kjv2p0a9m"
   }
  },
  {
@@ -100432,20 +100484,20 @@
   "repo": "akicho8/string-inflection",
   "unstable": {
    "version": [
-    20210712,
-    755
+    20210729,
+    658
    ],
-   "commit": "bf60b0c943cc0934aa188ada7c1c16053517df07",
-   "sha256": "077qxldhya397ka96786w0876bwa77x0il3zwixa9pcbqmqsg8qd"
+   "commit": "73b9a35e80e09ba744f2c364db4291f2d6f0a17a",
+   "sha256": "0g4lm384380q03pdspqzv8rb2gppb77m354r0xzw71340w8xh3hd"
   },
   "stable": {
    "version": [
     1,
     0,
-    13
+    14
    ],
-   "commit": "96a9baf4936df43b9f46804629384b79238691c3",
-   "sha256": "1v8h05m7iwxqp7lypdngib2620z0x23zc715vxqpqys79djwh9yh"
+   "commit": "73b9a35e80e09ba744f2c364db4291f2d6f0a17a",
+   "sha256": "0g4lm384380q03pdspqzv8rb2gppb77m354r0xzw71340w8xh3hd"
   }
  },
  {
@@ -101380,8 +101432,8 @@
    "deps": [
     "ivy"
    ],
-   "commit": "56139df678d9886d0612c0a192cce2cf6f156628",
-   "sha256": "0xjjdq3vmpm3fpvmd3g57m4ldixx8j73in0nmdx4vvnzvh0n904g"
+   "commit": "031d4d051da1d8fd20f0f46e8df66c426bf3174c",
+   "sha256": "16hsnh0l51vayr7a8h4y9h63pw0w5kzsdwhk90bypf2fpjgqdx94"
   },
   "stable": {
    "version": [
@@ -101591,14 +101643,14 @@
   "url": "https://tildegit.org/contrapunctus/sxiv",
   "unstable": {
    "version": [
-    20210713,
-    1845
+    20210514,
+    918
    ],
    "deps": [
     "dash"
    ],
-   "commit": "14057b156dd57610edf101403e653be874a342bb",
-   "sha256": "14wh7fw45w5cfdqibrcfzahsf4cwbi97xp16jd773ynkcf049cjs"
+   "commit": "028409c3a9ff7ba33a1cc2158abfc1793ed50717",
+   "sha256": "0zscfz1f6sgf4b9arfj9bmyvxqlpphm7q36k73zn5hn28kzd9di4"
   },
   "stable": {
    "version": [
@@ -101711,8 +101763,8 @@
   "repo": "countvajhula/symex.el",
   "unstable": {
    "version": [
-    20210720,
-    1708
+    20210727,
+    1646
    ],
    "deps": [
     "evil",
@@ -101724,8 +101776,8 @@
     "seq",
     "undo-tree"
    ],
-   "commit": "acd0874024018a3352761ffef3ca88916370b195",
-   "sha256": "17fi4jzsfp2k1fp772b75ihjsg602qyc1vzc0k6vv0p05kiv8s2x"
+   "commit": "e775e97d5bca462571078f727796727088833949",
+   "sha256": "0gmwkn5az4xrz9d85xd16bg1h8p5mph344800pqcpapqs389cpba"
   },
   "stable": {
    "version": [
@@ -101958,15 +102010,15 @@
   "repo": "vapniks/syslog-mode",
   "unstable": {
    "version": [
-    20210722,
-    1112
+    20210727,
+    1827
    ],
    "deps": [
     "hide-lines",
     "ov"
    ],
-   "commit": "e18d74d8a12b943a3a64eb8c693981e55aea8e9a",
-   "sha256": "0snf3pjnhff0r7v4iwqqq3568h0a4ff7b2s3axssxk4rfg8bm3ks"
+   "commit": "299042e1ce65bea0728bc56b0540a7ab8ab02010",
+   "sha256": "1y2p74am7v0n9bdzsix0fi6fzhi3pafxr8c2n36cm9hf5xdmb4q1"
   },
   "stable": {
    "version": [
@@ -102372,11 +102424,11 @@
   "repo": "11111000000/tao-theme-emacs",
   "unstable": {
    "version": [
-    20210417,
-    626
+    20210726,
+    1827
    ],
-   "commit": "d5ccf6f53d65e80083acdfb0bced6bcd678c6ea9",
-   "sha256": "1wgk0xngamwgh242wfmxizi5r1ji5dxmr8s542g3p7rgfv5w0qs8"
+   "commit": "f35b97823f27e8d0f378bbd18b79a61f9e34cc55",
+   "sha256": "097zvklc90dy90p62fbk5khnysijzmb6knvzyi8m6wba2g32v4mh"
   },
   "stable": {
    "version": [
@@ -102587,15 +102639,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20210711,
-    1323
+    20210728,
+    1000
    ],
    "deps": [
     "rainbow-identifiers",
     "visual-fill-column"
    ],
-   "commit": "377531fc19063b490b842e779df9b07195e8c496",
-   "sha256": "0gmjfw6kz5cflvj3zmyhw9qad850ckvq14k5vys62603yvm53qgw"
+   "commit": "e3ae2dfe048f25f3929b414279f6ceffbed748cf",
+   "sha256": "1lawl9gn59qkn7bfp6phzsiaw1nkmz3g38skbzrn86nsk9dczkzl"
   },
   "stable": {
    "version": [
@@ -102642,16 +102694,16 @@
   "repo": "dbordak/telephone-line",
   "unstable": {
    "version": [
-    20210322,
-    2248
+    20210724,
+    1411
    ],
    "deps": [
     "cl-generic",
     "cl-lib",
     "seq"
    ],
-   "commit": "aebac4658e553902369a3bf465bacc1f07a01106",
-   "sha256": "1kbxhrlg3pddg10zb9h3ky72f6l67nb5cziv17i3d0shx2z0sw17"
+   "commit": "ff5fcb2181cf1d52bfc5fb8d76ac37f9cad22ce2",
+   "sha256": "15l5w4avs3y6mj22k6c1vfvk7az69wiws0yym4vyqmfpdpsmwab2"
   },
   "stable": {
    "version": [
@@ -103535,14 +103587,14 @@
   "repo": "myTerminal/theme-looper",
   "unstable": {
    "version": [
-    20210714,
-    1807
+    20210727,
+    249
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "bb711c4bb992d7a129dd434a41a356cdaf8c387d",
-   "sha256": "09i7w2s594ksyi7a9bwpcycn4j7is19jh9kznrk39ar2kc3m118h"
+   "commit": "32ca76dfa8100a2069ca735e28e19ae87c74f956",
+   "sha256": "184n2r33d99wmzrnscpl0rqqivmvm17k60gfbrw5yjppq5fl55m3"
   },
   "stable": {
    "version": [
@@ -103678,8 +103730,8 @@
     20200212,
     1903
    ],
-   "commit": "1486e47402a5fa7df9791bd01c7e703671de9de6",
-   "sha256": "098hf7w27223v0h7090w4s2gcw5ylnj6fdfw3c1ifhblglyrbq1n"
+   "commit": "00e9095d6b2eeba01ba1b76b4816891d21ccf7e4",
+   "sha256": "0k9d7zb6l8v7pihgk5spy73jkdab9c7cwc4zwhbd9v65rd6756zj"
   },
   "stable": {
    "version": [
@@ -104630,10 +104682,10 @@
  },
  {
   "ename": "tracking",
-  "commit": "a2b295656d53fddc76cacc86b239e5648e49e3a4",
-  "sha256": "096h5bl7jcwz5hpbm2139bf8a784hijfy40vzf42y1c9794al46z",
+  "commit": "f0f88655608fec94c0a218e261cef10436aa8265",
+  "sha256": "1708zilyjwx0x27v2izd6yiqs2lfaxw620ikqiyx2fjfvxrf6794",
   "fetcher": "github",
-  "repo": "jorgenschaefer/circe",
+  "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
     20210713,
@@ -104743,11 +104795,11 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20210721,
-    2104
+    20210723,
+    1601
    ],
-   "commit": "769219b5f5757f1373a28e993f36b6a41c778651",
-   "sha256": "1s108ps8l563ywn4k5z64y67fgi3j0c7ln2zz9qi9xfih0lnz81b"
+   "commit": "efdf91980a6f8bcb151debb877302ead8751ab65",
+   "sha256": "17gyd76ih8b9f8jw0c47x337lfdynz98xq1kykxs8riwrih1dhip"
   },
   "stable": {
    "version": [
@@ -105051,14 +105103,14 @@
   "repo": "ubolonton/tree-sitter-langs",
   "unstable": {
    "version": [
-    20210314,
-    1704
+    20210724,
+    1056
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "5d362ce98dcf656d7a55fcad6ae21c0a2caca861",
-   "sha256": "11nfyyzyz9x4w4l4hpz0y27awknlwx3kn9dwvkzdn174jk2kxp9a"
+   "commit": "a516144aa9b109582e89702e5d76217e8fae907b",
+   "sha256": "1p2izm6n3r31jjxq8sazkqxnlhvg3kalf10323q246pdq6frk0qz"
   },
   "stable": {
    "version": [
@@ -105117,8 +105169,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20210713,
-    2032
+    20210726,
+    1955
    ],
    "deps": [
     "ace-window",
@@ -105130,8 +105182,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
-   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
+   "commit": "ac920b2265ca24c0536dd4502f792f06638a6fdc",
+   "sha256": "1md7way1yygljfpcf50wlm3mm4r6d33jigl02fyhbqi15dk48d10"
   },
   "stable": {
    "version": [
@@ -105167,8 +105219,8 @@
     "all-the-icons",
     "treemacs"
    ],
-   "commit": "a6f9e9f1cea3502b3ead082fd208c4011a55add0",
-   "sha256": "1g004yj613x6qr06gaffb6rp2n47ximb1w8776l0s6w8d40msyyg"
+   "commit": "ac920b2265ca24c0536dd4502f792f06638a6fdc",
+   "sha256": "1md7way1yygljfpcf50wlm3mm4r6d33jigl02fyhbqi15dk48d10"
   }
  },
  {
@@ -105186,8 +105238,8 @@
     "evil",
     "treemacs"
    ],
-   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
-   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
+   "commit": "ac920b2265ca24c0536dd4502f792f06638a6fdc",
+   "sha256": "1md7way1yygljfpcf50wlm3mm4r6d33jigl02fyhbqi15dk48d10"
   },
   "stable": {
    "version": [
@@ -105216,8 +105268,8 @@
    "deps": [
     "treemacs"
    ],
-   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
-   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
+   "commit": "ac920b2265ca24c0536dd4502f792f06638a6fdc",
+   "sha256": "1md7way1yygljfpcf50wlm3mm4r6d33jigl02fyhbqi15dk48d10"
   },
   "stable": {
    "version": [
@@ -105248,8 +105300,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
-   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
+   "commit": "ac920b2265ca24c0536dd4502f792f06638a6fdc",
+   "sha256": "1md7way1yygljfpcf50wlm3mm4r6d33jigl02fyhbqi15dk48d10"
   },
   "stable": {
    "version": [
@@ -105281,8 +105333,8 @@
     "persp-mode",
     "treemacs"
    ],
-   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
-   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
+   "commit": "ac920b2265ca24c0536dd4502f792f06638a6fdc",
+   "sha256": "1md7way1yygljfpcf50wlm3mm4r6d33jigl02fyhbqi15dk48d10"
   },
   "stable": {
    "version": [
@@ -105314,8 +105366,8 @@
     "perspective",
     "treemacs"
    ],
-   "commit": "a6f9e9f1cea3502b3ead082fd208c4011a55add0",
-   "sha256": "1g004yj613x6qr06gaffb6rp2n47ximb1w8776l0s6w8d40msyyg"
+   "commit": "ac920b2265ca24c0536dd4502f792f06638a6fdc",
+   "sha256": "1md7way1yygljfpcf50wlm3mm4r6d33jigl02fyhbqi15dk48d10"
   }
  },
  {
@@ -105333,8 +105385,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "e4a85e3266581b8a8f526dbf4142c26d6e76d294",
-   "sha256": "1bjjz504a6nyh8ymqj4zbakp7b2006r0ayid5akc6yzpmyrsb4rl"
+   "commit": "ac920b2265ca24c0536dd4502f792f06638a6fdc",
+   "sha256": "1md7way1yygljfpcf50wlm3mm4r6d33jigl02fyhbqi15dk48d10"
   },
   "stable": {
    "version": [
@@ -105381,11 +105433,11 @@
   "repo": "tilmanrassy/emacs-treeview",
   "unstable": {
    "version": [
-    20200921,
-    6
+    20210723,
+    2256
    ],
-   "commit": "e6012303670d112596e00eb3cb505eb0e0d61d84",
-   "sha256": "0drjzjwrk7fkcc6q8qbvzf60dgcbnysm482cdvzikc0phzgjpl9n"
+   "commit": "09c8c1d045c7c8eace61b10b6df9d2f9079de78e",
+   "sha256": "008m6ckrcc0ddnrc5p9b5agbvsma31bq0094yygv5dwg49lh7ly4"
   }
  },
  {
@@ -107976,8 +108028,8 @@
   "repo": "koral/veri-kompass",
   "unstable": {
    "version": [
-    20181103,
-    1246
+    20200213,
+    934
    ],
    "deps": [
     "cl-lib",
@@ -108564,6 +108616,29 @@
   }
  },
  {
+  "ename": "vline",
+  "commit": "515c6cd2efaa2c330122aabd7b23f29d5e4ec27d",
+  "sha256": "12kwxblqd8zdqhlcacvpd6z732l3ig92vklzbsv90n31k27yzzyn",
+  "fetcher": "github",
+  "repo": "emacsorphanage/vline",
+  "unstable": {
+   "version": [
+    20120108,
+    1245
+   ],
+   "commit": "8cc7947387f8da2888da25538668afa33a1d8662",
+   "sha256": "0iqnin1z8fxhh59199zakfd6jw7nj7425y642vrxxn043a3s08vw"
+  },
+  "stable": {
+   "version": [
+    1,
+    11
+   ],
+   "commit": "bc29e08c8e04845fb0e09155fe8f5212862f0a92",
+   "sha256": "1gcskm7p6f3b29ax41hafxjla38qw8cyvazmnn9xmx3pw0hf0jx0"
+  }
+ },
+ {
   "ename": "vmd-mode",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "1xjyl2xh3vig2rzjqm1a4h2ridygbanmal78s4yc32hacy0lfyrx",
@@ -108990,11 +109065,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20210615,
-    103
+    20210728,
+    2251
    ],
-   "commit": "635a71df74d755113f26a6c6d9ae48ccb485393d",
-   "sha256": "0llby9858sjfxrh6x5nklkm24lmk6d5xm6mw0y6d02pn6rinx0sx"
+   "commit": "f0baf78897c95799a725d6f9092eef4a55a7f518",
+   "sha256": "1cb5c8fmdg5fzqcj9dsqxb0xah7kk5sl0crm9rq6l13zvvqn714a"
   }
  },
  {
@@ -109998,11 +110073,11 @@
   "repo": "justbur/emacs-which-key",
   "unstable": {
    "version": [
-    20210712,
-    1852
+    20210728,
+    150
    ],
-   "commit": "55fcce0c6143044535bc6825a68f42ca83f58f00",
-   "sha256": "0bap1k6rzaqvqp7njzikw8clhky1fj78mdcx4zah1y57vhszavcw"
+   "commit": "cc84b2d0da629ecb62a92e3fd23cbee4ea20ce56",
+   "sha256": "0h4f1pdkvp92mqp6vy8vk1xbyjfhgccm4fw00kim08mzf0z8zjyy"
   },
   "stable": {
    "version": [
@@ -110709,8 +110784,8 @@
     20210405,
     1410
    ],
-   "commit": "c67784cc0c44dc7c590f1f1f5a979a36b1e8c11d",
-   "sha256": "0pisq1b2yjfplv64xn33lw38ymmpr8wah84pfnwvzqnlfsn5s1hs"
+   "commit": "a144cfd1604c308f65f990a1e994ab0d5d7fe244",
+   "sha256": "0q5ivjaxsw9ci40ap7qavziqjfbarlk7fwqivmndcgwnh0is3ddx"
   }
  },
  {
@@ -111560,11 +111635,11 @@
   "repo": "xahlee/xah-get-thing-or-selection",
   "unstable": {
    "version": [
-    20170821,
-    1053
+    20210724,
+    159
    ],
-   "commit": "e3ef069ea9fea3a092689d45c94c6211b51d0ea4",
-   "sha256": "0z9pflz99p2i7czccpzvw7bkbshfycpb6js9n8a12yhc1ndbz6z0"
+   "commit": "4f9041e7231108bc86ce722c623884146973343b",
+   "sha256": "1my96vqbwnnqfmh3r93ch6yqka6kqfq3qis9s3dqrmb91zvcjdl0"
   }
  },
  {
@@ -113815,8 +113890,8 @@
   "repo": "egh/zotxt-emacs",
   "unstable": {
    "version": [
-    20210129,
-    413
+    20210222,
+    347
    ],
    "deps": [
     "deferred",

--- a/pkgs/applications/editors/emacs/elisp-packages/tramp/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/tramp/default.nix
@@ -1,16 +1,28 @@
-{ lib, stdenv, fetchurl, emacs, texinfo }:
+{ lib
+, stdenv
+, fetchurl
+, emacs
+, texinfo
+}:
 
 stdenv.mkDerivation rec {
-  name = "tramp-2.4.2";
+  pname = "tramp";
+  version = "2.5.0";
+
   src = fetchurl {
-    url = "mirror://gnu/tramp/${name}.tar.gz";
-    sha256 = "082nwvi99y0bvpl1yhn4yjc8a613jh1pdck253lxn062lkcxxw61";
+    url = "mirror://gnu/tramp/${pname}-${version}.tar.gz";
+    sha256 = "sha256-w+6HJA8kFb75Z+7vM1zDnzOnkSSIXKnLVyCcEh+nMGY=";
   };
-  buildInputs = [ emacs texinfo ];
+
+  buildInputs = [
+    emacs
+    texinfo
+  ];
+
   meta = {
-    description = "Transparently access remote files from Emacs. Newer versions than built-in.";
     homepage = "https://www.gnu.org/software/tramp";
+    description = "Transparently access remote files from Emacs. Newer versions than built-in.";
     license = lib.licenses.gpl3Plus;
-    platforms = lib.platforms.all;
+    inherit (emacs.meta) platforms;
   };
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/update-nongnu
+++ b/pkgs/applications/editors/emacs/elisp-packages/update-nongnu
@@ -1,0 +1,4 @@
+#! /usr/bin/env nix-shell
+#! nix-shell --show-trace ./emacs2nix.nix -i bash
+
+exec nongnu-packages.sh --names $EMACS2NIX/names.nix -o nongnu-generated.nix

--- a/pkgs/applications/editors/emacs/elisp-packages/youtube-dl/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/youtube-dl/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, emacs, lib }:
+
+stdenv.mkDerivation {
+  pname = "youtube-dl";
+  version = "2018-10-12";
+
+  src = fetchFromGitHub {
+    owner = "skeeto";
+    repo = "youtube-dl-emacs";
+    rev = "af877b5bc4f01c04fccfa7d47a2c328926f20ef4";
+    sha256 = "sha256-Etl95rcoRACDPjcTPQqYK2L+w8OZbOrTrRT0JadMdH4=";
+  };
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ''
+    runHook preBuild
+    emacs -L . --batch -f batch-byte-compile *.el
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Emacs frontend to the youtube-dl utility";
+    homepage = "https://github.com/skeeto/youtube-dl-emacs";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ leungbk ];
+    platforms = emacs.meta.platforms;
+  };
+}

--- a/pkgs/applications/editors/kakoune/plugins/build-kakoune-plugin.nix
+++ b/pkgs/applications/editors/kakoune/plugins/build-kakoune-plugin.nix
@@ -27,7 +27,7 @@ rec {
     });
 
   buildKakounePluginFrom2Nix = attrs: buildKakounePlugin ({
-    buildPhase = ":";
-    configurePhase = ":";
+    dontBuild = true;
+    dontConfigure = true;
   } // attrs);
 }

--- a/pkgs/applications/misc/thinking-rock/default.nix
+++ b/pkgs/applications/misc/thinking-rock/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     chmod +x $out/bin/thinkingrock
   '';
 
-  installPhase = ":";
+  dontInstall = true;
 
   meta = with lib; {
     description = "Task management system";

--- a/pkgs/applications/science/biology/macse/default.nix
+++ b/pkgs/applications/science/biology/macse/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  dontUnpack = true;
   dontBuild = true;
-  unpackPhase = ":";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -226,7 +226,7 @@ in {
       mkdir -p $out/lib/vdr
     '';
 
-    installPhase = ":";
+    dontInstall = true;
 
     meta = with lib; {
       homepage = "https://projects.vdr-developer.org/projects/plg-text2skin";

--- a/pkgs/build-support/emacs/elpa.nix
+++ b/pkgs/build-support/emacs/elpa.nix
@@ -1,6 +1,6 @@
 # builder for Emacs packages built for packages.el
 
-{ lib, stdenv, emacs, texinfo, writeText }:
+{ lib, stdenv, emacs, texinfo, writeText, gcc }:
 
 with lib;
 
@@ -19,7 +19,7 @@ let
 
 in
 
-import ./generic.nix { inherit lib stdenv emacs texinfo writeText; } ({
+import ./generic.nix { inherit lib stdenv emacs texinfo writeText gcc; } ({
 
   phases = "installPhase fixupPhase distPhase";
 

--- a/pkgs/build-support/emacs/generic.nix
+++ b/pkgs/build-support/emacs/generic.nix
@@ -1,6 +1,6 @@
 # generic builder for Emacs packages
 
-{ lib, stdenv, emacs, texinfo, writeText, ... }:
+{ lib, stdenv, emacs, texinfo, writeText, gcc, ... }:
 
 with lib;
 
@@ -71,6 +71,8 @@ stdenv.mkDerivation ({
 // lib.optionalAttrs (emacs.nativeComp or false) {
 
   LIBRARY_PATH = "${lib.getLib stdenv.cc.libc}/lib";
+
+  nativeBuildInputs = [ gcc ];
 
   addEmacsNativeLoadPath = true;
 

--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -1,7 +1,7 @@
 # builder for Emacs packages built for packages.el
 # using MELPA package-build.el
 
-{ lib, stdenv, fetchFromGitHub, emacs, texinfo, writeText }:
+{ lib, stdenv, fetchFromGitHub, emacs, texinfo, writeText, gcc }:
 
 with lib;
 
@@ -28,7 +28,7 @@ let
 
 in
 
-import ./generic.nix { inherit lib stdenv emacs texinfo writeText; } ({
+import ./generic.nix { inherit lib stdenv emacs texinfo writeText gcc; } ({
 
   ename =
     if ename == null

--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -38,8 +38,8 @@ import ./generic.nix { inherit lib stdenv emacs texinfo writeText; } ({
   packageBuild = fetchFromGitHub {
     owner = "melpa";
     repo = "package-build";
-    rev = "0a22c3fbbf661822ec1791739953b937a12fa623";
-    sha256 = "0dpy5p34il600sc8ic5jdgb3glya9si3lrvhxab0swks8fdydjgs";
+    rev = "047801d301a73d4932f33f768d94a8ed26b8d524";
+    sha256 = "0ygzkpg7xc3mjjbxg1kcyz6fwbkb0prvca499f0ffmhfaiv28h59";
   };
 
   elpa2nix = ./elpa2nix.el;
@@ -70,7 +70,7 @@ import ./generic.nix { inherit lib stdenv emacs texinfo writeText; } ({
         -L "$NIX_BUILD_TOP/package-build" \
         -l "$melpa2nix" \
         -f melpa2nix-build-package \
-        $ename $version
+        $ename $version $commit
 
     runHook postBuild
     '';

--- a/pkgs/build-support/emacs/melpa2nix.el
+++ b/pkgs/build-support/emacs/melpa2nix.el
@@ -12,5 +12,8 @@
   (if (not noninteractive)
       (error "`melpa2nix-build-package' is to be used only with -batch"))
   (pcase command-line-args-left
-    (`(,package ,version)
+    (`(,package ,version ,commit)
+     ;; Monkey-patch package-build so it doesn't shell out to git/hg.
+     (defun package-build--get-commit (&rest _)
+       commit)
      (package-build--package (package-recipe-lookup package) version))))

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -32,7 +32,7 @@ in customEmacsPackages.emacs.pkgs.withPackages (epkgs: [ epkgs.evil epkgs.magit 
 
 */
 
-{ lib, lndir, makeWrapper, runCommand }: self:
+{ lib, lndir, makeWrapper, runCommand, gcc }: self:
 
 with lib;
 
@@ -65,7 +65,10 @@ runCommand
     # Store all paths we want to add to emacs here, so that we only need to add
     # one path to the load lists
     deps = runCommand "emacs-packages-deps"
-      { inherit explicitRequires lndir emacs; }
+      {
+        inherit explicitRequires lndir emacs;
+        nativeBuildInputs = lib.optional nativeComp gcc;
+      }
       ''
         findInputsOld() {
           local pkg="$1"; shift

--- a/pkgs/development/compilers/apache-flex-sdk/default.nix
+++ b/pkgs/development/compilers/apache-flex-sdk/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ jre ];
 
-  buildPhase = ":";
+  dontBuild = true;
 
   postPatch = ''
     shopt -s extglob
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
     cp ${playerglobal} $t/frameworks/libs/player/${playerglobal_ver}/playerglobal.swc
   '';
 
-  fixupPhase = ":";
+  dontFixup = true;
 
   meta = with lib; {
     description = "Flex SDK for Adobe Flash / ActionScript";

--- a/pkgs/development/libraries/nanopb/test-message-with-annotations/default.nix
+++ b/pkgs/development/libraries/nanopb/test-message-with-annotations/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   # proto_path. By default the current directory is automatically added to the
   # proto_path. I tried using --proto_path ${./.} ${./simple.proto} and it did
   # not work because they end up in the store at different locations.
-  installPhase = ":";
+  dontInstall = true;
   buildPhase = ''
     mkdir $out
 

--- a/pkgs/development/libraries/nanopb/test-message-with-options/default.nix
+++ b/pkgs/development/libraries/nanopb/test-message-with-options/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   # proto_path. By default the current directory is automatically added to the
   # proto_path. I tried using --proto_path ${./.} ${./simple.proto} and it did
   # not work because they end up in the store at different locations.
-  installPhase = ":";
+  dontInstall = true;
   buildPhase = ''
     mkdir $out
 

--- a/pkgs/development/libraries/nanopb/test-simple-proto2/default.nix
+++ b/pkgs/development/libraries/nanopb/test-simple-proto2/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   # proto_path. By default the current directory is automatically added to the
   # proto_path. I tried using --proto_path ${./.} ${./simple.proto} and it did
   # not work because they end up in the store at different locations.
-  installPhase = ":";
+  dontInstall = true;
   buildPhase = ''
     mkdir $out
 

--- a/pkgs/development/libraries/nanopb/test-simple-proto3/default.nix
+++ b/pkgs/development/libraries/nanopb/test-simple-proto3/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   # proto_path. By default the current directory is automatically added to the
   # proto_path. I tried using --proto_path ${./.} ${./simple.proto} and it did
   # not work because they end up in the store at different locations.
-  installPhase = ":";
+  dontInstall = true;
   buildPhase = ''
     mkdir $out
 

--- a/pkgs/development/python-modules/pytest-astropy/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   ];
 
   # pytest-astropy is a meta package and has no tests
-  checkPhase = ":";
+  doCheck = false;
 
   meta = with lib; {
     description = "Meta-package containing dependencies for testing";

--- a/pkgs/development/ruby-modules/with-packages/default.nix
+++ b/pkgs/development/ruby-modules/with-packages/default.nix
@@ -57,7 +57,7 @@ let
       nativeBuildInputs = [ makeWrapper ];
       buildInputs = [ selected ruby ];
 
-      unpackPhase = ":";
+      dontUnpack = true;
 
       installPhase = ''
         for i in ${ruby}/bin/* ${gemEnv}/bin/*; do

--- a/pkgs/development/tools/misc/gede/default.nix
+++ b/pkgs/development/tools/misc/gede/default.nix
@@ -17,7 +17,7 @@ mkDerivation rec {
 
   dontUseQmakeConfigure = true;
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     python build.py install --verbose --prefix="$out"

--- a/pkgs/development/tools/parsing/tree-sitter/grammar.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation {
   buildInputs = [ tree-sitter ];
 
   dontUnpack = true;
-  configurePhase = ":";
+  dontConfigure = true;
+
   buildPhase = ''
     runHook preBuild
     scanner_cc="$src/src/scanner.cc"

--- a/pkgs/development/web/now-cli/default.nix
+++ b/pkgs/development/web/now-cli/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     gunzip -c $curSrc > now-linux
   '';
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     mkdir $out

--- a/pkgs/misc/apulse/pressureaudio.nix
+++ b/pkgs/misc/apulse/pressureaudio.nix
@@ -8,8 +8,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config intltool autoreconfHook ];
 
   dontConfigure = true;
-
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     echo "Copying libraries from apulse."

--- a/pkgs/os-specific/linux/wooting-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/wooting-udev-rules/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   # Source: https://wooting.helpscoutdocs.com/article/68-wootility-configuring-device-access-for-wootility-under-linux-udev-rules
   src = [ ./wooting.rules ];
 
-  unpackPhase = ":";
+  dontUnpack = true;
 
   installPhase = ''
     install -Dpm644 $src $out/lib/udev/rules.d/70-wooting.rules

--- a/pkgs/servers/dict/dictd-db.nix
+++ b/pkgs/servers/dict/dictd-db.nix
@@ -12,7 +12,7 @@ let
      inherit src;
      locale = _locale;
      dbName = _name;
-     buildPhase = ":";
+     dontBuild = true;
      unpackPhase = ''
        tar xf  ${src}
      '';

--- a/pkgs/servers/foundationdb/vsmake.nix
+++ b/pkgs/servers/foundationdb/vsmake.nix
@@ -21,7 +21,7 @@ let
     };
 
     dontConfigure = true;
-    buildPhase = ":";
+    dontBuild = true;
     installPhase = "mkdir -p $out/include && cp -R boost $out/include/";
   };
 

--- a/pkgs/servers/sql/postgresql/ext/pgjwt.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgjwt.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "1riz0xvwb6y02j0fljbr9hcbqb2jqs4njlivmavy9ysbcrrv1vrf";
   };
 
-  buildPhase = ":";
+  dontBuild = true;
   installPhase = ''
     mkdir -p $out/share/postgresql/extension
     cp pg*sql *.control $out/share/postgresql/extension

--- a/pkgs/tools/backup/ori/default.nix
+++ b/pkgs/tools/backup/ori/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     scons PREFIX=$out WITH_ORILOCAL=1 install
   '';
 
-  installPhase = ":";
+  dontInstall = true;
 
   meta = with lib; {
     description = "A secure distributed file system";

--- a/pkgs/tools/misc/sweep-visualizer/default.nix
+++ b/pkgs/tools/misc/sweep-visualizer/default.nix
@@ -21,7 +21,7 @@
       ar p "$src" data.tar.xz | tar xJ
     '';
 
-    buildPhase = ":";
+    dontBuild = true;
 
     installPhase = ''
       mkdir -p $out/bin $out/share/sweep-visualizer

--- a/pkgs/tools/misc/zsh-autoenv/default.nix
+++ b/pkgs/tools/misc/zsh-autoenv/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "004svkfzhc3ab6q2qvwzgj36wvicg5bs8d2gcibx6adq042di7zj";
   };
 
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     mkdir -p $out/{bin,share}

--- a/pkgs/tools/system/uefitool/common.nix
+++ b/pkgs/tools/system/uefitool/common.nix
@@ -20,8 +20,10 @@ mkDerivation rec {
   buildInputs = [ qtbase ];
   nativeBuildInputs = [ qmake cmake zip ];
 
-  configurePhase = ":";
-  buildPhase = "bash unixbuild.sh";
+  dontConfigure = true;
+  buildPhase = ''
+    bash unixbuild.sh
+  '';
 
   installPhase = ''
     mkdir -p "$out"/bin

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -309,7 +309,7 @@ latexindent = perlPackages.buildPerlPackage rec {
   preConfigure = ''
     touch Makefile.PL
   '';
-  buildPhase = ":";
+  dontBuild = true;
   installPhase = ''
     install -D ./scripts/latexindent/latexindent.pl "$out"/bin/latexindent
     mkdir -p "$out"/${perl.libPrefix}

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -26,7 +26,7 @@
 let
 
   mkElpaPackages = { pkgs, lib }: import ../applications/editors/emacs/elisp-packages/elpa-packages.nix {
-    inherit (pkgs) stdenv texinfo writeText gcc;
+    inherit (pkgs) stdenv texinfo writeText gcc pkgs buildPackages;
     inherit lib;
   };
 

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -30,7 +30,8 @@ let
     inherit lib;
   };
 
-  mkNongnuPackages = { lib }: import ../applications/editors/emacs/elisp-packages/nongnu-packages.nix {
+  mkNongnuPackages = { pkgs, lib }: import ../applications/editors/emacs/elisp-packages/nongnu-packages.nix {
+    inherit (pkgs) buildPackages;
     inherit lib;
   };
 
@@ -57,7 +58,7 @@ in makeScope pkgs'.newScope (self: makeOverridable ({
   pkgs ? pkgs'
   , lib ? pkgs.lib
   , elpaPackages ? mkElpaPackages { inherit pkgs lib; } self
-  , nongnuPackages ? mkNongnuPackages { inherit lib; } self
+  , nongnuPackages ? mkNongnuPackages { inherit pkgs lib; } self
   , melpaStablePackages ? melpaGeneric { inherit pkgs lib; } "stable" self
   , melpaPackages ? melpaGeneric { inherit pkgs lib; } "unstable" self
   , orgPackages ? mkOrgPackages { inherit lib; } self

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -26,7 +26,7 @@
 let
 
   mkElpaPackages = { pkgs, lib }: import ../applications/editors/emacs/elisp-packages/elpa-packages.nix {
-    inherit (pkgs) stdenv texinfo writeText;
+    inherit (pkgs) stdenv texinfo writeText gcc;
     inherit lib;
   };
 
@@ -44,7 +44,7 @@ let
   };
 
   emacsWithPackages = { pkgs, lib }: import ../build-support/emacs/wrapper.nix {
-    inherit (pkgs) makeWrapper runCommand;
+    inherit (pkgs) makeWrapper runCommand gcc;
     inherit (pkgs.xorg) lndir;
     inherit lib;
   };

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -30,6 +30,10 @@ let
     inherit lib;
   };
 
+  mkNongnuPackages = { lib }: import ../applications/editors/emacs/elisp-packages/nongnu-packages.nix {
+    inherit lib;
+  };
+
   # Contains both melpa stable & unstable
   melpaGeneric = { pkgs, lib }: import ../applications/editors/emacs/elisp-packages/melpa-packages.nix {
     inherit lib pkgs;
@@ -53,12 +57,14 @@ in makeScope pkgs'.newScope (self: makeOverridable ({
   pkgs ? pkgs'
   , lib ? pkgs.lib
   , elpaPackages ? mkElpaPackages { inherit pkgs lib; } self
+  , nongnuPackages ? mkNongnuPackages { inherit lib; } self
   , melpaStablePackages ? melpaGeneric { inherit pkgs lib; } "stable" self
   , melpaPackages ? melpaGeneric { inherit pkgs lib; } "unstable" self
   , orgPackages ? mkOrgPackages { inherit lib; } self
   , manualPackages ? mkManualPackages { inherit pkgs lib; } self
 }: ({}
   // elpaPackages // { inherit elpaPackages; }
+  // nongnuPackages // { inherit nongnuPackages; }
   // melpaStablePackages // { inherit melpaStablePackages; }
   // melpaPackages // { inherit melpaPackages; }
   // orgPackages // { inherit orgPackages; }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

These commits contain fixes of known issues affecting 21.05. By updating to newer versions, it should solve Magit's interactive rebase not working, quite similar to magit/magit#4319.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
