### PR TITLE
github-runner: 2.279.0 -> 2.280.1

### DIFF
--- a/nixos/modules/services/continuous-integration/github-runner.nix
+++ b/nixos/modules/services/continuous-integration/github-runner.nix
@@ -120,13 +120,7 @@ in
         RUNNER_ROOT = runtimeDir;
       };
 
-      path = (with pkgs; [
-        bash
-        coreutils
-        git
-        gnutar
-        gzip
-      ]) ++ [
+      path = [
         config.nix.package
       ] ++ cfg.extraPackages;
 

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.280.1";
+  version = "2.280.2";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "4d17f77f5e8d552740a91ce2868fd05ff5a0dfee";
-    sha256 = "sha256:0ag18a8m6ymk0r2g1fn37332jsm3dw9qykc52k2qd6ykzhpigjvb";
+    rev = "ccafb91bfbcee5bed530aa82a1a0381b2c8f260c";
+    sha256 = "sha256:01g7ljczngmxndv6qgriafvjig919zvzp7h3lhlcmlyk600jyb12";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.279.0";
+  version = "2.280.1";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -84,8 +84,10 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "actions";
     repo = "runner";
-    rev = "6b75179ec79e2041b3b5b4e9206b73db2d206aac"; # v${version}
-    sha256 = "sha256-d7LAHL8Ff7R++d1HuLxWjtiBZRogySe7xHY/xJAcFms=";
+    # v${version} would be better but causes nuget to barf,
+    # so hash version of the tag instead.
+    rev = "4d17f77f5e8d552740a91ce2868fd05ff5a0dfee";
+    sha256 = "sha256:0ag18a8m6ymk0r2g1fn37332jsm3dw9qykc52k2qd6ykzhpigjvb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.280.3";
+  version = "2.281.1";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "409920e9f03bd38fe6e58807f069394993ce32e4";
-    sha256 = "sha256:0h13jlr6pah6sdndv4l53fc5hxk0n4ds87jvv61mvpjmdh9rx8xv";
+    rev = "c8caf59bb7adaa87c4cf8f61372670d338a13f2d";
+    sha256 = "sha256:1v81mrqxdcfwxzvd9d71brn9kjhi1zgalqa582fmly9h7i54ap9n";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.280.2";
+  version = "2.280.3";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "ccafb91bfbcee5bed530aa82a1a0381b2c8f260c";
-    sha256 = "sha256:01g7ljczngmxndv6qgriafvjig919zvzp7h3lhlcmlyk600jyb12";
+    rev = "409920e9f03bd38fe6e58807f069394993ce32e4";
+    sha256 = "sha256:0h13jlr6pah6sdndv4l53fc5hxk0n4ds87jvv61mvpjmdh9rx8xv";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
