### PR TITLE
nixos/v2ray: add an option for specifying v2ray package used in the systemd service

### DIFF
--- a/nixos/modules/services/networking/v2ray.nix
+++ b/nixos/modules/services/networking/v2ray.nix
@@ -16,6 +16,15 @@ with lib;
         '';
       };
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.v2ray;
+        defaultText = literalExpression "pkgs.v2ray";
+        description = ''
+          Which v2ray package to use.
+        '';
+      };
+
       configFile = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -62,7 +71,7 @@ with lib;
         name = "v2ray.json";
         text = builtins.toJSON cfg.config;
         checkPhase = ''
-          ${pkgs.v2ray}/bin/v2ray -test -config $out
+          ${cfg.package}/bin/v2ray -test -config $out
         '';
       };
 
@@ -78,10 +87,9 @@ with lib;
       description = "v2ray Daemon";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.v2ray ];
-      script = ''
-        exec v2ray -config ${configFile}
-      '';
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/v2ray -config ${configFile}";
+      };
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
To use a v2ray package with overridden GeoIP data in the systemd service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
