### PR TITLE
yarn-bash-completion: init at 0.17.0

### DIFF
--- a/pkgs/shells/bash/yarn-completion/default.nix
+++ b/pkgs/shells/bash/yarn-completion/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, installShellFiles
+}:
+
+stdenv.mkDerivation rec {
+  pname = "yarn-bash-completion";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "dsifford";
+    repo = "yarn-completion";
+    rev = "v${version}";
+    sha256 = "0xflbrbwskjqv3knvc8jqygpvfxh5ak66q7w22d1ng8gwrfqzcng";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installShellCompletion --cmd yarn ./yarn-completion.bash
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/dsifford/yarn-completion/";
+    description = "Bash completion for Yarn";
+    license = licenses.mit;
+    maintainers = with maintainers; [ DamienCassou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10611,6 +10611,8 @@ with pkgs;
 
   nix-bash-completions = callPackage ../shells/bash/nix-bash-completions { };
 
+  yarn-bash-completion = callPackage ../shells/bash/yarn-completion { };
+
   undistract-me = callPackage ../shells/bash/undistract-me { };
 
   dash = callPackage ../shells/dash { };


### PR DESCRIPTION
###### Motivation for this change

New package for [yarn-completion](https://github.com/dsifford/yarn-completion)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
