### PR TITLE
chrysalis: Expose udev rules

### DIFF
--- a/pkgs/applications/misc/chrysalis/default.nix
+++ b/pkgs/applications/misc/chrysalis/default.nix
@@ -3,12 +3,15 @@
 let
   pname = "chrysalis";
   version = "0.8.4";
-in appimageTools.wrapType2 rec {
+in appimageTools.wrapAppImage rec {
   name = "${pname}-${version}-binary";
 
-  src = fetchurl {
-    url = "https://github.com/keyboardio/${pname}/releases/download/v${version}/${pname}-${version}.AppImage";
-    sha256 = "b41f3e23dac855b1588cff141e3d317f96baff929a0543c79fccee0c6f095bc7";
+  src = appimageTools.extract {
+    inherit name;
+    src = fetchurl {
+      url = "https://github.com/keyboardio/${pname}/releases/download/v${version}/${pname}-${version}.AppImage";
+      sha256 = "b41f3e23dac855b1588cff141e3d317f96baff929a0543c79fccee0c6f095bc7";
+    };
   };
 
   profile = ''
@@ -20,7 +23,18 @@ in appimageTools.wrapType2 rec {
     p.glib
   ];
 
-  extraInstallCommands = "mv $out/bin/${name} $out/bin/${pname}";
+  # Also expose the udev rules here, so it can be used as:
+  #   services.udev.packages = [ pkgs.chrysalis ];
+  # to allow non-root modifications to the keyboards.
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+
+    mkdir -p $out/lib/udev/rules.d
+    ln -s \
+      --target-directory=$out/lib/udev/rules.d \
+      ${src}/resources/static/udev/60-kaleidoscope.rules
+  '';
 
   meta = with lib; {
     description = "A graphical configurator for Kaleidoscope-powered keyboards";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Chrysalis is an interface to modify the firmware of Kaleidoscope based keyboards (mostly [keyboardio](https://shop.keyboard.io/) products. In order to be able to access the device without being `root`, it comes with [some udev rules](https://github.com/keyboardio/Kaleidoscope/blob/bbcdff6f67bdf821d0fb39d5cb348e5224c898e5/etc/60-kaleidoscope.rules). This patch exposes those rules to the output path, so they can easily be used with:

```
services.udev.packages = [ pkgs.chrysalis ];
```

I had to switch from using `appimageTools.wrapType2` to `appimageTools.wrapAppImage` since I couldn't figure out a way to easily access the archive contents on the former one.

I tried this with an Keyboardio Atreus keyboard on NixOS and was able to use the application on a regular user.

cc @herrwiese as the maintainer (thanks for packaging this!).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
