### PR TITLE
yt-dlp: 2021.08.02 -> 2021.08.10

### DIFF
--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -1,6 +1,5 @@
-{ lib, fetchurl, buildPythonPackage
+{ lib, fetchPypi, buildPythonPackage
 , zip, ffmpeg, rtmpdump, phantomjs2, atomicparsley, pycryptodome, pandoc
-, fetchFromGitHub
 , websockets, mutagen
 , ffmpegSupport ? true
 , rtmpSupport ? true
@@ -10,17 +9,19 @@
 
 buildPythonPackage rec {
   pname = "yt-dlp";
-  # The websites yt-dlp deals with are a very moving target. That means that
-  # downloads break constantly. Because of that, updates should always be backported
-  # to the latest stable release.
-  version = "2021.08.02";
+  version = "2021.08.10";
 
-  src = fetchFromGitHub {
-    owner = "yt-dlp";
-    repo = "yt-dlp";
-    rev = version;
-    sha256 = "QEJKOZGVQNXLU8GfTbwBx2Zv3KO++ozTJcXLWxXA4hI=";
+  src = fetchPypi {
+    inherit pname;
+    version = with lib; concatMapStringsSep "." (removePrefix "0") (with versions; [(major version) (minor version) (patch version)]);
+    sha256 = "0h2jybl39mfiv5qd5q6mm8y3ks4y221lfg246z8kf7b4qi6vz8cd";
   };
+
+  # build_lazy_extractors assumes this directory exists
+  # but it is not present in the pypi package
+  postPatch = ''
+    mkdir -p ytdlp_plugins/extractor
+  '';
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
   buildInputs = [ zip pandoc ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/yt-dlp/yt-dlp/releases/tag/2021.08.10

This also switches to use the pypi package which

- Fix wrong version number in the program (the version is bumped after the git tag)
- Brings shell completions
- Brings manpage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
