### PR TITLE
perlPackages.mod_perl2: fix build on perl-5.34.0, add nixos test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -255,6 +255,7 @@ in
   miniflux = handleTest ./miniflux.nix {};
   minio = handleTest ./minio.nix {};
   misc = handleTest ./misc.nix {};
+  mod_perl = handleTest ./mod_perl.nix {};
   moinmoin = handleTest ./moinmoin.nix {};
   mongodb = handleTest ./mongodb.nix {};
   moodle = handleTest ./moodle.nix {};

--- a/nixos/tests/mod_perl.nix
+++ b/nixos/tests/mod_perl.nix
@@ -1,0 +1,53 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "mod_perl";
+
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ sgo ];
+  };
+
+  machine = { config, lib, pkgs, ... }: {
+    services.httpd = {
+      enable = true;
+      adminAddr = "admin@localhost";
+      virtualHosts."modperl" =
+        let
+          inc = pkgs.writeTextDir "ModPerlTest.pm" ''
+            package ModPerlTest;
+            use strict;
+            use Apache2::RequestRec ();
+            use Apache2::RequestIO ();
+            use Apache2::Const -compile => qw(OK);
+            sub handler {
+              my $r = shift;
+              $r->content_type('text/plain');
+              print "Hello mod_perl!\n";
+              return Apache2::Const::OK;
+            }
+            1;
+          '';
+          startup = pkgs.writeScript "startup.pl" ''
+            use lib "${inc}",
+              split ":","${with pkgs.perl.pkgs; makeFullPerlPath ([ mod_perl2 ])}";
+            1;
+          '';
+        in
+        {
+          extraConfig = ''
+            PerlRequire ${startup}
+          '';
+          locations."/modperl" = {
+            extraConfig = ''
+              SetHandler perl-script
+              PerlResponseHandler ModPerlTest
+            '';
+          };
+        };
+      enablePerl = true;
+    };
+  };
+  testScript = { ... }: ''
+    machine.wait_for_unit("httpd.service")
+    response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/modperl")
+    assert "Hello mod_perl!" in response, "/modperl handler did not respond"
+  '';
+})

--- a/pkgs/development/perl-modules/mod_perl2-PL_hash_seed.patch
+++ b/pkgs/development/perl-modules/mod_perl2-PL_hash_seed.patch
@@ -1,0 +1,13 @@
+From https://github.com/Perl/perl5/issues/18617#issuecomment-822056978 by Leont
+
+--- a/src/modules/perl/modperl_perl.c
++++ a/src/modules/perl/modperl_perl.c
+@@ -268,7 +268,7 @@
+ #ifdef MP_NEED_HASH_SEED_FIXUP
+     if (MP_init_hash_seed_set) {
+ #if MP_PERL_VERSION_AT_LEAST(5, 17, 6)
+-        memcpy(&PL_hash_seed, &MP_init_hash_seed,
++        memcpy(PL_hash_seed, &MP_init_hash_seed,
+                 sizeof(PL_hash_seed) > sizeof(MP_init_hash_seed) ?
+                     sizeof(MP_init_hash_seed) : sizeof(PL_hash_seed));
+         PL_hash_seed_set   = MP_init_hash_seed_set;

--- a/pkgs/servers/http/apache-modules/mod_perl/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_perl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, apacheHttpd, perl }:
+{ stdenv, fetchurl, apacheHttpd, perl, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "mod_perl";
@@ -28,4 +28,6 @@ stdenv.mkDerivation rec {
     mv $out${perl}/* $out
     rm $out/nix -rf
   '';
+
+  passthru.tests = nixosTests.mod_perl;
 }

--- a/pkgs/servers/http/apache-modules/mod_perl/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_perl/default.nix
@@ -9,6 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "0x3gq4nz96y202cymgrf56n8spm7bffkd1p74dh9q3zrrlc9wana";
   };
 
+  patches = [
+    # Fix build on perl-5.34.0, https://github.com/Perl/perl5/issues/18617
+    ../../../../development/perl-modules/mod_perl2-PL_hash_seed.patch
+  ];
+
   buildInputs = [ apacheHttpd perl ];
   buildPhase = ''
     perl Makefile.PL \

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13678,6 +13678,12 @@ let
       url = "mirror://cpan/authors/id/S/SH/SHAY/mod_perl-2.0.11.tar.gz";
       sha256 = "0x3gq4nz96y202cymgrf56n8spm7bffkd1p74dh9q3zrrlc9wana";
     };
+
+    patches = [
+      # Fix build on perl-5.34.0, https://github.com/Perl/perl5/issues/18617
+      ../development/perl-modules/mod_perl2-PL_hash_seed.patch
+    ];
+
     makeMakerFlags = "MP_AP_DESTDIR=$out";
     buildInputs = [ pkgs.apacheHttpd ];
     doCheck = false; # would try to start Apache HTTP server

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9,6 +9,7 @@
 , stdenv, lib, buildPackages, pkgs
 , fetchurl, fetchgit, fetchpatch, fetchFromGitHub
 , perl, overrides, buildPerl, shortenPerlShebang
+, nixosTests
 }:
 
 # cpan2nix assumes that perl-packages.nix will be used only with perl 5.30.3 or above
@@ -13691,6 +13692,8 @@ let
       description = "Embed a Perl interpreter in the Apache HTTP server";
       license = lib.licenses.asl20;
     };
+
+    passthru.tests = nixosTests.mod_perl;
   };
 
   Mojolicious = buildPerlPackage {


### PR DESCRIPTION
###### Motivation for this change

#133751

Fixes build problem of `perlPackages.mod_perl2` and `apacheHttpdPackages.mod_perl` on perl-5.34.0, also added nixos test for mod_perl.

- The same mod_perl source is used by `perlPackages.mod_perl2` and `apacheHttpdPackages.mod_perl`, so have applied same patch.
- ~TODO: Needs to be tested.~ Tests written
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
