### PR TITLE
luaPackages: fix plenary rockspec

### DIFF
--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1618,8 +1618,8 @@ plenary-nvim = buildLuarocksPackage {
   version = "scm-1";
 
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/plenary.nvim-scm-1.rockspec";
-    sha256 = "1xgqq0skg3vxahlnh1libc5dvhafp11k6k8cs65jcr9sw6xjycwh";
+    url    = "https://raw.githubusercontent.com/nvim-lua/plenary.nvim/master/plenary.nvim-scm-1.rockspec";
+    sha256 = "08kv1s66zhl9amzy9gx3101854ig992kl1gzzr51sx3szr43bx3x";
   }).outPath;
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The rockspec had become out of sync with `master`, causing build failures (see [here](https://github.com/nvim-lua/plenary.nvim/pull/212)):


<details>
<summary>Build failure</summary>

```
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/jbwlgm4fnb5kalgfhccqx60688lp86my-plenary.nvim-adf9d62
source root is plenary.nvim-adf9d62
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
@nix { "action": "setPhase", "phase": "buildPhase" }
building
@nix { "action": "setPhase", "phase": "installPhase" }
installing

cp: cannot stat 'lua/plenary/popup.lua': No such file or directory

Error: Build error: Failed installing lua/plenary/popup.lua in /nix/store/dqa8ip5nc0g7z2dxccqf0ksfx035w1yz-lua5.1-plenary.nvim-scm-1/plenary.nvim-scm-1-rocks/plenary.nvim/scm-1/lua/plenary/popup.lua: Failed copying lua/plenary/popup.lua to /nix/store/dqa8ip5nc0g7z2dxccqf0ksfx035w1yz-lua5.1-plenary.nvim-scm-1/plenary.nvim-scm-1-rocks/plenary.nvim/scm-1/lua/plenary/popup.lua
```

</details>

Now we can track the rockspec directly from the repo too, so that seems more appropriate considering this is a git-versioned unreleased package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
