### PR TITLE
ballerburg: include desktop file and icon

### DIFF
--- a/pkgs/games/ballerburg/default.nix
+++ b/pkgs/games/ballerburg/default.nix
@@ -1,6 +1,14 @@
-{ lib, stdenv, fetchurl, cmake, SDL }:
+{ lib, stdenv, fetchurl, cmake, SDL, makeDesktopItem, copyDesktopItems
+, imagemagick }:
 
-stdenv.mkDerivation rec {
+let
+
+  icon = fetchurl {
+    url = "https://baller.tuxfamily.org/king.png";
+    sha256 = "1xq2h87s648wjpjl72ds3xnnk2jp8ghbkhjzh2g4hpkq2zdz90hy";
+  };
+
+in stdenv.mkDerivation rec {
   pname = "ballerburg";
   version = "1.2.0";
 
@@ -9,9 +17,31 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-BiX0shPBGA8sshee8rxs41x+mdsrJzBqhpDDic6sYwA=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake copyDesktopItems imagemagick ];
 
   buildInputs = [ SDL ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Ballerburg";
+      desktopName = "Ballerburg SDL";
+      type = "Application";
+      exec = "_NET_WM_ICON=ballerburg ballerburg";
+      comment = meta.description;
+      icon = "ballerburg";
+      categories = "Game;";
+    })
+  ];
+
+  postInstall = ''
+    # Generate and install icon files
+    for size in 16 32 48 64 72 96 128 192 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert ${icon} -sample "$size"x"$size" \
+        -background white -gravity south -extent "$size"x"$size" \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/ballerburg.png
+    done
+  '';
 
   meta = with lib; {
     description = "Classic cannon combat game";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Improve user experience by providing a typical `.desktop` file along with icons

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
