### PR TITLE
kubernetes: fix breakage introduced by upgrade to 1.22

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -668,11 +668,6 @@
           to use wildcards in the <literal>source</literal> argument.
         </para>
       </listitem>
-    </itemizedlist>
-    <para>
-      &lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD
-    </para>
-    <itemizedlist>
       <listitem>
         <para>
           The <literal>openrazer</literal> and
@@ -713,6 +708,13 @@
           The <literal>varnish</literal> package was upgraded from 6.3.x
           to 6.5.x. <literal>varnish60</literal> for the last LTS
           release is also still available.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The <literal>kubernetes</literal> package was upgraded to
+          1.22. The <literal>kubernetes.apiserver.kubeletHttps</literal>
+          option was removed and HTTPS is always used.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -171,7 +171,6 @@ pt-services.clipcat.enable).
 
 - `programs.neovim.runtime` switched to a `linkFarm` internally, making it impossible to use wildcards in the `source` argument.
 
-<<<<<<< HEAD
 - The `openrazer` and `openrazer-daemon` packages as well as the `hardware.openrazer` module now require users to be members of the `openrazer` group instead of `plugdev`. With this change, users no longer need be granted the entire set of `plugdev` group permissions, which can include permissions other than those required by `openrazer`. This is desirable from a security point of view. The setting [`harware.openrazer.users`](options.html#opt-services.hardware.openrazer.users) can be used to add users to the `openrazer` group.
 
 - The `yambar` package has been split into `yambar` and `yambar-wayland`, corresponding to the xorg and wayland backend respectively. Please switch to `yambar-wayland` if you are on wayland.
@@ -181,6 +180,8 @@ configures the address and port the web UI is listening, it defaults to `:9001`.
 To be able to access the web UI this port needs to be opened in the firewall.
 
 - The `varnish` package was upgraded from 6.3.x to 6.5.x. `varnish60` for the last LTS release is also still available.
+
+- The `kubernetes` package was upgraded to 1.22.  The `kubernetes.apiserver.kubeletHttps` option was removed and HTTPS is always used.
 
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -190,12 +190,6 @@ in
       type = nullOr path;
     };
 
-    kubeletHttps = mkOption {
-      description = "Whether to use https for connections to kubelet.";
-      default = true;
-      type = bool;
-    };
-
     preferredAddressTypes = mkOption {
       description = "List of the preferred NodeAddressTypes to use for kubelet connections.";
       type = nullOr str;
@@ -365,7 +359,6 @@ in
                 "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
               ${optionalString (cfg.basicAuthFile != null)
                 "--basic-auth-file=${cfg.basicAuthFile}"} \
-              --kubelet-https=${boolToString cfg.kubeletHttps} \
               ${optionalString (cfg.kubeletClientCaFile != null)
                 "--kubelet-certificate-authority=${cfg.kubeletClientCaFile}"} \
               ${optionalString (cfg.kubeletClientCertFile != null)

--- a/nixos/modules/services/cluster/kubernetes/flannel.nix
+++ b/nixos/modules/services/cluster/kubernetes/flannel.nix
@@ -58,7 +58,7 @@ in
     services.kubernetes.addonManager.bootstrapAddons = mkIf ((storageBackend == "kubernetes") && (elem "RBAC" top.apiserver.authorizationMode)) {
 
       flannel-cr = {
-        apiVersion = "rbac.authorization.k8s.io/v1beta1";
+        apiVersion = "rbac.authorization.k8s.io/v1";
         kind = "ClusterRole";
         metadata = { name = "flannel"; };
         rules = [{
@@ -79,7 +79,7 @@ in
       };
 
       flannel-crb = {
-        apiVersion = "rbac.authorization.k8s.io/v1beta1";
+        apiVersion = "rbac.authorization.k8s.io/v1";
         kind = "ClusterRoleBinding";
         metadata = { name = "flannel"; };
         roleRef = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

### Motivation for this change

Kubernetes was broken on master by the upgrade to 1.22 in #132759.

#### Problem 1: --kubelet-https flag was removed

Error in the test logs:

```
machine1 # [   22.006042] kube-apiserver[896]: Error: unknown flag: --kubelet-https
```

Indeed, the kubelet-https flag was removed in 1.22: [commit](https://github.com/kubernetes/kubernetes/commit/5d186d0d0c1a2c350c5c6b9cfc58cd3718d5df32). In case anyone's wondering, there's nothing in the kubernetes [release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md) about this.

The fix is to just remove that option (which defaults to `true`) from `apiserver.nix`.

#### Problem 2: rbac.authorization.k8s.io/v1beta is not beta anymore

Error in test logs:

```
machine1 # [ 1132.701735] kube-addon-manager-pre-start[11156]: unable to recognize "/nix/store/6vznaz5xq5kkjacavq0xgyzvc4n5r22l-flannel-cr.json": no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1"
machine1 # [ 1132.705274] kube-addon-manager-pre-start[11156]: unable to recognize "/nix/store/081psb0ddvkpyh75kp2s4bqs611l9q85-flannel-crb.json": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
```

Indeed, if we look at the release notes, then follow the link to the blog post, then follow the link to the updated blog post, then follow the link to the deeply buried [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22), we will find the warning that `ClusterRole` and `ClusterRoleBinding` are no longer beta.

The fix is to replace `rbac.authorization.k8s.io/v1beta1` in the flannel addon with `rbac.authorization.k8s.io/v1`.

### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
