### PR TITLE
openjdk11: fix the share/man symlink on darwin

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -65,6 +65,12 @@ let
       EOF
     '';
 
+    # fixupPhase is moving the man to share/man which breaks it because it's a
+    # relative symlink.
+    postFixup = ''
+      ln -nsf ../zulu-11.jdk/Contents/Home/man $out/share/man
+    '';
+
     passthru = {
       home = jdk;
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

On master and release-21.05, when I build openjdk11 on Darwin, the $out/share/man is a broken symlink. This is causing an issue with buildEnv:

```
Use of uninitialized value $stat2 in numeric ne (!=) at /nix/store/m93r6l0di24f9wys93qhxycpxgijkwzw-builder.pl line 94.
Use of uninitialized value $stat1 in numeric ne (!=) at /nix/store/m93r6l0di24f9wys93qhxycpxgijkwzw-builder.pl line 94.
collision between `/nix/store/762nmp977mzjqyjhiy69fnqy4cz44nq1-zulu11.43.21-ca-jdk11.0.9/share/man' and `'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
