### PR TITLE
lib/formats: fix #133802

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -893,6 +893,13 @@
           sign OCSP responses and server certificates.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>lib.formats.yaml</literal>’s
+          <literal>generate</literal> will not generate JSON anymore,
+          but instead use more of the YAML-specific syntax.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -229,3 +229,5 @@ To be able to access the web UI this port needs to be opened in the firewall.
 - Zfs: `latestCompatibleLinuxPackages` is now exported on the zfs package. One can use `boot.kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;` to always track the latest compatible kernel with a given version of zfs.
 
 - Nginx will use the value of `sslTrustedCertificate` if provided for a virtual host, even if `enableACME` is set. This is useful for providers not using the same certificate to sign OCSP responses and server certificates.
+
+- `lib.formats.yaml`'s `generate` will not generate JSON anymore, but instead use more of the YAML-specific syntax.

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -48,14 +48,31 @@ rec {
 
   };
 
-  # YAML has been a strict superset of JSON since 1.2
-  yaml = {}:
-    let jsonSet = json {};
-    in jsonSet // {
-      type = jsonSet.type // {
+  yaml = {}: {
+
+    generate = name: value: pkgs.runCommand name {
+        nativeBuildInputs = [ pkgs.remarshal ];
+        value = builtins.toJSON value;
+        passAsFile = [ "value" ];
+      } ''
+        json2yaml "$valuePath" "$out"
+      '';
+
+    type = with lib.types; let
+      valueType = nullOr (oneOf [
+        bool
+        int
+        float
+        str
+        path
+        (attrsOf valueType)
+        (listOf valueType)
+      ]) // {
         description = "YAML value";
       };
-    };
+    in valueType;
+
+  };
 
   ini = {
     # Represents lists as duplicate keys

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -72,21 +72,17 @@ in runBuildTests {
       path = ./formats.nix;
     };
     expected = ''
-      {
-        "attrs": {
-          "foo": null
-        },
-        "false": false,
-        "float": 3.141,
-        "list": [
-          null,
-          null
-        ],
-        "null": null,
-        "path": "${./formats.nix}",
-        "str": "foo",
-        "true": true
-      }
+      attrs:
+        foo: null
+      'false': false
+      float: 3.141
+      list:
+        - null
+        - null
+      'null': null
+      path: ${./formats.nix}
+      str: foo
+      'true': true
     '';
   };
 


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixing a test + implementation issue with `pkgs.formats.yaml`

Fixes #133802

###### Things done
Making `(pkgs.formats.yaml {}).generate` generate yaml instead of json

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
