### PR TITLE
stdenv: add isMachO helper function

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -199,6 +199,29 @@ isELF() {
     if [ "$magic" = $'\177ELF' ]; then return 0; else return 1; fi
 }
 
+# Return success if the specified file is a Mach-O object.
+isMachO() {
+    local fn="$1"
+    local fd
+    local magic
+    exec {fd}< "$fn"
+    read -r -n 4 -u "$fd" magic
+    exec {fd}<&-
+    # https://opensource.apple.com/source/lldb/lldb-310.2.36/examples/python/mach_o.py.auto.html
+    if [[ "$magic" = $'\xfe\xed\xfa\xcf' || "$magic" = $'\xcf\xfa\xed\xfe' ]]; then
+        # MH_MAGIC_64 || MH_CIGAM_64
+        return 0;
+    elif [[ "$magic" = $'\xfe\xed\xfa\xce' || "$magic" = $'\xce\xfa\xed\xfe' ]]; then
+        # MH_MAGIC || MH_CIGAM
+        return 0;
+    elif [[ "$magic" = $'\xca\xfe\xba\xbe' || "$magic" = $'\xbe\xba\xfe\xca' ]]; then
+        # FAT_MAGIC || FAT_CIGAM
+        return 0;
+    else
+        return 1;
+    fi
+}
+
 # Return success if the specified file is a script (i.e. starts with
 # "#!").
 isScript() {


### PR DESCRIPTION
Detect if a binary is a Mach-O file.

In #131378, @veprbl suggested detecting if the binaries are Mach-O files, since there is already an `isELF` function, so I added the missing function.

I cannot try directly though, because since I modified `stdenv` it wants me to rebuild absolutely everything, and it would never finish on my Macbook. I did try it by copying it to an external script:

```
$ ./is-macho ~/.nix-profile/bin/nix
N: 4
Bytes:  cf  fa  ed  fe
----
Mach-O

$ ./is-macho /bin/ls
N: 4
Bytes:  ca  fe  ba  be
----
Mach-O

$ ./is-macho /usr/local/bin/git
N: 4
Bytes:  cf  fa  ed  fe
----
Mach-O

$ ./is-macho ~/sample.pdf
N: 4
Bytes:  25  50  44  46
----

$ ./is-macho flake.nix
N: 4
Bytes:  23  20  45  78
----

```

But it needs `LC_ALL=C` in order to work, otherwise `read -n 4` would not read 4 bytes, and I am not sure why. I couldn't find information about what `stdenv` does regarding locale.

Also, I test for both `MAGIC` an `CIGAM` magic numbers, although it seems nixpkgs/Homebrew binaries are in `CIGAM` format. I added the check for 32-bit and fat binaries for completion.

-------

This should help with #102044, but it should require a new PR that supersedes #131378. I believe the fix could be as simple as:

``` diff
diff --git i/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh w/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
index ce4d78fbb50..21de2a206f5 100644
--- i/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ w/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -85,7 +85,7 @@ wrapQtAppsHook() {
 
         find "$targetDir" ! -type d -executable -print0 | while IFS= read -r -d '' file
         do
-            patchelf --print-interpreter "$file" >/dev/null 2>&1 || continue
+            { isELF "$file" || isMachO "$file"; } >/dev/null 2>&1 || continue
 
             if [ -f "$file" ]
             then

```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
