### PR TITLE
gtk3: replace bugzilla patch with local file.

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -76,12 +76,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./patches/3.0-immodules.cache.patch
-
-    (fetchpatch {
-      name = "Xft-setting-fallback-compute-DPI-properly.patch";
-      url = "https://bug757142.bugzilla-attachments.gnome.org/attachment.cgi?id=344123";
-      sha256 = "0g6fhqcv8spfy3mfmxpyji93k8d4p4q4fz1v9a1c1cgcwkz41d7p";
-    })
+    ./patches/3.0-Xft-setting-fallback-compute-DPI-properly.patch
   ] ++ lib.optionals stdenv.isDarwin [
     # X11 module requires <gio/gdesktopappinfo.h> which is not installed on Darwin
     # let’s drop that dependency in similar way to how other parts of the library do it

--- a/pkgs/development/libraries/gtk/patches/3.0-Xft-setting-fallback-compute-DPI-properly.patch
+++ b/pkgs/development/libraries/gtk/patches/3.0-Xft-setting-fallback-compute-DPI-properly.patch
@@ -1,0 +1,34 @@
+From 269f2d80ea41cde17612600841fbdc32e99010f5 Mon Sep 17 00:00:00 2001
+From: Giuseppe Bilotta <giuseppe.bilotta@gmail.com>
+Date: Tue, 24 Jan 2017 12:30:08 +0100
+Subject: [PATCH] Xft setting fallback: compute DPI properly
+
+This is a partial revert of bdf0820c501437a2150d8ff0d5340246e713f73f. If
+the Xft DPI settings are not explicitly set, use the values provided by
+the X server rather than hard-coding the fallback value of 96.
+
+While an auto-configured Xorg already reports 96, this value can be
+overriden by the user, and we should respect the user choice in this
+case. There is no need to require them to set the same value in
+different places (the Xorg DPI settings and Xft.dpi).
+---
+ gdk/x11/gdkxftdefaults.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gdk/x11/gdkxftdefaults.c b/gdk/x11/gdkxftdefaults.c
+index fa1cfde2ec..c462b78c4b 100644
+--- a/gdk/x11/gdkxftdefaults.c
++++ b/gdk/x11/gdkxftdefaults.c
+@@ -174,7 +174,8 @@ init_xft_settings (GdkScreen *screen)
+     x11_screen->xft_rgba = FC_RGBA_UNKNOWN;
+ 
+   if (!get_double_default (xdisplay, "dpi", &dpi_double))
+-    dpi_double = 96.0;
++    dpi_double = (DisplayHeight(xdisplay, x11_screen->screen_num)*25.4)/
++		    DisplayHeightMM(xdisplay, x11_screen->screen_num);
+ 
+   x11_screen->xft_dpi = (int)(0.5 + PANGO_SCALE * dpi_double);
+ }
+-- 
+2.11.0.616.gd72966cf44.dirty
+


### PR DESCRIPTION
###### Motivation for this change

As mentioned in https://github.com/NixOS/nixpkgs/issues/133787, the existing hyperlinked patch returns an xz file that nix isn't too happy about and that makes the build fail with the message:

```
builder for '/nix/store/9cv52mcrm864khwrx3yvvkpm5cpjnsqw-Xft-setting-fallback-compute-DPI-properly.patch.drv' failed with exit code 1; last 10 log lines:
  trying https://bug757142.bugzilla-attachments.gnome.org/attachment.cgi?id=344123
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
  100   169  100   169    0     0    290      0 --:--:-- --:--:-- --:--:--   290
  100   888  100   888    0     0    833      0  0:00:01  0:00:01 --:--:--   833
  error: Normalized patch '/private/tmp/nix-build-Xft-setting-fallback-compute-DPI-properly.patch.drv-0/0g6fhqcv8spfy3mfmxpyji93k8d4p4q4fz1v9a1c1cgcwkz41d7p' is empty (while the fetched file was not)!
  Did you maybe fetch a HTML representation of a patch instead of a raw patch?
  Fetched file was:
  �7zXZ����ִF��!�������X���N�5]�#������q�9����]�E�͌o���%$�����]�Ht�Hަ/p�ѵ�����d��{���;1e����Lx�m�����-�ћ�!��v��r�)Q���<��g%��������8�;��()�%*���Rf�F��<��0��䍒�����H^� 
  [...]
```

I just did a curl | xzcat to get the file and put it in the patches directory to unbreak the build


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
