### PR TITLE
update.py: fix vim's updater script

### DIFF
--- a/maintainers/scripts/pluginupdate.py
+++ b/maintainers/scripts/pluginupdate.py
@@ -86,7 +86,7 @@ class PluginDesc:
     owner: str
     repo: str
     branch: str
-    alias: str
+    alias: Optional[str]
 
 
 class Repo:
@@ -317,12 +317,10 @@ def get_current_plugins(editor: Editor) -> List[Plugin]:
 
 
 def prefetch_plugin(
-    user: str,
-    repo_name: str,
-    branch: str,
-    alias: Optional[str],
+    p: PluginDesc,
     cache: "Optional[Cache]" = None,
 ) -> Tuple[Plugin, Dict[str, str]]:
+    user, repo_name, branch, alias = p.owner, p.repo, p.branch, p.alias
     log.info(f"Fetching last commit for plugin {user}/{repo_name}@{branch}")
     repo = Repo(user, repo_name, branch, alias)
     commit, date = repo.latest_commit()
@@ -347,7 +345,7 @@ def prefetch_plugin(
 
 
 def fetch_plugin_from_pluginline(plugin_line: str) -> Plugin:
-    plugin, _ = prefetch_plugin(*parse_plugin_line(plugin_line))
+    plugin, _ = prefetch_plugin(parse_plugin_line(plugin_line))
     return plugin
 
 
@@ -466,11 +464,11 @@ class Cache:
 
 
 def prefetch(
-    args: PluginDesc, cache: Cache
+    pluginDesc: PluginDesc, cache: Cache
 ) -> Tuple[str, str, Union[Exception, Plugin], dict]:
-    owner, repo = args.owner, args.repo
+    owner, repo = pluginDesc.owner, pluginDesc.repo
     try:
-        plugin, redirect = prefetch_plugin(owner, repo, args.branch, args.alias, cache)
+        plugin, redirect = prefetch_plugin(pluginDesc, cache)
         cache[plugin.commit] = plugin
         return (owner, repo, plugin, redirect)
     except Exception as e:
@@ -576,8 +574,9 @@ def update_plugins(editor: Editor, args):
         if autocommit:
             commit(
                 nixpkgs_repo,
-                "{editor.get_drv_name name}: init at {version}".format(
-                    editor=editor.name, name=plugin.normalized_name, version=plugin.version
+                "{drv_name}: init at {version}".format(
+                    drv_name=editor.get_drv_name(plugin.normalized_name),
+                    version=plugin.version
                 ),
                 [args.outfile, args.input_file],
             )


### PR DESCRIPTION
recent updates to luarocks updater had broken the vim plugin update script.

Thanks @figsoda for reporting.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
