### PR TITLE
vimPlugins.compe-tabnine: fix binaries symlink

### DIFF
--- a/pkgs/development/tools/tabnine/default.nix
+++ b/pkgs/development/tools/tabnine/default.nix
@@ -1,27 +1,23 @@
 { stdenv, lib, fetchurl, unzip }:
-
 let
-  # You can check the latest version with `curl -sS https://update.tabnine.com/bundles/version`
-  version = "3.5.37";
-  src =
-    if stdenv.hostPlatform.system == "x86_64-darwin" then
-      fetchurl
-        {
-          url = "https://update.tabnine.com/bundles/${version}/x86_64-apple-darwin/TabNine.zip";
-          sha256 = "sha256-Vxmhl4/bhRDeByGgkdSF8yEY5wI23WzT2iH1OFkEpck=";
-        }
-    else if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl
-        {
-          url = "https://update.tabnine.com/bundles/${version}/x86_64-unknown-linux-musl/TabNine.zip";
-          sha256 = "sha256-pttjlx7WWE3nog9L1APp8HN+a4ShhlBj5irHOaPgqHw=";
-        }
-    else throw "Not supported on ${stdenv.hostPlatform.system}";
+  platform =
+    if stdenv.hostPlatform.system == "x86_64-linux" then {
+      name = "x86_64-unknown-linux-musl";
+      sha256 = "sha256-pttjlx7WWE3nog9L1APp8HN+a4ShhlBj5irHOaPgqHw=";
+    } else if stdenv.hostPlatform.system == "x86_64-darwin" then {
+      name = "x86_64-apple-darwin";
+      sha256 = "sha256-Vxmhl4/bhRDeByGgkdSF8yEY5wI23WzT2iH1OFkEpck=";
+    } else throw "Not supported on ${stdenv.hostPlatform.system}";
 in
 stdenv.mkDerivation rec {
   pname = "tabnine";
+  # You can check the latest version with `curl -sS https://update.tabnine.com/bundles/version`
+  version = "3.5.37";
 
-  inherit version src;
+  src = fetchurl {
+    url = "https://update.tabnine.com/bundles/${version}/${platform.name}/TabNine.zip";
+    inherit (platform) sha256;
+  };
 
   dontBuild = true;
 
@@ -39,6 +35,8 @@ stdenv.mkDerivation rec {
     install -Dm755 WD-TabNine $out/bin/WD-TabNine
     runHook postInstall
   '';
+
+  passthru.platform = platform.name;
 
   meta = with lib; {
     homepage = "https://tabnine.com";

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -126,8 +126,8 @@ self: super: {
     buildInputs = [ tabnine ];
 
     postFixup = ''
-      mkdir $target/binaries
-      ln -s ${tabnine}/bin/TabNine $target/binaries/TabNine_$(uname -s)
+      mkdir -p $target/binaries/${tabnine.version}
+      ln -s ${tabnine}/bin/ $target/binaries/${tabnine.version}/${tabnine.passthru.platform}
     '';
   });
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The current master is broken due to upstream changing the expected path of the
TabNine binaries

- tabnine: expose binary platform in passthru
- vimPlugins.compe-tabnine: fix binaries symlink


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
