### PR TITLE
mkvtoolnix: fix GUI on darwin

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -122,6 +122,11 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = true;
 
+  # Avoid Qt 5.12 problem on Big Sur: https://bugreports.qt.io/browse/QTBUG-87014
+  qtWrapperArgs = lib.optionals stdenv.isDarwin [
+    "--set QT_MAC_WANTS_LAYER 1"
+  ];
+
   postFixup = optionalString withGUI ''
     wrapQtApp $out/bin/mkvtoolnix-gui
   '';
@@ -131,7 +136,6 @@ stdenv.mkDerivation rec {
     homepage = "https://mkvtoolnix.download/";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ codyopel rnhmjoj ];
-    platforms = platforms.linux
-      ++ optionals (!withGUI) platforms.darwin;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
The MKVToolNix GUI has been marked as unsupported on darwin since 88d7718a64d (mkvtoolnix-cli: fix build on darwin, 2017-03-13), but currently it builds without issues. It is when `mkvtoolnix-gui` is run that the window doesn't appear.

But I just stumbled upon this today:

https://github.com/NixOS/nixpkgs/blob/461466306ef3cef014c8ca4899879a77993b6f7d/pkgs/development/interpreters/octave/default.nix#L190-L193

So I picked the change, setting the environment variable `QT_MAC_WANTS_LAYER=1` fixes it and now the GUI runs on darwin too.

No icon in the dock though. I don't know how to fix that.

<img width="1440" alt="Captura de Pantalla 2021-08-13 a la(s) 19 25 45" src="https://user-images.githubusercontent.com/238528/129427342-bf0667db-a005-4512-9940-d0aa0d6ccede.png">

Tested on Big Sur.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

mkvtoolnix with GUI support builds but was not running on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
