### PR TITLE
taxi: 0.0.1-unstable=2020-09-03 -> 2.0.2

### DIFF
--- a/pkgs/applications/networking/ftp/taxi/default.nix
+++ b/pkgs/applications/networking/ftp/taxi/default.nix
@@ -4,6 +4,7 @@
 , gobject-introspection
 , gtk3
 , libgee
+, libhandy
 , libsecret
 , libsoup
 , meson
@@ -18,13 +19,13 @@
 
 stdenv.mkDerivation rec {
   pname = "taxi";
-  version = "0.0.1-unstable=2020-09-03";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "Alecaddd";
     repo = pname;
-    rev = "74aade67fd9ba9e5bc10c950ccd8d7e48adc2ea1";
-    sha256 = "sha256-S/FeKJxIdA30CpfFVrQsALdq7Gy4F4+P50Ky5tmqKvM=";
+    rev = version;
+    sha256 = "1a4a14b2d5vqbk56drzbbldp0nngfqhwycpyv8d3svi2nchkvpqa";
   };
 
   nativeBuildInputs = [
@@ -40,6 +41,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3
     libgee
+    libhandy
     libsecret
     libsoup
     pantheon.granite


### PR DESCRIPTION
###### Motivation for this change

https://github.com/Alecaddd/taxi/releases/tag/2.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
