### PR TITLE
libressl: remove vulnerable libressl_3_1

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -63,11 +63,6 @@ let
   };
 
 in {
-  libressl_3_1 = generic {
-    version = "3.1.5";
-    sha256 = "1504a1sf43frw43j14pij0q1f48rm5q86ggrlxxhw708qp7ds4rc";
-  };
-
   libressl_3_2 = generic {
     version = "3.2.5";
     sha256 = "1zkwrs3b19s1ybz4q9hrb7pqsbsi8vxcs44qanfy11fkc7ynb2kr";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17912,7 +17912,6 @@ in
   openvdb = callPackage ../development/libraries/openvdb {};
 
   inherit (callPackages ../development/libraries/libressl { })
-    libressl_3_1
     libressl_3_2;
 
   # Please keep this pointed to the latest version. See also


### PR DESCRIPTION
Fix https://github.com/NixOS/nixpkgs/issues/132137.

Apologies... github.dev did not apply the standard PR template. 