### PR TITLE
factorio: 1.1.36 → 1.1.37

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -10,30 +10,30 @@
         "version": "1.1.37"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.36.tar.xz",
+        "name": "factorio_alpha_x64-1.1.37.tar.xz",
         "needsAuth": true,
-        "sha256": "1x9a2lv6zbqawqlxg8bcbx04hjy0pq40macfa4sqi8w6h14wgww8",
+        "sha256": "0aj8w38lx8bx3d894qxr416x515ijadrlcynvvqjaj1zx3acldzh",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.36/alpha/linux64",
-        "version": "1.1.36"
+        "url": "https://factorio.com/get-download/1.1.37/alpha/linux64",
+        "version": "1.1.37"
       }
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.35.tar.xz",
+        "name": "factorio_demo_x64-1.1.37.tar.xz",
         "needsAuth": false,
-        "sha256": "0yqb4gf2avpxr4vwafws9pv74xyd9g84zggfikfc801ldc7sp29f",
+        "sha256": "06qwx9wd3990d3256y9y5qsxa0936076jgwhinmrlvjp9lxwl4ly",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.35/demo/linux64",
-        "version": "1.1.35"
+        "url": "https://factorio.com/get-download/1.1.37/demo/linux64",
+        "version": "1.1.37"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.1.36.tar.xz",
+        "name": "factorio_demo_x64-1.1.37.tar.xz",
         "needsAuth": false,
-        "sha256": "15fl4pza7n107rrmmdm26kkc12fnrmpn6rjb4ampgzqzn1fq854s",
+        "sha256": "06qwx9wd3990d3256y9y5qsxa0936076jgwhinmrlvjp9lxwl4ly",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.36/demo/linux64",
-        "version": "1.1.36"
+        "url": "https://factorio.com/get-download/1.1.37/demo/linux64",
+        "version": "1.1.37"
       }
     },
     "headless": {
@@ -46,12 +46,12 @@
         "version": "1.1.37"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.36.tar.xz",
+        "name": "factorio_headless_x64-1.1.37.tar.xz",
         "needsAuth": false,
-        "sha256": "1s8g030xp5nrlmnn21frrd8n4nd7jjmb5hbpj1vhxjrk6vpijh24",
+        "sha256": "0hawwjdaxgbrkb80vn9jk6dn0286mq35zkgg5vvv5zhi339pqwwg",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.36/headless/linux64",
-        "version": "1.1.36"
+        "url": "https://factorio.com/get-download/1.1.37/headless/linux64",
+        "version": "1.1.37"
       }
     }
   }


### PR DESCRIPTION
###### Motivation for this change

Users on 1.1.36 cannot play on 1.1.37 servers

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
