### PR TITLE
gocd-server, gocd-agent: 19.3.0-8959 -> 21.2.0-12498

### DIFF
--- a/nixos/modules/services/continuous-integration/gocd-agent/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-agent/default.nix
@@ -35,9 +35,18 @@ in {
         '';
       };
 
+      javaPackage = mkOption {
+        default = pkgs.adoptopenjdk-jre-hotspot-bin-15;
+        defaultText = "pkgs.adoptopenjdk-jre-hotspot-bin-15";
+        type = types.package;
+        description = ''
+          Java package to run the Go.CD agent's process.
+        '';
+      };
+
       packages = mkOption {
-        default = [ pkgs.stdenv pkgs.jre pkgs.git config.programs.ssh.package pkgs.nix ];
-        defaultText = "[ pkgs.stdenv pkgs.jre pkgs.git config.programs.ssh.package pkgs.nix ]";
+        default = [ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ];
+        defaultText = "[ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ]";
         type = types.listOf types.package;
         description = ''
           Packages to add to PATH for the Go.CD agent process.
@@ -191,7 +200,7 @@ in {
         ln -s "${pkgs.writeText "autoregister.properties" cfg.agentConfig}" config/autoregister.properties
 
         ${pkgs.git}/bin/git config --global --add http.sslCAinfo /etc/ssl/certs/ca-certificates.crt
-        ${pkgs.jre}/bin/java ${concatStringsSep " " cfg.startupOptions} \
+        ${cfg.javaPackage}/bin/java ${concatStringsSep " " cfg.startupOptions} \
                         ${concatStringsSep " " cfg.extraOptions} \
                               -jar ${pkgs.gocd-agent}/go-agent/lib/agent-bootstrapper.jar \
                               -serverUrl ${cfg.goServer}

--- a/nixos/modules/services/continuous-integration/gocd-agent/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-agent/default.nix
@@ -193,7 +193,7 @@ in {
         ${pkgs.git}/bin/git config --global --add http.sslCAinfo /etc/ssl/certs/ca-certificates.crt
         ${pkgs.jre}/bin/java ${concatStringsSep " " cfg.startupOptions} \
                         ${concatStringsSep " " cfg.extraOptions} \
-                              -jar ${pkgs.gocd-agent}/go-agent/agent-bootstrapper.jar \
+                              -jar ${pkgs.gocd-agent}/go-agent/lib/agent-bootstrapper.jar \
                               -serverUrl ${cfg.goServer}
       '';
 

--- a/nixos/modules/services/continuous-integration/gocd-agent/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-agent/default.nix
@@ -46,7 +46,7 @@ in {
 
       packages = mkOption {
         default = [ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ];
-        defaultText = "[ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ]";
+        defaultText = literalExample "[ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ]";
         type = types.listOf types.package;
         description = ''
           Packages to add to PATH for the Go.CD agent process.

--- a/nixos/modules/services/continuous-integration/gocd-server/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-server/default.nix
@@ -67,9 +67,18 @@ in {
         '';
       };
 
+      javaPackage = mkOption {
+        default = pkgs.adoptopenjdk-jre-hotspot-bin-15;
+        defaultText = "pkgs.adoptopenjdk-jre-hotspot-bin-15";
+        type = types.package;
+        description = ''
+          Java package run the Go.CD server's process.
+        '';
+      };
+
       packages = mkOption {
-        default = [ pkgs.stdenv pkgs.jre pkgs.git config.programs.ssh.package pkgs.nix ];
-        defaultText = "[ pkgs.stdenv pkgs.jre pkgs.git config.programs.ssh.package pkgs.nix ]";
+        default = [ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ];
+        defaultText = "[ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ]";
         type = types.listOf types.package;
         description = ''
           Packages to add to PATH for the Go.CD server's process.
@@ -182,9 +191,9 @@ in {
 
       script = ''
         ${pkgs.git}/bin/git config --global --add http.sslCAinfo /etc/ssl/certs/ca-certificates.crt
-        ${pkgs.jre}/bin/java -server ${concatStringsSep " " cfg.startupOptions} \
+        ${cfg.javaPackage}/bin/java -server ${concatStringsSep " " cfg.startupOptions} \
                                ${concatStringsSep " " cfg.extraOptions}  \
-                              -jar ${pkgs.gocd-server}/go-server/go.jar
+                              -jar ${pkgs.gocd-server}/go-server/lib/go.jar
       '';
 
       serviceConfig = {

--- a/nixos/modules/services/continuous-integration/gocd-server/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-server/default.nix
@@ -78,7 +78,7 @@ in {
 
       packages = mkOption {
         default = [ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ];
-        defaultText = "[ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ]";
+        defaultText = literalExample "[ pkgs.stdenv pkgs.git config.programs.ssh.package pkgs.nix ]";
         type = types.listOf types.package;
         description = ''
           Packages to add to PATH for the Go.CD server's process.

--- a/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "gocd-agent-${version}-${rev}";
-  version = "19.3.0";
-  rev = "8959";
+  version = "21.2.0";
+  rev = "12498";
 
   src = fetchurl {
     url = "https://download.go.cd/binaries/${version}-${rev}/generic/go-agent-${version}-${rev}.zip";
-    sha256 = "1nirdv82i8x4s1dyb0rmxldh8avappd4g3mbbl6xp7r7s0drcprp";
+    sha256 = "105e38058cb918bf0ff2c8a2458a911fddf2ff347d8e9ba7c9107972d58439f2";
   };
   meta = with lib; {
     description = "A continuous delivery server specializing in advanced workflow modeling and visualization";

--- a/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
-  name = "gocd-agent-${version}-${rev}";
-  version = "21.2.0";
-  rev = "12498";
+  pname = "gocd-agent";
+  version = "21.2.0-12498";
 
   src = fetchurl {
-    url = "https://download.go.cd/binaries/${version}-${rev}/generic/go-agent-${version}-${rev}.zip";
-    sha256 = "105e38058cb918bf0ff2c8a2458a911fddf2ff347d8e9ba7c9107972d58439f2";
+    url = "https://download.go.cd/binaries/${version}/generic/go-agent-${version}.zip";
+    sha256 = "1wirhkap4y8hr6krp3kx6kzz5p8zj654b8n8y87vy65rih2khphh";
   };
+
   meta = with lib; {
     description = "A continuous delivery server specializing in advanced workflow modeling and visualization";
     homepage = "http://www.go.cd";
@@ -19,8 +19,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ unzip ];
 
-  buildCommand = "
-    unzip $src -d $out
-    mv $out/go-agent-${version} $out/go-agent
-  ";
+  buildCommand =
+    let
+      versionParts = lib.splitString "-" version;
+      baseVersion = lib.lists.elemAt versionParts 0;
+    in
+    ''
+      unzip $src -d $out
+      mv $out/go-agent-${baseVersion} $out/go-agent
+    '';
 }

--- a/pkgs/development/tools/continuous-integration/gocd-server/default.nix
+++ b/pkgs/development/tools/continuous-integration/gocd-server/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "gocd-server-${version}-${rev}";
-  version = "19.3.0";
-  rev = "8959";
+  version = "21.2.0";
+  rev = "12498";
 
   src = fetchurl {
     url = "https://download.go.cd/binaries/${version}-${rev}/generic/go-server-${version}-${rev}.zip";
-    sha256 = "0c30qzd6awlw0zx91rk6na0mmgykqkgrw9ychx18ivjwma0hr0sc";
+    sha256 = "a465d23c55bd853636af6cff277b85665054fbd5864a8f13b48b2979f04ccac6";
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/continuous-integration/gocd-server/default.nix
+++ b/pkgs/development/tools/continuous-integration/gocd-server/default.nix
@@ -1,13 +1,12 @@
 { lib, stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
-  name = "gocd-server-${version}-${rev}";
-  version = "21.2.0";
-  rev = "12498";
+  pname = "gocd-server";
+  version = "21.2.0-12498";
 
   src = fetchurl {
-    url = "https://download.go.cd/binaries/${version}-${rev}/generic/go-server-${version}-${rev}.zip";
-    sha256 = "a465d23c55bd853636af6cff277b85665054fbd5864a8f13b48b2979f04ccac6";
+    url = "https://download.go.cd/binaries/${version}/generic/go-server-${version}.zip";
+    sha256 = "1ina9kq7jacbnh9qyjl6spxm8l36hmxjgzvcmwv3d1dxalyd4rd4";
   };
 
   meta = with lib; {
@@ -20,9 +19,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ unzip ];
 
-  buildCommand = "
-    unzip $src -d $out
-    mv $out/go-server-${version} $out/go-server
-    mkdir -p $out/go-server/conf
-  ";
+  buildCommand =
+    let
+      versionParts = lib.splitString "-" version;
+      baseVersion = lib.lists.elemAt versionParts 0;
+    in
+    ''
+      unzip $src -d $out
+      mv $out/go-server-${baseVersion} $out/go-server
+      mkdir -p $out/go-server/conf
+    '';
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The current versions of `gocd-server` and `gocd-agent` are not only way out of date, but also do not properly function at this point in time. As such I felt the need to update the packages and services to be up to date and functional. This conists of a version bum p and some minor change to the start script used for the systemd-Units. I also made the java package used to execute the services configurable and set `adoptopenjdk-hotspot-bin-15` as the default, since the current version of `gocd-server` requires a specific java version of 15 or [crash](https://gist.github.com/skeleten/8cbe11f1a620af4e702abebd62b63c95).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
