### PR TITLE
python3Packages.wrapio: 1.0.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/wrapio/default.nix
+++ b/pkgs/development/python-modules/wrapio/default.nix
@@ -1,15 +1,18 @@
 { lib
 , buildPythonPackage
+, pythonOlder
 , fetchPypi
 }:
 
 buildPythonPackage rec {
   pname = "wrapio";
-  version = "1.0.0";
+  version = "2.0.0";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-JWcPsqZy1wM6/mbU3H0W3EkpLg0wrEUUg3pT/QrL+rE=";
+    sha256 = "sha256-CUocIbdZ/tJQCxAHzhFpB267ynlXf8Mu+thcRRc0yeg=";
   };
 
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

Verified that the `maestral` reverse dependency still works.

Also

```
$ nixpkgs-review wip
[...]
8 packages updated:
maestral maestral-qt python3.8-maestral python3.8-survey python38Packages.wrapio (1.0.0 → 2.0.0) python3.9-maestral python3.9-survey python39Packages.wrapio (1.0.0 → 2.0.0)
[...]
7 packages built:
maestral maestral-gui python38Packages.maestral python38Packages.survey python38Packages.wrapio python39Packages.survey python39Packages.wrapio
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
