### PR TITLE
zd1211-firmware: less fixed-output derivation

### DIFF
--- a/pkgs/os-specific/linux/firmware/zd1211/default.nix
+++ b/pkgs/os-specific/linux/firmware/zd1211/default.nix
@@ -1,19 +1,25 @@
-{ lib, fetchzip }:
+{ stdenv
+, lib
+, fetchurl
+}:
 
-let
+stdenv.mkDerivation rec {
   pname = "zd1211-firmware";
   version = "1.5";
-in fetchzip rec {
-  name = "${pname}-${version}";
-  url = "mirror://sourceforge/zd1211/${name}.tar.bz2";
 
-  postFetch = ''
-    tar -xjvf $downloadedFile
+  src = fetchurl {
+    url = "mirror://sourceforge/zd1211/${pname}-${version}.tar.bz2";
+    hash = "sha256-8R04ENf3KDOZf2NFhKWG3M7XGjU/llq/gQYuxDHQKxI=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/lib/firmware/zd1211
-    cp zd1211-firmware/* $out/lib/firmware/zd1211
-  '';
+    cp * $out/lib/firmware/zd1211
 
-  sha256 = "0sj2zl3r0549mjz37xy6iilm1hm7ak5ax02gwrn81r5yvphqzd52";
+    runHook postInstall
+  '';
 
   meta = {
     description = "Firmware for the ZyDAS ZD1211(b) 802.11a/b/g USB WLAN chip";


### PR DESCRIPTION
###### Motivation for this change

This seems slightly neater/more 'controlled'.

Also, secretly, I hope it makes the weird timestamp issue from #125380
go away, though I have no watertight reasoning for why it would ;).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).