### PR TITLE
nixos/installer: simplify and document wifi setup

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -64,14 +64,51 @@
    </para>
 
    <para>
-    To manually configure the network on the graphical installer, first disable
-    network-manager with <command>systemctl stop NetworkManager</command>.
+    On the graphical installer, you can configure the network, wifi included,
+    through NetworkManager. Using the <command>nmtui</command> program, you
+    can do so even in a non-graphical session. If you prefer to configure the
+    network manually, disable NetworkManager with
+    <command>systemctl stop NetworkManager</command>.
    </para>
 
    <para>
-    To manually configure the wifi on the minimal installer, run
-    <command>wpa_supplicant -B -i interface -c &lt;(wpa_passphrase 'SSID'
-    'key')</command>.
+    On the minimal installer, NetworkManager is not available, so configuration
+    must be perfomed manually. To configure the wifi, first start wpa_supplicant
+    with <command>sudo systemctl start wpa_supplicant</command>, then run
+    <command>wpa_cli</command>. For most home networks, you need to type
+    in the following commands:
+    <programlisting>
+<prompt>&gt; </prompt>add_network
+0
+<prompt>&gt; </prompt>set_network 0 ssid "myhomenetwork"
+OK
+<prompt>&gt; </prompt>set_network 0 psk "mypassword"
+OK
+<prompt>&gt; </prompt>set_network 0 key_mgmt WPA-PSK
+OK
+<prompt>&gt; </prompt>enable_network 0
+OK
+    </programlisting>
+    For enterprise networks, for example <emphasis>eduroam</emphasis>, instead do:
+    <programlisting>
+<prompt>&gt; </prompt>add_network
+0
+<prompt>&gt; </prompt>set_network 0 ssid "eduroam"
+OK
+<prompt>&gt; </prompt>set_network 0 identity "myname@example.com"
+OK
+<prompt>&gt; </prompt>set_network 0 password "mypassword"
+OK
+<prompt>&gt; </prompt>set_network 0 key_mgmt WPA-EAP
+OK
+<prompt>&gt; </prompt>enable_network 0
+OK
+    </programlisting>
+    When successfully connected, you should see a line such as this one
+    <programlisting>
+&lt;3&gt;CTRL-EVENT-CONNECTED - Connection to 32:85:ab:ef:24:5c completed [id=0 id_str=]
+    </programlisting>
+    you can now leave <command>wpa_cli</command> by typing <command>quit</command>.
    </para>
 
    <para>

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -54,7 +54,12 @@ with lib;
       An ssh daemon is running. You then must set a password
       for either "root" or "nixos" with `passwd` or add an ssh key
       to /home/nixos/.ssh/authorized_keys be able to login.
+
+      If you need a wireless connection, type
+      `sudo systemctl start wpa_supplicant` and configure a
+      network using `wpa_cli`. See the NixOS manual for details.
     '' + optionalString config.services.xserver.enable ''
+
       Type `sudo systemctl start display-manager' to
       start the graphical user interface.
     '';
@@ -71,6 +76,7 @@ with lib;
 
     # Enable wpa_supplicant, but don't start it by default.
     networking.wireless.enable = mkDefault true;
+    networking.wireless.userControlled.enable = true;
     systemd.services.wpa_supplicant.wantedBy = mkOverride 50 [];
 
     # Tell the Nix evaluator to garbage collect more aggressively.


### PR DESCRIPTION
###### Motivation for this change

The wpa_supplicant service in the NixOS installer is unusable because
the control socket is disabled and /etc/wpa_supplicant.conf ignored.

The manual currently recommends manually starting the daemon and using
wpa_passphrase, but this requires figuring out the interface name,
driver and only works for WPA2 personal networks.

By enabling the control socket, instead, a user can configure the
network via wpa_cli (or wpa_gui in the graphical installer), which
support more advanced network configurations.

###### Things done

- [x] Built `iso_minimal`
- [x] Built manual
- [x] Connected to a network using `wpa_cli`
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).