### PR TITLE
python3Packages.tzlocal: 2.1 -> 3.0

### DIFF
--- a/pkgs/development/python-modules/tzlocal/default.nix
+++ b/pkgs/development/python-modules/tzlocal/default.nix
@@ -2,8 +2,10 @@
 , backports-zoneinfo
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
 , pytz
+, pythonOlder
+, pytest-mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -22,8 +24,15 @@ buildPythonPackage rec {
     backports-zoneinfo
   ];
 
-  # test fail (timezone test fail)
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  disabledTests = [
+    # Timezone test fail
+    "test_symlink_localtime"
+  ];
 
   pythonImportsCheck = [ "tzlocal" ];
 

--- a/pkgs/development/python-modules/tzlocal/default.nix
+++ b/pkgs/development/python-modules/tzlocal/default.nix
@@ -1,16 +1,26 @@
-{ lib, buildPythonPackage, fetchPypi
-, pytz }:
+{ lib
+, backports-zoneinfo
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pytz
+}:
 
 buildPythonPackage rec {
   pname = "tzlocal";
-  version = "2.1";
-
-  propagatedBuildInputs = [ pytz ];
+  version = "3.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44";
+    sha256 = "sha256-9ObjbbUEmeDZL3m2c2EEHwSOJgnRZuk0VrUHRtxK7xI=";
   };
+
+  propagatedBuildInputs = [
+    pytz
+  ]  ++ lib.optionals (pythonOlder "3.9") [
+    backports-zoneinfo
+  ];
 
   # test fail (timezone test fail)
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.0

Change log: https://github.com/regebro/tzlocal/blob/master/CHANGES.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
