### PR TITLE
Fix import path on `lib/flake.nix`

### DIFF
--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -1,5 +1,5 @@
 {
   description = "Library of low-level helper functions for nix expressions.";
 
-  outputs = { self }: { lib = import ./lib; };
+  outputs = { self }: { lib = import ./.; };
 }


### PR DESCRIPTION
###### Motivation for this change


Trying to create a simple flake with input:

```
{
     inputs.nixpkgs-lib.url = "github:NixOS/nixpkgs?dir=lib";
     outputs = {nixpkgs-lib, ...}: { };
}
```

Fails when trying to evaluate the nixpkgs-lib flake with an error like:

```
error: getting status of '/nix/store/xxxx-source/lib/lib': No such file or directory
(use '--show-trace' to show detailed location information)
```

###### Things done

Updated the import path to be `./.` since it's relative to the flake root that is specified via `?dir=lib`.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
