### PR TITLE
[21.05] openvswitch: add patch for CVE-2021-36980

### DIFF
--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, makeWrapper, pkg-config, util-linux, which
-, procps, libcap_ng, openssl, python3 , perl
+{ lib, stdenv, fetchurl, fetchpatch, makeWrapper, pkg-config, util-linux, which
+, procps, libcap_ng, openssl, python3, perl, autoconf, automake, libtool
 , kernel ? null }:
 
 with lib;
@@ -16,9 +16,22 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-ZfQg+VTiUNiV+y2yKhMuHLVgvF4rkFHoNFETSBCOWXo=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-36980.patch";
+      url = "https://github.com/openvswitch/ovs/commit/8ce8dc34b5f73b30ce0c1869af9947013c3c6575.patch";
+      sha256 = "1iyaqkiwijl2djjvnnvykh95qlzgvn9hmpszrwzmhwvik5m7b6g6";
+      # we don't run the tests, and the binary example missing from the patch
+      # file upsets the build process
+      excludes = [ "tests/*" ];
+    })
+  ];
+
+  preConfigure = "./boot.sh";
+
   kernel = optional (_kernel != null) _kernel.dev;
 
-  nativeBuildInputs = [ pkg-config makeWrapper ];
+  nativeBuildInputs = [ pkg-config makeWrapper autoconf automake libtool ];
   buildInputs = [ util-linux openssl libcap_ng pythonEnv
                   perl procps which ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-36980
#132151

See #134066 for master.

This patch is present on the 2.14.x branch, but it looks like upstream have just neglected to do a release lately.

`openvswitch-lts` not vulnerable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
