### PR TITLE
tree-sitter: update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-comment",
-  "rev": "894b61d68a31d93c33ed48dcc7f427174b440abe",
-  "date": "2021-04-27T15:25:48-05:00",
-  "path": "/nix/store/w0yz9imzi33glwk6ilm0jqipcyzl8hgm-tree-sitter-comment",
-  "sha256": "1vfayzzcv6lj63pgcxr8f7rcd81jkgnfdlmhs39i7w3m0s6dv1qg",
+  "rev": "8d480c0a86e3b95812252d29292b2686eb92418d",
+  "date": "2021-08-13T15:03:50-05:00",
+  "path": "/nix/store/4aqsac34f0pzpa889067dqci743axrmx-tree-sitter-comment",
+  "sha256": "0fqhgvpd391nxrpyhxcp674h8qph280ax6rm6dz1pj3lqs3grdka",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "c61212414a3e95b5f7507f98e83de1d638044adc",
-  "date": "2021-03-27T10:08:51-07:00",
-  "path": "/nix/store/a8cd3sv1j900sd8l7cdjw91iw7pp3jhv-tree-sitter-cpp",
-  "sha256": "04nv9j03q20idk9pnm2lgw7rbwzy5jf9v0y6l102by68z4lv79fi",
+  "rev": "53afc568b70e4b71ee799501f34c876ad511f56e",
+  "date": "2021-08-13T10:48:59-05:00",
+  "path": "/nix/store/6gj41lh1fnnmcrz4c1bk3ncw0kpm97nm-tree-sitter-cpp",
+  "sha256": "02avniqmb5hgpkzwmkgxhrxk296dbkra9miyi5pax461ab4j7a9r",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ram02z/tree-sitter-fish",
-  "rev": "db7139393e50765520618fa469f41dfbb0b3822b",
-  "date": "2021-07-06T21:05:19+02:00",
-  "path": "/nix/store/k67b4bn67zd3dj9yg0q7jywy3vnkv8gw-tree-sitter-fish",
-  "sha256": "09l5myivlq3z53nqlx8x8c45sww2k7vmjp8z0rvwzv08rnym0fah",
+  "rev": "04e54ab6585dfd4fee6ddfe5849af56f101b6d4f",
+  "date": "2021-08-02T21:46:56+01:00",
+  "path": "/nix/store/0n3jfh7gk16bmikix34y5m534ac12xgc-tree-sitter-fish",
+  "sha256": "1810z8ah1b09qpxcr4bh63bxsnxx24r6d2h46v2cpqv1lg0g4z14",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "a0c1adb59e390f7d839a146c57fdb33d36ed97e6",
-  "date": "2021-06-18T23:36:08+02:00",
-  "path": "/nix/store/7rl3najf8rn8ndh31vcxjz5px3r1scky-tree-sitter-haskell",
-  "sha256": "0a97w0qnj0fwy0yyg7hb9i1fyiwbyiz5mwx77aaw6md4jcsf4di8",
+  "rev": "30eea3c1339e573cda5dcffd8f9b06003ec31789",
+  "date": "2021-08-07T14:37:05+02:00",
+  "path": "/nix/store/b99w2q2y5gjj5h1bxipncaf40dyx5sd2-tree-sitter-haskell",
+  "sha256": "0cch7bcr4d9ll92vhcp79bjzs9dw0glvdrdj2q2h2mg5mmkzcya8",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-html",
-  "rev": "d93af487cc75120c89257195e6be46c999c6ba18",
-  "date": "2021-03-04T14:11:18-08:00",
-  "path": "/nix/store/26yjfh6v17n4ajs9ln7x25sf1m3ijcjg-tree-sitter-html",
-  "sha256": "1hg7vbcy7bir6b8x11v0a4x0glvqnsqc3i2ixiarbxmycbgl3axy",
+  "rev": "af9339f3deb131ab99acfac906713b81dbcc41c9",
+  "date": "2021-07-11T11:04:28-07:00",
+  "path": "/nix/store/jg23pmi6jfy4kykah645gl44a145929c-tree-sitter-html",
+  "sha256": "1qb4rfbra3nc0fwmla8q1hb4r48k8cv3nl60zc24xhrw3q1d9zh1",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "6de6d604c243b68f90dce14130d536c694d90dcc",
-  "date": "2021-06-29T15:54:12-07:00",
-  "path": "/nix/store/mmz8s440zplg88c0mb0w3dlg94dzgxmf-tree-sitter-javascript",
-  "sha256": "1bz8xhs7q4lp49q1id6dvz93l7vf0gxgngsbjk3x1nvw8rg171j6",
+  "rev": "bc2eb3994fd7cc605d27a32f9fcbee80bbb57f6d",
+  "date": "2021-08-13T14:29:43-07:00",
+  "path": "/nix/store/jkq26hbij9si8ri8k5agkdadr3p1nmbi-tree-sitter-javascript",
+  "sha256": "0f6bny38za17mmwqw0q0nmdb4f9i0xs7kbzixxgi44yyd43r5pzp",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/latex-lsp/tree-sitter-latex",
-  "rev": "7f720661de5316c0f8fee956526d4002fa1086d8",
-  "date": "2021-05-11T16:35:53+02:00",
-  "path": "/nix/store/ssqxahrza89qmb97bxas6dvhbqd7w0dr-tree-sitter-latex",
-  "sha256": "14jfmbv3czs643bggcsi3pyxhf81jirpvg8hxcbcdx1f3fzhs16m",
+  "rev": "2c0d03a36ee979bc697f6a9dd119174cf0ef15e0",
+  "date": "2021-07-19T17:50:34+02:00",
+  "path": "/nix/store/vrpfbjfps3bd9vrx8760l0vx7m7ijhja-tree-sitter-latex",
+  "sha256": "0dfpdv5sibvajf2grlc0mqhyggjf6ip9j01jikk58n1yc9va88ib",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-treesitter/tree-sitter-lua",
-  "rev": "b6d4e9e10ccb7b3afb45018fbc391b4439306b23",
-  "date": "2021-03-05T14:55:53+01:00",
-  "path": "/nix/store/mlvnfmm5q67810qdim11qs4ivq54jrmr-tree-sitter-lua",
-  "sha256": "17kf1m2qpflqv7xng6ls4v1qxfgdlpgxs4qjwb6rcc8nbcdsj4ms",
+  "rev": "6f5d40190ec8a0aa8c8410699353d820f4f7d7a6",
+  "date": "2021-08-02T15:13:28+02:00",
+  "path": "/nix/store/h1bhl291jac001w2c8fxi9w7dsqxq5q0-tree-sitter-lua",
+  "sha256": "05ash0l46s66q9yamzzh6ghk8yv0vas13c7dmz0c9xljbjk5ab1d",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "50f38ceab667f9d482640edfee803d74f4edeba5",
-  "date": "2021-04-27T17:21:51-05:00",
-  "path": "/nix/store/fhf3mvxg17g0xli59cgmmwqy4g21fbzj-tree-sitter-nix",
-  "sha256": "11gifb9b7x9v223hsrcb6wlkqpxbc4p5v4ny9aixzi9k8g0jhb3d",
+  "rev": "83ee5993560bf15854c69b77d92e34456f8fb655",
+  "date": "2021-07-21T20:36:40-05:00",
+  "path": "/nix/store/n5pq9gba570874akpwpvs052d7vyalhh-tree-sitter-nix",
+  "sha256": "03jhvyrsxq49smk9p2apjj839wmzjmrzy045wcxawz1g7xssp9pr",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "5e89808d490d893799ebcf229130afe4cf2b0324",
-  "date": "2021-06-22T09:23:44+02:00",
-  "path": "/nix/store/5c1pn1p183czqb43a0va7whd4sz81jf1-tree-sitter-php",
-  "sha256": "1mp5kv305a4rrgh7kklifqfg3680krfsd0h76sxn4i0wxyqfgczi",
+  "rev": "63cebc37ebed42887f14cdd0baec961d5a1e16c1",
+  "date": "2021-08-10T20:56:40+02:00",
+  "path": "/nix/store/bh4yl563l5fgh7r8f95zzybsavci8hyh-tree-sitter-php",
+  "sha256": "1psiamww22imw05z0h34yks7vh7y4x4bdn62dwic1gpwfbjdrfmr",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "bfa2a81388019d47f6a0a6a6e9c96910dec830b4",
-  "date": "2021-06-23T15:37:27-07:00",
-  "path": "/nix/store/nc5cndwzc5pzq3x64wa51bff0rl36hc8-tree-sitter-scala",
-  "sha256": "0x0lq78gjfsqi225mfvrpkl2jc6fbb378jgj04syxkm941lxc4bk",
+  "rev": "ec38674996753f9631615fa558d4f1fa3bf90633",
+  "date": "2021-08-08T14:43:30-07:00",
+  "path": "/nix/store/2b0z1j06gvpcn1rvq8hv5vdqlh3qlzmv-tree-sitter-scala",
+  "sha256": "1xv544wnyd075g5pc8lxi0ix6wrwiv82sdjhzf3wd1np42vxq3d4",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "28e757a2f498486931b3cb13a100a1bcc9261456",
-  "date": "2021-05-04T14:04:30-07:00",
-  "path": "/nix/store/d90hgv5g374a6mrwhq9vcxk6d6lp2ags-tree-sitter-typescript",
-  "sha256": "0dxy5h68hhypzq0z15q8iawjgw3kx7dlpw76zv6xkxh25idqgxqh",
+  "rev": "d598c96714a2dc9e346589c63369aff6719a51e6",
+  "date": "2021-08-02T14:05:14-07:00",
+  "path": "/nix/store/hf714sspmakhzra9bqazhbb0iljva1hi-tree-sitter-typescript",
+  "sha256": "0yra8fhgv7wqkik85icqyckf980v9ch411mqcjcf50n5dc1siaik",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

its been a while


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
