### PR TITLE
claws-mail: 3.17.8 -> 3.18.0, 3.99.0 -> 4.0.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, fetchgit, wrapGAppsHook, autoreconfHook, bison, flex
+{ stdenv, lib, fetchgit, fetchpatch, wrapGAppsHook, autoreconfHook, bison, flex
 , curl, gtk2, gtk3, pkg-config, python2, python3, shared-mime-info
 , glib-networking, gsettings-desktop-schemas
 
-# Use the experimental gtk3 branch.
-, useGtk3 ? false
+# Selector between the GTK+ 3 and GTK+ 2 releases.
+, useGtk3
 
 # Package compatibility: old parameters whose name were not directly derived
 , enablePgp ? true
@@ -57,16 +57,15 @@
 with lib;
 
 let
-  version = if useGtk3 then "3.99.0" else "3.17.8";
+  # Last release and hash for both the GTK+ 3 and GTK+ 2 version.
+  version = if useGtk3 then "4.0.0" else "3.18.0";
 
-  # The official release uses gtk2 and contains the version tag.
   gtk2src = {
-    sha256 = "0l4f8q11iyj8pi120lrapgq51k5j64xf0jlczkzbm99rym752ch5";
+    sha256 = "1vsiy3xsppw4d8ylsz70wsyrvmgy88lp2hj7vrc353ckny80r9lh";
   };
 
-  # The corresponding commit in the gtk3 branch.
   gtk3src = {
-    sha256 = "176h1swh1zx6dqyzfz470x4a1xicnv0zhy8ir47k7p23g6y17i2k";
+    sha256 = "0mwnjiqg2sj61va0y9yi3v52iyr5kzmbnvsqxav3a48m2f8p27qn";
   };
 
   python = if useGtk3 then python3 else python2;
@@ -125,7 +124,19 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  patches = [ ./mime.patch ];
+  patches = [
+    ./mime.patch
+
+    # Fixes a bug with the automatic authentication method, resulting in errors
+    # with certain mail providers.
+    # <https://www.thewildbeast.co.uk/claws-mail/bugzilla/show_bug.cgi?id=4497>
+    # This MUST be removed for the next release.
+    (fetchpatch {
+      name = "fix-automatic-auth.patch";
+      url = "https://git.claws-mail.org/?p=claws.git;a=patch;h=9c2585c58b49815a0eab8d683f0a94f75cbbe64e";
+      sha256 = "0v8v5q2p4h93lp7yq3gnlvarsrcssv96aks1wqy3187vsr4kdw7a";
+    })
+  ];
 
   preConfigure = ''
     # autotools check tries to dlopen libpython as a requirement for the python plugin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22857,6 +22857,7 @@ in
 
   claws-mail = callPackage ../applications/networking/mailreaders/claws-mail {
     inherit (xorg) libSM;
+    useGtk3 = false;
   };
   claws-mail-gtk3 = callPackage ../applications/networking/mailreaders/claws-mail {
     inherit (xorg) libSM;


### PR DESCRIPTION
###### Motivation for this change
Fixes CVE-2021-37746

Closes #133948

Basically #129833, except it doesn't default to the gtk3 branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
