### PR TITLE
Fixed replacement of `as` on aarch64-darwin when cross-compiling

### DIFF
--- a/pkgs/development/libraries/libnice/default.nix
+++ b/pkgs/development/libraries/libnice/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     openssl
-  ] ++ optional !stdenv.isDarwin gupnp-igd;
+  ] ++ optional (!stdenv.isDarwin) gupnp-igd;
 
   propagatedBuildInputs = [
     glib

--- a/pkgs/development/libraries/libnice/default.nix
+++ b/pkgs/development/libraries/libnice/default.nix
@@ -10,9 +10,8 @@
 , docbook_xsl
 , docbook_xml_dtd_412
 , glib
-, gupnp-igd
 , gst_all_1
-, gnutls
+, openssl
 }:
 
 stdenv.mkDerivation rec {
@@ -52,8 +51,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
-    gnutls
-    gupnp-igd
+    openssl
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/libnice/default.nix
+++ b/pkgs/development/libraries/libnice/default.nix
@@ -12,6 +12,7 @@
 , glib
 , gst_all_1
 , openssl
+, gupnp-igd ? !stdenv.isDarwin
 }:
 
 stdenv.mkDerivation rec {
@@ -52,7 +53,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     openssl
-  ];
+  ] ++ optional !stdenv.isDarwin gupnp-igd;
 
   propagatedBuildInputs = [
     glib
@@ -61,7 +62,9 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dgtk_doc=enabled" # Disabled by default as of libnice-0.1.15
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-  ];
+  ] ++ (if stdenv.isDarwin then [
+    "-Dgupnp=disabled" # gupnp-igd does not build on Darwin
+  ] else []);
 
   # Tests are flaky
   # see https://github.com/NixOS/nixpkgs/pull/53293#issuecomment-453739295
@@ -77,7 +80,7 @@ stdenv.mkDerivation rec {
       It provides a GLib-based library, libnice and a Glib-free library,
       libstun as well as GStreamer elements.'';
     homepage = "https://libnice.freedesktop.org/";
-    platforms = platforms.linux;
+    platforms = platforms.all;
     license = with licenses; [ lgpl21 mpl11 ];
   };
 }

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -56,8 +56,8 @@ stdenv.mkDerivation {
   # and using clang directly here is a better option than relying on cctools.
   # On x86_64-darwin the Clang version is too old to support this mode.
   + lib.optionalString stdenv.isAarch64 ''
-    rm $out/bin/as
-    makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/as" \
+    rm $out/bin/${targetPrefix}as
+    makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
       --add-flags "-x assembler -integrated-as -c"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Cross-compiling for iOS currently fails on aarch64-darwin due to this `rm` failing; the bare file `as` does not exist because it's prefixed with the target.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
