### PR TITLE
audiowaveform: 1.4.2 -> 1.5.1, fix gtest subproject

### DIFF
--- a/pkgs/tools/audio/audiowaveform/default.nix
+++ b/pkgs/tools/audio/audiowaveform/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "audiowaveform";
-  version = "1.4.2";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "bbc";
     repo = "audiowaveform";
     rev = version;
-    sha256 = "0k2s2f2hgq4pnjzfkgvjwgsflihmzdq7shicfjn0z2mzw4d1bvp2";
+    sha256 = "sha256-WODAgiwZ7UfoukTcujXE5atw/Z03+Vo6aR2jubPwQeU=";
   };
 
   nativeBuildInputs = [ cmake gtest ];
@@ -16,8 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ boost gd libsndfile libmad libid3tag ];
 
   preConfigure = ''
-    ln -s ${gtest.src}/googletest googletest
-    ln -s ${gtest.src}/googlemock googlemock
+    ln -s ${gtest.src} googletest
   '';
 
   # One test is failing, see PR #101947


### PR DESCRIPTION
Will be needed to fix build with gtest v1.11.0 (currently in staging-next #131928).
See https://github.com/bbc/audiowaveform/commit/7243739cb138e3952884786ba42694dd9ddc2c09

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
