### PR TITLE
cctools-binutils-darwin: Fixed replacement of `as` on aarch64-darwin when cross-compiling

### DIFF
--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -56,8 +56,8 @@ stdenv.mkDerivation {
   # and using clang directly here is a better option than relying on cctools.
   # On x86_64-darwin the Clang version is too old to support this mode.
   + lib.optionalString stdenv.isAarch64 ''
-    rm $out/bin/as
-    makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/as" \
+    rm $out/bin/${targetPrefix}as
+    makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
       --add-flags "-x assembler -integrated-as -c"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Cross-compiling for iOS currently fails on aarch64-darwin due to this rm failing; the bare file as does not exist because it's prefixed with the target.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
