### PR TITLE
intel2200BGFirmware: less fixed-output derivation

### DIFF
--- a/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
@@ -1,18 +1,25 @@
-{ lib, fetchzip }:
+{ stdenv
+, lib
+, fetchurl }:
 
-let version = "3.1"; in
+stdenv.mkDerivation rec {
+  pname = "intel2200BGFirmware";
+  version = "3.1";
 
-fetchzip {
-  name = "intel2200BGFirmware-${version}";
-  url = "https://src.fedoraproject.org/repo/pkgs/ipw2200-firmware/ipw2200-fw-${version}.tgz/eaba788643c7cc7483dd67ace70f6e99/ipw2200-fw-${version}.tgz";
-  sha256 = "0zjyjndyc401pn5x5lgypxdal21n82ymi3vbb2ja1b89yszj432b";
+  src = fetchurl {
+    url = "https://src.fedoraproject.org/repo/pkgs/ipw2200-firmware/ipw2200-fw-${version}.tgz/eaba788643c7cc7483dd67ace70f6e99/ipw2200-fw-${version}.tgz";
+    hash = "sha256-xoGMEcGMwDDVX/g/ZLK62P7vSF53QvhPlKYdgRpiWL0=";
+  };
 
-  postFetch = ''
-    tar -xzvf $downloadedFile --strip-components=1
+  installPhase = ''
+    runHook preInstall
+
     install -D -m644 ipw2200-bss.fw     $out/lib/firmware/ipw2200-bss.fw
     install -D -m644 ipw2200-ibss.fw    $out/lib/firmware/ipw2200-ibss.fw
     install -D -m644 ipw2200-sniffer.fw $out/lib/firmware/ipw2200-sniffer.fw
     install -D -m644 LICENSE.ipw2200-fw $out/share/doc/intel2200BGFirmware/LICENSE
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This seems slightly neater/more 'controlled'.

Also, secretly, I hope it makes the weird timestamp issue from #125380
go away, though I have no watertight reasoning for why it would
;).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).