### PR TITLE
tagutil: init at 3.1

### DIFF
--- a/pkgs/applications/audio/tagutil/default.nix
+++ b/pkgs/applications/audio/tagutil/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchFromGitHub
+, pkg-config, cmake, libyaml
+, jansson, libvorbis, taglib
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tagutil";
+  version = "3.1";
+
+  src = fetchFromGitHub {
+    owner = "kaworu";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-oY1aGl5CKVtpOfh8Wskio/huWYMiPuxWPqxlooTutcw=";
+  };
+
+  sourceRoot = "source/src";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libvorbis
+    libyaml
+    jansson
+    taglib
+    zlib
+  ];
+
+  meta = with lib; {
+    description = "Scriptable music files tags tool and editor";
+    homepage = "https://github.com/kaworu/tagutil";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dan4ik605743 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9308,6 +9308,8 @@ in
 
   tboot = callPackage ../tools/security/tboot { };
 
+  tagutil = callPackage ../applications/audio/tagutil { };
+
   tcpdump = callPackage ../tools/networking/tcpdump { };
 
   tcpflow = callPackage ../tools/networking/tcpflow { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
