### PR TITLE
elixir_ls: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/development/beam-modules/elixir_ls.nix
+++ b/pkgs/development/beam-modules/elixir_ls.nix
@@ -4,20 +4,20 @@
 
 mixRelease rec {
   pname = "elixir-ls";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "elixir-lsp";
     repo = "elixir-ls";
     rev = "v${version}";
-    sha256 = "0d0hqc35hfjkpm88vz21mnm2a9rxiqfrdi83whhhh6d2ba216b7s";
+    sha256 = "sha256-pUvONMTYH8atF/p2Ep/K3bwJUDxTzCsxLPbpjP0tQpM=";
     fetchSubmodules = true;
   };
 
   mixFodDeps = fetchMixDeps {
     pname = "mix-deps-${pname}";
     inherit src version;
-    sha256 = "0r9x223imq4j9pn9niskyaybvk7jmq8dxcyzk7kwfsi128qig1a1";
+    sha256 = "sha256-YRzPASpg1K2kZUga5/aQf4Q33d8aHCwhw7KJxSY56k4=";
   };
 
   # elixir_ls is an umbrella app


### PR DESCRIPTION
###### Motivation for this change

upstream update

https://github.com/elixir-lsp/elixir-ls/blob/v0.8.0/CHANGELOG.md#v080-14-august-2021

one more note for the interested. Elixir-ls still uses git dependencies in its lock, so the update to mixRelease is not straightforward. I personally would say that it's not worth doing stuff manually at the moment (even if there are like 10 dependencies)
https://github.com/elixir-lsp/elixir-ls/blob/v0.8.0/mix.lock

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
