### PR TITLE
bpb: init at unstable-2018-07-27

### DIFF
--- a/pkgs/tools/security/bpb/default.nix
+++ b/pkgs/tools/security/bpb/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "bpb";
+  version = "unstable-2018-07-27";
+
+  src = fetchFromGitHub {
+    owner = "withoutboats";
+    repo = "bpb";
+    rev = "b1ef5ca1d2dea0e2ec0b1616f087f110ea17adfa";
+    sha256 = "sVfM8tlAsF4uKLxl3g/nSYgOx+znHIdPalSIiCd18o4=";
+  };
+
+  cargoSha256 = "7cARRJWRxF1kMySX6KcB6nrVf8k1p/nr3OyAwNLmztc=";
+
+  # a nightly compiler is required unless we use this cheat code.
+  RUSTC_BOOTSTRAP = 1;
+
+  meta = with lib; {
+    description = "Tool to automatically sign git commits, replacing gpg for that purpose";
+    homepage = "https://github.com/withoutboats/bpb";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2067,6 +2067,8 @@ with pkgs;
   bozohttpd = callPackage ../servers/http/bozohttpd { };
   bozohttpd-minimal = callPackage ../servers/http/bozohttpd { minimal = true; };
 
+  bpb = callPackage ../tools/security/bpb { };
+
   bpytop = callPackage ../tools/system/bpytop { };
 
   brasero-original = lowPrio (callPackage ../tools/cd-dvd/brasero { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[Signing my git commits without GPG](https://without.boats/blog/signing-commits-without-gpg/)

[How to set up](https://github.com/withoutboats/bpb#how-to-set-up)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] Signed this commmit with the tool.
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
