### PR TITLE
python3Packages.pyppeteer: 0.2.5 -> 0.2.6

### DIFF
--- a/pkgs/development/python-modules/pyppeteer/default.nix
+++ b/pkgs/development/python-modules/pyppeteer/default.nix
@@ -2,7 +2,6 @@
 , appdirs
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , poetry-core
 , pyee
 , pytest-xdist
@@ -16,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "pyppeteer";
-  version = "0.2.5";
+  version = "0.2.6";
   disabled = pythonOlder "3.6";
   format = "pyproject";
 
@@ -24,7 +23,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "1hl4rw8j5yiak0d34vx1l1blr8125bscjd8m46a5m8xzm98csjc7";
+    sha256 = "sha256-mMFQp8GMjKUc3yyB4c8Tgxut7LkMFa2cySO3iSA/aI4=";
   };
 
   nativeBuildInputs = [
@@ -44,21 +43,6 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
   ];
-
-  patches = [
-    # Switch to poetry-core, https://github.com/pyppeteer/pyppeteer/pull/262
-    (fetchpatch {
-      name = "switch-poetry-core.patch";
-      url = "https://github.com/pyppeteer/pyppeteer/commit/e248baebefcf262fd96f261d940e74ed49ba2df9.patch";
-      sha256 = "03g8n35kn2alqki37s0hf2231fk2zkr4nr1x1g2rfrhps9d6fyvw";
-    })
-  ];
-
-  postPatch = ''
-    # https://github.com/pyppeteer/pyppeteer/pull/252
-    substituteInPlace pyproject.toml \
-      --replace 'websockets = "^8.1"' 'websockets = "*"'
-  '';
 
   disabledTestPaths = [
     # Requires network access


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.2.6

Change log: https://github.com/pyppeteer/pyppeteer/blob/dev/CHANGELOG.md#version-026

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
