### PR TITLE
binutils: try to fix plv8 build

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -70,6 +70,11 @@ stdenv.mkDerivation {
     #     https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=956ea65cd707707c0f725930214cbc781367a831
     ./bfd-elf-Dont-read-non-existing-secondary-relocs.patch
 
+    # Fix building plv8’s v8.
+    # https://github.com/NixOS/nixpkgs/issues/134190
+    # Obtained from: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=586e30940e640f67bd55bd72e1d1355a4faf8079
+    ./gold-Update-GNU_PROPERTY_X86_XXX-macros.patch
+
     ./CVE-2020-35448.patch
   ] ++ lib.optional stdenv.targetPlatform.isiOS ./support-ios.patch
     ++ # This patch was suggested by Nick Clifton to fix

--- a/pkgs/development/tools/misc/binutils/gold-Update-GNU_PROPERTY_X86_XXX-macros.patch
+++ b/pkgs/development/tools/misc/binutils/gold-Update-GNU_PROPERTY_X86_XXX-macros.patch
@@ -1,0 +1,292 @@
+From 586e30940e640f67bd55bd72e1d1355a4faf8079 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Tue, 13 Oct 2020 05:20:49 -0700
+Subject: [PATCH] gold: Update GNU_PROPERTY_X86_XXX macros
+
+This patch updates GNU_PROPERTY_X86_XXX macros for gold:
+
+1. GNU_PROPERTY_X86_UINT32_AND_XXX: A 4-byte unsigned integer property.
+A bit is set if it is set in all relocatable inputs:
+
+ #define GNU_PROPERTY_X86_UINT32_AND_LO      0xc0000002
+ #define GNU_PROPERTY_X86_UINT32_AND_HI      0xc0007fff
+
+2. GNU_PROPERTY_X86_UINT32_OR_XXX: A 4-byte unsigned integer property.
+A bit is set if it is set in any relocatable inputs:
+
+ #define GNU_PROPERTY_X86_UINT32_OR_LO    0xc0008000
+ #define GNU_PROPERTY_X86_UINT32_OR_HI    0xc000ffff
+
+3. GNU_PROPERTY_X86_UINT32_OR_AND_XXX: A 4-byte unsigned integer property.
+A bit is set if it is set in any relocatable inputs and the property is
+present in all relocatable inputs:
+
+ #define GNU_PROPERTY_X86_UINT32_OR_AND_LO   0xc0010000
+ #define GNU_PROPERTY_X86_UINT32_OR_AND_HI   0xc0017fff
+
+4. GNU_PROPERTY_X86_FEATURE_2_NEEDED, GNU_PROPERTY_X86_FEATURE_2_USED
+and GNU_PROPERTY_X86_FEATURE_2_XXX bits.
+
+GNU_PROPERTY_X86_FEATURE_1_AND is unchanged.  GNU_PROPERTY_X86_ISA_1_USED
+and GNU_PROPERTY_X86_ISA_1_NEEDED are updated to better support targeted
+processors since GNU_PROPERTY_X86_ISA_1_?86 aren't isn't very useful.
+A new set of GNU_PROPERTY_X86_ISA_1_XXX bits are defined.  The previous
+GNU_PROPERTY_X86_ISA_1_XXX macros are deprecated and renamed to
+GNU_PROPERTY_X86_COMPAT_ISA_1_XXX and GNU_PROPERTY_X86_COMPAT_2_ISA_1_XXX.
+
+elfcpp/
+
+	* elfcpp.h (GNU_PROPERTY_X86_ISA_1_USED): Renamed to ...
+	(GNU_PROPERTY_X86_COMPAT_ISA_1_USED): This.
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): Renamed to ...
+	(GNU_PROPERTY_X86_COMPAT_ISA_1_NEEDED): This.
+	(GNU_PROPERTY_X86_UINT32_AND_LO): New.
+	(GNU_PROPERTY_X86_UINT32_AND_HI): Likewise.
+	(GNU_PROPERTY_X86_UINT32_OR_LO): Likewise.
+	(GNU_PROPERTY_X86_UINT32_OR_HI): Likewise.
+	(GNU_PROPERTY_X86_UINT32_OR_AND_LO): Likewise.
+	(GNU_PROPERTY_X86_UINT32_OR_AND_HI): Likewise.
+	(GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED): New.
+	(GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED): Likewise.
+	(GNU_PROPERTY_X86_FEATURE_1_AND): Updated to
+	(GNU_PROPERTY_X86_UINT32_AND_LO + 0).
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): New.  Defined to
+	GNU_PROPERTY_X86_UINT32_OR_LO + 2.
+	(GNU_PROPERTY_X86_FEATURE_2_NEEDED): New.  Defined to
+	(GNU_PROPERTY_X86_UINT32_OR_LO + 1).
+	(GNU_PROPERTY_X86_ISA_1_USED): New.  Defined to
+	GNU_PROPERTY_X86_UINT32_OR_AND_LO + 2.
+	(GNU_PROPERTY_X86_FEATURE_2_USED): New.  Defined to
+	(GNU_PROPERTY_X86_UINT32_OR_AND_LO + 1).
+
+gold/
+
+	* x86_64.cc (Target_x86_64::Target_x86_64): Initialize
+	feature_2_used_, feature_2_needed_ and object_feature_2_used_.
+	(Target_x86_64::feature_2_used_): New data member.
+	(Target_x86_64::feature_2_needed_): Likewise.
+	(Target_x86_64::object_isa_1_used_): Likewise.
+	(Target_x86_64::record_gnu_property): Support
+	GNU_PROPERTY_X86_COMPAT_ISA_1_USED,
+	GNU_PROPERTY_X86_COMPAT_ISA_1_NEEDED,
+	GNU_PROPERTY_X86_COMPAT_2_ISA_1_USED,
+	GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED,
+	GNU_PROPERTY_X86_FEATURE_2_USED and
+	GNU_PROPERTY_X86_FEATURE_2_NEEDED.
+	(Target_x86_64::merge_gnu_properties): Merge FEATURE_2_USED bits.
+	Initialize object_feature_2_used_.
+	(Target_x86_64::do_finalize_gnu_properties): Support
+	GNU_PROPERTY_X86_FEATURE_2_USED and
+	GNU_PROPERTY_X86_FEATURE_2_NEEDED.
+	* testsuite/gnu_property_a.S (GNU_PROPERTY_X86_ISA_1_USED): Set
+	to 0xc0010002.
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): Set to 0xc0008002.
+	* testsuite/gnu_property_b.S (GNU_PROPERTY_X86_ISA_1_USED): Set
+	to 0xc0010002.
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): Set to 0xc0008002.
+	* testsuite/gnu_property_c.S (GNU_PROPERTY_X86_ISA_1_USED): Set
+	to 0xc0010002.
+	(GNU_PROPERTY_X86_ISA_1_NEEDED): Set to 0xc0008002.
+	* testsuite/gnu_property_test.sh: Updated.
+---
+ elfcpp/ChangeLog                    | [omitted]
+ elfcpp/elfcpp.h                     | 18 ++++++++++++---
+ gold/ChangeLog                      | [omitted]
+ gold/testsuite/gnu_property_a.S     |  4 ++--
+ gold/testsuite/gnu_property_b.S     |  4 ++--
+ gold/testsuite/gnu_property_c.S     |  4 ++--
+ gold/testsuite/gnu_property_test.sh |  4 ++--
+ gold/x86_64.cc                      | 34 +++++++++++++++++++++++++++--
+ 8 files changed, 110 insertions(+), 13 deletions(-)
+
+diff --git a/elfcpp/elfcpp.h b/elfcpp/elfcpp.h
+index 65d803c00e2..4b6ff94a654 100644
+--- a/elfcpp/elfcpp.h
++++ b/elfcpp/elfcpp.h
+@@ -1013,9 +1013,21 @@ enum
+   GNU_PROPERTY_STACK_SIZE = 1,
+   GNU_PROPERTY_NO_COPY_ON_PROTECTED = 2,
+   GNU_PROPERTY_LOPROC = 0xc0000000,
+-  GNU_PROPERTY_X86_ISA_1_USED = 0xc0000000,
+-  GNU_PROPERTY_X86_ISA_1_NEEDED = 0xc0000001,
+-  GNU_PROPERTY_X86_FEATURE_1_AND = 0xc0000002,
++  GNU_PROPERTY_X86_COMPAT_ISA_1_USED = 0xc0000000,
++  GNU_PROPERTY_X86_COMPAT_ISA_1_NEEDED = 0xc0000001,
++  GNU_PROPERTY_X86_UINT32_AND_LO = 0xc0000002,
++  GNU_PROPERTY_X86_UINT32_AND_HI = 0xc0007fff,
++  GNU_PROPERTY_X86_UINT32_OR_LO = 0xc0008000,
++  GNU_PROPERTY_X86_UINT32_OR_HI = 0xc000ffff,
++  GNU_PROPERTY_X86_UINT32_OR_AND_LO = 0xc0010000,
++  GNU_PROPERTY_X86_UINT32_OR_AND_HI = 0xc0017fff,
++  GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED = GNU_PROPERTY_X86_UINT32_OR_LO + 0,
++  GNU_PROPERTY_X86_COMPAT_2_ISA_1_USED = GNU_PROPERTY_X86_UINT32_OR_AND_LO + 0,
++  GNU_PROPERTY_X86_FEATURE_1_AND = GNU_PROPERTY_X86_UINT32_AND_LO + 0,
++  GNU_PROPERTY_X86_ISA_1_NEEDED = GNU_PROPERTY_X86_UINT32_OR_LO + 2,
++  GNU_PROPERTY_X86_FEATURE_2_NEEDED = GNU_PROPERTY_X86_UINT32_OR_LO + 1,
++  GNU_PROPERTY_X86_ISA_1_USED = GNU_PROPERTY_X86_UINT32_OR_AND_LO + 2,
++  GNU_PROPERTY_X86_FEATURE_2_USED = GNU_PROPERTY_X86_UINT32_OR_AND_LO + 1,
+   GNU_PROPERTY_HIPROC = 0xdfffffff,
+   GNU_PROPERTY_LOUSER = 0xe0000000,
+   GNU_PROPERTY_HIUSER = 0xffffffff
+diff --git a/gold/testsuite/gnu_property_a.S b/gold/testsuite/gnu_property_a.S
+index 463bc8e52fe..5fbbbc9c4bb 100644
+--- a/gold/testsuite/gnu_property_a.S
++++ b/gold/testsuite/gnu_property_a.S
+@@ -1,8 +1,8 @@
+ #define NT_GNU_PROPERTY_TYPE_0 5
+ 
+ #define GNU_PROPERTY_STACK_SIZE 1
+-#define GNU_PROPERTY_X86_ISA_1_USED 0xc0000000
+-#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0000001
++#define GNU_PROPERTY_X86_ISA_1_USED 0xc0010002
++#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0008002
+ #define GNU_PROPERTY_X86_FEATURE_1_AND 0xc0000002
+ 
+ #if __SIZEOF_PTRDIFF_T__  == 8
+diff --git a/gold/testsuite/gnu_property_b.S b/gold/testsuite/gnu_property_b.S
+index 0c0c038ead1..7028f73d7ab 100644
+--- a/gold/testsuite/gnu_property_b.S
++++ b/gold/testsuite/gnu_property_b.S
+@@ -2,8 +2,8 @@
+ 
+ #define GNU_PROPERTY_STACK_SIZE 1
+ #define GNU_PROPERTY_NO_COPY_ON_PROTECTED 2
+-#define GNU_PROPERTY_X86_ISA_1_USED 0xc0000000
+-#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0000001
++#define GNU_PROPERTY_X86_ISA_1_USED 0xc0010002
++#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0008002
+ #define GNU_PROPERTY_X86_FEATURE_1_AND 0xc0000002
+ 
+ #if __SIZEOF_PTRDIFF_T__  == 8
+diff --git a/gold/testsuite/gnu_property_c.S b/gold/testsuite/gnu_property_c.S
+index ace159a9a9d..c8cbd8bce28 100644
+--- a/gold/testsuite/gnu_property_c.S
++++ b/gold/testsuite/gnu_property_c.S
+@@ -2,8 +2,8 @@
+ 
+ #define GNU_PROPERTY_STACK_SIZE 1
+ #define GNU_PROPERTY_NO_COPY_ON_PROTECTED 2
+-#define GNU_PROPERTY_X86_ISA_1_USED 0xc0000000
+-#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0000001
++#define GNU_PROPERTY_X86_ISA_1_USED 0xc0010002
++#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0008002
+ #define GNU_PROPERTY_X86_FEATURE_1_AND 0xc0000002
+ 
+ #if __SIZEOF_PTRDIFF_T__  == 8
+diff --git a/gold/testsuite/gnu_property_test.sh b/gold/testsuite/gnu_property_test.sh
+index 1806d3474cc..a4096005b78 100755
+--- a/gold/testsuite/gnu_property_test.sh
++++ b/gold/testsuite/gnu_property_test.sh
+@@ -77,8 +77,8 @@ check_count gnu_property_test.stdout "^  NOTE" 2
+ 
+ check gnu_property_test.stdout "stack size: 0x111100"
+ check gnu_property_test.stdout "no copy on protected"
+-check gnu_property_test.stdout "x86 ISA used: i486, SSE2, SSE4_2, AVX512CD"
+-check gnu_property_test.stdout "x86 ISA needed: i486, SSE2, SSE4_2, AVX512CD"
++check gnu_property_test.stdout "x86 ISA used: x86-64-v2, <unknown: 10>, <unknown: 100>, <unknown: 1000>"
++check gnu_property_test.stdout "x86 ISA needed: x86-64-v2, <unknown: 10>, <unknown: 100>, <unknown: 1000>"
+ check gnu_property_test.stdout "x86 feature: IBT"
+ 
+ exit 0
+diff --git a/gold/x86_64.cc b/gold/x86_64.cc
+index 9cb2cf0a322..378bac16f78 100644
+--- a/gold/x86_64.cc
++++ b/gold/x86_64.cc
+@@ -706,8 +706,9 @@ class Target_x86_64 : public Sized_target<size, false>
+       rela_irelative_(NULL), copy_relocs_(elfcpp::R_X86_64_COPY),
+       got_mod_index_offset_(-1U), tlsdesc_reloc_info_(),
+       tls_base_symbol_defined_(false), isa_1_used_(0), isa_1_needed_(0),
+-      feature_1_(0), object_isa_1_used_(0), object_feature_1_(0),
+-      seen_first_object_(false)
++      feature_1_(0), feature_2_used_(0), feature_2_needed_(0),
++      object_isa_1_used_(0), object_feature_1_(0),
++      object_feature_2_used_(0), seen_first_object_(false)
+   { }
+ 
+   // Hook for a new output section.
+@@ -1382,6 +1383,8 @@ class Target_x86_64 : public Sized_target<size, false>
+   uint32_t isa_1_used_;
+   uint32_t isa_1_needed_;
+   uint32_t feature_1_;
++  uint32_t feature_2_used_;
++  uint32_t feature_2_needed_;
+   // Target-specific properties from the current object.
+   // These bits get ORed into ISA_1_USED_ after all properties for the object
+   // have been processed. But if either is all zeroes (as when the property
+@@ -1391,6 +1394,7 @@ class Target_x86_64 : public Sized_target<size, false>
+   // These bits get ANDed into FEATURE_1_ after all properties for the object
+   // have been processed.
+   uint32_t object_feature_1_;
++  uint32_t object_feature_2_used_;
+   // Whether we have seen our first object, for use in initializing FEATURE_1_.
+   bool seen_first_object_;
+ };
+@@ -1594,9 +1598,15 @@ Target_x86_64<size>::record_gnu_property(
+ 
+   switch (pr_type)
+     {
++    case elfcpp::GNU_PROPERTY_X86_COMPAT_ISA_1_USED:
++    case elfcpp::GNU_PROPERTY_X86_COMPAT_ISA_1_NEEDED:
++    case elfcpp::GNU_PROPERTY_X86_COMPAT_2_ISA_1_USED:
++    case elfcpp::GNU_PROPERTY_X86_COMPAT_2_ISA_1_NEEDED:
+     case elfcpp::GNU_PROPERTY_X86_ISA_1_USED:
+     case elfcpp::GNU_PROPERTY_X86_ISA_1_NEEDED:
+     case elfcpp::GNU_PROPERTY_X86_FEATURE_1_AND:
++    case elfcpp::GNU_PROPERTY_X86_FEATURE_2_USED:
++    case elfcpp::GNU_PROPERTY_X86_FEATURE_2_NEEDED:
+       if (pr_datasz != 4)
+ 	{
+ 	  gold_warning(_("%s: corrupt .note.gnu.property section "
+@@ -1625,6 +1635,12 @@ Target_x86_64<size>::record_gnu_property(
+       // If we see multiple feature props in one object, OR them together.
+       this->object_feature_1_ |= val;
+       break;
++    case elfcpp::GNU_PROPERTY_X86_FEATURE_2_USED:
++      this->object_feature_2_used_ |= val;
++      break;
++    case elfcpp::GNU_PROPERTY_X86_FEATURE_2_NEEDED:
++      this->feature_2_needed_ |= val;
++      break;
+     }
+ }
+ 
+@@ -1642,15 +1658,23 @@ Target_x86_64<size>::merge_gnu_properties(const Object*)
+       else if (this->isa_1_used_ != 0)
+ 	this->isa_1_used_ |= this->object_isa_1_used_;
+       this->feature_1_ &= this->object_feature_1_;
++      // If any object is missing the FEATURE_2_USED property, we must
++      // omit it from the output file.
++      if (this->object_feature_2_used_ == 0)
++	this->feature_2_used_ = 0;
++      else if (this->feature_2_used_ != 0)
++	this->feature_2_used_ |= this->object_feature_2_used_;
+     }
+   else
+     {
+       this->isa_1_used_ = this->object_isa_1_used_;
+       this->feature_1_ = this->object_feature_1_;
++      this->feature_2_used_ = this->object_feature_2_used_;
+       this->seen_first_object_ = true;
+     }
+   this->object_isa_1_used_ = 0;
+   this->object_feature_1_ = 0;
++  this->object_feature_2_used_ = 0;
+ }
+ 
+ static inline void
+@@ -1676,6 +1700,12 @@ Target_x86_64<size>::do_finalize_gnu_properties(Layout* layout) const
+   if (this->feature_1_ != 0)
+     add_property(layout, elfcpp::GNU_PROPERTY_X86_FEATURE_1_AND,
+ 		 this->feature_1_);
++  if (this->feature_2_used_ != 0)
++    add_property(layout, elfcpp::GNU_PROPERTY_X86_FEATURE_2_USED,
++		 this->feature_2_used_);
++  if (this->feature_2_needed_ != 0)
++    add_property(layout, elfcpp::GNU_PROPERTY_X86_FEATURE_2_NEEDED,
++		 this->feature_2_needed_);
+ }
+ 
+ // Write the first three reserved words of the .got.plt section.
+-- 
+2.27.0
+


### PR DESCRIPTION
Backport patch from 2.36 so that gold can succeed in linking programs without complaining
unknown program property type 0xc0008002 in .note.gnu.property section

Should fix: https://github.com/NixOS/nixpkgs/issues/134190

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Verified it fixes plv8 using https://github.com/jtojnar/nixpkgs/commit/94446ca4058a6fcdefa89c2d3b1b7352377368a0
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
