### PR TITLE
python3Packages.desktop-notifier: 3.3.0 -> 3.3.1

### DIFF
--- a/pkgs/development/python-modules/desktop-notifier/default.nix
+++ b/pkgs/development/python-modules/desktop-notifier/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pythonOlder
 , stdenv
 , packaging
@@ -10,12 +10,14 @@
 
 buildPythonPackage rec {
   pname = "desktop-notifier";
-  version = "3.3.0";
+  version = "3.3.1";
   disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-ROSZorkA2wAp2Ubh3B3KWIUxM/4r7cv/1aSJqeKnPqg=";
+  src = fetchFromGitHub {
+    owner = "SamSchott";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-GbsbwCKRTgLk0xK6MGKb1Tp6cd8q3h6OUdJ2f+VPyzk=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Upstream update.
Switched to GitHub fetcher because Pypi doesn't supply required resources in their tarball.

###### Things done

Tested that `maestral-gui` still works.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
