### PR TITLE
wimboot: 2.6.0 -> 2.7.3

### DIFF
--- a/pkgs/tools/misc/wimboot/default.nix
+++ b/pkgs/tools/misc/wimboot/default.nix
@@ -1,38 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, libbfd, zlib, libiberty }:
+{ lib, stdenv, fetchFromGitHub, libbfd, zlib, libiberty }:
 
 stdenv.mkDerivation rec {
   pname = "wimboot";
-  version = "2.6.0";
+  version = "2.7.3";
 
   src = fetchFromGitHub {
     owner = "ipxe";
     repo = "wimboot";
     rev = "v${version}";
-    sha256 = "134wqqr147az5vbj4szd0xffwa99b4rar7w33zm3119zsn7sd79k";
+    sha256 = "12c677agkmiqs35qfpqfj7c4kxkizhbk9l6hig36dslzp4fwpl70";
   };
 
-  NIX_CFLAGS_COMPILE = "-Wno-address-of-packed-member"; # Fails on gcc9
-
-  patches = [
-    # Fixes for newer binutils
-    # Add R_X86_64_PLT32 as known reloc target
-    (fetchpatch {
-      url = "https://github.com/ipxe/wimboot/commit/91be50c17d4d9f463109d5baafd70f9fdadd86db.patch";
-      sha256 = "113448n49hmk8nz1dxbhxiciwl281zwalvb8z5p9xfnjvibj8274";
-    })
-    # Fix building with binutils 2.34 (bfd_get_section_* removed in favour of bfd_section_*)
-    (fetchpatch {
-      url = "https://github.com/ipxe/wimboot/commit/2f97e681703d30b33a4d5032a8025ab8b9f2de75.patch";
-      sha256 = "0476mp74jaq3k099b654al6yi2yhgn37d9biz0wv3ln2q1gy94yf";
-    })
-  ];
-
-  # We cannot use sourceRoot because the patch wouldn't apply
-  postPatch = ''
-    cd src
-  '';
-
-  hardeningDisable = [ "pic" ];
+  sourceRoot = "source/src";
 
   buildInputs = [ libbfd zlib libiberty ];
   makeFlags = [ "wimboot.x86_64.efi" ];


### PR DESCRIPTION
###### Motivation for this change
Upstrem release.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
