### PR TITLE
jibri: init at 8.0-93-g51fe7a2

### DIFF
--- a/pkgs/servers/jibri/default.nix
+++ b/pkgs/servers/jibri/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchurl, dpkg, jre_headless, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "jibri";
+  version = "8.0-93-g51fe7a2";
+  src = fetchurl {
+    url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
+    sha256 = "1w78aa3rfdc4frb68ymykrbazxqrcv8mcdayqmcb72q1aa854c7j";
+  };
+
+  dontBuild = true;
+  nativeBuildInputs = [ dpkg makeWrapper ];
+  unpackCmd = "dpkg-deb -x $src debcontents";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,opt/jitsi/jibri,etc/jitsi/jibri}
+    mv etc/jitsi/jibri/* $out/etc/jitsi/jibri/
+    mv opt/jitsi/jibri/* $out/opt/jitsi/jibri/
+
+    makeWrapper ${jre_headless}/bin/java $out/bin/jibri --add-flags "-jar $out/opt/jitsi/jibri/jibri.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "JItsi BRoadcasting Infrastructure";
+    longDescription = ''
+      Jibri provides services for recording or streaming a Jitsi Meet conference.
+      It works by launching a Chrome instance rendered in a virtual framebuffer and capturing and
+      encoding the output with ffmpeg. It is intended to be run on a separate machine (or a VM), with
+      no other applications using the display or audio devices. Only one recording at a time is
+      supported on a single jibri.
+    '';
+    homepage = "https://github.com/jitsi/jibri";
+    license = licenses.asl20;
+    maintainers = teams.jitsi.members;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19828,6 +19828,8 @@ in
 
   jetty = callPackage ../servers/http/jetty { };
 
+  jibri = callPackage ../servers/jibri { };
+
   jicofo = callPackage ../servers/jicofo { };
 
   jitsi-meet = callPackage ../servers/web-apps/jitsi-meet { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/132623

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
