### PR TITLE
nixos/nzbget: add declarative configuration

### DIFF
--- a/nixos/modules/services/misc/nzbget.nix
+++ b/nixos/modules/services/misc/nzbget.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.services.nzbget;
-  pkg = pkgs.nzbget;
+  pkg = cfg.package;
   stateDir = "/var/lib/nzbget";
   configFile = if cfg.declarativeConfig == null then
                  "${stateDir}/nzbget.conf"
@@ -43,6 +43,13 @@ in
   options = {
     services.nzbget = {
       enable = mkEnableOption "NZBGet";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.nzbget;
+        defaultText = "pkgs.nzbget";
+        description = "NZBGet package to use";
+      };
 
       user = mkOption {
         type = types.str;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add declarative configuration for NZBGet.

With `declarativeConfig` it is possible to configure NZBGet declaratively and `appendConfigFile` allow for options that should not be stored in the nix store (for example passwords). The default settings, declarative settings, and overrides are merged by the service's preStart script and written to the service's RuntimeDirectory. No write permission is given to the config file, to disallow NZBGet from modifying the configuration.

If `services.nzbget.declarativeConfig` is unused the configuration can be changed through NZBGet's web interface as before.

This is somewhat similar to #132722.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
