### PR TITLE
moonlight-embedded: 2.4.11 -> 2.5.1

### DIFF
--- a/pkgs/applications/misc/moonlight-embedded/default.nix
+++ b/pkgs/applications/misc/moonlight-embedded/default.nix
@@ -1,18 +1,18 @@
 { lib, stdenv, fetchFromGitHub, cmake, perl
 , alsa-lib, libevdev, libopus, udev, SDL2
 , ffmpeg, pkg-config, xorg, libvdpau, libpulseaudio, libcec
-, curl, expat, avahi, enet, libuuid, libva
+, curl, expat, avahi, libuuid, libva
 }:
 
 stdenv.mkDerivation rec {
   pname = "moonlight-embedded";
-  version = "2.4.11";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
-    owner = "irtimmer";
+    owner = "moonlight-stream";
     repo = "moonlight-embedded";
     rev = "v${version}";
-    sha256 = "19wm4gizj8q6j4jwqfcn3bkhms97d8afwxmqjmjnqqxzpd2gxc16";
+    sha256 = "0wn6yjpqyjv52278xsx1ivnqrwca4fnk09a01fwzk4adpry1q9ck";
     fetchSubmodules = true;
   };
 
@@ -22,13 +22,13 @@ stdenv.mkDerivation rec {
   buildInputs = [
     alsa-lib libevdev libopus udev SDL2
     ffmpeg pkg-config xorg.libxcb libvdpau libpulseaudio libcec
-    xorg.libpthreadstubs curl expat avahi enet libuuid libva
+    xorg.libpthreadstubs curl expat avahi libuuid libva
   ];
 
   meta = with lib; {
     description = "Open source implementation of NVIDIA's GameStream";
-    homepage = "https://github.com/irtimmer/moonlight-embedded";
-    license = licenses.gpl3;
+    homepage = "https://github.com/moonlight-stream/moonlight-embedded";
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.globin ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update package and adjust repository to new upstream location. FYI, I am the upstream maintainer of moonlight-embedded.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
