### PR TITLE
[21.05] ndpi: add patch for CVE-2021-36082

### DIFF
--- a/pkgs/development/libraries/ndpi/3.4-CVE-2021-36082.patch
+++ b/pkgs/development/libraries/ndpi/3.4-CVE-2021-36082.patch
@@ -1,0 +1,101 @@
+Based on upstream https://github.com/ntop/nDPI/commit/1ec621c85b9411cc611652fd57a892cfef478af3
+adapted by ris to apply to ndpi 3.4
+
+diff --git a/src/lib/protocols/netbios.c b/src/lib/protocols/netbios.c
+index 1f3850cb..0d3b705f 100644
+--- a/src/lib/protocols/netbios.c
++++ b/src/lib/protocols/netbios.c
+@@ -42,7 +42,7 @@ int ndpi_netbios_name_interpret(char *in, size_t inlen, char *out, u_int out_len
+   int ret = 0, len, idx = inlen;
+   char *b;
+ 
+-  len = (*in++)/2;
++  len = (*in++)/2, inlen--;
+   b  = out;
+   *out = 0;
+ 
+ 
+diff --git a/src/lib/protocols/tls.c b/src/lib/protocols/tls.c
+index 5b572cae..304d5799 100644
+--- a/src/lib/protocols/tls.c
++++ b/src/lib/protocols/tls.c
+@@ -994,21 +994,23 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
+ 	i += 4 + extension_len, offset += 4 + extension_len;
+       }
+ 
+-      ja3_str_len = snprintf(ja3_str, sizeof(ja3_str), "%u,", ja3.tls_handshake_version);
++      ja3_str_len = snprintf(ja3_str, JA3_STR_LEN, "%u,", ja3.tls_handshake_version);
+ 
+-      for(i=0; i<ja3.num_cipher; i++) {
+-	rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, "%s%u", (i > 0) ? "-" : "", ja3.cipher[i]);
++      for(i=0; (i<ja3.num_cipher) && (JA3_STR_LEN > ja3_str_len); i++) {
++	rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, "%s%u", (i > 0) ? "-" : "", ja3.cipher[i]);
+ 
+ 	if(rc <= 0) break; else ja3_str_len += rc;
+       }
+ 
+-      rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, ",");
++      if(JA3_STR_LEN > ja3_str_len) {
++      rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, ",");
+       if(rc > 0 && ja3_str_len + rc < JA3_STR_LEN) ja3_str_len += rc;
++      }
+ 
+       /* ********** */
+ 
+-      for(i=0; i<ja3.num_tls_extension; i++) {
+-	int rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, "%s%u", (i > 0) ? "-" : "", ja3.tls_extension[i]);
++      for(i=0; (i<ja3.num_tls_extension) && (JA3_STR_LEN > ja3_str_len); i++) {
++	int rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, "%s%u", (i > 0) ? "-" : "", ja3.tls_extension[i]);
+ 
+ 	if(rc <= 0) break; else ja3_str_len += rc;
+       }
+@@ -1443,41 +1445,41 @@ int processClientServerHello(struct ndpi_detection_module_struct *ndpi_struct,
+ 	      int rc;
+ 
+ 	    compute_ja3c:
+-	      ja3_str_len = snprintf(ja3_str, sizeof(ja3_str), "%u,", ja3.tls_handshake_version);
++	      ja3_str_len = snprintf(ja3_str, JA3_STR_LEN, "%u,", ja3.tls_handshake_version);
+ 
+ 	      for(i=0; i<ja3.num_cipher; i++) {
+-		rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, "%s%u",
++		rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, "%s%u",
+ 			      (i > 0) ? "-" : "", ja3.cipher[i]);
+ 		if(rc > 0 && ja3_str_len + rc < JA3_STR_LEN) ja3_str_len += rc; else break;
+ 	      }
+ 
+-	      rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, ",");
++	      rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, ",");
+ 	      if(rc > 0 && ja3_str_len + rc < JA3_STR_LEN) ja3_str_len += rc;
+ 
+ 	      /* ********** */
+ 
+ 	      for(i=0; i<ja3.num_tls_extension; i++) {
+-		rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, "%s%u",
++		rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, "%s%u",
+ 			      (i > 0) ? "-" : "", ja3.tls_extension[i]);
+ 		if(rc > 0 && ja3_str_len + rc < JA3_STR_LEN) ja3_str_len += rc; else break;
+ 	      }
+ 
+-	      rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, ",");
++	      rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, ",");
+ 	      if(rc > 0 && ja3_str_len + rc < JA3_STR_LEN) ja3_str_len += rc;
+ 
+ 	      /* ********** */
+ 
+ 	      for(i=0; i<ja3.num_elliptic_curve; i++) {
+-		rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, "%s%u",
++		rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, "%s%u",
+ 			      (i > 0) ? "-" : "", ja3.elliptic_curve[i]);
+ 		if(rc > 0 && ja3_str_len + rc < JA3_STR_LEN) ja3_str_len += rc; else break;
+ 	      }
+ 
+-	      rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, ",");
++	      rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, ",");
+ 	      if(rc > 0 && ja3_str_len + rc < JA3_STR_LEN) ja3_str_len += rc;
+ 
+ 	      for(i=0; i<ja3.num_elliptic_curve_point_format; i++) {
+-		rc = snprintf(&ja3_str[ja3_str_len], sizeof(ja3_str)-ja3_str_len, "%s%u",
++		rc = snprintf(&ja3_str[ja3_str_len], JA3_STR_LEN-ja3_str_len, "%s%u",
+ 			      (i > 0) ? "-" : "", ja3.elliptic_curve_point_format[i]);
+ 		if(rc > 0 && ja3_str_len + rc < JA3_STR_LEN) ja3_str_len += rc; else break;
+ 	      }

--- a/pkgs/development/libraries/ndpi/default.nix
+++ b/pkgs/development/libraries/ndpi/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation {
     sha256 = "0xjh9gv0mq0213bjfs5ahrh6m7l7g99jjg8104c0pw54hz0p5pq1";
   };
 
+  patches = [
+    ./3.4-CVE-2021-36082.patch
+  ];
+
   configureScript = "./autogen.sh";
 
   nativeBuildInputs = [which autoconf automake libtool];


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-36082
#132144

See  #134234 for master.

The patch to `processClientServerHello` does two things:
 - guards every use of `ja3_str_len` with a check to ensure it's smaller than `JA3_STR_LEN`
 - uses `JA3_STR_LEN` in place of `sizeof(ja3_str)`. I don't think this really makes any difference when used on a stack variable as long as it remains a single-byte underlying type, but I included it anyway.

It should be possible to confirm that given the patch, every use of `ja3_str_len` is indeed now guarded.

There's also another change included in upstream's fix commit, affecting `ndpi_netbios_name_interpret`, seemingly totally unrelated. This is just appropriately decrementing the recorded `inlen` as it consumes the first element of `in`. Could in theory lead to a 1 element OOB access, but don't know if this is also exploitable - CVE doesn't mention it. Included anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
