### PR TITLE
pythonPackages.pyroma: fix tests phase

### DIFF
--- a/pkgs/development/python-modules/pyroma/default.nix
+++ b/pkgs/development/python-modules/pyroma/default.nix
@@ -2,10 +2,10 @@
 , buildPythonPackage
 , fetchFromGitHub
 , docutils
+, python
 , pygments
 , setuptools
 , requests
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -26,16 +26,11 @@ buildPythonPackage rec {
     requests
   ];
 
-  checkInputs = [
-    pytestCheckHook
-  ];
-
-  pytestFlagsArray = [ "pyroma/tests.py" ];
-
-  disabledTests = [
-    # PyPI tests require network access
-    "PyPITest"
-  ];
+  # https://github.com/regebro/pyroma/blob/3.2/Makefile#L23
+  # PyPITest requires network access
+  checkPhase = ''
+    ${python.interpreter} -m unittest -k 'not PyPITest' pyroma.tests
+  '';
 
   pythonImportsCheck = [ "pyroma" ];
 
@@ -43,6 +38,6 @@ buildPythonPackage rec {
     description = "Test your project's packaging friendliness";
     homepage = "https://github.com/regebro/pyroma";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ kamadorueda ];
   };
 }


### PR DESCRIPTION
- The package was not building due to an infinite
  recursion error in pytest
- After looking how they the package owners test
  it I discover they use unittest module instead
  of pytest
- Rewrite so it uses unittest

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
