### PR TITLE
xdotool: 3.20160805.1 → 3.20210804.2

### DIFF
--- a/pkgs/tools/X11/xdotool/default.nix
+++ b/pkgs/tools/X11/xdotool/default.nix
@@ -1,16 +1,18 @@
-{ lib, stdenv, fetchurl, pkg-config, libX11, perl, libXtst, xorgproto, libXi, libXinerama, libxkbcommon }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, libX11, perl, libXtst, xorgproto, libXi, libXinerama, libxkbcommon, libXext }:
 
 stdenv.mkDerivation rec {
   pname = "xdotool";
-  version = "3.20160805.1";
+  version = "3.20210804.2";
 
-  src = fetchurl {
-    url = "https://github.com/jordansissel/xdotool/releases/download/v${version}/xdotool-${version}.tar.gz";
-    sha256 = "1a6c1zr86zb53352yxv104l76l8x21gfl2bgw6h21iphxpv5zgim";
+  src = fetchFromGitHub {
+    owner = "jordansissel";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-7N5f/BFtq/m5MsXe7ZCTUTc1yp+JDJNRF1P9qB2l554=";
   };
 
   nativeBuildInputs = [ pkg-config perl ];
-  buildInputs = [ libX11 libXtst xorgproto libXi libXinerama libxkbcommon ];
+  buildInputs = [ libX11 libXtst xorgproto libXi libXinerama libxkbcommon libXext ];
 
   preBuild = ''
     mkdir -p $out/lib


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/jordansissel/xdotool/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
