### PR TITLE
linuxPackages.ply: 1.0.beta1-9e810b1 -> 2.1.1

### DIFF
--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -36,6 +36,6 @@ in stdenv.mkDerivation {
     homepage = "https://wkz.github.io/ply/";
     license = [ licenses.gpl2 ];
     maintainers = with maintainers; [ mic92 mbbx6spp ];
-    broken = lib.versionAtLeast kernel.version "4.0";
+    broken = lib.versionOlder kernel.version "4.0";
   };
 }

--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -1,17 +1,16 @@
 { lib, stdenv, kernel, fetchFromGitHub, autoreconfHook, bison, flex, p7zip, rsync }:
 
-let
-  version = "2.1.1";
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "ply";
-  inherit version;
+  version = "2.1.1-${lib.substring 0 7 src.rev}";
+
   nativeBuildInputs = [ autoreconfHook flex bison p7zip rsync ];
 
   src = fetchFromGitHub {
     owner = "iovisor";
     repo = "ply";
-    rev = version;
-    sha256 = "0mfnfczk6kw6p15nx5l735qmcnb0pkix7ngq0j8nndg7r2fsckah";
+    rev = "e25c9134b856cc7ffe9f562ff95caf9487d16b59";
+    sha256 = "1178z7vvnjwnlxc98g2962v16878dy7bd0b2njsgn4vqgrnia7i5";
   };
 
   preAutoreconf = ''

--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -34,7 +34,7 @@ in stdenv.mkDerivation {
   meta = with lib; {
     description = "Dynamic tracing in Linux";
     homepage = "https://wkz.github.io/ply/";
-    license = [ licenses.gpl2 ];
+    license = [ licenses.gpl2Only ];
     maintainers = with maintainers; [ mic92 mbbx6spp ];
     broken = lib.versionOlder kernel.version "4.0";
   };

--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -3,7 +3,7 @@
 assert kernel != null -> lib.versionAtLeast kernel.version "4.0";
 
 let
-  version = "1.0.beta1-9e810b1";
+  version = "2.1.1";
 in stdenv.mkDerivation {
   pname = "ply";
   inherit version;
@@ -12,8 +12,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "iovisor";
     repo = "ply";
-    rev = "9e810b157ba079c32c430a7d4c6034826982056e";
-    sha256 = "15cp6iczawaqlhsa0af6i37zn5iq53kh6ya8s2hzd018yd7mhg50";
+    rev = "899afb0c35ba2191dd7aa21f13bc7fde2655c475";
+    sha256 = "0mfnfczk6kw6p15nx5l735qmcnb0pkix7ngq0j8nndg7r2fsckah";
   };
 
   preAutoreconf = ''
@@ -34,7 +34,7 @@ in stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "dynamic Tracing in Linux";
+    description = "Dynamic tracing in Linux";
     homepage = "https://wkz.github.io/ply/";
     license = [ licenses.gpl2 ];
     maintainers = with maintainers; [ mic92 mbbx6spp ];

--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -10,7 +10,7 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "iovisor";
     repo = "ply";
-    rev = "899afb0c35ba2191dd7aa21f13bc7fde2655c475";
+    rev = version;
     sha256 = "0mfnfczk6kw6p15nx5l735qmcnb0pkix7ngq0j8nndg7r2fsckah";
   };
 

--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, kernel, fetchFromGitHub, autoreconfHook, bison, flex, p7zip, rsync }:
 
-assert kernel != null -> lib.versionAtLeast kernel.version "4.0";
-
 let
   version = "2.1.1";
 in stdenv.mkDerivation {
@@ -38,5 +36,6 @@ in stdenv.mkDerivation {
     homepage = "https://wkz.github.io/ply/";
     license = [ licenses.gpl2 ];
     maintainers = with maintainers; [ mic92 mbbx6spp ];
+    broken = lib.versionAtLeast kernel.version "4.0";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This PR upgrades the `linuxPackages.ply` package mentioned in #134265.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
