### PR TITLE
makeOverridable: Preserve function arguments

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -64,21 +64,20 @@ rec {
      "<pkg>.overrideDerivation" to learn about `overrideDerivation` and caveats
      related to its use.
   */
-  makeOverridable = f: origArgs:
-    let
-      result = f origArgs;
+  makeOverridable = f:
+    let fArgs = lib.functionArgs f;
+    in lib.setFunctionArgs (origArgs:
+      let
+        result = f origArgs;
 
-      # Creates a functor with the same arguments as f
-      copyArgs = g: lib.setFunctionArgs g (lib.functionArgs f);
-      # Changes the original arguments with (potentially a function that returns) a set of new attributes
-      overrideWith = newArgs: origArgs // (if lib.isFunction newArgs then newArgs origArgs else newArgs);
+        # Changes the original arguments with (potentially a function that returns) a set of new attributes
+        overrideWith = newArgs: origArgs // (if lib.isFunction newArgs then newArgs origArgs else newArgs);
 
-      # Re-call the function but with different arguments
-      overrideArgs = copyArgs (newArgs: makeOverridable f (overrideWith newArgs));
-      # Change the result of the function call by applying g to it
-      overrideResult = g: makeOverridable (copyArgs (args: g (f args))) origArgs;
-    in
-      if builtins.isAttrs result then
+        # Re-call the function but with different arguments
+        overrideArgs = lib.setFunctionArgs (newArgs: makeOverridable f (overrideWith newArgs)) fArgs;
+        # Change the result of the function call by applying g to it
+        overrideResult = g: makeOverridable (lib.setFunctionArgs (args: g (f args)) fArgs) origArgs;
+      in if builtins.isAttrs result then
         result // {
           override = overrideArgs;
           overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
@@ -90,7 +89,7 @@ rec {
         lib.setFunctionArgs result (lib.functionArgs result) // {
           override = overrideArgs;
         }
-      else result;
+      else result) fArgs;
 
 
   /* Call the package function in the file `fn' with the required


### PR DESCRIPTION
###### Motivation for this change

Before:

```nix
nix-repl> lib.functionArgs (lib.makeOverridable ({ foo ? null, bar }: { }))
{ }
```

After:

```nix
nix-repl> lib.functionArgs (lib.makeOverridable ({ foo ? null, bar }: { }))
{ bar = false; foo = true; }
```

The motivation in this case is that commit 711d674e1322a8ccdbf985322468da87a141bc9c (#130116) broke the [nixpkgs-mozilla overlay](https://github.com/mozilla/nixpkgs-mozilla/blob/ad227c55c34124cde17b30c9bb28be6cd3c70815/firefox-overlay.nix#L148), and there doesn’t seem to be a good way for the overlay to feature-detect this change when `lib.functionArgs` doesn’t work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
