### PR TITLE
ffmpeg: patch CVE-2021-33815 and CVE-2021-38114

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -244,7 +244,7 @@ assert opensslExtlib -> gnutls == null && openssl != null && nonfreeLicensing;
 
 stdenv.mkDerivation rec {
   pname = "ffmpeg-full";
-  inherit (ffmpeg) src version;
+  inherit (ffmpeg) src version patches;
 
   prePatch = ''
     patchShebangs .

--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -13,6 +13,16 @@ callPackage ./generic.nix (rec {
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
 
   patches = [
+    (fetchpatch {
+      name = "CVE-2021-33815.patch";
+      url = "https://github.com/FFmpeg/FFmpeg/commit/26d3c81bc5ef2f8c3f09d45eaeacfb4b1139a777.patch";
+      sha256 = "0l8dqga5845f7d3wdbvd05i23saldq4pm2cyfdgszbr0c18sxagf";
+    })
+    (fetchpatch {
+      name = "CVE-2021-38114.patch";
+      url = "https://github.com/FFmpeg/FFmpeg/commit/7150f9575671f898382c370acae35f9087a30ba1.patch";
+      sha256 = "0gwkc7v1wsh4j0am2nnskhsca1b5aqzhcfd41sd9mh2swsdyf27i";
+    })
     # Fix incorrect segment length in HLS child playlist with fmp4 segment format
     # FIXME remove in version 4.5
     # https://trac.ffmpeg.org/ticket/9193


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-33815
https://nvd.nist.gov/vuln/detail/CVE-2021-38114

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).