### PR TITLE
pypi-mirror: init at 4.0.6

### DIFF
--- a/pkgs/development/tools/pypi-mirror/default.nix
+++ b/pkgs/development/tools/pypi-mirror/default.nix
@@ -1,0 +1,24 @@
+{ fetchFromGitHub
+, lib
+, python3
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "pypi-mirror";
+  version = "4.0.6";
+
+  src = fetchFromGitHub {
+    owner = "montag451";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0slh8ahywcgbggfcmzyqpb8bmq9dkk6vvjfkbi0ashnm8c6x19vd";
+  };
+
+  pythonImportsCheck = [ "pypi_mirror" ];
+
+  meta = with lib; {
+    description = "A script to create a partial PyPI mirror";
+    homepage = "https://github.com/montag451/pypi-mirror";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kamadorueda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12853,6 +12853,8 @@ with pkgs;
 
   pypi2nix = callPackage ../development/tools/pypi2nix {};
 
+  pypi-mirror = callPackage ../development/tools/pypi-mirror {};
+
   setupcfg2nix = python3Packages.callPackage ../development/tools/setupcfg2nix {};
 
   # These pyside tools do not provide any Python modules and are meant to be here.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
