### PR TITLE
qview: fix build on darwin, support extra formats

### DIFF
--- a/pkgs/applications/graphics/qview/default.nix
+++ b/pkgs/applications/graphics/qview/default.nix
@@ -1,4 +1,11 @@
-{ mkDerivation, lib, fetchFromGitHub, qmake, qtbase }:
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, qmake
+, qtbase
+, qtimageformats
+, qtsvg
+}:
 
 mkDerivation rec {
   pname = "qview";
@@ -15,6 +22,8 @@ mkDerivation rec {
 
   buildInputs = [
     qtbase
+    qtimageformats
+    qtsvg
   ];
 
   patchPhase = ''
@@ -24,7 +33,7 @@ mkDerivation rec {
   meta = with lib; {
     description = "Practical and minimal image viewer";
     homepage = "https://interversehq.com/qview/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ acowley ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
Clarified license to GPL3+.
Building on darwin requires qtsvg.
qtimageformats adds support for extra image formats, such as WebP.

Closes https://github.com/NixOS/nixpkgs/issues/134210 (cc @Jiehong)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
