### PR TITLE
openstackclient: init at 1.5

### DIFF
--- a/pkgs/development/python-modules/debtcollector/default.nix
+++ b/pkgs/development/python-modules/debtcollector/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, six, wrapt
+, stestr }:
+
+buildPythonPackage rec {
+  pname = "debtcollector";
+  version = "2.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ab8ic9bk644i8134z044kpcf6pvawqf4rq4xgv1p11msbs82ybq";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    six
+    wrapt
+  ];
+
+  checkInputs = [ stestr ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "debtcollector" ];
+
+  meta = with lib; {
+    description = "A collection of deprecation patterns and strategies that help you collect your technical debt in a non-destructive manner";
+    homepage = "https://docs.openstack.org/debtcollector/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/hacking/default.nix
+++ b/pkgs/development/python-modules/hacking/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, flake8
+, stestr, eventlet, ddt, testtools, testscenarios }:
+
+buildPythonPackage rec {
+  pname = "hacking";
+  version = "4.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fg19rlcky3n1y1ri61xyjp7534yzf8r102z9dw3zqg93f4kj20m";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt --replace "flake8<3.9.0,>=3.8.0" "flake8"
+  '';
+
+  propagatedBuildInputs = [
+    pbr
+    flake8
+  ];
+
+  checkInputs = [ stestr eventlet ddt testtools testscenarios ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "hacking" ];
+
+  meta = with lib; {
+    description = "OpenStack Hacking Guideline Enforcement";
+    homepage = "https://docs.openstack.org/hacking/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/keystoneauth1/default.nix
+++ b/pkgs/development/python-modules/keystoneauth1/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, iso8601, requests, six, stevedore, os-service-types, requests-kerberos
+, stestr, requests-mock, oslo-config, oslo-utils, lxml, hacking, betamax, oauthlib }:
+
+buildPythonPackage rec {
+  pname = "keystoneauth1";
+  version = "4.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r4ach6adh7z1kq9k378aii9mgn1kmg6iicvclqlyhnilqq58q4k";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    iso8601
+    requests
+    six
+    stevedore
+    os-service-types
+    requests-kerberos
+    lxml
+    oauthlib
+    betamax
+  ];
+
+  checkInputs = [ stestr requests-mock oslo-config oslo-utils hacking ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "keystoneauth1" ];
+
+  meta = with lib; {
+    description = "Authentication Library for OpenStack Identity";
+    homepage = "https://docs.openstack.org/keystoneauth/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/openstacksdk/default.nix
+++ b/pkgs/development/python-modules/openstacksdk/default.nix
@@ -1,0 +1,41 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, pyyaml, appdirs, requestsexceptions, jsonpatch, os-service-types, keystoneauth1, munch, decorator, jmespath, iso8601, netifaces, dogpile_cache, cryptography, importlib-metadata }:
+
+buildPythonPackage rec {
+  pname = "openstacksdk";
+  version = "0.58.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0y520jd7nanjqp92ljs2w7x2j5ppxviwhb6j2d1131pn50bqsdnq";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    pyyaml
+    appdirs
+    requestsexceptions
+    jsonpatch
+    os-service-types
+    keystoneauth1
+    munch
+    decorator
+    jmespath
+    iso8601
+    netifaces
+    dogpile_cache
+    cryptography
+    importlib-metadata
+  ];
+
+  # Of ~3800 tests, ~10 are flaky. Maybe at some point this will be fixed and we can enable checks
+  doCheck = false;
+  pythonImportsCheck = [ "openstack" ];
+
+  meta = with lib; {
+    description = "An SDK for building applications to work with OpenStack";
+    homepage = "https://docs.openstack.org/openstacksdk/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/os-service-types/default.nix
+++ b/pkgs/development/python-modules/os-service-types/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr
+, stestr, oslotest, requests-mock, testscenarios, subunit }:
+
+buildPythonPackage rec {
+  pname = "os-service-types";
+  version = "1.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0v4chwr5jykkvkv4w7iaaic7gb06j6ziw7xrjlwkcf92m2ch501i";
+  };
+
+  postPatch = ''
+    # This test has circular dependency on keystoneauth1
+    rm os_service_types/tests/test_remote.py
+  '';
+
+  propagatedBuildInputs = [
+    pbr
+  ];
+
+  checkInputs = [ stestr oslotest requests-mock testscenarios subunit ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "os_service_types" ];
+
+
+  meta = with lib; {
+    description = "Library for consuming OpenStack sevice-types-authority data";
+    homepage = "https://docs.openstack.org/os-service-types/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/osc-lib/default.nix
+++ b/pkgs/development/python-modules/osc-lib/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, cliff, keystoneauth1, openstacksdk, oslo-i18n, oslo-utils, simplejson, stevedore
+, stestr, requests-mock }:
+
+buildPythonPackage rec {
+  pname = "osc-lib";
+  version = "2.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ianpk32vwdllpbk4zhfifqb5b064cbmia2hm02lcrh2m76z0zi5";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    cliff
+    keystoneauth1
+    openstacksdk
+    oslo-i18n
+    oslo-utils
+    simplejson
+    stevedore
+  ];
+
+  checkInputs = [ stestr requests-mock ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "osc_lib" ];
+
+  meta = with lib; {
+    description = "OpenStackClient Library";
+    homepage = "https://docs.openstack.org/osc-lib/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/oslo-config/default.nix
+++ b/pkgs/development/python-modules/oslo-config/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchPypi
+, debtcollector, netaddr, stevedore, oslo-i18n, rfc3986, pyyaml, requests, importlib-metadata }:
+
+buildPythonPackage rec {
+  pname = "oslo-config";
+  version = "8.7.1";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "oslo.config";
+    sha256 = "0q3v4yicqls9zsfxkmh5mrgz9dailaz3ir25p458gj6dg3bldhx0";
+  };
+
+  propagatedBuildInputs = [
+    debtcollector
+    netaddr
+    stevedore
+    oslo-i18n
+    rfc3986
+    pyyaml
+    requests
+    importlib-metadata
+  ];
+
+  # Tests have a circular dependency with oslo-log
+  doCheck = false;
+  pythonImportsCheck = [ "oslo_config" ];
+
+  meta = with lib; {
+    description = "Oslo Configuration API";
+    homepage = "https://docs.openstack.org/oslo.config/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/oslo-context/default.nix
+++ b/pkgs/development/python-modules/oslo-context/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, debtcollector
+, stestr, oslotest }:
+
+buildPythonPackage rec {
+  pname = "oslo-context";
+  version = "3.3.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "oslo.context";
+    sha256 = "027w23sspvwx0669an9jrzi17chn5jl5jbgyab1k21zfg670jgyq";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    debtcollector
+  ];
+
+  checkInputs = [ stestr oslotest ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "oslo_context" ];
+
+  meta = with lib; {
+    description = "Oslo Context library";
+    homepage = "https://docs.openstack.org/oslo.context/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/oslo-i18n/default.nix
+++ b/pkgs/development/python-modules/oslo-i18n/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, six
+, stestr, oslotest, testscenarios }:
+
+buildPythonPackage rec {
+  pname = "oslo-i18n";
+  version = "5.0.1";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "oslo.i18n";
+    sha256 = "0nq3dr2kbrawqvp9q9i8i44z9jliq98i2b9h4dsl6p7p60gbg11l";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    six
+  ];
+
+  checkInputs = [ stestr oslotest testscenarios ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "oslo_i18n" ];
+
+  meta = with lib; {
+    description = "Oslo i18n library";
+    homepage = "https://docs.openstack.org/oslo.i18n/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/oslo-log/default.nix
+++ b/pkgs/development/python-modules/oslo-log/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi
+, pbr, oslo-config, oslo-context, oslo-i18n, oslo-utils, oslo-serialization, debtcollector, pyinotify, python-dateutil
+, stestr, oslotest }:
+
+buildPythonPackage rec {
+  pname = "oslo-log";
+  version = "4.6.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "oslo.log";
+    sha256 = "19sv70dx77l47vkwq1ahkn9a764znwdnmlsnncr13w4h2bzxgmfs";
+  };
+
+  postPatch = lib.optionalString (!stdenv.isLinux) ''
+    # Test depends on pyinotify
+    substituteInPlace oslo_log/tests/unit/test_log.py --replace test_watchlog_on_linux __test_watchlog_on_linux
+  '';
+
+  propagatedBuildInputs = [
+    pbr
+    oslo-config
+    oslo-context
+    oslo-i18n
+    oslo-utils
+    oslo-serialization
+    debtcollector
+    python-dateutil
+  ] ++ lib.optionals stdenv.isLinux [
+    pyinotify
+  ];
+
+  checkInputs = [ stestr oslotest ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "oslo_log" ];
+
+  meta = with lib; {
+    description = "Oslo Logging Library";
+    homepage = "https://docs.openstack.org/oslo.log/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/oslo-serialization/default.nix
+++ b/pkgs/development/python-modules/oslo-serialization/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, msgpack, oslo-utils, pytz
+, stestr, oslotest }:
+
+buildPythonPackage rec {
+  pname = "oslo-serialization";
+  version = "4.1.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "oslo.serialization";
+    sha256 = "0yakvsja145y89j3r7njg826ig0rmyrw5mnvf35qav40vya7gk6f";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    msgpack
+    oslo-utils
+    pytz
+  ];
+
+  checkInputs = [ stestr oslotest ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "oslo_serialization" ];
+
+  meta = with lib; {
+    description = "Oslo Serialization library";
+    homepage = "https://docs.openstack.org/oslo.utils/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/oslo-utils/default.nix
+++ b/pkgs/development/python-modules/oslo-utils/default.nix
@@ -1,0 +1,44 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, iso8601, oslo-i18n, pytz, netaddr, netifaces, debtcollector, pyparsing, packaging
+, stestr, oslotest, ddt, testscenarios }:
+
+buildPythonPackage rec {
+  pname = "oslo-utils";
+  version = "4.9.2";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "oslo.utils";
+    sha256 = "1jd584n3yws3xpz7dj7v0axcgq5dj0kwpbx6sm83nv7z6ibjinr0";
+  };
+
+  postPatch = ''
+    # Test requires network
+    rm oslo_utils/tests/test_eventletutils.py
+  '';
+
+  propagatedBuildInputs = [
+    pbr
+    iso8601
+    oslo-i18n
+    pytz
+    netaddr
+    netifaces
+    debtcollector
+    pyparsing
+    packaging
+  ];
+
+  checkInputs = [ stestr oslotest ddt testscenarios ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "oslo_utils" ];
+
+  meta = with lib; {
+    description = "Oslo Utility library";
+    homepage = "https://docs.openstack.org/oslo.utils/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/oslotest/default.nix
+++ b/pkgs/development/python-modules/oslotest/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchPypi
+, fixtures, subunit, six, testtools
+, stestr }:
+
+buildPythonPackage rec {
+  pname = "oslotest";
+  version = "4.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r50sz55m8ljv2vk1k7sp88iz1iqq4p9w6kb8hn8g8c50r9zdi5i";
+  };
+
+  propagatedBuildInputs = [
+    fixtures
+    subunit
+    six
+    testtools
+  ];
+
+  checkInputs = [ stestr ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "oslotest" ];
+
+  meta = with lib; {
+    description = "Library for consuming OpenStack sevice-types-authority data";
+    homepage = "https://docs.openstack.org/oslotest/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/python-cinderclient/default.nix
+++ b/pkgs/development/python-modules/python-cinderclient/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, prettytable, keystoneauth1, simplejson, oslo-i18n, oslo-utils, requests, stevedore
+, stestr, requests-mock, ddt, oslo-serialization }:
+
+buildPythonPackage rec {
+  pname = "python-cinderclient";
+  version = "8.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05pizhgkvpr4grcybzpih8fgrwdady22c7frazvp7av441b8rvac";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    prettytable
+    keystoneauth1
+    simplejson
+    oslo-i18n
+    oslo-utils
+    requests
+    stevedore
+  ];
+
+  checkInputs = [ stestr requests-mock ddt oslo-serialization ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "cinderclient" ];
+
+  meta = with lib; {
+    description = "OpenStack Block Storage API Client Library";
+    homepage = "https://docs.openstack.org/python-cinderclient/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/python-keystoneclient/default.nix
+++ b/pkgs/development/python-modules/python-keystoneclient/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, debtcollector, keystoneauth1, oslo-config, oslo-serialization, oslo-utils, requests, six, stevedore
+, stestr, testresources, testscenarios, requests-mock, openssl }:
+
+buildPythonPackage rec {
+  pname = "python-keystoneclient";
+  version = "4.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12jsiw82x2zcn8sf78xisf85kr28gl3jqj46a0wxx59v91p44j02";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    debtcollector
+    keystoneauth1
+    oslo-config
+    oslo-serialization
+    oslo-utils
+    requests
+    six
+    stevedore
+  ];
+
+  checkInputs = [ stestr testresources testscenarios requests-mock openssl ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "keystoneclient" ];
+
+  meta = with lib; {
+    description = "Client Library for OpenStack Identity";
+    homepage = "https://docs.openstack.org/python-keystoneclient/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/python-novaclient/default.nix
+++ b/pkgs/development/python-modules/python-novaclient/default.nix
@@ -1,0 +1,42 @@
+{ lib, buildPythonPackage, fetchPypi
+, pbr, keystoneauth1, iso8601, oslo-i18n, oslo-serialization, oslo-utils, prettytable, stevedore
+, stestr, testscenarios, requests-mock, ddt, openssl }:
+
+buildPythonPackage rec {
+  pname = "python-novaclient";
+  version = "17.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zzfkd6gjr5knzf43fnpzgdjkbabw0a5z5ppq9b6wcxifjdgx83s";
+  };
+
+  postPatch = ''
+    # Skip 2 broken tests
+    substituteInPlace novaclient/tests/unit/test_shell.py --replace "test_osprofiler" "__test_osprofiler"
+  '';
+
+  propagatedBuildInputs = [
+    pbr
+    keystoneauth1
+    iso8601
+    oslo-i18n
+    oslo-serialization
+    oslo-utils
+    prettytable
+    stevedore
+  ];
+
+  checkInputs = [ stestr testscenarios requests-mock ddt openssl ];
+  checkPhase = ''
+    stestr run
+  '';
+  pythonImportsCheck = [ "novaclient" ];
+
+  meta = with lib; {
+    description = "Client library for OpenStack Compute API";
+    homepage = "https://docs.openstack.org/python-novaclient/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/development/python-modules/stestr/default.nix
+++ b/pkgs/development/python-modules/stestr/default.nix
@@ -1,0 +1,42 @@
+{ lib, buildPythonPackage, fetchPypi
+, future, pbr, cliff, subunit, fixtures, testtools, pyyaml, voluptuous
+, pytestCheckHook, ddt }:
+
+buildPythonPackage rec {
+  pname = "stestr";
+  version = "3.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1i1b2z44ja8sbkqhaxyxc2xni6m9hky4x0254s0xdzfkyfyjqjgv";
+  };
+
+  propagatedBuildInputs = [
+    future
+    pbr
+    cliff
+    subunit
+    fixtures
+    testtools
+    pyyaml
+    voluptuous
+  ];
+
+  checkInputs = [ pytestCheckHook ddt ];
+  preCheck = ''
+    export PATH=$out/bin:$PATH
+    export HOME=$TMPDIR
+  '';
+  disabledTests = [
+    # Broken test
+    "test_empty_with_pretty_out"
+  ];
+  pythonImportsCheck = [ "stestr" ];
+
+  meta = with lib; {
+    description = "A parallel Python test runner built around subunit";
+    homepage = "https://stestr.readthedocs.io/en/latest/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ angustrau ];
+  };
+}

--- a/pkgs/tools/admin/openstackclient/base.nix
+++ b/pkgs/tools/admin/openstackclient/base.nix
@@ -1,0 +1,52 @@
+{ lib, python3Packages }:
+
+let
+  openstackclient = optionalPlugins: python3Packages.buildPythonApplication rec {
+    pname = "openstackclient";
+    version = "5.5.0";
+
+    src = python3Packages.fetchPypi {
+      inherit version;
+      pname = "python-${pname}";
+      sha256 = "1058v5zqbgly5b6dn3ijcjjvbjxi60iaqhhnrrsr6bqpfh9ljh4d";
+    };
+
+    propagatedBuildInputs = with python3Packages; [
+      pbr
+      cliff
+      iso8601
+      openstacksdk
+      osc-lib
+      oslo-i18n
+      oslo-utils
+      stevedore
+    ] ++ lib.unique ([
+      # Required client plugins
+      python-keystoneclient
+      python-novaclient
+      python-cinderclient
+    ] ++ optionalPlugins);
+
+    checkInputs = with python3Packages; [ stestr requests-mock ddt ];
+    checkPhase = ''
+      stestr run
+    '';
+    pythonImportsCheck = [ "openstackclient" ];
+
+    meta = with lib; {
+      description = "A command-line client for OpenStack";
+      longDescription = "OpenStackClient (aka OSC) is a command-line client for OpenStack that brings the command set for Compute, Identity, Image, Network, Object Store and Block Storage APIs together in a single shell with a uniform command structure";
+      homepage = "https://docs.openstack.org/python-openstackclient/latest/";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ angustrau ];
+    };
+  };
+  base = plugins: (openstackclient plugins) // { inherit withPlugins; };
+
+  # Optional client plugins
+  availablePlugins = with python3Packages; {
+    inherit python-cinderclient python-keystoneclient python-novaclient;
+  };
+  withPlugins = f: base (f availablePlugins);
+in
+  { inherit withPlugins; }

--- a/pkgs/tools/admin/openstackclient/default.nix
+++ b/pkgs/tools/admin/openstackclient/default.nix
@@ -1,0 +1,5 @@
+{ callPackage, lib }:
+let
+  inherit (callPackage ./base.nix { }) withPlugins;
+in
+  withPlugins (lib.const [])

--- a/pkgs/tools/admin/openstackclient/full.nix
+++ b/pkgs/tools/admin/openstackclient/full.nix
@@ -1,0 +1,5 @@
+{ callPackage }:
+let
+  inherit (callPackage ./base.nix { }) withPlugins;
+in
+  withPlugins (availablePlugins: builtins.attrValues availablePlugins)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3193,6 +3193,10 @@ with pkgs;
 
   libpsm2 = callPackage ../os-specific/linux/libpsm2 { };
 
+  openstackclient = callPackage ../tools/admin/openstackclient { };
+
+  openstackclientFull = callPackage ../tools/admin/openstackclient/full.nix { };
+
   optar = callPackage ../tools/graphics/optar {};
 
   obinskit = callPackage ../applications/misc/obinskit {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27321,6 +27321,8 @@ with pkgs;
 
   stella = callPackage ../misc/emulators/stella { };
 
+  stestr = with python3Packages; toPythonApplication stestr;
+
   linuxstopmotion = libsForQt5.callPackage ../applications/video/linuxstopmotion { };
 
   sweethome3d = recurseIntoAttrs (

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5096,6 +5096,8 @@ in {
 
   oslo-config = callPackage ../development/python-modules/oslo-config { };
 
+  oslo-context = callPackage ../development/python-modules/oslo-context { };
+
   oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
 
   oslo-utils = callPackage ../development/python-modules/oslo-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5051,6 +5051,8 @@ in {
 
   opensimplex = callPackage ../development/python-modules/opensimplex { };
 
+  openstacksdk = callPackage ../development/python-modules/openstacksdk { };
+
   opentimestamps = callPackage ../development/python-modules/opentimestamps { };
 
   opentracing = callPackage ../development/python-modules/opentracing { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5094,6 +5094,8 @@ in {
 
   oset = callPackage ../development/python-modules/oset { };
 
+  oslo-config = callPackage ../development/python-modules/oslo-config { };
+
   oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
 
   oslo-utils = callPackage ../development/python-modules/oslo-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5096,6 +5096,8 @@ in {
 
   oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
 
+  oslo-utils = callPackage ../development/python-modules/oslo-utils { };
+
   oslotest = callPackage ../development/python-modules/oslotest { };
 
   osmnx = callPackage ../development/python-modules/osmnx { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1876,6 +1876,8 @@ in {
 
   debts = callPackage ../development/python-modules/debts { };
 
+  debtcollector = callPackage ../development/python-modules/debtcollector { };
+
   debugpy = callPackage ../development/python-modules/debugpy { };
 
   decorator = callPackage ../development/python-modules/decorator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5092,6 +5092,8 @@ in {
 
   oset = callPackage ../development/python-modules/oset { };
 
+  oslotest = callPackage ../development/python-modules/oslotest { };
+
   osmnx = callPackage ../development/python-modules/osmnx { };
 
   osmpythontools = callPackage ../development/python-modules/osmpythontools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5086,6 +5086,8 @@ in {
 
   orvibo = callPackage ../development/python-modules/orvibo { };
 
+  os-service-types = callPackage ../development/python-modules/os-service-types { };
+
   osc = callPackage ../development/python-modules/osc { };
 
   oscrypto = callPackage ../development/python-modules/oscrypto { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3926,6 +3926,8 @@ in {
 
   keystone-engine = callPackage ../development/python-modules/keystone-engine { };
 
+  keystoneauth1 = callPackage ../development/python-modules/keystoneauth1 { };
+
   keyutils = callPackage ../development/python-modules/keyutils {
     inherit (pkgs) keyutils;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5094,6 +5094,8 @@ in {
 
   oset = callPackage ../development/python-modules/oset { };
 
+  oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
+
   oslotest = callPackage ../development/python-modules/oslotest { };
 
   osmnx = callPackage ../development/python-modules/osmnx { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5100,6 +5100,8 @@ in {
 
   oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
 
+  oslo-log = callPackage ../development/python-modules/oslo-log { };
+
   oslo-serialization = callPackage ../development/python-modules/oslo-serialization { };
 
   oslo-utils = callPackage ../development/python-modules/oslo-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5100,6 +5100,8 @@ in {
 
   oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
 
+  oslo-serialization = callPackage ../development/python-modules/oslo-serialization { };
+
   oslo-utils = callPackage ../development/python-modules/oslo-utils { };
 
   oslotest = callPackage ../development/python-modules/oslotest { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5480,6 +5480,8 @@ in {
 
   python-juicenet = callPackage ../development/python-modules/python-juicenet { };
 
+  python-keystoneclient = callPackage ../development/python-modules/python-keystoneclient { };
+
   python-lsp-black = callPackage ../development/python-modules/python-lsp-black { };
 
   python-openems = callPackage ../development/python-modules/python-openems { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5094,6 +5094,8 @@ in {
 
   osc = callPackage ../development/python-modules/osc { };
 
+  osc-lib = callPackage ../development/python-modules/osc-lib { };
+
   oscrypto = callPackage ../development/python-modules/oscrypto { };
 
   oset = callPackage ../development/python-modules/oset { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7184,6 +7184,8 @@ in {
 
   python-nomad = callPackage ../development/python-modules/python-nomad { };
 
+  python-novaclient = callPackage ../development/python-modules/python-novaclient { };
+
   python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };
 
   pythonocc-core = toPythonModule (callPackage ../development/python-modules/pythonocc-core {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7049,6 +7049,8 @@ in {
 
   python-box = callPackage ../development/python-modules/python-box { };
 
+  python-cinderclient = callPackage ../development/python-modules/python-cinderclient { };
+
   python-constraint = callPackage ../development/python-modules/python-constraint { };
 
   python-crontab = callPackage ../development/python-modules/python-crontab { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8435,6 +8435,8 @@ in {
 
   stem = callPackage ../development/python-modules/stem { };
 
+  stestr = callPackage ../development/python-modules/stestr { };
+
   stevedore = callPackage ../development/python-modules/stevedore { };
 
   stm32loader = callPackage ../development/python-modules/stm32loader { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3247,6 +3247,8 @@ in {
 
   hachoir = callPackage ../development/python-modules/hachoir { };
 
+  hacking = callPackage ../development/python-modules/hacking { };
+
   hdate = callPackage ../development/python-modules/hdate { };
 
   ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This brings back the openstack CLI client. It was removed along with the rest of openstack back in #32637. This time it's just the clients, so it should be less of a maintenance hassle. This PR creates all the necessary python packages required in the minimal dependency tree of `openstackclient`. I've stopped at including all of the ([many](https://docs.openstack.org/newton/user-guide/common/cli-overview.html#individual-command-line-clients)) optional plugins to keep the PR size somewhat reasonable, to be added later.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
