### PR TITLE
iTerm2: 3.4.0 -> 3.4.8

### DIFF
--- a/pkgs/applications/terminal-emulators/iterm2/0001-Revert-Fix-installing-delta-updates-of-runtime.patch
+++ b/pkgs/applications/terminal-emulators/iterm2/0001-Revert-Fix-installing-delta-updates-of-runtime.patch
@@ -1,0 +1,43 @@
+From 2315f3912a8bf24d9df0ee72285dfdde87c7eb6a Mon Sep 17 00:00:00 2001
+From: Vanilla <neko@hydev.org>
+Date: Mon, 16 Aug 2021 10:22:55 +0800
+Subject: [PATCH] Revert "Fix installing delta updates of runtime"
+
+This reverts commit 2a4869a54e49f7b43b599a0b461b8f9a5fa5eed1.
+---
+ iTerm2.xcodeproj/xcshareddata/xcschemes/iTerm2.xcscheme | 1 -
+ sources/iTermPythonRuntimeDownloader.m                  | 6 +++---
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/iTerm2.xcodeproj/xcshareddata/xcschemes/iTerm2.xcscheme b/iTerm2.xcodeproj/xcshareddata/xcschemes/iTerm2.xcscheme
+index 969833c87..8f59f0b52 100644
+--- a/iTerm2.xcodeproj/xcshareddata/xcschemes/iTerm2.xcscheme
++++ b/iTerm2.xcodeproj/xcshareddata/xcschemes/iTerm2.xcscheme
+@@ -67,7 +67,6 @@
+       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+       enableASanStackUseAfterReturn = "YES"
+-      enableUBSanitizer = "YES"
+       disableMainThreadChecker = "YES"
+       launchStyle = "0"
+       useCustomWorkingDirectory = "NO"
+diff --git a/sources/iTermPythonRuntimeDownloader.m b/sources/iTermPythonRuntimeDownloader.m
+index ca8f685fb..881f7edc8 100644
+--- a/sources/iTermPythonRuntimeDownloader.m
++++ b/sources/iTermPythonRuntimeDownloader.m
+@@ -568,9 +568,9 @@ NSString *const iTermPythonRuntimeDownloaderDidInstallRuntimeNotification = @"iT
+         NSString *replaceWith1 = [NSString stringWithFormat:@"/iterm2env-%@/", @(runtimeVersion)];
+         NSString *searchFor2 = [NSString stringWithFormat:@"/iterm2env-%@\"", @(latestFullComponent)];
+         NSString *replaceWith2 = [NSString stringWithFormat:@"/iterm2env-%@\"", @(runtimeVersion)];
+-        NSDictionary<NSString *, NSString *> *subs =
+-            @{ searchFor1: replaceWith1,
+-               searchFor2: replaceWith2 } ;
++        NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *subs =
++        @{ @"": @{ searchFor1: replaceWith1,
++                   searchFor2: replaceWith2 } };
+         [self performSubstitutions:subs inFilesUnderFolder:tempDestination];
+         [self unzip:[NSURL fileURLWithPath:zip] to:tempDestination completion:^(BOOL ok) {
+             if (!ok) {
+-- 
+2.32.0
+

--- a/pkgs/applications/terminal-emulators/iterm2/default.nix
+++ b/pkgs/applications/terminal-emulators/iterm2/default.nix
@@ -10,16 +10,22 @@
 
 stdenv.mkDerivation rec {
   pname = "iterm2";
-  version = "3.4.0";
+  version = "3.4.8";
 
   src = fetchFromGitHub {
     owner = "gnachman";
     repo = "iTerm2";
     rev = "v${version}";
-    sha256 = "09nhrmi25zxw3vp0wlib9kjr3p1j6am2zpwimdzqn0c80fq1lwvi";
+    sha256 = "sha256-7nhlg5BBudfa0hWtnHx4aujWpOLv6ByrUKmo+nqtb2M=";
   };
 
-  patches = [ ./disable_updates.patch ];
+  patches = [
+    ./disable_updates.patch
+
+    # v3.4.5 cannot build but v3.4.4 can,
+    # revert 2a4869a54e49f7b43b599a0b461b8f9a5fa5eed1 from git bisect.
+    ./0001-Revert-Fix-installing-delta-updates-of-runtime.patch
+   ];
   postPatch = ''
     sed -i -e 's/CODE_SIGN_IDENTITY = "Developer ID Application"/CODE_SIGN_IDENTITY = ""/g' ./iTerm2.xcodeproj/project.pbxproj
   '';
@@ -42,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.iterm2.com/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ tricktron ];
-    platforms = platforms.darwin;
+    platforms = [ "x86_64-darwin" ];
     hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
