### PR TITLE
saleae-logic-2: init at 2.3.33

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4755,6 +4755,12 @@
     githubId = 40566146;
     name = "Jonas Braun";
   };
+  j-hui = {
+    email = "j-hui@cs.columbia.edu";
+    github = "j-hui";
+    githubId = 11800204;
+    name = "John Hui";
+  };
   j-keck = {
     email = "jhyphenkeck@gmail.com";
     github = "j-keck";

--- a/pkgs/development/tools/misc/saleae-logic-2/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic-2/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchurl, appimageTools }:
+let
+  name = "saleae-logic-2";
+  version = "2.3.33";
+  src = fetchurl {
+    url = "https://downloads.saleae.com/logic2/Logic-${version}-master.AppImage";
+    sha256 = "09vypl03gj58byk963flskzkhl4qrd9qw1kh0sywbqnzbzvj5cgm";
+  };
+in
+appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands =
+    let appimageContents = appimageTools.extractType2 { inherit name src; }; in
+    ''
+      mkdir -p $out/etc/udev/rules.d
+      cp ${appimageContents}/resources/linux/99-SaleaeLogic.rules $out/etc/udev/rules.d/
+    '';
+
+  meta = with lib; {
+    homepage = "https://www.saleae.com/";
+    description = "Software for Saleae logic analyzers";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.j-hui ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14353,6 +14353,8 @@ with pkgs;
 
   saleae-logic = callPackage ../development/tools/misc/saleae-logic { };
 
+  saleae-logic-2 = callPackage ../development/tools/misc/saleae-logic-2 { };
+
   sauce-connect = callPackage ../development/tools/sauce-connect { };
 
   sd-local = callPackage ../development/tools/sd-local { };


### PR DESCRIPTION
###### Motivation for this change

Saleae has released version 2 of their logic analyzer software, Logic 2, though the original version Logic 1 still appears to be available.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
