### PR TITLE
catgirl: 1.9 -> 1.9a

### DIFF
--- a/pkgs/applications/networking/irc/catgirl/default.nix
+++ b/pkgs/applications/networking/irc/catgirl/default.nix
@@ -1,20 +1,13 @@
-{ ctags, fetchurl, fetchpatch, lib, libressl, ncurses, pkg-config, stdenv }:
+{ ctags, fetchurl, lib, libressl, ncurses, pkg-config, stdenv }:
 
 stdenv.mkDerivation rec {
   pname = "catgirl";
-  version = "1.9";
+  version = "1.9a";
 
   src = fetchurl {
     url = "https://git.causal.agency/catgirl/snapshot/${pname}-${version}.tar.gz";
-    sha256 = "182l7yryqm1ffxqgz3i4lcnzwzpbpm2qvadddmj0xc8dh8513s0w";
+    sha256 = "sha256-MEm5mrrWfNp+mBHFjGSOGvvfvBJ+Ho/K+mPUxzJDkV0=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://git.causal.agency/catgirl/patch/?id=3f3585d0f32e66ad5c8c6c713f315e14810230eb";
-      sha256 = "1vrgimvf007bxz8blxm3vjc7g3xwxplwxyrblnsryq54cqaw0xv3";
-    })
-  ];
 
   nativeBuildInputs = [ ctags pkg-config ];
   buildInputs = [ libressl ncurses ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

As I use it, and noticed there is an update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
