### PR TITLE
bottles: update version + bugfixes

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -8,13 +8,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2021.7.14-treviso";
+  version = "2021.7.28-treviso-2";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    sha256 = "0xhfk1ll8vacgrr0kkhynq4bryjhfjs29j824bark5mj9b6lkbix";
+    sha256 = "0kvwcajm9izvkwfg7ir7bks39bpc665idwa8mc8d536ajyjriysn";
   };
 
   postPatch = ''
@@ -52,6 +52,7 @@ python3Packages.buildPythonApplication rec {
     dbus-python
     gst-python
     liblarch
+    patool
   ] ++ [ steam-run-native ];
 
   format = "other";

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -3,7 +3,7 @@
 , desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy
 , python3Packages, gettext
 , appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3
-, steam-run-native, xdg-utils, pciutils
+, steam-run, xdg-utils, pciutils, cabextract, wineWowPackages
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -54,9 +54,11 @@ python3Packages.buildPythonApplication rec {
     liblarch
     patool
   ] ++ [
-    steam-run-native
+    steam-run
     xdg-utils
     pciutils
+    cabextract
+    wineWowPackages.minimal
   ];
 
   format = "other";
@@ -67,10 +69,10 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace build-aux/meson/postinstall.py \
       --replace "'update-desktop-database'" "'${desktop-file-utils}/bin/update-desktop-database'"
     substituteInPlace src/runner.py \
-      --replace " {runner}" " ${steam-run-native}/bin/steam-run {runner}" \
-      --replace " {dxvk_setup}" " ${steam-run-native}/bin/steam-run {dxvk_setup}"
+      --replace " {runner}" " ${steam-run}/bin/steam-run {runner}" \
+      --replace " {dxvk_setup}" " ${steam-run}/bin/steam-run {dxvk_setup}"
       substituteInPlace src/runner_utilities.py \
-        --replace " {runner}" " ${steam-run-native}/bin/steam-run {runner}" \
+        --replace " {runner}" " ${steam-run}/bin/steam-run {runner}" \
   '';
 
   preFixup = ''

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -69,6 +69,8 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace src/runner.py \
       --replace " {runner}" " ${steam-run-native}/bin/steam-run {runner}" \
       --replace " {dxvk_setup}" " ${steam-run-native}/bin/steam-run {dxvk_setup}"
+      substituteInPlace src/runner_utilities.py \
+        --replace " {runner}" " ${steam-run-native}/bin/steam-run {runner}" \
   '';
 
   preFixup = ''

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -3,7 +3,7 @@
 , desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy
 , python3Packages, gettext
 , appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3
-, steam-run-native
+, steam-run-native, xdg-utils
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -53,7 +53,10 @@ python3Packages.buildPythonApplication rec {
     gst-python
     liblarch
     patool
-  ] ++ [ steam-run-native ];
+  ] ++ [
+    steam-run-native
+    xdg-utils
+  ];
 
   format = "other";
   strictDeps = false; # broken with gobject-introspection setup hook, see https://github.com/NixOS/nixpkgs/issues/56943

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -3,7 +3,7 @@
 , desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy
 , python3Packages, gettext
 , appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3
-, steam-run-native, xdg-utils
+, steam-run-native, xdg-utils, pciutils
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -56,6 +56,7 @@ python3Packages.buildPythonApplication rec {
   ] ++ [
     steam-run-native
     xdg-utils
+    pciutils
   ];
 
   format = "other";


### PR DESCRIPTION
###### Motivation for this change
Previous state of `bottles` was not able to run any `wine` related commands beside installation of a wine prefix.

As it seems `staging-next` is stuck for some time and I want to get rid of that changes I want to merge this PR into `staging`.

see #132342

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
 asbachb@nixo-t14s  ~/dev/src/nix/nixpkgs   update/bottles  nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-ecb3c84196017d3ea37c6e7ec9c56a82d237b719-dirty-1/nixpkgs 739f0b22b74a35f65e5b862108db4d4380feecc8
Preparing worktree (detached HEAD 739f0b22b74)
Updating files: 100% (27423/27423), done.
HEAD is now at 739f0b22b74 elixir_ls: 0.7.0 -> 0.8.0
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-ecb3c84196017d3ea37c6e7ec9c56a82d237b719-dirty-1/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
