### PR TITLE
[21.05] thunderbird-91: init at 91.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -1,4 +1,4 @@
-{ pname, ffversion, meta, updateScript ? null
+{ pname, ffversion, meta, updateScript ? null, binaryName ? "firefox", application ? "browser"
 , src, unpackPhase ? null, patches ? []
 , extraNativeBuildInputs ? [], extraConfigureFlags ? [], extraMakeFlags ? [], tests ? [] }:
 
@@ -87,7 +87,6 @@ let
   default-toolkit = if stdenv.isDarwin then "cairo-cocoa"
                     else "cairo-gtk3${lib.optionalString waylandSupport "-wayland"}";
 
-  binaryName = "firefox";
   binaryNameCapitalized = lib.toUpper (lib.substring 0 1 binaryName) + lib.substring 1 (-1) binaryName;
 
   browserName = if stdenv.isDarwin then binaryNameCapitalized else binaryName;
@@ -287,7 +286,7 @@ buildStdenv.mkDerivation ({
   '');
 
   configureFlags = [
-    "--enable-application=browser"
+    "--enable-application=${application}"
     "--with-system-jpeg"
     "--with-system-zlib"
     "--with-system-libevent"

--- a/pkgs/applications/networking/mailreaders/thunderbird/91/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/91/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, callPackage, fetchurl }:
+
+callPackage (import ../../../browsers/firefox/common.nix rec {
+  pname = "thunderbird";
+  ffversion = "91.0";
+  application = "comm/mail";
+  binaryName = pname;
+  src = fetchurl {
+    url = "mirror://mozilla/thunderbird/releases/${ffversion}/source/thunderbird-${ffversion}.source.tar.xz";
+    sha512 = "f3fcaff97b37ef41850895e44fbd2f42b0f1cb982542861bef89ef7ee606c6332296d61f666106be9455078933a2844c46bf243b71cc4364d9ff457d9c808a7a";
+  };
+  patches = [
+    ./no-buildconfig-90.patch
+  ];
+
+  meta = with lib; {
+    description = "A full-featured e-mail client";
+    homepage = "https://thunderbird.net/";
+    maintainers = with maintainers; [ eelco lovesegfault pierron vcunat ];
+    platforms = platforms.unix;
+    badPlatforms = platforms.darwin;
+    broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".
+                                           # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
+    license = licenses.mpl20;
+  };
+
+  updateScript = callPackage ./update.nix {
+    attrPath = "thunderbird-unwrapped-91";
+    versionKey = "ffversion";
+  };
+}) {
+  webrtcSupport = false;
+  geolocationSupport = false;
+}

--- a/pkgs/applications/networking/mailreaders/thunderbird/91/no-buildconfig-90.patch
+++ b/pkgs/applications/networking/mailreaders/thunderbird/91/no-buildconfig-90.patch
@@ -1,0 +1,13 @@
+Remove about:buildconfig.  If used as-is, it would add unnecessary runtime dependencies.
+--- a/comm/mail/base/jar.mn
++++ b/comm/mail/base/jar.mn
+@@ -119,9 +119,6 @@ messenger.jar:
+ % override chrome://mozapps/content/profile/profileDowngrade.js chrome://messenger/content/profileDowngrade.js
+ % override chrome://mozapps/content/profile/profileDowngrade.xhtml chrome://messenger/content/profileDowngrade.xhtml
+ 
+-*   content/messenger/buildconfig.html              (content/buildconfig.html)
+-% override chrome://global/content/buildconfig.html chrome://messenger/content/buildconfig.html
+-
+ # L10n resources and overrides.
+ % override chrome://mozapps/locale/profile/profileDowngrade.dtd chrome://messenger/locale/profileDowngrade.dtd
+ % override chrome://global/locale/netError.dtd chrome://messenger/locale/netError.dtd

--- a/pkgs/applications/networking/mailreaders/thunderbird/91/update.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/91/update.nix
@@ -1,0 +1,7 @@
+{ callPackage
+, ...
+}@args:
+
+callPackage ../../../browsers/firefox/update.nix ({
+  baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
+} // (builtins.removeAttrs args ["callPackage"]))

--- a/pkgs/applications/networking/mailreaders/thunderbird/91/wrapper.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/91/wrapper.nix
@@ -1,0 +1,23 @@
+{ lib, wrapFirefox, gpgme, gnupg }:
+
+browser:
+args:
+
+(wrapFirefox browser ({
+  firefoxLibName = "thunderbird";
+} // args))
+
+.overrideAttrs (old: {
+  # Thunderbird's native GPG support does not yet support smartcards.
+  # The official upstream recommendation is to configure fall back to gnupg
+  # using the Thunderbird config `mail.openpgp.allow_external_gnupg`
+  # and GPG keys set up; instructions with pictures at:
+  # https://anweshadas.in/how-to-use-yubikey-or-any-gpg-smartcard-in-thunderbird-78/
+  # For that to work out of the box, it requires `gnupg` on PATH and
+  # `gpgme` in `LD_LIBRARY_PATH`; we do this below.
+  buildCommand = old.buildCommand + ''
+    wrapProgram $out/bin/thunderbird \
+      --prefix LD_LIBRARY_PATH ':' "${lib.makeLibraryPath [ gpgme ]}" \
+      --prefix PATH ':' "${lib.makeBinPath [ gnupg ]}"
+  '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26759,6 +26759,19 @@ in
     gtk3Support = true;
   };
 
+  thunderbird-91-unwrapped = callPackage ../applications/networking/mailreaders/thunderbird/91 {
+    callPackage = pkgs.newScope {
+      inherit (rustPackages) cargo rustc;
+      libpng = libpng_apng;
+      gnused = gnused_422;
+      inherit (darwin.apple_sdk.frameworks) CoreMedia ExceptionHandling
+                                            Kerberos AVFoundation MediaToolbox
+                                            CoreLocation Foundation AddressBook;
+      inherit (darwin) libobjc;
+    };
+  };
+  thunderbird-91 = wrapThunderbird thunderbird-91-unwrapped { };
+
   thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
 
   thunderbird-bin = thunderbird-bin-78;
@@ -27347,6 +27360,9 @@ in
   wpsoffice = libsForQt514.callPackage ../applications/office/wpsoffice {};
 
   wrapFirefox = callPackage ../applications/networking/browsers/firefox/wrapper.nix { };
+
+  # Only used for new Thunderbird 91.x
+  wrapThunderbird = callPackage ../applications/networking/mailreaders/thunderbird/91/wrapper.nix { };
 
   wp-cli = callPackage ../development/tools/wp-cli { };
 


### PR DESCRIPTION
###### Motivation for this change

This adds Thunderbird 91
- without changing the existing Thunderbird 78
- while leaving 78 as default
- with only the minimal required changes to the Firefox expression (no rebuilds)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
