### PR TITLE
haskellPackages.readline: fix Setup.hs to work with Cabal 3

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1458,6 +1458,10 @@ self: super: {
     addBuildDepend (unmarkBroken super.hercules-ci-cli) super.hercules-ci-optparse-applicative
   );
 
+  # Readline uses Distribution.Simple from Cabal 2, in a way that is not
+  # compatible with Cabal 3. No upstream repository found so far
+  readline =  appendPatch super.readline ./patches/readline-fix-for-cabal-3.patch;
+
   # 2020-12-05: http-client is fixed on too old version
   essence-of-live-coding-warp = doJailbreak (super.essence-of-live-coding-warp.override {
     http-client = self.http-client_0_7_8;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3898,7 +3898,6 @@ broken-packages:
   - read-bounded
   - read-ctags
   - read-io
-  - readline
   - readme-lhs
   - readshp
   - really-simple-xml-parser

--- a/pkgs/development/haskell-modules/patches/readline-fix-for-cabal-3.patch
+++ b/pkgs/development/haskell-modules/patches/readline-fix-for-cabal-3.patch
@@ -1,0 +1,8 @@
+--- a/Setup.hs	2021-02-04 14:01:09.557970245 +0100
++++ b/Setup.hs	2021-02-04 14:07:45.047443753 +0100
+@@ -3,4 +3,4 @@
+ import           Distribution.Simple
+ 
+ main :: IO ()
+-main = defaultMainWithHooks defaultUserHooks
++main = defaultMainWithHooks autoconfUserHooks


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/111985/ for previous discussion

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

readline is broken for Cabal3 build. I have not yet found an active maintainer or an upstream repository, thus I added a one line patch here to get the package compiling again.

See [this pr](https://github.com/NixOS/nixpkgs/pull/134124) to `release-21.05` for more details

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
