### PR TITLE
nixos/smartdns: rewrite and simplify the systemd service

### DIFF
--- a/nixos/modules/services/networking/smartdns.nix
+++ b/nixos/modules/services/networking/smartdns.nix
@@ -52,11 +52,18 @@ in {
   config = lib.mkIf cfg.enable {
     services.smartdns.settings.bind = mkDefault ":${toString cfg.bindPort}";
 
-    systemd.packages = [ pkgs.smartdns ];
-    systemd.services.smartdns.wantedBy = [ "multi-user.target" ];
-    systemd.services.smartdns.restartTriggers = [ confFile ];
-    environment.etc."smartdns/smartdns.conf".source = confFile;
-    environment.etc."default/smartdns".source =
-      "${pkgs.smartdns}/etc/default/smartdns";
+    systemd.services.smartdns = {
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      unitConfig = {
+        StartLimitBurst = 0;
+        StartLimitIntervalSec = 60;
+      };
+      serviceConfig = {
+        ExecStart = "${pkgs.smartdns}/bin/smartdns -f -c ${confFile}";
+        Restart = "always";
+        TimeoutStopSec = 5;
+      };
+    };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The old, bundled systemd service requires /etc/smartdns/smartdns.conf and /etc/default/smartdns to be written and runs in fork mode when running in foreground is already supported. This new systemd service file solves all these issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

closes #134303
cc @LEXUGE