### PR TITLE
mypy: 0.812 → 0.910

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7690,6 +7690,12 @@
     githubId = 151337;
     name = "Nick Novitski";
   };
+  nicoo = {
+    email = "nicoo@debian.org";
+    github = "nbraud";
+    githubId = 1155801;
+    name = "nicoo";
+  };
   nico202 = {
     email = "anothersms@gmail.com";
     github = "nico202";

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -1,18 +1,19 @@
 { lib, stdenv, fetchPypi, buildPythonPackage, typed-ast, psutil, isPy3k
 , mypy-extensions
 , typing-extensions
+, toml, types-toml
 }:
 buildPythonPackage rec {
   pname = "mypy";
-  version = "0.812";
+  version = "0.910";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "069i9qnfanp7dn8df1vspnqb0flvsszzn22v00vj08nzlnd061yd";
+    sha256 = "0l31s5pr3j4xkqg44ac2q6s30srp7f3mlxzi32i33jvk4hq9hh3h";
   };
 
-  propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];
+  propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions toml types-toml ];
 
   # Tests not included in pip package.
   doCheck = false;

--- a/pkgs/development/python-modules/types-toml/default.nix
+++ b/pkgs/development/python-modules/types-toml/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-toml";
+  version = "0.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nfwymw2pmc88w524ypamc62nwqfky75cqqc6vj08m145kwisppw";
+  };
+
+  # Modules doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "toml-stubs" ];
+
+  meta = with lib; {
+    description = "Typing stubs for toml";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nicoo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8966,6 +8966,8 @@ in {
 
   types-requests = callPackage ../development/python-modules/types-requests { };
 
+  types-toml = callPackage ../development/python-modules/types-toml { };
+
   typesentry = callPackage ../development/python-modules/typesentry { };
 
   typesystem = callPackage ../development/python-modules/typesystem { };


### PR DESCRIPTION
- types-toml: Init at 0.1.5
- mypy: 0.812 → 0.910

###### Motivation for this change

- types-toml: Init at 0.1.5
  type annotations for `toml`, a new dependency of `mypy`.

- mypy: 0.812 → 0.910
  New versions of `mypy` include significant changes:
  - Switch to [modular `typeshed`](https://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html)
  - [`TypeGuard`](https://www.python.org/dev/peps/pep-0647/) support
  - Configuration via `pyproject.toml`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~ N/A
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


###### Issues

@lnl7 @martingms I am having issues getting this to build, as `mypy` apparently
doesn't find the type hints for the `toml` module, even though it should be in
`$PYTHONPATH`.  Any hint (^^') how to proceed?
