### PR TITLE
python3Packages.furo: init at 2021.8.11b42

### DIFF
--- a/pkgs/development/python-modules/furo/default.nix
+++ b/pkgs/development/python-modules/furo/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, sphinx
+, beautifulsoup4
+}:
+
+buildPythonPackage rec {
+  pname = "furo";
+  version = "2021.8.11b42";
+  format = "flit";
+  disable = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-rhi2T57EfidQV1IHBkplCbzLlBCC5gVGmbkCf40s0qU=";
+  };
+
+  propagatedBuildInputs = [
+    sphinx
+    beautifulsoup4
+  ];
+
+  pythonImportsCheck = [ "furo" ];
+
+  meta = with lib; {
+    description = "A clean customizable documentation theme for Sphinx";
+    homepage = "https://github.com/pradyunsg/furo";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2784,6 +2784,8 @@ in {
 
   furl = callPackage ../development/python-modules/furl { };
 
+  furo = callPackage ../development/python-modules/furo { };
+
   fuse = callPackage ../development/python-modules/fuse-python {
     inherit (pkgs) fuse;
   };


### PR DESCRIPTION
###### Motivation for this change
This sphinx extension is the last missing package which is required to build the documentation of the next kitty version (#131559).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).