### PR TITLE
premid: init at 2.3.2

### DIFF
--- a/pkgs/applications/misc/premid/default.nix
+++ b/pkgs/applications/misc/premid/default.nix
@@ -1,0 +1,92 @@
+{ autoPatchelfHook, makeDesktopItem, lib, stdenv, wrapGAppsHook, fetchurl, copyDesktopItems
+, alsa-lib, at-spi2-atk, at-spi2-core, atk, cairo, cups, dbus, expat, fontconfig
+, freetype, gdk-pixbuf, glib, gtk3, libcxx, libdrm, libnotify, libpulseaudio, libuuid
+, libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
+, libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence
+, mesa, nspr, nss, pango, systemd, libappindicator-gtk3, libdbusmenu
+}:
+
+stdenv.mkDerivation rec {
+  pname = "premid";
+  version = "2.3.2";
+
+  src = fetchurl {
+    url = "https://github.com/premid/Linux/releases/download/v${version}/${pname}.tar.gz";
+    sha256 = "sha256-TuID63cVZkQ2kBl2iZeuVvjRUJYBt62ppPvgffBlOXY=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    alsa-lib
+    cups
+    libdrm
+    libuuid
+    libXdamage
+    libX11
+    libXScrnSaver
+    libXtst
+    libxcb
+    libxshmfence
+    mesa
+    nss
+  ];
+
+  dontWrapGApps = true;
+  dontBuild = true;
+  dontConfigure = true;
+
+  libPath = lib.makeLibraryPath [
+    libcxx systemd libpulseaudio libdrm mesa
+    stdenv.cc.cc alsa-lib atk at-spi2-atk at-spi2-core cairo cups dbus expat fontconfig freetype
+    gdk-pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
+    libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
+    libXtst nspr nss libxcb pango systemd libXScrnSaver
+    libappindicator-gtk3 libdbusmenu
+   ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,opt/PreMiD,share/pixmaps}
+    mv * $out/opt/PreMiD
+
+    chmod +x $out/opt/PreMiD/${pname}
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+        $out/opt/PreMiD/${pname}
+
+    wrapProgram $out/opt/PreMiD/${pname} \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+        --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/${pname}
+
+    ln -s $out/opt/PreMiD/${pname} $out/bin/
+  '';
+
+  # This is the icon used by the desktop file
+  postInstall = ''
+    ln -s $out/opt/PreMiD/assets/appIcon.png $out/share/pixmaps/${pname}.png
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "PreMiD";
+      icon = pname;
+      desktopName = "PreMiD";
+      genericName = meta.description;
+      mimeType = "x-scheme-handler/premid";
+    })
+  ];
+
+  meta = with lib; {
+    description = "A simple, configurable utility to show your web activity as playing status on Discord";
+    homepage = "https://premid.app";
+    downloadPage = "https://premid.app/downloads";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ natto1784 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26712,6 +26712,8 @@ in
 
   qiv = callPackage ../applications/graphics/qiv { };
 
+  premid = callPackage ../applications/misc/premid { };
+
   processing = callPackage ../applications/graphics/processing {
     jdk = oraclejdk8;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
It is a cool little app I use which isn't present in nixpkgs *yet*

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note: The library deps are the same as [Discord](https://github.com/NixOS/nixpkgs/tree/8e170dc44a9d782c6991c7f9386187be3d5ffbbc/pkgs/applications/networking/instant-messengers/discord)