### PR TITLE
scons: use python2 for all scons versions <4

### DIFF
--- a/pkgs/development/tools/build-managers/scons/default.nix
+++ b/pkgs/development/tools/build-managers/scons/default.nix
@@ -8,7 +8,7 @@ in {
   scons_3_0_1 = (mkScons {
     version = "3.0.1";
     sha256 = "0wzid419mlwqw9llrg8gsx4nkzhqy16m4m40r0xnh6cwscw5wir4";
-  }).override { python = python3; };
+  }).override { python = python2; };
   scons_3_1_2 = (mkScons {
     version = "3.1.2";
     sha256 = "1yzq2gg9zwz9rvfn42v5jzl3g4qf1khhny6zfbi2hib55zvg60bq";


### PR DESCRIPTION
###### Motivation for this change


While refactoring this file in a previous PR I accidentally ported
scons 3.0.1 to Python3 which doesn't work. Only Scons >=4 supports
Python3.

cc @putchar: this should fix the conky build (and others)

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
