### PR TITLE
mpg123: Refactor, 1.26.5 -> 1.28.2

### DIFF
--- a/pkgs/applications/audio/mpg123/default.nix
+++ b/pkgs/applications/audio/mpg123/default.nix
@@ -2,8 +2,10 @@
 , fetchurl
 , makeWrapper
 , alsa-lib
+, AudioUnit
+, AudioToolbox
 , perl
-, withConplay ? !stdenv.targetPlatform.isWindows
+, withConplay ? !stdenv.hostPlatform.isWindows
 }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +22,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = lib.optionals withConplay [ makeWrapper ];
 
   buildInputs = lib.optionals withConplay [ perl ]
-    ++ lib.optionals (!stdenv.isDarwin && !stdenv.targetPlatform.isWindows) [ alsa-lib ];
+    ++ lib.optionals (stdenv.hostPlatform.isLinux) [ alsa-lib ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ AudioUnit AudioToolbox ];
 
   configureFlags = lib.optional
     (stdenv.hostPlatform ? mpg123)
@@ -43,8 +46,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Fast console MPEG Audio Player and decoder library";
     homepage = "https://mpg123.org";
-    license = licenses.lgpl21;
-    maintainers = [ maintainers.ftrvxmtrx ];
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ ftrvxmtrx ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/audio/mpg123/default.nix
+++ b/pkgs/applications/audio/mpg123/default.nix
@@ -18,11 +18,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mpg123";
-  version = "1.26.5";
+  version = "1.28.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-UCqX4Nk1vn432YczgCHY8wG641wohPKoPVnEtSRm7wY=";
+    sha256 = "006v44nz4nkpgvxz1k2vbbrfpa2m47hyydscs0wf3iysiyvd9vvy";
   };
 
   outputs = [ "out" ] ++ lib.optionals withConplay [ "conplay" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26073,7 +26073,9 @@ with pkgs;
 
   mpc123 = callPackage ../applications/audio/mpc123 { };
 
-  mpg123 = callPackage ../applications/audio/mpg123 { };
+  mpg123 = callPackage ../applications/audio/mpg123 {
+    inherit (darwin.apple_sdk.frameworks) AudioUnit AudioToolbox;
+  };
 
   mpg321 = callPackage ../applications/audio/mpg321 { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26075,6 +26075,7 @@ with pkgs;
 
   mpg123 = callPackage ../applications/audio/mpg123 {
     inherit (darwin.apple_sdk.frameworks) AudioUnit AudioToolbox;
+    jack = libjack2;
   };
 
   mpg321 = callPackage ../applications/audio/mpg321 { };


### PR DESCRIPTION
###### Motivation for this change
Started out as a small change to only add audio support on Darwin, turned into a slightly bigger refactoring & bump.

Dunno how to test mpg123 itself but I tested libout123 via sidplayfp:

```
nix-build -E 'with import ./. { }; sidplayfp.override { out123Support = true; }'
curl -Ls 'https://hvsc.csdb.dk/MUSICIANS/L/Linus/I_Dug_Some_Graves_Youll_Never_Find.sid' | ./result/bin/sidplayfp -
```

![Bildschirmfoto_2021-08-16_19-22-50](https://user-images.githubusercontent.com/23431373/129604181-7b8b49e0-6f3c-41e4-b979-05e7fcabb937.png)

JACK errors are fine since I'm not running a JACK server. I don't get these messages on macOS despite it loading the JACK module, not sure if something's borked there or if it just fails silently instead.

---

CC @Radvendii I touched your changes for cross-compiling to Windows abit without testing, I think everything should still be fine?

- `stdenv.targetPlatform` AFAIU is mostly for stuff like compilers that produce further binaries while `stdenv.hostPlatform` should be correct in this case, see https://nixos.org/manual/nixpkgs/stable/#ssec-cross-platform-parameters
- restricting `alsa-lib` to `isLinux` makes more sense to me than `!isDarwin && !isWindows`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
