### PR TITLE
gpgme: fix failing patch downloads.

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -23,12 +23,18 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch { # probably included in > 1.16.0
       name = "test_t-edit-sign.diff"; # we experienced segmentation fault in this test
-      url = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=patch;h=81a33ea5e1b86d586b956e893a5b25c4cd41c969";
+      urls = [
+        "https://files.gnupg.net/file/data/w43xz2zf73pnyqk5mm5l/PHID-FILE-hm2x5mjntsdyxrxve5tb/file"
+        "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=patch;h=81a33ea5e1b86d586b956e893a5b25c4cd41c969"
+      ];
       sha256 = "1xxvv0kc9wdj5hzpddzs3cn8dhmm2cb29224a7h9vairraq5272h";
     })
     (fetchpatch { # gpg: Send --with-keygrip when listing keys
       name = "c4cf527ea227edb468a84bf9b8ce996807bd6992.patch";
-      url = "http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=patch;h=c4cf527ea227edb468a84bf9b8ce996807bd6992";
+      urls = [
+        "https://files.gnupg.net/file/data/2ufcg7ny5jdnv7hmewb4/PHID-FILE-7iwvryn2btti6txr3bsz/file"
+        "http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=patch;h=c4cf527ea227edb468a84bf9b8ce996807bd6992"
+      ];
       sha256 = "0y0b0lb2nq5p9kx13b59b2jaz157mvflliw1qdvg1v1hynvgb8m4";
     })
     # https://lists.gnupg.org/pipermail/gnupg-devel/2020-April/034591.html


### PR DESCRIPTION
###### Motivation for this change

The existing patches error out with a 5xx

https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=patch;h=81a33ea5e1b86d586b956e893a5b25c4cd41c969
http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=patch;h=c4cf527ea227edb468a84bf9b8ce996807bd6992

```
builder for '/nix/store/xc51ldnhhjb1zjjfj48y6i7bwjm1kdky-c4cf527ea227edb468a84bf9b8ce996807bd6992.patch.drv' failed with exit code 1; last 10 log lines:
  Warning: Problem : HTTP error. Will retry in 1 seconds. 3 retries left.
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  curl: (22) The requested URL returned error: 503
  Warning: Problem : HTTP error. Will retry in 2 seconds. 2 retries left.
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  curl: (22) The requested URL returned error: 503
  Warning: Problem : HTTP error. Will retry in 4 seconds. 1 retries left.
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  curl: (22) The requested URL returned error: 503
  error: cannot download c4cf527ea227edb468a84bf9b8ce996807bd6992.patch from any mirror
  ```

I am not sure if that's just a temporary outage, but I added alternate URLs that work


###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
