### PR TITLE
lsd2dsl: 0.5.2 → 0.5.4

### DIFF
--- a/pkgs/applications/misc/lsd2dsl/default.nix
+++ b/pkgs/applications/misc/lsd2dsl/default.nix
@@ -1,22 +1,32 @@
-{ stdenv, mkDerivation, lib, fetchFromGitHub, cmake
+{ lib, stdenv, mkDerivation, fetchFromGitHub
+, makeDesktopItem, copyDesktopItems, cmake
 , boost, libvorbis, libsndfile, minizip, gtest, qtwebkit }:
 
 mkDerivation rec {
   pname = "lsd2dsl";
-  version = "0.5.2";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "nongeneric";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0s0la6zkg584is93p4nj1ha3pbnvadq84zgsv8nym3r35n7k8czi";
+    sha256 = "sha256-PLgfsVVrNBTxI4J0ukEOFRoBkbmB55/sLNn5KyiHeAc=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ] ++ lib.optional stdenv.isLinux copyDesktopItems;
 
   buildInputs = [ boost libvorbis libsndfile minizip gtest qtwebkit ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=unused-result -Wno-error=missing-braces";
+
+  desktopItems = lib.singleton (makeDesktopItem {
+    name = "lsd2dsl";
+    exec = "lsd2dsl-qtgui";
+    desktopName = "lsd2dsl";
+    genericName = "lsd2dsl";
+    comment = meta.description;
+    categories = "Dictionary;FileTools;Qt;";
+  });
 
   installPhase = ''
     install -Dm755 console/lsd2dsl gui/lsd2dsl-qtgui -t $out/bin
@@ -33,6 +43,6 @@ mkDerivation rec {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
-    platforms = with platforms; linux ++ darwin;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/nongeneric/lsd2dsl/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
