### PR TITLE
cmark: fix pkg-config file (and tests on darwin)

### DIFF
--- a/pkgs/development/libraries/cmark/default.nix
+++ b/pkgs/development/libraries/cmark/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "cmark";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-UjDM2N6gCwO94F1nW3qCP9JX42MYAicAuGTKAXMy1Gg=";
   };
+
+  patches = [
+    # Fix libcmark.pc paths (should be incorporated next release)
+    (fetchpatch {
+      url = "https://github.com/commonmark/cmark/commit/15762d7d391483859c241cdf82b1615c6b6a5a19.patch";
+      sha256 = "sha256-wdyK1tQolgfiwYMAaWMQZdCSbMDCijug5ykpoDl/HwI=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/libraries/cmark/default.nix
+++ b/pkgs/development/libraries/cmark/default.nix
@@ -19,10 +19,12 @@ stdenv.mkDerivation rec {
     "-DCMARK_STATIC=OFF"
   ];
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = true;
 
-  preCheck = ''
-    export LD_LIBRARY_PATH=$(readlink -f ./src)
+  preCheck = let
+    lib_path = if stdenv.isDarwin then "DYLD_FALLBACK_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+  in ''
+    export ${lib_path}=$(readlink -f ./src)
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
 
Wrong include/lib paths when cmark is searched with `pkg-config --cflags cmark`.

###### Things done

- Apply upstream patch commonmark/cmark#391 to fix `libcmark.pc`. Should be incorporated in next release.

- Also make the tests run on Darwin, but that `preCheck` should not be needed once #22060 is fixed (someday?). 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
