### PR TITLE
caddy: add config option for multiple configurations

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -995,7 +995,7 @@
   ./services/web-apps/youtrack.nix
   ./services/web-apps/zabbix.nix
   ./services/web-servers/apache-httpd/default.nix
-  ./services/web-servers/caddy.nix
+  ./services/web-servers/caddy/default.nix
   ./services/web-servers/darkhttpd.nix
   ./services/web-servers/fcgiwrap.nix
   ./services/web-servers/hitch/default.nix

--- a/nixos/modules/services/web-servers/caddy/vhost-options.nix
+++ b/nixos/modules/services/web-servers/caddy/vhost-options.nix
@@ -1,0 +1,28 @@
+# This file defines the options that can be used both for the Nginx
+# main server configuration, and for the virtual hosts.  (The latter
+# has additional options that affect the web server as a whole, like
+# the user/group to run under.)
+
+{ lib, ... }:
+
+with lib;
+{
+  options = {
+    serverAliases = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "www.example.org" "example.org" ];
+      description = ''
+        Additional names of virtual hosts served by this virtual host configuration.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        These lines go into the vhost verbatim
+      '';
+    };
+  };
+}

--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -43,49 +43,64 @@ import ./make-test-python.nix ({ pkgs, ... }: {
           }
         '';
       };
+      specialisation.multiple-configs.configuration = {
+        services.caddy.virtualHosts = {
+          "http://localhost:8080" = { };
+          "http://localhost:8081" = { };
+        };
+      };
     };
-  };
 
-  testScript = { nodes, ... }: let
-    etagSystem = "${nodes.webserver.config.system.build.toplevel}/specialisation/etag";
-    justReloadSystem = "${nodes.webserver.config.system.build.toplevel}/specialisation/config-reload";
-  in ''
-    url = "http://localhost/example.html"
-    webserver.wait_for_unit("caddy")
-    webserver.wait_for_open_port("80")
+    testScript = { nodes, ... }:
+      let
+        etagSystem = "${nodes.webserver.config.system.build.toplevel}/specialisation/etag";
+        justReloadSystem = "${nodes.webserver.config.system.build.toplevel}/specialisation/config-reload";
+        multipleConfigs = "${nodes.webserver.config.system.build.toplevel}/specialisation/multiple-configs";
+      in
+      ''
+        url = "http://localhost/example.html"
+        webserver.wait_for_unit("caddy")
+        webserver.wait_for_open_port("80")
 
 
-    def check_etag(url):
-        etag = webserver.succeed(
-            "curl --fail -v '{}' 2>&1 | sed -n -e \"s/^< [Ee][Tt][Aa][Gg]: *//p\"".format(
-                url
+        def check_etag(url):
+            etag = webserver.succeed(
+                "curl --fail -v '{}' 2>&1 | sed -n -e \"s/^< [Ee][Tt][Aa][Gg]: *//p\"".format(
+                    url
+                )
             )
-        )
-        etag = etag.replace("\r\n", " ")
-        http_code = webserver.succeed(
-            "curl --fail --silent --show-error -o /dev/null -w \"%{{http_code}}\" --head -H 'If-None-Match: {}' {}".format(
-                etag, url
+            etag = etag.replace("\r\n", " ")
+            http_code = webserver.succeed(
+                "curl --fail --silent --show-error -o /dev/null -w \"%{{http_code}}\" --head -H 'If-None-Match: {}' {}".format(
+                    etag, url
+                )
             )
-        )
-        assert int(http_code) == 304, "HTTP code is {}, expected 304".format(http_code)
-        return etag
+            assert int(http_code) == 304, "HTTP code is {}, expected 304".format(http_code)
+            return etag
 
 
-    with subtest("check ETag if serving Nix store paths"):
-        old_etag = check_etag(url)
-        webserver.succeed(
-            "${etagSystem}/bin/switch-to-configuration test >&2"
-        )
-        webserver.sleep(1)
-        new_etag = check_etag(url)
-        assert old_etag != new_etag, "Old ETag {} is the same as {}".format(
-            old_etag, new_etag
-        )
+        with subtest("check ETag if serving Nix store paths"):
+            old_etag = check_etag(url)
+            webserver.succeed(
+                "${etagSystem}/bin/switch-to-configuration test >&2"
+            )
+            webserver.sleep(1)
+            new_etag = check_etag(url)
+            assert old_etag != new_etag, "Old ETag {} is the same as {}".format(
+                old_etag, new_etag
+            )
 
-    with subtest("config is reloaded on nixos-rebuild switch"):
-        webserver.succeed(
-            "${justReloadSystem}/bin/switch-to-configuration test >&2"
-        )
-        webserver.wait_for_open_port("8080")
-  '';
-})
+        with subtest("config is reloaded on nixos-rebuild switch"):
+            webserver.succeed(
+                "${justReloadSystem}/bin/switch-to-configuration test >&2"
+            )
+            webserver.wait_for_open_port("8080")
+
+        with subtest("multiple configs are correctly merged"):
+            webserver.succeed(
+                "${multipleConfigs}/bin/switch-to-configuration test >&2"
+            )
+            webserver.wait_for_open_port("8080")
+            webserver.wait_for_open_port("8081")
+      '';
+  })


### PR DESCRIPTION
this adds an api similar to nginx where you can define part of your config in different modules. If you want to expose some service, you can keep the logic for exposing it in that module and not have to define a global caddy config in the caddy module. This is to improve separation of concerns


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
