### PR TITLE
beam-modules: fix phase deprecation

### DIFF
--- a/pkgs/development/beam-modules/fetch-hex.nix
+++ b/pkgs/development/beam-modules/fetch-hex.nix
@@ -11,6 +11,9 @@ with lib;
 stdenv.mkDerivation ({
   pname = "hex-source-${pkg}";
   inherit version;
+  dontBuild = true;
+  dontConfigure = true;
+  dontFixup = true;
 
   src = fetchurl {
     url = "https://repo.hex.pm/tarballs/${pkg}-${version}.tar";

--- a/pkgs/development/beam-modules/fetch-rebar-deps.nix
+++ b/pkgs/development/beam-modules/fetch-rebar-deps.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation ({
   inherit version;
 
   dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
 
   prePhases = ''
     cp ${src} .


### PR DESCRIPTION
###### Motivation for this change

using the phases attributes is deprecated. An original PR did this for fetch-hex and fetch-rebar-deps, however the behavior changed a bit in which some phases where run
https://github.com/NixOS/nixpkgs/pull/134355/files

This PR removes the added phases that were being run.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
