### PR TITLE
colpack: refactor builder and build on darwin

### DIFF
--- a/pkgs/applications/science/math/colpack/default.nix
+++ b/pkgs/applications/science/math/colpack/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, gettext }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
 
@@ -12,20 +12,32 @@ stdenv.mkDerivation rec {
     sha256 = "1p05vry940mrjp6236c0z83yizmw9pk6ly2lb7d8rpb7j9h03glr";
   };
 
-  buildInputs = [ autoconf automake gettext libtool ];
+  nativeBuildInputs = [ autoreconfHook ];
 
-  configurePhase = ''
-    autoreconf -vif
-    ./configure --prefix=$out --enable-openmp
+  configureFlags = [
+    "--enable-openmp=${if stdenv.isLinux then "yes" else "no"}"
+    "--enable-examples=no"
+  ];
+
+  postInstall = ''
+    # Remove libtool archive
+    rm $out/lib/*.la
+
+    # Remove compiled examples (Basic examples get compiled anyway)
+    rm -r $out/examples
+
+    # Copy the example sources (Basic tree contains scripts and object files)
+    mkdir -p $out/share/ColPack/examples/Basic
+    cp SampleDrivers/Basic/*.cpp $out/share/ColPack/examples/Basic
+    cp -r SampleDrivers/Matrix* $out/share/ColPack/examples
   '';
 
   meta = with lib; {
     description = "A package comprising of implementations of algorithms for
     vertex coloring and derivative computation";
     homepage = "http://cscapes.cs.purdue.edu/coloringpage/software.htm#functionalities";
-    license = licenses.lgpl3;
-    platforms = platforms.linux;
+    license = licenses.lgpl3Plus;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ edwtjo ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Need it to build on Darwin to build `shogun` on Darwin.

###### Things done

- Use `autoreconfHook` and set flags with `configureFlags`.
- Only enable OpenMP on Linux, so it can be built on Darwin.
- Do not install `.la` file. Other distros also remove them.
- Do not build examples.
- Install example sources into a proper location (or maybe they can just not be installed at all?)

This should make `shogun` build on Darwin but it probably won't build  due to being pinned to `gcc8`. I am working on `shogun` to make it work on Darwin so I will sent a new PR soon.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change (only `shogun`).
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
