### PR TITLE
mono6: 6.12.0.90 -> 6.12.0.122

### DIFF
--- a/pkgs/development/compilers/mono/6.nix
+++ b/pkgs/development/compilers/mono/6.nix
@@ -2,8 +2,8 @@
 
 callPackage ./generic.nix ({
   inherit Foundation libobjc;
-  version = "6.12.0.90";
+  version = "6.12.0.122";
   srcArchiveSuffix = "tar.xz";
-  sha256 = "1b6d0926rd0nkmsppwjgmwsxx1479jjvr1gm7zwk64siml15rpji";
+  sha256 = "sha256-KcJ3Zg/F51ExB67hy/jFBXyTcKTN/tovx4G+aYbYnSM=";
   enableParallelBuilding = true;
 })


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
