### PR TITLE
nixos/sd_image: fix armv7l build

### DIFF
--- a/pkgs/development/libraries/libopus/default.nix
+++ b/pkgs/development/libraries/libopus/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   configureFlags = lib.optional fixedPoint "--enable-fixed-point"
                 ++ lib.optional withCustomModes "--enable-custom-modes";
 
-  doCheck = !stdenv.isi686; # test_unit_LPC_inv_pred_gain fails
+  doCheck = !stdenv.isi686 && !stdenv.isAarch32; # test_unit_LPC_inv_pred_gain fails
 
   meta = with lib; {
     description = "Open, royalty-free, highly versatile audio codec";

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -139,6 +139,9 @@ stdenv.mkDerivation rec {
     ++ optional (!enablePam) "--without-pam"
     ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "--bundled-libraries=!asn1_compile,!compile_et"
+  ] ++ optional stdenv.isAarch32 [
+    # https://bugs.gentoo.org/683148
+    "--jobs 1"
   ];
 
   # python-config from build Python gives incorrect values when cross-compiling.

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -112,7 +112,8 @@ stdenv.mkDerivation (rec {
   # and {Open,Free}BSD.
   # With non-standard storeDir: https://github.com/NixOS/nix/issues/512
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform
-    && (stdenv.hostPlatform.libc == "glibc" || stdenv.hostPlatform.isMusl);
+    && (stdenv.hostPlatform.libc == "glibc" || stdenv.hostPlatform.isMusl)
+    && !stdenv.isAarch32;
 
   # Prevents attempts of running 'help2man' on cross-built binaries.
   PERL = if stdenv.hostPlatform == stdenv.buildPlatform then null else "missing";


### PR DESCRIPTION
###### Motivation for this change
Make it easier to bootstrap armv7l hardware outside of cross-compiling.

Tested successfully on a Tinkerboard and an XU4 (u-boot installed separately).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
