### PR TITLE
woeusb-ng: Init at 0.2.8

### DIFF
--- a/pkgs/tools/misc/woeusb-ng/default.nix
+++ b/pkgs/tools/misc/woeusb-ng/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchurl, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "woeusb-ng";
+  version = "0.2.8";
+
+  doCheck = false;
+
+  src = fetchurl {
+    url = "https://github.com/WoeUSB/WoeUSB-ng/archive/refs/tags/v${version}.tar.gz";
+    sha256 = "8a7e0bd6ced96a02d7a3ad829073809a67d20e6099104ce0a9f5234699a07666";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    wxPython_4_1
+    termcolor
+    pillow
+    six
+    numpy
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/WoeUSB/WoeUSB-ng";
+    description = "A Linux program to create a Windows USB stick installer from a real Windows DVD or image.";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ felixsinger ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10230,6 +10230,8 @@ with pkgs;
 
   woeusb = callPackage ../tools/misc/woeusb { };
 
+  woeusb-ng = callPackage ../tools/misc/woeusb-ng { };
+
   wslu = callPackage ../tools/system/wslu { };
 
   chase = callPackage ../tools/system/chase { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
WIP

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
