### PR TITLE
git: 2.32.0 -> 2.33.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -25,7 +25,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.32.0";
+  version = "2.33.0";
   svn = subversionClient.override { perlBindings = perlSupport; };
 
   gitwebPerlLibs = with perlPackages; [ CGI HTMLParser CGIFast FCGI FCGIProcManager HTMLTagCloud ];
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "08rnm3ipjqdd2n31dw7mxl3iv9g4nxgc409krmz892a37kd43a38";
+    sha256 = "0kqcs8nj5h7rh3q86pw5777awq7gn77lgxk88ynjl1rfz2snlg5z";
   };
 
   outputs = [ "out" ] ++ lib.optional withManual "doc";
@@ -297,6 +297,8 @@ stdenv.mkDerivation {
     disable_test t0001-init 'shared overrides system'
     disable_test t0001-init 'init honors global core.sharedRepository'
     disable_test t1301-shared-repo
+    # git-completion.bash: line 405: compgen: command not found:
+    disable_test t9902-completion 'option aliases are shown with GIT_COMPLETION_SHOW_ALL'
 
     # Our patched gettext never fallbacks
     disable_test t0201-gettext-fallbacks

--- a/pkgs/applications/version-management/git-and-tools/git/git-send-email-honor-PATH.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-send-email-honor-PATH.patch
@@ -1,28 +1,31 @@
 diff --git a/Documentation/git-send-email.txt b/Documentation/git-send-email.txt
-index 1afe9fc858..05dd7c3a90 100644
+index 3db4eab4ba..39bc0e77c9 100644
 --- a/Documentation/git-send-email.txt
 +++ b/Documentation/git-send-email.txt
-@@ -215,8 +215,7 @@ a password is obtained using 'git-credential'.
- 	specify a full pathname of a sendmail-like program instead;
- 	the program must support the `-i` option.  Default value can
- 	be specified by the `sendemail.smtpServer` configuration
--	option; the built-in default is to search for `sendmail` in
--	`/usr/sbin`, `/usr/lib` and $PATH if such program is
-+	option; the built-in default is to search in $PATH if such program is
- 	available, falling back to `localhost` otherwise.
- 
- --smtp-server-port=<port>::
+@@ -220,9 +220,9 @@ a password is obtained using 'git-credential'.
+ --smtp-server=<host>::
+ 	If set, specifies the outgoing SMTP server to use (e.g.
+ 	`smtp.example.com` or a raw IP address).  If unspecified, and if
+-	`--sendmail-cmd` is also unspecified, the default is to search
+-	for `sendmail` in `/usr/sbin`, `/usr/lib` and $PATH if such a
+-	program is available, falling back to `localhost` otherwise.
++	`--sendmail-cmd` is also unspecified, the default is to search for
++	`sendmail` in $PATH if such a program is available, falling back to
++	`localhost` otherwise.
+ +
+ For backward compatibility, this option can also specify a full pathname
+ of a sendmail-like program instead; the program must support the `-i`
 diff --git a/git-send-email.perl b/git-send-email.perl
-index 8eb63b5a2f..74a61d8213 100755
+index e65d969d0b..508d49483d 100755
 --- a/git-send-email.perl
 +++ b/git-send-email.perl
-@@ -956,8 +956,7 @@ sub expand_one_alias {
+@@ -1066,8 +1066,7 @@ sub expand_one_alias {
  }
  
- if (!defined $smtp_server) {
+ if (!defined $sendmail_cmd && !defined $smtp_server) {
 -	my @sendmail_paths = qw( /usr/sbin/sendmail /usr/lib/sendmail );
 -	push @sendmail_paths, map {"$_/sendmail"} split /:/, $ENV{PATH};
 +	my @sendmail_paths = map {"$_/sendmail"} split /:/, $ENV{PATH};
  	foreach (@sendmail_paths) {
  		if (-x $_) {
- 			$smtp_server = $_;
+ 			$sendmail_cmd = $_;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```console
$ nix-build -A git -A gitMinimal -A gitFull
/nix/store/xzawgiwgf1bi0skw9kkhy1z2k90srgb0-git-2.33.0
/nix/store/fa91a4gngyk7ghwi6b9hki42ccpv6wjj-git-2.33.0
/nix/store/yrbxp64d6jgh4rwn88z5w9jghhcfd49z-git-2.33.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
