### PR TITLE
Allow overriding firefox addon src

### DIFF
--- a/pkgs/build-support/fetchfirefoxaddon/default.nix
+++ b/pkgs/build-support/fetchfirefoxaddon/default.nix
@@ -2,19 +2,22 @@
 
 {
   name
-, url
+, url ? null
 , md5 ? ""
 , sha1 ? ""
 , sha256 ? ""
 , sha512 ? ""
 , fixedExtid ? null
 , hash ? ""
+, src ? ""
 }:
 
-stdenv.mkDerivation rec {
-
-  inherit name;
+let
   extid = if fixedExtid == null then "nixos@${name}" else fixedExtid;
+in
+stdenv.mkDerivation {
+  inherit name extid;
+
   passthru = {
     inherit extid;
   };
@@ -33,9 +36,11 @@ stdenv.mkDerivation rec {
     zip -r -q -FS "$out/$UUID.xpi" *
     rm -r "$out/$UUID"
   '';
-  src = fetchurl {
+
+  src = if url == null then src else fetchurl {
     url = url;
     inherit md5 sha1 sha256 sha512 hash;
   };
+
   nativeBuildInputs = [ coreutils unzip zip jq  ];
 }


### PR DESCRIPTION
###### Motivation for this change
This extends the fetchfirefoxaddon function so that it is possible to pass in the src for the extension into the function. This enables importing of extensions from flakes or other nix derivation builds. 

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
