### PR TITLE
traefik-certs-dumper: init at 2.7.4

### DIFF
--- a/pkgs/tools/misc/traefik-certs-dumper/default.nix
+++ b/pkgs/tools/misc/traefik-certs-dumper/default.nix
@@ -1,0 +1,22 @@
+{ fetchFromGitHub, buildGoModule, lib }:
+buildGoModule rec {
+  pname = "traefik-certs-dumper";
+  version = "2.7.4";
+
+  src = fetchFromGitHub {
+    owner = "ldez";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-exkBDrNGvpOz/VD6yfE1PKL4hzs/oZ+RxMwm/ytuV/0=";
+  };
+
+  vendorSha256 = "sha256-NmYfdX5BKHZvFzlkh/kkK0voOzNj1EPn53Mz/B7eLd0=";
+  excludedPackages = "integrationtest";
+
+  meta = with lib; {
+    description = "dump ACME data from traefik to certificates";
+    homepage = "https://github.com/ldez/traefik-certs-dumper";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/tools/misc/traefik-certs-dumper/default.nix
+++ b/pkgs/tools/misc/traefik-certs-dumper/default.nix
@@ -1,4 +1,5 @@
 { fetchFromGitHub, buildGoModule, lib }:
+
 buildGoModule rec {
   pname = "traefik-certs-dumper";
   version = "2.7.4";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2178,6 +2178,8 @@ with pkgs;
 
   traefik = callPackage ../servers/traefik { };
 
+  traefik-certs-dumper = callPackage ../tools/misc/traefik-certs-dumper { };
+
   calamares = libsForQt514.callPackage ../tools/misc/calamares {
     python = python3;
     boost = pkgs.boost.override { python = python3; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
