### PR TITLE
i2p: get rid of duplicate Java Service Wrapper

### DIFF
--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -1,34 +1,4 @@
-{ lib, stdenv, ps, coreutils, fetchurl, jdk, jre, ant, gettext, which }:
-
-let wrapper = stdenv.mkDerivation rec {
-  pname = "wrapper";
-  version = "3.5.46";
-
-  src = fetchurl {
-    url = "https://wrapper.tanukisoftware.com/download/${version}/wrapper_${version}_src.tar.gz";
-    sha256 = "sha256-guHQyFSI0TidAuOr4zWaf3WRGeNW4+Or1sbWdhWuWtg=";
-  };
-
-  buildInputs = [ jdk ];
-
-  buildPhase = ''
-    export ANT_HOME=${ant}
-    export JAVA_HOME=${jdk}/lib/openjdk/jre/
-    export JAVA_TOOL_OPTIONS=-Djava.home=$JAVA_HOME
-    export CLASSPATH=${jdk}/lib/openjdk/lib/tools.jar
-    sed 's/ testsuite$//' -i src/c/Makefile-linux-x86-64.make
-    ${if stdenv.isi686 then "./build32.sh" else "./build64.sh"}
-  '';
-
-  installPhase = ''
-    mkdir -p $out/{bin,lib}
-    cp bin/wrapper $out/bin/wrapper
-    cp lib/wrapper.jar $out/lib/wrapper.jar
-    cp lib/libwrapper.so $out/lib/libwrapper.so
-  '';
-};
-
-in
+{ lib, stdenv, ps, coreutils, fetchurl, jdk, jre, ant, gettext, which, java-service-wrapper }:
 
 stdenv.mkDerivation rec {
   pname = "i2p";
@@ -52,9 +22,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share}
     cp -r pkg-temp/* $out
 
-    cp ${wrapper}/bin/wrapper $out/i2psvc
-    cp ${wrapper}/lib/wrapper.jar $out/lib
-    cp ${wrapper}/lib/libwrapper.so $out/lib
+    cp ${java-service-wrapper}/bin/wrapper $out/i2psvc
+    cp ${java-service-wrapper}/lib/wrapper.jar $out/lib
+    cp ${java-service-wrapper}/lib/libwrapper.so $out/lib
 
     sed -i $out/i2prouter -i $out/runplain.sh \
       -e "s#uname#${coreutils}/bin/uname#" \


### PR DESCRIPTION
###### Motivation for this change
The definition of Java Service Wrapper in i2p is identical to the java-service-wrapper package except that the latter also executes the test suite, which requires some extra dependencies.
The java-service-wrapper package was actually added in https://github.com/NixOS/nixpkgs/pull/67824 to move the definition from the i2p package into a separate package. While it was added as a separate package, it was never removed from i2p. This commit fixes that.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).