### PR TITLE
SerAPI + Alectryon

### DIFF
--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -1,0 +1,72 @@
+{ lib, fetchzip, mkCoqDerivation, coq, version ? null }:
+
+let
+  ocamlPackages =
+    coq.ocamlPackages.overrideScope'
+      (self: super: {
+        ppxlib = super.ppxlib.override { version = "0.15.0"; };
+        # the following does not work
+        ppx_sexp_conv = super.ppx_sexp_conv.overrideAttrs (_: {
+          src = fetchzip {
+            url = "https://github.com/janestreet/ppx_sexp_conv/archive/v0.14.1.tar.gz";
+            sha256 = "04bx5id99clrgvkg122nx03zig1m7igg75piphhyx04w33shgkz2";
+          };
+        });
+      });
+
+  release = {
+    "8.13.0+0.13.0".sha256 = "sha256:0k69907xn4k61w4mkhwf8kh8drw9pijk9ynijsppihw98j8w38fy";
+    "8.12.0+0.12.1".sha256 = "sha256:048x3sgcq4h845hi6hm4j4dsfca8zfj70dm42w68n63qcm6xf9hn";
+    "8.11.0+0.11.1".sha256 = "sha256:1phmh99yqv71vlwklqgfxiq2vj99zrzxmryj2j4qvg5vav3y3y6c";
+    "8.10.0+0.7.2".sha256  = "sha256:1ljzm63hpd0ksvkyxcbh8rdf7p90vg91gb4h0zz0941v1zh40k8c";
+  };
+in
+
+(with lib; mkCoqDerivation rec {
+  pname = "serapi";
+  inherit version release;
+
+  defaultVersion =  with versions; switch coq.version [
+      { case = isEq "8.13"; out = "8.13.0+0.13.0"; }
+      { case = isEq "8.12"; out = "8.12.0+0.12.1"; }
+      { case = isEq "8.11"; out = "8.11.0+0.11.1"; }
+      { case = isEq "8.10"; out = "8.10.0+0.7.2";  }
+    ] null;
+
+  useDune2 = true;
+
+  propagatedBuildInputs =
+    with ocamlPackages; [
+      cmdliner
+      findlib # run time dependency of SerAPI
+      ppx_deriving
+      ppx_deriving_yojson
+      ppx_import
+      ppx_sexp_conv
+      sexplib
+      yojson
+      zarith # needed because of Coq
+    ];
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $out --libdir $OCAMLFIND_DESTDIR coq-serapi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/ejgallego/coq-serapi;
+    description = "SerAPI is a library for machine-to-machine interaction with the Coq proof assistant";
+    license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.Zimmi48 ];
+  };
+}).overrideAttrs(o:
+  let inherit (o) version; in {
+  src = fetchzip {
+    url = "https://github.com/ejgallego/coq-serapi/releases/download/${version}/coq-serapi-${
+        if version == "8.11.0+0.11.1" then version
+        else builtins.replaceStrings [ "+" ] [ "." ] version
+      }.tbz";
+    sha256 = release."${version}".sha256;
+  };
+})

--- a/pkgs/development/python-modules/alectryon/default.nix
+++ b/pkgs/development/python-modules/alectryon/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, pygments, dominate, beautifulsoup4, docutils, sphinx }:
+
+buildPythonPackage rec {
+  pname = "alectryon";
+  owner = "cpitclaudel";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256:0mca25jv917myb4n91ccpl5fz058aiqsn8cniflwfw5pp6lqnfg7";
+  };
+
+  propagatedBuildInputs = [
+    pygments
+    dominate
+    beautifulsoup4
+    docutils
+    sphinx
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/cpitclaudel/alectryon";
+    description = "A collection of tools for writing technical documents that mix Coq code and prose";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Zimmi48 ];
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -80,6 +80,7 @@ let
       reglang = callPackage ../development/coq-modules/reglang {};
       relation-algebra = callPackage ../development/coq-modules/relation-algebra {};
       semantics = callPackage ../development/coq-modules/semantics {};
+      serapi = callPackage ../development/coq-modules/serapi {};
       simple-io = callPackage ../development/coq-modules/simple-io { };
       stdpp = callPackage ../development/coq-modules/stdpp { };
       StructTact = callPackage ../development/coq-modules/StructTact {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -397,6 +397,8 @@ in {
 
   alarmdecoder = callPackage ../development/python-modules/alarmdecoder { };
 
+  alectryon = callPackage ../development/python-modules/alectryon { };
+
   alembic = callPackage ../development/python-modules/alembic { };
 
   algebraic-data-types = callPackage ../development/python-modules/algebraic-data-types { };


### PR DESCRIPTION
Package SerAPI (in `coqPackages`) and Alectryon (in `python3Packages`).

I didn't add a dependency from Alectryon (which isn't in `coqPackages`) to SerAPI (this is only a runtime dependency anyway) to allow the user to select the version of Coq they want more easily.

I tested this on a small example with Coq 8.10 to 8.13.

The only issue I have detected is that Alectryon copies assets from the installation directory. But because this directory is in read-only mode, the files do not have write permissions after the copy, and Alectryon fails at the next run because of this (cc @cpitclaudel).

Closes https://github.com/ejgallego/coq-serapi/issues/241

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @nyraghu @Ptival @vbgl @siraben