### PR TITLE
dhallToNix: Permit inputs referring to derivations

### DIFF
--- a/pkgs/build-support/dhall-to-nix.nix
+++ b/pkgs/build-support/dhall-to-nix.nix
@@ -15,12 +15,12 @@
     Note that this uses "import from derivation", meaning that Nix will perform
     a build during the evaluation phase if you use this `dhallToNix` utility
 */
-{ stdenv, dhall-nix }:
+{ stdenv, dhall-nix, writeText }:
 
 let
   dhallToNix = code :
     let
-      file = builtins.toFile "dhall-expression" code;
+      file = writeText "dhall-expression" code;
 
       drv = stdenv.mkDerivation {
         name = "dhall-compiled.nix";


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2267

`pkgs.dhallToNix` currently fails when a Dhall package is
interpolated into the input source code, like this:

```nix
let
  pkgs = import <nixpkgs> { };

  f = { buildDhallPackage }: buildDhallPackage {
    name = "not";
    code = "λ(x : Bool) → x == False";
    source = true;
  };

  not = pkgs.dhallPackages.callPackage f {};

in
  pkgs.dhallToNix "${not}/source.dhall True"
```

This is because `dhallToNix` was using `builtins.toFile`, which
does not permit inputs with interpolated derivations.  However,
`pkgs.writeText` does not have this limitation, so we can switch
to using that instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
