### PR TITLE
lucenepp: 3.0.7 -> 3.0.8

### DIFF
--- a/pkgs/development/libraries/lucene++/default.nix
+++ b/pkgs/development/libraries/lucene++/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
             --replace "add_subdirectory(gtest)" ""
   '';
 
-  checkPhase= ''
+  checkPhase = ''
     runHook preCheck
     LD_LIBRARY_PATH=$PWD/src/contrib:$PWD/src/core \
             src/test/lucene++-tester

--- a/pkgs/development/libraries/lucene++/default.nix
+++ b/pkgs/development/libraries/lucene++/default.nix
@@ -1,28 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, cmake, boost, gtest }:
+{ lib, stdenv, fetchFromGitHub, cmake, boost, gtest, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "lucene++";
-  version = "3.0.7";
+  version = "3.0.8";
 
   src = fetchFromGitHub {
     owner = "luceneplusplus";
     repo = "LucenePlusPlus";
     rev = "rel_${version}";
-    sha256 = "06b37fly6l27zc6kbm93f6khfsv61w792j8xihfagpcm9cfz2zi1";
+    sha256 = "12v7r62f7pqh5h210pb74sfx6h70lj4pgfpva8ya2d55fn0qxrr2";
   };
 
-  postPatch = ''
-    sed -i -e '/Subversion *REQUIRED/d' \
-           -e '/include.*CMakeExternal/d' \
-           CMakeLists.txt
-  '';
-
-  cmakeFlags = [ "-DGTEST_INCLUDE_DIR=${gtest}/include" ];
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ boost gtest ];
+  buildInputs = [ boost gtest zlib ];
 
   doCheck = true;
-  checkTarget = "test";
+
+  postPatch = ''
+     substituteInPlace src/test/CMakeLists.txt \
+            --replace "add_subdirectory(gtest)" ""
+  '';
+
+  checkPhase= ''
+    runHook preCheck
+    LD_LIBRARY_PATH=$PWD/src/contrib:$PWD/src/core \
+            src/test/lucene++-tester
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    mv $out/include/pkgconfig $out/lib/
+  '';
 
   meta = {
     description = "C++ port of the popular Java Lucene search engine";

--- a/pkgs/tools/text/poedit/default.nix
+++ b/pkgs/tools/text/poedit/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     "--without-cpprest"
     "--with-boost-libdir=${boost.out}/lib"
     "CPPFLAGS=-I${nlohmann_json}/include/nlohmann/"
+    "LDFLAGS=-llucene++"
   ];
 
   preFixup = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19404,9 +19404,7 @@ with pkgs;
 
   lucene = callPackage ../development/libraries/java/lucene { };
 
-  lucenepp = callPackage ../development/libraries/lucene++ {
-    boost = boost155;
-  };
+  lucenepp = callPackage ../development/libraries/lucene++ { };
 
   mockobjects = callPackage ../development/libraries/java/mockobjects { };
 


### PR DESCRIPTION
###### Motivation for this change

The motivation is mostly to get rid of `boost155` eventually.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).