### PR TITLE
monotone: fix key encryption

### DIFF
--- a/pkgs/applications/version-management/monotone/default.nix
+++ b/pkgs/applications/version-management/monotone/default.nix
@@ -30,7 +30,10 @@ stdenv.mkDerivation rec {
     hash = "sha256:1hfy8vaap3184cd7h3qhz0da7c992idkc6q2nz9frhma45c5vgmd";
   };
 
-  patches = [ ./monotone-1.1-Adapt-to-changes-in-pcre-8.42.patch ];
+  patches = [
+    ./monotone-1.1-Adapt-to-changes-in-pcre-8.42.patch
+    ./monotone-1.1-adapt-to-botan2.patch
+  ];
 
   postPatch = ''
     sed -e 's@/usr/bin/less@${less}/bin/less@' -i src/unix/terminal.cc

--- a/pkgs/applications/version-management/monotone/monotone-1.1-adapt-to-botan2.patch
+++ b/pkgs/applications/version-management/monotone/monotone-1.1-adapt-to-botan2.patch
@@ -1,0 +1,15 @@
+Botan2 has switched the parameter order in encryption descriptions
+
+--- monotone-upstream/src/botan_glue.hh 2021-08-17 19:06:32.736753732 +0200
++++ monotone-patched/src/botan_glue.hh  2021-08-17 19:07:44.437750535 +0200
+@@ -45,7 +45,9 @@
+ // In Botan revision d8021f3e (back when it still used monotone) the name
+ // of SHA-1 changed to SHA-160.
+ const static char * PBE_PKCS5_KEY_FORMAT =
+-#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(1,11,0)
++#if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(2,0,0)
++  "PBE-PKCS5v20(TripleDES/CBC,SHA-160)";
++#elif BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(1,11,0)
+   "PBE-PKCS5v20(SHA-160,TripleDES/CBC)";
+ #else
+   "PBE-PKCS5v20(SHA-1,TripleDES/CBC)";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/134469

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
