### PR TITLE
gnome-backgrounds: stable image paths

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-backgrounds/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-backgrounds/default.nix
@@ -13,6 +13,13 @@ stdenv.mkDerivation rec {
     updateScript = gnome.updateScript { packageName = "gnome-backgrounds"; attrPath = "gnome.gnome-backgrounds"; };
   };
 
+  patches = [
+    # Makes the database point to stable paths in /run/current-system/sw/share, which don't decay whenever this package's hash changes.
+    # This assumes a nixos + gnome system, where this package is installed in environment.systemPackages,
+    # and /share outputs are included in environment.pathsToLink.
+    ./stable-dir.patch
+  ];
+
   nativeBuildInputs = [ meson ninja pkg-config gettext ];
 
   meta = with lib; {

--- a/pkgs/desktops/gnome/core/gnome-backgrounds/stable-dir.patch
+++ b/pkgs/desktops/gnome/core/gnome-backgrounds/stable-dir.patch
@@ -1,0 +1,9 @@
+diff --git a/backgrounds/meson.build b/backgrounds/meson.build
+index 2175a16..cf521df 100644
+--- a/backgrounds/meson.build
++++ b/backgrounds/meson.build
+@@ -1,5 +1,5 @@
+ dataconf = configuration_data()
+-dataconf.set('BACKGROUNDDIR', backgrounddir)
++dataconf.set('BACKGROUNDDIR', '/run/current-system/sw/share/backgrounds/gnome')
+ dataconf.set('datadir', datadir)


### PR DESCRIPTION
###### Motivation for this change
The background database located in $out/share/gnome-background-properties/gnome-backgrounds.xml points to image paths in the /nix/store.
When a background is selected in gnome-control-center, its path at that moment is stored in a dconf setting.
It isn't updated when this package's hash changes, so once the old path is garbage-collected, gnome can no longer find the file.
So, we need to make it point to the stable directory /run/current-system/sw/share/backgrounds/gnome.

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
