### PR TITLE
netcdf: 4.7.4 -> 4.8.0

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -1,6 +1,7 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , dxflib
 , eigen
@@ -18,7 +19,7 @@
 
 mkDerivation rec {
   pname = "cloudcompare";
-  version = "2.11.2";
+  version = "2.11.2"; # Remove below patch with the next version bump.
 
   src = fetchFromGitHub {
     owner = "CloudCompare";
@@ -32,6 +33,15 @@ mkDerivation rec {
     # * CCCoreLib
     fetchSubmodules = true;
   };
+
+  patches = [
+    # TODO: Remove with next CloudCompare release (see https://github.com/CloudCompare/CloudCompare/pull/1478)
+    (fetchpatch {
+      name = "CloudCompare-fix-for-PDAL-2.3.0.patch";
+      url = "https://github.com/CloudCompare/CloudCompare/commit/f3038dcdeb0491c4a653c2ee6fb017326eb676a3.patch";
+      sha256 = "0ca5ry987mcgsdawz5yd4xhbsdb5k44qws30srxymzx2djvamwli";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/netcdf/default.nix
+++ b/pkgs/development/libraries/netcdf/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv
+, fetchpatch
 , fetchurl
 , hdf5
 , m4
@@ -11,12 +12,24 @@ let
   mpi = hdf5.mpi;
 in stdenv.mkDerivation rec {
   pname = "netcdf";
-  version = "4.7.4";
+  version = "4.8.0"; # Remove patch mentioned below on upgrade
 
   src = fetchurl {
     url = "https://www.unidata.ucar.edu/downloads/netcdf/ftp/${pname}-c-${version}.tar.gz";
-    sha256 = "1a2fpp15a2rl1m50gcvvzd9y6bavl6vjf9zzf63sz5gdmq06yiqf";
+    sha256 = "1mfn8qi4k0b8pyar3wa8v0npj69c7rhgfdlppdwmq5jqk88kb5k7";
   };
+
+  patches = [
+    # Fixes:
+    #     *** Checking vlen of compound file...Sorry! Unexpected result, tst_h_atts3.c, line: 289
+    #     FAIL tst_h_atts3 (exit status: 2)
+    # TODO: Remove with next netcdf release (see https://github.com/Unidata/netcdf-c/pull/1980)
+    (fetchpatch {
+      name = "netcdf-Fix-tst_h_atts3-for-hdf5-1.12.patch";
+      url = "https://github.com/Unidata/netcdf-c/commit/9fc8ae62a8564e095ff17f4612874581db0e4db5.patch";
+      sha256 = "128kxz5jikq32x5qjmi0xdngi0k336rf6bvbcppvlk5gibg5nk7v";
+    })
+  ];
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/development/libraries/pdal/default.nix
+++ b/pkgs/development/libraries/pdal/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pdal";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "PDAL";
     repo = "PDAL";
     rev = version;
-    sha256 = "1i7nbfvv60jjlf3iq7a7xci4dycmg2wrd35dqvjwl6hpfynpb6wz";
+    sha256 = "sha256-DKIraCyp8fcgnVp5dFrtQ4Wq96cQGC9SiAPLS6htUZc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7328,10 +7328,12 @@ with pkgs;
 
   netatalk = callPackage ../tools/filesystems/netatalk { };
 
-  netcdf = callPackage ../development/libraries/netcdf { };
+  netcdf = callPackage ../development/libraries/netcdf {
+    hdf5 = hdf5.override { usev110Api = true; };
+  };
 
   netcdf-mpi = appendToName "mpi" (netcdf.override {
-    hdf5 = hdf5-mpi;
+    hdf5 = hdf5-mpi.override { usev110Api = true; };
   });
 
   netcdfcxx4 = callPackage ../development/libraries/netcdf-cxx4 { };


### PR DESCRIPTION
###### Motivation for this change

Hopefully fixes aarch65: #115788 (see https://github.com/NixOS/nixpkgs/issues/115788#issuecomment-900506112)

Changelog: https://github.com/Unidata/netcdf-c/releases/tag/v4.8.0

###### TODO

* [x] ~Based on PR #134436, merge that first.~ I merged this one instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).