### PR TITLE
hck: init at 0.5.4

### DIFF
--- a/pkgs/tools/text/hck/default.nix
+++ b/pkgs/tools/text/hck/default.nix
@@ -1,0 +1,23 @@
+{ fetchFromGitHub, lib, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hck";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "sstadick";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zdzi98qywlwk5bp47963vya2p2ahrbjkc9h63lmb05wlas9s78y";
+  };
+
+  cargoSha256 = "0lvd5xpgh2vq2lszzb0fs6ha2vb419a5w0hlkq3287vq3ya3p4qg";
+
+  meta = with lib; {
+    description = "A close to drop in replacement for cut that can use a regex delimiter instead of a fixed string";
+    homepage = "https://github.com/sstadick/hck";
+    changelog = "https://github.com/sstadick/hck/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ mit /* or */ unlicense ];
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31463,6 +31463,8 @@ with pkgs;
 
   hatari = callPackage ../misc/emulators/hatari { };
 
+  hck = callPackage ../tools/text/hck { };
+
   helm = callPackage ../applications/audio/helm { };
 
   helmfile = callPackage ../applications/networking/cluster/helmfile { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`hck` is a close to drop in replacement for cut that can use a regex delimiter instead of a fixed string

https://github.com/sstadick/hck

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
