### PR TITLE
[21.05] listadmin: init at 2.73

### DIFF
--- a/pkgs/applications/networking/listadmin/default.nix
+++ b/pkgs/applications/networking/listadmin/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenvNoCC, fetchurl, makeWrapper, perl, installShellFiles }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "listadmin";
+  version = "2.73";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/listadmin/${version}/listadmin-${version}.tar.gz";
+    sha256 = "00333d65ygdbm1hqr4yp2j8vh1cgh3hyfm7iy9y1alf0p0f6aqac";
+  };
+
+  buildInputs = [ perl ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  # There is a Makefile, but we don’t need it, and it prints errors
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man1
+    install -m 755 listadmin.pl $out/bin/listadmin
+    installManPage listadmin.1
+
+    wrapProgram $out/bin/listadmin \
+      --prefix PERL5LIB : "${with perl.pkgs; makeFullPerlPath [
+        TextReform NetINET6Glue LWPProtocolhttps
+        ]}"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/listadmin --help 2> /dev/null
+  '';
+
+  meta = with lib; {
+    description = "Command line mailman moderator queue manipulation";
+    longDescription = ''
+       listadmin is a command line tool to manipulate the queues of messages
+       held for moderator approval by mailman. It is designed to keep user
+       interaction to a minimum, in theory you could run it from cron to prune
+       the queue. It can use the score from a header added by SpamAssassin to
+       filter, or it can match specific senders, subjects, or reasons.
+    '';
+    homepage = "https://sourceforge.net/projects/listadmin/";
+    license = licenses.publicDomain;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ nomeata ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19161,6 +19161,8 @@ in
 
   mailman-web = with python3.pkgs; toPythonApplication mailman-web;
 
+  listadmin = callPackage ../applications/networking/listadmin {};
+
   mastodon = callPackage ../servers/mastodon { };
 
   materialize = callPackage ../servers/sql/materialize {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15169,6 +15169,20 @@ let
     };
   };
 
+  NetINET6Glue = buildPerlPackage {
+    pname = "Net-INET6Glue";
+    version = "0.604";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SU/SULLR/Net-INET6Glue-0.604.tar.gz";
+      sha256 = "05xvbdrqq88npzg14bjm9wmjykzplwirzcm8rp61852hz6c67hwh";
+    };
+    meta = {
+      homepage = "https://github.com/noxxi/p5-net-inet6glue";
+      description = "Make common modules IPv6 ready by hotpatching";
+      license = lib.licenses.artistic1;
+    };
+  };
+
   NetAddrIP = buildPerlPackage {
     pname = "NetAddr-IP";
     version = "4.079";


### PR DESCRIPTION
backport of #133596 to release-21.05, which fixed #133239.

(cherry picked from commit 53fc34dcf0dcd60783d4df74f5cd35a685185d2f)