### PR TITLE
matrix-appservice-irc: add update script

### DIFF
--- a/pkgs/servers/matrix-synapse/matrix-appservice-irc/default.nix
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-irc/default.nix
@@ -20,6 +20,7 @@ ourNodePackages."${packageName}".override {
   '';
 
   passthru.tests.matrix-appservice-irc = nixosTests.matrix-appservice-irc;
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Node.js IRC bridge for Matrix";

--- a/pkgs/servers/matrix-synapse/matrix-appservice-irc/update.sh
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-irc/update.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p nodePackages.node2nix nodejs-12_x curl jq
+
+set -euo pipefail
+# cd to the folder containing this script
+cd "$(dirname "$0")"
+
+CURRENT_VERSION=$(nix eval --raw '(with import ../../../../. {}; matrix-appservice-irc.version)')
+TARGET_VERSION="$(curl https://api.github.com/repos/matrix-org/matrix-appservice-irc/releases/latest | jq -r ".tag_name")"
+
+if [[ "$CURRENT_VERSION" == "$TARGET_VERSION" ]]; then
+    echo "matrix-appservice-irc is up-to-date: ${CURRENT_VERSION}"
+    exit 0
+fi
+
+echo "matrix-appservice-irc: $CURRENT_VERSION -> $TARGET_VERSION"
+
+sed -i "s/#$CURRENT_VERSION/#$TARGET_VERSION/" package.json
+
+./generate-dependencies.sh
+
+# Apparently this is done by r-ryantm, so only uncomment for manual usage
+#git add ./package.json ./node-packages.nix
+#git commit -m "matrix-appservice-irc: ${CURRENT_VERSION} -> ${TARGET_VERSION}"


### PR DESCRIPTION
###### Motivation for this change

Why should I do dumb repetitive work if I can also automate it away?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
