### PR TITLE
luks: automatic tpm unlocking

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -439,10 +439,30 @@ let
     }
     ''}
 
+    ${optionalString (luks.tpm2Support && (dev.tpm2KeyFile != null)) ''
+      open_with_hardware() {
+        export TPM2TOOLS_TCTI="device:/dev/tpm0"
+
+        tpm2_unseal -c ${dev.tpm2KeyFile.persistentObject} -p ${dev.tpm2KeyFile.authString} > /crypt-ramfs/tpmKeyfile
+        if [ $? -ne 0 ]; then
+          echo "TPM keyfile could not be unsealed, falling back to normal open procedure"
+          open_normally
+          return
+        fi
+
+        ${csopen} --key-file=/crypt-ramfs/tpmKeyfile
+        if [ $? -ne 0 ]; then
+          echo "Cannot unlock with TPM keyfile, falling back to normal open procedure"
+          open_normally
+          return
+        fi
+      }
+    ''}
+
     # commands to run right before we mount our device
     ${dev.preOpenCommands}
 
-    ${if (luks.yubikeySupport && (dev.yubikey != null)) || (luks.gpgSupport && (dev.gpgCard != null)) || (luks.fido2Support && (dev.fido2.credential != null)) then ''
+    ${if (luks.yubikeySupport && (dev.yubikey != null)) || (luks.gpgSupport && (dev.gpgCard != null)) || (luks.fido2Support && (dev.fido2.credential != null)) || (luks.tpm2Support && (dev.tpm2KeyFile != null)) then ''
     open_with_hardware
     '' else ''
     open_normally
@@ -647,6 +667,31 @@ in
             '';
           };
 
+          tpm2KeyFile = mkOption {
+            description = ''
+              Use a TPM-sealed object as a keyfile.
+              Specify the keyfile object with either <literal>tpm2KeyFile.persistentObject</literal> or <literal>tpm2KeyFile.transientObject</literal>
+            '';
+            default = null;
+            type = types.nullOr (types.submodule { options = {
+              authString = mkOption {
+                description = ''
+                  The object's authorization value as defined in <literal>tpm2_unseal (1)</literal>.
+                  For PCR-sealed objects, it would be <literal>pcr:[hash algorithm]:[register numbers, comma-separated]</literal>.
+                '';
+                type = types.str;
+                example = "pcr:sha256:0,1,2,3,4,5,6,7";
+              };
+              persistentObject = mkOption {
+                description = ''
+                  The handle as a string of the keyfile object stored in NVRAM.
+                '';
+                example = "0x81000000";
+                type = types.str;
+              };
+            };});
+          };
+
           gpgCard = mkOption {
             default = null;
             description = ''
@@ -833,28 +878,28 @@ in
       '';
     };
 
+    boot.initrd.luks.tpm2Support = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Enables support for authenticating with TPM-sealed keys.
+      '';
+    };
+
   };
 
   config = mkIf (luks.devices != {} || luks.forceLuksSupportInInitrd) {
 
-    assertions =
-      [ { assertion = !(luks.gpgSupport && luks.yubikeySupport);
-          message = "YubiKey and GPG Card may not be used at the same time.";
-        }
+    assertions = [
+      { assertion = builtins.length (builtins.filter (a: a) [ luks.gpgSupport luks.yubikeySupport luks.fido2Support luks.tpm2Support ]) <= 1;
+        message = "Only one hardware unlocking method (GPG, Yubikey, FIDO2, TPM keyfile) can be used at once.";
+      }
 
-        { assertion = !(luks.gpgSupport && luks.fido2Support);
-          message = "FIDO2 and GPG Card may not be used at the same time.";
-        }
-
-        { assertion = !(luks.fido2Support && luks.yubikeySupport);
-          message = "FIDO2 and YubiKey may not be used at the same time.";
-        }
-
-        { assertion = any (dev: dev.bypassWorkqueues) (attrValues luks.devices)
-                      -> versionAtLeast kernelPackages.kernel.version "5.9";
-          message = "boot.initrd.luks.devices.<name>.bypassWorkqueues is not supported for kernels older than 5.9";
-        }
-      ];
+      { assertion = any (dev: dev.bypassWorkqueues) (attrValues luks.devices)
+                    -> versionAtLeast kernelPackages.kernel.version "5.9";
+        message = "boot.initrd.luks.devices.<name>.bypassWorkqueues is not supported for kernels older than 5.9";
+      }
+    ];
 
     # actually, sbp2 driver is the one enabling the DMA attack, but this needs to be tested
     boot.blacklistedKernelModules = optionals luks.mitigateDMAAttacks
@@ -865,7 +910,8 @@ in
       ++ luks.cryptoModules
       # workaround until https://marc.info/?l=linux-crypto-vger&m=148783562211457&w=4 is merged
       # remove once 'modprobe --show-depends xts' shows ecb as a dependency
-      ++ (if builtins.elem "xts" luks.cryptoModules then ["ecb"] else []);
+      ++ (if builtins.elem "xts" luks.cryptoModules then ["ecb"] else [])
+      ++ (lib.optionals luks.tpm2Support ["rng-core" "tpm" "tpm-tis-core" "tpm-tis"]);
 
     # copy the cryptsetup binary and it's dependencies
     boot.initrd.extraUtilsCommands = ''
@@ -914,6 +960,24 @@ in
           ) (attrValues luks.devices)
         }
       ''}
+
+      ${optionalString luks.tpm2Support (
+        # tpm2-tools uses the busybox technique of multiple commands symlinked to a single executable.
+        # But the symlinks in this package point to an intermediary wrapper, bin/tpm2, which calls bash.
+        # So we should manually build the symlinks.
+
+        # tpm2-tcti patches in hardcoded nix store paths for the tcti drivers '.so's,
+        # which doesn't work in the initrd structure. We need to disable that.
+        let
+          tpm2-tools' = pkgs.tpm2-tools.override { tpm2-tss = pkgs.tpm2-tss.override { loader-path-patch = false; }; };
+        in ''
+          copy_bin_and_libs ${tpm2-tools'}/bin/.tpm2-wrapped
+          ln -s $out/bin/.tpm2-wrapped $out/bin/tpm2_createprimary
+          ln -s $out/bin/.tpm2-wrapped $out/bin/tpm2_load
+          ln -s $out/bin/.tpm2-wrapped $out/bin/tpm2_unseal
+          cp -pv ${pkgs.tpm2-tss}/lib/libtss2-tcti-device.so $out/lib/libtss2-tcti-device.so
+        ''
+      )}
     '';
 
     boot.initrd.extraUtilsCommandsTest = ''
@@ -930,6 +994,11 @@ in
       ''}
       ${optionalString luks.fido2Support ''
         $out/bin/fido2luks --version
+      ''}
+      ${optionalString luks.tpm2Support ''
+        $out/bin/tpm2_createprimary --version
+        $out/bin/tpm2_load --version
+        $out/bin/tpm2_unseal --version
       ''}
     '';
 

--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -2,6 +2,7 @@
 , autoreconfHook, autoconf-archive, pkg-config, doxygen, perl
 , openssl, json_c, curl, libgcrypt
 , cmocka, uthash, ibm-sw-tpm2, iproute2, procps, which
+, loader-path-patch ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patches = [
+  patches = lib.optional loader-path-patch [
     # Do not rely on dynamic loader path
     # TCTI loader relies on dlopen(), this patch prefixes all calls with the output directory
     ./no-dynamic-loader-path.patch
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs script
+  '' + lib.optionalString loader-path-patch ''
     substituteInPlace src/tss2-tcti/tctildr-dl.c \
       --replace '@PREFIX@' $out/lib/
     substituteInPlace ./test/unit/tctildr-dl.c \


### PR DESCRIPTION
###### Motivation for this change
This is an attempt to implement TPM unlocking for LUKS volumes.

The method is based on this guide: https://threat.tevora.com/secure-boot-tpm-2/

Set it up by generating a keyfile, registering it in a LUKS keyslot, and storing it in the TPM sealed with your selected PCRs:
```sh
dd if=/dev/urandom of=secret.bin bs=1 count=32

cryptsetup luksAddKey /dev/my-disk secret.bin #or cryptsetup luksFormat /dev/my-disk --key-file secret.bin

tpm2_pcrread sha256:0,2,3,7 -o pcrs.bin
tpm2_createpolicy --policy-pcr -l sha256:0,2,3,7 --pcr pcrs.bin --policy policy.digest
tpm2_createprimary -g sha256 -G rsa --key-context primary.context
tpm2_create -g sha256 --public obj.pub --private obj.priv --parent-context primary.context --policy policy.digest -i secret.bin
tpm2_load --parent-context primary.context --public obj.pub --private obj.priv --key-context load.context
tpm2_evictcontrol --object-context load.context 
# This will output a handle such as "0x81000000", which points to where our keyfile is saved in the TPM's non-volatile memory.
# Don't forget to delete secret.bin.
```

Then, specify the handle and PCRs in your system configuration:
```nix
{
  boot.initrd.luks.devices.root = {
    device = "/dev/my-disk";
    tpm2KeyFile = {
      authString = "pcr:sha256:0,2,3,7";
      persistentObject = "0x81000000";
    };
  };
}
```

Once the system is rebuilt, it should unseal the volume without any intervention if the PCR values check out, or fall back to a password prompt.

I also have a version that supports transient keyfiles (stored on a disk but encrypted by the TPM) https://github.com/cwyc/nixpkgs/commits/tpmluks, but it's not working.

It's not a very elegant solution. Ideally, it should use systemd-cryptsetup, which can handle TPM unlocking without directly messing around with tpm commands, as well as replace the existing GPG, FIDO2, and Yubikey code. But it doesn't have a standalone executable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module __should do__
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
