### PR TITLE
treewide: ensure pre/post phase hooks are strings

### DIFF
--- a/doc/languages-frameworks/perl.section.md
+++ b/doc/languages-frameworks/perl.section.md
@@ -122,7 +122,7 @@ ImageExifTool = buildPerlPackage {
   };
 
   buildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
-  postInstall = lib.optional stdenv.isDarwin ''
+  postInstall = lib.optionalString stdenv.isDarwin ''
     shortenPerlShebang $out/bin/exiftool
   '';
 };

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -91,7 +91,7 @@ in stdenv.mkDerivation rec {
 
   # When building with zest GUI, patch plugins
   # and standalone executable to properly locate zest
-  postFixup = lib.optional (guiModule == "zest") ''
+  postFixup = lib.optionalString (guiModule == "zest") ''
     patchelf --set-rpath "${mruby-zest}:$(patchelf --print-rpath "$out/lib/lv2/ZynAddSubFX.lv2/ZynAddSubFX_ui.so")" \
       "$out/lib/lv2/ZynAddSubFX.lv2/ZynAddSubFX_ui.so"
 

--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     ++ optionals withWallet [ db48 sqlite ]
     ++ optionals withGui [ qrencode qtbase qttools ];
 
-  postInstall = optional withGui ''
+  postInstall = optionalString withGui ''
     install -Dm644 ${desktop} $out/share/applications/bitcoin-qt.desktop
     substituteInPlace $out/share/applications/bitcoin-qt.desktop --replace "Icon=bitcoin128" "Icon=bitcoin"
     install -Dm644 share/pixmaps/bitcoin256.png $out/share/pixmaps/bitcoin.png

--- a/pkgs/applications/graphics/rx/default.nix
+++ b/pkgs/applications/graphics/rx/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
   # FIXME: GLFW (X11) requires DISPLAY env variable for all tests
   doCheck = false;
 
-  postInstall = optional stdenv.isLinux ''
+  postInstall = optionalString stdenv.isLinux ''
     mkdir -p $out/share/applications
     cp $src/rx.desktop $out/share/applications
     wrapProgram $out/bin/rx --prefix LD_LIBRARY_PATH : ${libGL}/lib

--- a/pkgs/applications/misc/waybar/default.nix
+++ b/pkgs/applications/misc/waybar/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     "-Dman-pages=enabled"
   ];
 
-  preFixup = lib.optional withMediaPlayer ''
+  preFixup = lib.optionalString withMediaPlayer ''
       cp $src/resources/custom_modules/mediaplayer.py $out/bin/waybar-mediaplayer.py
 
       wrapProgram $out/bin/waybar-mediaplayer.py \

--- a/pkgs/applications/misc/wmname/default.nix
+++ b/pkgs/applications/misc/wmname/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libX11 ];
 
-  preConfigure = [ ''sed -i "s@PREFIX = /usr/local@PREFIX = $out@g" config.mk'' ];
+  preConfigure = ''sed -i "s@PREFIX = /usr/local@PREFIX = $out@g" config.mk'';
 
   meta = {
     description = "Prints or set the window manager name property of the root window";

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -104,7 +104,7 @@ let
   server = source: generic {
     type = "murmur";
 
-    postPatch = lib.optional iceSupport ''
+    postPatch = lib.optionalString iceSupport ''
       grep -Rl '/usr/share/Ice' . | xargs sed -i 's,/usr/share/Ice/,${zeroc-ice.dev}/share/ice/,g'
     '';
 

--- a/pkgs/applications/science/biology/neuron/default.nix
+++ b/pkgs/applications/science/biology/neuron/default.nix
@@ -60,13 +60,13 @@ stdenv.mkDerivation rec {
                         else ["--without-mpi"]);
 
 
-  postInstall = lib.optionals (python != null) [ ''
+  postInstall = lib.optionalString (python != null) ''
     ## standardise python neuron install dir if any
     if [[ -d $out/lib/python ]]; then
         mkdir -p ''${out}/${python.sitePackages}
         mv ''${out}/lib/python/*  ''${out}/${python.sitePackages}/
     fi
-  ''];
+  '';
 
   propagatedBuildInputs = [ readline ncurses which libtool ];
 

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -64,7 +64,7 @@ assert lib.assertMsg (!(sanitizeAddress && sanitizeThreads))
   "'sanitizeAddress' and 'sanitizeThreads' are mutually exclusive, use one.";
 
 let
-  inherit (lib) optional optionals;
+  inherit (lib) optional optionals optionalString;
 in
 stdenv.mkDerivation rec {
   pname = "kicad-base";
@@ -172,7 +172,7 @@ stdenv.mkDerivation rec {
 
   dontStrip = debug;
 
-  postInstall = optional (withI18n) ''
+  postInstall = optionalString (withI18n) ''
     mkdir -p $out/share
     lndir ${i18n}/share $out/share
   '';

--- a/pkgs/applications/science/physics/sherpa/default.nix
+++ b/pkgs/applications/science/physics/sherpa/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1iwa17s8ipj6a2b8zss5csb1k5y9s5js38syvq932rxcinbyjsl4";
   };
 
-  postPatch = lib.optional (stdenv.hostPlatform.libc == "glibc") ''
+  postPatch = lib.optionalString (stdenv.hostPlatform.libc == "glibc") ''
     sed -ie '/sys\/sysctl.h/d' ATOOLS/Org/Run_Parameter.C
   '';
 

--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -31,7 +31,7 @@ buildPythonApplication rec {
   ];
 
   doCheck = true;
-  preCheck = lib.optional stdenv.isDarwin ''
+  preCheck = lib.optionalString stdenv.isDarwin ''
     export DYLD_FRAMEWORK_PATH=/System/Library/Frameworks
   '';
 

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -69,7 +69,7 @@ let
     # so that it can be used to regenerate documentation.
     patches        = lib.optionals disableGraphviz [ graphvizPatch ./gvc-compat.patch ];
     configureFlags = lib.optional  disableGraphviz "--disable-graphviz";
-    preBuild       = lib.optional  disableGraphviz "buildFlagsArray+=(\"VALAC=$(pwd)/compiler/valac\")";
+    preBuild       = lib.optionalString disableGraphviz "buildFlagsArray+=(\"VALAC=$(pwd)/compiler/valac\")";
 
     outputs = [ "out" "devdoc" ];
 

--- a/pkgs/development/libraries/flatbuffers/1.12.nix
+++ b/pkgs/development/libraries/flatbuffers/1.12.nix
@@ -20,7 +20,7 @@ callPackage ./generic.nix {
     })
   ];
 
-  preConfigure = lib.optional stdenv.buildPlatform.isDarwin ''
+  preConfigure = lib.optionalString stdenv.buildPlatform.isDarwin ''
     rm BUILD
   '';
 }

--- a/pkgs/development/libraries/libfm/default.nix
+++ b/pkgs/development/libraries/libfm/default.nix
@@ -13,7 +13,7 @@
 
 let
     gtk = if withGtk3 then gtk3 else gtk2;
-    inherit (lib) optional;
+    inherit (lib) optional optionalString;
 in
 stdenv.mkDerivation rec {
   pname = if extraOnly
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "sysconfdir=${placeholder "out"}/etc" ];
 
   # libfm-extra is pulled in by menu-cache and thus leads to a collision for libfm
-  postInstall = optional (!extraOnly) ''
+  postInstall = optionalString (!extraOnly) ''
      rm $out/lib/libfm-extra.so $out/lib/libfm-extra.so.* $out/lib/libfm-extra.la $out/lib/pkgconfig/libfm-extra.pc
   '';
 

--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  postConfigure = lib.optionals enableThreading ''
+  postConfigure = lib.optionalString enableThreading ''
     perl scripts/config.pl set MBEDTLS_THREADING_C    # Threading abstraction layer
     perl scripts/config.pl set MBEDTLS_THREADING_PTHREAD    # POSIX thread wrapper layer for the threading layer.
   '';

--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   # Remove a test that fails to statically link (undefined reference to png and
   # freetype symbols)
-  postConfigure = lib.optionals static ''
+  postConfigure = lib.optionalString static ''
     sed -e '/freetype freetype.c/d' -i ../tests/examples/CMakeLists.txt
   '';
 

--- a/pkgs/development/libraries/t1lib/default.nix
+++ b/pkgs/development/libraries/t1lib/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   buildInputs = [ libX11 libXaw ];
   buildFlags = [ "without_doc" ];
 
-  postInstall = lib.optional (!stdenv.isDarwin) "chmod +x $out/lib/*.so.*"; # ??
+  postInstall = lib.optionalString (!stdenv.isDarwin) "chmod +x $out/lib/*.so.*"; # ??
 
   meta = with lib; {
     description = "A type 1 font rasterizer library for UNIX/X11";

--- a/pkgs/development/libraries/zeroc-ice/3.6.nix
+++ b/pkgs/development/libraries/zeroc-ice/3.6.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     sourceRoot=$sourceRoot/cpp
   '';
 
-  prePatch = lib.optional stdenv.isDarwin ''
+  prePatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace config/Make.rules.Darwin \
         --replace xcrun ""
   '';

--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-Wno-error=class-memaccess -Wno-error=deprecated-copy";
 
-  prePatch = lib.optional stdenv.isDarwin ''
+  prePatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace Make.rules.Darwin \
         --replace xcrun ""
   '';

--- a/pkgs/development/python-modules/cmd2/default.nix
+++ b/pkgs/development/python-modules/cmd2/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   LC_ALL="en_US.UTF-8";
 
-  postPatch = lib.optional stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.isDarwin ''
     # Fake the impure dependencies pbpaste and pbcopy
     mkdir bin
     echo '#!${stdenv.shell}' > bin/pbpaste

--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   ];
 
   # Required flags from https://github.com/cvxgrp/cvxpy/releases/tag/v1.1.11
-  preBuild = lib.optional useOpenmp ''
+  preBuild = lib.optionalString useOpenmp ''
     export CFLAGS="-fopenmp"
     export LDFLAGS="-lgomp"
   '';

--- a/pkgs/development/python-modules/spacy/models.nix
+++ b/pkgs/development/python-modules/spacy/models.nix
@@ -25,7 +25,7 @@ let
       ++ lib.optionals (lang == "ru") [ pymorphy2 ]
       ++ lib.optionals (pname == "fr_dep_news_trf") [ sentencepiece ];
 
-    postPatch = lib.optionals (pname == "fr_dep_news_trf") ''
+    postPatch = lib.optionalString (pname == "fr_dep_news_trf") ''
       substituteInPlace meta.json \
         --replace "sentencepiece==0.1.91" "sentencepiece>=0.1.91"
     '';

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
   ];
 
   # make install attempts to use the just-built cmake
-  preInstall = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     sed -i 's|bin/cmake|${buildPackages.cmakeMinimal}/bin/cmake|g' Makefile
   '';
 

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -16,10 +16,10 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [ m4 ];
 
-  preConfigure = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "ac_cv_func_malloc_0_nonnull=yes"
-    "ac_cv_func_realloc_0_nonnull=yes"
-  ];
+  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    ac_cv_func_malloc_0_nonnull=yes
+    ac_cv_func_realloc_0_nonnull=yes
+  '';
 
   doCheck = false; # fails 2 out of 46 tests
 

--- a/pkgs/development/tools/parsing/flex/2.6.1.nix
+++ b/pkgs/development/tools/parsing/flex/2.6.1.nix
@@ -18,10 +18,10 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [ m4 ];
 
-  preConfigure = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "ac_cv_func_malloc_0_nonnull=yes"
-    "ac_cv_func_realloc_0_nonnull=yes"
-  ];
+  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    ac_cv_func_malloc_0_nonnull=yes
+    ac_cv_func_realloc_0_nonnull=yes
+  '';
 
   postConfigure = lib.optionalString (stdenv.isDarwin || stdenv.isCygwin) ''
     sed -i Makefile -e 's/-no-undefined//;'

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -33,10 +33,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ bison ];
   propagatedBuildInputs = [ m4 ];
 
-  preConfigure = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "export ac_cv_func_malloc_0_nonnull=yes"
-    "export ac_cv_func_realloc_0_nonnull=yes"
-  ];
+  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    export ac_cv_func_malloc_0_nonnull=yes
+    export ac_cv_func_realloc_0_nonnull=yes
+  '';
 
   postConfigure = lib.optionalString (stdenv.isDarwin || stdenv.isCygwin) ''
     sed -i Makefile -e 's/-no-undefined//;'

--- a/pkgs/development/tools/parsing/ragel/default.nix
+++ b/pkgs/development/tools/parsing/ragel/default.nix
@@ -15,7 +15,7 @@ let
 
       buildInputs = lib.optional build-manual [ transfig ghostscript tex ];
 
-      preConfigure = lib.optional build-manual ''
+      preConfigure = lib.optionalString build-manual ''
         sed -i "s/build_manual=no/build_manual=yes/g" DIST
       '';
 

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -68,7 +68,7 @@ mkDerivation rec {
       --replace 'LLVM_CXXFLAGS ~= s,-gsplit-dwarf,' '${lib.concatStringsSep "\n" ["LLVM_CXXFLAGS ~= s,-gsplit-dwarf," "    LLVM_CXXFLAGS += -fno-rtti"]}'
   '';
 
-  preBuild = optional withDocumentation ''
+  preBuild = optionalString withDocumentation ''
     ln -s ${getLib qtbase}/$qtDocPrefix $NIX_QT5_TMP/share
   '';
 

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -834,7 +834,7 @@ self: super: {
   });
 
   vim-xdebug = super.vim-xdebug.overrideAttrs (old: {
-    postInstall = false;
+    postInstall = null;
   });
 
   vim-xkbswitch = super.vim-xkbswitch.overrideAttrs (old: {

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  postInstall = optional nftablesCompat ''
+  postInstall = optionalString nftablesCompat ''
     rm $out/sbin/{iptables,iptables-restore,iptables-save,ip6tables,ip6tables-restore,ip6tables-save}
     ln -sv xtables-nft-multi $out/bin/iptables
     ln -sv xtables-nft-multi $out/bin/iptables-restore

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   # We have no LTO on i686 since commit 22284b0
-  postPatch = lib.optional stdenv.isi686 ''
+  postPatch = lib.optionalString stdenv.isi686 ''
     substituteInPlace chelper/__init__.py \
       --replace "-flto -fwhole-program " ""
   '';

--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -16,7 +16,7 @@ self = stdenv.mkDerivation rec {
     sha256 = "1fhv16zr46pxm1j8vb8x8mh3nwzglg01arz8gnazbmjqldr5idpq";
   };
 
-  preConfigure = lib.optional stdenv.isDarwin ''
+  preConfigure = lib.optionalString stdenv.isDarwin ''
     ln -s /bin/ps $TMPDIR/ps
     export PATH=$PATH:$TMPDIR
   '';

--- a/pkgs/tools/filesystems/moosefs/default.nix
+++ b/pkgs/tools/filesystems/moosefs/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       "/usr/local/lib/pkgconfig" "/nonexistent"
   '';
 
-  preBuild = lib.optional stdenv.isDarwin ''
+  preBuild = lib.optionalString stdenv.isDarwin ''
     substituteInPlace config.h --replace \
       "#define HAVE_STRUCT_STAT_ST_BIRTHTIME 1" \
       "#undef HAVE_STRUCT_STAT_ST_BIRTHTIME"

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "DBDIR=$(TMPDIR)/db" "SYSCONFDIR=${placeholder "out"}/etc" ];
 
   # Check that the udev plugin got built.
-  postInstall = lib.optional (udev != null) "[ -e ${placeholder "out"}/lib/dhcpcd/dev/udev.so ]";
+  postInstall = lib.optionalString (udev != null) "[ -e ${placeholder "out"}/lib/dhcpcd/dev/udev.so ]";
 
   meta = with lib; {
     description = "A client for the Dynamic Host Configuration Protocol (DHCP)";


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Some derivations use `lib.optional` or `lib.optionals` when setting pre/post phase hooks. Ensure the proper `lib.optionalString` is used.

###### Things done

I fixed a similar issue a couple of weeks ago when working on `libcanberra`, and I though that a treewide fix would be useful.

I don't have the computer power to rebuild all modified derivations, but visual inspection of the patch looks fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
