### PR TITLE
palemoon: 29.3.0 -> 29.4.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -52,14 +52,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "29.3.0";
+  version = "29.4.0";
 
   src = fetchFromGitHub {
     githubBase = "repo.palemoon.org";
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "1q0w1ffmdfk22df4p2ks4n55zmz44ir8fbcdn5a5h4ihy73nf6xp";
+    sha256 = "0hm96n73d446hx4mfsav24mlm6l7fa0dx7br2s1kqcabswh8rk5g";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -52,14 +52,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "29.4.0";
+  version = "29.4.0.1";
 
   src = fetchFromGitHub {
     githubBase = "repo.palemoon.org";
     owner = "MoonchildProductions";
     repo = "Pale-Moon";
     rev = "${version}_Release";
-    sha256 = "0hm96n73d446hx4mfsav24mlm6l7fa0dx7br2s1kqcabswh8rk5g";
+    sha256 = "1qzsryhlxvh9xx9j7s4dmxv575z13wdx8iigj8r0pdmg5kx6rpkb";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
https://repo.palemoon.org/MoonchildProductions/Pale-Moon/releases/tag/29.4.0_Release

> Updated libcubeb to the current development version.
This improves OSS compatibility and addresses potential crashes, performance issues and security issues.
> …
> Improved thread safety of the web content cache. DiD
> Added several fixes to avoid potential crashes and security issues. DiD
> Unified XUL Platform Mozilla Security Patch Summary: 5 DiD, 12 not applicable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
