### PR TITLE
pulumi: added support for aarch64-darwin and added script to help fetch latest plugins version

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,20 +1,20 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "3.10.0";
+  version = "3.11.0";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.10.0-linux-x64.tar.gz";
-        sha256 = "0rhsdxiz5lz4hlw6a1pkjfblsh42vnk9bw8xg7wbjl9wpld3rys1";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.11.0-linux-x64.tar.gz";
+        sha256 = "1mkl9w70xhrfn1xq427vschdrih7p7j258qr3m90g1rp4nypvczf";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-linux-amd64.tar.gz";
         sha256 = "0d88xfi7zzmpyrnvakwxsyavdx6d5hmfrcf4jhmd53mni0m0551l";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.15.0-linux-amd64.tar.gz";
-        sha256 = "1s8w5kh9nfdv1vcdrpa2m76r2470k0j4frc3j3ijmqq1i0vv5yhk";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.17.0-linux-amd64.tar.gz";
+        sha256 = "1ny9x7s03i2kckswxldsgzzsfllmpwpia9dww5kgnmmd4d6ywrnj";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v3.4.0-linux-amd64.tar.gz";
@@ -25,8 +25,8 @@
         sha256 = "14s6jyackhp324gdlvvqnyi8s7hj0fb92ilrpd460p05p653zb4x";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v3.3.0-linux-amd64.tar.gz";
-        sha256 = "1ppwha1zk73w39msp6jym9in7jsrxzc530qgj4lj0961mb9rdkra";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.0.0-linux-amd64.tar.gz";
+        sha256 = "18yklyljzr9s5rf8ghd4zb12i8mfcvjzy4a942n9gr32r4si5072";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.0-linux-amd64.tar.gz";
@@ -41,28 +41,28 @@
         sha256 = "0yhdcjscdkvvai95z2v6xabvvsfvaqi38ngpqrb73ahlwqhz3nys";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.15.0-linux-amd64.tar.gz";
-        sha256 = "11m1f80i33m4dh13z96yh655pfiwvk46sjspwql7s80kapl93pq9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.16.0-linux-amd64.tar.gz";
+        sha256 = "10zrj0ca5wqfc2bkz0ddf6425860pdh4nj70bmyndb71d07b29sl";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.2.0-linux-amd64.tar.gz";
-        sha256 = "159lk4iv9zi2ggcjwjsg9an4rfjc0lbyn8d3kbv10p6cx109ljzg";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.3.0-linux-amd64.tar.gz";
+        sha256 = "1k7zd2cir6844awf1kpj7pifwvw74yfnrk78j0pall2jwmnf2zaa";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.1.0-linux-amd64.tar.gz";
-        sha256 = "13rchk54wpjwci26kfa519gqagwfrp31w6a9nk1xfdxj45ha9d3x";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-linux-amd64.tar.gz";
+        sha256 = "1h5159y7xlslnijs8lpi4vqgvj2px6whxk9m17p9n7wiyqbmd5na";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.2.0-linux-amd64.tar.gz";
-        sha256 = "0inx40vasjlxfvzr0pxbzm6rki50h5x5qkzx2wc51vv3gjln104q";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.3.0-linux-amd64.tar.gz";
+        sha256 = "0lbacvjpglniwghrbr9xznjfxfdfviv7ij451xcc0m47nshyfgkh";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.6.0-linux-amd64.tar.gz";
-        sha256 = "19zvqxf13lr98sp3p1ry3q1fvzx0rpxwz5wbk331n5jn0ljzr783";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.6.3-linux-amd64.tar.gz";
+        sha256 = "0n1s623zq3cs8csx52mfvfpgi989phg54gvlc3zvf7smpwqsbpi2";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.3.0-linux-amd64.tar.gz";
-        sha256 = "0vyqzphk75h1mk9p6wblgsw2cypycv32glzrnk4fildj48dakm5y";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.3.1-linux-amd64.tar.gz";
+        sha256 = "1wq006n1xnh9ngdjm046cnrgg3b3isn6vbgzdjgiaqhaypicay1g";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-linux-amd64.tar.gz";
@@ -75,10 +75,6 @@
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-linux-amd64.tar.gz";
         sha256 = "0rpf48snjm5n1xn7s6lnda6ny1gjgmfsqmbibw6w7h7la0ff78jp";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-linux-amd64.tar.gz";
-        sha256 = "0glbjhgrb2hiyhd6kwmy7v384j8zw641pw9737g1fczv3x16a3s3";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.1.0-linux-amd64.tar.gz";
@@ -99,16 +95,16 @@
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.10.0-darwin-x64.tar.gz";
-        sha256 = "18q1v1n3a497wbbzzjngpl90wpjnffn9wnpdp171r47k6xvbcsyq";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.11.0-darwin-x64.tar.gz";
+        sha256 = "14kkm7mksrxynrj4v1wd3ymaka4br7m8rhf0qlklk7dpm2llnfms";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-amd64.tar.gz";
         sha256 = "12mkr0xczdnp21k0k7qn4r3swkaq3pr6v2z853p1db7ksz5kds23";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.15.0-darwin-amd64.tar.gz";
-        sha256 = "1jnwlhfyyxz7196igi3gas3459k4nq1f4m1i4vdnxhkskp5838l0";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.17.0-darwin-amd64.tar.gz";
+        sha256 = "1vflwhj6c4zv7h6sbxidr14n28f4pkaf1n4l9y4advhny5b0qczx";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v3.4.0-darwin-amd64.tar.gz";
@@ -119,8 +115,8 @@
         sha256 = "1bb78g8k6gnhyxxvcjspnhbw2fig58flr14zi5i1cbd89xkz0m3i";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v3.3.0-darwin-amd64.tar.gz";
-        sha256 = "1wwldhy6r6985rwx9vv73jb1nsna387sk6mba81lyc55ar67nsp9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.0.0-darwin-amd64.tar.gz";
+        sha256 = "0z3hrm8m2br7gn46kbyp39a64c9zyl06hyjbssfv7i34j7i97qgh";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.0-darwin-amd64.tar.gz";
@@ -135,28 +131,28 @@
         sha256 = "1dpsbq3b0fz86355jy7rz4kcsa1lnw4azn25vzlis89ay1ncbblc";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.15.0-darwin-amd64.tar.gz";
-        sha256 = "01vrivbdhsl50kiv092j2a5jvikhrw1kzpa5ags701l721zslycq";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.16.0-darwin-amd64.tar.gz";
+        sha256 = "1f8yfi2vzypayl97mka83fcsdzs9pvjjf596k8sbbanlaplakjvg";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.2.0-darwin-amd64.tar.gz";
-        sha256 = "1iwx80r9kmlrf961zck3qz2jb9shpmywdm5nkflvz6mhwrfsbz72";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.3.0-darwin-amd64.tar.gz";
+        sha256 = "0fabb3zi5p24xfgsc0jn8ynavd1g0qrlm1yqifxv12zr5id4vcvk";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.1.0-darwin-amd64.tar.gz";
-        sha256 = "0qbw4b5zm6dmwdilaz4bjdg55gc5lilwagrxwrab37vq4a8and4c";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-darwin-amd64.tar.gz";
+        sha256 = "0r2ykjwam5m2mfiibhq993s8n5pzmks837cwb57jwgwx8lc3ra4x";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.2.0-darwin-amd64.tar.gz";
-        sha256 = "0bj7ir7dpkfsb75bjl45irwi692zxnys0125kmwdn8gnamlij5fx";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.3.0-darwin-amd64.tar.gz";
+        sha256 = "1nhx104dpjylwwfmwhdhxnf0rvvfkq1q4iak21cm4mf0w69ycgvx";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.6.0-darwin-amd64.tar.gz";
-        sha256 = "0i06q1hrxi84r8ss3ck7jgk3g4lblkjvgm3wx35v551l0ynmmqqw";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.6.3-darwin-amd64.tar.gz";
+        sha256 = "0vhlk1xfhrvwks4vfr1rr160bafx1zin1v00afhhds4gznn3p5ir";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.3.0-darwin-amd64.tar.gz";
-        sha256 = "0fwbh02n7cjmv6d9jbqpjnmvvdp1cnsyhy7gxd2863j4w5f17q48";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.3.1-darwin-amd64.tar.gz";
+        sha256 = "0ysfjz6774592kf746xid7gw4pffcw1ysjlbagjv22m154pdry8y";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-darwin-amd64.tar.gz";
@@ -169,10 +165,6 @@
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-darwin-amd64.tar.gz";
         sha256 = "0jlvdnvcmml009a84lfa6745qwjsifa9zmdrv4gqy9p76iydfs1n";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-darwin-amd64.tar.gz";
-        sha256 = "0621njipng32x43lw8n49mapq10lnvibg8vlvgciqsfvrbpz1yp5";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.1.0-darwin-amd64.tar.gz";
@@ -189,6 +181,96 @@
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-darwin-amd64.tar.gz";
         sha256 = "1qb2gaiinclmbswyn5aakwjmm3gaggscckb1q2syx69k42hvp3s3";
+      }
+    ];
+    aarch64-darwin = [
+      {
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.11.0-darwin-arm64.tar.gz";
+        sha256 = "1xkc3aqwrxj6q37b2sw01rzlzg84pr2sv02cm4q2pfk182f4fbdy";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-arm64.tar.gz";
+        sha256 = "1rmvc2kgjmb978sfmlga6xy4i0f629lk1l95i30wg0rmj1hx3dag";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.17.0-darwin-arm64.tar.gz";
+        sha256 = "10qyycax616c83hrrqlks1brsn4hx0ndgbpz4r5g8yn9x6s3brsp";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v3.4.0-darwin-arm64.tar.gz";
+        sha256 = "0i2bx6vjqwydvd2hv8jh3f44f4yl926c55s431zyvmzxq0vaflxy";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.2.0-darwin-arm64.tar.gz";
+        sha256 = "1mz5ii44ny9fiwk805xprb1kcxszjjrbxj2vgv6pgi55z1cd0rjr";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.0.0-darwin-arm64.tar.gz";
+        sha256 = "0dmbjdlskwkilq0636kfmaqv8ksq0h615pnnw1ngp9p4lygczffv";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.0-darwin-arm64.tar.gz";
+        sha256 = "0xbh1idj1avkkq73jz8qmz7r39bw1v07ly6sxglrl5cbi7wp64b7";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.0.0-darwin-arm64.tar.gz";
+        sha256 = "0vm151vscqypjy5709ppgbga4fc8qprnln5n0b4ipf6l1v89srbj";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v2.0.0-darwin-arm64.tar.gz";
+        sha256 = "1170s85p6d850czb0amzk06d3bcyzyp14p49sgqvpa099jyvs4mm";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.16.0-darwin-arm64.tar.gz";
+        sha256 = "061pxdh90xn7ssbdgi52vzlcamyrbqjfqz3vkwwjsdzi1jvigs7f";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.3.0-darwin-arm64.tar.gz";
+        sha256 = "0qjpay735gff28xdvippm11lh8gk2xsvh2mcil679ybgpk6kypw2";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-darwin-arm64.tar.gz";
+        sha256 = "1c3pchbnk6dsnxsl02ypq7s4mmkxdgxszdhql1klpx5js7i1lv8k";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.3.0-darwin-arm64.tar.gz";
+        sha256 = "1m0v94d297fgy2zyqrnc81iajzkgh27d6z9hsglqlh7vbd43pyc3";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.6.3-darwin-arm64.tar.gz";
+        sha256 = "0gh85mp4rx5fljp4b5y7yxrd6rbkl7if5fyfn57rr277yv0i63qz";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.3.1-darwin-arm64.tar.gz";
+        sha256 = "1vxasak8kx3jgp4f7pf7ljvyw4a4kaia54x5hzwjkqzg8jncdck4";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-darwin-arm64.tar.gz";
+        sha256 = "118kszs5y3ajh702dyy4wivwdima30s3spbr3cdm9g7aabqhl5l6";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-arm64.tar.gz";
+        sha256 = "10a2f5kdgk3jcd1441zbfcfnrl5zj6ks832jjmbyym33by7scvgc";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-darwin-arm64.tar.gz";
+        sha256 = "17imdik9gb3bhqh71b82h12sx6rn13iann9dlbdxy3zj3g59k3ri";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.1.0-darwin-arm64.tar.gz";
+        sha256 = "1zml2klmw7i0r1wdj6wbq3yk5wnpba8x46ab1wyzr2pbn07b1vkb";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.2.0-darwin-arm64.tar.gz";
+        sha256 = "0waf4apw5bzn276s34yaxvm3xyk5333l3zcz2j52c56wkadzxvpg";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.3.0-darwin-arm64.tar.gz";
+        sha256 = "1i0wn28q1cja26j8ykffhvp3xbrnvawjhlws1wnm87s5zfn0y74z";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-darwin-arm64.tar.gz";
+        sha256 = "0ci3xnxnwrk6dds21yifis1mrz24z2nxqdbya0qpqprkq6syvx41";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/get_latest_plugins.sh
+++ b/pkgs/tools/admin/pulumi/get_latest_plugins.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+plugins=(
+    "auth0"
+    "aws"
+    "cloudflare"
+    "consul"
+    "datadog"
+    "digitalocean"
+    "docker"
+    "equinix-metal"
+    "gcp"
+    "github"
+    "gitlab"
+    "hcloud"
+    "kubernetes"
+    "linode"
+    "mailgun"
+    "mysql"
+    "openstack"
+    "postgresql"
+    "random"
+    "vault"
+    "vsphere"
+)
+
+
+for plug in "${plugins[@]}"; do
+    version=$(curl -s https://api.github.com/repos/pulumi/pulumi-${plug}/releases/latest | jq -r .tag_name)
+    echo "    \"${plug}=${version}\""
+done

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -3,32 +3,31 @@
 
 # Version of Pulumi from
 # https://www.pulumi.com/docs/get-started/install/versions/
-VERSION="3.10.0"
+VERSION="3.11.0"
 
 # Grab latest release ${VERSION} using get_latest_plugins.sh
 plugins=(
-    "auth0=2.2.0"
-    "aws=4.15.0"
-    "cloudflare=3.4.0"
-    "consul=3.2.0"
-    "datadog=3.3.0"
-    "digitalocean=4.6.0"
-    "docker=3.0.0"
-    "equinix-metal=2.0.0"
-    "gcp=5.15.0"
-    "github=4.2.0"
-    "gitlab=4.1.0"
-    "hcloud=1.2.0"
-    "kubernetes=3.6.0"
-    "linode=3.3.0"
-    "mailgun=3.1.0"
-    "mysql=3.0.0"
-    "openstack=3.3.0"
-    "packet=3.2.2"
-    "postgresql=3.1.0"
-    "random=4.2.0"
-    "vault=4.3.0"
-    "vsphere=4.0.1"
+    "auth0=v2.2.0"
+    "aws=v4.17.0"
+    "cloudflare=v3.4.0"
+    "consul=v3.2.0"
+    "datadog=v4.0.0"
+    "digitalocean=v4.6.0"
+    "docker=v3.0.0"
+    "equinix-metal=v2.0.0"
+    "gcp=v5.16.0"
+    "github=v4.3.0"
+    "gitlab=v4.2.0"
+    "hcloud=v1.3.0"
+    "kubernetes=v3.6.3"
+    "linode=v3.3.1"
+    "mailgun=v3.1.0"
+    "mysql=v3.0.0"
+    "openstack=v3.3.0"
+    "postgresql=v3.1.0"
+    "random=v4.2.0"
+    "vault=v4.3.0"
+    "vsphere=v4.0.1"
 )
 
 function genMainSrc() {
@@ -82,3 +81,4 @@ EOF
   echo "  };"
   echo "}"
 } > data.nix
+

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -5,8 +5,7 @@
 # https://www.pulumi.com/docs/get-started/install/versions/
 VERSION="3.10.0"
 
-# Grab latest release ${VERSION} from
-# https://github.com/pulumi/pulumi-${NAME}/releases
+# Grab latest release ${VERSION} using get_latest_plugins.sh
 plugins=(
     "auth0=2.2.0"
     "aws=4.15.0"

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -33,7 +33,7 @@ plugins=(
 )
 
 function genMainSrc() {
-    local url="https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-$1-x64.tar.gz"
+    local url="https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-$1.tar.gz"
     local sha256
     sha256=$(nix-prefetch-url "$url")
     echo "      {"
@@ -48,7 +48,7 @@ function genSrcs() {
         local version=${plugVers#*=}
         # url as defined here
         # https://github.com/pulumi/pulumi/blob/06d4dde8898b2a0de2c3c7ff8e45f97495b89d82/pkg/workspace/plugins.go#L197
-        local url="https://api.pulumi.com/releases/plugins/pulumi-resource-${plug}-v${version}-$1-amd64.tar.gz"
+        local url="https://api.pulumi.com/releases/plugins/pulumi-resource-${plug}-${version}-$1.tar.gz"
         local sha256
         sha256=$(nix-prefetch-url "$url")
         echo "      {"
@@ -67,13 +67,18 @@ function genSrcs() {
   pulumiPkgs = {
     x86_64-linux = [
 EOF
-  genMainSrc "linux"
-  genSrcs "linux"
+  genMainSrc "linux-x64"
+  genSrcs "linux-amd64"
   echo "    ];"
   echo "    x86_64-darwin = ["
 
-  genMainSrc "darwin"
-  genSrcs "darwin"
+  genMainSrc "darwin-x64"
+  genSrcs "darwin-amd64"
+  echo "    ];"
+  echo "    aarch64-darwin = ["
+
+  genMainSrc "darwin-arm64"
+  genSrcs "darwin-arm64"
   echo "    ];"
   echo "  };"
   echo "}"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
