### PR TITLE
osquery: init at 4.9.0

### DIFF
--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -1,0 +1,64 @@
+{ libcxxStdenv, lib, fetchurl, fetchFromGitHub, pkgconfig, git,
+  cmake, python3, which, flex, bison, perl, libunwind, openssl,
+  buildAws ? false, buildBpf ? true
+}:
+
+libcxxStdenv.mkDerivation rec {
+  pname = "osquery";
+  version = "4.9.0";
+
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = pname;
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "sha256:0zr4fyw88jrg1z2cpy3gijmwjyr5qwdp5np1if6cy74rq6bdhfkw";
+  };
+
+  nativeBuildInputs = [python3 which git cmake pkgconfig flex bison perl];
+
+  buildInputs = [libunwind];
+
+  patches = [
+    ./libaudit-define.patch
+    ./libmagic-xlocale.patch
+    ./nosysctl-header.patch
+    ./openssl-src.patch
+    ./sysmacros.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace ./libraries/cmake/formula/openssl/CMakeLists.txt \
+    --replace "@OSQUERY_OPENSSL_TARBALL@" \
+              "${openssl.src}"
+    # Make dummy git repositories for cmake to detect.
+    git init
+    git config user.name "John Doe"
+    git config user.email "JohnDoe@nixos.org"
+    touch _NOTHING_
+    git add _NOTHING_
+    git commit -m "Convince build system we have git."
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DOSQUERY_VERSION=${version}"
+  ] ++ (if buildAws then [] else ["-DOSQUERY_BUILD_AWS=OFF"])
+    ++ (if buildBpf then [] else ["-DOSQUERY_BUILD_BPF=OFF"]);
+
+  installPhase = ''
+    mkdir dist
+    export DESTDIR="$(pwd)/dist"
+    cmake --build . --target install
+    cp -r ./dist/$out $out
+  '';
+
+  meta = with lib; {
+    description = "SQL powered operating system instrumentation, monitoring, and analytics";
+    homepage = https://osquery.io/;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ andrewchambers ];
+  };
+}

--- a/pkgs/tools/system/osquery/libaudit-define.patch
+++ b/pkgs/tools/system/osquery/libaudit-define.patch
@@ -1,0 +1,14 @@
+Fixes repeated define: https://bugs.gentoo.org/669532
+--- ./libraries/cmake/source/libaudit/src/lib/libaudit.h
++++ ./libraries/cmake/source/libaudit/src/lib/libaudit.h
+@@ -260,7 +260,9 @@
+ #define AUDIT_KEY_SEPARATOR 0x01
+ 
+ /* These are used in filter control */
+-#define AUDIT_FILTER_EXCLUDE	AUDIT_FILTER_TYPE
++#ifndef AUDIT_FILTER_EXCLUDE
++#define AUDIT_FILTER_EXCLUDE    AUDIT_FILTER_TYPE
++#endif
+ #define AUDIT_FILTER_MASK	0x07	/* Mask to get actual filter */
+ #define AUDIT_FILTER_UNSET	0x80	/* This value means filter is unset */
+ 

--- a/pkgs/tools/system/osquery/libmagic-xlocale.patch
+++ b/pkgs/tools/system/osquery/libmagic-xlocale.patch
@@ -1,0 +1,11 @@
+--- a/libraries/cmake/source/libmagic/config/linux/config.h
++++ b/libraries/cmake/source/libmagic/config/linux/config.h
+@@ -248,7 +248,7 @@
+ #define HAVE_WORKING_VFORK 1
+ 
+ /* Define to 1 if you have the <xlocale.h> header file. */
+-#define HAVE_XLOCALE_H 1
++/* #undef HAVE_XLOCALE_H */
+ 
+ /* Define to 1 if you have the <zlib.h> header file. */
+ #define HAVE_ZLIB_H 1

--- a/pkgs/tools/system/osquery/nosysctl-header.patch
+++ b/pkgs/tools/system/osquery/nosysctl-header.patch
@@ -1,0 +1,69 @@
+Linux and glibc have removed these calls.
+--- a/libraries/cmake/source/lldpd/config/x86_64/linux/libevent/config.h
++++ b/libraries/cmake/source/lldpd/config/x86_64/linux/libevent/config.h
+@@ -288,7 +288,7 @@
+ #define HAVE_SYS_STAT_H 1
+ 
+ /* Define to 1 if you have the <sys/sysctl.h> header file. */
+-#define HAVE_SYS_SYSCTL_H 1
++/* #undef HAVE_SYS_SYSCTL_H */
+ 
+ /* Define to 1 if you have the <sys/time.h> header file. */
+ #define HAVE_SYS_TIME_H 1
+--- a/libraries/cmake/source/lldpd/config/x86_64/linux/libevent/event2/event-config.h
++++ b/libraries/cmake/source/lldpd/config/x86_64/linux/libevent/event2/event-config.h
+@@ -301,7 +301,7 @@
+ #define _EVENT_HAVE_SYS_STAT_H 1
+ 
+ /* Define to 1 if you have the <sys/sysctl.h> header file. */
+-#define _EVENT_HAVE_SYS_SYSCTL_H 1
++/* #undef _EVENT_HAVE_SYS_SYSCTL_H */
+ 
+ /* Define to 1 if you have the <sys/time.h> header file. */
+ #define _EVENT_HAVE_SYS_TIME_H 1
+--- a/osquery/tables/system/linux/sysctl_utils.cpp
++++ b/osquery/tables/system/linux/sysctl_utils.cpp
+@@ -7,8 +7,6 @@
+  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+  */
+ 
+-#include <sys/sysctl.h>
+-
+ #include <boost/algorithm/string/trim.hpp>
+ 
+ #include <osquery/core/tables.h>
+@@ -70,20 +68,7 @@ void genControlInfo(int* oid,
+                     size_t oid_size,
+                     QueryData& results,
+                     const std::map<std::string, std::string>& config) {
+-  // Get control size
+-  size_t response_size = CTL_MAX_VALUE;
+-  char response[CTL_MAX_VALUE + 1] = {0};
+-  if (sysctl(oid, oid_size, response, &response_size, 0, 0) != 0) {
+-    // Cannot request MIB data.
+-    return;
+-  }
+-
+-  // Data is output, but no way to determine type (long, int, string, struct).
+-  Row r;
+-  r["oid"] = stringFromMIB(oid, oid_size);
+-  r["current_value"] = std::string(response);
+-  r["type"] = "string";
+-  results.push_back(r);
++  return; // Syscall has been deprecated, always fail.
+ }
+ 
+ void genAllControls(QueryData& results,
+diff --git a/osquery/tables/system/posix/sysctl_utils.h b/osquery/tables/system/posix/sysctl_utils.h
+index e119f8a9e..40a96dbc4 100644
+--- a/osquery/tables/system/posix/sysctl_utils.h
++++ b/osquery/tables/system/posix/sysctl_utils.h
+@@ -9,7 +9,7 @@
+ 
+ #pragma once
+ 
+-#include <sys/sysctl.h>
++#define CTL_MAXNAME 10
+ 
+ #include <osquery/core/tables.h>
+ 

--- a/pkgs/tools/system/osquery/openssl-src.patch
+++ b/pkgs/tools/system/osquery/openssl-src.patch
@@ -1,0 +1,33 @@
+This patch stops cmake from attempting to download openssl at build time.
+This patch could be further improved to just link against the system openssl
+instead of trying to build one.
+
+--- a/libraries/cmake/formula/openssl/CMakeLists.txt
++++ b/libraries/cmake/formula/openssl/CMakeLists.txt
+@@ -1,8 +1,5 @@
+ project(thirdparty_openssl)
+ 
+-set(OPENSSL_VERSION "1.1.1k")
+-set(OPENSSL_ARCHIVE_SHA256 "892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5")
+-
+ include(ExternalProject)
+ 
+ function(opensslMain)
+@@ -162,16 +159,8 @@ function(opensslMain)
+   list(APPEND openssl_c_flags ${OSQUERY_FORMULA_CFLAGS})
+   string(REPLACE ";" " " openssl_c_flags "${openssl_c_flags}")
+ 
+-  string(REGEX MATCH "[0-9]\.[0-9]\.[0-9]" OPENSSL_VERSION_NO_PATCH "${OPENSSL_VERSION}")
+-
+-  set(openssl_urls
+-    "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
+-    "https://www.openssl.org/source/old/${OPENSSL_VERSION_NO_PATCH}/openssl-${OPENSSL_VERSION}.tar.gz"
+-  )
+-
+   ExternalProject_Add(openssl
+-    URL "${openssl_urls}"
+-    URL_HASH SHA256=${OPENSSL_ARCHIVE_SHA256}
++    URL "@OSQUERY_OPENSSL_TARBALL@"
+     CONFIGURE_COMMAND ${configure_command}
+     BUILD_COMMAND ${build_command}
+     INSTALL_COMMAND ""

--- a/pkgs/tools/system/osquery/sysmacros.patch
+++ b/pkgs/tools/system/osquery/sysmacros.patch
@@ -1,0 +1,115 @@
+Submodule libraries/cmake/source/libudev/src contains modified content
+diff --git a/libraries/cmake/source/libudev/src/libudev/libudev-device.c b/libraries/cmake/source/libudev/src/libudev/libudev-device.c
+index 1024b46803..21e9d46c65 100644
+--- a/libraries/cmake/source/libudev/src/libudev/libudev-device.c
++++ b/libraries/cmake/source/libudev/src/libudev/libudev-device.c
+@@ -23,6 +23,10 @@
+ #include <sys/stat.h>
+ #include <sys/ioctl.h>
+ #include <sys/socket.h>
++#include <sys/types.h>
++#ifdef __GNU_LIBRARY__
++#include <sys/sysmacros.h>
++#endif
+ #include <linux/sockios.h>
+ 
+ #include "libudev.h"
+diff --git a/libraries/cmake/source/libudev/src/libudev/libudev-enumerate.c b/libraries/cmake/source/libudev/src/libudev/libudev-enumerate.c
+index f14d5c8f57..85669c6f53 100644
+--- a/libraries/cmake/source/libudev/src/libudev/libudev-enumerate.c
++++ b/libraries/cmake/source/libudev/src/libudev/libudev-enumerate.c
+@@ -20,6 +20,9 @@
+ #include <stdbool.h>
+ #include <sys/stat.h>
+ #include <sys/param.h>
++#ifdef __GNU_LIBRARY__
++#include <sys/sysmacros.h>
++#endif
+ 
+ #include "libudev.h"
+ #include "libudev-private.h"
+Submodule libraries/cmake/source/util-linux/src contains modified content
+diff --git a/libraries/cmake/source/util-linux/src/lib/sysfs.c b/libraries/cmake/source/util-linux/src/lib/sysfs.c
+index 51ec2bfe2..51be12db2 100644
+--- a/libraries/cmake/source/util-linux/src/lib/sysfs.c
++++ b/libraries/cmake/source/util-linux/src/lib/sysfs.c
+@@ -5,6 +5,9 @@
+  * Written by Karel Zak <kzak@redhat.com>
+  */
+ #include <ctype.h>
++#ifdef __GNU_LIBRARY__
++#include <sys/sysmacros.h>
++#endif
+ 
+ #include "c.h"
+ #include "at.h"
+diff --git a/libraries/cmake/source/util-linux/src/libblkid/src/partitions/partitions.c b/libraries/cmake/source/util-linux/src/libblkid/src/partitions/partitions.c
+index 6e55a8f3e..4be4113b6 100644
+--- a/libraries/cmake/source/util-linux/src/libblkid/src/partitions/partitions.c
++++ b/libraries/cmake/source/util-linux/src/libblkid/src/partitions/partitions.c
+@@ -14,6 +14,9 @@
+ #include <fcntl.h>
+ #include <ctype.h>
+ #include <sys/types.h>
++#ifdef __GNU_LIBRARY__
++#include <sys/sysmacros.h>
++#endif
+ #include <sys/stat.h>
+ #include <errno.h>
+ #include <stdint.h>
+diff --git a/libraries/cmake/source/util-linux/src/libblkid/src/topology/dm.c b/libraries/cmake/source/util-linux/src/libblkid/src/topology/dm.c
+index e061632ca..8708215d2 100644
+--- a/libraries/cmake/source/util-linux/src/libblkid/src/topology/dm.c
++++ b/libraries/cmake/source/util-linux/src/libblkid/src/topology/dm.c
+@@ -17,6 +17,9 @@
+ #include <string.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#ifdef __GNU_LIBRARY__
++#include <sys/sysmacros.h>
++#endif
+ #include <unistd.h>
+ 
+ #include "topology.h"
+diff --git a/libraries/cmake/source/util-linux/src/libblkid/src/topology/evms.c b/libraries/cmake/source/util-linux/src/libblkid/src/topology/evms.c
+index 7a4fd554d..d1a413d90 100644
+--- a/libraries/cmake/source/util-linux/src/libblkid/src/topology/evms.c
++++ b/libraries/cmake/source/util-linux/src/libblkid/src/topology/evms.c
+@@ -18,6 +18,9 @@
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#ifdef __GNU_LIBRARY__
++#include <sys/sysmacros.h>
++#endif
+ #include <unistd.h>
+ 
+ #include "topology.h"
+diff --git a/libraries/cmake/source/util-linux/src/libblkid/src/topology/lvm.c b/libraries/cmake/source/util-linux/src/libblkid/src/topology/lvm.c
+index bd079d47b..c9b580ff3 100644
+--- a/libraries/cmake/source/util-linux/src/libblkid/src/topology/lvm.c
++++ b/libraries/cmake/source/util-linux/src/libblkid/src/topology/lvm.c
+@@ -17,6 +17,9 @@
+ #include <string.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#ifdef __GNU_LIBRARY__
++#include <sys/sysmacros.h>
++#endif
+ #include <unistd.h>
+ 
+ #include "topology.h"
+diff --git a/libraries/cmake/source/util-linux/src/libblkid/src/topology/md.c b/libraries/cmake/source/util-linux/src/libblkid/src/topology/md.c
+index 5eba94787..6a869adb3 100644
+--- a/libraries/cmake/source/util-linux/src/libblkid/src/topology/md.c
++++ b/libraries/cmake/source/util-linux/src/libblkid/src/topology/md.c
+@@ -18,6 +18,9 @@
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#ifdef __GNU_LIBRARY__
++#include <sys/sysmacros.h>
++#endif
+ #include <unistd.h>
+ 
+ #include "topology.h"

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -561,7 +561,6 @@ mapAliases ({
   openssh_with_kerberos = openssh; # added 2018-01-28
   orchis = orchis-theme; # added 2021-06-09
   onnxruntime = throw "onnxruntime has been removed due to poor maintainability"; # added 2020-12-04
-  osquery = throw "osquery has been removed."; # added 2019-11-24
   osxfuse = macfuse-stubs; # added 2021-03-20
   otter-browser = throw "otter-browser has been removed from nixpkgs, as it was unmaintained"; # added 2020-02-02
   owncloudclient = owncloud-client;  # added 2016-08

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26595,6 +26595,8 @@ with pkgs;
 
   osmium-tool = callPackage ../applications/misc/osmium-tool { };
 
+  osquery = callPackage ../tools/system/osquery { };
+
   osu-lazer = callPackage ../games/osu-lazer { };
 
   owamp = callPackage ../applications/networking/owamp { };


### PR DESCRIPTION
This re-enables the previously broken osquery package and fixes the build on linux.

Unfortunately due to how the upstream package is developed, it seems to prefer its own internal copies of packages, it would require a lot more work to use the system libraries.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Pinging old maintainers:

ping @Ma27 
ping @cstrahan 


