### PR TITLE
sparse: 0.5.0 -> 0.6.3 and fixes

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5091,6 +5091,12 @@
     githubId = 9866621;
     name = "Jack";
   };
+  jkarlson = {
+    email = "jekarlson@gmail.com";
+    github = "jkarlson";
+    githubId = 1204734;
+    name = "Emil Karlson";
+  };
   jlesquembre = {
     email = "jl@lafuente.me";
     github = "jlesquembre";

--- a/pkgs/development/tools/analysis/sparse/default.nix
+++ b/pkgs/development/tools/analysis/sparse/default.nix
@@ -1,27 +1,36 @@
-{ fetchurl, lib, stdenv, pkg-config, libxml2, llvm, perl }:
+{ callPackage, fetchurl, lib, stdenv, gtk3, pkg-config, libxml2, llvm, perl, sqlite }:
 
-stdenv.mkDerivation rec {
+let
+  GCC_BASE = "${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.uname.processor}-unknown-linux-gnu/${stdenv.cc.cc.version}";
+in stdenv.mkDerivation rec {
   pname = "sparse";
-  version = "0.5.0";
+  version = "0.6.3";
 
   src = fetchurl {
     url = "mirror://kernel/software/devel/sparse/dist/${pname}-${version}.tar.xz";
-    sha256 = "1mc86jc5xdrdmv17nqj2cam2yqygnj6ar1iqkwsx2y37ij8wy7wj";
+    sha256 = "16d8c4dhipjzjf8z4z7pix1pdpqydz0v4r7i345f5s09hjnxpxnl";
   };
 
   preConfigure = ''
-    sed -i Makefile -e "s|^PREFIX=.*$|PREFIX=$out|g"
+    sed -i 's|"/usr/include"|"${stdenv.cc.libc.dev}/include"|' pre-process.c
+    sed -i 's|qx(\$ccom -print-file-name=)|"${GCC_BASE}"|' cgcc
+    makeFlags+=" PREFIX=$out"
   '';
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libxml2 llvm perl ];
+  buildInputs = [ gtk3 libxml2 llvm perl sqlite ];
   doCheck = true;
+  buildFlags = "GCC_BASE:=${GCC_BASE}";
 
-  meta = {
+  passthru.tests = {
+    simple-execution = callPackage ./tests.nix { };
+  };
+
+  meta = with lib; {
     description = "Semantic parser for C";
     homepage    = "https://git.kernel.org/cgit/devel/sparse/sparse.git/";
-    license     = lib.licenses.mit;
-    platforms   = lib.platforms.linux;
-    maintainers = [ lib.maintainers.thoughtpolice ];
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ thoughtpolice jkarlson ];
   };
 }

--- a/pkgs/development/tools/analysis/sparse/tests.nix
+++ b/pkgs/development/tools/analysis/sparse/tests.nix
@@ -1,0 +1,24 @@
+{ runCommand, gcc, sparse, writeText }:
+let
+  src = writeText "CODE.c" ''
+    #include <stdio.h>
+    #include <stddef.h>
+    #include <stdlib.h>
+
+    int main(int argc, char *argv[]) {
+      return EXIT_SUCCESS;
+    }
+  '';
+in
+  runCommand "${sparse.pname}-tests" { buildInputs = [ gcc sparse ]; meta.timeout = 3; }
+''
+  set -eu
+  ${sparse}/bin/cgcc ${src} > output 2>&1 || ret=$?
+  if [[ -z $(<output) ]]; then
+    mv output $out
+  else
+    echo "Test build returned $ret"
+    cat output
+    exit 1
+  fi
+''


### PR DESCRIPTION
Added sqlite and gtk+3 that are now wanted by sparse.

Sparse expects to find system includes at /usr/include redirect this
to glibc.dev.

Sparse uses gcc -print-file-name= extensively to find gcc includes, due
to split in nixos this direct to gcc-lib, which does not include the headers
so redirect to GCC_BASE as defined in derivation. There might be a better way
to do this, but I did not immediately find one.

Define PREFIX as Make parameter, as old sed expression was broken.

Slightly irrelevant ref.
https://bugzilla.redhat.com/show_bug.cgi?id=1114755

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
