### PR TITLE
tar2ext4: init at 0.8.20

### DIFF
--- a/pkgs/tools/filesystems/tar2ext4/default.nix
+++ b/pkgs/tools/filesystems/tar2ext4/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "tar2ext4";
+  version = "0.8.20";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "hcsshim";
+    rev = "v${version}";
+    sha256 = "sha256-X7JsUFL9NkNT7ihE5olrqMUP8RnoVC10KLrQeT/OU3o=";
+  };
+
+  sourceRoot = "source/cmd/tar2ext4";
+  vendorSha256 = null;
+
+  meta = with lib; {
+    description = "Convert a tar archive to an ext4 image";
+    maintainers = with maintainers; [ qyliss ];
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/filesystems/tar2ext4/default.nix
+++ b/pkgs/tools/filesystems/tar2ext4/default.nix
@@ -18,6 +18,5 @@ buildGoModule rec {
     description = "Convert a tar archive to an ext4 image";
     maintainers = with maintainers; [ qyliss ];
     license = licenses.mit;
-    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9298,6 +9298,8 @@ with pkgs;
 
   znapzend = callPackage ../tools/backup/znapzend { };
 
+  tar2ext4 = callPackage ../tools/filesystems/tar2ext4 { };
+
   targetcli = callPackage ../os-specific/linux/targetcli { };
 
   target-isns = callPackage ../os-specific/linux/target-isns { };


### PR DESCRIPTION
This is a single program that's part of a big Microsoft project.
Everything else looks pretty specialised, and some of it only targets
Windows, so I didn't try packaging anything else.  If we ever do end
up with a need for other software from this project, this derivation
could be extended and renamed, with tar2ext4 becoming an alias.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
