### PR TITLE
[21.05] firefox{,-bin}: 91.0 -> 91.0.1; firefox-esr-91: 91.0esr -> 91.0.1esr; firefox-esr-78: 78.12.0esr -> 78.13.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "91.0";
+  version = "91.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ach/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ach/firefox-91.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "2994fee72d674891a4e05fb32e210f8b2c9f7bf4d3a0a8309bda91f7f3643880";
+      sha256 = "d3ffa075821d9c11dcb96e7edaf8e8d71df251d53c9d0451fb01fcaee62ef8f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/af/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/af/firefox-91.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "dc3e1370fba43b34513104acfb6027ae16b675649ccccfdf57b95fbb9c969e6e";
+      sha256 = "dc51c73414bcffd8b36741f1d6ab2734b15b4bec786502f35a4b9421b9ca3f0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/an/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/an/firefox-91.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "c6f9c813bf1ea4d5e9b5f2facea73cee5345c2ce53e6bdc8d9ccef2cc1c11e14";
+      sha256 = "4e629d00106765cf22cf4c78d7ad04ba0379838addcd7cb991fae3d0881cb850";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ar/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ar/firefox-91.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "343e6dac789d95f4c3fd247a62a820289e9829f8e5c183e760137686d3a6a4ac";
+      sha256 = "c7054c65464e149d3a59ccaa8e9bf2d69bc77677ea5a2ba3ae918db5be8fdaed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ast/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ast/firefox-91.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "e7befd2ac2ffd2a03df135c2ed511823996eb00c6ed38b7a53a02f99909d0156";
+      sha256 = "8270e3217f302700c0a3771f68bb88df45100d9d1d0631351f22053e891e66b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/az/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/az/firefox-91.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "82b55afce5a0016f5deffc3e56e52b32b2b0cf8da68d9044ec4b86ce351e7a6e";
+      sha256 = "8b1085c48b5e0181c9771763406592bbdbc244d4d3151f33a16988356b5a0952";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/be/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/be/firefox-91.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "39929a09ab442795ba39818d39b0190c14c343acca867e6c5b4df5dd4a1d3216";
+      sha256 = "447646e47e60981affd8d08c2dba13be7cea36298acf0b5fbb643ad8c65cb3d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/bg/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/bg/firefox-91.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "bf0b8704f873acf2a2e1edd415769d57bb0c10a9b60461de4748c5947f98d01c";
+      sha256 = "f684ce4051cffe8e5f49450368b11ba92dfe745a7676c815b48d34649594eb08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/bn/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/bn/firefox-91.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "9711f2484ede52236b9cbe97b82a1f7ba544421e1c182106d7f2b21d148822e2";
+      sha256 = "9ba47714afcd7919c681b426c5df76664e7115b1c29f44082a84fe352f2a55be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/br/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/br/firefox-91.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "c14c6a0716f8ced15c27edace60138bead407cdeff3e2b1eab4fa33b424a6576";
+      sha256 = "da820985c59c010f6de527347c5e475db73aae93180517451c3b06ed4605515f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/bs/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/bs/firefox-91.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "c66c10beb69eac9b42dd61e349f7c0593eea7a704a8e8efe60b192c39fefac8c";
+      sha256 = "7fcf9509831a7b44b07525d6622a29e8e3f83e1cf2aaf60c66afc73e4514a952";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ca-valencia/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ca-valencia/firefox-91.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "2408cc49bb6e8b091af511dd0321c4a39f6bc70fcc168a605bfae7a667679440";
+      sha256 = "6764d541d324578c381fe723a36c5ccb298276f34749ac61e8ae7a2218036d6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ca/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ca/firefox-91.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "86712676ca2d4bbb734c6a0e21b9777d0b1ad93e25c85d57e1adaa3d41955a95";
+      sha256 = "d598fee99118b2d881326458f8bede038ddf51779bed99d581c6bdc31272fa5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/cak/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/cak/firefox-91.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "b0bec96b9bc4d6e43735964a2350182fd0f6e7ea142ac35b6b93a15926032bc9";
+      sha256 = "6c8ed355c7b6b50e9e1752543f7367fd2a1249ab54a7c459f53f0b3e9b5568ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/cs/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/cs/firefox-91.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "0e65a190647d2569421d07a12f742989acedb6804dcebe8cffe0582282edd5c2";
+      sha256 = "c2f42dc7fa41645583649aac6da440eb6868b42b4522330c282890bbd11a056c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/cy/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/cy/firefox-91.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "e45a94e9b12e039e99a061e994e6837037cb197268697ba374bc03d5102f94db";
+      sha256 = "0efe41d3566e6ee405f87c7e76c97725580c25cdcf4753eaac925baca52e31d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/da/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/da/firefox-91.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "d3798723fb877c8e0b5f0331251ee4088a32f05f2b42f7831792282eb474cc1c";
+      sha256 = "76f8dbe67bd73c20b219184337ca36b529ff5afbb38278975acc2579c497c938";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/de/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/de/firefox-91.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "e14dbc808f746c828a8c8a81a7d860bcb89135bc7f8efe8975700117a54da18e";
+      sha256 = "a0886d38dc116d087f3cd06aad8f496f7c969bdb0761a4da09621b04b1c4dad6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/dsb/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/dsb/firefox-91.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "fc9ac755e5d3259e57c292f2b883d88e34c7962e0a9311652d1c5e9978c26bce";
+      sha256 = "f84647095269cbe6714109ffc8432606be0e3ec7664c26680fbe9d79eaaf6274";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/el/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/el/firefox-91.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "20fb8f044aed5e440c31c201e6b9abd7e167fb2aaab248374a7e109e34048e78";
+      sha256 = "5773765759d427f491ee809c89fe038f43fb0e0680047ae072fdca973439107f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/en-CA/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/en-CA/firefox-91.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "031594c33c321c59a33fae75556c5da68d9ef3553b56a4ebd590ef2205229836";
+      sha256 = "694df869386c430f5f410e81ecd1e6d9f50448dc1bf8773ff544e40f86ba9015";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/en-GB/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/en-GB/firefox-91.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "02f3ac078c7e071f73fa4ff1fb6e4d01b4f9417ee6b6d9d03837b8560bc7375c";
+      sha256 = "abaccbf19c75df6a077a669f3c70380d589756768f776874c7b44253876cd645";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/en-US/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/en-US/firefox-91.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "bced054543003caf29d0c93aa63359809bdf1f1fcbca92b82c57167fe94ca1c9";
+      sha256 = "f3cce733e83ea3abc8085a9809a03afc8caafe6d858f9da5f1823789ee740307";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/eo/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/eo/firefox-91.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "9bf644eb700c30c078377a44cfdfe58ee9cf376d508bd4c815d125255e11dd72";
+      sha256 = "0f7a104438d8175f22998c3e626cac6a85ceb955201bc0961c9f50a2d3c6942d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/es-AR/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/es-AR/firefox-91.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "54069c3a8988e50639e3f3a0126c3607360ccbff04ef979f7c5347a395ad9971";
+      sha256 = "6622a16486eff0dcb34c77882dccf94f7e85d22c09e04c6ef8e2be2eb7ca4971";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/es-CL/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/es-CL/firefox-91.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "db78bb546dfeb835b1d1a3c22337b388d50ea73a46af94d2f506442e45328725";
+      sha256 = "06208db32a2bc11296aa516c83394162e96da2f2e2d947ec56aeacc3711f9c2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/es-ES/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/es-ES/firefox-91.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "1311a3c391a2b3f3f4487acedb43be984f094e8adbd3e0bba1d9f2554c74899d";
+      sha256 = "edeec59af78cea871f1ffcbf49194eb0395300160373c5a51716e3bb3ef528a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/es-MX/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/es-MX/firefox-91.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "6a2a590aa416415dfd2a17646d53bb7430ba79d2b882322e1cddf8a8633ee5ba";
+      sha256 = "157f71cde8354b5c8a03cfd106a17a4748592030177b804432e8d61af7a99bd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/et/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/et/firefox-91.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "80ff6ea68418a46059376332a3bb9a476f43a9af2949f50061582bebea8f5635";
+      sha256 = "4e90edde6e458a7858e01247c09a585e78eeadfcdd756b0c5cb18a0ea6e587bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/eu/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/eu/firefox-91.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "d3a53a13a88fb8071589e81a620b476396ee8e09815b3287733ab3bfd5fc30d1";
+      sha256 = "01b398b9ad33b3543a0dbf2d0fbc425044d3204109b14d8d0b9aa894c0a3003b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/fa/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/fa/firefox-91.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "ec7144fd10c0c34ee41866a55426d9929f139813a1f238f79b48f3c2753595a7";
+      sha256 = "7687e30c2812033ad6c36c2abad3bb3e2983bc7c6554ceb8de331e9f168ad4dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ff/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ff/firefox-91.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "9b03ba831ee43a0a44a658c1788a705727c9f38c5a55ec9524547989a624973a";
+      sha256 = "05dbe4360ec07378ab16c3e7e0b7554107a7d2277f330a68d48f91177386ecfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/fi/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/fi/firefox-91.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "b3293e17a72b9259e8e124f3bb49f43150c0e44bc987c5e181db91cbe1994a89";
+      sha256 = "98c4a8299bad3392ec33315034828a322189f67c90d10dff6cd76c74de0579d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/fr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/fr/firefox-91.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "be60d1bbb97879148d4bda0718ba5b27c6611ff094113e0fe5ac8ec774e5f831";
+      sha256 = "f0ebd26d849f54b87e3330629cacf0928804c2bbe739533e64105391e67dc579";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/fy-NL/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/fy-NL/firefox-91.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "dda8ec3b7886874d52402e306f3520818298881cfe60f028d257031747cab7eb";
+      sha256 = "5ce2534b6298c2d2796445d5ddb7b6bcd0643dbcf17a96177130df8f481eda86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ga-IE/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ga-IE/firefox-91.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "fdc5645d6896420fa7c4fbd8398dff53a3896ffdfaccf0f3d9a8735e77cb30ac";
+      sha256 = "80a422b732154d75b5e6a56082b367506bb04629dff74d26dd412ccab3a94a41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/gd/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/gd/firefox-91.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "741c3e7139eae2ee4825ca7eabc62cfb3c4bbe4bfdaa79632f713344ecbe5b4a";
+      sha256 = "f277afca343edbf9dbe56c2fe84d0d7204ba70501894cec0107e6cbab112c213";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/gl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/gl/firefox-91.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "1cb6980e1ab247fc8f60cca701ade8a6a2185adbd413579d38ce0137d6def58c";
+      sha256 = "f5d238ec36d881729dc6b92b41cf73fdcf73419f4706e1578bb226769d272f69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/gn/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/gn/firefox-91.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "0d8c4f389cdf4ac429b6bc1de5b872f3e1bdec8aae938603cf0ec6318a967357";
+      sha256 = "bddab5b3c78078c70d80a99eb963dd7c159f24acaf186f94ef2a032fd15ca1bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/gu-IN/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/gu-IN/firefox-91.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "8bc81a38b954a1a2677942b41c2ea1f8b3daafded0443a88137cdf071e48a4ec";
+      sha256 = "a4a62c689fe6aa5b2c0f0d196fccc5ad6dba42fc4616c25ad45ecdfc18db6c39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/he/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/he/firefox-91.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "8772cb5fdab78a1fc713500e03579ec78bca60acd35361a8c073d8155c74be61";
+      sha256 = "06a9b9b88f458af96e500d1ddcc58ee587cd3595d152a155a90bfcb9695cf6b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/hi-IN/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/hi-IN/firefox-91.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "cf93177250cfb1c452f34666816db7d35db312db39bcc09c78bd098e5d76cfab";
+      sha256 = "65a1f2e57f0ec59e8b1b6995b6f7c2511b56557abb35f4bb77a0b7fa0e07fc53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/hr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/hr/firefox-91.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "163f82311bcf2828055b6290a140dce79dc764a299857d064b727aac379e9de3";
+      sha256 = "1dc71379aed8b5537bd751db50c4810f7fa5940575341921b4e111c6b727ac6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/hsb/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/hsb/firefox-91.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "fd1877100bfd2652b34424c8e8555d3d2dd7ef9e37fd3313247a2b44e6fe63db";
+      sha256 = "acd5df918ef7e09d08a6fb94696d9a15431e5c899f8137caa8431b2f38d9962a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/hu/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/hu/firefox-91.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "26d98047b977923cac28ae2f8134c2c1291a3b39b733b3ef433366a550b85b4e";
+      sha256 = "afeb9429b3aad80c7f92bde3c42c4cf8e6b1e51e221b62a2e7d405da5f1c9ea3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/hy-AM/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/hy-AM/firefox-91.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "c2c4263d6b5052494412b48023b32c27ce4f155e9e1c4f92ef1f49cb40f5fadf";
+      sha256 = "bf5fc5658ae5ba925685d06340ef66fe3d80eeb6297406637cb4ee8d05f02f57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ia/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ia/firefox-91.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "4e1cbbda4d6f0db79ea79c01f442f15216deef7cbb65d302d8ca89f21eba8d6f";
+      sha256 = "d5269e41a98722c264fc6a9e3299d667bd2f8796b2640989c853e6f1b0beab39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/id/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/id/firefox-91.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "5e783893a5bc0182e376628a39a2c30c35d97e97f4196161269774771c22c1f5";
+      sha256 = "47e2e461b7635f7026af8685c2dc6aed981b3e5c8e6953ea855bd08af2a6ee81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/is/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/is/firefox-91.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "924003de57aab415942d169300f527b4fb1416c85d84c6940c5f480dbdb2e349";
+      sha256 = "3d93b22ad196777b13ba6d17871fcc46cb6ecde1e8775171624cbd9d527fa345";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/it/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/it/firefox-91.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "f779166a2f93b732cbf12a3877dacc83c57a067d6746919e75134c42a2094c92";
+      sha256 = "310b5f10f1ff96805f691dfcf0f8c034a9a1a54e84d6e0ae5ecaafa8ab229764";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ja/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ja/firefox-91.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "571c88dab620d3b39a306fc4800fe97b1b5a93fc8c91d5363f387b34313efb70";
+      sha256 = "6e50b5b236da722a01c11402fc6fb5ff362d9c6476ac43815d5c7f48245d158f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ka/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ka/firefox-91.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "947cdd7809a90dc742fff69dfecad91814b7b670d618f7be2958efb0d3b4823e";
+      sha256 = "e39a97ca32c43d53e95af91de0e58051fc74174eead6ce4346d8a201fed56800";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/kab/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/kab/firefox-91.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "a8815674bb41de86bf4cfcfbae800f1b4f72b7bea75f0fb197f86e49b51283a7";
+      sha256 = "851f4eb72487e5a22777905017e91d9b55e6f10eb06ef366e24d4d96272e18e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/kk/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/kk/firefox-91.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "11756fdb24cc2627f91b92b62972f5aa17262b04d993c2555e887290388743c4";
+      sha256 = "cf83913fd67615c8ed9d542c75d22401b051760eb4c0c4e2a5367f954d473dbc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/km/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/km/firefox-91.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "3282b75df7fb48207fab2d7079066854a95aed9069ef69a6fd57f527f72a70b4";
+      sha256 = "82343a709dbb9061d5a71b1f8c5be6adbd8f27e9c0016ff6d0a0ed395f75e4d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/kn/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/kn/firefox-91.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "8af46418c39dc85d02749ee2ef42199c90e1d05817bf863df7bf5a102bd9c040";
+      sha256 = "56fe5ee2e6abd203252ec8643bef2fd019c53ee298ac063ee492c67c6377dcac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ko/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ko/firefox-91.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "466117f4af7f2c5bfde4ae6e50e000f28bc438c5c7230235316a7779379f66c4";
+      sha256 = "dbcfce2f941e817cdf6427ef70c3ce1b7d14898ee9b3a30e470d7ce604f4d816";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/lij/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/lij/firefox-91.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "0c8901115e01d2aa332e141b3e01d83afe6f38ffba51fa739bb31d1d6a291b40";
+      sha256 = "7764585a7bb44f5d139cf822ddd2f89ae12c32ece08844549724b805ed1c86af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/lt/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/lt/firefox-91.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "5c37c92c2ee1bd13cd0a3446ce9442898b2a0d384a27247fbd4306ba1eefb300";
+      sha256 = "a64c6ee25e8011f63651085ff3c1c853cbeab97ad24d8988d5c419ac2f3fe660";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/lv/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/lv/firefox-91.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "f0fd8eaa7ea7b5b89ff7e8c2ee80cd79d9ad8d00a6e1609e0ec7a7b898cb7dd6";
+      sha256 = "a7bb8ede18fbe6d9d75d9327104e4f0cef1aa6ae8add6045b6952e4c4c4c9df0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/mk/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/mk/firefox-91.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "4d382a3c88f53c2430a19d09d59482f574ee950f54a7c7e06abc3d2cde1a131b";
+      sha256 = "c8cb79bd2d0f244aa6b236ebd026c79b25ebbc23d53f429bed4d00e333180f6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/mr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/mr/firefox-91.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "7af396b0a6c69ceda9689560b36b4f884c44a7909a6b75494ee1f11b54c0e0dc";
+      sha256 = "5b451466b9f21f4163c0339c226c475c1d5519e947f98a544fb4fd2a315b2652";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ms/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ms/firefox-91.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "d9eb79856c9222ca8ca0c458c38203fa25ecec1dbf480002db5278de87e872bf";
+      sha256 = "2fc219544e852aae4bc65b97b6a2cf90509eecfa8728358e9bb747c309d7e3a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/my/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/my/firefox-91.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "5ce0929aa7b0d12d2ed6e38d72245de0d37fdd3e7e69a618a3301b8bf83c7dfc";
+      sha256 = "fb2ef8be7e7e553a9529def262c5b072a4a6f36d459858be81ce4d7d7d7f65ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/nb-NO/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/nb-NO/firefox-91.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "62d9169d11f6e9812dcdbaf19e38168cb9cdb2b1e6b17e9eac87e7c2e518ecea";
+      sha256 = "67bd49a41d34a1f2f14f9fa98998b49b4837c9cf90bd0d393eb9454248562f3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ne-NP/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ne-NP/firefox-91.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "2bab2d066daa1d56e23db20bd65a94a74d8421556eef47fc8c3d5b647ebd196c";
+      sha256 = "3cf1ec8e18765292105f092e199806281d8e5c10e24b1a2ad02f3cc8e2a03384";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/nl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/nl/firefox-91.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "c627406d909e1e69c5bb229d87a9f99bfddd5014c5911089384275701b580af4";
+      sha256 = "c4254c7b2b54abc68ea1ea01fe3ca3a47745477d7e972c1e242288b799035457";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/nn-NO/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/nn-NO/firefox-91.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "2d365f5aeb223248d3c3f4e40618bcba411f64e3b034ec9f9b1a629e7e416037";
+      sha256 = "629b16c5b060d20b4992aa9b4f6601c13495ba8e0f48e6bed299fbb2db1b2dbf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/oc/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/oc/firefox-91.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "a246c0a9aefd8803aeb20ccfbb9f8613f9028fb590e349e0b277d314e0ddb1ac";
+      sha256 = "ddd22460bc90e2b0ea468923478114d55ced9b351b954ce354142a93321e369f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/pa-IN/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/pa-IN/firefox-91.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "d28023509c07e7f8792e2efbfa9d38574a52d82bcf178a34fcf93af5fedd0f59";
+      sha256 = "9f8127b05b46dae4d3f953d83d10815f29e3c7c3d84631be488d68005a81f803";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/pl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/pl/firefox-91.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "79a4f0253b27e69abd67a2aba53dc0290e4ad74740f7dc2977230b1761ecce0e";
+      sha256 = "05dda135b165b1f3e90432a25846d1f9deb0e0e4eff4985bc0b8156d4ce03db9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/pt-BR/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/pt-BR/firefox-91.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "9c7f200e5777153be99946ef551341e6ad82f123e1d6ca449b369ffaf7fc1b64";
+      sha256 = "6fc80a89332e3f7fbb15ef035f53a854a408209e1d1a2e12adeffd51e3c7a49d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/pt-PT/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/pt-PT/firefox-91.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "f8d035f3d1fe0a7c0ef42a416ee74974ddc088c5f2a9c0b1668952ba84c5aa10";
+      sha256 = "542e38d07c041845abff165eb17740cf729075020a210e4b11b3a7627c325668";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/rm/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/rm/firefox-91.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "600e5dbe6780aa21f2b0738bb2062cf5bbc9b6ccda92512f5d94b4e3410ec15e";
+      sha256 = "6a484c541b31400b30c193697d5512ed6cccf228c58bc8953187451ceab255e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ro/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ro/firefox-91.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "a9c1e0c650d7502e9130c7bfd96acdac87c7cdad4f63dcf963dec2954f45dfc6";
+      sha256 = "a235174d99da396b491b0ba802558b6ae8e124ad3baa80bc471b65b34ec8cd33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ru/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ru/firefox-91.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "56c911b0973e9ffb0d4ad2252dc75602b6474d0f85d2ecacec5c3cb3895bb374";
+      sha256 = "e0e6584185798695f92b34bfef5643a8e60e8d8745e8162b4e1de5962a91f072";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/sco/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/sco/firefox-91.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "db2b0fefa6089d28a66b5606b7d32535c1c82795c9a45812ca7a606c1fec013e";
+      sha256 = "bfc2e413320b9bd4479aa36d41fcf881237f6051b978dfb6e0ac8871dc43f272";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/si/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/si/firefox-91.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "294bc137b4c56d7c65927078bb6adc2f2299d3645749d75b6a66be060f0e6bd6";
+      sha256 = "91b68d52ee3f49e922d9bb85fb34ce8f81f4413f4246d2131430606cdf0dbf27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/sk/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/sk/firefox-91.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "a75cc03d71e7b4de99e0976f82fa7771f41179ed1517812bc3de9bae323bb21f";
+      sha256 = "6e705eec8f8c99cd8f7761a65df781b094276f3c4ea2483dfab4a2344755aee0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/sl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/sl/firefox-91.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "e4706fc5dcd19aa946f5b3701e4e89b508fffc7c6f89648730f5bc61bacfd894";
+      sha256 = "4f868d14d0b0f07e5f2204fae2bf3074e9b4b9ad20c715f3618e20fbf5340046";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/son/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/son/firefox-91.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "a4ed3b6fd7d4794406daca865db37e9bd69aa8bae0bbd0925ed53a66a1c31601";
+      sha256 = "3d9596c5d74aff035ad15178d26d48cafb6baec6a3cbdabf4a9df10560558726";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/sq/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/sq/firefox-91.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "7ea16267ca165b630ccf3615778f29c2a8b85f860c179a87735c79a0d1d2d122";
+      sha256 = "c52577d01a098c808b83a21b9f49123287e58c2cde78818dcee5541b545c8924";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/sr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/sr/firefox-91.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "bb6024f56521965fd6415d9f5da8442e61a611a5f5e68a08c1b447fdc0ca7b47";
+      sha256 = "9ded38976438030a6edb5c4c38b1d6a6c5a32006afd2f72b2aadefd4e6a5e9c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/sv-SE/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/sv-SE/firefox-91.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "84bacbac0f236496e20e4de06de07ac13c86ee3b24ca20f9c878c131ca5d89d2";
+      sha256 = "b83c19762d22d7cd0f6f60e095bcc6245bba32695de6672caded6bbb0ebbae62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/szl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/szl/firefox-91.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "a0b13ca6141f650f67b362a8405006abfd46ee967bb51921cbe38a8dc11f03b2";
+      sha256 = "470d77255bab962ca51393593f4416e0a6464e9dbf65e2d3c735901709ade7db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ta/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ta/firefox-91.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "35a0d686c5183c7177cfba431716ce8016496d70485464292ec6fa5ff2fb3a50";
+      sha256 = "d2dbc50bab3854aa0b16580aeee2836e5a59a9cbbc7283230b8e1367f07cff8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/te/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/te/firefox-91.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "1482d773023a6a0b6a9c42bd076f6fd006e60d747ad4f54e4d55b4754208c5f8";
+      sha256 = "4f488f890cddeb3726ed745a3503a6efbf25081d91b3008b9b99e5c23753f75e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/th/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/th/firefox-91.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "c129a4749f879469d573160e3fcc389fc7c81de38afedf139a16345bc6fa44e3";
+      sha256 = "e988d6aa3392c68307767a01bef615186d8c40937f8efb39ddee7b0401a8b216";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/tl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/tl/firefox-91.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "c98142f0dd0aea08487b29a5aa59563ada4d66c7d79f0e6cec7dded01739c346";
+      sha256 = "d51ca2bcdaabb9bf6ca885cc7b01d1cf4cd13ba98fbc403c9fafe3b8d3870007";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/tr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/tr/firefox-91.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "11ccbbb58e92cae8cbc8a17f4a778d18a311fd8e15dc719a5a1ffb3d9315e853";
+      sha256 = "74a188ca542d32bda09a44fc5d7f11f4e0ff77f7cfb65b2b083a233f7ec164d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/trs/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/trs/firefox-91.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "790bdd26f40c7babfffc4acfec00b63a1e6697448895e9adc9031ec20ffc93ef";
+      sha256 = "7f458cd74a2798391cf46ecca3075e2d7a8fcb89bbec699d466fe02aef5ce1e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/uk/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/uk/firefox-91.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "59810f729ba81e20e1167d075065a4eba5bac092e6b9716c959ca62f1fa52e3f";
+      sha256 = "8b491ad4234b7bf1b920ad4456e1e416287fed0a272e4e49295dee5bbfa3081a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/ur/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/ur/firefox-91.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "01ab7a50f5def0b0d8981d12c1a82edb5b29ff5f94433d3b94abb1014943f698";
+      sha256 = "68ef530ab99c08854d99b7f9315ee4e5a664538be849b5654df47dc205bf2a78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/uz/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/uz/firefox-91.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "177c037b6bd0dbfa11717ee1a0aefe7b2d907d8e32ef2e788f459ce19e3ae5e3";
+      sha256 = "865aaed959c41461ba6c7275c36170bf633f8a2064612d6deb68fe98a34e19cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/vi/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/vi/firefox-91.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "ef73002956f865aaad63c41f4620c6cb8eb420f6b25b65bd0b2398823c6400b8";
+      sha256 = "00f2d6282faa8fcb0ecd7d4f5d07514ed9ae23d8cb8ea64ec9911a327153bb13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/xh/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/xh/firefox-91.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "7d3ab2b3a7e21be7d52f1bb88f76f563d5ce6f2c4d83d242308883e596fc254b";
+      sha256 = "9ef4bd1d054ea8c9773082699f1cc7b2493bb3eed8d99386db8ec6910ea828b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/zh-CN/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/zh-CN/firefox-91.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "48ded67925ff82690e75f17386cdf99f9967700a6eadb2b1b9512fb0d1e39a77";
+      sha256 = "b91a7fbd4478b913c29b295be9ca968b4992d38410dcdd63fffdb4750b10b872";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-x86_64/zh-TW/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-x86_64/zh-TW/firefox-91.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "58bb86a951dba4b1680890fcd1baf6fe3ca4f9ccc0bb661bcd84c232ae055f52";
+      sha256 = "4d2317c96524b21c842af70f6e4096be3518e707f894713d99edfc7d71153dff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ach/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ach/firefox-91.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "9dc06632248c42c4743fcc6c5c06860435b6c316b2db4587a357699ba15e2676";
+      sha256 = "d3bf432eec6a56c869c6c3f9cc25e99f6843b806c3a569fcfc8365cdaaf49bdc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/af/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/af/firefox-91.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "8ee2d5fe82aa9b3ab36e2cd6017cc4a83951c19b60a4e9ca8d1f73a186fb5f63";
+      sha256 = "bf00fcaf0d322e995ece30f7bc3479d37651f866607ead0090f429a4c582bc91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/an/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/an/firefox-91.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "7b6d9bae3389585e2c7733590b665aef2e96056f507309d860db207c00c7c972";
+      sha256 = "757247fac4eb7232a2668a56e547d031cb55ac76bd8b4c0143c637483ae8ea13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ar/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ar/firefox-91.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "44f858443e0778dc195a6bae64b33d93d052d156479d967fd11bff4a28db8cf5";
+      sha256 = "072237ecdaf5bccd8d99aa5ea00e0686a064554bf7039dfb37b05634879e0218";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ast/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ast/firefox-91.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "b9e8d9bc233e4fab3d889a82dce29e8c53bac412e828bab8471b28a8390c17e8";
+      sha256 = "cec45238e8e7291bde4d9bc66e489777280b80b6b2d38445899908ca0acf0251";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/az/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/az/firefox-91.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "e9e80694c86dbfc21b1b9d001c49a42ee0abb8f961266984f63605497dd2cb11";
+      sha256 = "6b178343e28818a29e64b24033e2b5851d77901c372d27ed94fdd93d566527d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/be/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/be/firefox-91.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "3fdbfaff86f74acc9566acb4b5df9c052128025fab15fb4d68933bacf64a3b05";
+      sha256 = "b7ec62a226648166d5942d6064df72e58a70d5ccb4c8489c7cf691bc10812284";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/bg/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/bg/firefox-91.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "becc7d28c6438082355f528867ed56bb812d6256a28d559dac88e8e2096a23db";
+      sha256 = "95eabbdb1016491e8daece292f12cad165eadc906bf7929121bef665eb15100b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/bn/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/bn/firefox-91.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "a65aabb5e1184814a1c6a7275039cf163aeacf0f73f80157c34be9cc419a41a7";
+      sha256 = "c07547743841020f6b8072a76e398ad067b9991955c73229e74bb28cbe4ba2f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/br/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/br/firefox-91.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "05add35005f3c323529d4cccfa2aad2883a5eaf61d87eba756ed88685b8bb2d7";
+      sha256 = "6c8edc45cf932549e92c1baee6bbbe06f2f412b4087f95ad1d77ac60d48742c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/bs/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/bs/firefox-91.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "8bb57da2a7d59e14fbbbd7c297776e54944e109f007d30fd0efca1cad00deb50";
+      sha256 = "7f175edda71591a1ff00679d79c51bb63d777090f8e9920280396dbcc2dd0c47";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ca-valencia/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ca-valencia/firefox-91.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "351b05ed3bb4cfa044fcba00fb36dcbabcc78f7ce0c8a38624b94895b1db43a8";
+      sha256 = "30bec0fa1b027f3dfe3255f214cfe2bc10b19346cc0ed9bd546d9ce63fe53de5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ca/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ca/firefox-91.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "03a71864efa362fbdad5ef7969af2340d59b198404dec6ccd417c380b3b9ee68";
+      sha256 = "33dbe31e5613ace4f58e5f748b58c7c6f9b0a2a192df660904d4c03a2f7faa0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/cak/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/cak/firefox-91.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "44592f26bc020539c7a73e9b2bc6f6ca6c847a44b03ca1f37541ce4c3347d317";
+      sha256 = "26b995231e3c95b8189114f1682f975b4e6041cb99e081af99ac215e2ad23352";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/cs/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/cs/firefox-91.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "24c900672eb370503598638c824efe999d1aa0fe007729c31d59363b93e803f7";
+      sha256 = "946a570a68551772a1590fc69f006f9269a3e669b002dfa0c30ae036c47b52ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/cy/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/cy/firefox-91.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "c1c7df2abedf6fc54b4051f782be997b2334be7a1d683c89c2291594bb9b3abc";
+      sha256 = "b5f2b8b412b149672646775c421d67f2b243d9fe16cabb3cd34e853b4ce2de8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/da/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/da/firefox-91.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "004c4c690e0873cd3b83c5e5ab914a58a3753b9b58ff5211a7ace303d6952417";
+      sha256 = "263430400e8fc7e1177923df2dee3eeba05680250e96303f63c8a6c2f163a36b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/de/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/de/firefox-91.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "dcc9d81a41c98767087e6936b4fe9db40ac1ef5851406aba0c636747c655c38f";
+      sha256 = "b90f12c6f4e09e2b8282bd87ad830932073bd41bece3f2309bc698491e4373ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/dsb/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/dsb/firefox-91.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "3bd88e656d10c9f163e96ed2049717021205ffcdc62a15c369775707df94e997";
+      sha256 = "e2bb197a3dd9864496e92f9280b2655e27cb4052e3c5ee17ea41b7387bff5a3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/el/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/el/firefox-91.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "af948701e0e5df6246993efa145d23e60f9e7cfb6188cde70f722a42fe7d89c8";
+      sha256 = "4018eb187e3534142c5fe760a4d35657693950119ce1aea6d6a0fab7177cbbea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/en-CA/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/en-CA/firefox-91.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "116109ef5e3a10b0f290eff480f107831673cb0b79f74e418ad92027311d4676";
+      sha256 = "3f52e42c0ca74036b65b0221eeceb382c7cf28aa63d70a6e26b7f0278da2086d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/en-GB/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/en-GB/firefox-91.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "0bc9532f7dc70234ae34b8d8121595782eacc9c28f178bb50ef7fdf16cb7a56a";
+      sha256 = "7a0e416b48038d7b827ec90d3f5b3656d5099e35283e09f0f9c2833e337f76f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/en-US/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/en-US/firefox-91.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "16264125112e0798570e2d9a996750e6ac6d009fd876987e0f3dd708e6c3ee45";
+      sha256 = "754be9b9e175fc43f96827dcbd894ac539ab4f882d8d078a1a24a8c60cd78fb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/eo/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/eo/firefox-91.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "937b62708e0b5281a14f933e2d599676bd552d06b428e14a1ce79f4b013999e2";
+      sha256 = "99c612d0748e8980e80750ca1a0477872bbc8151a0703c69bc85fb603dea352d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/es-AR/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/es-AR/firefox-91.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e4af8197d74256eb33f67021a4a3a224e5b9fa6140826a74ffed7a3adfe1735a";
+      sha256 = "49db8ffbc5c396d7eff390c0bd856ce9f9d38f878584beb8dde90476aaa70fb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/es-CL/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/es-CL/firefox-91.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "01b1808337c8e14febb6a673364e8fed637c450f6f00800c06af179b24952922";
+      sha256 = "9fdcd97e6301c2f650a5354b7284705be071f5736c7d356d19dfb097f033f5e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/es-ES/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/es-ES/firefox-91.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "2e6de3d841defda2ef527c6db82197b448dd5d066d32987f8c62a54b309cb953";
+      sha256 = "ec2fadaeb087f75172531077ed034a230d57385a05d170bdc0b1f0e5ccc86b59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/es-MX/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/es-MX/firefox-91.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "34d6894bda103dfa576b323f1f2fc365557978db64f400a4f98dcaedbd1248bc";
+      sha256 = "c268d56c1409c60a1d502b524391ea8cfc221e217cdd9e933b5af785486aaa36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/et/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/et/firefox-91.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "f46e4fc634af77c1a5e0f9a50aaa3f833bc0e023902b3fb02eba4e816cd0aa05";
+      sha256 = "e22530e22d58a82b0efc6f7f97b48e6b3a36164b65a7e7851fde4b92f6cfe63c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/eu/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/eu/firefox-91.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "fb7aecb90c1654ef0288a1339d95b3142378e6b254e84cc49398dd0e5d6e776d";
+      sha256 = "0602c61dc05853c4622cd420c93d85d70931ef4dfa240d9d5a342cc199159762";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/fa/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/fa/firefox-91.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "3241e8123ca000b90e08de54eb4acac68744acba60b1f90cbf2dc39c6f0f27ae";
+      sha256 = "6c77f6673f0b4745596be16273fd126f53798b3ef4c118f6602623f09452c317";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ff/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ff/firefox-91.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "feeede23f94ab3009132d9ba68cc0987fd43a8776eabdcbe82b1aedac75c5d13";
+      sha256 = "c492aeb925c7ca214fe74513d4296f6ed8774098709d2383101ff29274f2ef94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/fi/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/fi/firefox-91.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "253e7b236d36418a882e3a02284480b76a28bbf5946c39a128b7439a98a76670";
+      sha256 = "164d5579dbb14ad0335afce5fc99ab18e433f7c75920a6836d390eb67b8ac743";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/fr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/fr/firefox-91.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "79afba324b29e3c1e8ddb6a0b1f8fcd352833a18869aa14cf0498fa29a91ef44";
+      sha256 = "2b0f336fbb9496ee28d00114c4e6492663573a5e4fad4f1e40ab3a6a498645ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/fy-NL/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/fy-NL/firefox-91.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "b06223a20e076f45b5ed1025d155dea95580b5c9d7b07493b1450701de861c88";
+      sha256 = "ebae965bb9faafe4aaa781bc63551a9e885e77501e39aa8db81a03537e802777";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ga-IE/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ga-IE/firefox-91.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "30c47a2fc30dfc55f1afe0cc31d884c17cb1ecd052839e034898c038398317ba";
+      sha256 = "8b4640af9b69620b0dcbc07eb677624bfb0c210e8204ac421e5efb87ea8c5aed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/gd/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/gd/firefox-91.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "28f8328085cc3250893fe0e884b0ff615c794ee2cb4f24b94e165d3741bc6042";
+      sha256 = "336df4ba9eb7773eb59e1b437f9cea47ddcb25114f26982402792fae9fb6bc8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/gl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/gl/firefox-91.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "926069fec9a30185986cbfecd8a9c26915fd1e741e6ea0ffea0f6a20af2ddc99";
+      sha256 = "92917b113b9cb7d383e97fa542cedadc6cb37fcaf9f861bb68eafcf46faaf23a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/gn/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/gn/firefox-91.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "a8e18f3c9d6873e533cd5ccf5bae9567528b46b82c5e8d6f63bbcfeefdd66337";
+      sha256 = "8dace2530483ab4774e1d5377ec11b36b71a7af393ca6155db2acf223c74c433";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/gu-IN/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/gu-IN/firefox-91.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "565c9864f773d9815a5116502c0c6f5662f3b07c2f69a1a9ee3c9148e2535098";
+      sha256 = "982fa9b19585a12c53436eb4c76e75b0836b8ee55326bee0ca5d979af66094a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/he/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/he/firefox-91.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "537998ef23693ffeadc2f15b2a32b8c45473071b859363ba383621bae5b6a92c";
+      sha256 = "b74efdb1e0167e9b5fe3849df91b252a3958f308dffcf3d055840832b2f5bbed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/hi-IN/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/hi-IN/firefox-91.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "4cfb83db79ff8537ff210667f00d88f9155693e0872a4eeb5bfd9eff1ea66248";
+      sha256 = "4f51b08ce8029f1e4a7f9fd25c949255042b0f7dbd5a0a85800e1e914a56cf1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/hr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/hr/firefox-91.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "013e10a8b1144242a8bc4d27f3d8218c39982990ffeae323c238bdc65090f2ff";
+      sha256 = "48bf30b5955b2232ed55a9c67450662a3f378fe1e2c9e994ce68759540718d81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/hsb/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/hsb/firefox-91.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "8373057ef102f31d3cb262ab060215718eb4487acbd2275cd311be2b4932b091";
+      sha256 = "cd4a5758c4073b7d18da174b47e81a82ef828ef5791f49d47ee58fe43426964d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/hu/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/hu/firefox-91.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "4143a2d0e1696ec8fcaaaea9ac345bafa976123196fdddec5e94570db1e6f255";
+      sha256 = "012beccd9fbb7c561b8cbdaedeefbb2bde6ec5fee18208d9794ad04cecd25c6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/hy-AM/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/hy-AM/firefox-91.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "097bc98861b1d8396a0753bed6d483cfecc9a4ef63b286d6a150225f7e5a531b";
+      sha256 = "512f6679b880bc5b1f4f98dd74ee255f94592692ca7987a172bef20ac2722edd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ia/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ia/firefox-91.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "ccaafbc46e722de7d32ec09319bdd57c68b8ccc02393b5b0d95838507feb019b";
+      sha256 = "6d252ec4bcc81917fe61210c60deb87b187b13b6957d07d169339f31bae57ef9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/id/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/id/firefox-91.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "3e9497d12226458d962aa94207697c9694fdb30a2dcd42cdd1411bd83dfbdf64";
+      sha256 = "80b41c75ba207724bb55521a24292713862057cc1b05056dedf135c3e368346b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/is/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/is/firefox-91.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "80c5fb3f6a96195c6e023f37ec3aaf35ac30d6eb777d3b1c74f4d4898f4bbb52";
+      sha256 = "be35a2937d4fbab20386574d27dd714704338e313f6c4232005e50aedc52e75d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/it/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/it/firefox-91.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "375c5a338adb7acb2c1b192cf0d9e479a954866156f59c264f469a2894f50d39";
+      sha256 = "d05ecd1685954054601c848f59af446bdb5b3b1399d20421033448122e093792";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ja/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ja/firefox-91.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ab4298e63dd5625d0f7af12af53e5e78ecf50a5f95ae556c5d55ec49659ee74f";
+      sha256 = "a71d96f6b3d2e30d422a74b6656b78eb0d43be59c6e46db76bf6c8cae6e65394";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ka/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ka/firefox-91.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "a027603bdc4e5d67224a060b6577e3cc389e476df2af2b098c9d97aac3e694ed";
+      sha256 = "19629e7c91f887b4e5cb2a9a93ab2002d7409787a7e84ece914cb969724e9c7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/kab/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/kab/firefox-91.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "0b1c986ca661040a9902b875a8a64b83b05dadcbe03bdb0205eecc0886ef0c53";
+      sha256 = "36e9bcae974500da350a1f60114845a127862f972ff435378c45d18d950957d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/kk/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/kk/firefox-91.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "6cb3ceda7ba9bfa726909f390ed487904a284b84e2c522a7ea36fdeded22066e";
+      sha256 = "e19473a3dac5f41bf02b783427161c933257d68d24bddef0381354cd86ad5151";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/km/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/km/firefox-91.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "3b8c0530b4bff8f7b33d0fb70f322f1fc7a75d219bbdd7badb656e6740fdcce1";
+      sha256 = "7f1fc2bd4fafa346838fec02a64bafdf2cbde52550c2b28bc7190c35e72de939";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/kn/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/kn/firefox-91.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "462468372055c64b94df027aa4a9bd2d02f7c82bd4845667d974e6cf1c58f839";
+      sha256 = "3b27a6fe3eb654bf20d7b49e9deef1cd2dd44537b0d1de7b2ad7c63dbb2ad133";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ko/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ko/firefox-91.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "68ce96d841fc715897297dc0c4f9b9321e84298a789f9de49066d37cef1e368c";
+      sha256 = "40e8972a4b20e41ad4a24dc75064748e508e30bd7a33f9926cfa0693348f6222";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/lij/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/lij/firefox-91.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "843a9f5e1758344f51276d5dd77c901d85b5d2bc1d183c4390a9d7783e8c82a8";
+      sha256 = "7a7db77418d2dab962d26107cf54cb8d1eb743fb5324bb507016dd46c84f4fed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/lt/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/lt/firefox-91.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "97e3efa010e2fcd07750f808ec533efa858e70a664eab80d9550f0835adbd242";
+      sha256 = "094fe53032aa6df3ded2e4eb49d56588267f02c3378054ede51aa221d9d69dbf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/lv/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/lv/firefox-91.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "860b26016d587e24e9e7f308d39041418618564a6029334beed6b56244be7300";
+      sha256 = "668b677734c550c7e707f9e3b9c38e4c65d800fa902d1ee3d8c357116acf2700";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/mk/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/mk/firefox-91.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "3cf4e7e1a7bd6afa365574c5c8a94a64d6621ac2b40ae7c6f078a20f374f9719";
+      sha256 = "10c9760c2eea05c9d1187e3575cf80eee1be3b8eb40a6d401d924a6528ae1359";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/mr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/mr/firefox-91.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "334c149ee5079259772f102d81fb6fe31ff6d81755ca253da68fb48d6eb0605b";
+      sha256 = "bb1ad7d9dc90237c3bf914c33576024575c634fbdf682e0002a4d1edee011c7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ms/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ms/firefox-91.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "203ab92d93c0b867a01b1e1b41e65dc6beac79a5dcad040442d9c9ab54747df4";
+      sha256 = "49b4e751d17b6ca9f13d632b6b0e8815bfa503d28ddb22aab62b2247c91aced7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/my/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/my/firefox-91.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "09f23e56f10c34354bf17cd5f299d54425abb10b3c3ffac13ca70005b9530d32";
+      sha256 = "d546e7449ea8e68b948ebf33d9bf94fbce2f62f4b273830fe5f1e8228bbcf339";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/nb-NO/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/nb-NO/firefox-91.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "ea404f454d1a89fafa1591419c942ce9a72b7cdeb4361a0d47c4b8d3842de99f";
+      sha256 = "954bc07f32b59fccca996050240dcdfa76240b7f01929665431935834e50e170";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ne-NP/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ne-NP/firefox-91.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "b5a34f466497603b966502af30031a96a33deed13b83c95bdb83ac9b0dfbaf20";
+      sha256 = "ebf70abdcea48b9c9a4e0b5d5f4a80568a1c9215c93482a555eff5aacceba0ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/nl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/nl/firefox-91.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "b0767df12075247c2068103bf72adb881fb19ce021615dad7fb6dbbb4f563303";
+      sha256 = "1f780554975799773e5a8f158b50b188362f94174916a4e1f4ac005ac3538a6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/nn-NO/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/nn-NO/firefox-91.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "78767f2a1f367bd211760a3d96397a017c8757efe6da3c3d3db1f3d42a65995c";
+      sha256 = "0da1e744122f745522960dae64933f322410ab0439043da9d5785bd8d3af058a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/oc/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/oc/firefox-91.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "ed7db4b9c07e1ca0cc200aa4b110d069e537b91f3e7165b4e573cdd25722e23d";
+      sha256 = "14ff5cd790fba8dee449d7754c3c629db28d35e5ac8d0bae2880f11fdcfc1de1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/pa-IN/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/pa-IN/firefox-91.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "42648d9cbbba903d0b4f0b7c23e729a35a06935cee287e541e6523c051d61d96";
+      sha256 = "86366ec7227c08a72d9ba296bbc42401ce2c9cb6f5ed314d0a2eb686f9ec11fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/pl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/pl/firefox-91.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "478244c5a95ff65f0961ecd4cc3479f1824316a62a40a743d1c51a94a20ff0bf";
+      sha256 = "a1bec4f47cdef2cfd1c4253a47d1512b69aa5ae1b1f4f88f277387e983b4a2da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/pt-BR/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/pt-BR/firefox-91.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "5a8dd0db2148fd61d104121883fcb8626b8acc193397bc33c5ff6465379fdc2a";
+      sha256 = "f553fb4a38dc3c71ee1a37e56aa1719639ad9c83da5bf2c2757e73a362ca50f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/pt-PT/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/pt-PT/firefox-91.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "7a4d9201dbb8f085ae841e90d1c78af9e4c837454b1b9093b0e0d276457c8d8d";
+      sha256 = "6194d2616f2fe18b98c107b178014c65bc74c6c00cc744cd97ece3dbc844bb9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/rm/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/rm/firefox-91.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "634402368a039fb0d88f3e5dbec9696166207ba8dd5a1d4f1e8f823e9b30d3ad";
+      sha256 = "bf0c9adbd0a0ca0a00414e6ccbb09ef53a722d4cb5640584c95d40422a67a159";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ro/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ro/firefox-91.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "0323eb9385708a8c95f7fce30a00c7f66c42aa49560fee49e26fa5852165cd23";
+      sha256 = "20a69f3723937342eb53cfaa47fcb18ac50c0dfa641052fd3cc113af1804b508";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ru/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ru/firefox-91.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "67374f18744a069d1e8ae62ae531eafab600fd6082cc709cb2afd0e7a11f0bc6";
+      sha256 = "67ee468fed1c544aedb4e11aa217909e1dbf804f720b6899d9ccec396577e229";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/sco/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/sco/firefox-91.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "1ac45172f8d725b3a6dd96553a0d34d4c0869d83acc0c40951a442fac0db8743";
+      sha256 = "70c6309032e919f4b206f6de2b2cd233583422be15510b0fa6b1d1ed28444fec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/si/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/si/firefox-91.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "1b8d65efbc710cb981895c194fdf51902c88b6e4b7bc90a8a900f8d006783f00";
+      sha256 = "d102448eba1055c231ca8983fcbf0cfb57da9f7a43addedcdae44858ff387643";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/sk/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/sk/firefox-91.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "da72e14c76bd906f13aec33fb771f944d47cf03c90fcc88a7b4dda5765c62303";
+      sha256 = "4cc3e5e2c929a5b3775439509a4f917e85962bd9646397ca1c4d41eea83d6284";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/sl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/sl/firefox-91.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "93f932ce8352aba2dc29bbfd3d4cc68ade4b98194716aa8f00715bb5cc261f78";
+      sha256 = "ec8d97a98bf3c72a1dcef53cc09ea13d39f6ec6b60e1fc24ffaa3fdfeccbdc47";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/son/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/son/firefox-91.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "e4fd4ea76ad67dd640d4046e3829ffc8d347f4754fd828fc9238b91e1e740b47";
+      sha256 = "c5452583e32a70cd19f40572bce96f18ff37dd09b2116567c8b2867d0a2a2d10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/sq/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/sq/firefox-91.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "6fb7123f665de0d565cfcab0ed76b78672c3b1b7627c6024a8d4126d9adafbac";
+      sha256 = "a6d43eef8633ea4cb94307b40ccd76abffc5b59f28d42eead7cbcc9bb9e4bade";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/sr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/sr/firefox-91.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "d3bfbf5ec2d21c658661a601f1be2173415f0e20a433519d9639645b054553ca";
+      sha256 = "442905f80fd06bc19e3422ffe13c1acc98ab86681f1a829c0fc04bbb81f1f757";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/sv-SE/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/sv-SE/firefox-91.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "65e423386062c6d43fb3c1008f7a10d44facdfb113f77ed49a11e2922e1c6f97";
+      sha256 = "9943b50c9771a0fd7aca1c3197f8d1f4ceae0fbe2e48f636652c68748bf86826";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/szl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/szl/firefox-91.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "e072f5a41ba8f987ba49d33345a09a49fa9b8e170ccc6d3b40fac38c44393f85";
+      sha256 = "5de3407570162f1a458aef71f279c0b6a4f496b3e293a7b18d210e154ecafe1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ta/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ta/firefox-91.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "446149c944787c0ef6fd7735a8811d6510b81013e12642d426e5a9e4952576d8";
+      sha256 = "5b8185d511d8d40c8cea1fa542578fda89e3ae6c80b43a64d4942339968e2349";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/te/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/te/firefox-91.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "6033a318247e51b95d83b345d81825be172a411e47b12f6ab1ad3596a87e559c";
+      sha256 = "2afc3041ba9ef4ba74a0a1abd44b5e71270917a8f640dced04dad44da253f787";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/th/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/th/firefox-91.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "b3518819c570140b86b3c1941486e7392c0b4fecd99b74bf431fdc3f20568a6a";
+      sha256 = "4cd235f4b74d7e35bcd714acd2c9823ef790b40e77335faef7d024ddb9791adc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/tl/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/tl/firefox-91.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "527f34fe1b0dc17959a6d02dbc08d436938a0c0dc3d8fc2485fd107934293867";
+      sha256 = "885f1ce73b9633dca06ec91332d88e3783ed8a699cd9a56346c7d2a550511d80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/tr/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/tr/firefox-91.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "35f131cec53cd86ca34ee39aa8c827483178a49bf4c602923cc97587f10c6f6a";
+      sha256 = "485dbbf6ba54385ac605b627dd63adc1dd0b1f10b8e34f37b1aadc115308bf17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/trs/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/trs/firefox-91.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "374436eeb3ec60eb802421cd7aca90b9ddbb9ae986e132c2488474270b4bc349";
+      sha256 = "24d04d03c8e936ce614de375410c5da867995688118e469543fc66dafe6e1532";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/uk/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/uk/firefox-91.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "7779c3e4e09a5d9ebb4091b59cf699eef0cd758b2da84ba3844a21f74a5a10e9";
+      sha256 = "beb3566a07a5f1e1acd2aea6d78fc5b970929d7eab51a10d870866da916095c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/ur/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/ur/firefox-91.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "9cebe40000b97506e010b3126f7ad9f227933d29abbbcfb2d394d45132e99b4e";
+      sha256 = "39cbcffe0a7c4f490ff26366c2bdaec7b432ba4c6d00321141d05637a723b8c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/uz/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/uz/firefox-91.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "5a79be67283042db3e9906f19bfa2733dee22973559bc8909ab1dff3c2df6f77";
+      sha256 = "511fc678e43522fc8c5f33ea4ab9d1a06cf0b8946c7a520ec774e159be00861f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/vi/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/vi/firefox-91.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "6bf11408757a4861f776188efc8b6d88df387adf7870d90ff5d9a5e52f08466c";
+      sha256 = "637d3743e5a853a54872053f97b91ac664d303fab76b0d6553a4c5fe3817495c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/xh/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/xh/firefox-91.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "39b91255e9f61fc8e86025b05b30a8ff84b18cb696835d113247f15c582fd53e";
+      sha256 = "10594aaaf2b2fa1a71c90b0b0d900978d33bfdd4db00b133a37b4edb4a13c8e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/zh-CN/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/zh-CN/firefox-91.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "e9454287ed8f73c4829ab764ae7c62d96efce97cdb743b9f2951d010c434d833";
+      sha256 = "c6cb4c1d22d380b86910a5ec4971e1d40fd77669be9e16caf1e3962e80f3100d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0/linux-i686/zh-TW/firefox-91.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/91.0.1/linux-i686/zh-TW/firefox-91.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "c425ca54f5130d23b1b2dc513d52942e1b5603c803f138a9dcaf3cfed616af76";
+      sha256 = "79722e27df9badbac931d25f77b8d241d5568a34a586d0e34099ce3355677027";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -32,10 +32,10 @@ rec {
 
   firefox-esr-91 = common rec {
     pname = "firefox-esr";
-    ffversion = "91.0esr";
+    ffversion = "91.0.1esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "e518e1536094a1da44eb45b3b0f3adc1b5532f17da2dbcc994715419ec4fcec40574fdf633349a8e5de6382942f5706757a35f1b96b11de4754855b9cf7946ae";
+      sha512 = "79703b3ec615d10957350719b2c034df10fd47d140c3557cd7de665ef4430973b97c1906d5408ddaf8855c1424e87eb9b1b568322ad8fbdb956fca219a865d66";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -58,10 +58,10 @@ rec {
 
   firefox-esr-78 = common rec {
     pname = "firefox-esr";
-    ffversion = "78.12.0esr";
+    ffversion = "78.13.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "646eb803e0d0e541773e3111708c7eaa85e784e4bae6e4a77dcecdc617ee29e2e349c9ef16ae7e663311734dd7491aebd904359124dda62672dbc18bfb608f0a";
+      sha512 = "78a5dc8713ab879ebfc3b8fd7a8219844d06f0d897342fdf9a11471633d98e148ff85cf10e561899df4910b94a33b57709b64788df4621a8c0b83eb9a7102cef";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "91.0";
+    ffversion = "91.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "a02486a3996570e0cc815e92c98890bca1d27ce0018c2ee3d4bff9a6e54dbc8f5926fea8b5864f208e15389d631685b2add1e4e9e51146e40224d16d5c02f730";
+      sha512 = "9388789bfe3dca596542b082d0eca7b1a6d1bbbf69eb97cc445f563d1a5ff0c9b530f3be02ee290805e311b0fcb392a4f5341e9f256d9764a787b43b232bdf67";
     };
 
     meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Backport #134584 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
