### PR TITLE
python3Packages.webtest: 2.0.32 -> 2.0.35

### DIFF
--- a/pkgs/development/python-modules/webtest/default.nix
+++ b/pkgs/development/python-modules/webtest/default.nix
@@ -28,17 +28,30 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace "nose<1.3.0" "nose"
   '';
 
-  propagatedBuildInputs = [ webob six beautifulsoup4 waitress ];
+  propagatedBuildInputs = [
+    webob
+    six
+    beautifulsoup4
+    waitress
+  ];
 
-  checkInputs = [ nose mock PasteDeploy wsgiproxy2 pyquery ];
+  checkInputs = [
+    nose
+    mock
+    PasteDeploy
+    wsgiproxy2
+    pyquery
+  ];
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [ "webtest" ];
 
   meta = with lib; {
     description = "Helper to test WSGI applications";
     homepage = "https://webtest.readthedocs.org/en/latest/";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
-
 }

--- a/pkgs/development/python-modules/webtest/default.nix
+++ b/pkgs/development/python-modules/webtest/default.nix
@@ -14,14 +14,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "2.0.32";
+  version = "2.0.35";
   pname = "webtest";
   disabled = isPy27; # paste.deploy is not longer a valid import
 
   src = fetchPypi {
     pname = "WebTest";
     inherit version;
-    sha256 = "4221020d502ff414c5fba83c1213985b83219cb1cc611fe58aa4feaf96b5e062";
+    sha256 = "sha256-qsFotbK08gCvTjWGfPMWcSIQ49XbgcHL3/OHImR7sIc=";
   };
 
   preConfigure = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.35

Change log: https://github.com/Pylons/webtest/blob/master/CHANGELOG.rst#2035-2020-04-27

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
