### PR TITLE
rdrview: unstable-2020-12-22 -> unstable-2021-05-30

### DIFF
--- a/pkgs/tools/networking/rdrview/default.nix
+++ b/pkgs/tools/networking/rdrview/default.nix
@@ -1,21 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, libxml2, curl, libseccomp }:
+{ lib, stdenv, fetchFromGitHub, libxml2, curl, libseccomp, installShellFiles }:
 
 stdenv.mkDerivation {
-  name = "rdrview";
-  version = "unstable-2020-12-22";
+  pname = "rdrview";
+  version = "unstable-2021-05-30";
 
   src = fetchFromGitHub {
     owner = "eafer";
     repo = "rdrview";
-    rev = "7be01fb36a6ab3311a9ad1c8c2c75bf5c1345d93";
-    sha256 = "00hnvrrrkyp5429rzcvabq2z00lp1l8wsqxw4h7qsdms707mjnxs";
+    rev = "444ce3d6efd8989cd6ecfdc0560071b20e622636";
+    sha256 = "02VC8r8PdcAfMYB0/NtbPnhsWatpLQc4mW4TmSE1+zk=";
   };
 
   buildInputs = [ libxml2 curl libseccomp ];
+  nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     install -Dm755 rdrview -t $out/bin
+    installManPage rdrview.1
+    runHook postInstall
   '';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Command line tool to extract main content from a webpage";


### PR DESCRIPTION
###### Motivation for this change

Updated it.
Added man page to output too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
