### PR TITLE
aws-c-common: disable flaky test

### DIFF
--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, coreutils
 }:
 
 stdenv.mkDerivation rec {
@@ -21,6 +22,13 @@ stdenv.mkDerivation rec {
     "-DBUILD_SHARED_LIBS=ON"
     "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
   ];
+
+  # Prevent the execution of tests known to be flaky.
+  preCheck = ''
+    cat <<EOW >CTestCustom.cmake
+    SET(CTEST_CUSTOM_TESTS_IGNORE promise_test_multiple_waiters)
+    EOW
+  '';
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

this aws-c-common test is known to be flaky.
I've opened an issue upstream, without answer. https://github.com/awslabs/aws-c-common/issues/834
I propose to disable it for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
