### PR TITLE
s6-rc: fix cross builds that run s6-rc-compile

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -15,6 +15,8 @@
   # TODO(Profpatsch): automatically infer most of these
   # : list string
 , configureFlags
+  # : string
+, postConfigure ? null
   # mostly for moving and deleting files from the build directory
   # : lines
 , postInstall
@@ -78,6 +80,8 @@ in stdenv.mkDerivation {
     # http://www.skarnet.org/cgi-bin/archive.cgi?1:mss:623:heiodchokfjdkonfhdph
     ++ (lib.optional stdenv.isDarwin
          "--build=${stdenv.hostPlatform.system}");
+
+  inherit postConfigure;
 
   # TODO(Profpatsch): ensure that there is always a $doc output!
   postInstall = ''

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -1,4 +1,4 @@
-{ lib, skawarePackages }:
+{ lib, stdenv, skawarePackages, targetPackages }:
 
 with skawarePackages;
 
@@ -29,6 +29,25 @@ buildPackage {
     "--with-dynlib=${execline.lib}/lib"
     "--with-dynlib=${s6.out}/lib"
   ];
+
+  # s6-rc-compile generates built-in service definitions containing
+  # absolute paths to execline, s6, and s6-rc programs.  If we're
+  # running s6-rc-compile as part of a Nix derivation, and we want to
+  # cross-compile that derivation, those paths will be wrong --
+  # they'll be for execline, s6, and s6-rc on the platform we're
+  # running s6-rc-compile on, not the platform we're targeting.
+  #
+  # We can detect this special case of s6-rc being used at build time
+  # in a derivation that's being cross-compiled, because that's the
+  # only time hostPlatform != targetPlatform.  When that happens we
+  # modify s6-rc-compile to use the configuration headers for the
+  # system we're cross-compiling for.
+  postConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+    substituteInPlace src/s6-rc/s6-rc-compile.c \
+        --replace '<execline/config.h>' '"${targetPackages.execline.dev}/include/execline/config.h"' \
+        --replace '<s6/config.h>' '"${targetPackages.s6.dev}/include/s6/config.h"' \
+        --replace '<s6-rc/config.h>' '"${targetPackages.s6-rc.dev}/include/s6-rc/config.h"'
+  '';
 
   postInstall = ''
     # remove all s6 executables from build directory


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The reason for this change is explained in the long comment I added.

Here's a simple example of the problem:

```nix
let
  pkgs = import <nixpkgs> { crossSystem.system = "aarch64-linux"; };
in

pkgs.callPackage ({ stdenv, s6-rc }: stdenv.mkDerivation {
  name = "s6-rc-compiled";

  nativeBuildInputs = [ s6-rc ];

  buildCommand = ''
    mkdir in
    s6-rc-compile $out in
  '';
}) {}
```

We're cross compiling for aarch64 here, so we'd expect the scripts generated by this derivation to be things we could run on aarch64. But when I build this on my x86_64 machine, without this change applied, $out/servicedirs/s6rc-oneshot-runner/run gets generated full of references to x86_64 non-cross store paths for execline, s6, and s6-rc.

With this change applied, the scripts generated by the above expression now refer to the cross-compiled aarch64 store paths for execline, s6, and s6-rc.

***

As an aside, having to add the postConfigure argument to buildSkawarePackages made me wish #75322 hadn't been reverted...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
