### PR TITLE
python3Packages.versioneer: 0.19 -> 0.20

### DIFF
--- a/pkgs/development/python-modules/versioneer/default.nix
+++ b/pkgs/development/python-modules/versioneer/default.nix
@@ -3,12 +3,12 @@
 
 buildPythonPackage rec {
   pname = "versioneer";
-  version = "0.19";
+  version = "0.20";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a4fed39bbebcbd2d07f8a86084773f303cb442709491955a0e6754858e47afae";
+    sha256 = "sha256-Ljk2AOwnF7efWcmE942TX3bkbEyu+HWoe4tO1gLy/2U=";
   };
 
   # Couldn't get tests to work because, for instance, they used virtualenv and

--- a/pkgs/development/python-modules/versioneer/default.nix
+++ b/pkgs/development/python-modules/versioneer/default.nix
@@ -1,10 +1,13 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27 }:
-
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "versioneer";
   version = "0.20";
-  disabled = isPy27;
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -15,11 +18,12 @@ buildPythonPackage rec {
   # pip.
   doCheck = false;
 
+  pythonImportsCheck = [ "versioneer" ];
+
   meta = with lib; {
     description = "Version-string management for VCS-controlled trees";
     homepage = "https://github.com/warner/python-versioneer";
     license = licenses.publicDomain;
     maintainers = with maintainers; [ jluttine ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.20

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
