### PR TITLE
spandsp: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/spandsp/default.nix
+++ b/pkgs/development/libraries/spandsp/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, audiofile, libtiff}:
+{ lib, stdenv, fetchurl, audiofile, libtiff, buildPackages }:
 stdenv.mkDerivation rec {
   version = "0.0.6";
   pname = "spandsp";
@@ -8,7 +8,19 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" ];
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
 
+  configureFlags = [
+    # This flag is required to prevent linking error in the cross-compilation case.
+    # I think it's fair to assume that realloc(NULL, size) will return a valid memory
+    # block for most libc implementation, so let's just assume that and hope for the best.
+    "ac_cv_func_malloc_0_nonnull=yes"
+  ];
+
+  strictDeps = true;
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
   propagatedBuildInputs = [audiofile libtiff];
   meta = {
     description = "A portable and modular SIP User-Agent with audio and video support";


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for spandsp, a dependency of gstreamer-bad.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
