### PR TITLE
libbs2b: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/audio/libbs2b/default.nix
+++ b/pkgs/development/libraries/audio/libbs2b/default.nix
@@ -12,6 +12,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libsndfile ];
 
+  configureFlags = [
+    # Required for cross-compilation.
+    # Prevents linking error with 'undefined reference to rpl_malloc'.
+    # I think it's safe to assume that most libcs will properly handle
+    # realloc(NULL, size) and treat it like malloc(size).
+    "ac_cv_func_malloc_0_nonnull=yes"
+  ];
   hardeningDisable = [ "format" ];
 
   meta = {


### PR DESCRIPTION


###### Motivation for this change

Support cross-compilation for libbs2b, a dependency of gstreamer-bad.

prevent undefined reference to rpl_malloc when cross-compiling

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
