### PR TITLE
gpgme: move flaky patch URLs to local files.

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -21,22 +21,10 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (fetchpatch { # probably included in > 1.16.0
-      name = "test_t-edit-sign.diff"; # we experienced segmentation fault in this test
-      urls = [
-        "https://files.gnupg.net/file/data/w43xz2zf73pnyqk5mm5l/PHID-FILE-hm2x5mjntsdyxrxve5tb/file"
-        "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=patch;h=81a33ea5e1b86d586b956e893a5b25c4cd41c969"
-      ];
-      sha256 = "1xxvv0kc9wdj5hzpddzs3cn8dhmm2cb29224a7h9vairraq5272h";
-    })
-    (fetchpatch { # gpg: Send --with-keygrip when listing keys
-      name = "c4cf527ea227edb468a84bf9b8ce996807bd6992.patch";
-      urls = [
-        "https://files.gnupg.net/file/data/2ufcg7ny5jdnv7hmewb4/PHID-FILE-7iwvryn2btti6txr3bsz/file"
-        "http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=patch;h=c4cf527ea227edb468a84bf9b8ce996807bd6992"
-      ];
-      sha256 = "0y0b0lb2nq5p9kx13b59b2jaz157mvflliw1qdvg1v1hynvgb8m4";
-    })
+    # probably included in > 1.16.0
+    ./test_t-edit-sign.diff
+    # https://dev.gnupg.org/rMc4cf527ea227edb468a84bf9b8ce996807bd6992
+    ./fix_gpg_list_keys.diff
     # https://lists.gnupg.org/pipermail/gnupg-devel/2020-April/034591.html
     (fetchpatch {
       name = "0001-Fix-python-tests-on-non-Linux.patch";

--- a/pkgs/development/libraries/gpgme/fix_gpg_list_keys.diff
+++ b/pkgs/development/libraries/gpgme/fix_gpg_list_keys.diff
@@ -1,0 +1,12 @@
+diff --git a/src/engine-gpg.c b/src/engine-gpg.c
+index b51ea173..4e74665e 100644
+--- a/src/engine-gpg.c
++++ b/src/engine-gpg.c
+@@ -3005,6 +3005,7 @@ gpg_keylist_build_options (engine_gpg_t gpg, int secret_only,
+   gpg_error_t err;
+ 
+   err = add_arg (gpg, "--with-colons");
++  err = add_arg (gpg, "--with-keygrip");
+ 
+   /* Since gpg 2.1.15 fingerprints are always printed, thus there is
+    * no more need to explicitly request them.  */

--- a/pkgs/development/libraries/gpgme/test_t-edit-sign.diff
+++ b/pkgs/development/libraries/gpgme/test_t-edit-sign.diff
@@ -1,0 +1,125 @@
+From 81a33ea5e1b86d586b956e893a5b25c4cd41c969 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ingo=20Kl=C3=B6cker?= <dev@ingo-kloecker.de>
+Date: Sat, 26 Jun 2021 18:02:47 +0200
+Subject: [PATCH] core: Fix use-after-free issue in test
+
+* tests/gpg/t-edit-sign.c (sign_key, verify_key_signature): New.
+(main): Factored out signing and verifying the result.
+--
+
+Factoring the two steps of the test into different functions fixes the
+use-after-free issue that was caused by accidentaly using a variable
+of the first step in the second step.
+
+GnuPG-bug-id: 5509
+---
+ tests/gpg/t-edit-sign.c | 54 ++++++++++++++++++++++++++++-------------
+ 1 file changed, 37 insertions(+), 17 deletions(-)
+
+diff --git a/tests/gpg/t-edit-sign.c b/tests/gpg/t-edit-sign.c
+index 2f983622..e0494c54 100644
+--- a/tests/gpg/t-edit-sign.c
++++ b/tests/gpg/t-edit-sign.c
+@@ -107,31 +107,19 @@ interact_fnc (void *opaque, const char *status, const char *args, int fd)
+ }
+ 
+ 
+-int
+-main (int argc, char **argv)
++void
++sign_key (const char *key_fpr, const char *signer_fpr)
+ {
+   gpgme_ctx_t ctx;
+   gpgme_error_t err;
+   gpgme_data_t out = NULL;
+-  const char *signer_fpr = "A0FF4590BB6122EDEF6E3C542D727CC768697734"; /* Alpha Test */
+   gpgme_key_t signing_key = NULL;
+-  const char *key_fpr = "D695676BDCEDCC2CDD6152BCFE180B1DA9E3B0B2"; /* Bravo Test */
+   gpgme_key_t key = NULL;
+-  gpgme_key_t signed_key = NULL;
+-  gpgme_user_id_t signed_uid = NULL;
+-  gpgme_key_sig_t key_sig = NULL;
+   char *agent_info;
+-  int mode;
+-
+-  (void)argc;
+-  (void)argv;
+-
+-  init_gpgme (GPGME_PROTOCOL_OpenPGP);
+ 
+   err = gpgme_new (&ctx);
+   fail_if_err (err);
+ 
+-  /* Sign the key */
+   agent_info = getenv("GPG_AGENT_INFO");
+   if (!(agent_info && strchr (agent_info, ':')))
+     gpgme_set_passphrase_cb (ctx, passphrase_cb, 0);
+@@ -159,8 +147,23 @@ main (int argc, char **argv)
+   gpgme_data_release (out);
+   gpgme_key_unref (key);
+   gpgme_key_unref (signing_key);
++  gpgme_release (ctx);
++}
++
++
++void
++verify_key_signature (const char *key_fpr, const char *signer_keyid)
++{
++  gpgme_ctx_t ctx;
++  gpgme_error_t err;
++  gpgme_key_t signed_key = NULL;
++  gpgme_user_id_t signed_uid = NULL;
++  gpgme_key_sig_t key_sig = NULL;
++  int mode;
++
++  err = gpgme_new (&ctx);
++  fail_if_err (err);
+ 
+-  /* Verify the key signature */
+   mode  = gpgme_get_keylist_mode (ctx);
+   mode |= GPGME_KEYLIST_MODE_SIGS;
+   err = gpgme_set_keylist_mode (ctx, mode);
+@@ -168,7 +171,7 @@ main (int argc, char **argv)
+   err = gpgme_get_key (ctx, key_fpr, &signed_key, 0);
+   fail_if_err (err);
+ 
+-  signed_uid = key->uids;
++  signed_uid = signed_key->uids;
+   if (!signed_uid)
+     {
+       fprintf (stderr, "Signed key has no user IDs\n");
+@@ -180,7 +183,7 @@ main (int argc, char **argv)
+       exit (1);
+     }
+   key_sig = signed_uid->signatures->next;
+-  if (strcmp ("2D727CC768697734", key_sig->keyid))
++  if (strcmp (signer_keyid, key_sig->keyid))
+     {
+       fprintf (stderr, "Unexpected key ID in second user ID sig: %s\n",
+                 key_sig->keyid);
+@@ -196,6 +199,23 @@ main (int argc, char **argv)
+ 
+   gpgme_key_unref (signed_key);
+   gpgme_release (ctx);
++}
++
++
++int
++main (int argc, char **argv)
++{
++  const char *signer_fpr = "A0FF4590BB6122EDEF6E3C542D727CC768697734"; /* Alpha Test */
++  const char *signer_keyid = signer_fpr + strlen(signer_fpr) - 16;
++  const char *key_fpr = "D695676BDCEDCC2CDD6152BCFE180B1DA9E3B0B2"; /* Bravo Test */
++
++  (void)argc;
++  (void)argv;
++
++  init_gpgme (GPGME_PROTOCOL_OpenPGP);
++
++  sign_key (key_fpr, signer_fpr);
++  verify_key_signature (key_fpr, signer_keyid);
+ 
+   return 0;
+ }
+-- 
+2.32.0


### PR DESCRIPTION
###### Motivation for this change

There was an attempt to fix a build failure in https://github.com/NixOS/nixpkgs/pull/134354 , but the URL in that PR seems to error out and produce a 404, that it's probably best to just use local patches to unbreak builds for now:

```
 % curl -XGET -I https://files.gnupg.net/file/data/2ufcg7ny5jdnv7hmewb4/PHID-FILE-7iwvryn2btti6txr3bsz/file
HTTP/2 404 
date: Wed, 18 Aug 2021 21:30:24 GMT
server: Apache/2.4.46 (Debian)
x-frame-options: Deny
strict-transport-security: max-age=31536000
content-security-policy: default-src https://files.gnupg.net; img-src https://files.gnupg.net data:; style-src https://files.gnupg.net 'unsafe-inline'; script-src https://files.gnupg.net; connect-src 'self'; frame-src 'self'; frame-ancestors 'none'; object-src 'none'; form-action 'self'; base-uri 'none'
referrer-policy: no-referrer
cache-control: no-store
expires: Sat, 01 Jan 2000 00:00:00 GMT
x-content-type-options: nosniff
content-length: 7990
content-type: text/html; charset=UTF-8

```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
