### PR TITLE
otpauth: init at 0.3.4

### DIFF
--- a/pkgs/tools/security/otpauth/default.nix
+++ b/pkgs/tools/security/otpauth/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+}:
+
+buildGoModule rec {
+  pname = "otpauth";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "dim13";
+    repo = "otpauth";
+    rev = "v${version}";
+    sha256 = "199kh544kx4cbsczc9anmciczi738gdc5g518ybb05h49vlb51dp";
+  };
+
+  runVend = true;
+  vendorSha256 = "1762cchqydgsf94y05dwxcrajvjr64ayi5xk1svn1xissyc7vgpv";
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Google Authenticator migration decoder";
+    homepage = "https://github.com/dim13/otpauth";
+    license = licenses.isc;
+    maintainers = with maintainers; [ ereslibre ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7974,6 +7974,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
+  otpauth = callPackage ../tools/security/otpauth { };
+
   pcsclite = callPackage ../tools/security/pcsclite {
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };


### PR DESCRIPTION
Signed-off-by: Rafael Fernández López <ereslibre@ereslibre.es>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add the [`otpauth`](https://github.com/dim13/otpauth) program that is able to decode Google Authenticator migration data to regular `otpauth` links for importing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
