### PR TITLE
ffmpeg, ffmpeg-full: enable basic tests

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -447,6 +447,14 @@ stdenv.mkDerivation rec {
   buildFlags = [ "all" ]
     ++ optional qtFaststartProgram "tools/qt-faststart"; # Build qt-faststart executable
 
+  doCheck = true;
+  checkPhase = let
+    ldLibraryPathEnv = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+  in ''
+    ${ldLibraryPathEnv}="libavcodec:libavdevice:libavfilter:libavformat:libavresample:libavutil:libpostproc:libswresample:libswscale:''${${ldLibraryPathEnv}}" \
+      make check -j$NIX_BUILD_CORES
+  '';
+
   # Hacky framework patching technique borrowed from the phantomjs2 package
   postInstall = optionalString qtFaststartProgram ''
     cp -a tools/qt-faststart $out/bin/

--- a/pkgs/development/libraries/ffmpeg/2.8.nix
+++ b/pkgs/development/libraries/ffmpeg/2.8.nix
@@ -7,4 +7,5 @@ callPackage ./generic.nix (rec {
   knownVulnerabilities = [
     "CVE-2021-30123"
   ];
+  doCheck = false;
 } // args)


### PR DESCRIPTION
###### Motivation for this change
Having tests enabled would allow us to be more confident when we're applying patches etc. to ffmpeg.

This is the cut-down version of the full ffmpeg test suite (known as "fate").  I have got the full version running successfully too - it doesn't take significantly longer to run, the only issue is that it relies on a ~1GB dataset of sample files which, besides being quite big, only appears to be distributed over rsync (rsync://fate-suite.ffmpeg.org/fate-suite/) and continually updated. So I don't know how we'd be able to reference a stable revision to base a derivation on - we'd have to make our own periodic snapshots and host them somewhere.. all seems too much to me.

I've got these tests passing on macos and nixos x86_64. Clearly will need people with more exotic systems to chip in and test this (the saving grace here being that a full `nixpkgs-review` shouldn't be needed as we're not really modifying the output of this derivation).

Feels kinda dumb to be copypasta'ing the `checkPhase` across to `ffmpeg-full`, but I imagine it's not the first time duplication between the two packages has been discussed, so I'm guessing it exists for a reason.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
