### PR TITLE
tabnine: 3.5.37 -> 3.5.49

### DIFF
--- a/pkgs/development/tools/tabnine/default.nix
+++ b/pkgs/development/tools/tabnine/default.nix
@@ -3,16 +3,16 @@ let
   platform =
     if stdenv.hostPlatform.system == "x86_64-linux" then {
       name = "x86_64-unknown-linux-musl";
-      sha256 = "sha256-pttjlx7WWE3nog9L1APp8HN+a4ShhlBj5irHOaPgqHw=";
+      sha256 = "sha256-uy3+/+XMq56rO75mmSeOmE1HW7hhefaGwfY/QJPk3Ok=";
     } else if stdenv.hostPlatform.system == "x86_64-darwin" then {
       name = "x86_64-apple-darwin";
-      sha256 = "sha256-Vxmhl4/bhRDeByGgkdSF8yEY5wI23WzT2iH1OFkEpck=";
+      sha256 = "sha256-EK7FbRzgaCXviOuBcRf/ElllRdakhDmOLsKkwrIEhBU=";
     } else throw "Not supported on ${stdenv.hostPlatform.system}";
 in
 stdenv.mkDerivation rec {
   pname = "tabnine";
   # You can check the latest version with `curl -sS https://update.tabnine.com/bundles/version`
-  version = "3.5.37";
+  version = "3.5.49";
 
   src = fetchurl {
     url = "https://update.tabnine.com/bundles/${version}/${platform.name}/TabNine.zip";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
