### PR TITLE
onlykey-cli: 1.2.2 -> 1.2.5

### DIFF
--- a/pkgs/development/python-modules/onlykey-solo-python/default.nix
+++ b/pkgs/development/python-modules/onlykey-solo-python/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage
+, click
+, ecdsa
+, fetchPypi
+, fido2
+, intelhex
+, lib
+, pyserial
+, pyusb
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "onlykey-solo-python";
+  version = "0.0.28";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Mbi5So2OgeXjg4Fzg7v2gAJuh1Y7ZCYu8Lrha/7PQfY=";
+  };
+
+  propagatedBuildInputs = [ click ecdsa fido2 intelhex pyserial pyusb requests ];
+
+  # no tests
+  doCheck = false;
+  pythonImportsCheck = [ "solo" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/trustcrypto/onlykey-solo-python";
+    description = "Python library for OnlyKey with Solo FIDO2";
+    maintainers = with maintainers; [ kalbasit ];
+    license = licenses.asl20;
+  };
+}
+

--- a/pkgs/tools/security/onlykey-cli/default.nix
+++ b/pkgs/tools/security/onlykey-cli/default.nix
@@ -2,18 +2,28 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "onlykey-cli";
-  version = "1.2.2";
+  version = "1.2.5";
 
   src = python3Packages.fetchPypi {
     inherit version;
     pname = "onlykey";
-    sha256 = "1qkbgab5xlg7bd0jfzf8k5ppb1zhib76r050fiaqi5wibrqrfwdi";
+    sha256 = "sha256-7Pr1gXaPF5mctGxDciKKj0YDDQVFFi1+t6QztoKqpAA=";
   };
+
+  propagatedBuildInputs = with python3Packages; [
+    aenum
+    cython
+    ecdsa
+    hidapi
+    onlykey-solo-python
+    prompt-toolkit
+    pynacl
+    six
+  ];
 
   # Requires having the physical onlykey (a usb security key)
   doCheck = false;
-  propagatedBuildInputs =
-    with python3Packages; [ hidapi aenum six prompt-toolkit pynacl ecdsa cython ];
+  pythonImportsCheck = [ "onlykey.cli" ];
 
   meta = with lib; {
     description = "OnlyKey client and command-line tool";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5009,6 +5009,8 @@ in {
 
   onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };
 
+  onlykey-solo-python = callPackage ../development/python-modules/onlykey-solo-python { };
+
   onnx = callPackage ../development/python-modules/onnx { };
 
   open-garage = callPackage ../development/python-modules/open-garage { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update onlykey-cli to v1.2.5: https://github.com/trustcrypto/python-onlykey/compare/v1.2.2...v1.2.5

On release-21.05, I couldn't get onlykey-cli to work without #124815 and this update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
