### PR TITLE
python3Packages.pytest-astropy: add empty checkPhase

### DIFF
--- a/pkgs/development/python-modules/pytest-astropy/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy/default.nix
@@ -10,11 +10,13 @@
 , pytest-openfiles
 , pytest-arraydiff
 , setuptools-scm
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pytest-astropy";
   version = "0.8.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -25,7 +27,9 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  buildInputs = [ pytest ];
+  buildInputs = [
+    pytest
+  ];
 
   propagatedBuildInputs = [
     hypothesis
@@ -38,12 +42,15 @@ buildPythonPackage rec {
   ];
 
   # pytest-astropy is a meta package and has no tests
-  doCheck = false;
+  #doCheck = false;
+  checkPhase = ''
+    # 'doCheck = false;' still invokes the pytestCheckPhase which makes the build fail
+  '';
 
   meta = with lib; {
     description = "Meta-package containing dependencies for testing";
     homepage = "https://astropy.org";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`pytest-astropy` fails to build. `doCheck = false;` is set but somehow the check phase is running.

```bash
[...]
Executing pythonImportsCheckPhase
pytestcachePhase
pytestCheckPhase
Executing pytestCheckPhase
============================= test session starts ==============================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /build/pytest-astropy-0.8.0
plugins: hypothesis-6.14.0, astropy-header-0.1.2, doctestplus-0.9.0, filter-subpackage-0.1.1, cov-2.12.1, remotedata-0.3.2, openfiles-0.5.0, arraydiff-0.3
collected 0 items                                                              

============================ no tests ran in 0.01s =============================
builder for '/nix/store/yv6b95hqxw6qwybbn28pxgn3msx2lc8c-python3.9-pytest-astropy-0.8.0.drv' failed with exit code 5
error: build of '/nix/store/yv6b95hqxw6qwybbn28pxgn3msx2lc8c-python3.9-pytest-astropy-0.8.0.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
