### PR TITLE
python3Packages.feedgenerator: 1.9.1 -> 1.9.2

### DIFF
--- a/pkgs/development/python-modules/feedgenerator/default.nix
+++ b/pkgs/development/python-modules/feedgenerator/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "feedgenerator";
-  version = "1.9.1";
+  version = "1.9.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0m6fjnrx3sd0bm6pnbhxxx5ywlwqh8bx0lka386kj28mg3fmm2m2";
+    sha256 = "sha256-sG1pQej9aiyecXkQeehsvno3iMciRKzAbwWTtJzaN5s=";
   };
 
   buildInputs = [ glibcLocales ];

--- a/pkgs/development/python-modules/feedgenerator/default.nix
+++ b/pkgs/development/python-modules/feedgenerator/default.nix
@@ -1,23 +1,44 @@
-{ lib, buildPythonPackage, glibcLocales, fetchPypi, six, pytz }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, glibcLocales
+, pytestCheckHook
+, pythonOlder
+, pytz
+, six
+}:
 
 buildPythonPackage rec {
   pname = "feedgenerator";
   version = "1.9.2";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-sG1pQej9aiyecXkQeehsvno3iMciRKzAbwWTtJzaN5s=";
   };
 
-  buildInputs = [ glibcLocales ];
+  buildInputs = [
+    glibcLocales
+  ];
 
-  LC_ALL="en_US.UTF-8";
+  LC_ALL = "en_US.UTF-8";
 
-  propagatedBuildInputs = [ six pytz ];
+  propagatedBuildInputs = [
+    pytz
+    six
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "feedgenerator" ];
 
   meta = with lib; {
-    description = "Standalone version of django.utils.feedgenerator, compatible with Py3k";
-    homepage = "https://github.com/dmdm/feedgenerator-py3k.git";
+    description = "Standalone version of Django's feedgenerator module";
+    homepage = "https://github.com/getpelican/feedgenerator";
+    license = licenses.bsd3;
     maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.9.2

Change log: https://github.com/getpelican/feedgenerator/releases/tag/1.9.2

- Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
