### PR TITLE
libreoffice: xdg-open-brief.patch not needed for 7.2

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -63,8 +63,6 @@ in (mkDrv rec {
     "-fno-visibility-inlines-hidden" # https://bugs.documentfoundation.org/show_bug.cgi?id=78174#c10
   ];
 
-  patches = [ ./xdg-open-brief.patch ];
-
   tarballPath = "external/tarballs";
 
   postUnpack = ''
@@ -92,9 +90,6 @@ in (mkDrv rec {
     libs = list:
       lib.concatMapStringsSep " " (e: "-L${lib.getLib e}/lib") list;
   in ''
-    substituteInPlace shell/source/unix/exec/shellexec.cxx \
-      --replace /usr/bin/xdg-open ${if kdeIntegration then "kde-open5" else "xdg-open"}
-
     # configure checks for header 'gpgme++/gpgmepp_version.h',
     # and if it is found (no matter where) uses a hardcoded path
     # in what presumably is an effort to make it possible to write

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -90,6 +90,9 @@ in (mkDrv rec {
     libs = list:
       lib.concatMapStringsSep " " (e: "-L${lib.getLib e}/lib") list;
   in ''
+    substituteInPlace shell/source/unix/exec/shellexec.cxx \
+      --replace /usr/bin/xdg-open ${if kdeIntegration then "kde-open5" else "xdg-open"}
+
     # configure checks for header 'gpgme++/gpgmepp_version.h',
     # and if it is found (no matter where) uses a hardcoded path
     # in what presumably is an effort to make it possible to write

--- a/pkgs/applications/office/libreoffice/src-fresh/override.nix
+++ b/pkgs/applications/office/libreoffice/src-fresh/override.nix
@@ -7,4 +7,5 @@ attrs:
   configureFlags = attrs.configureFlags ++ [
     (lib.enableFeature kdeIntegration "kf5")
   ];
+  patches = [ ../xdg-open-brief.patch ]; # drop this when switching fresh to 7.2.0
 }

--- a/pkgs/applications/office/libreoffice/src-still/override.nix
+++ b/pkgs/applications/office/libreoffice/src-still/override.nix
@@ -7,7 +7,7 @@ attrs:
   configureFlags = attrs.configureFlags ++ [
     (lib.enableFeature kdeIntegration "kf5")
   ];
-  patches = [ ./xdg-open-brief.patch ];
+  patches = [ ../xdg-open-brief.patch ];
   postPatch = attrs.postPatch + ''
     substituteInPlace shell/source/unix/exec/shellexec.cxx \
       --replace /usr/bin/xdg-open ${if kdeIntegration then "kde-open5" else "xdg-open"}

--- a/pkgs/applications/office/libreoffice/src-still/override.nix
+++ b/pkgs/applications/office/libreoffice/src-still/override.nix
@@ -8,8 +8,4 @@ attrs:
     (lib.enableFeature kdeIntegration "kf5")
   ];
   patches = [ ../xdg-open-brief.patch ];
-  postPatch = attrs.postPatch + ''
-    substituteInPlace shell/source/unix/exec/shellexec.cxx \
-      --replace /usr/bin/xdg-open ${if kdeIntegration then "kde-open5" else "xdg-open"}
-  '';
 }

--- a/pkgs/applications/office/libreoffice/src-still/override.nix
+++ b/pkgs/applications/office/libreoffice/src-still/override.nix
@@ -7,4 +7,9 @@ attrs:
   configureFlags = attrs.configureFlags ++ [
     (lib.enableFeature kdeIntegration "kf5")
   ];
+  patches = attrs.patches ++ [ ./xdg-open-brief.patch ];
+  postPatch = attrs.postPatch + ''
+    substituteInPlace shell/source/unix/exec/shellexec.cxx \
+      --replace /usr/bin/xdg-open ${if kdeIntegration then "kde-open5" else "xdg-open"}
+  '';
 }

--- a/pkgs/applications/office/libreoffice/src-still/override.nix
+++ b/pkgs/applications/office/libreoffice/src-still/override.nix
@@ -7,7 +7,7 @@ attrs:
   configureFlags = attrs.configureFlags ++ [
     (lib.enableFeature kdeIntegration "kf5")
   ];
-  patches = attrs.patches ++ [ ./xdg-open-brief.patch ];
+  patches = [ ./xdg-open-brief.patch ];
   postPatch = attrs.postPatch + ''
     substituteInPlace shell/source/unix/exec/shellexec.cxx \
       --replace /usr/bin/xdg-open ${if kdeIntegration then "kde-open5" else "xdg-open"}


### PR DESCRIPTION
###### Motivation for this change

xdg-open patch was upstreamed with https://git.libreoffice.org/core/commit/85462ef7aed85bcfb0e0628c5252a07c369ff606

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
