### PR TITLE
closurecompiler: 20200719 -> 20210808

### DIFF
--- a/pkgs/development/compilers/closure/default.nix
+++ b/pkgs/development/compilers/closure/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   pname = "closure-compiler";
-  version = "20200719";
+  version = "20210808";
 
   src = fetchurl {
-    url = "https://dl.google.com/closure-compiler/compiler-${version}.tar.gz";
-    sha256 = "18095i98mk5kc1vpaf6gvmvhiyl2x4zrcwd7ix5l98jydldiz7wx";
+    url = "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/v${version}/closure-compiler-v${version}.jar";
+    sha256 = "1cvibvm8l4mp64ml6lpsh3w62bgbr42pi3i7ga8ss0prhr0dsk3y";
   };
 
-  sourceRoot = ".";
+  dontUnpack = true;
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jre ];
 
   installPhase = ''
     mkdir -p $out/share/java $out/bin
-    cp closure-compiler-v${version}.jar $out/share/java
+    cp ${src} $out/share/java/closure-compiler-v${version}.jar
     makeWrapper ${jre}/bin/java $out/bin/closure-compiler \
       --add-flags "-jar $out/share/java/closure-compiler-v${version}.jar"
   '';


### PR DESCRIPTION
###### Motivation for this change

No new releases will be published on the previous URL, see https://github.com/google/closure-compiler/wiki/Binary-Downloads

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Arch Linux
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
