### PR TITLE
vscode: fix updateScript

### DIFF
--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -39,7 +39,7 @@ in
 
     sourceRoot = "";
 
-    updateScript = ./update-vscodium.sh;
+    updateScript = ./update-vscode.sh;
 
     meta = with lib; {
       description = ''


### PR DESCRIPTION
###### Motivation for this change

Maybe `update-vscode.sh` should be used.

https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vscode/update-vscode.sh

Probably related: 
- https://github.com/NixOS/nixpkgs/pull/124291
- https://github.com/NixOS/nixpkgs/pull/97938

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
