### PR TITLE
python3Packages.pelican: 4.5.4 -> 4.6.0

### DIFF
--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -1,38 +1,48 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy27
-, glibcLocales, git
-, mock, nose, markdown, lxml, typogrify
-, jinja2, pygments, docutils, pytz, unidecode, six, python-dateutil, feedgenerator
-, blinker, pillow, beautifulsoup4, markupsafe, pandoc }:
+{ lib
+, beautifulsoup4
+, blinker
+, buildPythonPackage
+, docutils
+, feedgenerator
+, fetchFromGitHub
+, git
+, glibcLocales
+, isPy27
+, jinja2
+, lxml
+, markdown
+, markupsafe
+, mock
+, pytestCheckHook
+, pandoc
+, pillow
+, pygments
+, python-dateutil
+, pythonOlder
+, pytz
+, rich
+, pytest-xdist
+, six
+, typogrify
+, unidecode
+}:
 
 buildPythonPackage rec {
   pname = "pelican";
-  version = "4.5.4";
-
-  disabled = isPy27;
+  version = "4.6.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "getpelican";
-    repo = "pelican";
+    repo = pname;
     rev = version;
-    sha256 = "08l8kk3c7ca1znxmgdmfgzn28dzjcziwflzq80fn9zigqj0y7fi8";
+    sha256 = "10a0dl8aw1vhyz8nangcd3cqwpa2axmqrr04c1k390qlnd3lr8yc";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     extraPostFetch = ''
       rm -r $out/pelican/tests/output/custom_locale/posts
     '';
   };
-
-  doCheck = true;
-
-  # Exclude custom locale test, which files were removed above to fix the source checksum
-  checkPhase = ''
-    nosetests -s \
-      --exclude=test_basic_generation_works \
-      --exclude=test_custom_generation_works \
-      --exclude=test_custom_locale_generation_works \
-      --exclude=test_log_filter \
-      pelican
-  '';
 
   buildInputs = [
     glibcLocales
@@ -44,21 +54,46 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    jinja2 pygments docutils pytz unidecode six python-dateutil feedgenerator
-    blinker pillow beautifulsoup4 markupsafe lxml
+    beautifulsoup4
+    blinker
+    docutils
+    feedgenerator
+    jinja2
+    lxml
+    markupsafe
+    pillow
+    pygments
+    python-dateutil
+    pytz
+    rich
+    six
+    unidecode
   ];
 
   checkInputs = [
-    nose
+    pytest-xdist
+    pytestCheckHook
     pandoc
   ];
 
-  postPatch= ''
+  postPatch = ''
     substituteInPlace pelican/tests/test_pelican.py \
       --replace "'git'" "'${git}/bin/git'"
   '';
 
-  LC_ALL="en_US.UTF-8";
+  pytestFlagsArray = [
+    # DeprecationWarning: 'jinja2.Markup' is deprecated and...
+    "-W ignore::DeprecationWarning"
+  ];
+
+  disabledTests = [
+    # AssertionError
+    "test_basic_generation_works"
+    "test_custom_generation_works"
+    "test_custom_locale_generation_works"
+  ];
+
+  LC_ALL = "en_US.UTF-8";
 
   # We only want to patch shebangs in /bin, and not those
   # of the project scripts that are created by Pelican.
@@ -69,8 +104,10 @@ buildPythonPackage rec {
     patchShebangs $out/bin
   '';
 
+  pythonImportsCheck = [ "pelican" ];
+
   meta = with lib; {
-    description = "A tool to generate a static blog from reStructuredText or Markdown input files";
+    description = "Static site generator that requires no database or server-side logic";
     homepage = "http://getpelican.com/";
     license = licenses.agpl3;
     maintainers = with maintainers; [ offline prikhi ];

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "getpelican";
     repo = pname;
     rev = version;
-    sha256 = "10a0dl8aw1vhyz8nangcd3cqwpa2axmqrr04c1k390qlnd3lr8yc";
+    sha256 = "0xrz0cmjyaylr81rmy5i3qbp4ms1iwh0gpb07q1dwljffb8xzbhr";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     extraPostFetch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 4.6.0

Change log: https://github.com/getpelican/pelican/releases/tag/4.6.0

- Fix build
- Switch to `pytestCheckHook`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
