### PR TITLE
[21.05] ffmpeg: apply patches for CVE-2021-3811{4,5} & incorrect segment length

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -243,7 +243,7 @@ assert opensslExtlib -> gnutls == null && openssl != null && nonfreeLicensing;
 
 stdenv.mkDerivation rec {
   pname = "ffmpeg-full";
-  inherit (ffmpeg) src version;
+  inherit (ffmpeg) src version patches;
 
   prePatch = ''
     patchShebangs .

--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -13,6 +13,16 @@ callPackage ./generic.nix (rec {
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
 
   patches = [
+    (fetchpatch {
+      name = "CVE-2021-33815.patch";
+      url = "https://github.com/FFmpeg/FFmpeg/commit/26d3c81bc5ef2f8c3f09d45eaeacfb4b1139a777.patch";
+      sha256 = "0l8dqga5845f7d3wdbvd05i23saldq4pm2cyfdgszbr0c18sxagf";
+    })
+    (fetchpatch {
+      name = "CVE-2021-38114.patch";
+      url = "https://github.com/FFmpeg/FFmpeg/commit/7150f9575671f898382c370acae35f9087a30ba1.patch";
+      sha256 = "0gwkc7v1wsh4j0am2nnskhsca1b5aqzhcfd41sd9mh2swsdyf27i";
+    })
     # Fix incorrect segment length in HLS child playlist with fmp4 segment format
     # FIXME remove in version 4.5
     # https://trac.ffmpeg.org/ticket/9193

--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -2,6 +2,7 @@
 # Darwin frameworks
 , Cocoa, CoreMedia, VideoToolbox
 , stdenv, lib
+, fetchpatch
 , ...
 }@args:
 
@@ -11,7 +12,18 @@ callPackage ./generic.nix (rec {
   sha256 = "03kxc29y8190k4y8s8qdpsghlbpmchv1m8iqygq2qn0vfm4ka2a2";
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
 
-  /* Work around https://trac.ffmpeg.org/ticket/9242 */
-  patches = lib.optional stdenv.isDarwin
-    ./v2-0001-avcodec-videotoolboxenc-define-TARGET_CPU_ARM64-t.patch;
+  patches = [
+    # Fix incorrect segment length in HLS child playlist with fmp4 segment format
+    # FIXME remove in version 4.5
+    # https://trac.ffmpeg.org/ticket/9193
+    # https://trac.ffmpeg.org/ticket/9205
+    (fetchpatch {
+      name = "ffmpeg_fix_incorrect_segment_length_in_hls.patch";
+      url = "https://git.videolan.org/?p=ffmpeg.git;a=commitdiff_plain;h=59032494e81a1a65c0b960aaae7ec4c2cc9db35a";
+      sha256 = "03zz1lw51kkc3g3vh47xa5hfiz3g3g1rbrll3kcnslvwylmrqmy3";
+    })
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Work around https://trac.ffmpeg.org/ticket/9242
+    ./v2-0001-avcodec-videotoolboxenc-define-TARGET_CPU_ARM64-t.patch
+  ];
 } // args)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* #129317, #134274

It seemed reasonable to backport the other bugfix as well to me, but we can of course only backport the actual CVE patches :) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
