### PR TITLE
gnomeExtensions.bluetooth-battery: init at unstable-2021-08-13

### DIFF
--- a/pkgs/desktops/gnome/extensions/bluetooth-battery-indicator/default.nix
+++ b/pkgs/desktops/gnome/extensions/bluetooth-battery-indicator/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, substituteAll
+, glib
+, python3
+, bluetooth_battery
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-bluetooth-battery-indicator";
+  version = "unstable-2021-08-13";
+
+  src = fetchFromGitHub {
+    owner = "MichalW";
+    repo = "gnome-bluetooth-battery-indicator";
+    rev = "3b5e6b93e251058a99e3f258bceb2723166c085b";
+    sha256 = "ZHM3OAqXLKoh2IUXEtfBht8rfOgg259sXNelbmYTPSw=";
+  };
+
+  patches = [
+    # Make dependencies available at runtime.
+    (substituteAll {
+      src = ./fix-paths.patch;
+      bluetooth_battery = "${bluetooth_battery}/bin/bluetooth_battery";
+      python = python3.interpreter;
+    })
+  ];
+
+  nativeBuildInputs = [
+    glib
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    glib-compile-schemas --strict --targetdir=schemas schemas
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/gnome-shell/extensions/${passthru.extensionUuid}"
+    cp -r *.js *.json schemas/ "$out/share/gnome-shell/extensions/${passthru.extensionUuid}"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    extensionUuid = "bluetooth-battery@michalw.github.com";
+    extensionPortalSlug = "bluetooth-battery";
+
+    updateScript = unstableGitUpdater {
+      # The updater tries src.url by default, which does not exist for fetchFromGitHub (fetchurl).
+      url = "${src.meta.homepage}.git";
+    };
+  };
+
+  meta = with lib; {
+    description = "GNOME Shell extension displaying battery percentage for bluetooth devices";
+    homepage = "https://github.com/MichalW/gnome-bluetooth-battery-indicator";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [
+      jtojnar
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome/extensions/bluetooth-battery-indicator/fix-paths.patch
+++ b/pkgs/desktops/gnome/extensions/bluetooth-battery-indicator/fix-paths.patch
@@ -1,0 +1,17 @@
+--- a/constants.js
++++ b/constants.js
+@@ -1,3 +1,3 @@
+ var GETTEXT_DOMAIN = 'bluetooth_battery_indicator';
+ var SETTINGS_ID = 'org.gnome.shell.extensions.bluetooth_battery_indicator';
+-var SCRIPT_PATH = 'Bluetooth_Headset_Battery_Level/bluetooth_battery.py';
++var SCRIPT_PATH = '@bluetooth_battery@';
+--- a/utils.js
++++ b/utils.js
+@@ -36,6 +36,7 @@ function addSignalsHelperMethods(prototype) {
+ }
+ 
+ function getPythonExec() {
++    return '@python@';
+ 	//return ['python', 'python3', 'python2'].find(cmd => GLib.find_program_in_path(cmd));
+ 	return ['python3'].find(cmd => GLib.find_program_in_path(cmd)); //Hotfix for no percentage shown
+ }

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -1,6 +1,7 @@
 { callPackage }:
 {
   "arcmenu@arcmenu.com" = callPackage ./arcmenu { };
+  "bluetooth-battery@michalw.github.com" = callPackage ./bluetooth-battery-indicator { };
   "caffeine@patapon.info" = callPackage ./caffeine { };
   "clock-override@gnomeshell.kryogenix.org" = callPackage ./clock-override { };
   "dash-to-dock@micxgx.gmail.com" = callPackage ./dash-to-dock { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Untested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
