### PR TITLE
libvisio2svg: init at 0.5.5

### DIFF
--- a/pkgs/development/libraries/libemf2svg/default.nix
+++ b/pkgs/development/libraries/libemf2svg/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, fontconfig
+, freetype
+, libpng
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libemf2svg";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "kakwa";
+    repo = pname;
+    rev = version;
+    sha256 = "04g6dp5xadszqjyjl162x26mfhhwinia65hbkl3mv70bs4an9898";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ fontconfig freetype libpng ];
+
+  meta = with lib; {
+    description = "Microsoft EMF to SVG conversion library";
+    homepage = "https://github.com/kakwa/libemf2svg";
+    maintainers = with maintainers; [ erdnaxe ];
+    license = licenses.gpl2Only;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/libraries/libvisio2svg/default.nix
+++ b/pkgs/development/libraries/libvisio2svg/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, freetype
+, libemf2svg
+, librevenge
+, libvisio
+, libwmf
+, libxml2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libvisio2svg";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "kakwa";
+    repo = pname;
+    rev = version;
+    sha256 = "14m37mmib1596c76j9w178jqhwxyih2sy5w5q9xglh8cmlfn1hfx";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libxml2 freetype librevenge libvisio libwmf libemf2svg ];
+
+  meta = with lib; {
+    description = "Library and tools to convert Microsoft Visio documents (VSS and VSD) to SVG";
+    homepage = "https://github.com/kakwa/libvisio2svg";
+    maintainers = with maintainers; [ erdnaxe ];
+    license = licenses.gpl2Only;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16756,6 +16756,8 @@ with pkgs;
 
   libechonest = callPackage ../development/libraries/libechonest { };
 
+  libemf2svg = callPackage ../development/libraries/libemf2svg { };
+
   libev = callPackage ../development/libraries/libev { };
 
   libevent = callPackage ../development/libraries/libevent { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17485,6 +17485,8 @@ with pkgs;
 
   libvisio = callPackage ../development/libraries/libvisio { };
 
+  libvisio2svg = callPackage ../development/libraries/libvisio2svg { };
+
   libvisual = callPackage ../development/libraries/libvisual { };
 
   libvmaf = callPackage ../development/libraries/libvmaf { };


### PR DESCRIPTION
###### Motivation for this change

libvisio2svg is useful to do Microsoft Visio stencils conversion to SVG as LibreOffice is not able to load these files.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
