### PR TITLE
ftxui: init at unstable-2021-08-13

### DIFF
--- a/pkgs/development/libraries/ftxui/default.nix
+++ b/pkgs/development/libraries/ftxui/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, doxygen
+, graphviz
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ftxui";
+  version = "unstable-2021-08-13";
+
+  src = fetchFromGitHub {
+    owner = "ArthurSonzogni";
+    repo = pname;
+    rev = "69b0c9e53e523ac43a303964fc9c5bc0da7d5d61";
+    sha256 = "0cbljksgy1ckw34h0mq70s8sma0p16sznn4z9r4hwv76y530m0ww";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    graphviz
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/ArthurSonzogni/FTXUI";
+    description = "Functional Terminal User Interface for C++";
+    license = licenses.mit;
+    maintainers = [ maintainers.ivar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5041,6 +5041,8 @@ with pkgs;
 
   ftop = callPackage ../os-specific/linux/ftop { };
 
+  ftxui = callPackage ../development/libraries/ftxui { };
+
   fsarchiver = callPackage ../tools/archivers/fsarchiver { };
 
   fsfs = callPackage ../tools/filesystems/fsfs { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/ArthurSonzogni/FTXUI

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
