### PR TITLE
Bump re2c: 2.1.1 -> 2.2

### DIFF
--- a/pkgs/development/tools/parsing/re2c/default.nix
+++ b/pkgs/development/tools/parsing/re2c/default.nix
@@ -1,23 +1,31 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, python3
+}:
 
 stdenv.mkDerivation rec {
   pname = "re2c";
-  version = "2.1.1";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner  = "skvadrik";
     repo   = "re2c";
     rev    = version;
-    sha256 = "06nvk5sf4vrc2bvpj4vi2xwy3ggv548sn530drz5fi67nhzgga26";
+    sha256 = "0snfxk1cf2f4dy4hcxd1fx1grav3di0qjgqqn97k85zsf9f6ys78";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    python3
+  ];
 
   doCheck = true;
   enableParallelBuilding = true;
 
   preCheck = ''
-    patchShebangs run_tests.sh
+    patchShebangs run_tests.py
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
