### PR TITLE
[21.05] rsync: add patch for CVE-2020-14387

### DIFF
--- a/pkgs/applications/networking/sync/rsync/base.nix
+++ b/pkgs/applications/networking/sync/rsync/base.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl }:
+{ lib, fetchurl, fetchpatch }:
 
 rec {
   version = "3.2.3";
@@ -12,6 +12,13 @@ rec {
     url = "mirror://samba/rsync/rsync-patches-${version}.tar.gz";
     sha256 = "1wj21v57v135n6fnmlm2dxmb9lhrrg62jgkggldp1gb7d6s4arny";
   };
+  extraPatches = [
+    (fetchpatch {
+      name = "CVE-2020-14387.patch";
+      url = "https://git.samba.org/?p=rsync.git;a=patch;h=c3f7414;hp=4c4fce51072c9189cfb11b52aa54fed79f5741bd";
+      sha256 = "000lyx48lns84p53nsdlr45mb9558lrvnsz3yic0y3z6h2izv82x";
+    })
+  ];
 
   meta = with lib; {
     description = "Fast incremental file transfer utility";

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, perl, libiconv, zlib, popt
+{ lib, stdenv, fetchurl, fetchpatch, perl, libiconv, zlib, popt
 , enableACLs ? !(stdenv.isDarwin || stdenv.isSunOS || stdenv.isFreeBSD), acl ? null
 , enableLZ4 ? true, lz4 ? null
 , enableOpenSSL ? true, openssl ? null
@@ -15,7 +15,7 @@ assert enableXXHash -> xxHash != null;
 assert enableZstd -> zstd != null;
 
 let
-  base = import ./base.nix { inherit lib fetchurl; };
+  base = import ./base.nix { inherit lib fetchurl fetchpatch; };
 in
 stdenv.mkDerivation rec {
   name = "rsync-${base.version}";
@@ -25,7 +25,8 @@ stdenv.mkDerivation rec {
   patchesSrc = base.upstreamPatchTarball;
 
   srcs = [mainSrc] ++ lib.optional enableCopyDevicesPatch patchesSrc;
-  patches = lib.optional enableCopyDevicesPatch "./patches/copy-devices.diff";
+  patches = lib.optional enableCopyDevicesPatch "./patches/copy-devices.diff"
+    ++ base.extraPatches;
 
   buildInputs = [libiconv zlib popt]
                 ++ lib.optional enableACLs acl

--- a/pkgs/applications/networking/sync/rsync/rrsync.nix
+++ b/pkgs/applications/networking/sync/rsync/rrsync.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl, perl, rsync }:
+{ lib, stdenv, fetchurl, perl, rsync, fetchpatch }:
 
 let
-  base = import ./base.nix { inherit lib fetchurl; };
+  base = import ./base.nix { inherit lib fetchurl fetchpatch; };
 in
 stdenv.mkDerivation {
   name = "rrsync-${base.version}";
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
   # We just want something from the support directory
   dontConfigure = true;
   dontBuild = true;
+
+  patches = base.extraPatches;
 
   postPatch = ''
     substituteInPlace support/rrsync --replace /usr/bin/rsync ${rsync}/bin/rsync


### PR DESCRIPTION
###### Motivation for this change
Backport of #130545 addressing https://nvd.nist.gov/vuln/detail/CVE-2020-14387

Should resolve #128426

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
