### PR TITLE
add librem-ec-acpi-dkms kernel module

### DIFF
--- a/pkgs/os-specific/linux/purism/librem-ec-acpi-dkms.nix
+++ b/pkgs/os-specific/linux/purism/librem-ec-acpi-dkms.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchgit, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "librem-ec-acpi-dkms-${version}-${kernel.version}";
+  version = "0.9.1";
+
+  src = fetchgit {
+    url = "https://source.puri.sm/nicole.faerber/librem-ec-acpi-dkms.git";
+    rev = "9be1cc47fbe245f84adb5979c61ce74ae7f68b83";
+    sha256 = "1qnbfj60i8nn2ahgj2zp5ixd79bb0wl1ld36x3igws2f3c0f5pfi";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  KERNEL_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  INSTALL_MOD_PATH = placeholder "out";
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  #preBuild = "cd src";
+  buildFlags = [ "all" ];
+
+  installFlags = [ "DEPMOD=true" ];
+  enableParallelBuilding = true;
+
+  patches = [
+    ./librem-ec-acpi-dkms.patch
+  ];
+
+  meta = with lib; {
+    homepage = "https://source.puri.sm/nicole.gaerber/librem-ec-acpi-dkms";
+    license = lib.licenses.gpl2;
+    description = "Kernel module for the Purism Librem EC ACPI DKMS";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/purism/librem-ec-acpi-dkms.patch
+++ b/pkgs/os-specific/linux/purism/librem-ec-acpi-dkms.patch
@@ -1,0 +1,16 @@
+diff --git a/Makefile b/Makefile
+index d8d3f91..47abc37 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,8 +1,10 @@
+ obj-m := librem_ec_acpi.o
+-KERNEL_DIR = /lib/modules/$(shell uname -r)/build
+ 
+ all:
+ 	$(MAKE) -C "$(KERNEL_DIR)" M="$(PWD)" modules
+ 
++install:
++	$(MAKE) -C "$(KERNEL_DIR)" M="$(PWD)" modules_install
++
+ clean:
+ 	$(MAKE) -C "$(KERNEL_DIR)" M="$(PWD)" clean

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20543,6 +20543,8 @@ in
 
     it87 = callPackage ../os-specific/linux/it87 {};
 
+    librem-ec-acpi-dkms = callPackage ../os-specific/linux/purism/librem-ec-acpi-dkms.nix {};
+
     asus-wmi-sensors = callPackage ../os-specific/linux/asus-wmi-sensors {};
 
     ena = callPackage ../os-specific/linux/ena {};


### PR DESCRIPTION
###### Motivation for this change

Users of NixOS on the Librem 14 laptop from Purism will want to include
this out-of-tree kernel module in their system configuration. Without it,
certain features are only partially usable (controls regarding power
 source, LEDs, fans).

```
  boot.extraModulePackages = with config.boot.kernelPackages;
    [ librem-ec-acpi-dkms ];
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
