### PR TITLE
restool: init at 20.12

### DIFF
--- a/pkgs/os-specific/linux/restool/default.nix
+++ b/pkgs/os-specific/linux/restool/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchgit, bash, coreutils, dtc, file, gawk, gnugrep, gnused }:
+
+stdenv.mkDerivation rec {
+  pname = "restool";
+  version = "20.12";
+
+  src = fetchgit {
+    url = "https://source.codeaurora.org/external/qoriq/qoriq-components/restool";
+    rev = "LSDK-${version}";
+    sha256 = "137xvvms3n4wwb5v2sv70vsib52s3s314306qa0mqpgxf9fb19zl";
+  };
+
+  nativeBuildInputs = [ file ];
+  buildInputs = [ bash coreutils dtc gawk gnugrep gnused ];
+
+  makeFlags = [
+    "prefix=$(out)"
+    "VERSION=${version}"
+  ];
+
+  preFixup = ''
+    # wrapProgram interacts badly with the ls-main tool, which relies on the
+    # shell's $0 argument to figure out which operation to run (busybox-style
+    # symlinks). Instead, inject the environment directly into the shell
+    # scripts we need to wrap.
+    for tool in ls-append-dpl ls-debug ls-main; do
+      sed -i "1 a export PATH=\"$out/bin:${lib.makeBinPath buildInputs}:\$PATH\"" $out/bin/$tool
+    done
+  '';
+
+  meta = with lib; {
+    description = "DPAA2 Resource Management Tool";
+    longDescription = ''
+      restool is a user space application providing the ability to dynamically
+      create and manage DPAA2 containers and objects from Linux.
+    '';
+    homepage = "https://source.codeaurora.org/external/qoriq/qoriq-components/restool/about/";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8549,6 +8549,8 @@ with pkgs;
   inherit (callPackage ../development/misc/resholve { })
     resholve resholvePackage;
 
+  restool = callPackage ../os-specific/linux/restool {};
+
   reuse = callPackage ../tools/package-management/reuse { };
 
   rewritefs = callPackage ../os-specific/linux/rewritefs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[restool](https://source.codeaurora.org/external/qoriq/qoriq-components/restool/tree/README.md) is a Linux application used to manage the network controller of hardware using the Freescale/NXP DPAA2 architecture. It interacts with a kernel side driver (available in mainline kernels, doesn't require a vendor fork) and allows users to e.g. create network interfaces, manage hardware switch acceleration, and more.

I've been using this derivation for a few months on my [Honeycomb](https://www.solid-run.com/arm-servers-networking-platforms/honeycomb-workstation/) ARMv8 router to initialize the 10Gbps interfaces on the device. I've tested it to work fine on AArch64 platforms, it builds on amd64 but realistically nobody is ever going to use it on an amd64 platform :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
