### PR TITLE
jax: init at 0.2.19, jaxlib: init at 0.1.71

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9542,6 +9542,12 @@
     githubId = 115821;
     name = "Sam Rose";
   };
+  samuela = {
+    email = "skainsworth@gmail.com";
+    github = "samuela";
+    githubId = 226872;
+    name = "Samuel Ainsworth";
+  };
   samueldr = {
     email = "samuel@dionne-riel.com";
     github = "samueldr";

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   pytestFlagsArray = [ "-W ignore::DeprecationWarning" "tests/" ];
 
   meta = with lib; {
-    description = "Differentiate, compile, and transform Numpy code.";
+    description = "Differentiate, compile, and transform Numpy code";
     homepage    = "https://github.com/google/jax";
     license     = licenses.asl20;
     maintainers = with maintainers; [ samuela ];

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -1,0 +1,39 @@
+{ buildPythonPackage, fetchFromGitHub, lib
+# propagatedBuildInputs
+, absl-py, numpy, opt-einsum
+# checkInputs
+, jaxlib, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "jax";
+  version = "0.2.19";
+
+  # Fetching from pypi doesn't allow us to run the test suite. See https://discourse.nixos.org/t/pythonremovetestsdir-hook-being-run-before-checkphase/14612/3.
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = "jax-v${version}";
+    sha256 = "sha256-pVn62G7pydR7ybkf7gSbu0FlEq2c0US6H2GTBAljup4=";
+  };
+
+  # jaxlib is _not_ included in propagatedBuildInputs because there are
+  # different versions of jaxlib depending on the desired target hardware. The
+  # JAX project ships separate wheels for CPU, GPU, and TPU. Currently only the
+  # CPU wheel is packaged.
+  propagatedBuildInputs = [ absl-py numpy opt-einsum ];
+
+  checkInputs = [ jaxlib pytestCheckHook ];
+  # NOTE: Don't run the tests in the expiremental directory as they require flax
+  # which creates a circular dependency. See https://discourse.nixos.org/t/how-to-nix-ify-python-packages-with-circular-dependencies/14648/2.
+  # Not a big deal, this is how the JAX docs suggest running the test suite
+  # anyhow.
+  pytestFlagsArray = [ "-W ignore::DeprecationWarning" "tests/" ];
+
+  meta = with lib; {
+    description = "Differentiate, compile, and transform Numpy code.";
+    homepage    = "https://github.com/google/jax";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -2,10 +2,13 @@
 # backend will require some additional work. Those wheels are located here:
 # https://storage.googleapis.com/jax-releases/libtpu_releases.html.
 
-# For future reference, the easiest way to test that the gpu is being used is:
+# For future reference, the easiest way to test the GPU backend is to run
 #   NIX_PATH=.. nix-shell -p python3 python3Packages.jax "python3Packages.jaxlib.override { cudaSupport = true; }"
-#   python -c "from jax.lib import xla_bridge; print(xla_bridge.get_backend().platform)"
-# See https://github.com/google/jax/issues/971#issuecomment-508216439.
+#   python -c "from jax.lib import xla_bridge; assert xla_bridge.get_backend().platform == 'gpu'"
+#   python -c "from jax import random; random.PRNGKey(0)"
+# See https://github.com/google/jax/issues/971#issuecomment-508216439. There's
+# no convenient way to test the GPU backend in the derivation since the nix
+# build environment blocks access to the GPU.
 
 { addOpenGLRunpath, autoPatchelfHook, buildPythonPackage, config, fetchPypi
 , fetchurl, isPy39, lib, stdenv
@@ -66,8 +69,8 @@ buildPythonPackage rec {
     done
   '';
 
-  # pip dependencies
-  propagatedBuildInputs = [ absl-py flatbuffers scipy ];
+  # pip dependencies and optionally cudatoolkit.
+  propagatedBuildInputs = [ absl-py flatbuffers scipy ] ++ lib.optional cudaSupport cudatoolkit_11;
 
   pythonImportsCheck = [ "jaxlib" ];
 

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -1,16 +1,28 @@
-# For the moment we only support the CPU backend of jaxlib. GPU and TPU backends
-# require some additional work. Their wheels are not located on PyPI.
-#  * CPU/GPU: https://storage.googleapis.com/jax-releases/jax_releases.html
-#  * TPU: https://storage.googleapis.com/jax-releases/libtpu_releases.html
+# For the moment we only support the CPU and GPU backends of jaxlib. The TPU
+# backend will require some additional work. Those wheels are located here:
+# https://storage.googleapis.com/jax-releases/libtpu_releases.html.
 
-{ autoPatchelfHook, buildPythonPackage, fetchPypi, isPy39, lib, stdenv
+# For future reference, the easiest way to test that the gpu is being used is:
+#   NIX_PATH=.. nix-shell -p python3 python3Packages.jax "python3Packages.jaxlib.override { cudaSupport = true; }"
+#   python -c "from jax.lib import xla_bridge; print(xla_bridge.get_backend().platform)"
+# See https://github.com/google/jax/issues/971#issuecomment-508216439.
+
+{ addOpenGLRunpath, autoPatchelfHook, buildPythonPackage, config, fetchPypi
+, fetchurl, isPy39, lib, stdenv
 # propagatedBuildInputs
-, absl-py, flatbuffers, scipy
+, absl-py, flatbuffers, scipy, cudatoolkit_11
+# Options:
+, cudaSupport ? config.cudaSupport or false
 }:
 
+assert cudaSupport -> lib.versionAtLeast cudatoolkit_11.version "11.1";
+
+let
+  device = if cudaSupport then "gpu" else "cpu";
+in
 buildPythonPackage rec {
   pname = "jaxlib";
-  version = "0.1.70";
+  version = "0.1.71";
   format = "wheel";
 
   # At the time of writing (8/19/21), there are releases for 3.7-3.9. Supporting
@@ -18,22 +30,46 @@ buildPythonPackage rec {
   # version.
   disabled = !isPy39;
 
-  src = fetchPypi {
-    inherit pname version format;
-    dist = "cp39";
-    python = "cp39";
-    platform = "manylinux2010_x86_64";
-    sha256 = "sha256-mytMTqoavpuRawj52MU5/iFj27SGlm8DaoQ5vd/3bss=";
-  };
+  src = {
+    cpu = fetchurl {
+      url = "https://storage.googleapis.com/jax-releases/nocuda/jaxlib-${version}-cp39-none-manylinux2010_x86_64.whl";
+      sha256 = "sha256:0rqhs6qabydizlv5d3rb20dbv6612rr7dqfniy9r6h4kazdinsn6";
+    };
+    gpu = fetchurl {
+      url = "https://storage.googleapis.com/jax-releases/cuda111/jaxlib-${version}+cuda111-cp39-none-manylinux2010_x86_64.whl";
+      sha256 = "sha256:065kyzjsk9m84d138p99iymdiiicm1qz8a3iwxz8rspl43rwrw89";
+    };
+  }.${device};
 
   # Prebuilt wheels are dynamically linked against things that nix can't find.
   # Run `autoPatchelfHook` to automagically fix them.
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [ autoPatchelfHook ] ++ lib.optional cudaSupport addOpenGLRunpath;
   # Dynamic link dependencies
   buildInputs = [ stdenv.cc.cc ];
 
+  # jaxlib contains shared libraries that open other shared libraries via dlopen
+  # and these implicit dependencies are not recognized by ldd or
+  # autoPatchelfHook. That means we need to sneak them into rpath. This step
+  # must be done after autoPatchelfHook and the automatic stripping of
+  # artifacts. autoPatchelfHook runs in postFixup and auto-stripping runs in the
+  # patchPhase. Dependencies:
+  #   * libcudart.so.11.0 -> cudatoolkit_11.lib
+  #   * libcuda.so.1      -> opengl driver in /run/opengl-driver/lib
+  preInstallCheck = lib.optional cudaSupport ''
+    shopt -s globstar
+
+    addOpenGLRunpath $out/**/*.so
+
+    for file in $out/**/*.so; do
+      rpath=$(patchelf --print-rpath $file)
+      patchelf --set-rpath "$rpath:${lib.makeLibraryPath [ cudatoolkit_11.lib ]}" $file
+    done
+  '';
+
   # pip dependencies
   propagatedBuildInputs = [ absl-py flatbuffers scipy ];
+
+  pythonImportsCheck = [ "jaxlib" ];
 
   meta = with lib; {
     description = "XLA library for JAX";

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -1,0 +1,45 @@
+# For the moment we only support the CPU backend of jaxlib. GPU and TPU backends
+# require some additional work. Their wheels are not located on PyPI.
+#  * CPU/GPU: https://storage.googleapis.com/jax-releases/jax_releases.html
+#  * TPU: https://storage.googleapis.com/jax-releases/libtpu_releases.html
+
+{ autoPatchelfHook, buildPythonPackage, fetchPypi, isPy39, lib, stdenv
+# propagatedBuildInputs
+, absl-py, flatbuffers, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "jaxlib";
+  version = "0.1.70";
+  format = "wheel";
+
+  # At the time of writing (8/19/21), there are releases for 3.7-3.9. Supporting
+  # all of them is a pain, so we focus on 3.9, the current nixpkgs python3
+  # version.
+  disabled = !isPy39;
+
+  src = fetchPypi {
+    inherit pname version format;
+    dist = "cp39";
+    python = "cp39";
+    platform = "manylinux2010_x86_64";
+    sha256 = "sha256-mytMTqoavpuRawj52MU5/iFj27SGlm8DaoQ5vd/3bss=";
+  };
+
+  # Prebuilt wheels are dynamically linked against things that nix can't find.
+  # Run `autoPatchelfHook` to automagically fix them.
+  nativeBuildInputs = [ autoPatchelfHook ];
+  # Dynamic link dependencies
+  buildInputs = [ stdenv.cc.cc ];
+
+  # pip dependencies
+  propagatedBuildInputs = [ absl-py flatbuffers scipy ];
+
+  meta = with lib; {
+    description = "XLA library for JAX";
+    homepage    = "https://github.com/google/jax";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ samuela ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3716,6 +3716,8 @@ in {
 
   javaproperties = callPackage ../development/python-modules/javaproperties { };
 
+  jax = callPackage ../development/python-modules/jax { };
+
   jaxlib = callPackage ../development/python-modules/jaxlib { };
 
   JayDeBeApi = callPackage ../development/python-modules/JayDeBeApi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3716,6 +3716,8 @@ in {
 
   javaproperties = callPackage ../development/python-modules/javaproperties { };
 
+  jaxlib = callPackage ../development/python-modules/jaxlib { };
+
   JayDeBeApi = callPackage ../development/python-modules/JayDeBeApi { };
 
   jc = callPackage ../development/python-modules/jc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Packaging of the JAX (https://github.com/google/jax) library. JAX is a modern framework for differentiable programming. The `jax` package uses `jaxlib` as it's "backend". Currently only the CPU backend running on x86_64-linux is packaged.

TODO, unfinished items left to future PRs:
- [x] Fix `jnp.array([1, 2, 3])`.
- [x] Run the jax test suite.
- [x] GPU backend support
- [ ] TPU backend support
- [ ] Fix the build on macOS. Currently segfaults when running the test suite.

Useful resources:
* https://jax.readthedocs.io/en/latest/developer.html#running-the-tests
* https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/python.section.md

###### Things done
Created derivations for the jax and jaxlib python packages.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
