### PR TITLE
bitlbee-plugins: use runCommandLocal instead of mkDerivation

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bitlbee/plugins.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/plugins.nix
@@ -1,20 +1,15 @@
-{ lib, stdenv, bitlbee }:
+{ lib, runCommandLocal, bitlbee }:
 
 with lib;
 
-plugins:
-
-stdenv.mkDerivation {
-  inherit bitlbee plugins;
-  name = "bitlbee-plugins";
+plugins: runCommandLocal "bitlbee-plugins" {
+  inherit plugins;
   buildInputs = [ bitlbee plugins ];
-  phases = [ "installPhase" ];
-  installPhase = ''
-    mkdir -p $out/lib/bitlbee
-    for plugin in $plugins; do
-      for thing in $(ls $plugin/lib/bitlbee); do
-        ln -s $plugin/lib/bitlbee/$thing $out/lib/bitlbee/
-      done
+} ''
+  mkdir -p $out/lib/bitlbee
+  for plugin in $plugins; do
+    for thing in $(ls $plugin/lib/bitlbee); do
+      ln -s $plugin/lib/bitlbee/$thing $out/lib/bitlbee/
     done
-  '';
-}
+  done
+''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#28910

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
