### PR TITLE
Revert "python38Packages.pytest-mpl: 0.12 -> 0.13" - mistaken merge

### DIFF
--- a/pkgs/development/python-modules/pytest-mpl/default.nix
+++ b/pkgs/development/python-modules/pytest-mpl/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "pytest-mpl";
-  version = "0.13";
+  version = "0.12";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "582db6e14315f9b08cbd2df39b136dc344bfe8a27c2f05b995460fb0969ec19e";
+    sha256 = "4a223909e5148c99bd18891848c7871457729322c752c9c470bd8dd6bdf9f940";
   };
 
   buildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#134812

Approved/merged wrong PR. This actually seems to break `datashader`.