### PR TITLE
openroad: init at 2.0

### DIFF
--- a/pkgs/applications/science/electronics/openroad/default.nix
+++ b/pkgs/applications/science/electronics/openroad/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, bison
+, cmake
+, doxygen
+, flex
+, git
+, python3
+, swig4
+, boost172
+, cimg
+, eigen
+, lcov
+, lemon-graph
+, libjpeg
+, pcre
+, qtbase
+, readline
+, spdlog
+, tcl
+, tcllib
+, xorg
+, yosys
+, zlib
+}:
+
+mkDerivation rec {
+  pname = "openroad";
+  version = "2.0";
+
+  src = fetchFromGitHub {
+    owner = "The-OpenROAD-Project";
+    repo = "OpenROAD";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "1p677xh16wskfj06jnplhpc3glibhdaqxmk0j09832chqlryzwyx";
+  };
+
+  nativeBuildInputs = [
+    bison
+    cmake
+    doxygen
+    flex
+    git
+    swig4
+  ];
+
+  buildInputs = [
+    boost172
+    cimg
+    eigen
+    lcov
+    lemon-graph
+    libjpeg
+    pcre
+    python3
+    qtbase
+    readline
+    spdlog
+    tcl
+    tcllib
+    yosys
+    xorg.libX11
+    zlib
+  ];
+
+  postPatch = ''
+    patchShebangs --build etc/find_messages.py
+  '';
+
+  # Enable output images from the placer.
+  cmakeFlags = [ "-DUSE_CIMG_LIB=ON" ];
+
+  # Resynthesis needs access to the Yosys binaries.
+  qtWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ yosys ]}" ];
+
+  # Upstream uses vendored package versions for some dependencies, so regression testing is prudent
+  # to see if there are any breaking changes in unstable that should be vendored as well.
+  doCheck = false; # Disabled pending upstream release with fix for rcx log file creation.
+  checkPhase = ''
+    # Regression tests must be run from the project root not from within the CMake build directory.
+    cd ..
+    test/regression
+  '';
+
+  meta = with lib; {
+    description = "OpenROAD's unified application implementing an RTL-to-GDS flow";
+    homepage = "https://theopenroadproject.org";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ trepetti ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30960,6 +30960,8 @@ with pkgs;
 
   openems = callPackage ../applications/science/electronics/openems { };
 
+  openroad = libsForQt5.callPackage ../applications/science/electronics/openroad { };
+
   pcb = callPackage ../applications/science/electronics/pcb { };
 
   qucs = callPackage ../applications/science/electronics/qucs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[OpenROAD](https://theopenroadproject.org/) is a complete open source RTL-to-GDSII flow (digital IC implementation) that chip designers can use. It is under rapid development and has already seen a lot of use. It would complement the many other EDA tools available in the Nix ecosystem nicely.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
