### PR TITLE
glm: 0.9.8.5 -> 0.9.9.8

### DIFF
--- a/pkgs/development/libraries/glm/glm.pc.in
+++ b/pkgs/development/libraries/glm/glm.pc.in
@@ -1,0 +1,7 @@
+prefix=@out@
+includedir=@out@/include
+
+Name: GLM
+Description: OpenGL Mathematics
+Version: @version@
+Cflags: -I${includedir}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump abandoned package to close #132479.

I don't really use it. I was just skimming through the list of issues to find something I may help with.

###### Things done

<details>
<summary>Bump version and refactor derivation to make it work</summary>

- Use `fetchFromGitHub` to download the archive.

- No need for the updated `platform.h` patch. The released archive builds with default `stdenv`. (It may be needed again in the future?)

- Use the proper attribute to set CMake flags.

- Don't build the (dummy?) libraries. They are not used anyway by any other target nor made available by the `glmConfig.cmake` file.

- Build and run the tests now.

- Don't define the `GLM_COMPILER` macro on Darwin. Doesn't seem necessary anymore, there are no errors without it. (And it is not even documented what was the original error that required it to be defined.)

- Upstream became package-unfriendly and removed the install command, so it needs to be installed manually.

  - Don't set the now unsupported CMake option `GLM_INSTALL_ENABLE`.

  - Remove unwanted files from the include directory.

  - Fix `glmConfig.cmake` with the proper path to the include directory.

  - While on it, install a custom pkg-config file, since it is trivial.

  - Don't install unnecessary files as documentation.

- Since I practically rewrote the entire derivation and the package is abandoned, add myself as maintainer (I guess?).

</details> 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

---------

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
