### PR TITLE
psst: init at 318e069

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7595,6 +7595,16 @@
     githubId = 4996739;
     name = "Masayuki Takeda";
   };
+  mth = {
+    name = "Matthias Totschnig";
+    email = "matthias@totschnig.org";
+    github = "matthias-t";
+    githubId = 26206173;
+    keys = [{
+      longkeyid = "rsa4096/0x5261FB421242D9A1";
+      fingerprint = "53FD 487B DAA0 35BA E250  D415 5261 FB42 1242 D9A1";
+    }];
+  };
   MtP = {
     email = "marko.nixos@poikonen.de";
     github = "MtP76";

--- a/pkgs/applications/audio/psst/default.nix
+++ b/pkgs/applications/audio/psst/default.nix
@@ -1,0 +1,30 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, gtk3, glib,
+gdk-pixbuf, cairo , pango, dbus, stdenv, darwin ? null }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "psst";
+  version = "unstable-2021-08-19";
+
+  src = fetchFromGitHub {
+    owner = "jpochyla";
+    repo = pname;
+    rev = "724aa251407dfa93b8ede8e879fd5ca35de1ddd2";
+    sha256 = "08m6h2gkgnpmfpw93zb6rhrvbw5rhq0mgpcfzingdvsqw531r13w";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gtk3 glib gdk-pixbuf cairo pango dbus ]
+  ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    AppKit CoreFoundation CoreGraphics CoreText CoreVideo
+    Foundation MediaPlayer QuartzCore Security ]);
+
+  cargoSha256 = "19xfpmlfpq6ba0i4pissxlngdqg5ydnpa7izg8hky2ryyf48kvf7";
+
+  meta = with lib; {
+    description = "Fast and multi-platform Spotify client with native GUI";
+    homepage = "https://github.com/jpochyla/psst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3290,6 +3290,8 @@ with pkgs;
 
   psstop = callPackage ../tools/system/psstop { };
 
+  psst = callPackage ../applications/audio/psst { };
+
   precice = callPackage ../development/libraries/precice { };
 
   pueue = callPackage ../applications/misc/pueue {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #115155. This won't build until `rustc` 1.54.0 is merged.

Tangentially, I resorted to `fetchgit` since `fetchFromGitHub` seemingly fails to fetch the minivorbis submodule, even with `fetchSubmodules = true`. Could somebody reproduce or investigate this?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
