### PR TITLE
treewide: buildFlags{,Array} -> ldflags, tags

### DIFF
--- a/pkgs/applications/networking/cluster/docker-machine/xhyve.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/xhyve.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
     export CGO_CFLAGS=-I$(pwd)/go/src/${goPackagePath}/vendor/github.com/jceel/lib9p
     export CGO_LDFLAGS=$(pwd)/go/src/${goPackagePath}/vendor/build/lib9p/lib9p.a
   '';
-  buildFlags = "--tags lib9p";
+  tags = [ "lib9p" ];
 
   src = fetchFromGitHub {
     rev    = "v${version}";

--- a/pkgs/applications/networking/cluster/kubebuilder/default.nix
+++ b/pkgs/applications/networking/cluster/kubebuilder/default.nix
@@ -20,13 +20,13 @@ buildGoModule rec {
 
   subPackages = ["cmd"];
 
-  preBuild = ''
-    export buildFlagsArray+=("-ldflags=-X main.kubeBuilderVersion=v${version} \
-        -X main.goos=$GOOS \
-        -X main.goarch=$GOARCH \
-        -X main.gitCommit=v${version} \
-        -X main.buildDate=v${version}")
-  '';
+  ldflags = [
+    "-X main.kubeBuilderVersion=v${version}"
+    "-X main.goos=${go.GOOS}"
+    "-X main.goarch=${go.GOARCH}"
+    "-X main.gitCommit=v${version}"
+    "-X main.buildDate=v${version}"
+  ];
 
   doCheck = true;
 

--- a/pkgs/applications/terminal-emulators/aminal/default.nix
+++ b/pkgs/applications/terminal-emulators/aminal/default.nix
@@ -33,9 +33,9 @@ buildGoPackage rec {
     sha256 = "0syv9md7blnl6i19zf8s1xjx5vfz6s755fxyg2ply0qc1pwhsj8n";
   };
 
-  preBuild = ''
-    buildFlagsArray=("-ldflags=-X ${goPackagePath}/version.Version=${version}")
-  '';
+  ldflags = [
+    "-X ${goPackagePath}/version.Version=${version}"
+  ];
 
   meta = with lib; {
     description = "Golang terminal emulator from scratch";

--- a/pkgs/development/tools/kubeprompt/default.nix
+++ b/pkgs/development/tools/kubeprompt/default.nix
@@ -11,12 +11,10 @@ buildGoModule rec {
     sha256 = "1a0xi31bd7n2zrx2z4srhvixlbj028h63dlrjzqxgmgn2w6akbz2";
   };
 
-  preBuild = ''
-    export buildFlagsArray+=(
-      "-ldflags=
-        -w -s
-        -X github.com/jlesquembre/kubeprompt/pkg/version.Version=${version}")
-  '';
+  ldflags = [
+    "-w" "-s"
+    "-X github.com/jlesquembre/kubeprompt/pkg/version.Version=${version}"
+  ];
 
   vendorSha256 = "089lfkvyf00f05kkmr935jbrddf2c0v7m2356whqnz7ad6a2whsi";
 

--- a/pkgs/servers/monitoring/alertmanager-bot/default.nix
+++ b/pkgs/servers/monitoring/alertmanager-bot/default.nix
@@ -17,11 +17,9 @@ buildGoModule rec {
     sed "s;/templates/default.tmpl;$out/share&;" -i cmd/alertmanager-bot/main.go
   '';
 
-  preBuild = ''
-    export buildFlagsArray=(
-      "-ldflags=-s -w -X main.Version=v${version} -X main.Revision=${src.rev}"
-    )
-  '';
+  ldflags = [
+    "-s" "-w" "-X main.Version=v${version}" "-X main.Revision=${src.rev}"
+  ];
 
   postInstall = ''
     install -Dm644 -t $out/share/templates $src/default.tmpl


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
