### PR TITLE
[21.05] mautrix telegram: 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -13,14 +13,14 @@ let
 
 in buildPythonPackage rec {
   pname = "mautrix-telegram";
-  version = "unstable-2021-08-12";
+  version = "0.10.1";
   disabled = python.pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "tulir";
     repo = pname;
-    rev = "ec64c83cb01791525a39f937f3b847368021dce8";
-    sha256 = "0rg4f4abdddhhf1xpz74y4468dv3mnm7k8nj161r1xszrk9f2n76";
+    rev = "v${version}";
+    sha256 = "sha256-1Dmc7WRlT2ivGkdrGDC1b44DE0ovQKfUR0gDiQE4h5c=";
   };
 
   patches = [ ./0001-Re-add-entrypoint.patch ./0002-Don-t-depend-on-pytest-runner.patch ];

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -13,19 +13,21 @@ let
 
 in buildPythonPackage rec {
   pname = "mautrix-telegram";
-  version = "0.9.0";
-  disabled = pythonOlder "3.7";
+  version = "unstable-2021-08-12";
+  disabled = python.pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "tulir";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1543ljjl3jg3ayid7ifi4bamqh4gq85pmlbs3m8i7phjbbm7g9dn";
+    rev = "ec64c83cb01791525a39f937f3b847368021dce8";
+    sha256 = "0rg4f4abdddhhf1xpz74y4468dv3mnm7k8nj161r1xszrk9f2n76";
   };
 
   patches = [ ./0001-Re-add-entrypoint.patch ./0002-Don-t-depend-on-pytest-runner.patch ];
   postPatch = ''
     sed -i -e '/alembic>/d' requirements.txt
+    substituteInPlace requirements.txt \
+      --replace "telethon>=1.22,<1.23" "telethon"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -2,16 +2,26 @@
 , withE2BE ? true
 }:
 
-with python3.pkgs;
-
 let
+  python = python3.override {
+    packageOverrides = self: super: {
+      mautrix = super.mautrix.overridePythonAttrs (oldAttrs: rec {
+        version = "0.10.4";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "ffbc4e29eb56089539b408f8e4c12a5d5a5d11d7fe7d40f8c6279784c618b869";
+        };
+      });
+    };
+  };
+
   # officially supported database drivers
-  dbDrivers = [
+  dbDrivers = with python.pkgs; [
     psycopg2
     # sqlite driver is already shipped with python by default
   ];
 
-in buildPythonPackage rec {
+in with python.pkgs; buildPythonPackage rec {
   pname = "mautrix-telegram";
   version = "0.10.1";
   disabled = python.pythonOlder "3.7";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#134792

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
