### PR TITLE
xcolor: unstable -> 0.5.0

### DIFF
--- a/pkgs/tools/graphics/xcolor/default.nix
+++ b/pkgs/tools/graphics/xcolor/default.nix
@@ -1,18 +1,7 @@
-{ lib, rustPlatform, fetchFromGitHub, fetchpatch, pkg-config, libX11, libXcursor
-, libxcb, python3, makeDesktopItem }:
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, libX11, libXcursor
+, libxcb, python3, installShellFiles, makeDesktopItem, copyDesktopItems }:
 
-let
-  desktopItem = makeDesktopItem {
-    name = "XColor";
-    exec = "xcolor -s";
-    desktopName = "XColor";
-    comment =
-      "Select colors visible anywhere on the screen to get their RGB representation";
-    icon = "xcolor";
-    categories = "Graphics;";
-  };
-
-in rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "xcolor";
   version = "0.5.0";
 
@@ -25,21 +14,28 @@ in rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1r2s4iy5ls0svw5ww51m37jhrbvnj690ig6n9c60hzw1hl4krk30";
 
-  nativeBuildInputs = [ pkg-config python3 ];
+  nativeBuildInputs = [ pkg-config python3 installShellFiles copyDesktopItems ];
 
   buildInputs = [ libX11 libXcursor libxcb ];
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "XColor";
+      exec = "xcolor -s";
+      desktopName = "XColor";
+      comment = "Select colors visible anywhere on the screen to get their RGB representation";
+      icon = "xcolor";
+      categories = "Graphics;";
+    })
+  ];
+
   postInstall = ''
     mkdir -p $out/share/applications
-    cp "${desktopItem}"/share/applications/* $out/share/applications/
 
-    install -D -m644 -- man/xcolor.1 $out/share/man/man1/xcolor.1
-    install -D -m644 -- extra/icons/xcolor-16.png $out/share/icons/hicolor/16x16/apps/xcolor.png
-    install -D -m644 -- extra/icons/xcolor-24.png $out/share/icons/hicolor/24x24/apps/xcolor.png
-    install -D -m644 -- extra/icons/xcolor-32.png $out/share/icons/hicolor/32x32/apps/xcolor.png
-    install -D -m644 -- extra/icons/xcolor-48.png $out/share/icons/hicolor/48x48/apps/xcolor.png
-    install -D -m644 -- extra/icons/xcolor-256.png $out/share/icons/hicolor/256x256/apps/xcolor.png
-    install -D -m644 -- extra/icons/xcolor-512.png $out/share/icons/hicolor/512x512/apps/xcolor.png
+    installManPage man/xcolor.1
+    for x in 16 24 32 48 256 512; do
+        install -D -m644 extra/icons/xcolor-''${x}.png $out/share/icons/hicolor/''${x}x''${x}/apps/xcolor.png
+    done
   '';
 
   meta = with lib; {

--- a/pkgs/tools/graphics/xcolor/default.nix
+++ b/pkgs/tools/graphics/xcolor/default.nix
@@ -1,29 +1,46 @@
-{ lib, rustPlatform, fetchFromGitHub, fetchpatch, pkg-config, libX11, libXcursor, libxcb, python3 }:
+{ lib, rustPlatform, fetchFromGitHub, fetchpatch, pkg-config, libX11, libXcursor
+, libxcb, python3, makeDesktopItem }:
 
-rustPlatform.buildRustPackage rec {
+let
+  desktopItem = makeDesktopItem {
+    name = "XColor";
+    exec = "xcolor -s";
+    desktopName = "XColor";
+    comment =
+      "Select colors visible anywhere on the screen to get their RGB representation";
+    icon = "xcolor";
+    categories = "Graphics;";
+  };
+
+in rustPlatform.buildRustPackage rec {
   pname = "xcolor";
-  version = "unstable-2021-02-02";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "Soft";
     repo = pname;
-    rev = "0e99e67cd37000bf563aa1e89faae796ec25f163";
-    sha256 = "sha256-rHqK05dN5lrvDNbRCWGghI7KJwWzNCuRDEThEeMzmio=";
+    rev = version;
+    sha256 = "0i04jwvjasrypnsfwdnvsvcygp8ckf1a5sxvjxaivy73cdvy34vk";
   };
 
-  cargoPatches = [
-    # Update Cargo.lock, lexical_core doesn't build on Rust 1.52.1
-    (fetchpatch {
-      url = "https://github.com/Soft/xcolor/commit/324d80a18a39a11f2f7141b226f492e2a862d2ce.patch";
-      sha256 = "sha256-5VzXitpl/gMef40UQBh1EoHezXPyB08aflqp0mSMAVI=";
-    })
-  ];
-
-  cargoSha256 = "sha256-yD4pX+dCJvbDecsdB8tNt1VsEcyAJxNrB5WsZUhPGII=";
+  cargoSha256 = "1r2s4iy5ls0svw5ww51m37jhrbvnj690ig6n9c60hzw1hl4krk30";
 
   nativeBuildInputs = [ pkg-config python3 ];
 
   buildInputs = [ libX11 libXcursor libxcb ];
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp "${desktopItem}"/share/applications/* $out/share/applications/
+
+    install -D -m644 -- man/xcolor.1 $out/share/man/man1/xcolor.1
+    install -D -m644 -- extra/icons/xcolor-16.png $out/share/icons/hicolor/16x16/apps/xcolor.png
+    install -D -m644 -- extra/icons/xcolor-24.png $out/share/icons/hicolor/24x24/apps/xcolor.png
+    install -D -m644 -- extra/icons/xcolor-32.png $out/share/icons/hicolor/32x32/apps/xcolor.png
+    install -D -m644 -- extra/icons/xcolor-48.png $out/share/icons/hicolor/48x48/apps/xcolor.png
+    install -D -m644 -- extra/icons/xcolor-256.png $out/share/icons/hicolor/256x256/apps/xcolor.png
+    install -D -m644 -- extra/icons/xcolor-512.png $out/share/icons/hicolor/512x512/apps/xcolor.png
+  '';
 
   meta = with lib; {
     description = "Lightweight color picker for X11";


### PR DESCRIPTION
Also create a desktop item so xcolor shows up in application launchers.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
