### PR TITLE
fix toRustTarget for windows

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -10,7 +10,6 @@
 , importCargoLock
 , rustPlatform
 , callPackage
-, remarshal
 , git
 , rust
 , rustc

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -38,8 +38,11 @@
       "armv5tel" = "armv5te";
       "riscv64" = "riscv64gc";
     }.${cpu.name} or cpu.name;
+    vendor_ = platform.rustc.platform.vendor or {
+      "w64" = "pc";
+    }.${vendor.name} or vendor.name;
   in platform.rustc.config
-    or "${cpu_}-${vendor.name}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
+    or "${cpu_}-${vendor_}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
 
   # Returns the name of the rust target if it is standard, or the json file
   # containing the custom target spec.


### PR DESCRIPTION
###### Motivation for this change

Rust cross compilation to windows broke in 91718534f1f476a727b51a256c93885e57cf602d because the vendor component in the target triplet/"quadlet" was changed from `pc` to `w64`. Rust still uses `pc` so this PR just adds this replacement to the `toRustTarget` function in the spirit of #66613, which seems to have first introduced the idea of target component replacement.

You can test this using the following derivation, which should **not evaluate** before this change and successfully build after it.

The expected error is:

```
$ nix-build test.nix
error: attribute '*' missing

       at /nix/store/vgmjaczw53f7iknzwjhjr7fq1dlld37i-source/rust-overlay.nix:67:80:

           66|       pkg = pkgs.${pkgname};
           67|       srcInfo = pkg.target.${super.rust.toRustTarget stdenv.targetPlatform} or pkg.target."*";
             |                                                                                ^
           68|       extensions = srcInfo.extensions or [];
```

The repro snippet:
(I'm using the nixpkgs-mozilla overlay because building the rust tools in nixpkgs OOMs on my machine)

```nix
let
  ## TOGGLE THIS ##
  withFix = false;

  nixpkgs = builtins.fetchGit (if withFix then {
    url = "https://github.com/dermetfan/nixpkgs";
    ref = "rust-target-windows";
  } else {
    url = "https://github.com/NixOS/nixpkgs";
    rev = "456481aa3dd633038c86635f3bcf83d339254119";
  });

  pkgs = (import nixpkgs { system = builtins.currentSystem; })
    .pkgsCross.mingwW64;

  nixpkgs-mozilla = import "${builtins.fetchGit "https://github.com/mozilla/nixpkgs-mozilla"}/package-set.nix"
    { pkgs = pkgs.pkgsBuildHost; };

  # Only rustPlatform needs to target the host platform
  # because it produces the actual derivation
  # and the rest is build-time dependencies.
  crossPackage = pkgs.pkgsBuildHost.callPackage package {
    rustPlatform = let
      rustStable = (nixpkgs-mozilla.rustChannelOf {
        channel = "1.52.0";
        sha256 = "0qzaq3hsxh7skxjix4d4k38rv0cxwwnvi32arg08p11cxvpsmikx";
      }).rust.override {
        targets = [
          "x86_64-pc-windows-msvc"
        ];
      };
    in pkgs.makeRustPlatform {
      rustc = rustStable;
      cargo = rustStable;
    };
  };

  package =
    { lib, rustPlatform, runCommandNoCCLocal }:

    rustPlatform.buildRustPackage rec {
      pname = "pr-test";
      version = "0.0.0";

      src = let
        nv = ''
          name = "${pname}"
          version = "${version}"
        '';
      in runCommandNoCCLocal "gen-src" {} ''
        mkdir -p $out/src
        cd $out

        cat > Cargo.toml <<'EOF'
        [package]
        ${nv}
        EOF

        cat > Cargo.lock <<'EOF'
        [[package]]
        ${nv}
        EOF

        cat > src/main.rs <<'EOF'
        fn main() { println!("Hello, world!"); }
        EOF
      '';

      cargoHash = "sha256-g/msjJNAr+c3Av1GZUNZw40yb/9msHfkKPDPijn7P+k=";

      meta.platforms = lib.platforms.windows;
    };
in crossPackage
```

There is probably more work ahead to make cross compilation work the way it should, see #68804.

I also removed the unused dependency on `remarshal`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
