### PR TITLE
buildenv: fix regression introduced by #134215

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -14,6 +14,7 @@ $SIG{__WARN__} = sub { warn "warning: ", @_ };
 $SIG{__DIE__}  = sub { die "error: ", @_ };
 
 my $out = $ENV{"out"};
+my $extraPrefix = $ENV{"extraPrefix"};
 
 my @pathsToLink = split ' ', $ENV{"pathsToLink"};
 
@@ -256,7 +257,6 @@ while (scalar(keys %postponed) > 0) {
 
 
 # Create the symlinks.
-my $extraPrefix = $ENV{"extraPrefix"};
 my $nrLinks = 0;
 foreach my $relName (sort keys %symlinks) {
     my ($target, $priority) = @{$symlinks{$relName}};


### PR DESCRIPTION
As @Mindavi correctly pointed out in https://github.com/NixOS/nixpkgs/pull/134215#issuecomment-902468414, the definition of the global variable extraPrefix needs to be moved up in the file.