### PR TITLE
ko: general improvements

### DIFF
--- a/pkgs/development/tools/ko/default.nix
+++ b/pkgs/development/tools/ko/default.nix
@@ -2,6 +2,7 @@
 , buildGoModule
 , fetchFromGitHub
 , git
+, installShellFiles
 }:
 
 buildGoModule rec {
@@ -14,18 +15,37 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "sha256-LoOXZY4uF7GSS3Dh/ozCsLJTxgmPmZZuEisJ4ShjCBc=";
   };
-
   vendorSha256 = null;
-  excludedPackages = "test";
+  # Don't build the legacy main.go or test dir
+  excludedPackages = "\\(cmd/ko\\|test\\)";
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [ "-s" "-w" "-X github.com/google/ko/pkg/commands.Version=${version}" ];
+
   checkInputs = [ git ];
   preCheck = ''
+    # resolves some complaints from ko
+    export GOROOT="$(go env GOROOT)"
     git init
   '';
 
+  postInstall = ''
+    installShellCompletion --cmd ko \
+      --bash <($out/bin/ko completion) \
+      --zsh <($out/bin/ko completion --zsh)
+  '';
+
   meta = with lib; {
-    description = "A simple, fast container image builder for Go applications.";
     homepage = "https://github.com/google/ko";
+    changelog = "https://github.com/google/ko/releases/tag/v${version}";
+    description = "Build and deploy Go applications on Kubernetes";
+    longDescription = ''
+      ko is a simple, fast container image builder for Go applications.
+      It's ideal for use cases where your image contains a single Go application without any/many dependencies on the OS base image (e.g. no cgo, no OS package dependencies).
+      ko builds images by effectively executing go build on your local machine, and as such doesn't require docker to be installed. This can make it a good fit for lightweight CI/CD use cases.
+      ko also includes support for simple YAML templating which makes it a powerful tool for Kubernetes applications.
+    '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ nickcao ];
+    maintainers = with maintainers; [ nickcao jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* exclude cmd/ko so the correct entrypoint is built

Current build outputs this warning on every command:

```
2021/08/20 13:53:46 NOTICE!
-----------------------------------------------------------------
Please install ko from github.com/google/ko.

For more information see:
   https://github.com/google/ko/issues/258
-----------------------------------------------------------------
```

* suppress GOROOT warnings during tests

Example of the warnings:
```
2021/08/20 13:21:20 NOTICE!
-----------------------------------------------------------------
ko and go have mismatched GOROOT:
    go/build.Default.GOROOT = "go"
    $(go env GOROOT) = "/nix/store/d358abhmxia8l28xhif8rjhb75cqzh37-go-1.16.7/share/go"

Inferring GOROOT="/nix/store/d358abhmxia8l28xhif8rjhb75cqzh37-go-1.16.7/share/go"

Run this to remove this warning:
    export GOROOT=$(go env GOROOT)

For more information see:
    https://github.com/google/ko/issues/106
-----------------------------------------------------------------
```


* add ldflags for smaller builds and version
  * 35MB -> 31MB
* add completion
* add changelog
* add long description
* added myself as a maintainer

@NickCao

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
