### PR TITLE
arpa2common: init at 2.2.14

### DIFF
--- a/pkgs/development/libraries/arpa2common/default.nix
+++ b/pkgs/development/libraries/arpa2common/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+
+, arpa2cm
+, doxygen
+, e2fsprogs
+, lmdb
+, openssl
+, pkg-config
+, ragel
+}:
+
+stdenv.mkDerivation rec {
+  pname = "arpa2common";
+  version = "2.2.14";
+
+  src = fetchFromGitLab {
+    owner = "arpa2";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-LWsWoHRdLWRSF9JaEwrw+CXm5Azgh7zNeq0a8Z/hijQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    arpa2cm
+    doxygen
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [
+    e2fsprogs
+    lmdb
+    openssl
+    ragel
+  ];
+
+  # the project uses single argument `printf` throughout the program
+  hardeningDisable = [ "format" ];
+
+  meta = {
+    description =
+      "ARPA2 ID and ACL libraries and other core data structures for ARPA2";
+    longDescription = ''
+      The ARPA2 Common Library package offers elementary services that can
+      benefit many software packages.  They are designed to be easy to
+      include, with a minimum of dependencies.  At the same time, they were
+      designed with the InternetWide Architecture in mind, thus helping to
+      liberate users.
+    '';
+    homepage = "https://gitlab.com/arpa2/arpa2common";
+    license = with lib.licenses; [ bsd2 cc-by-sa-40 cc0 isc ];
+    maintainers = with lib.maintainers; [ fufexan ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13181,6 +13181,8 @@ with pkgs;
 
   arpa2cm = callPackage ../development/tools/build-managers/arpa2cm { };
 
+  arpa2common = callPackage ../development/libraries/arpa2common { };
+
   asn2quickder = python2Packages.callPackage ../development/tools/asn2quickder {};
 
   astyle = callPackage ../development/tools/misc/astyle { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Dependency of NixOS/nixpkgs#134332 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
