### PR TITLE
purism-ectool: init at 0.3.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1038,6 +1038,12 @@
     githubId = 1222;
     name = "Aaron VonderHaar";
   };
+  avieth = {
+    email = "aovieth@gmail.com";
+    github = "avieth";
+    name = "Alexander Vieth";
+    githubId = 1420272;
+  };
   avitex = {
     email = "theavitex@gmail.com";
     github = "avitex";

--- a/pkgs/os-specific/linux/purism/ectool.nix
+++ b/pkgs/os-specific/linux/purism/ectool.nix
@@ -1,0 +1,28 @@
+{ lib, fetchgit, rustPlatform, udev, pkg-config }:
+let
+
+  gitsrc = fetchgit {
+      url = "https://source.puri.sm/firmware/librem-ec.git";
+      rev = "05d9990d7500e1cf3d09844407f77cb64c049a12";
+      sha256 = "145x8v5zmc9vp9hci0hf3lczyi1bf8hj4bawyy5vgy8bpvdsjgk7";
+    };
+
+in
+rustPlatform.buildRustPackage rec {
+  pname = "purism-ectool";
+  version = "0.3.5";
+
+  src = gitsrc + /tool;
+
+  cargoSha256 = "sha256:16ahi0qpwfk7vc2wymishg19rbyadv4sk1hp0qzsjj0m3s9ws3yh";
+
+  buildInputs = [ udev ];
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = with lib; {
+    description = "The Purism EC tool";
+    homepage = "https://source.puri.sm/firmware/librem-ec";
+    license = licenses.gpl3;
+    maintainers = [maintainers.avieth];
+  };
+}

--- a/pkgs/os-specific/linux/purism/ectool/default.nix
+++ b/pkgs/os-specific/linux/purism/ectool/default.nix
@@ -1,11 +1,13 @@
-{ lib, fetchgit, rustPlatform, udev, pkg-config }:
+{ lib, fetchFromGitLab, rustPlatform, udev, pkg-config }:
 let
 
-  gitsrc = fetchgit {
-      url = "https://source.puri.sm/firmware/librem-ec.git";
-      rev = "05d9990d7500e1cf3d09844407f77cb64c049a12";
-      sha256 = "145x8v5zmc9vp9hci0hf3lczyi1bf8hj4bawyy5vgy8bpvdsjgk7";
-    };
+  gitsrc = fetchFromGitLab {
+    domain = "source.puri.sm";
+    owner = "firmware";
+    repo = "librem-ec";
+    rev = "05d9990d7500e1cf3d09844407f77cb64c049a12";
+    sha256 = "145x8v5zmc9vp9hci0hf3lczyi1bf8hj4bawyy5vgy8bpvdsjgk7";
+  };
 
 in
 rustPlatform.buildRustPackage rec {
@@ -14,7 +16,7 @@ rustPlatform.buildRustPackage rec {
 
   src = gitsrc + /tool;
 
-  cargoSha256 = "sha256:16ahi0qpwfk7vc2wymishg19rbyadv4sk1hp0qzsjj0m3s9ws3yh";
+  cargoSha256 = "16ahi0qpwfk7vc2wymishg19rbyadv4sk1hp0qzsjj0m3s9ws3yh";
 
   buildInputs = [ udev ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/os-specific/linux/purism/ectool/default.nix
+++ b/pkgs/os-specific/linux/purism/ectool/default.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "The Purism EC tool";
     homepage = "https://source.puri.sm/firmware/librem-ec";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = [maintainers.avieth];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -326,7 +326,7 @@ with pkgs;
 
   deviceTree = callPackage ../os-specific/linux/device-tree {};
 
-  purism-ec-tool = callPackage ../os-specific/linux/purism/ectool.nix {};
+  purism-ectool = callPackage ../os-specific/linux/purism/ectool {};
 
   enum4linux = callPackage ../tools/security/enum4linux {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -326,6 +326,8 @@ with pkgs;
 
   deviceTree = callPackage ../os-specific/linux/device-tree {};
 
+  purism-ec-tool = callPackage ../os-specific/linux/purism/ectool.nix {};
+
   enum4linux = callPackage ../tools/security/enum4linux {};
 
   enum4linux-ng = python3Packages.callPackage ../tools/security/enum4linux-ng { };


### PR DESCRIPTION
###### Motivation for this change

Adds the os-specific/linux Purism EC tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
