### PR TITLE
python3Packages.cattrs: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/development/python-modules/cattrs/default.nix
+++ b/pkgs/development/python-modules/cattrs/default.nix
@@ -1,14 +1,14 @@
 { lib
 , attrs
-, bson
-, pythonOlder
 , buildPythonPackage
 , fetchFromGitHub
 , hypothesis
 , immutables
+, motor
 , msgpack
 , poetry-core
 , pytestCheckHook
+, pythonOlder
 , pyyaml
 , tomlkit
 , ujson
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "cattrs";
-  version = "1.7.0";
+  version = "1.8.0";
   format = "pyproject";
 
   # https://cattrs.readthedocs.io/en/latest/history.html#id33:
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "Tinche";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-7F4S4IeApbULXhkEZ0oab3Y7sk20Ag2fCYxsyi4WbWw=";
+    sha256 = "sha256-CKAsvRKS8kmLcyPA753mh6d3S04ObzO7xLPpmlmxrxI=";
   };
 
   nativeBuildInputs = [
@@ -39,9 +39,9 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    bson
     hypothesis
     immutables
+    motor
     msgpack
     pytestCheckHook
     pyyaml
@@ -57,6 +57,10 @@ buildPythonPackage rec {
     substituteInPlace tests/test_preconf.py \
       --replace "from orjson import dumps as orjson_dumps" "" \
       --replace "from orjson import loads as orjson_loads" ""
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d);
   '';
 
   disabledTestPaths = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.8.0

Change log: https://github.com/Tinche/cattrs/blob/master/HISTORY.rst#180-2021-08-13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
