### PR TITLE
Hardened Kernels 2021-08-18

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -7,9 +7,9 @@
     },
     "4.19": {
         "extra": "-hardened1",
-        "name": "linux-hardened-4.19.202-hardened1.patch",
-        "sha256": "0bylyc7k5azs8335mmzrgsx42cg8l3vm4izzikc8kchs2grb1q5v",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.202-hardened1/linux-hardened-4.19.202-hardened1.patch"
+        "name": "linux-hardened-4.19.204-hardened1.patch",
+        "sha256": "08i7985aqiiyi6h42rgf4hc09di3iy5p3i7iajzyfrzxfmgkdgdz",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.204-hardened1/linux-hardened-4.19.204-hardened1.patch"
     },
     "5.10": {
         "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -19,8 +19,8 @@
     },
     "5.4": {
         "extra": "-hardened1",
-        "name": "linux-hardened-5.4.139-hardened1.patch",
-        "sha256": "0lznmwy8yqc8rq5pr0akxclpnwz98pgai6ib5a3d77ncfham6fnl",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.139-hardened1/linux-hardened-5.4.139-hardened1.patch"
+        "name": "linux-hardened-5.4.141-hardened1.patch",
+        "sha256": "1i6arkayhc7x4jgbnshar7g2n9v2bf39yrsg07ga0sadqw3ky2sv",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.141-hardened1/linux-hardened-5.4.141-hardened1.patch"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -19,8 +19,8 @@
     },
     "5.4": {
         "extra": "-hardened1",
-        "name": "linux-hardened-5.4.141-hardened1.patch",
-        "sha256": "1i6arkayhc7x4jgbnshar7g2n9v2bf39yrsg07ga0sadqw3ky2sv",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.141-hardened1/linux-hardened-5.4.141-hardened1.patch"
+        "name": "linux-hardened-5.4.142-hardened1.patch",
+        "sha256": "05195sxrs99gfwbb8icg8rzvqljhf1gpyhxr8da3qg6b4rvvnf0p",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.142-hardened1/linux-hardened-5.4.142-hardened1.patch"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -1,9 +1,9 @@
 {
     "4.14": {
         "extra": "-hardened1",
-        "name": "linux-hardened-4.14.243-hardened1.patch",
-        "sha256": "0ngz1ywkxjqyv92wirj9m6l99p4caj6n75h2mv0a6rhk9r4di6p6",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.243-hardened1/linux-hardened-4.14.243-hardened1.patch"
+        "name": "linux-hardened-4.14.244-hardened1.patch",
+        "sha256": "0cm5ylwxz2lzjx8c7z90h443sw7mjbr33cbrgfhaczvdzm6wxx0b",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.244-hardened1/linux-hardened-4.14.244-hardened1.patch"
     },
     "4.19": {
         "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -13,9 +13,9 @@
     },
     "5.10": {
         "extra": "-hardened1",
-        "name": "linux-hardened-5.10.57-hardened1.patch",
-        "sha256": "0zqv77k0i4q5w4qhgiknvrh4fav1jc4a2i9cdracwqlrk8fgmiih",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.57-hardened1/linux-hardened-5.10.57-hardened1.patch"
+        "name": "linux-hardened-5.10.59-hardened1.patch",
+        "sha256": "1v1i003arw8vxpdr52pxqmzqca06psrkk6zihyf36hvzpxbkapsk",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.59-hardened1/linux-hardened-5.10.59-hardened1.patch"
     },
     "5.4": {
         "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -13,9 +13,9 @@
     },
     "5.10": {
         "extra": "-hardened1",
-        "name": "linux-hardened-5.10.59-hardened1.patch",
-        "sha256": "1v1i003arw8vxpdr52pxqmzqca06psrkk6zihyf36hvzpxbkapsk",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.59-hardened1/linux-hardened-5.10.59-hardened1.patch"
+        "name": "linux-hardened-5.10.60-hardened1.patch",
+        "sha256": "0hnc12ypggwln4b5i1zqd9mmhdkcky24xj4jxqp23dwzp03pwfh8",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.60-hardened1/linux-hardened-5.10.60-hardened1.patch"
     },
     "5.4": {
         "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/update.py
+++ b/pkgs/os-specific/linux/kernel/hardened/update.py
@@ -226,7 +226,7 @@ for release in repo.get_releases():
     else:
         # Fall back to the latest patch for this major kernel version,
         # skipping patches for kernels newer than the packaged one.
-        if kernel_version > packaged_kernel_version:
+        if '.'.join(str(x) for x in kernel_version) > '.'.join(str(x) for x in packaged_kernel_version):
             continue
         elif (
             kernel_key not in releases or releases[kernel_key].version < version


### PR DESCRIPTION
###### Motivation for this change
cc @TredwellGit @emilazy @Mic92 @Ma27 

Fixes 4.14 and 4.19, 5.4 and 5.10 still don't apply.
Also the updater (probably) works again. I used it, but I really didn't look through the code much.

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
