### PR TITLE
spring: 104.0.1 -> 105.0.1

### DIFF
--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -7,9 +7,9 @@
 
 stdenv.mkDerivation rec {
   pname = "spring";
-  version = "104.0.1-${buildId}-g${shortRev}";
+  version = "105.0.1-${buildId}-g${shortRev}";
   # usually the latest in https://github.com/spring/spring/commits/maintenance
-  rev = "f266c8107b3e5dda5a78061ef00ca0ed8736d6f2";
+  rev = "8581792eac65e07cbed182ccb1e90424ce3bd8fc";
   shortRev = builtins.substring 0 7 rev;
   buildId = "1486";
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "spring";
     repo = pname;
     inherit rev;
-    sha256 = "1nx68d894yfmqc6df72hmk75ph26fqdvlmmq58cca0vbwpz9hf5v";
+    sha256 = "05lvd8grqmv7vl8rrx02rhl0qhmm58dyi6s78b64j3fkia4sfj1r";
     fetchSubmodules = true;
   };
 
@@ -60,7 +60,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ phreedom qknight domenkozar sorki ];
     platforms = platforms.linux;
-    # error: 'snprintf' was not declared in this scope
-    broken = true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This was marked as broken and upstream has patched the issue.


###### Things done
- version bump
- removed broken marker and comment

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
