### PR TITLE
buildFHSUserEnvBubblewrap: mount vulkan ICDs

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -112,6 +112,11 @@ let
       fi
     done
 
+    # Use system's icd.d if available and populated
+    if [ -n "$(ls -A /run/opengl-driver/share/vulkan/icd.d/)" ]; then
+      ro_mounts+=(--ro-bind /run/opengl-driver/share/vulkan/icd.d/ /usr/share/vulkan/icd.d/)
+    fi
+
     if [[ -d ${env}/etc ]]; then
       for i in ${env}/etc/*; do
         path="/''${i##*/}"

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -326,7 +326,7 @@ in buildFHSUserEnv rec {
     targetPkgs = commonTargetPkgs;
     inherit multiPkgs extraBuildCommands;
 
-    inherit unshareIpc unsharePid;
+    inherit unshareIpc unsharePid profile;
 
     runScript = writeScript "steam-run" ''
       #!${runtimeShell}

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -282,7 +282,6 @@ in buildFHSUserEnv rec {
 
     export STEAM_RUNTIME=${if nativeOnly then "0" else "/steamrt"}
 
-    export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/intel_icd.x86_64.json:/usr/share/vulkan/icd.d/intel_icd.i686.json:/usr/share/vulkan/icd.d/lvp_icd.x86_64.json:/usr/share/vulkan/icd.d/lvp_icd.i686.json:/usr/share/vulkan/icd.d/nvidia_icd.json:/usr/share/vulkan/icd.d/nvidia_icd32.json:/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:/usr/share/vulkan/icd.d/radeon_icd.i686.json
   '' + extraProfile;
 
   runScript = writeScript "steam-wrapper.sh" ''


### PR DESCRIPTION
###### Motivation for this change
Another alternative solution to #130984, just mount the system ICDs (if they exist) at the default location. If there aren't any, then it will revert to the existing Mesa drivers brought in by steamfhs

This should inherit the behavior of the system, and avoid trying to load ICDs which may or may not exist.

overlaps with: #126435
may solve: #126428

closes: #134556

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
