### PR TITLE
cnping: init at 2021-04-04

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -127,6 +127,7 @@
   ./programs/cdemu.nix
   ./programs/chromium.nix
   ./programs/clickshare.nix
+  ./programs/cnping.nix
   ./programs/command-not-found/command-not-found.nix
   ./programs/criu.nix
   ./programs/dconf.nix

--- a/nixos/modules/programs/cnping.nix
+++ b/nixos/modules/programs/cnping.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.cnping;
+in
+{
+  options = {
+    programs.cnping = {
+      enable = mkEnableOption "Whether to install a setcap wrapper for cnping";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    security.wrappers.cnping = {
+      source = "${pkgs.cnping}/bin/cnping";
+      capabilities = "cap_net_raw+ep";
+    };
+  };
+}

--- a/pkgs/tools/networking/cnping/default.nix
+++ b/pkgs/tools/networking/cnping/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, libglvnd, xorg }:
+
+stdenv.mkDerivation rec {
+  pname = "cnping";
+  version = "unstable-2021-04-04";
+
+  src = fetchFromGitHub {
+    owner = "cntools";
+    repo = "cnping";
+    rev = "6b89363e6b79ecbf612306d42a8ef94a5a2f756a";
+    sha256 = "sha256-E3Wm5or6C4bHq7YoyaEbtDwyd+tDVYUOMeQrprlmL4A=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ libglvnd xorg.libXinerama xorg.libXext xorg.libX11 ];
+
+  # The "linuxinstall" target won't work for us:
+  # it tries to setcap and copy to a FHS directory
+  installPhase = ''
+    mkdir -p $out/{bin,share/man/man1}
+    cp cnping $out/bin/cnping
+    cp cnping.1 $out/share/man/man1/cnping.1
+  '';
+
+  meta = with lib; {
+    description = "Minimal Graphical IPV4 Ping Tool";
+    homepage = "https://github.com/cntools/cnping";
+    license = with licenses; [ mit bsd3 ]; # dual licensed, MIT-x11 & BSD-3-Clause
+    maintainers = with maintainers; [ ckie ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8554,6 +8554,8 @@ with pkgs;
 
   cntlm = callPackage ../tools/networking/cntlm { };
 
+  cnping = callPackage ../tools/networking/cnping { };
+
   past-time = python3Packages.callPackage ../tools/misc/past-time { };
 
   pastebinit = callPackage ../tools/misc/pastebinit { };


### PR DESCRIPTION
###### Motivation for this change

My ISP is playing games with me, so I'm doing the same back: https://github.com/ckiee/nixfiles/commit/36b054a and I need this to monitor how well it's working.

Depends on https://github.com/NixOS/nixpkgs/pull/131526 for maintainer name change so it won't build until that's in master.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<hr>

I didn't add a release note since this is tiny and nix segfaulted when I tried to build a VM to test the `setcap` wrapper.