### PR TITLE
python38Packages.whitenoise: 5.2.0 -> 5.3.0

### DIFF
--- a/pkgs/development/python-modules/whisper/default.nix
+++ b/pkgs/development/python-modules/whisper/default.nix
@@ -1,19 +1,40 @@
-{ lib, buildPythonPackage, fetchPypi, mock, six }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, six
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "whisper";
   version = "1.1.8";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "345f35d0dccaf181e0aa4353e6c13f40f5cceda10a3c7021dafab29f004f62ae";
+  src = fetchFromGitHub {
+    owner = "graphite-project";
+    repo = pname;
+    rev = version;
+    sha256 = "11f7sarj62zgpw3ak4a2q55lj7ap4039l9ybc3a6yvs1ppvrcn7x";
   };
 
-  propagatedBuildInputs = [ six ];
-  checkInputs = [ mock ];
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # whisper-resize.py: not found
+    "test_resize_with_aggregate"
+  ];
+
+  pythonImportsCheck = [ "whisper" ];
 
   meta = with lib; {
-    homepage = "http://graphite.wikidot.com/";
+    homepage = "https://github.com/graphite-project/whisper";
     description = "Fixed size round-robin style database";
     maintainers = with maintainers; [ offline basvandijk ];
     license = licenses.asl20;

--- a/pkgs/development/python-modules/whitenoise/default.nix
+++ b/pkgs/development/python-modules/whitenoise/default.nix
@@ -1,21 +1,51 @@
-{ lib, fetchPypi, buildPythonPackage, isPy27 }:
+{ lib
+, brotli
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, requests
+}:
 
 buildPythonPackage rec {
   pname = "whitenoise";
-  version = "5.2.0";
-  disabled = isPy27;
+  version = "5.3.0";
+  disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "05ce0be39ad85740a78750c86a93485c40f08ad8c62a6006de0233765996e5c7";
+  src = fetchFromGitHub {
+    owner = "evansd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "17j1rml1hb43c7fs7kf4ygkpmnjppzgsbnyw3plq9w3yh9w5hkhg";
   };
 
-  # No tests
-  doCheck = false;
+  propagatedBuildInputs = [
+    brotli
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    requests
+  ];
+
+  disabledTestPaths = [
+    # Don't run Django tests
+    "tests/test_django_whitenoise.py"
+    "tests/test_runserver_nostatic.py"
+    "tests/test_storage.py"
+  ];
+
+  disabledTests = [
+    # Test fails with AssertionError
+    "test_modified"
+  ];
+
+  pythonImportsCheck = [ "whitenoise" ];
 
   meta = with lib; {
     description = "Radically simplified static file serving for WSGI applications";
     homepage = "http://whitenoise.evans.io/";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 5.3.0

Change log: http://whitenoise.evans.io/en/stable/changelog.html#v5-3-0

- Enable tests
- Fix build of `whisper`

Previous PR https://github.com/NixOS/nixpkgs/pull/134884

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
