### PR TITLE
treewide: buildFlagsArray -> ldflags

### DIFF
--- a/pkgs/applications/misc/ticker/default.nix
+++ b/pkgs/applications/misc/ticker/default.nix
@@ -16,9 +16,9 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-XBfTVd3X3IDxLCAaNnijf6E5bw+AZ94UdOG9w7BOdBU=";
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X github.com/achannarasappa/ticker/cmd.Version=v${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X github.com/achannarasappa/ticker/cmd.Version=v${version}"
+  ];
 
   # Tests require internet
   doCheck = false;

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -17,10 +17,10 @@ buildGoModule rec {
 
   excludedPackages = "\\(tools\\|docgen\\)";
 
-  preBuild = let t = "github.com/rancher/k3d/v4/version"; in
-    ''
-      buildFlagsArray+=("-ldflags" "-s -w -X ${t}.Version=v${version} -X ${t}.K3sVersion=v${k3sVersion}")
-    '';
+  ldflags = let t = "github.com/rancher/k3d/v4/version"; in
+    [
+      "-s" "-w" "-X ${t}.Version=v${version}" "-X ${t}.K3sVersion=v${k3sVersion}"
+    ];
 
   doCheck = false;
 

--- a/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
+++ b/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
@@ -13,9 +13,9 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-EM0lPwwWJuLD+aqZWshz1ILaeEtUU4wJ0Puwv1Ikgf4=";
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w")
-  '';
+  ldflags = [
+    "-s" "-w"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/aquasecurity/starboard-octant-plugin";

--- a/pkgs/applications/networking/cluster/starboard/default.nix
+++ b/pkgs/applications/networking/cluster/starboard/default.nix
@@ -16,9 +16,9 @@ buildGoModule rec {
   # Don't build and check the integration tests
   excludedPackages = "itest";
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X main.version=v${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X main.version=v${version}"
+  ];
 
   preCheck = ''
     # Remove test that requires networking

--- a/pkgs/development/tools/continuous-integration/drone-cli/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-cli/default.nix
@@ -9,9 +9,9 @@ buildGoModule rec {
 
   doCheck = false;
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-X main.version=${version}")
-  '';
+  ldflags = [
+    "-X main.version=${version}"
+  ];
 
   src = fetchFromGitHub {
     owner = "drone";

--- a/pkgs/development/tools/dockle/default.nix
+++ b/pkgs/development/tools/dockle/default.nix
@@ -16,9 +16,9 @@ buildGoModule rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ btrfs-progs lvm2 ];
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X main.version=${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X main.version=${version}"
+  ];
 
   preCheck = ''
     # Remove tests that use networking

--- a/pkgs/development/tools/golangci-lint/default.nix
+++ b/pkgs/development/tools/golangci-lint/default.nix
@@ -19,9 +19,9 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags=-s -w -X main.version=${version} -X main.commit=v${version} -X main.date=19700101-00:00:00")
-  '';
+  ldflags = [
+    "-s" "-w" "-X main.version=${version}" "-X main.commit=v${version}" "-X main.date=19700101-00:00:00"
+  ];
 
   postInstall = ''
     for shell in bash zsh; do

--- a/pkgs/servers/monitoring/telegraf/default.nix
+++ b/pkgs/servers/monitoring/telegraf/default.nix
@@ -18,9 +18,9 @@ buildGoModule rec {
   vendorSha256 = "sha256-J48ezMi9+PxohDKFhBpbcu6fdojlZPXnQQw2IcyimTA=";
   proxyVendor = true;
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags=-w -s -X main.version=${version}")
-  '';
+  ldflags = [
+    "-w" "-s" "-X main.version=${version}"
+  ];
 
   passthru.tests = { inherit (nixosTests) telegraf; };
 

--- a/pkgs/tools/admin/trivy/default.nix
+++ b/pkgs/tools/admin/trivy/default.nix
@@ -15,9 +15,9 @@ buildGoModule rec {
 
   excludedPackages = "misc";
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X main.version=v${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X main.version=v${version}"
+  ];
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/tools/misc/envdir-go/default.nix
+++ b/pkgs/tools/misc/envdir-go/default.nix
@@ -14,10 +14,10 @@ buildGoPackage rec {
     sha256 = "1wdlblj127skgynf9amk7waabc3abbyxys9dvyc6c72zpcpdy5nc";
   };
 
-  preBuild = ''
-   # TODO: is there a way to get the commit ref so we can set main.buildCommit?
-    buildFlagsArray+=("-ldflags" "-X main.buildDate=1970-01-01T00:00:00+0000 -X main.buildVersion=${version}")
-'';
+  # TODO: is there a way to get the commit ref so we can set main.buildCommit?
+  ldflags = [
+    "-X main.buildDate=1970-01-01T00:00:00+0000" "-X main.buildVersion=${version}"
+  ];
 
   meta = {
     description = "A go rewrite of envdir";

--- a/pkgs/tools/misc/goss/default.nix
+++ b/pkgs/tools/misc/goss/default.nix
@@ -14,9 +14,9 @@ buildGoModule rec {
   vendorSha256 = "1lyqjkwj8hybj5swyrv6357hs8sxmf4wim0c8yhfb9mv7fsxhrv7";
 
   CGO_ENABLED = 0;
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X main.version=v${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X main.version=v${version}"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/aelsabbahy/goss/";

--- a/pkgs/tools/misc/noti/default.nix
+++ b/pkgs/tools/misc/noti/default.nix
@@ -16,9 +16,9 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/variadico/noti";
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-X ${goPackagePath}/internal/command.Version=${version}")
-  '';
+  ldflags = [
+    "-X ${goPackagePath}/internal/command.Version=${version}"
+  ];
 
   postInstall = ''
     install -Dm444 -t $out/share/man/man1 $src/docs/man/*.1

--- a/pkgs/tools/networking/assh/default.nix
+++ b/pkgs/tools/networking/assh/default.nix
@@ -20,9 +20,9 @@ buildGoModule rec {
 
   doCheck = false;
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X moul.io/assh/v2/pkg/version.Version=${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X moul.io/assh/v2/pkg/version.Version=${version}"
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/security/gitleaks/default.nix
+++ b/pkgs/tools/security/gitleaks/default.nix
@@ -16,9 +16,9 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-Cc4DJPpOMHxDcH22S7znYo7QHNRXv8jOJhznu09kaE4=";
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X github.com/zricethezav/gitleaks/v${lib.versions.major version}/version.Version=${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X github.com/zricethezav/gitleaks/v${lib.versions.major version}/version.Version=${version}"
+  ];
 
   meta = with lib; {
     description = "Scan git repos (or files) for secrets";

--- a/pkgs/tools/security/grype/default.nix
+++ b/pkgs/tools/security/grype/default.nix
@@ -19,9 +19,9 @@ buildGoModule rec {
 
   propagatedBuildInputs = [ docker ];
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X github.com/anchore/grype/internal/version.version=${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X github.com/anchore/grype/internal/version.version=${version}"
+  ];
 
   # Tests require a running Docker instance
   doCheck = false;

--- a/pkgs/tools/security/kiterunner/default.nix
+++ b/pkgs/tools/security/kiterunner/default.nix
@@ -16,9 +16,9 @@ buildGoModule rec {
 
   vendorSha256 = "1nczzzsnh38qi949ki5268y39ggkwncanc1pv7727qpwllzl62vy";
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X github.com/assetnote/kiterunner/cmd/kiterunner/cmd.Version=${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X github.com/assetnote/kiterunner/cmd/kiterunner/cmd.Version=${version}"
+  ];
 
   subPackages = [ "./cmd/kiterunner" ];
 

--- a/pkgs/tools/security/safe/default.nix
+++ b/pkgs/tools/security/safe/default.nix
@@ -18,9 +18,9 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/starkandwayne/safe";
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-X main.Version=${version}")
-  '';
+  ldflags = [
+    "-X main.Version=${version}"
+  ];
 
   meta = with lib; {
     description = "A Vault CLI";

--- a/pkgs/tools/security/teler/default.nix
+++ b/pkgs/tools/security/teler/default.nix
@@ -16,9 +16,9 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-TQjwPem+RMuoF5T02CL/CTvBS6W7Q786gTvYUFIvxjE=";
 
-  preBuild = ''
-    buildFlagsArray+=("-ldflags" "-s -w -X ktbs.dev/teler/common.Version=${version}")
-  '';
+  ldflags = [
+    "-s" "-w" "-X ktbs.dev/teler/common.Version=${version}"
+  ];
 
   # test require internet access
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
