### PR TITLE
perlPackages.PerlTidy: revert "use shortenPerlShebang on darwin"

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17118,10 +17118,6 @@ let
       description = "Indent and reformat perl scripts";
       license = lib.licenses.gpl2Plus;
     };
-    nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.isDarwin ''
-      shortenPerlShebang $out/bin/perltidy
-    '';
   };
 
   PHPSerialization = buildPerlPackage {


### PR DESCRIPTION
Reverts NixOS/nixpkgs#113227. This is not necessary anymore after https://github.com/NixOS/nixpkgs/pull/113800 (see also the comments on https://github.com/NixOS/nixpkgs/issues/113330).