### PR TITLE
python3Packages.pydmd: init at 0.3.3

### DIFF
--- a/pkgs/development/python-modules/pydmd/default.nix
+++ b/pkgs/development/python-modules/pydmd/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , python
 , fetchFromGitHub
 , buildPythonPackage
@@ -33,5 +34,6 @@ buildPythonPackage rec {
     homepage = "https://mathlab.github.io/PyDMD/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yl3dy ];
+    broken = stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/development/python-modules/pydmd/default.nix
+++ b/pkgs/development/python-modules/pydmd/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, python
+, fetchFromGitHub
+, buildPythonPackage
+, future
+, numpy
+, scipy
+, matplotlib
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "pydmd";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "mathLab";
+    repo = "PyDMD";
+    rev = "v${version}";
+    sha256 = "1516dhmpwi12v9ly9jj18wpz9k696q5k6aamlrbby8wp8smajgrv";
+  };
+
+  propagatedBuildInputs = [ future numpy scipy matplotlib ];
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    ${python.interpreter} test.py
+  '';
+  pythonImportsCheck = [ "pydmd" ];
+
+  meta = {
+    description = "Python Dynamic Mode Decomposition";
+    homepage = "https://mathlab.github.io/PyDMD/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yl3dy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5963,6 +5963,8 @@ in {
 
   pydispatcher = callPackage ../development/python-modules/pydispatcher { };
 
+  pydmd = callPackage ../development/python-modules/pydmd { };
+
   pydns = callPackage ../development/python-modules/py3dns { };
 
   pydocstyle = callPackage ../development/python-modules/pydocstyle { };


### PR DESCRIPTION
###### Motivation for this change

PyDMD is a library for Dynamic Mode Decomposition, linear interpolation/extrapolation method useful for multivariate Time Series Analysis.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
