### PR TITLE
nixos/wakeonwlan: init WoWLAN service

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -274,6 +274,14 @@
       </listitem>
       <listitem>
         <para>
+          <literal>wakeonwlan</literal>, a service to enable Wake on
+          Wireless LAN similar to the <literal>wakeonlan</literal>
+          service for ethernet Wake on LAN. Available as
+          <link linkend="opt-services.wakeonwlan.interfaces">services.wakeonwlan</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/mbrubeck/agate">agate</link>,
           a very simple server for the Gemini hypertext protocol.
           Available as

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -79,6 +79,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [tetrd](https://tetrd.app), share your internet connection from your device to your PC and vice versa through a USB cable. Available at [services.tetrd](#opt-services.tetrd.enable).
 
+- `wakeonwlan`, a service to enable Wake on Wireless LAN similar to the `wakeonlan` service for ethernet Wake on LAN. Available as [services.wakeonwlan](#opt-services.wakeonwlan.interfaces).
+
 - [agate](https://github.com/mbrubeck/agate), a very simple server for the Gemini hypertext protocol. Available as [services.agate](options.html#opt-services.agate.enable).
 
 - [ArchiSteamFarm](https://github.com/JustArchiNET/ArchiSteamFarm), a C# application with primary purpose of idling Steam cards from multiple accounts simultaneously. Available as [services.archisteamfarm](options.html#opt-services.archisteamfarm.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -935,6 +935,7 @@
   ./services/video/rtsp-simple-server.nix
   ./services/networking/v2ray.nix
   ./services/networking/vsftpd.nix
+  ./services/networking/wakeonwlan.nix
   ./services/networking/wasabibackend.nix
   ./services/networking/websockify.nix
   ./services/networking/wg-netmanager.nix

--- a/nixos/modules/services/networking/wakeonwlan.nix
+++ b/nixos/modules/services/networking/wakeonwlan.nix
@@ -1,0 +1,65 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.wakeonwlan;
+
+  mkWowlanService = name: cfg:
+    nameValuePair "wowlan-${name}" {
+      description = "Enable WoWLAN for interface ${name}";
+      requires = [ "network.target" ];
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+      };
+      script = ''
+        ${pkgs.iw}/bin/iw phy ${name} wowlan enable ${concatStringsSep " " cfg.methods}
+      '';
+    };
+in
+{
+  options.services.wakeonwlan.interfaces = mkOption {
+    default = { };
+    description = ''
+      Wireless interfaces where you want to enable WoWLAN. You can list
+      available interfaces with <code>iw dev</code>.
+    '';
+    example = literalExample ''
+      {
+        phy0.methods = [
+          "magic-packet"
+          "disconnect"
+          "gtk-rekey-failure"
+          "eap-identity-request"
+          "rfkill-release"
+        ];
+        phy2.methods = [ "any" ];
+      }
+    '';
+    type = types.attrsOf (
+      types.submodule {
+        options = {
+          methods = mkOption {
+            type = types.listOf (types.enum [
+              "4way-handshake"
+              "any"
+              "disconnect"
+              "eap-identity-request"
+              "gtk-rekey-failure"
+              "magic-packet"
+              "rfkill-release"
+            ]);
+            description = "Wake-On-WiFiLan methods for this interface.";
+          };
+        };
+      }
+    );
+  };
+
+  config = mkIf (cfg.interfaces != {}) {
+    systemd.services = mapAttrs' mkWowlanService cfg.interfaces;
+  };
+}
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There's already a Wake On LAN module, I figured the equivalent for Wake On WiFi LAN was worth writing :) I've been using this on my home desktop with no issues.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
