### PR TITLE
perlPackages.PerlCritic: shortenPerlShebang on Darwin

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16905,12 +16905,16 @@ let
       sha256 = "2ad194f91ef24df4698369c2562d4164e9bf74f2d5565c681841abf79789ed82";
     };
     buildInputs = [ TestDeep ];
+    nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
     propagatedBuildInputs = [ BKeywords ConfigTiny FileWhich ListMoreUtils ModulePluggable PPIxQuoteLike PPIxRegexp PPIxUtilities PerlTidy PodSpell StringFormat ];
     meta = {
       homepage = "http://perlcritic.com";
       description = "Critique Perl source code for best-practices";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
+    postInstall = lib.optionalString stdenv.isDarwin ''
+      shortenPerlShebang $out/bin/perlcritic
+    '';
   };
 
   PerlCriticCommunity = buildPerlModule {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I ran into this on my MBP M1:

```
% nix-shell -p perl -p perlPackages.PerlCritic
 (nix-shell)  % perlcritic
/nix/store/vxn0syzdd7qrh8flhz4sdgwb57lcr9y3-perl5.34.0-Perl-Critic-1.138/bin/perlcritic: line 3: package: command not found
/nix/store/vxn0syzdd7qrh8flhz4sdgwb57lcr9y3-perl5.34.0-Perl-Critic-1.138/bin/perlcritic: line 5: use: command not found
/nix/store/vxn0syzdd7qrh8flhz4sdgwb57lcr9y3-perl5.34.0-Perl-Critic-1.138/bin/perlcritic: line 6: use: command not found
/nix/store/vxn0syzdd7qrh8flhz4sdgwb57lcr9y3-perl5.34.0-Perl-Critic-1.138/bin/perlcritic: line 7: use: command not found
/nix/store/vxn0syzdd7qrh8flhz4sdgwb57lcr9y3-perl5.34.0-Perl-Critic-1.138/bin/perlcritic: line 9: syntax error near unexpected token `;'
/nix/store/vxn0syzdd7qrh8flhz4sdgwb57lcr9y3-perl5.34.0-Perl-Critic-1.138/bin/perlcritic: line 9: `use Perl::Critic::Command qw< run >;'
```

Which is apparently caused by a too long shebang on `perlcritic`:

```
 (nix-shell) 2 % head -1 $(which perlcritic)
#!/nix/store/ka2cfja2z5z1kfv97lx61n8rmr93mww2-perl-5.34.0/bin/perl -I/nix/store/ka2cfja2z5z1kfv97lx61n8rmr93mww2-perl-5.34.0/lib/perl5/site_perl -I/nix/store/556yxmbba26z7ylcwl79k0nq61yigd0s-perl5.34.0-Test-Deep-1.130/lib/perl5/site_perl -I/nix/store/11brs6mbi25rgsl3304d8jk2bn8lzhfj-perl5.34.0-Module-Build-0.4231/lib/perl5/site_perl -I/nix/store/1d4nygzfwchz6gpx68kkb5aijk1ndap1-perl5.34.0-B-Keywords-1.22/lib/perl5/site_perl -I/nix/store/75wf5ff6hwnjq0i2b3j8gs2xwp49qfkl-perl5.34.0-Config-Tiny-2.24/lib/perl5/site_perl -I/nix/store/xi7fpgnrdcnjcsgrg0alir5x28xlg0m8-perl5.34.0-File-Which-1.23/lib/perl5/site_perl -I/nix/store/0chpysvkrvnka0wdd3b2ws3h51bppny2-perl5.34.0-List-MoreUtils-0.430/lib/perl5/site_perl -I/nix/store/6jm7811gpg1hqdjdd00rc43vwfwgyn68-perl5.34.0-Exporter-Tiny-1.002002/lib/perl5/site_perl -I/nix/store/m4glm2jd8fl8zhplagb9fkvgziq76n05-perl5.34.0-List-MoreUtils-XS-0.430/lib/perl5/site_perl -I/nix/store/lipb2miam2jfws2d6ksx1qs5ppakrqw3-perl5.34.0-Module-Pluggable-5.2/lib/perl5/site_perl -I/nix/store/6mhvw2wnyc32vq7j2f5capalrqh6f6dn-perl5.34.0-PPIx-QuoteLike-0.013/lib/perl5/site_perl -I/nix/store/bv3vfbxpsqnz9jkmr7p7i7y9jydvdmbd-perl5.34.0-PPI-1.270/lib/perl5/site_perl -I/nix/store/8y5vbckfand4mjrix08izi1xp1xcmpcs-perl5.34.0-Clone-0.45/lib/perl5/site_perl -I/nix/store/d2h5jmaf3g78pi6xjasnwicag8679v00-perl5.34.0-IO-String-1.08/lib/perl5/site_perl -I/nix/store/9djnnqhmv3d6xagjlkap6w7rd6gpg8lv-perl5.34.0-Params-Util-1.102/lib/perl5/site_perl -I/nix/store/79mj9g7ab4rrak2m9vnpmyr6wfx59bl4-perl5.34.0-Task-Weaken-1.06/lib/perl5/site_perl -I/nix/store/sqsfjkalhhzk2n1z5z8xm9aax2ps9qa2-perl5.34.0-Readonly-2.05/lib/perl5/site_perl -I/nix/store/pasbb7cyv9281x8jjvh9ym1hcrgny9gc-perl5.34.0-PPIx-Regexp-0.076/lib/perl5/site_perl -I/nix/store/qif5wny66hh4wz9ddn128v08yk4m513p-perl5.34.0-PPIx-Utilities-1.001000/lib/perl5/site_perl -I/nix/store/rj6i4s5fxih8mmnvv6si4d46qzhicx7y-perl5.34.0-Exception-Class-1.44/lib/perl5/site_perl -I/nix/store/9gva2d9q2f9q0svgxgm9xnp127khxa0a-perl5.34.0-Class-Data-Inheritable-0.08/lib/perl5/site_perl -I/nix/store/q16w3klvqh5krh3x9may1g0bfngx8kqq-perl5.34.0-Devel-StackTrace-2.04/lib/perl5/site_perl -I/nix/store/rh03n1f8m28k3icw0axngnglz5k88f5x-perl5.34.0-Perl-Tidy-20201207/lib/perl5/site_perl -I/nix/store/8k9nljjg9bd428lliqjnhl8cb2j8ws17-perl5.34.0-Pod-Spell-1.20/lib/perl5/site_perl -I/nix/store/xsbh0y5wx4zjlwaccifx5ppnls7y8za4-perl5.34.0-Class-Tiny-1.008/lib/perl5/site_perl -I/nix/store/j6sz9gri3y488hsx8mw7qhdl0xwihy0v-perl5.34.0-File-ShareDir-1.118/lib/perl5/site_perl -I/nix/store/n6pwqkmjp6bbj9b0ghk7swpbn0w3164s-perl5.34.0-Class-Inspector-1.36/lib/perl5/site_perl -I/nix/store/mix3hp6z21zwwlx4hnx86m43zrc9fp6y-perl5.34.0-Lingua-EN-Inflect-1.905/lib/perl5/site_perl -I/nix/store/sqhv2fajq2hcmljw8yjdsxdvrr3xmmnk-perl5.34.0-Path-Tiny-0.114/lib/perl5/site_perl -I/nix/store/k28gz89djzqxyl422cf5pn8kiyk2s3r9-perl5.34.0-Pod-Parser-1.63/lib/perl5/site_perl -I/nix/store/6g5fczs17w8mjad5k2zj1lkq2nf0m5zv-perl5.34.0-String-Format-1.18/lib/perl5/site_perl -I/nix/store/vxn0syzdd7qrh8flhz4sdgwb57lcr9y3-perl5.34.0-Perl-Critic-1.138/lib/perl5/site_perl
```

Fortunately most other scripts like `perltidy` on darwin have been affected by this before and the workaround is known:

```
    postInstall = lib.optionalString stdenv.isDarwin ''
      shortenPerlShebang $out/bin/perlcritic
    '';
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
