### PR TITLE
openal: 1.19.1 -> 1.21.1

### DIFF
--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -10,21 +10,21 @@ assert alsaSupport -> alsa-lib != null;
 assert pulseSupport -> libpulseaudio != null;
 
 stdenv.mkDerivation rec {
-  version = "1.19.1";
+  version = "1.21.1";
   pname = "openal-soft";
 
   src = fetchFromGitHub {
     owner = "kcat";
     repo = "openal-soft";
-    rev = "${pname}-${version}";
-    sha256 = "0b0g0q1c36nfb289xcaaj3cmyfpiswvvgky3qyalsf9n4dj7vnzi";
+    rev = version;
+    sha256 = "sha256-rgc6kjXaZb6sCR+e9Gu7BEEHIiCHMygpLIeSqgWkuAg=";
   };
 
   # this will make it find its own data files (e.g. HRTF profiles)
   # without any other configuration
   patches = [ ./search-out.patch ];
   postPatch = ''
-    substituteInPlace Alc/helpers.c \
+    substituteInPlace alc/helpers.cpp \
       --replace "@OUT@" $out
   '';
 

--- a/pkgs/development/libraries/openal-soft/search-out.patch
+++ b/pkgs/development/libraries/openal-soft/search-out.patch
@@ -1,12 +1,12 @@
-diff -Nuar a/Alc/helpers.c b/Alc/helpers.c
---- a/Alc/helpers.c	1970-01-01 00:00:01.000000000 +0000
-+++ b/Alc/helpers.c	1970-01-01 00:00:02.000000000 +0000
-@@ -951,6 +951,8 @@
-             }
-         }
+diff --git a/alc/helpers.cpp b/alc/helpers.cpp
+index 8c1c856..19bbc0f 100644
+--- a/alc/helpers.cpp
++++ b/alc/helpers.cpp
+@@ -402,6 +402,7 @@ al::vector<std::string> SearchDataFiles(const char *ext, const char *subdir)
  
-+        DirectorySearch("@OUT@/share", ext, &results);
-+
-         alstr_reset(&path);
+         DirectorySearch(path.c_str(), ext, &results);
      }
++    DirectorySearch("@OUT@/share/", ext, &results);
  
+     return results;
+ }


### PR DESCRIPTION
###### Motivation for this change

Changelog: https://github.com/kcat/openal-soft/blob/master/ChangeLog.

The main goal was to support cross-compilation, but it doesn't work due to the library using `<atomic>`, and that errors out with `cannot find gnu/stubs-32.h` for some reason. (note that 1.19.1 had a 'native-tools' target, but that was also not fully working as I'd like to.)

Anyhow, I did the update anyways, so let's share :hearts:.

If anyone has a clue on the cross-compilation stuff, please let me know.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested building minetest and executing it, the sound worked fine.
