### PR TITLE
zenmonitor,zenpower: switch to maintained forks

### DIFF
--- a/pkgs/os-specific/linux/zenmonitor/default.nix
+++ b/pkgs/os-specific/linux/zenmonitor/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zenmonitor";
-  version = "1.4.2";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
-    owner = "ocerman";
-    repo = "zenmonitor";
+    owner = "Ta180m";
+    repo = "zenmonitor3";
     rev = "v${version}";
-    sha256 = "0smv94vi36hziw42gasivyw25h5n1sgwwk1cv78id5g85w0kw246";
+    sha256 = "sha256-dbjLpfflIsEU+wTApghJYBPxBXqS/7MJqcMBcj50o6I=";
   };
 
   buildInputs = [ gtk3 ];
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Monitoring software for AMD Zen-based CPUs";
-    homepage = "https://github.com/ocerman/zenmonitor";
+    homepage = "https://github.com/Ta180m/zenmonitor3";
     license = licenses.mit;
     platforms = [ "i686-linux" "x86_64-linux" ];
-    maintainers = with maintainers; [ alexbakker ];
+    maintainers = with maintainers; [ alexbakker artturin ];
   };
 }

--- a/pkgs/os-specific/linux/zenpower/default.nix
+++ b/pkgs/os-specific/linux/zenpower/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zenpower";
-  version = "0.1.12";
+  version = "0.1.13";
 
   src = fetchFromGitHub {
-    owner = "ocerman";
-    repo = "zenpower";
+    owner = "Ta180m";
+    repo = "zenpower3";
     rev = "v${version}";
-    sha256 = "116yrw4ygh3fqwhniaqq0nps29pq87mi2q1375f1ylkfiak8n63a";
+    sha256 = "sha256-2QScHDwOKN3Psui0M2s2p6D97jjbfe3Us5Nkn2srKC0=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -23,9 +23,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs.";
-    homepage = "https://github.com/ocerman/zenpower";
+    homepage = "https://github.com/Ta180m/zenpower3";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ alexbakker ];
+    maintainers = with maintainers; [ alexbakker artturin ];
     platforms = [ "x86_64-linux" ];
     broken = versionOlder kernel.version "4.14";
   };


### PR DESCRIPTION
add myself to maintainers

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The original doesn't work for zen3 but the forks do

###### Things done
tested with
```nix
      (self: super: {
        zenmonitor = super.callPackage /home/artturin/nixgits/my-nixpkgs/pkgs/os-specific/linux/zenmonitor { };
        linuxPackages_zen = super.linuxPackages_zen.extend (lpself: lpsuper: {
          zenpower = lpsuper.callPackage /home/artturin/nixgits/my-nixpkgs/pkgs/os-specific/linux/zenpower { };
        });
      })
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
