### PR TITLE
zeroc-ice-36: 3.6.3 -> 3.6.5, fix; zeroc-ice: 3.7.2 -> 3.7.6, enable tests; both: clarify license

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -91,7 +91,7 @@ let
       concatImapStringsSep makeSearchPath makeSearchPathOutput
       makeLibraryPath makeBinPath optionalString
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
-      escapeShellArg escapeShellArgs replaceChars lowerChars
+      escapeShellArg escapeShellArgs escapeRegex replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast
       getName getVersion

--- a/pkgs/development/libraries/zeroc-ice/3.6.nix
+++ b/pkgs/development/libraries/zeroc-ice/3.6.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchFromGitHub
 , mcpp, bzip2, expat, openssl, db5
 , darwin, libiconv, Security
+, zeroc-ice # to share meta
 , cpp11 ? false
 }:
 
@@ -54,10 +55,5 @@ stdenv.mkDerivation rec {
     rm -rf $out/share/slice
   '';
 
-  meta = with lib; {
-    homepage = "http://www.zeroc.com/ice.html";
-    description = "The internet communications engine";
-    license = licenses.gpl2;
-    platforms = platforms.unix;
-  };
+  inherit (zeroc-ice) meta;
 }

--- a/pkgs/development/libraries/zeroc-ice/3.6.nix
+++ b/pkgs/development/libraries/zeroc-ice/3.6.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
       sha256 = "17j5r7gsa3izrm7zln4mrp7l16h532gvmpas0kzglybicbiz7d56";
       stripLen = 1;
     })
+    # Fixes compilation warning about uninitialied variables (in test code)
+    ./uninitialized-variable-warning.patch
   ];
 
   preBuild = ''

--- a/pkgs/development/libraries/zeroc-ice/3.6.nix
+++ b/pkgs/development/libraries/zeroc-ice/3.6.nix
@@ -1,17 +1,18 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, mcpp, bzip2, expat, openssl, db5
+{ stdenv, lib, fetchFromGitHub
+, mcpp, bzip2, expat, openssl, db5
 , darwin, libiconv, Security
 , cpp11 ? false
 }:
 
 stdenv.mkDerivation rec {
   pname = "zeroc-ice";
-  version = "3.6.3";
+  version = "3.6.5";
 
   src = fetchFromGitHub {
     owner = "zeroc-ice";
     repo = "ice";
     rev = "v${version}";
-    sha256 = "05xympbns32aalgcfcpxwfd7bvg343f16xpg6jv5s335ski3cjy2";
+    sha256 = "073h7v1f2sw77cr1a6xxa5l9j547pz24sxa9qdjc4zki0ivcnq15";
   };
 
   buildInputs = [ mcpp bzip2 expat openssl db5 ]
@@ -27,13 +28,6 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
-    # Fixes compilation issues with GCC 8 using one of the patches
-    # provided in https://github.com/zeroc-ice/ice/issues/82
-    ( fetchpatch {
-      url = "https://github.com/zeroc-ice/ice/commit/a6a4981616b669432ff7b588179d6e93694d9e3f.patch";
-      sha256 = "17j5r7gsa3izrm7zln4mrp7l16h532gvmpas0kzglybicbiz7d56";
-      stripLen = 1;
-    })
     # Fixes compilation warning about uninitialied variables (in test code)
     ./uninitialized-variable-warning.patch
   ];

--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -67,7 +67,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.zeroc.com/ice.html";
     description = "The internet communications engine";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.unix;
     maintainers = with maintainers; [ abbradar ];
   };

--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, bzip2, expat, openssl, lmdb
+{ stdenv, lib, fetchFromGitHub
+, bzip2, expat, libedit, lmdb, openssl
 , darwin, libiconv, Security
 , cpp11 ? false
 }:
@@ -21,16 +22,16 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "zeroc-ice";
-  version = "3.7.2";
+  version = "3.7.6";
 
   src = fetchFromGitHub {
     owner = "zeroc-ice";
     repo = "ice";
     rev = "v${version}";
-    sha256 = "0m9lh79dfpcwcp2jhmj0wqdcsw3rl633x2hzfw9n2i34jjv64fvg";
+    sha256 = "0zc8gmlzl2f38m1fj6pv2vm8ka7fkszd6hx2lb8gfv65vn3m4sk4";
   };
 
-  buildInputs = [ zeroc_mcpp bzip2 expat openssl lmdb ]
+  buildInputs = [ zeroc_mcpp bzip2 expat libedit lmdb openssl ]
     ++ lib.optionals stdenv.isDarwin [ darwin.cctools libiconv Security ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=class-memaccess -Wno-error=deprecated-copy";

--- a/pkgs/development/libraries/zeroc-ice/uninitialized-variable-warning.patch
+++ b/pkgs/development/libraries/zeroc-ice/uninitialized-variable-warning.patch
@@ -1,0 +1,20 @@
+diff --git a/test/Glacier2/dynamicFiltering/TestControllerI.h b/test/Glacier2/dynamicFiltering/TestControllerI.h
+index 7e21639..1279200 100644
+--- a/test/Glacier2/dynamicFiltering/TestControllerI.h
++++ b/test/Glacier2/dynamicFiltering/TestControllerI.h
+@@ -21,13 +21,12 @@ struct SessionTuple
+ {
+     Glacier2::SessionPrx session;
+     Glacier2::SessionControlPrx sessionControl;
+-    bool configured;
++    bool configured = false;
+
+     SessionTuple() {}
+     SessionTuple(Glacier2::SessionPrx s, Glacier2::SessionControlPrx control):
+         session(s),
+-        sessionControl(control),
+-        configured(false)
++        sessionControl(control)
+     {}
+
+     SessionTuple&


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- `zeroc-ice-36` is broken
- `zeroc-ice` does not run tests
- The license for both is specified as `gpl2` where `gpl2Only` [is the correct license](https://github.com/zeroc-ice/ice/blob/3.7/README.md#copyright-and-license)
- Both are out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
