### PR TITLE
openal-soft: cleanup, remove ? null from inputs

### DIFF
--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -1,17 +1,12 @@
 { lib, stdenv, fetchFromGitHub, cmake
-, alsaSupport ? !stdenv.isDarwin, alsa-lib ? null
-, pulseSupport ? !stdenv.isDarwin, libpulseaudio ? null
+, alsaSupport ? !stdenv.isDarwin, alsa-lib
+, pulseSupport ? !stdenv.isDarwin, libpulseaudio
 , CoreServices, AudioUnit, AudioToolbox
 }:
 
-with lib;
-
-assert alsaSupport -> alsa-lib != null;
-assert pulseSupport -> libpulseaudio != null;
-
 stdenv.mkDerivation rec {
-  version = "1.21.1";
   pname = "openal-soft";
+  version = "1.21.1";
 
   src = fetchFromGitHub {
     owner = "kcat";
@@ -30,16 +25,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = []
-    ++ optional alsaSupport alsa-lib
-    ++ optional pulseSupport libpulseaudio
-    ++ optionals stdenv.isDarwin [ CoreServices AudioUnit AudioToolbox ];
+  buildInputs = lib.optional alsaSupport alsa-lib
+    ++ lib.optional pulseSupport libpulseaudio
+    ++ lib.optionals stdenv.isDarwin [ CoreServices AudioUnit AudioToolbox ];
 
-  NIX_LDFLAGS = toString ([]
-    ++ optional alsaSupport "-lasound"
-    ++ optional pulseSupport "-lpulse");
+  NIX_LDFLAGS = toString (
+    lib.optional alsaSupport "-lasound"
+    ++ lib.optional pulseSupport "-lpulse");
 
-  meta = {
+  meta = with lib; {
     description = "OpenAL alternative";
     homepage = "https://kcat.strangesoft.net/openal.html";
     license = licenses.lgpl2;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
