### PR TITLE
python3Packages.pytest-socket: 0.3.3 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/pytest-socket/default.nix
+++ b/pkgs/development/python-modules/pytest-socket/default.nix
@@ -1,19 +1,28 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
+, poetry-core
 , pytest
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pytest-socket";
-  version = "0.3.3";
+  version = "0.4.0";
+  disabled = pythonOlder "3.6";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "miketheman";
     repo = pname;
     rev = version;
-    sha256 = "1jbzkyp4xki81h01yl4vg3nrg9b6shsk1ryrmkaslffyhrqnj8zh";
+    sha256 = "sha256-cFYtJqZ/RjFbn9XlEy6ffxZ2djisajQAwjV/YR2f59Q=";
   };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   buildInputs = [
     pytest
@@ -23,18 +32,24 @@ buildPythonPackage rec {
     pytest
   ];
 
-  checkPhase = ''
-    pytest
-  '';
+  patches = [
+    # Switch to poetry-core, https://github.com/miketheman/pytest-socket/pull/74
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/miketheman/pytest-socket/commit/32519170e656e731d24b81770a170333d3efa6a8.patch";
+      sha256 = "19ksgx77rsa6ijcbml74alwc5052mdqr4rmvqhlzvfcvv3676ig2";
+    })
+  ];
 
-  # unsurprisingly pytest-socket require network for majority of tests
-  # to pass...
+  # pytest-socket require network for majority of tests
   doCheck = false;
+
+  pythonImportsCheck = [ "pytest_socket" ];
 
   meta = with lib; {
     description = "Pytest Plugin to disable socket calls during tests";
     homepage = "https://github.com/miketheman/pytest-socket";
     license = licenses.mit;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.4.0

Change log: https://github.com/miketheman/pytest-socket/releases/tag/0.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
