### PR TITLE
python3Packages.pymongo: 3.11.4 -> 3.12.0, python3Packages.motor: 2.4.0 -> 2.5.1

### DIFF
--- a/pkgs/development/python-modules/motor/default.nix
+++ b/pkgs/development/python-modules/motor/default.nix
@@ -1,23 +1,29 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, pymongo, mockupdb
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mockupdb
+, pymongo
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "motor";
-  version = "2.4.0";
+  version = "2.5.1";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "mongodb";
     repo = pname;
     rev = version;
-    sha256 = "1sgaqg98h35lazzdi015q1i60ig7krid8b10a5rm6lf755y8yj2c";
+    sha256 = "sha256-r+HyIEC+Jafn7eMqkAldsZ5hbem+n+P76RJGAymmBks=";
   };
 
   propagatedBuildInputs = [ pymongo ];
 
+  checkInputs = [ mockupdb ];
+
   # network connections
   doCheck = false;
-  checkInputs = [ mockupdb ];
 
   pythonImportsCheck = [ "motor" ];
 

--- a/pkgs/development/python-modules/pymongo/default.nix
+++ b/pkgs/development/python-modules/pymongo/default.nix
@@ -1,20 +1,28 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "pymongo";
-  version = "3.11.4";
+  version = "3.12.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "539d4cb1b16b57026999c53e5aab857fe706e70ae5310cc8c232479923f932e6";
+    sha256 = "sha256-uI0XQhWbyToHhzP5eJ9WPO8m9eNw66gQR2pxqpjl+8I=";
   };
 
   # Tests call a running mongodb instance
   doCheck = false;
 
+  pythonImportsCheck = [ "pymongo" ];
+
   meta = with lib; {
+    description = "Python driver for MongoDB";
     homepage = "https://github.com/mongodb/mongo-python-driver";
     license = licenses.asl20;
-    description = "Python driver for MongoDB";
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream releases.

Change log:
- https://motor.readthedocs.io/en/2.5.1/changelog.html
- https://pymongo.readthedocs.io/en/stable/changelog.html#changes-in-version-3-12-0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
