### PR TITLE
ocamlPackages.integers: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/development/ocaml-modules/integers/default.nix
+++ b/pkgs/development/ocaml-modules/integers/default.nix
@@ -1,20 +1,23 @@
-{ lib, fetchzip, buildDunePackage, ocaml }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml }:
 
 buildDunePackage rec {
   pname = "integers";
-  version = "0.4.0";
+  version = "0.5.1";
 
   useDune2 = lib.versionAtLeast ocaml.version "4.08";
 
-  src = fetchzip {
-    url = "https://github.com/ocamllabs/ocaml-integers/archive/${version}.tar.gz";
-    sha256 = "0yp3ab0ph7mp5741g7333x4nx8djjvxzpnv3zvsndyzcycspn9dd";
+  src = fetchFromGitHub {
+    owner = "ocamllabs";
+    repo = "ocaml-integers";
+    rev = version;
+    sha256 = "0by5pc851fk7ccxqy1w2qc5jwn9z8whyqhs5gxlm5986vr9msnyi";
   };
 
   meta = {
     description = "Various signed and unsigned integer types for OCaml";
     license = lib.licenses.mit;
     homepage = "https://github.com/ocamllabs/ocaml-integers";
+    changelog = "https://github.com/ocamllabs/ocaml-integers/raw/${version}/CHANGES.md";
     maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
@@ -13,7 +13,7 @@
 
 buildDunePackage rec {
   pname = "ppx_cstubs";
-  version = "0.6.1.1";
+  version = "0.6.1.2";
 
   useDune2 = true;
 
@@ -21,7 +21,7 @@ buildDunePackage rec {
     owner = "fdopen";
     repo = "ppx_cstubs";
     rev = version;
-    sha256 = "0rgg78435ypi6ryhcq5ljkch4qjvra2jqjd47c2hhhcbwvi2ssxh";
+    sha256 = "15cjb9ygnvp2kv85rrb7ncz7yalifyl7wd2hp2cl8r1qrpgi1d0w";
   };
 
   buildInputs = [
@@ -37,8 +37,9 @@ buildDunePackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/fdopen/ppx_cstubs";
+    changelog = "https://github.com/fdopen/ppx_cstubs/raw/${version}/CHANGES.md";
     description = "Preprocessor for easier stub generation with ocaml-ctypes";
-    license = licenses.mit;
+    license = licenses.lgpl21Plus;
     maintainers = [ maintainers.osener ];
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/ocamllabs/ocaml-integers/raw/0.5.1/CHANGES.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
