### PR TITLE
zfs-autobackup: init at 3.1

### DIFF
--- a/pkgs/tools/backup/zfs-autobackup/default.nix
+++ b/pkgs/tools/backup/zfs-autobackup/default.nix
@@ -1,0 +1,33 @@
+{ lib, python3Packages }:
+
+let
+  pythonPackages = python3Packages;
+
+in
+pythonPackages.buildPythonApplication rec {
+  pname = "zfs_autobackup";
+  version = "3.1";
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "42c22001717b3d7cfdae6297fedc11b2dd1eb2a4bd25b6bb1c9232dd3b70ad67";
+  };
+
+  # argparse is part of the standardlib
+  prePatch = ''
+    substituteInPlace setup.py --replace "argparse" ""
+  '';
+
+  propagatedBuildInputs = with pythonPackages; [ colorama ];
+
+  # tests need zfs filesystem
+  doCheck = false;
+  pythonImportsCheck = [ "colorama" "argparse" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/psy0rz/zfs_autobackup";
+    description = "ZFS backup, replicationand snapshot tool";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mschneider ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10472,6 +10472,8 @@ with pkgs;
 
   zerofree = callPackage ../tools/filesystems/zerofree { };
 
+  zfs-autobackup = callPackage ../tools/backup/zfs-autobackup { };
+
   zfsbackup = callPackage ../tools/backup/zfsbackup { };
 
   zfstools = callPackage ../tools/filesystems/zfstools { };


### PR DESCRIPTION
###### Motivation for this change

Adding the tool zfs-autobackup to nixpkgs.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
