### PR TITLE
treewide: fixes, buildflags -> ldflags/tags

### DIFF
--- a/pkgs/applications/networking/bee/bee.nix
+++ b/pkgs/applications/networking/bee/bee.nix
@@ -44,8 +44,8 @@ buildGoModule {
   subPackages = [ "cmd/bee" ];
 
   # no symbol table, no debug info, and pass the commit for the version string
-  buildFlags = lib.optionalString ( lib.hasAttr "goVersionString" versionSpec)
-    "-ldflags -s -ldflags -w -ldflags -X=github.com/ethersphere/bee.commit=${versionSpec.goVersionString}";
+  ldflags = lib.optionals ( lib.hasAttr "goVersionString" versionSpec)
+    [ "-s" "-w" "-X=github.com/ethersphere/bee.commit=${versionSpec.goVersionString}" ];
 
   # Mimic the bee Makefile: without disabling CGO, two (transitive and
   # unused) dependencies would fail to compile.

--- a/pkgs/applications/networking/instant-messengers/pond/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pond/default.nix
@@ -30,4 +30,7 @@ buildGoPackage rec {
       -e "s,golang.org/x/crypto/bn256,github.com/agl/pond/bn256cgo,g" \
       -e "s,bn256\.,bn256cgo.,g"
   '';
+
+  # https://hydra.nixos.org/build/150102618/nixlog/2
+  meta.broken = stdenv.isAarch64;
 }

--- a/pkgs/applications/networking/instant-messengers/pond/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pond/default.nix
@@ -23,7 +23,7 @@ buildGoPackage rec {
   buildInputs = [ trousers gtk3 gtkspell3 ]
     ++ lib.optional stdenv.hostPlatform.isx86_64 dclxvi
     ++ lib.optionals gui [ wrapGAppsHook ];
-  buildFlags = lib.optionals (!gui) [ "-tags" "nogui" ];
+  tags = lib.optionals (!gui) [ "nogui" ];
   excludedPackages = "\\(appengine\\|bn256cgo\\)";
   postPatch = lib.optionalString stdenv.hostPlatform.isx86_64 ''
     grep -r 'bn256' | awk -F: '{print $1}' | xargs sed -i \

--- a/pkgs/applications/virtualization/containerd/1.4.nix
+++ b/pkgs/applications/virtualization/containerd/1.4.nix
@@ -26,12 +26,10 @@ buildGoPackage rec {
 
   buildInputs = [ btrfs-progs ];
 
-  buildFlags = [ "VERSION=v${version}" "REVISION=${src.rev}" ];
-
   buildPhase = ''
     cd go/src/${goPackagePath}
     patchShebangs .
-    make binaries man $buildFlags
+    make binaries man "VERSION=v${version}" "REVISION=${src.rev}"
   '';
 
   installPhase = ''

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -27,14 +27,12 @@ buildGoModule rec {
 
   buildInputs = [ btrfs-progs ];
 
-  buildFlags = [ "VERSION=v${version}" "REVISION=${src.rev}" ];
-
   BUILDTAGS = lib.optionals (btrfs-progs == null) [ "no_btrfs" ];
 
   buildPhase = ''
     runHook preBuild
     patchShebangs .
-    make binaries man $buildFlags
+    make binaries man "VERSION=v${version}" "REVISION=${src.rev}"
     runHook postBuild
   '';
 

--- a/pkgs/tools/misc/teleconsole/default.nix
+++ b/pkgs/tools/misc/teleconsole/default.nix
@@ -25,7 +25,6 @@ buildGoPackage rec {
   '';
 
   CGO_ENABLED = 1;
-  buildFlags = [ "-ldflags" ];
 
   meta = with lib; {
     homepage = "https://www.teleconsole.com/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
