### PR TITLE
tarsnapper: add meta

### DIFF
--- a/pkgs/tools/backup/tarsnapper/default.nix
+++ b/pkgs/tools/backup/tarsnapper/default.nix
@@ -1,25 +1,49 @@
-{ python3Packages, fetchFromGitHub , tarsnap }:
+{ lib
+, python3Packages
+, fetchFromGitHub
+, tarsnap
+}:
 
 python3Packages.buildPythonApplication rec {
-  name = "tarsnapper-${version}";
+  pname = "tarsnapper";
   version = "0.4";
 
   src = fetchFromGitHub {
     owner = "miracle2k";
-    repo = "tarsnapper";
+    repo = pname;
     rev = version;
     sha256 = "03db49188f4v1946c8mqqj30ah10x68hbg3a58js0syai32v12pm";
   };
 
-  checkInputs = with python3Packages; [ nose pytest ];
+  propagatedBuildInputs = with python3Packages; [
+    pyyaml
+    python-dateutil
+    pexpect
+  ];
+
+  checkInputs = with python3Packages; [
+    nose
+  ];
+
+  patches = [
+    # Remove standard module argparse from requirements
+    ./remove-argparse.patch
+  ];
+
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ tarsnap ]}" ];
 
   checkPhase = ''
-    py.test .
+    runHook preCheck
+    nosetests tests
+    runHook postCheck
   '';
 
-  propagatedBuildInputs = with python3Packages; [ pyyaml python-dateutil pexpect ];
+  pythonImportsCheck = [ "tarsnapper" ];
 
-  patches = [ ./remove-argparse.patch ];
-
-  makeWrapperArgs = ["--prefix PATH : ${tarsnap}/bin"];
+  meta = with lib; {
+    description = "Wrapper which expires backups using a gfs-scheme";
+    homepage = "https://github.com/miracle2k/tarsnapper";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ];
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Add `meta`
- Use `pname` instead of `name`
- Add `pythonImportsCheck` and switch to `pytestCheckHook`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
