### PR TITLE
maestral-gui: 1.4.6 -> 1.4.8

### DIFF
--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maestral-qt";
-  version = "1.4.6";
+  version = "1.4.8";
   disabled = python3.pkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-qt";
     rev = "v${version}";
-    sha256 = "sha256-Y4n67LJyNUsLmGMu7B73n888qmCQ9HjxCSM1MlfTbqQ=";
+    sha256 = "sha256-lP6ASWizIQC3TkkIOHS6cBbgLNoGrSx/sThtl9bMjys=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -40,6 +40,8 @@ python3.pkgs.buildPythonApplication rec {
   # no tests
   doCheck = false;
 
+  pythonImportsCheck = [ "maestral_qt" ];
+
   meta = with lib; {
     description = "GUI front-end for maestral (an open-source Dropbox client) for Linux";
     license = licenses.mit;

--- a/pkgs/development/python-modules/desktop-notifier/default.nix
+++ b/pkgs/development/python-modules/desktop-notifier/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "desktop-notifier";
-  version = "3.3.1";
+  version = "3.3.2";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-GbsbwCKRTgLk0xK6MGKb1Tp6cd8q3h6OUdJ2f+VPyzk=";
+    sha256 = "sha256-h7an/Fm9pNnThCHXg9PAKG822dqXE/CUuW8lDJlwMfw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "maestral";
-  version = "1.4.6";
+  version = "1.4.8";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral";
     rev = "v${version}";
-    sha256 = "sha256-kaRcM8Z0xeDp3JYputKZmzTfYYq2oKpF7AM6ciFF7I4=";
+    sha256 = "sha256-sxPogzQW+P8yrqaaJHrQu7e0ztgwWUI0kLikcmrhYoQ=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -5,6 +5,7 @@
 , python
 , click, desktop-notifier, dropbox, fasteners, keyring, keyrings-alt, packaging, pathspec, Pyro5, requests, setuptools, sdnotify, survey, watchdog
 , importlib-metadata
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -44,8 +45,24 @@ buildPythonPackage rec {
     "--prefix" "PYTHONPATH" ":" "$out/lib/${python.libPrefix}/site-packages"
   ];
 
-  # no tests
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # We don't want to benchmark
+    "test_performance"
+    # Requires systemd
+    "test_autostart"
+    # Requires network access
+    "test_check_for_updates"
+    # Tries to look at /usr
+    "test_filestatus"
+    "test_path_exists_case_insensitive"
+    "test_cased_path_candidates"
+  ];
+
+  pythonImportsCheck = [ "maestral" ];
 
   meta = with lib; {
     description = "Open-source Dropbox client for macOS and Linux";


### PR DESCRIPTION
###### Motivation for this change

Upstream update, including update for dependency desktop-notifier.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
