### PR TITLE
python3Packages.python-lsp-server: make some dependencies optional

### DIFF
--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -22,6 +22,15 @@
 , setuptools
 , ujson
 , yapf
+, withAutopep8 ? true
+, withFlake8 ? true
+, withMccabe ? true
+, withPycodestyle ? true
+, withPydocstyle ? true
+, withPyflakes ? true
+, withPylint ? true
+, withRope ? true
+, withYapf ? true
 }:
 
 buildPythonPackage rec {
@@ -37,21 +46,20 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    autopep8
-    flake8
     jedi
-    mccabe
     pluggy
-    pycodestyle
-    pydocstyle
-    pyflakes
-    pylint
     python-lsp-jsonrpc
-    rope
     setuptools
     ujson
-    yapf
-  ];
+  ] ++ lib.optional withAutopep8 autopep8
+    ++ lib.optional withFlake8 flake8
+    ++ lib.optional withMccabe mccabe
+    ++ lib.optional withPycodestyle pycodestyle
+    ++ lib.optional withPydocstyle pydocstyle
+    ++ lib.optional withPyflakes pyflakes
+    ++ lib.optional withPylint pylint
+    ++ lib.optional withRope rope
+    ++ lib.optional withYapf yapf;
 
   checkInputs = [
     flaky
@@ -61,6 +69,19 @@ buildPythonPackage rec {
     pyqt5
     pytestCheckHook
   ];
+
+  disabledTests = lib.optional (!withPycodestyle) "test_workspace_loads_pycodestyle_config";
+
+  disabledTestPaths = lib.optional (!withAutopep8) "test/plugins/test_autopep8_format.py"
+    ++ lib.optional (!withRope) "test/plugins/test_completion.py"
+    ++ lib.optional (!withFlake8) "test/plugins/test_flake8_lint.py"
+    ++ lib.optional (!withMccabe) "test/plugins/test_mccabe_lint.py"
+    ++ lib.optional (!withPycodestyle) "test/plugins/test_pycodestyle_lint.py"
+    ++ lib.optional (!withPydocstyle) "test/plugins/test_pydocstyle_lint.py"
+    ++ lib.optional (!withPyflakes) "test/plugins/test_pyflakes_lint.py"
+    ++ lib.optional (!withPylint) "test/plugins/test_pylint_lint.py"
+    ++ lib.optional (!withRope) "test/plugins/test_rope_rename.py"
+    ++ lib.optional (!withYapf) "test/plugins/test_yapf_format.py";
 
   postPatch = ''
     substituteInPlace setup.cfg \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Some dependencies of python-lsp-server can be optional
https://github.com/python-lsp/python-lsp-server/blob/v1.2.1/setup.py#L47

`cq-editor` fails to build with `nixpkgs-review` because it is [already broken](https://hydra.nixos.org/eval/1698305?filter=cq-editor)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
