### PR TITLE
treewide: Fix homepages

### DIFF
--- a/pkgs/applications/kde/bomber.nix
+++ b/pkgs/applications/kde/bomber.nix
@@ -6,7 +6,7 @@
 mkDerivation {
   pname = "bomber";
   meta = with lib; {
-    homepage = "https://kde.org/applications/en/games/org.kde.bomber";
+    homepage = "https://apps.kde.org/bomber/";
     description = "A single player arcade game";
     longDescription = ''
       Bomber is a single player arcade game. The player is invading various

--- a/pkgs/applications/networking/cluster/argocd/default.nix
+++ b/pkgs/applications/networking/cluster/argocd/default.nix
@@ -68,7 +68,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Declarative continuous deployment for Kubernetes";
     downloadPage = "https://github.com/argoproj/argo-cd";
-    homepage = "https://argoproj.github.io/projects/argo-cd";
+    homepage = "https://argo-cd.readthedocs.io/en/stable/";
     license = licenses.asl20;
     maintainers = with maintainers; [ shahrukh330 superherointj ];
   };

--- a/pkgs/applications/science/biology/bowtie/default.nix
+++ b/pkgs/applications/science/biology/bowtie/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An ultrafast memory-efficient short read aligner";
     license = licenses.artistic2;
-    homepage = "http://bowtie-bio.sf.net/bowtie";
+    homepage = "http://bowtie-bio.sourceforge.net";
     maintainers = with maintainers; [ prusnak ];
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/a52dec/default.nix
+++ b/pkgs/development/libraries/a52dec/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "ATSC A/52 stream decoder";
-    homepage = "https://liba52.sourceforge.net/";
+    homepage = "https://liba52.sourceforge.io/";
     platforms = platforms.unix;
     license = licenses.gpl2Plus;
   };

--- a/pkgs/development/libraries/alure/default.nix
+++ b/pkgs/development/libraries/alure/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A utility library to help manage common tasks with OpenAL applications";
-    homepage = "https://kcat.strangesoft.net/alure.html";
+    homepage = "https://github.com/kcat/alure";
     license = licenses.mit;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/boolstuff/default.nix
+++ b/pkgs/development/libraries/boolstuff/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Library for operations on boolean expression binary trees";
-    homepage = "https://perso.b2b2c.ca/~sarrazip/dev/boolstuff.html";
+    homepage = "http://perso.b2b2c.ca/~sarrazip/dev/boolstuff.html";
     license = "GPL";
     maintainers = [ lib.maintainers.marcweber ];
     platforms = lib.platforms.all;

--- a/pkgs/development/python-modules/ansible/collections.nix
+++ b/pkgs/development/python-modules/ansible/collections.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Radically simple IT automation";
-    homepage = "http://www.ansible.com";
+    homepage = "https://www.ansible.com";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ hexa ];
   };

--- a/pkgs/development/python-modules/ansible/legacy.nix
+++ b/pkgs/development/python-modules/ansible/legacy.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    homepage = "http://www.ansible.com";
+    homepage = "https://www.ansible.com";
     description = "Radically simple IT automation";
     license = [ licenses.gpl3 ] ;
     maintainers = with maintainers; [ joamaki costrouc hexa ];

--- a/pkgs/games/banner/default.nix
+++ b/pkgs/games/banner/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://software.cedar-solutions.com/utilities.html";
+    homepage = "https://software.cedar-solutions.com/utilities.html";
     description = "Print large banners to ASCII terminals";
     license = licenses.gpl2Only;
 

--- a/pkgs/os-specific/linux/firmware/b43-firmware/5.1.138.nix
+++ b/pkgs/os-specific/linux/firmware/b43-firmware/5.1.138.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Firmware for cards supported by the b43 kernel module";
-    homepage = "http://wireless.kernel.org/en/users/Drivers/b43";
+    homepage = "https://wireless.wiki.kernel.org/en/users/drivers/b43";
     license = lib.licenses.unfree;
   };
 }

--- a/pkgs/os-specific/linux/firmware/b43-firmware/6.30.163.46.nix
+++ b/pkgs/os-specific/linux/firmware/b43-firmware/6.30.163.46.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Firmware for cards supported by the b43 kernel module";
-    homepage = "http://wireless.kernel.org/en/users/Drivers/b43";
+    homepage = "https://wireless.wiki.kernel.org/en/users/drivers/b43";
     downloadPage = "http://www.lwfinger.com/b43-firmware";
     license = licenses.unfree;
   };

--- a/pkgs/tools/X11/arandr/default.nix
+++ b/pkgs/tools/X11/arandr/default.nix
@@ -32,7 +32,7 @@ in buildPythonApplication rec {
   propagatedBuildInputs = [ xrandr pygobject3 ];
 
   meta = {
-    homepage = "http://christian.amsuess.com/tools/arandr/";
+    homepage = "https://christian.amsuess.com/tools/arandr/";
     description = "A simple visual front end for XRandR";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.domenkozar ];

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -265,7 +265,7 @@ in pythonPackages.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Music tagger and library organizer";
-    homepage = "http://beets.io";
+    homepage = "https://beets.io";
     license = licenses.mit;
     maintainers = with maintainers; [ aszlig doronbehar lovesegfault pjones ];
     platforms = platforms.linux;

--- a/pkgs/tools/misc/betterdiscord-installer/default.nix
+++ b/pkgs/tools/misc/betterdiscord-installer/default.nix
@@ -24,7 +24,7 @@ in appimageTools.wrapType2 {
 
   meta = with lib; {
     description = "Installer for BetterDiscord";
-    homepage = "https://betterdiscord.net";
+    homepage = "https://betterdiscord.app";
     license = licenses.mit;
     maintainers = [ maintainers.ivar ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
