### PR TITLE
meh: 2015-04-11 -> 2018-10-22

### DIFF
--- a/pkgs/applications/graphics/meh/default.nix
+++ b/pkgs/applications/graphics/meh/default.nix
@@ -1,18 +1,16 @@
 { lib, stdenv, fetchFromGitHub, libX11, libXext, libjpeg, libpng, giflib }:
 
 stdenv.mkDerivation {
-  name = "meh-unstable-2015-04-11";
+  name = "meh-unstable-2018-10-22";
 
   src = fetchFromGitHub {
     owner = "jhawthorn";
     repo = "meh";
-    rev = "4ab1c75f97cb70543db388b3ed99bcfb7e94c758";
-    sha256 = "1j1n3m9hjhz4faryai97jq7cr6a322cqrd878gpkm9nrikap3bkk";
+    rev = "69f653a1f16d11b12e5b600e808a740898f3223e";
+    sha256 = "sha256-srSwoaajW4H4+kmE7NQAqVz9d/1q2XQ5ayQaOcGwzI0=";
   };
 
-  installPhase = ''
-    make PREFIX=$out install
-  '';
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
 
   outputs = [ "out" "man" ];
 

--- a/pkgs/applications/graphics/meh/default.nix
+++ b/pkgs/applications/graphics/meh/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, fetchFromGitHub, libX11, libXext, libjpeg, libpng, giflib }:
 
 stdenv.mkDerivation {
-  name = "meh-unstable-2018-10-22";
+  pname = "meh";
+  version = "unstable-2018-10-22";
 
   src = fetchFromGitHub {
     owner = "jhawthorn";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
