### PR TITLE
vips: Add optional dependencies; update to python3 

### DIFF
--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -1,29 +1,39 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , pkg-config
 , glib
 , libxml2
 , expat
-, fftw
-, orc
-, lcms
-, imagemagick
-, openexr
-, libtiff
-, libjpeg
-, libgsf
-, libexif
-, libheif
-, librsvg
 , ApplicationServices
 , Foundation
-, python27
-, libpng
+, python3
 , fetchFromGitHub
 , fetchpatch
 , autoreconfHook
 , gtk-doc
 , gobject-introspection
-,
+  # Optional dependencies
+, libjpeg
+, libexif
+, librsvg
+, poppler
+, libgsf
+, libtiff
+, fftw
+, lcms2
+, libpng
+, libimagequant
+, imagemagick
+, pango
+, orc
+, matio
+, cfitsio
+, libwebp
+, openexr
+, openjpeg
+, libjxl
+, openslide
+, libheif
 }:
 
 stdenv.mkDerivation rec {
@@ -54,22 +64,31 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     libxml2
-    fftw
-    orc
-    lcms
-    imagemagick
-    openexr
-    libtiff
-    libjpeg
-    libgsf
-    libexif
-    libheif
-    libpng
-    librsvg
-    python27
-    libpng
     expat
-  ] ++ lib.optionals stdenv.isDarwin [ApplicationServices Foundation];
+    (python3.withPackages (p: [ p.pycairo ]))
+    # Optional dependencies
+    libjpeg
+    libexif
+    librsvg
+    poppler
+    libgsf
+    libtiff
+    fftw
+    lcms2
+    libpng
+    libimagequant
+    imagemagick
+    pango
+    orc
+    matio
+    cfitsio
+    libwebp
+    openexr
+    openjpeg
+    libjxl
+    openslide
+    libheif
+  ] ++ lib.optionals stdenv.isDarwin [ ApplicationServices Foundation ];
 
   # Required by .pc file
   propagatedBuildInputs = [

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -28,7 +28,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vips";
-  version = "8.11.2";
+  version = "8.11.3";
 
   outputs = [ "bin" "out" "man" "dev" ];
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     owner = "libvips";
     repo = "libvips";
     rev = "v${version}";
-    sha256 = "sha256-Psb+LrpTWtZwO9ekOLJIXsy8W49jW4Jdi+EmiJ+1MsQ=";
+    sha256 = "sha256-CWuULuUMBV2VUCZEBg0MzS7rXI8UUkNh5XPV2eA8xt8=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     extraPostFetch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This goes on top of https://github.com/NixOS/nixpkgs/pull/135130

I was testing https://github.com/NixOS/nixpkgs/pull/135130 (using nip2, with the commit from https://github.com/NixOS/nixpkgs/pull/135309) and the bundled example I happened to try out rendered text, so it had pangocairo as a dependency, which vips didn't have. So I went through the optional dependencies of vips and added a bunch.

The new optional dependencies increase closure size from 388.92 MiB to 414.0 MiB, a negligible change. I didn't think there was any reason to add `withLibjpeg ? true` flags (or `enableLibjpeg`).

The optional dependencies are sorted in the order of https://github.com/libvips/libvips/blob/master/README.md and I have used `nix log` on the build to check they are all picked up in configure.

The python3 support was in for ages (libvips/libvips#202), the remaining python3 support in tools/vipsprofile landed in libvips/libvips#1262 so I upgraded it to python3. I wasn't sure if I should use a specific version, or just leave it as python3.

###### Things done

Note, for testing the binary I tested it using nip2, see PR https://github.com/NixOS/nixpkgs/pull/135309.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) They all executed fine, beyond that I didn't know how to use them, though as noted I used nip2 (see https://github.com/NixOS/nixpkgs/pull/135309) to test it.
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
