### PR TITLE
nip2: Fix location of builtins by setting VIPSHOME 

### DIFF
--- a/pkgs/tools/graphics/nip2/default.nix
+++ b/pkgs/tools/graphics/nip2/default.nix
@@ -1,5 +1,19 @@
-{ lib, stdenv, fetchurl, pkg-config, glib, libxml2, flex, bison, vips, gtk2
-, fftw, gsl, goffice, libgsf }:
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, glib
+, libxml2
+, flex
+, bison
+, vips
+, gtk2
+, fftw
+, gsl
+, goffice
+, libgsf
+, makeWrapper
+}:
 
 stdenv.mkDerivation rec {
   pname = "nip2";
@@ -11,9 +25,24 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-  [ pkg-config glib libxml2 flex bison vips
-    gtk2 fftw gsl goffice libgsf
-  ];
+    [
+      pkg-config
+      glib
+      libxml2
+      flex
+      bison
+      vips
+      gtk2
+      fftw
+      gsl
+      goffice
+      libgsf
+      makeWrapper
+    ];
+
+  postFixup = ''
+    wrapProgram $out/bin/nip2 --set VIPSHOME "$out"
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/libvips/nip2";

--- a/pkgs/tools/graphics/nip2/default.nix
+++ b/pkgs/tools/graphics/nip2/default.nix
@@ -24,21 +24,23 @@ stdenv.mkDerivation rec {
     sha256 = "0l7n427njif53npqn02gfjjly8y3khbrkzqxp10j5vp9h97psgiw";
   };
 
-  buildInputs =
-    [
-      pkg-config
-      glib
-      libxml2
-      flex
-      bison
-      vips
-      gtk2
-      fftw
-      gsl
-      goffice
-      libgsf
-      makeWrapper
-    ];
+  nativeBuildInputs = [
+    bison
+    flex
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    glib
+    libxml2
+    vips
+    gtk2
+    fftw
+    gsl
+    goffice
+    libgsf
+  ];
 
   postFixup = ''
     wrapProgram $out/bin/nip2 --set VIPSHOME "$out"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I was testing https://github.com/NixOS/nixpkgs/pull/135130 (and this PR depends on that, it doesn't need to but that is uncontroversial and I expect it'll be merged first).

The program `nip2` didn't really work without this, as it didn't know where to find the bundled scripts. Though VIPSHOME should really be called NIP2HOME. I suppose I should open an issue upstream to also consider `datarootdir` from autotools?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
