### PR TITLE
micromamba: 0.14.1 -> 0.15.0

### DIFF
--- a/pkgs/tools/package-management/micromamba/default.nix
+++ b/pkgs/tools/package-management/micromamba/default.nix
@@ -1,23 +1,54 @@
-{ lib, stdenv, fetchFromGitHub, cmake
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake
 , cli11, nlohmann_json, curl, libarchive, libyamlcpp, libsolv, reproc
 }:
 
 let
   libsolv' = libsolv.overrideAttrs (oldAttrs: {
     cmakeFlags = oldAttrs.cmakeFlags ++ [
-      "-DENABLE_CONDA=true"  # Maybe enable this in the original libsolv package? No idea about the implications.
+      "-DENABLE_CONDA=true"
     ];
+
+    patches = [
+      # Patch added by the mamba team
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/f766da0cc18701c4d107a41de22417a65b53cc2d/libsolv/add_strict_repo_prio_rule.patch";
+        sha256 = "19c47i5cpyy88nxskf7k6q6r43i55w61jvnz7fc2r84hpjkcrv7r";
+      })
+      # Patch added by the mamba team
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/f766da0cc18701c4d107a41de22417a65b53cc2d/libsolv/conda_variant_priorization.patch";
+        sha256 = "1iic0yx7h8s662hi2jqx68w5kpyrab4fr017vxd4wyxb6wyk35dd";
+      })
+      # Patch added by the mamba team
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/mamba-org/boa-forge/f766da0cc18701c4d107a41de22417a65b53cc2d/libsolv/memcpy_to_memmove.patch";
+        sha256 = "1c9ir40l6crcxllj5zwhzbrbgibwqaizyykd0vip61gywlfzss64";
+      })
+    ];
+  });
+
+  # fails linking with yaml-cpp 0.7.x
+  libyamlcpp' = libyamlcpp.overrideAttrs (oldAttrs: rec {
+
+    version = "0.6.3";
+
+    src = fetchFromGitHub {
+      owner = "jbeder";
+      repo = "yaml-cpp";
+      rev = "yaml-cpp-${version}";
+      sha256 = "0ykkxzxcwwiv8l8r697gyqh1nl582krpvi7m7l6b40ijnk4pw30s";
+    };
   });
 in
 stdenv.mkDerivation rec {
   pname = "micromamba";
-  version = "0.14.1";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "mamba-org";
     repo = "mamba";
     rev = version;
-    sha256 = "0a5kmwk44ll4d8b2akjc0vm6ap9jfxclcw4fclvjxr2in3am9256";
+    sha256 = "1zksp4zqj4wn9p9jb1qx1acajaz20k9xnm80yi7bab2d37y18hcw";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -27,7 +58,7 @@ stdenv.mkDerivation rec {
     nlohmann_json
     curl
     libarchive
-    libyamlcpp
+    libyamlcpp'
     libsolv'
     reproc
     # python3Packages.pybind11 # Would be necessary if someone wants to build with bindings I guess.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Haven't been able to update further that 0.15.0 for now, getting a compile-time error apparently caused by https://github.com/mamba-org/mamba/commit/ba6e2d9a994f6b21026edd1f70a433860c35c3aa

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
