### PR TITLE
python3Packages.aws-sam-translator: enable tests

### DIFF
--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -1,10 +1,14 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-, pythonOlder
 , boto3
+, buildPythonPackage
 , enum34
+, fetchFromGitHub
 , jsonschema
+, mock
+, parameterized
+, pytestCheckHook
+, pythonOlder
+, pyyaml
 , six
 }:
 
@@ -12,23 +16,39 @@ buildPythonPackage rec {
   pname = "aws-sam-translator";
   version = "1.38.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-Dsrdqc9asjGPV/ElMYGiFR5MU8010hcXqSPAdaWmXLY=";
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "serverless-application-model";
+    rev = "v${version}";
+    sha256 = "0nn9jfqz13kzmxm0r9vy24p8sqxv3mrm5d3lx7ah6rc581q8nv1k";
   };
-
-  # Tests are not included in the PyPI package
-  doCheck = false;
 
   propagatedBuildInputs = [
     boto3
     jsonschema
     six
-  ] ++ lib.optionals (pythonOlder "3.4") [ enum34 ];
+  ] ++ lib.optionals (pythonOlder "3.4") [
+    enum34
+  ];
+
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace " --cov samtranslator --cov-report term-missing --cov-fail-under 95" ""
+  '';
+
+  checkInputs = [
+    mock
+    parameterized
+    pytestCheckHook
+    pyyaml
+  ];
+
+  pythonImportsCheck = [ "samtranslator" ];
 
   meta = with lib; {
-    homepage = "https://github.com/awslabs/serverless-application-model";
     description = "Python library to transform SAM templates into AWS CloudFormation templates";
+    homepage = "https://github.com/awslabs/serverless-application-model";
     license = licenses.asl20;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
