### PR TITLE
cramfsswap: 1.4.1 -> 1.4.2, cleanup

### DIFF
--- a/pkgs/os-specific/linux/cramfsswap/default.nix
+++ b/pkgs/os-specific/linux/cramfsswap/default.nix
@@ -2,12 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "cramfsswap";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/c/cramfsswap/${pname}_${version}.tar.gz";
-    sha256 = "0c6lbx1inkbcvvhh3y6fvfaq3w7d1zv7psgpjs5f3zjk1jysi9qd";
+    url = "mirror://debian/pool/main/c/cramfsswap/${pname}_${version}.tar.xz";
+    sha256 = "10mj45zx71inaa3l1d81g64f7yn1xcprvq4v4yzpdwbxqmqaikw1";
   };
+
+  # Needed for cross-compilation
+  postPatch = ''
+    substituteInPlace Makefile --replace 'strip ' '$(STRIP) '
+  '';
 
   buildInputs = [zlib];
 
@@ -18,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Swap endianess of a cram filesystem (cramfs)";
     homepage = "https://packages.debian.org/sid/utils/cramfsswap";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
* fix cross-compilation
* clarify license

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
