### PR TITLE
imake: do not skip Linux* vendor definitions

### DIFF
--- a/pkgs/applications/misc/xcruiser/default.nix
+++ b/pkgs/applications/misc/xcruiser/default.nix
@@ -12,8 +12,10 @@ stdenv.mkDerivation {
   buildInputs = [ libXt libXaw libXpm libXext ];
 
   makeFlags = [
-    "BINDIR=$(out)/bin"
-    "XAPPLOADDIR=$(out)/etc/X11/app-defaults"
+    "BINDIR=${placeholder "out"}/bin"
+    "CONFDIR=${placeholder "out"}/etc/X11"
+    "LIBDIR=${placeholder "out"}/lib/X11"
+    "XAPPLOADDIR=${placeholder "out"}/etc/X11/app-defaults"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/xxkb/default.nix
+++ b/pkgs/applications/misc/xxkb/default.nix
@@ -24,7 +24,9 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "BINDIR=${placeholder "out"}/bin"
+    "CONFDIR=${placeholder "out"}/etc/X11"
     "PIXMAPDIR=${placeholder "out"}/share/xxkb"
+    "LIBDIR=${placeholder "out"}/lib/X11"
     "XAPPLOADDIR=${placeholder "out"}/etc/X11/app-defaults"
     "MANDIR=${placeholder "man"}/share/man"
   ];

--- a/pkgs/servers/x11/xorg/imake.patch
+++ b/pkgs/servers/x11/xorg/imake.patch
@@ -1,31 +1,35 @@
-diff -Naur imake-1.0.7-orig/imake.c imake-1.0.7/imake.c
---- imake-1.0.7-orig/imake.c	2013-08-17 10:11:50.000000000 +0000
-+++ imake-1.0.7/imake.c	2015-02-04 09:41:59.000000000 +0000
-@@ -1045,6 +1045,7 @@
- static void
- get_distrib(FILE *inFile)
- {
-+#if 0
-   struct stat sb;
+Disable imake autodetection for:
+- LinuxDistribution to avoid injection of /usr paths
+- gcc to avoid use uf /usr/bin/gcc
+
+https://github.com/NixOS/nixpkgs/issues/135337
+--- a/imake.c
++++ b/imake.c
+@@ -1065,6 +1065,7 @@ get_distrib(FILE *inFile)
+   fprintf (inFile, "%s\n", "#define LinuxWare       11");
+   fprintf (inFile, "%s\n", "#define LinuxYggdrasil  12");
  
-   static const char*   suse = "/etc/SuSE-release";
-@@ -1090,6 +1091,7 @@
++#if 0 /* disable system autodetection. Fall through to LinuxUnknown. */
+ # ifdef CROSSCOMPILE
+   if (CrossCompiling) {
+       fprintf (inFile, "%s\n",
+@@ -1090,6 +1091,7 @@ get_distrib(FILE *inFile)
       * at the content of /etc/debian_version */
      return;
    }
-+#endif  
++#endif
    /* what's the definitive way to tell what any particular distribution is? */
  
    fprintf (inFile, "%s\n", "#define DefaultLinuxDistribution LinuxUnknown");
-@@ -1337,6 +1339,7 @@
+@@ -1337,6 +1339,7 @@ get_gcc_version(FILE *inFile, char *name)
  static boolean
  get_gcc(char *cmd)
  {
-+#if 0
++#if 0 /* disable gcc autodetection. Fall through to explicitly set. */
    struct stat sb;
      static const char* gcc_path[] = {
  #if defined(linux) || \
-@@ -1385,6 +1388,9 @@
+@@ -1385,6 +1388,9 @@ get_gcc(char *cmd)
  	}
        }
      return FALSE;

--- a/pkgs/tools/X11/xvkbd/default.nix
+++ b/pkgs/tools/X11/xvkbd/default.nix
@@ -13,9 +13,11 @@ stdenv.mkDerivation {
   buildInputs = [ libXt libXaw libXtst xorgproto libXi Xaw3d libXpm ];
   installTargets = [ "install" "install.man" ];
   makeFlags = [
-    "BINDIR=$(out)/bin"
-    "XAPPLOADDIR=$(out)/etc/X11/app-defaults"
-    "MANPATH=$(out)/man"
+    "BINDIR=${placeholder "out"}/bin"
+    "CONFDIR=${placeholder "out"}/etc/X11"
+    "LIBDIR=${placeholder "out"}/lib/X11"
+    "XAPPLOADDIR=${placeholder "out"}/etc/X11/app-defaults"
+    "MANPATH=${placeholder "out"}/man"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Initial build failure is onserved on `staging` branch:

```
$ nix-build -A transfig
...
make[1]: Entering directory '/build/transfig.3.2.4'
Imakefile.c:20:2: Include file Imake.tmpl not found
imake: Exit code 1.
  Stop.
```

This happened after 8675ca0 ("xorg.xorgcffiles: 1.0.6 -> 1.0.7")
bump which exposed an old bug in `imake.patch`. `imake.patch`
dropped by accident definiton of `LinuxRedHat` enum and changed
evaluation of the following code:

```
 #if LinuxDistribution == LinuxRedHat
 ...
 # define ProjectRoot /usr
 #endif
```

References to `/usr` were addded in https://gitlab.freedesktop.org/xorg/util/cf/-/commit/d47131ed97ee491bb883c29ec0b106e8d5acfcd3.

Before this change `LinuxDistribution == LinuxRedHat` evaluated to true.
After this change `LinuxDistribution == LinuxRedHat` evaluates to false.

Mechanically I moved `#if 0` right after enum definitions but still
before system autodetection.

Now `transfig` builds successfully.

Closes: https://github.com/NixOS/nixpkgs/issues/135337
Signed-off-by: Sergei Trofimovich <slyich@gmail.com>