### PR TITLE
prometheus-knot-exporter: 2020-01-30 -> 2021-08-21

### DIFF
--- a/pkgs/servers/monitoring/prometheus/knot-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/knot-exporter.nix
@@ -1,24 +1,15 @@
-{ stdenv, fetchFromGitHub, lib, python3, nixosTests, fetchpatch }:
+{ stdenv, fetchFromGitHub, lib, python3, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "knot-exporter";
-  version = "unstable-2020-01-30";
+  version = "unstable-2021-08-21";
 
   src = fetchFromGitHub {
     owner = "ghedo";
     repo = "knot_exporter";
-    rev = "21dd46b401e0c1aea0b173e19462cdf89e1f444e";
-    sha256 = "sha256-4au4lpaq3jcqC2JXdCcf8h+YN8Nmm4eE0kZwA+1rWlc=";
+    rev = "b18eb7db735b50280f0815497475f4c7092a6550";
+    sha256 = "sha256-FGzkO/KHDhkM3PA2urNQcrMi3MHADkd0YwAvu1jvfrU=";
   };
-
-  patches = [
-    # Fixes a crash with all metrics enabled. See
-    # https://github.com/ghedo/knot_exporter/pull/6 for further context.
-    (fetchpatch {
-      url = "https://github.com/ghedo/knot_exporter/commit/2317476e080369450ae51a707ccd30d4b89d680f.patch";
-      sha256 = "sha256-yEPu8EE1V/draNx9DeMrPj+bMfJRxauweo33dITl4AA=";
-    })
-  ];
 
   dontBuild = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The only change that is relevant for us is that my Knot fix is now part
of the repo itself[1], so no need apply a patch anymore.

[1] https://github.com/ghedo/knot_exporter/commit/b18eb7db735b50280f0815497475f4c7092a6550


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
