### PR TITLE
[21.05] haskell-ci: no longer mark as broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1817,7 +1817,6 @@ broken-packages:
   - haskell-awk
   - haskell-bitmex-rest
   - haskell-brainfuck
-  - haskell-ci
   - haskell-cnc
   - haskell-coffee
   - haskell-compression


### PR DESCRIPTION
haskell-ci just builds (again?) without any necessary changes

(cherry picked from commit 1be4cb6748318e7a6e0f96908b095ea6fef5ac6c)