### PR TITLE
dtc: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   pname = "dtc";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/utils/dtc/dtc.git";
     rev = "refs/tags/v${version}";
-    sha256 = "0li992wwd7kgy71bikanqky49y4hq3p3vx35p2hvyxy1k0wfy7i8";
+    sha256 = "sha256-gx9LG3U9etWhPxm7Ox7rOu9X5272qGeHqZtOe68zFs4=";
   };
 
   buildInputs = [ libyaml ];


### PR DESCRIPTION
###### Motivation for this change
New upstream release:
Changes since v1.6.0 include:
 * A number of bugfixes
 * Fix many warnings with -Wsign-compare
 * Add compilation with meson (not used by default so far)
 * Yet another revamp of how we handle unaligned accesses
 * Added a number of extra checks for common tree errors
   * Checks for interrupt providers
   * i2c reg properties
   * Tighten checking of gpio properties
 * Reduce dependencies when building libfdt only
 * Allow libfdt.h header to be used from C++ more easily
 * Accept .dtbo extension for overlays
 * Update valid node and property characters to match current devicetree spec
 * Add several checks for root node sanity in fdt_check_full()
 * Somewhat more robust type labelling for the benefit of yaml output

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
