### PR TITLE
python3Packages.pynacl: fix cross compilation

### DIFF
--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -6,6 +6,7 @@
 , libsodium
 , cffi
 , hypothesis
+, six
 }:
 
 buildPythonPackage rec {
@@ -23,8 +24,12 @@ buildPythonPackage rec {
     libsodium
   ];
 
-  propagatedBuildInputs = [
+  propagatedNativeBuildInputs = [
     cffi
+  ];
+
+  propagatedBuildInputs = [
+    six
   ];
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/135149

Similar PR's should probably be created for every other derivation that also lists `cffi` in such a cross-compiling unfriendly way.

![image](https://user-images.githubusercontent.com/30902201/130455862-e8fb03b4-3a86-42b3-ad68-24a096394467.png)

![image](https://user-images.githubusercontent.com/30902201/130455962-a82603b1-e1db-41f3-b9cc-efbd1cd5b8a4.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
