### PR TITLE
Erlang package set improvements

### DIFF
--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -3,14 +3,17 @@
 with beam; {
   lib = callPackage ../development/beam-modules/lib.nix { };
 
+  # R24 is the default version.
+  # The main switch to change default Erlang version.
+  defaultVersion = "erlangR24";
+
   # Each
   interpreters = with beam.interpreters; {
 
-    # R24 is the default version.
-    erlang = erlangR24; # The main switch to change default Erlang version.
-    erlang_odbc = erlangR24_odbc;
-    erlang_javac = erlangR24_javac;
-    erlang_odbc_javac = erlangR24_odbc_javac;
+    erlang = beam.interpreters.${defaultVersion};
+    erlang_odbc = beam.interpreters."${defaultVersion}_odbc";
+    erlang_javac = beam.interpreters."${defaultVersion}_javac";
+    erlang_odbc_javac = beam.interpreters."${defaultVersion}_odbc_javac";
 
     # Standard Erlang versions, using the generic builder.
 
@@ -98,7 +101,7 @@ with beam; {
   # appropriate Erlang/OTP version.
   packages = {
     # Packages built with default Erlang version.
-    erlang = packagesWith interpreters.erlang;
+    erlang = packages.${defaultVersion};
 
     erlangR24 = packagesWith interpreters.erlangR24;
     erlangR23 = packagesWith interpreters.erlangR23;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,10 +1,10 @@
-{ callPackage, wxGTK30, buildPackages, wxSupport ? true }:
+{ beam, callPackage, wxGTK30, buildPackages, wxSupport ? true }:
 
-rec {
+with beam; {
   lib = callPackage ../development/beam-modules/lib.nix { };
 
   # Each
-  interpreters = rec {
+  interpreters = with beam.interpreters; {
 
     # R24 is the default version.
     erlang = erlangR24; # The main switch to change default Erlang version.


### PR DESCRIPTION
###### Motivation for this change
These two commits fix these problems:
- Overlays to `beam` were previously not applied properly. E.g. overriding `beam.interpreters.erlangR24` would not influence `beam.interpreters.erlang`, even though `erlangR24` is the default.
- Similarly, the package set `beam.packages.erlangR24` was completely separate from `beam.packages.erlang`, sharing no evaluations.

To fix the latter and make changing the default version convenient, `beam.defaultVersion = "erlangR24"` is introduced.

Ping @DianaOlympos @happysalada 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
