### PR TITLE
kotlin-native: init at 1.5.21

### DIFF
--- a/pkgs/development/compilers/kotlin-native/default.nix
+++ b/pkgs/development/compilers/kotlin-native/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  pname = "kotlin-native";
+  version = "1.5.21";
+
+  src = fetchurl {
+    url = "https://github.com/JetBrains/kotlin/releases/download/v${version}/kotlin-native-linux-${version}.tar.gz";
+    hash = "sha256-+j3+ycEXEcK3E6FIK8xFEbuPc/GC8Sqn2FiUP28IQ5c=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ] ;
+
+  installPhase = ''
+    mkdir -p $out
+    mv * $out
+
+    wrapProgram $out/bin/run_konan --prefix PATH ":" ${lib.makeBinPath [ jre ]}
+  '';
+
+  meta = with lib; {
+    description = "An LLVM backend for the Kotlin compiler";
+    longDescription = ''
+      Kotlin/Native is an LLVM backend for the Kotlin compiler, runtime
+      implementation, and native code generation facility using the LLVM
+      toolchain.
+    '';
+    homepage = "https://kotlinlang.org/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ malvo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11802,6 +11802,8 @@ with pkgs;
 
   kotlin = callPackage ../development/compilers/kotlin { };
 
+  kotlin-native = callPackage ../development/compilers/kotlin-native { };
+
   lazarus = callPackage ../development/compilers/fpc/lazarus.nix {
     fpc = fpc;
   };


### PR DESCRIPTION
Co-authored-by: @vctibor

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add kotlin-native, an LLVM backend for the Kotlin compiler

This is just #94671 with the latest version and some cleanup.

Closes #94627
Closes #94671

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
