### PR TITLE
cudatext: 1.139.5 → 1.142.0

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.139.5";
+  version = "1.142.0";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "sha256-oBdEPLnM08gC3FZNDi1uyGar2MP8EmFkWJhH+fr6gBA=";
+    sha256 = "sha256-4kVi921dromMqiAuFjm2EOCDXCq4oT+ijko4/uT4LLs=";
   };
 
   postPatch = ''

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -11,23 +11,23 @@
   },
   "ATFlatControls": {
     "owner": "Alexey-T",
-    "rev": "2021.07.09",
-    "sha256": "sha256-hVoHH29JLPy3qq73e5EV4bxERcizocO4RBgvqD+VhWo="
+    "rev": "2021.07.22",
+    "sha256": "sha256-sAF/klzPa8fCKKBtpj0h9B+zoGDvA80uL4u4VTikUaI="
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2021.07.29",
-    "sha256": "sha256-XgkpadcTPeMu2B3XVX+9gHLZiAaLwNuHTCnZPtjakIk="
+    "rev": "2021.08.20",
+    "sha256": "sha256-cVl1HJHLsYTFKQ/Ov+rcP6UAwRJPp7rtmLlZC9S+Jek="
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
-    "rev": "2021.07.20",
-    "sha256": "sha256-yh9/2kHfg7swNzPe+7i+ON7MKhFrhxtGAT+pxL4GdVQ="
+    "rev": "2021.08.20",
+    "sha256": "sha256-PZtP/J4tJN2Egk/Bp/5DtHlV46yRjhcZL9xhDk6xjBk="
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2021.07.29",
-    "sha256": "sha256-2Wc4udsSEM0Ngzt/bokuDHcR0imKyHgkeG3RCWu3nXw="
+    "rev": "2021.08.12",
+    "sha256": "sha256-Ht7jfFGlvb7khLD0OekuBvkU9ROyDiyUSe+lLI/Rm64="
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",
@@ -36,8 +36,8 @@
   },
   "Python-for-Lazarus": {
     "owner": "Alexey-T",
-    "rev": "2021.04.16",
-    "sha256": "sha256-HN3Lr3uDCyNk+8+J09ivyC0LZxQ6x6SaUH4swZJBFkM="
+    "rev": "2021.07.27",
+    "sha256": "sha256-izCyBNRLRCizSjR7v9RhcLrQ6+aQA4eejCHFUzJ0IpE="
   },
   "Emmet-Pascal": {
     "owner": "Alexey-T",


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://cudatext.github.io/history.txt)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
