### PR TITLE
yubico-pam: unstable-2019-07-01 -> 2.27

### DIFF
--- a/pkgs/development/libraries/yubico-pam/default.nix
+++ b/pkgs/development/libraries/yubico-pam/default.nix
@@ -1,15 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config
-, asciidoc, libxslt, docbook_xsl
-, pam, yubikey-personalization, libyubikey, libykclient }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, asciidoc
+, libxslt
+, docbook_xsl
+, pam
+, yubikey-personalization
+, libyubikey
+, libykclient
+}:
 
 stdenv.mkDerivation rec {
   pname = "yubico-pam";
-  version = "unstable-2019-07-01";
+  version = "2.27";
   src = fetchFromGitHub {
     owner = "Yubico";
     repo = pname;
-    rev = "b5bd00db81e0e0e0ecced65c684080bb56ddc35b";
-    sha256 = "10dq8dqi3jldllj6p8r9hldx9sank9n82c44w8akxrs1vli6nj3m";
+    rev = version;
+    sha256 = "0hb773zlf11xz4bwmsqv2mq5d4aq2g0crdr5cp9xwc4ivi5gd4kg";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config asciidoc libxslt docbook_xsl ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update yubico-pam

###### Things done
version update and reformat with nixpkgs-fmt

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
