### PR TITLE
sx-go: init at 0.4.0

### DIFF
--- a/pkgs/tools/security/sx-go/default.nix
+++ b/pkgs/tools/security/sx-go/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, libpcap
+}:
+
+buildGoModule rec {
+  pname = "sx-go";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "v-byte-cpu";
+    repo = "sx";
+    rev = "v${version}";
+    sha256 = "0djpwy40wj5asky8a16i7a117816p8g94p5y0wkl74jp07cybmrl";
+  };
+
+  vendorSha256 = "0n1h9jch0zfafli8djjr6wkgfxxpnh4q873d5mr1xg8a25qhlifr";
+
+  buildInputs = [
+    libpcap
+  ];
+
+  postFixup = ''
+    # Rename binary to avoid conflict with sx
+    mv $out/bin/sx $out/bin/${pname}
+  '';
+
+  meta = with lib; {
+    description = "Command-line network scanner";
+    homepage = "https://github.com/v-byte-cpu/sx";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -891,6 +891,8 @@ with pkgs;
 
   redfang = callPackage ../tools/networking/redfang { };
 
+  sx-go = callPackage ../tools/security/sx-go { };
+
   tfk8s = callPackage ../tools/misc/tfk8s { };
 
   tnat64 = callPackage ../tools/networking/tnat64 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Command-line network scanner

https://github.com/v-byte-cpu/sx

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
