### PR TITLE
unixODBC: Add additional URL

### DIFF
--- a/pkgs/development/libraries/unixODBC/default.nix
+++ b/pkgs/development/libraries/unixODBC/default.nix
@@ -5,7 +5,10 @@ stdenv.mkDerivation rec {
   version = "2.3.9";
 
   src = fetchurl {
-    url = "ftp://ftp.unixodbc.org/pub/unixODBC/${pname}-${version}.tar.gz";
+    urls = [
+      "ftp://ftp.unixodbc.org/pub/unixODBC/${pname}-${version}.tar.gz"
+      "http://www.unixodbc.org/${pname}-${version}.tar.gz"
+    ];
     sha256 = "sha256-UoM+rD1oHIsMmlpl8uvXRbOpZPII/HSPl35EAVoxsgc=";
   };
 


### PR DESCRIPTION
###### Motivation for this change

I just ran into a build where the FTP server error'ed out. The HTTP link (taken from their homepage) worked.
By now, the build works again, but it's probably worth adding another mirror just in case.

```
% curl "ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-2.3.9.tar.gz" --output ftp.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1636k  100 1636k    0     0  47608      0  0:00:35  0:00:35 --:--:-- 41007
% curl "http://www.unixodbc.org/unixODBC-2.3.9.tar.gz" --output http.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1636k  100 1636k    0     0  51134      0  0:00:32  0:00:32 --:--:-- 33246
% shasum < ftp.tgz 
8787833ccfa6b7b6b14a391ae9cbefcff13fb753  -
% shasum < http.tgz
8787833ccfa6b7b6b14a391ae9cbefcff13fb753  -
```



###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
