### PR TITLE
lib/attrsets: *attrByPath functions optimizations.

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -313,6 +313,21 @@ runTests {
     expected = { success = false; value = false; };
   };
 
+  testGetAttrFromPath = {
+    expr = getAttrFromPath [ "a" "c" "b" ] { a = { c = { b = 1; }; }; };
+    expected = 1;
+  };
+
+  testSetAttrByPath = {
+    expr = setAttrByPath [ "a" "b" ] true;
+    expected = { a = { b = true; }; };
+  };
+
+  testAttrByPathDefault = {
+    expr = attrByPath [ "a" "b" ] 0 { a = { c = "test"; }; };
+    expected = 0;
+  };
+
   testHasAttrByPathTrue = {
     expr = hasAttrByPath ["a" "b"] { a = { b = "yey"; }; };
     expected = true;


### PR DESCRIPTION
- Inline customized `foldr` to query/get attributes using the `elemAt` lookup
  pattern. This avoids the O(n) runtime of `tail` on each recursive call.
- Rename atDepth helper function to setDepth for clarity.
- Add relevant tests for `setAttrByPath`, `getAttrFromPath` and `attrByPath`.
- Eta reduction on sets argument for `getAttrFromPath`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
While implementing https://github.com/NixOS/nixpkgs/pull/134969, I noticed the class of *attrBypath functions all have the same access pattern to the passed path. In particular, only the first element of the path list is used while the rest to propagated with `tail`. However, due to the underlying implementation of lists, `tail` will take O(n) which wastes both space and time.

The proposed solution uses a customized inline `foldr` as suggested by @roberth (https://github.com/NixOS/nixpkgs/pull/134969#discussion_r693569457) which takes advantage of the "head" access pattern by sharing the list across all recursive calls. This approach reduces both time and space complexity while retaining the laziness and short circuit property of the current implementation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
