### PR TITLE
python3Packages.poetry: 1.1.7 -> 1.1.8

### DIFF
--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "astroid";
-  version = "2.5.6"; # Check whether the version is compatible with pylint
+  version = "2.7.2"; # Check whether the version is compatible with pylint
 
   disabled = pythonOlder "3.6";
 
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "PyCQA";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-/nWXzuWkerUDvFT/tJTZuhfju46MAM0cwosVH9BXoY8=";
+    sha256 = "1vlibff93z9fvkniviwzizsfffw1j0ywkh4rragnlps797143iv4";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION=version;

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -1,7 +1,6 @@
 { lib, buildPythonPackage, fetchFromGitHub, pythonOlder, isPy27
 , importlib-metadata
 , intreehooks
-, isort
 , pathlib2
 , pep517
 , pytest-mock
@@ -13,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "poetry-core";
-  version = "1.0.3";
+  version = "1.0.4";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = pname;
     rev = version;
-    sha256 = "07x0zagf9cfr7g3132jjd5byywkbnzpfbxjfjzpzpj70fqw70qrc";
+    sha256 = "0jgd4d7m5y8ly8n0l9lcq7cjab2y3hifk90f343ksmjzssfd5lg3";
   };
 
   postPatch = lib.optionalString (pythonOlder "3.8") ''

--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "poetry";
-  version = "1.1.7";
+  version = "1.1.8";
   format = "pyproject";
   disabled = isPy27;
 
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "python-poetry";
     repo = pname;
     rev = version;
-    sha256 = "03cbzjw0sb8rs85iq191ndk9523d6qpymh2nhw5bvcxfvsf9042d";
+    sha256 = "0qcgjb78nj69sppd8146519q9422xxg1bi34gyxy51sjkvd5lxhz";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -1,13 +1,14 @@
 { stdenv
 , lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pythonOlder
 , installShellFiles
 , astroid
 , isort
 , mccabe
 , toml
+, platformdirs
 , pytest-benchmark
 , pytest-xdist
 , pytestCheckHook
@@ -15,13 +16,15 @@
 
 buildPythonPackage rec {
   pname = "pylint";
-  version = "2.7.4";
+  version = "2.10.2";
 
   disabled = pythonOlder "3.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "bd38914c7731cdc518634a8d3c5585951302b6e2b6de60fbb3f7a0220e21eeee";
+  src = fetchFromGitHub {
+    owner = "PyCQA";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06xrv79ns4bsk819iqrhjcb36k925yl2zi93l6sv7r228y0y8jl6";
   };
 
   nativeBuildInputs = [
@@ -32,6 +35,7 @@ buildPythonPackage rec {
     astroid
     isort
     mccabe
+    platformdirs
     toml
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Upgrade Poetry. The newer Poetry seemed to cause `pylint` to fail to build and `pylint` was quite out of date so I figured see if the upgrade to `pylint` fixes it, and it did. That said it ends up being a very big rebuild and it leaves me wondering if `pylint` intentionally was out of date?

I tried to run `nixpkgs-review rev HEAD` but it stalls 80% or so of the way through the tests on `python38Packages.ignite`, although running `nix-build -A python38Packages.ignite` works fine.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).