### PR TITLE
joplin-desktop: 2.1.9 -> 2.3.5

### DIFF
--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "joplin-desktop";
-  version = "2.1.9";
+  version = "2.3.5";
   name = "${pname}-${version}";
 
   inherit (stdenv.hostPlatform) system;
@@ -16,8 +16,8 @@ let
   src = fetchurl {
     url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}.${suffix}";
     sha256 = {
-      x86_64-linux = "1s7zydi90yzafii42m3aaf3niqlmdy2m494j2b3yrz2j26njj4q9";
-      x86_64-darwin = "1pvl08yhcrnrvdybfmkigaidhfrrg42bb6rzv96zyq9w4k0l0lm8";
+      x86_64-linux = "sha256-Qy/CpIEfAZ9735mwcNaJIw+qVmYXVwQ7gJuUj2lpQc4=";
+      x86_64-darwin = "sha256-7I+fhcFFW/WihuUkSE5Pc8RhKszSgByP58H3sKSJbrc=";
     }.${system} or throwSystem;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a necessary update, because the iOS version of Joplin automatically upgrades the sync target version. The desktop version of Joplin (2.1.9) is unable to sync with this newer version. (The terminal client is already able to sync with the newer sync target version)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (I upgraded the sha256, but it would be nice if someone could test this)
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
