### PR TITLE
stdenv: introduce withCFlags

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -238,4 +238,25 @@ rec {
         allowSubstitutes = false;
       });
     });
+
+
+  /* Modify a stdenv so that it builds binaries with the specified list of
+     compilerFlags appended and passed to the compiler.
+
+     This example would recompile every derivation on the system with
+     -funroll-loops and -O3 passed to each gcc invocation.
+
+     Example:
+       nixpkgs.overlays = [
+         (self: super: {
+           stdenv = super.withCFlags [ "-funroll-loops" "-O3" ] super.stdenv;
+         })
+       ];
+  */
+  withCFlags = compilerFlags: stdenv:
+    stdenv.override (old: {
+      mkDerivationFromStdenv = extendMkDerivationArgs old (args: {
+        NIX_CFLAGS_COMPILE = toString (args.NIX_CFLAGS_COMPILE or "") + " ${toString compilerFlags}";
+      });
+    });
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds an easy method of appending compiler flags to your stdenv via a list.

It adds a new function called `withCFlags` which lets anyone create a new stdenv with a *list* of compiler flags, or anything one might want to add to the CLI of each gcc invocation.

In my own system, I wanted to have everything use `-O3` and `-funroll-loops` so I did that like this.

```nix
{
  nixpkgs.overlays = [
    (self: super: {
      stdenv = super.withCFlags [ "-funroll-loops" "-O3" ] super.stdenv;
    })
  ];
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
