### PR TITLE
nix-prefetch-git: add iterative shallow clone, fix invalid refspec

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -116,10 +116,8 @@ init_remote(){
 # Return the reference of an hash if it exists on the remote repository.
 ref_from_hash(){
     local hash=$1
-    ref=$(git ls-remote origin | sed -n "\,$hash\t, { s,\(.*\)\t\(.*\),\2,; p; q}")
-    # ref may be "ref" (foo-1.2.3) or "annotated ref" (peeled tag, foo-1.2.3^{})
-    if (echo "$ref" | grep '\^{}$' >/dev/null); then return; fi
-    echo "$ref"
+    git ls-remote origin | sed -n "\,$hash\t, { s,\(.*\)\t\(.*\),\2,; p; q}" | sed 's/\^{}$//'
+    # sed 's/\^{}$//': get tag from peeled tag
 }
 
 debug() {

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -72,6 +72,8 @@ for arg; do
             --branch-name) argfun=set_branchName;;
             --deepClone) deepClone=true;;
             --quiet) QUIET=true;;
+            --debug) DEBUG=true;;
+            --trace) TRACE=true;;
             --no-deepClone) deepClone=;;
             --leave-dotGit) leaveDotGit=true;;
             --fetch-lfs) fetchLFS=true;;
@@ -114,7 +116,25 @@ init_remote(){
 # Return the reference of an hash if it exists on the remote repository.
 ref_from_hash(){
     local hash=$1
-    git ls-remote origin | sed -n "\,$hash\t, { s,\(.*\)\t\(.*\),\2,; p; q}"
+    ref=$(git ls-remote origin | sed -n "\,$hash\t, { s,\(.*\)\t\(.*\),\2,; p; q}")
+    # ref may be "ref" (foo-1.2.3) or "annotated ref" (peeled tag, foo-1.2.3^{})
+    if (echo "$ref" | grep '\^{}$' >/dev/null); then return; fi
+    echo "$ref"
+}
+
+debug() {
+    if test -n "$DEBUG"; then
+        echo "$@" >&2
+    fi
+}
+
+# Return the next reference after an hash if it exists on the remote repository.
+next_ref_from_hash(){
+    local hash=$1
+    refs_after="$(git ls-remote origin | awk "/$hash/{found=1} found")"
+    debug "found $(echo "$refs_after" | wc -l | awk '{ print $1 - 1 }') refs after the requested hash"
+    # find next non-annotated ref
+    echo "$refs_after" | grep -v '\^{}$' | head -n1 | cut -d$'\t' -f2
 }
 
 # Return the hash of a reference if it exists on the remote repository.
@@ -149,7 +169,40 @@ checkout_hash(){
         hash=$(hash_from_ref "$ref")
     fi
 
+    next_ref=$(next_ref_from_hash "$hash")
+    debug "checkout_hash: find hash with next_ref=$next_ref"
+
+    local FETCH_LOOP_MAX_DEPTH=1000 # TODO? handle "hash not found" and "max depth reached"
+    local FETCH_LOOP_DEPTH_EXPONENT=1.5 # can be float. growing too fast can be wasteful. maybe grow linearly?
+
+    # shallow clone, iterative shallow clone, full clone
     clean_git fetch ${builder:+--progress} --depth=1 origin "$hash" || \
+    for ((depth=2; depth<FETCH_LOOP_MAX_DEPTH; ))
+    do
+        fetch_output=$(clean_git fetch $builder --progress --depth="$depth" origin "$next_ref" 2>&1 | sed 's/^.*\r//')
+        # --progress: force live output
+        # sed 's/^.*\r//': parse live output. \r = clear line
+        # TODO? allow to see live output with --debug. https://stackoverflow.com/questions/12451278
+
+        debug "fetch_output: $fetch_output :fetch_output"
+        fetch_objects_size=$(echo "$fetch_output" | grep 'Receiving objects: ' | cut -d' ' -f5-6) # sample: 12.06 KiB
+        fetch_objects_speed=$(echo "$fetch_output" | grep 'Receiving objects: ' | cut -d' ' -f8-9 | tr -d ,) # sample: 5.15 MiB/s
+        fetch_objects_num=$(echo "$fetch_output" | grep 'Receiving objects: ' | sed -E 's/^.*?\/([0-9]+)\).*$/\1/') # sample: 12345
+        if [ -z "$fetch_objects_size" ]; then
+            echo "fetch loop: depth $depth: received nothing" # TODO why?
+        else
+            echo "fetch loop: depth $depth: received $fetch_objects_num objects = $fetch_objects_size @ $fetch_objects_speed"
+        fi
+
+        local object_type=$(git cat-file -t "$hash" 2>/dev/null)
+        debug "fetch loop: object_type=$object_type"
+        if [[ "$object_type" == "commit" ]] || [[ "$object_type" == "tree" ]]; then
+            echo "fetch loop: done: found object $hash, type $object_type"
+            break
+        fi
+
+        depth=$(echo "$depth" | awk "{print int(\$1 * $FETCH_LOOP_DEPTH_EXPONENT)}") # depth grows exponentially
+    done || \
     clean_git fetch -t ${builder:+--progress} origin || return 1
 
     local object_type=$(git cat-file -t "$hash")
@@ -361,6 +414,10 @@ quiet_mode() {
     exec 3>&2 2>"$errfile"
 }
 
+trace_mode() {
+    set -o xtrace # print cmds
+}
+
 json_escape() {
     local s="$1"
     s="${s//\\/\\\\}" # \
@@ -410,6 +467,10 @@ remove_tmpPath() {
 
 if test -n "$QUIET"; then
     quiet_mode
+fi
+
+if test -n "$TRACE"; then
+    trace_mode
 fi
 
 if test -z "$branchName"; then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
avoid full clone in fetchgit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


### Describe the bug
`nix-prefetch-git` fails to do a shallow clone, when the commit is not directly reachable

related:
[stackoverflow: How to shallow clone a specific commit with depth 1?](https://stackoverflow.com/questions/31278902/how-to-shallow-clone-a-specific-commit-with-depth-1)

### Reproduce the bug

```
$ /nix/store/*-nixos-$(nixos-version --json | jq -r .nixosVersion)/nixos/pkgs/build-support/fetchgit/nix-prefetch-git \
  --url https://git.torproject.org/tor.git --rev 62a500dd1d3ad012e12b7bf49fad912c9733107a
```

### Actual behavior

full clone = large and slow

```
Receiving objects: 100% (278793/278793), 62.76 MiB | 5.51 MiB/s, done.

real    0m47.457s
user    0m52.799s
sys     0m3.514s
```

### Expected behavior

iterative shallow clone = small and fast

```
fetch loop: depth 2: received 2137 objects = 7.80 MiB @ 5.58 MiB/s
fetch loop: depth 6: received 1166 objects = 292.95 KiB @ 3.85 MiB/s

real    0m7.307s
user    0m3.003s
sys     0m1.153s
```

= 7x smaller and 6x faster

or: shallow clone with correct refspec

```
Receiving objects: 100% (2133/2133), 7.80 MiB | 5.30 MiB/s, done.

real    0m3.511s
user    0m1.180s
sys     0m0.687s
```

= 7x smaller and 12x faster

### Details

<details>
<summary>when the commit is not directly reachable</summary>

this means:
1. there is no refspec (tag or branch) to reach the commit.  
only the nearest tag can be found ("peeled tag", sample: `foo-1.2.3^{}`)
2. `git clone $url --branch $hash` fails,  
cos the git server config has `uploadpack.allowReachableSHA1InWant = false`

example:

the expected tag is `tor-0.4.6.6`, but fetchgit requests `tor-0.4.6.5^{}`

```
fatal: invalid refspec '+refs/tags/tor-0.4.6.5^{}'
```

"fetch by hash" fails

```
error: Server does not allow request for unadvertised object 62a500dd1d3ad012e12b7bf49fad912c9733107a
```

... so fetchgit does fallback to full-clone, which is wasteful

</details>

<details>
<summary>git fetch only works for refs</summary>

[fetchgit/default.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgit/default.nix#L25) says:

> NOTE:
>    fetchgit has one problem: git fetch only works for refs.
>    This is because fetching arbitrary (maybe dangling) commits may be a security risk
>    and checking whether a commit belongs to a ref is expensive. This may
>    change in the future when some caching is added to git (?)
>    Usually refs are either tags (refs/tags/\*) or branches (refs/heads/\*)
>    Cloning branches will make the hash check fail when there is an update.
>    But not all patches we want can be accessed by tags.
>    The workaround is getting the last n commits so that it's likely that they
>    still contain the hash we want.
>    for now : increase depth iteratively (TODO)

</details>

<details>
<summary>where does the invalid refspec <code>tor-0.4.6.5^{}</code> come from?</summary>

[fetchgit/nix-prefetch-git](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgit/nix-prefetch-git#L113) function `ref_from_hash` is trying to map the commit hash to a refspec (tag or branch)

```
$ cd ricochet-refresh/src/extern/tor
$ git ls-remote origin | grep -C1 62a500dd1d3ad012e12b7bf49fad912c9733107a

553177a8ee0c4a698ed05a49994dff7a7137a93e        refs/tags/tor-0.4.6.5
62a500dd1d3ad012e12b7bf49fad912c9733107a        refs/tags/tor-0.4.6.5^{}
3b9e8205ef57f6551b9449c23bb39f7ad63a1e18        refs/tags/tor-0.4.6.6
```

`refs/tags/tor-0.4.6.5^{}` is a "peeled tag" or "annotated tag".
this means, the commit `62a500d` comes AFTER the tag `tor-0.4.6.5` = commit `553177a`

now, fetchgit runs `git clone ... --branch '+refs/tags/tor-0.4.6.5^{}'`
which throws the error `fatal: invalid refspec '+refs/tags/tor-0.4.6.5^{}'`

fetchgit should clone the next tag, in this case `tor-0.4.6.6`,
and from there, seek back to the commit `62a500d`.
since the exact distance is unknown, we need "iterative shallow clone"

</details>

<details>
<summary>sample output</summary>

```
$ ./nix-prefetch-git --url https://git.torproject.org/tor.git --rev 62a500dd1d3ad012e12b7bf49fad912c9733107a
Initialized empty Git repository in /tmp/git-checkout-tmp-bQWK82co/tor-62a500d/.git/
error: Server does not allow request for unadvertised object 62a500dd1d3ad012e12b7bf49fad912c9733107a
fetch loop: depth 2: received 2137 objects = 7.80 MiB @ 5.15 MiB/s
fetch loop: depth 3: received nothing
fetch loop: depth 4: received nothing
fetch loop: depth 6: received 1166 objects = 292.95 KiB @ 4.96 MiB/s
fetch loop: depth 9: received nothing
fetch loop: done: found object 62a500dd1d3ad012e12b7bf49fad912c9733107a, type commit
Switched to a new branch 'fetchgit'
removing `.git'...

git revision is 62a500dd1d3ad012e12b7bf49fad912c9733107a
path is /nix/store/44cgvmjr9jvziprv2jmin96c5xz39glm-tor-62a500d
git human-readable version is -- none --
Commit date is 2021-06-10 13:17:19 -0400
hash is 0nwm6h2y31d20h67vqc9hr44z3b359h3dsnifdijw5fcp1h3gwri
{
  "url": "https://git.torproject.org/tor.git",
  "rev": "62a500dd1d3ad012e12b7bf49fad912c9733107a",
  "date": "2021-06-10T13:17:19-04:00",
  "path": "/nix/store/44cgvmjr9jvziprv2jmin96c5xz39glm-tor-62a500d",
  "sha256": "0nwm6h2y31d20h67vqc9hr44z3b359h3dsnifdijw5fcp1h3gwri",
  "fetchSubmodules": false,
  "deepClone": false,
  "leaveDotGit": false
}
```

</details>

<details>
<summary>where does the invalid refspec <code>tor-0.4.6.5^{}</code> REALLY come from? (fixed)</summary>

`553177a` = tag `tor-0.4.6.5` pointing to commit `62a500d`
`62a500d` = commit of git submodule, in `git ls-remote` appears as "peeled tag" `refs/tags/tor-0.4.6.5^{}`

so the correct solution is

1. commit `62a500d` to peeled tag `refs/tags/tor-0.4.6.5^{}`
2. peeled tag to tag `refs/tags/tor-0.4.6.5` = commit `553177a`
3. clone by tag `refs/tags/tor-0.4.6.5`
4. `git rev-parse --short HEAD` should now be `62a500d`

</details>
