### PR TITLE
emacs: Add custom elpa fetcher (backport)

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -21,7 +21,7 @@ formats commits for you.
 
 */
 
-{ lib, stdenv, texinfo, writeText }:
+{ lib, stdenv, buildPackages, texinfo, writeText }:
 
 self: let
 
@@ -41,7 +41,10 @@ self: let
   }: let
 
     imported = import generated {
-      inherit (self) callPackage;
+      callPackage = pkgs: args: self.callPackage pkgs (args // {
+        # Use custom elpa url fetcher with fallback/uncompress
+        fetchurl = buildPackages.callPackage ./fetchelpa.nix { };
+      });
     };
 
     super = removeAttrs imported [ "dash" ];

--- a/pkgs/applications/editors/emacs/elisp-packages/fetchelpa.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/fetchelpa.nix
@@ -1,0 +1,21 @@
+# Elpa only serves the latest version of a given package uncompressed.
+# Once that release is no longer the latest & greatest it gets archived and compressed
+# meaning that both the URL and the hash changes.
+#
+# To work around this issue we fall back to the URL with the .lz suffix and if that's the
+# one we downloaded we uncompress the file to ensure the hash matches regardless of compression.
+
+{ fetchurl, lzip }:
+
+{ url, ... }@args: fetchurl ((removeAttrs args [ "url" ]) // {
+  urls = [
+    url
+    (url + ".lz")
+  ];
+  postFetch = ''
+    if [[ $url == *.lz ]]; then
+      ${lzip}/bin/lzip -c -d $out > uncompressed
+      mv uncompressed $out
+    fi
+  '';
+})

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -26,7 +26,7 @@
 let
 
   mkElpaPackages = { pkgs, lib }: import ../applications/editors/emacs/elisp-packages/elpa-packages.nix {
-    inherit (pkgs) stdenv texinfo writeText;
+    inherit (pkgs) stdenv texinfo writeText buildPackages;
     inherit lib;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of #132937 to 21.05, quoting the original motivation here:

> Elpa (and by extension nongnu) only serves the latest version of a given package uncompressed.
> Once that release is no longer the latest & greatest it gets archived and compressed meaning that both the URL and the hash changes.
> 
> To work around this issue we fall back to the URL with the .lz suffix and if that's the one we downloaded we uncompress the file to ensure the hash matches regardless of compression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
