### PR TITLE
nixos/append-initrd-secrets: fix shebang

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -347,7 +347,7 @@ let
       compressorExe = initialRamdisk.compressorExecutableFunction pkgs;
     in pkgs.writeScriptBin "append-initrd-secrets"
       ''
-        #!${pkgs.bash}/bin/bash -e
+        #!/usr/bin/env bash
         function usage {
           echo "USAGE: $0 INITRD_FILE" >&2
           echo "Appends this configuration's secrets to INITRD_FILE" >&2


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
I've changed one shebang that was causing trouble when called from python's subprocess. I've made a PoC to isolate the problem and it's clearly the wrong shebang. I don't know why the non-standard shebang was being used BTW but I was able to replicate the problem [1]. This problem caused a system generation build to fail [2].

[1] https://github.com/lucasew/playground/blob/master/poc/subprocess_shebang
[2] https://gist.github.com/superherointj/5c2a8574e63366f2c4df4cf3506ee0f3


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
