### PR TITLE
python3Packages.smart-meter-texas: 0.4.4 -> 0.4.6

### DIFF
--- a/pkgs/development/python-modules/asn1/default.nix
+++ b/pkgs/development/python-modules/asn1/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, future
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "asn1";
+  version = "2.4.1";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "andrivet";
+    repo = "python-asn1";
+    rev = "v${version}";
+    sha256 = "0g2d5cr1pxsm5ackba7padf7gvlgrgv807kh0312s5axjd2cww2l";
+  };
+
+  propagatedBuildInputs = [
+    future
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "enum-compat" ""
+  '';
+
+  pytestFlagsArray = [ "tests/test_asn1.py" ];
+
+  pythonImportsCheck = [ "asn1" ];
+
+  meta = with lib; {
+    description = "Python ASN.1 encoder and decoder";
+    homepage = "https://github.com/andrivet/python-asn1";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/smart-meter-texas/default.nix
+++ b/pkgs/development/python-modules/smart-meter-texas/default.nix
@@ -3,13 +3,14 @@
 , pythonOlder
 , fetchFromGitHub
 , aiohttp
+, asn1
 , python-dateutil
 , tenacity
 }:
 
 buildPythonPackage rec {
   pname = "smart-meter-texas";
-  version = "0.4.4";
+  version = "0.4.6";
 
   disabled = pythonOlder "3.6";
 
@@ -17,7 +18,7 @@ buildPythonPackage rec {
     owner = "grahamwetzler";
     repo = "smart-meter-texas";
     rev = "v${version}";
-    sha256 = "sha256-jewibcsqWnl0OQ2oEEOSOcyyDCIGZiG4EZQfuFUbxK4=";
+    sha256 = "sha256-BZb02eIFYCrTDDqeo6FlGpm8LCN/GxcdKGTR5L2/DpE=";
   };
 
   postPatch = ''
@@ -27,6 +28,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     aiohttp
+    asn1
     python-dateutil
     tenacity
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -563,6 +563,8 @@ in {
 
   asgiref = callPackage ../development/python-modules/asgiref { };
 
+  asn1 = callPackage ../development/python-modules/asn1 { };
+
   asn1ate = callPackage ../development/python-modules/asn1ate { };
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.4.6

Change log: https://github.com/grahamwetzler/smart-meter-texas/releases/tag/v0.4.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
