### PR TITLE
gst: init at 5.0.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gst/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gst/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+, ghq
+}:
+
+buildGoModule rec {
+  pname = "gst";
+  version = "5.0.4";
+
+  src = fetchFromGitHub {
+    owner = "uetchy";
+    repo = "gst";
+    rev = "v${version}";
+    sha256 = "0fqgkmhn84402hidxv4niy9himcdwm1h80prkfk9vghwcyynrbsj";
+  };
+
+  vendorSha256 = "0k5xl55vzpl64gwsgaff92jismpx6y7l2ia0kx7gamd1vklf0qwh";
+
+  doCheck = false;
+
+  nativeBuildInputs = [
+    git
+    ghq
+  ];
+
+  ldflags = [
+    "-s" "-w" "-X=main.Version=${version}"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    if [[ "$("$out/bin/${pname}" --version)" == "${pname} version ${version}" ]]; then
+      export HOME=$(mktemp -d)
+      git config --global user.name "Test User"
+      git config --global user.email "test@example.com"
+      git config --global init.defaultBranch "main"
+      git config --global ghq.user "user"
+      ghq create test > /dev/null 2>&1
+      touch $HOME/ghq/github.com/user/test/SmokeTest
+      $out/bin/${pname} list | grep SmokeTest > /dev/null
+      echo '${pname} smoke check passed'
+    else
+      echo '${pname} smoke check failed'
+      return 1
+    fi
+  '';
+
+  meta = {
+    description = "Supercharge your ghq workflow";
+    homepage = "https://github.com/uetchy/gst";
+    maintainers = with lib.maintainers; [ _0x4A6F ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5180,6 +5180,8 @@ with pkgs;
 
   ghq = callPackage ../applications/version-management/git-and-tools/ghq { };
 
+  gst = callPackage ../applications/version-management/git-and-tools/gst { };
+
   ghr = callPackage ../applications/version-management/git-and-tools/ghr { };
 
   gibberish-detector = with python3Packages; toPythonApplication gibberish-detector;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [gst](https://github.com/uetchy/gst) to nixpkgs.

@tomberek @blaggacao 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
