### PR TITLE
ly: change maintainer to vidister

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11355,6 +11355,12 @@
     githubId = 335406;
     name = "David Asabina";
   };
+  vidister = {
+    email = "v@vidister.de";
+    github = "vidister";
+    githubId = 11413574;
+    name = "Fiona Weber";
+  };
   vifino = {
     email = "vifino@tty.sh";
     github = "vifino";

--- a/pkgs/applications/display-managers/ly/default.nix
+++ b/pkgs/applications/display-managers/ly/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     description = "TUI display manager";
     license = licenses.wtfpl;
     homepage = "https://github.com/cylgom/ly";
-    maintainers = [ maintainers.spacekookie ];
+    maintainers = [ maintainers.vidister ];
   };
 }


### PR DESCRIPTION
This commit changes the package maintainer of ly to vidister. The former maintainer @spacekookie agreed to hand over maintainership.

###### Motivation for this change
I plan to update ly to a recent version and build a module for it.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
