### PR TITLE
acpi_call: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/os-specific/linux/acpi-call/default.nix
+++ b/pkgs/os-specific/linux/acpi-call/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "acpi-call";
-  version = "1.2.1";
+  version = "1.2.2";
   name = "${pname}-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "acpi_call";
     rev = "v${version}";
-    sha256 = "0mr4rjbv6fj4phf038addrgv32940bphghw2v9n1z4awvw7wzkbg";
+    sha256 = "1s7h9y3adyfhw7cjldlfmid79lrwz3vqlvziw9nwd6x5qdj4w9vp";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

**This needs to be backported, because it contains a fix for Thinkpad users using Linux 5.13 on NixOS 21.05.**

Thinkpads pull in the `acpi_call` out-of-tree module for power management via [nixos-hardware](https://github.com/NixOS/nixos-hardware/blob/master/common/pc/laptop/acpi_call.nix).  The 1.2.1 version of `acpi_call` is unfortunately incompatible to Linux 5.13 and will cause a [null pointer dereference](https://github.com/mkottman/acpi_call/issues/96) in the kernel.

This was [fixed](https://github.com/nix-community/acpi_call/commit/48011f82726c263f49a2b9ca3d9f674bdb4cfd22) in `acpi_call` 1.2.2.

I'm running the update `acpi_call` module on the Thinkpad I'm writing this on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
