### PR TITLE
code-server: init code-server-module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10768,6 +10768,12 @@
     github = "staccato";
     githubId = 86573128;
   };
+  stackshadow = {
+    email = "stackshadow@evilbrain.de";
+    github = "stackshadow";
+    githubId = 7512804;
+    name = "Martin Langlotz";
+  };
   steell = {
     email = "steve@steellworks.com";
     github = "Steell";

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -388,6 +388,11 @@
           <link linkend="opt-hardware.rasdaemon.enable">hardware.rasdaemon</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>code-server</literal>-module now available
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -118,6 +118,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [rasdaemon](https://github.com/mchehab/rasdaemon), a hardware error logging daemon. Available as [hardware.rasdaemon](#opt-hardware.rasdaemon.enable).
 
+- `code-server`-module now available
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 - The `services.wakeonlan` option was removed, and replaced with `networking.interfaces.<name>.wakeOnLan`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -971,6 +971,7 @@
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/bookstack.nix
   ./services/web-apps/calibre-web.nix
+  ./services/web-apps/code-server.nix
   ./services/web-apps/convos.nix
   ./services/web-apps/cryptpad.nix
   ./services/web-apps/dex.nix

--- a/nixos/modules/services/web-apps/code-server.nix
+++ b/nixos/modules/services/web-apps/code-server.nix
@@ -135,5 +135,5 @@ in {
 
   };
 
-  meta.maintainers = with maintainers; [ ymarkus ];
+  meta.maintainers = with maintainers; [ stackshadow ];
 }

--- a/nixos/modules/services/web-apps/code-server.nix
+++ b/nixos/modules/services/web-apps/code-server.nix
@@ -1,0 +1,139 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+
+  cfg = config.services.code-server;
+  defaultUser = "code-server";
+  defaultGroup = defaultUser;
+
+in {
+  ###### interface
+  options = {
+    services.code-server = {
+      enable = mkEnableOption "code-server";
+
+      package = mkOption {
+        default = pkgs.code-server;
+        defaultText = "pkgs.code-server";
+        description = "Which code-server derivation to use.";
+        type = types.package;
+      };
+
+      extraPackages = mkOption {
+        default = [ ];
+        description = "Packages that are available in the PATH of code-server.";
+        example = "[ pkgs.go ]";
+        type = types.listOf types.package;
+      };
+
+      extraEnvironment = mkOption {
+        type = types.attrsOf types.str;
+        description =
+          "Additional environment variables to passed to code-server.";
+        default = { };
+        example = { PKG_CONFIG_PATH = "/run/current-system/sw/lib/pkgconfig"; };
+      };
+
+      extraArguments = mkOption {
+        default = [ "--disable-telemetry" ];
+        description = "Additional arguments that passed to code-server";
+        example = ''[ "--verbose" ]'';
+        type = types.listOf types.str;
+      };
+
+      host = mkOption {
+        default = "127.0.0.1";
+        description = "The host-ip to bind to.";
+        type = types.str;
+      };
+
+      port = mkOption {
+        default = 4444;
+        description = "The port where code-server runs.";
+        type = types.port;
+      };
+
+      auth = mkOption {
+        default = "password";
+        description = "The type of authentication to use.";
+        type = types.enum [ "none" "password" ];
+      };
+
+      hashedPassword = mkOption {
+        default = "";
+        description =
+          "Create the password with: 'echo -n 'thisismypassword' | npx argon2-cli -e'.";
+        type = types.str;
+      };
+
+      user = mkOption {
+        default = defaultUser;
+        example = "yourUser";
+        description = ''
+          The user to run code-server as.
+          By default, a user named <literal>${defaultUser}</literal> will be created.
+        '';
+        type = types.str;
+      };
+
+      group = mkOption {
+        default = defaultGroup;
+        example = "yourGroup";
+        description = ''
+          The group to run code-server under.
+          By default, a group named <literal>${defaultGroup}</literal> will be created.
+        '';
+        type = types.str;
+      };
+
+      extraGroups = mkOption {
+        default = [ ];
+        description =
+          "An array of additional groups for the <literal>${defaultUser}</literal> user.";
+        example = [ "docker" ];
+        type = types.listOf types.str;
+      };
+
+    };
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    systemd.services.code-server = {
+      description = "VSCode server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      path = cfg.extraPackages;
+      environment = {
+        HASHED_PASSWORD = cfg.hashedPassword;
+      } // cfg.extraEnvironment;
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/code-server --bind-addr ${cfg.host}:${toString cfg.port} --auth ${cfg.auth} " + builtins.concatStringsSep " " cfg.extraArguments;
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        RuntimeDirectory = cfg.user;
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "on-failure";
+      };
+
+    };
+
+    users.users."${cfg.user}" = mkMerge [
+      (mkIf (cfg.user == defaultUser) {
+        isNormalUser = true;
+        description = "code-server user";
+        inherit (cfg) group;
+      })
+      {
+        packages = cfg.extraPackages;
+        inherit (cfg) extraGroups;
+      }
+    ];
+
+    users.groups."${defaultGroup}" = mkIf (cfg.group == defaultGroup) { };
+
+  };
+
+  meta.maintainers = with maintainers; [ ymarkus ];
+}


### PR DESCRIPTION


###### Motivation for this change
- an nixos-module was missing for code-server to easy config code-server

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
