### PR TITLE
python3Packages.pyee: 8.1.0 -> 8.2.2

### DIFF
--- a/pkgs/development/python-modules/pyee/default.nix
+++ b/pkgs/development/python-modules/pyee/default.nix
@@ -1,28 +1,24 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchPypi
-, lib
 , vcversioner
-, pytest-runner
 , mock
-, pytest
+, pytestCheckHook
 , pytest-asyncio
 , pytest-trio
 , twisted
-, zipp ? null
-, pyparsing ? null
-, pyhamcrest
-, futures ? null
-, attrs ? null
-, isPy27
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pyee";
-  version = "8.1.0";
+  version = "8.2.2";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "92dacc5bd2bdb8f95aa8dd2585d47ca1c4840e2adb95ccf90034d64f725bfd31";
+    sha256 = "sha256-XH5g+N+VcQ2+F1UOFs4BU/g5kMAO90SEG0Pzce1T6+o=";
   };
 
   buildInputs = [
@@ -31,23 +27,18 @@ buildPythonPackage rec {
 
   checkInputs = [
     mock
-    pyhamcrest
-    pytest
     pytest-asyncio
     pytest-trio
-    pytest-runner
+    pytestCheckHook
     twisted
-  ] ++ lib.optional isPy27 [
-    attrs
-    futures
-    pyparsing
-    zipp
   ];
 
-  meta = {
-    description = "A port of Node.js's EventEmitter to python";
+  pythonImportsCheck = [ "pyee" ];
+
+  meta = with lib; {
+    description = "A port of Node.js's EventEmitter to Python";
     homepage = "https://github.com/jfhbrook/pyee";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kmein ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ kmein ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 8.2.2

Change log:
- https://github.com/jfhbrook/pyee/blob/main/CHANGELOG.rst#2021814-version-822
- https://github.com/jfhbrook/pyee/blob/main/CHANGELOG.rst#2021814-version-821
- https://github.com/jfhbrook/pyee/blob/main/CHANGELOG.rst#2021814-version-820

Support for Python 2.x was removed with 8.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
