### PR TITLE
rust-analyzer: enable check by default

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -1,8 +1,7 @@
 { lib, stdenv, fetchFromGitHub, rustPlatform, CoreServices, cmake
 , libiconv
 , useMimalloc ? false
-# FIXME: Test doesn't pass under rustc 1.52.1 due to different escaping of `'` in string.
-, doCheck ? false
+, doCheck ? true
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -17,9 +16,16 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-6Tbgy77Essi3Hyd5kdJ7JJbx7RuFZQWURfRrpScvPPQ=";
   };
 
+  patches = [
+    # Code format and git history check require more dependencies but don't really matter for packaging.
+    # So just ignore them.
+    ./ignore-git-and-rustfmt-tests.patch
+  ];
+
   buildAndTestSubdir = "crates/rust-analyzer";
 
   cargoBuildFlags = lib.optional useMimalloc "--features=mimalloc";
+  cargoTestFlags = lib.optional useMimalloc "--features=mimalloc";
 
   nativeBuildInputs = lib.optional useMimalloc cmake;
 

--- a/pkgs/development/tools/rust/rust-analyzer/ignore-git-and-rustfmt-tests.patch
+++ b/pkgs/development/tools/rust/rust-analyzer/ignore-git-and-rustfmt-tests.patch
@@ -1,0 +1,18 @@
+--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
++++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
+@@ -6,6 +6,7 @@ use std::{
+ use xshell::{cmd, pushd, pushenv, read_file};
+ 
+ #[test]
++#[ignore]
+ fn check_code_formatting() {
+     let _dir = pushd(sourcegen::project_root()).unwrap();
+     let _e = pushenv("RUSTUP_TOOLCHAIN", "stable");
+@@ -138,6 +139,7 @@ fn check_cargo_toml(path: &Path, text: String) -> () {
+ }
+ 
+ #[test]
++#[ignore]
+ fn check_merge_commits() {
+     let stdout = cmd!("git rev-list --merges --invert-grep --author 'bors\\[bot\\]' HEAD~19..")
+         .read()


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

We have rustc 1.53.0 in nixpkgs and the tests should pass now.
Currently only the crate `rust-analyzer` is checked. Other dependent crates are not since it will cause too many crate rebuilds.

Tested via the vscode extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
