### PR TITLE
pipes-rs: init at 1.4.4

### DIFF
--- a/pkgs/misc/screensavers/pipes-rs/default.nix
+++ b/pkgs/misc/screensavers/pipes-rs/default.nix
@@ -1,0 +1,33 @@
+{ rustPlatform, fetchFromGitHub, lib }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pipes-rs";
+  version = "1.4.4";
+
+  src = fetchFromGitHub {
+    owner = "lhvy";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "drqoKkju1EkcWGNnliEah37wVhtU2ddJSOZ5MnCNbuo=";
+  };
+
+  cargoSha256 = "0j6b5697ichw4ly7lsj3nbm0mw6bvjma81nd0fl7v1ra9kbmsysk";
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    if [[ "$("$out/bin/${pname}" --version)" == "${pname} ${version}" ]]; then
+      echo '${pname} smoke check passed'
+    else
+      echo '${pname} smoke check failed'
+      return 1
+    fi
+  '';
+
+  meta = with lib; {
+    description = "An over-engineered rewrite of pipes.sh in Rust";
+    homepage = "https://github.com/lhvy/pipes-rs";
+    license = with licenses; [ asl20 mit ];
+    maintainers = [ maintainers.vanilla ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21947,6 +21947,8 @@ with pkgs;
 
   pipes = callPackage ../misc/screensavers/pipes { };
 
+  pipes-rs = callPackage ../misc/screensavers/pipes-rs { };
+
   pipework = callPackage ../os-specific/linux/pipework { };
 
   pktgen = callPackage ../os-specific/linux/pktgen { };


### PR DESCRIPTION
###### Motivation for this change
An over-engineered rewrite of pipes.sh in Rust.
-- https://github.com/lhvy/pipes-rs

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
