### PR TITLE
[staging] {cc,binutils}-wrapper: fixes for PIE hardening

### DIFF
--- a/pkgs/build-support/bintools-wrapper/add-hardening.sh
+++ b/pkgs/build-support/bintools-wrapper/add-hardening.sh
@@ -37,7 +37,11 @@ fi
 for flag in "${!hardeningEnableMap[@]}"; do
   case $flag in
     pie)
-      if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static " || "$*" =~ " -r " || "$*" =~ " -Ur " || "$*" =~ " -i ") ]]; then
+      if [[ ! (" $* " =~ " -shared " \
+            || " $* " =~ " -static " \
+            || " $* " =~ " -r " \
+            || " $* " =~ " -Ur " \
+            || " $* " =~ " -i ") ]]; then
         if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
         hardeningLDFlags+=('-pie')
       fi

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -48,7 +48,7 @@ for flag in "${!hardeningEnableMap[@]}"; do
       # NB: we do not use `+=` here, because PIE flags must occur before any PIC flags
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling CFlags -fPIE >&2; fi
       hardeningCFlags=('-fPIE' "${hardeningCFlags[@]}")
-      if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static ") ]]; then
+      if [[ ! (" $* " =~ " -shared " || " $* " =~ " -static ") ]]; then
         if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
         hardeningCFlags=('-pie' "${hardeningCFlags[@]}")
       fi

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -45,11 +45,12 @@ for flag in "${!hardeningEnableMap[@]}"; do
       hardeningCFlags+=('-fstack-protector-strong' '--param' 'ssp-buffer-size=4')
       ;;
     pie)
+      # NB: we do not use `+=` here, because PIE flags must occur before any PIC flags
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling CFlags -fPIE >&2; fi
-      hardeningCFlags+=('-fPIE')
+      hardeningCFlags=('-fPIE' "${hardeningCFlags[@]}")
       if [[ ! ("$*" =~ " -shared " || "$*" =~ " -static ") ]]; then
         if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling LDFlags -pie >&2; fi
-        hardeningCFlags+=('-pie')
+        hardeningCFlags=('-pie' "${hardeningCFlags[@]}")
       fi
       ;;
     pic)

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -45,9 +45,7 @@
 # enableLTO is a subset of the enableOptimizations flag that doesn't harm reproducibility.
 # enabling LTO on 32bit arch causes downstream packages to fail when linking
 # enabling LTO on *-darwin causes python3 to fail when linking.
-# enabling LTO with musl and dynamic linking fails with a linker error although it should
-# be possible as alpine is doing it: https://github.com/alpinelinux/aports/blob/a8ccb04668c7729e0f0db6c6ff5f25d7519e779b/main/python3/APKBUILD#L82
-, enableLTO ? stdenv.is64bit && stdenv.isLinux && !(stdenv.hostPlatform.isMusl && !stdenv.hostPlatform.isStatic)
+, enableLTO ? stdenv.is64bit && stdenv.isLinux
 , reproducibleBuild ? false
 , pythonAttr ? "python${sourceVersion.major}${sourceVersion.minor}"
 }:

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -134,8 +134,6 @@ stdenv.mkDerivation rec {
     "-DG_DISABLE_CAST_CHECKS"
   ];
 
-  hardeningDisable = [ "pie" ];
-
   postPatch = ''
     chmod +x gio/tests/gengiotypefuncs.py
     patchShebangs gio/tests/gengiotypefuncs.py

--- a/pkgs/development/libraries/libiscsi/default.nix
+++ b/pkgs/development/libraries/libiscsi/default.nix
@@ -13,10 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  # This can be removed after >=1.20.0, or if the build suceeds with
-  # pie enabled (default on Musl).
-  hardeningDisable = [ "pie" ];
-
   # This problem is gone on libiscsi master.
   NIX_CFLAGS_COMPILE =
     lib.optional stdenv.hostPlatform.is32bit "-Wno-error=sign-compare";


### PR DESCRIPTION
Fixes a number of packages which were broken on musl (where PIE hardening is currently enabled). For example:
* pkgsMusl.python3
* pkgsMusl.bulletml
* pkgsMusl.proot
* pkgsMusl.libfsm
* pkgsMusl.libiscsi
* pkgsMusl.nsjail
* pkgsMusl.pv

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/124476

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
