### PR TITLE
qtile: restore derivation name

### DIFF
--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -10,7 +10,7 @@ let
   pythonPackages = python.pkgs;
 
   unwrapped = pythonPackages.buildPythonPackage rec {
-    name = "qtile-${version}";
+    pname = "qtile";
     version = "0.18.0";
 
     src = fetchFromGitHub {
@@ -61,6 +61,8 @@ let
   };
 in
   (python.withPackages (ps: [ unwrapped ])).overrideAttrs (_: {
+    # otherwise will be exported as "env", this restores `nix search` behavior
+    name = "${unwrapped.pname}-${unwrapped.version}";
     # export underlying qtile package
     passthru = { inherit unwrapped; };
   })


### PR DESCRIPTION
###### Motivation for this change
closes: #135613

before:
```
$ nix-build -A qtile
this derivation will be built:
  /nix/store/ddi3var8hd6pg9zpqr6nxkg45lbg3yf3-python3-3.9.6-env.drv
building '/nix/store/ddi3var8hd6pg9zpqr6nxkg45lbg3yf3-python3-3.9.6-env.drv'...
created 279 symlinks in user environment
/nix/store/hnnrsl70vlbi9yhhxg824f1j4giz6jar-python3-3.9.6-env
```
after:
```
[21:04:57] jon@jon-desktop /home/jon/projects/nixpkgs (qtile-restore)
$ nix-build -A qtile
/nix/store/02p0a5nypkhr2pzifb0k95d027r5269c-qtile-0.18.0
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
