### PR TITLE
python3Packages.codecov: 2.1.11 -> 2.1.12

### DIFF
--- a/pkgs/development/python-modules/codecov/default.nix
+++ b/pkgs/development/python-modules/codecov/default.nix
@@ -1,18 +1,22 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, requests
 , coverage
-, unittest2
+, ddt
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, requests
 }:
 
 buildPythonPackage rec {
   pname = "codecov";
   version = "2.1.12";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-oNpGu1AlQm2ola+Qk43vjuEtN/y8u7wVttxkz368UcE=";
+  src = fetchFromGitHub {
+    owner = "codecov";
+    repo = "codecov-python";
+    rev = "v${version}";
+    sha256 = "0bdk1cp3hxydpx9knqfv88ywwzw7yqhywi0inxjd6x53qh75prqy";
   };
 
   propagatedBuildInputs = [
@@ -20,14 +24,22 @@ buildPythonPackage rec {
     coverage
   ];
 
-  checkInputs = [ unittest2 ];
+  checkInputs = [
+    ddt
+    mock
+    pytestCheckHook
+  ];
 
-  postPatch = ''
-    sed -i 's/, "argparse"//' setup.py
-  '';
+  pytestFlagsArray = [ "tests/test.py" ];
 
-  # No tests in archive
-  doCheck = false;
+  disabledTests = [
+    # No git repo available and network
+    "test_bowerrc_none"
+    "test_prefix"
+    "test_send"
+  ];
+
+  pythonImportsCheck = [ "codecov" ];
 
   meta = with lib; {
     description = "Python report uploader for Codecov";

--- a/pkgs/development/python-modules/codecov/default.nix
+++ b/pkgs/development/python-modules/codecov/default.nix
@@ -1,17 +1,26 @@
-{ lib, buildPythonPackage, fetchPypi, requests, coverage, unittest2 }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, coverage
+, unittest2
+}:
 
 buildPythonPackage rec {
   pname = "codecov";
-  version = "2.1.11";
+  version = "2.1.12";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6cde272454009d27355f9434f4e49f238c0273b216beda8472a65dc4957f473b";
+    sha256 = "sha256-oNpGu1AlQm2ola+Qk43vjuEtN/y8u7wVttxkz368UcE=";
   };
 
-  checkInputs = [ unittest2 ]; # Tests only
+  propagatedBuildInputs = [
+    requests
+    coverage
+  ];
 
-  propagatedBuildInputs = [ requests coverage ];
+  checkInputs = [ unittest2 ];
 
   postPatch = ''
     sed -i 's/, "argparse"//' setup.py
@@ -24,5 +33,6 @@ buildPythonPackage rec {
     description = "Python report uploader for Codecov";
     homepage = "https://codecov.io/";
     license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.12

Change log: https://github.com/codecov/codecov-python/releases/tag/v2.1.12

- enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
