### PR TITLE
writers: drop writeC

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -99,51 +99,6 @@ rec {
   writeBashBin = name:
     writeBash "/bin/${name}";
 
-  # writeC writes an executable c package called `name` to `destination` using `libraries`.
-  #
-  #  Examples:
-  #    writeC "hello-world-ncurses" { libraries = [ pkgs.ncurses ]; } ''
-  #      #include <ncurses.h>
-  #      int main() {
-  #        initscr();
-  #        printw("Hello World !!!");
-  #        refresh(); endwin();
-  #        return 0;
-  #      }
-  #    ''
-  writeC = name: {
-    libraries ? [],
-    strip ? true
-  }:
-    makeBinWriter {
-      compileScript = ''
-        PATH=${makeBinPath [
-          pkgs.binutils-unwrapped
-          pkgs.coreutils
-          pkgs.findutils
-          pkgs.gcc
-          pkgs.pkg-config
-        ]}
-        export PKG_CONFIG_PATH=${concatMapStringsSep ":" (pkg: "${pkg}/lib/pkgconfig") libraries}
-        gcc \
-            ${optionalString (libraries != [])
-              "$(pkg-config --cflags --libs ${
-                concatMapStringsSep " " (pkg: "$(find ${escapeShellArg pkg}/lib/pkgconfig -name \\*.pc)") libraries
-              })"
-            } \
-            -O \
-            -o "$out" \
-            -Wall \
-            -x c \
-            "$contentPath"
-      '';
-      inherit strip;
-    } name;
-
-  # writeCBin takes the same arguments as writeC but outputs a directory (like writeScriptBin)
-  writeCBin = name:
-    writeC "/bin/${name}";
-
   # Like writeScript but the first line is a shebang to dash
   #
   # Example:

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -17,14 +17,6 @@ let
      if [[ "test" == "test" ]]; then echo "success"; fi
     '';
 
-    c = writeCBin "test-writers-c" { libraries = [ ]; } ''
-      #include <stdio.h>
-      int main() {
-        printf("success\n");
-        return 0;
-      }
-    '';
-
     dash = writeDashBin "test-writers-dash-bin" ''
      test '~' = '~' && echo 'success'
     '';
@@ -86,24 +78,6 @@ let
   simple = {
     bash = writeBash "test-writers-bash" ''
      if [[ "test" == "test" ]]; then echo "success"; fi
-    '';
-
-    c = writeC "test-writers-c" { libraries = [ glib.dev ]; } ''
-      #include <gio/gio.h>
-      #include <stdio.h>
-      int main() {
-        GApplication *application = g_application_new ("hello.world", G_APPLICATION_FLAGS_NONE);
-        g_application_register (application, NULL, NULL);
-        GNotification *notification = g_notification_new ("Hello world!");
-        g_notification_set_body (notification, "This is an example notification.");
-        GIcon *icon = g_themed_icon_new ("dialog-information");
-        g_notification_set_icon (notification, icon);
-        g_object_unref (icon);
-        g_object_unref (notification);
-        g_object_unref (application);
-        printf("success\n");
-        return 0;
-      }
     '';
 
     dash = writeDash "test-writers-dash" ''


### PR DESCRIPTION
This function is fundamentally broken.
Not even the ncurses example will compile.
The interface needs to be rethought for it to work (i.e. don't
unconditionally include all pc files, set include path and ld path and
rpath).
Since it is unlikely that in the current form this has any user, just drop it for now.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
