### PR TITLE
kde-gruvbox: init at unstable-2015-08-09

### DIFF
--- a/pkgs/data/themes/kde-gruvbox/default.nix
+++ b/pkgs/data/themes/kde-gruvbox/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "kde-gruvbox";
+  version = "unstable-2015-08-09";
+
+  src = fetchFromGitHub {
+    owner = "printesoi";
+    repo = pname;
+    rev = "2dd95283076d7194345a460edb3630cfd020759c";
+    sha256 = "sha256-ppAeEfwoHZg7XEj3zGc+uq4Z6hUgJNM2EjuDsc8pFQo=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/{plasma/desktoptheme,yakuake/kns_skins}
+    cp -R color-schemes konsole $out/share
+    cp -R plasma5/gruvbox $out/share/plasma/desktoptheme
+    cp -R yakuake/breeze-gruvbox-dark $out/share/yakuake/kns_skins
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A suite of themes for KDE applications that match the retro gruvbox colorscheme";
+    homepage = "https://github.com/printesoi/kde-gruvbox";
+    license = licenses.mit;
+    maintainers = [ maintainers.ymarkus ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25477,6 +25477,8 @@ with pkgs;
 
   kaidan = libsForQt5.callPackage ../applications/networking/instant-messengers/kaidan { };
 
+  kde-gruvbox = callPackage ../data/themes/kde-gruvbox { };
+
   kdeltachat = libsForQt5.callPackage ../applications/networking/instant-messengers/kdeltachat { };
 
   kdevelop-pg-qt = libsForQt5.callPackage ../applications/editors/kdevelop5/kdevelop-pg-qt.nix { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
