### PR TITLE
python3Packages.pytest-randomly: 3.6.0 -> 3.10.1

### DIFF
--- a/pkgs/development/python-modules/pytest-randomly/default.nix
+++ b/pkgs/development/python-modules/pytest-randomly/default.nix
@@ -1,24 +1,35 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
-, factory_boy, faker, numpy, backports-entry-points-selectable
-, pytestCheckHook, pytest-xdist
+{ lib
+, buildPythonPackage
+, factory_boy
+, faker
+, fetchFromGitHub
+, importlib-metadata
+, numpy
+, pytest
+, pytest-xdist
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pytest-randomly";
-  version = "3.6.0";
+  version = "3.10.1";
 
   disabled = pythonOlder "3.6";
 
-  # fetch from GitHub as pypi tarball doesn't include tests
   src = fetchFromGitHub {
     repo = pname;
     owner = "pytest-dev";
     rev = version;
-    sha256 = "17s7gx8b7sl7mp77f5dxzwbb32qliz9awrp6xz58bhjqp7pcsa5h";
+    sha256 = "sha256-c8Alt3FjhDZ2CrGTe/rEFrDwwA0mjhCK0wA1j7KG54M=";
   };
 
+  buildInputs = [
+    pytest
+  ];
+
   propagatedBuildInputs = [
-    backports-entry-points-selectable
+    importlib-metadata
   ];
 
   checkInputs = [
@@ -28,13 +39,16 @@ buildPythonPackage rec {
     factory_boy
     faker
   ];
+
   # needs special invocation, copied from tox.ini
   pytestFlagsArray = [ "-p" "no:randomly" ];
+
+  pythonImportsCheck = [ "pytest_randomly" ];
 
   meta = with lib; {
     description = "Pytest plugin to randomly order tests and control random.seed";
     homepage = "https://github.com/pytest-dev/pytest-randomly";
     license = licenses.bsd3;
-    maintainers = [ maintainers.sternenseemann ];
+    maintainers = with maintainers; [ sternenseemann ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.10.1

Change log:
- https://github.com/pytest-dev/pytest-randomly/blob/main/HISTORY.rst#3101-2021-08-13
- https://github.com/pytest-dev/pytest-randomly/blob/main/HISTORY.rst#3100-2021-08-13
- https://github.com/pytest-dev/pytest-randomly/blob/main/HISTORY.rst#390-2021-08-12
- https://github.com/pytest-dev/pytest-randomly/blob/main/HISTORY.rst#380-2021-05-10
- https://github.com/pytest-dev/pytest-randomly/blob/main/HISTORY.rst#370-2021-04-11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
