### PR TITLE
cbqn: init at unstable-2021-08-24

### DIFF
--- a/pkgs/development/interpreters/cbqn/default.nix
+++ b/pkgs/development/interpreters/cbqn/default.nix
@@ -1,17 +1,18 @@
 let
   # Allow the entire bootstrap sequence to be overridden
   # if bootstrap == null, we just use the given bytecode and call it a day.
-  usingBytecode = generic: generic {
-    useBytecode = true;
-    testSuitePasses = false;
-  };
-  bootstrapProcess = generic: let
-    phase1 = usingBytecode generic;
-    phase2 = generic { bqn = phase1; };
-    phase3 = generic { bqn = phase2; };
-  in phase3;
-in
-{ stdenv, lib, fetchFromGitHub, bootstrap ? bootstrapProcess, ripgrep }:
+  usingBytecode = generic:
+    generic {
+      useBytecode = true;
+      testSuitePasses = false;
+    };
+  bootstrapProcess = generic:
+    let
+      phase1 = usingBytecode generic;
+      phase2 = generic { bqn = phase1; };
+      phase3 = generic { bqn = phase2; };
+    in phase3;
+in { stdenv, lib, fetchFromGitHub, bootstrap ? bootstrapProcess, ripgrep }:
 
 let
   libBQN = fetchFromGitHub {
@@ -71,7 +72,9 @@ let
         echo "'w'+↕4" | ./BQN | grep "wxyz"
 
         ./BQN ${libBQN}/test/this.bqn \
-          | rg --passthru ${if testSuitePasses then "'All passed'" else "'\\d+ failed'"}
+          | rg --passthru ${
+            if testSuitePasses then "'All passed'" else "'\\d+ failed'"
+          }
       '';
 
       meta = with lib; {
@@ -82,5 +85,4 @@ let
         homepage = "https://mlochbaum.github.io/BQN/";
       };
     };
-in
-  if bootstrap != null then bootstrap generic else usingBytecode generic
+in if bootstrap != null then bootstrap generic else usingBytecode generic

--- a/pkgs/development/interpreters/cbqn/default.nix
+++ b/pkgs/development/interpreters/cbqn/default.nix
@@ -1,0 +1,76 @@
+{ stdenv, lib, fetchFromGitHub, bootstrapped ? true, ripgrep }:
+
+let
+  libBQN = fetchFromGitHub {
+    owner = "mlochbaum";
+    repo = "bqn";
+    rev = "e46d1edb07cea7f9a5be26165213db8a17b4fa4f";
+    sha256 = "13kbak06ivw935jfdc98k8bxy0qkpdj2xwp1ajqbkckbr02pqz40";
+  };
+
+  bytecode = fetchFromGitHub {
+    owner = "dzaima";
+    repo = "cbqn";
+    rev = "6aa6834666e91f2490a86efd249ba9c7b1d35794";
+    sha256 = "046k0gkwc5mw4wm551hsgiqcvmh0a7j43pr55l8sh6faliqgrnhi";
+  };
+
+  src = fetchFromGitHub {
+    owner = "dzaima";
+    repo = "cbqn";
+    rev = "a7ee8044d165119c6df8e93c5c13286bac54bf59";
+    sha256 = "1zqfa8pzqhgg1n7xs46fjqhqh3njsyrk9b8lbzcl6ka4rrjkx4j5";
+  };
+
+  generic = { useBytecode ? false, bqn ? null, fullTestSuite ? true }:
+    # Either use bytecode, or have bqn specified.
+    assert (bqn != null) == !useBytecode;
+
+    stdenv.mkDerivation rec {
+      pname = "cbqn" + lib.optionalString useBytecode "-bytecode";
+      version = "unstable-2021-08-24";
+
+      inherit src;
+      patches = lib.optional useBytecode ./generated.patch;
+      nativeBuildInputs = [ bqn ];
+      checkInputs = lib.optional fullTestSuite ripgrep;
+
+      buildPhase = (if useBytecode then ''
+        echo "Copying bytecode from bootstrap"
+        cp ${bytecode}/src/gen/* src/gen/
+      '' else ''
+        echo "Generating bytecode..."
+        bqn ./genRuntime ${libBQN}
+      '') + ''
+        sed -i 's|/usr/bin/env bash|${stdenv.shell}|' makefile
+        make
+      '';
+
+      installPhase = ''
+        mkdir -p $out/bin
+        cp BQN $out/bin
+        ln -s $out/bin/BQN $out/bin/bqn
+      '';
+
+      doCheck = true;
+      checkPhase = ''
+        # Implement a very rudimentary smoke test
+        echo "↕4" | ./BQN | grep "0 1 2 3"
+      '' + lib.optionalString fullTestSuite ''
+        ./BQN ${libBQN}/test/this.bqn | rg --passthru "All passed!"
+      '';
+
+      meta = with lib; {
+        description = "An APL-like programming language";
+        maintainers = with maintainers; [ synthetica ];
+        platforms = with platforms; all;
+        license = licenses.isc;
+        homepage = "https://mlochbaum.github.io/BQN/";
+      };
+    };
+
+  phase1 = generic { useBytecode = true; fullTestSuite = false; };
+  phase2 = generic { bqn = phase1; };
+  phase3 = generic { bqn = phase2; };
+in
+  if bootstrapped then phase3 else phase1

--- a/pkgs/development/interpreters/cbqn/default.nix
+++ b/pkgs/development/interpreters/cbqn/default.nix
@@ -1,4 +1,17 @@
-{ stdenv, lib, fetchFromGitHub, bootstrapped ? true, ripgrep }:
+let
+  # Allow the entire bootstrap sequence to be overridden
+  # if bootstrap == null, we just use the given bytecode and call it a day.
+  usingBytecode = generic: generic {
+    useBytecode = true;
+    testSuitePasses = false;
+  };
+  bootstrapProcess = generic: let
+    phase1 = usingBytecode generic;
+    phase2 = generic { bqn = phase1; };
+    phase3 = generic { bqn = phase2; };
+  in phase3;
+in
+{ stdenv, lib, fetchFromGitHub, bootstrap ? bootstrapProcess, ripgrep }:
 
 let
   libBQN = fetchFromGitHub {
@@ -69,9 +82,5 @@ let
         homepage = "https://mlochbaum.github.io/BQN/";
       };
     };
-
-  phase1 = generic { useBytecode = true; testSuitePasses = false; };
-  phase2 = generic { bqn = phase1; };
-  phase3 = generic { bqn = phase2; };
 in
-  if bootstrapped then phase3 else phase1
+  if bootstrap != null then bootstrap generic else usingBytecode generic

--- a/pkgs/development/interpreters/cbqn/default.nix
+++ b/pkgs/development/interpreters/cbqn/default.nix
@@ -22,7 +22,7 @@ let
     sha256 = "1zqfa8pzqhgg1n7xs46fjqhqh3njsyrk9b8lbzcl6ka4rrjkx4j5";
   };
 
-  generic = { useBytecode ? false, bqn ? null, fullTestSuite ? true }:
+  generic = { useBytecode ? false, bqn ? null, testSuitePasses ? true }:
     # Either use bytecode, or have bqn specified.
     assert (bqn != null) == !useBytecode;
 
@@ -33,7 +33,7 @@ let
       inherit src;
       patches = lib.optional useBytecode ./generated.patch;
       nativeBuildInputs = [ bqn ];
-      checkInputs = lib.optional fullTestSuite ripgrep;
+      checkInputs = [ ripgrep ];
 
       buildPhase = (if useBytecode then ''
         echo "Copying bytecode from bootstrap"
@@ -56,8 +56,9 @@ let
       checkPhase = ''
         # Implement a very rudimentary smoke test
         echo "'w'+↕4" | ./BQN | grep "wxyz"
-      '' + lib.optionalString fullTestSuite ''
-        ./BQN ${libBQN}/test/this.bqn | rg --passthru "All passed!"
+
+        ./BQN ${libBQN}/test/this.bqn \
+          | rg --passthru ${if testSuitePasses then "'All passed'" else "'\\d+ failed'"}
       '';
 
       meta = with lib; {
@@ -69,7 +70,7 @@ let
       };
     };
 
-  phase1 = generic { useBytecode = true; fullTestSuite = false; };
+  phase1 = generic { useBytecode = true; testSuitePasses = false; };
   phase2 = generic { bqn = phase1; };
   phase3 = generic { bqn = phase2; };
 in

--- a/pkgs/development/interpreters/cbqn/default.nix
+++ b/pkgs/development/interpreters/cbqn/default.nix
@@ -55,7 +55,7 @@ let
       doCheck = true;
       checkPhase = ''
         # Implement a very rudimentary smoke test
-        echo "↕4" | ./BQN | grep "0 1 2 3"
+        echo "'w'+↕4" | ./BQN | grep "wxyz"
       '' + lib.optionalString fullTestSuite ''
         ./BQN ${libBQN}/test/this.bqn | rg --passthru "All passed!"
       '';

--- a/pkgs/development/interpreters/cbqn/generated.patch
+++ b/pkgs/development/interpreters/cbqn/generated.patch
@@ -1,0 +1,15 @@
+diff --git a/makefile b/makefile
+index a5f3d75..f617e25 100644
+--- a/makefile
++++ b/makefile
+@@ -109,9 +109,7 @@ ${bd}/%.o: src/builtins/%.c
+ 
+ 
+ src/gen/customRuntime:
+-	@echo "Copying precompiled bytecode from the bytecode branch"
+-	git checkout remotes/origin/bytecode src/gen/{compiler,formatter,runtime0,runtime1,src}
+-	git reset src/gen/{compiler,formatter,runtime0,runtime1,src}
++	@echo "Generated files handled by Nix"
+ ${bd}/load.o: src/gen/customRuntime
+ 
+ -include $(bd)/*.d

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1395,6 +1395,10 @@ with pkgs;
 
   catcli = python3Packages.callPackage ../tools/filesystems/catcli { };
 
+  cbqn = callPackage ../development/interpreters/cbqn {
+    stdenv = clangStdenv;
+  };
+
   chezmoi = callPackage ../tools/misc/chezmoi { };
 
   chipsec = callPackage ../tools/security/chipsec {


### PR DESCRIPTION

###### Motivation for this change
https://mlochbaum.github.io/BQN/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
