### PR TITLE
Python3Packages.versiontag: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6688,6 +6688,12 @@
     githubId = 775189;
     name = "Jordi Masip";
   };
+  MaskedBelgian = {
+    email = "michael.colicchia@imio.be";
+    github = "MaskedBelgian";
+    githubId = 29855073;
+    name = "Michael Colicchia";
+  };
   matdsoupe = {
     github = "matdsoupe";
     githubId = 44469426;

--- a/pkgs/development/python-modules/versiontag/default.nix
+++ b/pkgs/development/python-modules/versiontag/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub, git }:
+
+buildPythonPackage rec {
+  pname = "versiontag";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "thelabnyc";
+    repo = "python-versiontag";
+    rev = "r${version}";
+    sha256 = "1axv2214ykgv5adajv10v2zy5fr9v77db54rkik6ja29p66zl90n";
+  };
+
+  checkInputs = [ git ];
+
+  pythonImportsCheck = [ "versiontag" ];
+
+  meta = with lib; {
+    description = "Python library designed to make accessing the current version number of your software easy";
+    homepage = "https://github.com/thelabnyc/python-versiontag";
+    license = licenses.isc;
+    maintainers = with maintainers; [ MaskedBelgian ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9204,6 +9204,8 @@ in {
 
   versioneer = callPackage ../development/python-modules/versioneer { };
 
+  versiontag = callPackage ../development/python-modules/versiontag { };
+
   versiontools = callPackage ../development/python-modules/versiontools { };
 
   vertica-python = callPackage ../development/python-modules/vertica-python { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
library design to make accessing the current version number of your software easy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
