### PR TITLE
weechatScripts.url_hint: init at 0.8

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -7,6 +7,8 @@
     inherit (perlPackages) PodParser;
   };
 
+  url_hint = callPackage ./url_hint { };
+
   weechat-matrix-bridge = callPackage ./weechat-matrix-bridge {
     inherit (luaPackages) cjson luaffi;
   };

--- a/pkgs/applications/networking/irc/weechat/scripts/url_hint/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/url_hint/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchurl, weechat }:
+
+stdenv.mkDerivation {
+  pname = "url_hint";
+  version = "0.8";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/weechat/scripts/10671d785ea3f9619d0afd0d7a1158bfa4ee3938/python/url_hint.py";
+    sha256 = "0aw59kq74yqh0qbdkldfl6l83d0bz833232xr2w4741szck43kss";
+  };
+
+  dontUnpack = true;
+
+  passthru.scripts = [ "url_hint.py" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D $src $out/share/url_hint.py
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit (weechat.meta) platforms;
+    description = "url_hint.py is a URL opening script.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ eraserhd ];
+  };
+}


### PR DESCRIPTION
Basically copied auto_buffer script and updated details.

###### Motivation for this change

Package new script

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).