### PR TITLE
fbmenugen: 0.85 -> 0.86

### DIFF
--- a/pkgs/applications/misc/fbmenugen/0001-Fix-paths.patch
+++ b/pkgs/applications/misc/fbmenugen/0001-Fix-paths.patch
@@ -1,14 +1,14 @@
-From 76c25147328d71960c70bbdd5a9396aac4a362a2 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Jos=C3=A9=20Romildo=20Malaquias?= <malaquias@gmail.com>
-Date: Wed, 20 May 2020 14:19:07 -0300
+From b65921873585616c86a591eee9efbc68f84eb3d3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Romildo?= <malaquias@gmail.com>
+Date: Wed, 25 Aug 2021 12:03:09 -0300
 Subject: [PATCH] Fix paths
 
 ---
- fbmenugen | 14 ++++++--------
- 1 file changed, 6 insertions(+), 8 deletions(-)
+ fbmenugen | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/fbmenugen b/fbmenugen
-index 46a18dc..0c8eb08 100755
+index 241be16..5fc9aea 100755
 --- a/fbmenugen
 +++ b/fbmenugen
 @@ -214,9 +214,7 @@ my %CONFIG = (
@@ -22,15 +22,6 @@ index 46a18dc..0c8eb08 100755
              "$home_dir/.local/share/applications",
          ],
  #>>>
-@@ -232,7 +230,7 @@ my %CONFIG = (
-     force_icon_size  => 0,
-     generic_fallback => 0,
-     locale_support   => 1,
--    use_gtk3         => 0,
-+    use_gtk3         => 1,
- 
-     VERSION => $version,
-              );
 @@ -252,7 +250,7 @@ if (not -e $config_file) {
  }
  
@@ -40,7 +31,7 @@ index 46a18dc..0c8eb08 100755
          require File::Copy;
          File::Copy::copy($etc_schema_file, $schema_file)
            or warn "$0: can't copy file `$etc_schema_file' to `$schema_file': $!\n";
-@@ -570,7 +568,7 @@ EXIT
+@@ -588,7 +586,7 @@ EXIT
          $generated_menu .= begin_category(@{$schema->{fluxbox}}) . <<"FOOTER";
  [config] (Configure)
  [submenu] (System Styles) {Choose a style...}
@@ -49,7 +40,7 @@ index 46a18dc..0c8eb08 100755
  [end]
  [submenu] (User Styles) {Choose a style...}
    [stylesdir] (~/.fluxbox/styles)
-@@ -580,12 +578,12 @@ EXIT
+@@ -598,12 +596,13 @@ EXIT
    [exec] (Screenshot - JPG) {import screenshot.jpg && display -resize 50% screenshot.jpg}
    [exec] (Screenshot - PNG) {import screenshot.png && display -resize 50% screenshot.png}
    [exec] (Run) {fbrun}
@@ -59,11 +50,11 @@ index 46a18dc..0c8eb08 100755
  [commanddialog] (Fluxbox Command)
    [reconfig] (Reload config)
    [restart] (Restart)
--  [exec] (About) {(fluxbox -v; fluxbox -info | sed 1d) | xmessage -file - -center}
+   [exec] (About) {(fluxbox -v; fluxbox -info | sed 1d) | xmessage -file - -center}
 +  [exec] (About) {(@fluxbox@/bin/fluxbox -v; @fluxbox@/bin/fluxbox -info | @gnused@/bin/sed 1d) | @xmessage@/bin/xmessage -file - -center}
    [separator]
    [exit] (Exit)
  [end]
 -- 
-2.26.2
+2.32.0
 

--- a/pkgs/applications/misc/fbmenugen/default.nix
+++ b/pkgs/applications/misc/fbmenugen/default.nix
@@ -11,13 +11,13 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "fbmenugen";
-  version = "0.85";
+  version = "0.86";
 
   src = fetchFromGitHub {
     owner = "trizen";
     repo = pname;
     rev = version;
-    sha256 = "1pmms3wzkm8h41a8zrkpn6gq9m9yy5wr5rrzmb84lbacprqq6q7q";
+    sha256 = "0ya7s8b5xbaplz365bnr580szxxsngrs2n7smj8vz8a7kwi0319q";
   };
 
   patches = [
@@ -68,7 +68,7 @@ perlPackages.buildPerlPackage rec {
   meta = with lib; {
     homepage = "https://github.com/trizen/fbmenugen";
     description = "Simple menu generator for the Fluxbox Window Manager";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [0.86](https://github.com/trizen/fbmenugen/releases/tag/0.86)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
