### PR TITLE
neovim-qt: add qtsvg depedency

### DIFF
--- a/pkgs/applications/editors/neovim/neovim-qt.nix
+++ b/pkgs/applications/editors/neovim/neovim-qt.nix
@@ -19,7 +19,8 @@ mkDerivation rec {
 
   buildInputs = [
     neovim.unwrapped # only used to generate help tags at build time
-    qtbase
+    qt5.qtbase
+    qt5.qtsvg
   ] ++ (with python3Packages; [
     jinja2 python msgpack
   ]);

--- a/pkgs/applications/editors/neovim/neovim-qt.nix
+++ b/pkgs/applications/editors/neovim/neovim-qt.nix
@@ -1,5 +1,5 @@
 { lib, mkDerivation, fetchFromGitHub, cmake, doxygen, makeWrapper
-, msgpack, neovim, python3Packages, qtbase }:
+, msgpack, neovim, python3Packages, qtbase, qtsvg }:
 
 mkDerivation rec {
   pname = "neovim-qt-unwrapped";

--- a/pkgs/applications/editors/neovim/neovim-qt.nix
+++ b/pkgs/applications/editors/neovim/neovim-qt.nix
@@ -19,8 +19,8 @@ mkDerivation rec {
 
   buildInputs = [
     neovim.unwrapped # only used to generate help tags at build time
-    qt5.qtbase
-    qt5.qtsvg
+    qtbase
+    qtsvg
   ] ++ (with python3Packages; [
     jinja2 python msgpack
   ]);


### PR DESCRIPTION
QtSvg is required by neovim-qt: https://github.com/equalsraf/neovim-qt/blob/master/CMakeLists.txt#L137

However, qtbase does not provide it.