### PR TITLE
sonic-pi: wrap sonic-pi-server.rb as standalone executable

### DIFF
--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -102,7 +102,12 @@ mkDerivation rec {
   dontWrapQtApps = true;
   preFixup = ''
     wrapQtApp "$out/bin/sonic-pi" \
-      --prefix PATH : ${ruby}/bin:${bash}/bin:${supercollider}/bin:${jack2}/bin \
+      --prefix PATH : ${lib.makeBinPath [ bash jack2 ruby supercollider ] } \
+      --set AUBIO_LIB "${aubio}/lib/libaubio.so"
+    makeWrapper \
+      $out/app/server/ruby/bin/sonic-pi-server.rb \
+      $out/bin/sonic-pi-server \
+      --prefix PATH : ${lib.makeBinPath [ bash jack2 ruby supercollider ] } \
       --set AUBIO_LIB "${aubio}/lib/libaubio.so"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Wrap `sonic-pi-server.rb` to be able to run it as a headless server without launching the gui.

edit: I couldn't find a way to start the server headless without this. If it already was possible I'm all ears, and please go ahead and close this :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
