### PR TITLE
ocamlPackages.vlq: init at 0.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/vlq/default.nix
+++ b/pkgs/development/ocaml-modules/vlq/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchurl
+, dune-configurator
+}:
+
+buildDunePackage rec {
+  pname = "vlq";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://github.com/flowtype/ocaml-vlq/releases/download/v${version}/vlq-v${version}.tbz";
+    sha256 = "02wr9ph4q0nxmqgbc67ydf165hmrdv9b655krm2glc3ahb6larxi";
+  };
+
+  useDune2 = true;
+
+  buildInputs = [ dune-configurator ];
+
+  meta = {
+    description = "encoding variable-length quantities, in particular base64";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/flowtype/ocaml-vlq";
+    maintainers = [ lib.maintainers.nomeata ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1304,6 +1304,8 @@ let
 
     vg = callPackage ../development/ocaml-modules/vg { };
 
+    vlq = callPackage ../development/ocaml-modules/vlq { };
+
     visitors = callPackage ../development/ocaml-modules/visitors { };
 
     wasm = callPackage ../development/ocaml-modules/wasm { };


### PR DESCRIPTION
###### Motivation for this change

It’s an ocaml package I need in a nixified project (motoko).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
