### PR TITLE
souffle: 2.0.2 -> 2.1

### DIFF
--- a/pkgs/development/compilers/souffle/bash-completion-dir.patch
+++ b/pkgs/development/compilers/souffle/bash-completion-dir.patch
@@ -1,0 +1,16 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -333,12 +333,7 @@ endif()
+ # Installing bash completion file
+ # --------------------------------------------------
+ find_package (bash-completion)
+-if (BASH_COMPLETION_FOUND)
+-    message(STATUS "Using bash completion dir ${BASH_COMPLETION_COMPLETIONSDIR}")
+-else()
+-    set (BASH_COMPLETION_COMPLETIONSDIR "/etc/bash_completion.d")
+-    message (STATUS "Using fallback bash completion dir ${BASH_COMPLETION_COMPLETIONSDIR}")
+-endif()
++set(BASH_COMPLETION_COMPLETIONSDIR "${CMAKE_INSTALL_PREFIX}/share/bash-completion/completions" CACHE PATH "Location of bash_completion.d")
+ 
+ install(
+     FILES "${CMAKE_SOURCE_DIR}/debian/souffle.bash-completion"

--- a/pkgs/development/compilers/souffle/lsb-release.patch
+++ b/pkgs/development/compilers/souffle/lsb-release.patch
@@ -1,0 +1,22 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -327,18 +327,7 @@ install(
+ # --------------------------------------------------
+ 
+ function(get_linux_lsb_release_information)
+-    find_program(LSB_RELEASE_EXEC lsb_release)
+-    if(NOT LSB_RELEASE_EXEC)
+-        message(FATAL_ERROR "Could not detect lsb_release executable, can not gather required information")
+-    endif()
+-
+-    execute_process(COMMAND "${LSB_RELEASE_EXEC}" --short --id OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    execute_process(COMMAND "${LSB_RELEASE_EXEC}" --short --release OUTPUT_VARIABLE LSB_RELEASE_VERSION_SHORT OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    execute_process(COMMAND "${LSB_RELEASE_EXEC}" --short --codename OUTPUT_VARIABLE LSB_RELEASE_CODENAME_SHORT OUTPUT_STRIP_TRAILING_WHITESPACE)
+-
+-    set(LSB_RELEASE_ID_SHORT "${LSB_RELEASE_ID_SHORT}" PARENT_SCOPE)
+-    set(LSB_RELEASE_VERSION_SHORT "${LSB_RELEASE_VERSION_SHORT}" PARENT_SCOPE)
+-    set(LSB_RELEASE_CODENAME_SHORT "${LSB_RELEASE_CODENAME_SHORT}" PARENT_SCOPE)
++    set(LSB_RELEASE_ID_SHORT "NixOS" PARENT_SCOPE)
+ endfunction()
+ 
+ # --------------------------------------------------

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12384,9 +12384,7 @@ with pkgs;
 
   solc = callPackage ../development/compilers/solc { };
 
-  souffle = callPackage ../development/compilers/souffle {
-    autoreconfHook = buildPackages.autoreconfHook269;
-  };
+  souffle = callPackage ../development/compilers/souffle { };
 
   spasm-ng = callPackage ../development/compilers/spasm-ng { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
