### PR TITLE
nixos/tests: ensure nix can fetch data from sandbox

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -307,6 +307,7 @@ in
   nginx-sso = handleTest ./nginx-sso.nix {};
   nginx-variants = handleTest ./nginx-variants.nix {};
   nitter = handleTest ./nitter.nix {};
+  nix-fetch = handleTest ./nix-fetch.nix {};
   nix-serve = handleTest ./nix-ssh-serve.nix {};
   nix-ssh-serve = handleTest ./nix-ssh-serve.nix {};
   nixos-generate-config = handleTest ./nixos-generate-config.nix {};

--- a/nixos/tests/nix-fetch.nix
+++ b/nixos/tests/nix-fetch.nix
@@ -1,0 +1,110 @@
+import ./make-test-python.nix ({ lib, ... } : {
+  name = "nix-fetch";
+  meta.maintainers = with lib.maintainers; [ baloo ];
+
+  nodes = {
+    http_dns = { lib, pkgs, config, ... }: {
+      networking.firewall.enable = false;
+      networking.interfaces.eth1.ipv6.addresses = lib.mkForce [
+        { address = "fd21::1"; prefixLength = 64; }
+      ];
+      networking.interfaces.eth1.ipv4.addresses = lib.mkForce [
+        { address = "192.168.0.1"; prefixLength = 24; }
+      ];
+
+      services.unbound = {
+        enable = true;
+        enableRootTrustAnchor = false;
+        settings = {
+          server = {
+            interface = [ "192.168.0.1" "fd21::1" "::1" "127.0.0.1" ];
+            access-control = [ "192.168.0.0/24 allow" "fd21::/64 allow" "::1 allow" "127.0.0.0/8 allow" ];
+            local-data = [
+              ''"example.com. IN A 192.168.0.1"''
+              ''"example.com. IN AAAA fd21::1"''
+              ''"tarballs.nixos.org. IN A 192.168.0.1"''
+              ''"tarballs.nixos.org. IN AAAA fd21::1"''
+            ];
+          };
+        };
+      };
+
+      services.nginx = {
+        enable = true;
+        virtualHosts."example.com" = {
+          root = pkgs.runCommand "testdir" {} ''
+            mkdir "$out"
+            echo hello world > "$out/index.html"
+          '';
+        };
+      };
+    };
+
+    # client consumes a remote resolver
+    client = { lib, nodes, pkgs, ... }: {
+      networking.useDHCP = false;
+      networking.nameservers = [
+        (lib.head nodes.http_dns.config.networking.interfaces.eth1.ipv6.addresses).address
+        (lib.head nodes.http_dns.config.networking.interfaces.eth1.ipv4.addresses).address
+      ];
+      networking.interfaces.eth1.ipv6.addresses = [
+        { address = "fd21::10"; prefixLength = 64; }
+      ];
+      networking.interfaces.eth1.ipv4.addresses = [
+        { address = "192.168.0.10"; prefixLength = 24; }
+      ];
+
+      nix.sandboxPaths = lib.mkForce [];
+      nix.binaryCaches = lib.mkForce [];
+      nix.useSandbox = lib.mkForce true;
+    };
+  };
+
+  testScript = { nodes, ... }: ''
+    http_dns.wait_for_unit("nginx")
+    http_dns.wait_for_open_port(80)
+    http_dns.wait_for_unit("unbound")
+    http_dns.wait_for_open_port(53)
+
+    client.start()
+    client.wait_for_unit('multi-user.target')
+
+    with subtest("can fetch data from a remote server outside sandbox"):
+        client.succeed("nix --version >&2")
+        client.succeed("curl -vvv http://example.com/index.html >&2")
+
+    with subtest("nix-build can lookup dns and fetch data"):
+        client.succeed("""
+          nix-build -E 'derivation {
+              builder = "builtin:fetchurl";
+
+              # New-style output content requirements.
+              outputHash = "0ix4jahrkll5zg01wandq78jw3ab30q4nscph67rniqg5x7r0j59";
+              outputHashAlgo = "sha256";
+              outputHashMode = "flat";
+
+              name = "example.com";
+              url = "http://example.com";
+
+              unpack = false;
+              executable = false;
+
+              system = "builtin";
+
+              # No need to double the amount of network traffic
+              preferLocalBuild = true;
+
+              impureEnvVars = [
+                # We borrow these environment variables from the caller to allow
+                # easy proxy configuration.  This is impure, but a fixed-output
+                # derivation like fetchurl is allowed to do so since its result is
+                # by definition pure.
+                "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
+              ];
+
+              # To make "nix-prefetch-url" work.
+              urls = [ "http://example.com" ];
+            }' >&2
+          """)
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

I tried to reproduce the issue described in https://github.com/NixOS/nix/issues/5089 and I ended up writing a test for it.
It tests nix is able to fetch data from remote and do dns lookups to a resolver from within a sandbox.

I have a hard time evaluating if this is worth a merge, and being added as tests. Feedback is most welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
