### PR TITLE
flexoptix-app: 5.9.0 -> 5.11.0 and fixes

### DIFF
--- a/pkgs/tools/misc/flexoptix-app/default.nix
+++ b/pkgs/tools/misc/flexoptix-app/default.nix
@@ -1,12 +1,12 @@
-{ lib, appimageTools, fetchurl }: let
+{ lib, appimageTools, fetchurl, nodePackages }: let
   pname = "flexoptix-app";
-  version = "5.9.0";
+  version = "5.11.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     name = "${name}.AppImage";
     url = "https://flexbox.reconfigure.me/download/electron/linux/x64/FLEXOPTIX%20App.${version}.AppImage";
-    sha256 = "0gbqaj9b11mxx0knmmh2d5863kaslbb3r6c4h8rjhg8qy4cws7hj";
+    sha256 = "sha256:1hzdb2fbkwpsf0d3ws4z32blk6549jwhf1lrlqmcxhzqfvkr4gin";
   };
 
   udevRules = fetchurl {
@@ -14,12 +14,20 @@
     sha256 = "0mr1bhgvavq1ax4206z1vr2y64s3r676w9jjl9ysziklbrsvk5rr";
   };
 
-  appimageContents = appimageTools.extractType2 {
-    inherit name src;
-  };
+  appimageContents = (appimageTools.extract { inherit name src; }).overrideAttrs (oA: {
+    buildCommand = ''
+      ${oA.buildCommand}
 
-in appimageTools.wrapType2 {
-  inherit name src;
+      # Get rid of the autoupdater
+      ${nodePackages.asar}/bin/asar extract $out/resources/app.asar app
+      sed -i 's/async isUpdateAvailable.*/async isUpdateAvailable(updateInfo) { return false;/g' app/node_modules/electron-updater/out/AppUpdater.js
+      ${nodePackages.asar}/bin/asar pack app $out/resources/app.asar
+    '';
+  });
+
+in appimageTools.wrapAppImage {
+  inherit name;
+  src = appimageContents;
 
   multiPkgs = null; # no 32bit needed
   extraPkgs = { pkgs, ... }@args: [
@@ -27,11 +35,14 @@ in appimageTools.wrapType2 {
   ] ++ appimageTools.defaultFhsEnvArgs.multiPkgs args;
 
   extraInstallCommands = ''
+    # Add desktop convencience stuff
     mv $out/bin/{${name},${pname}}
     install -Dm444 ${appimageContents}/flexoptix-app.desktop -t $out/share/applications
     install -Dm444 ${appimageContents}/flexoptix-app.png -t $out/share/pixmaps
     substituteInPlace $out/share/applications/flexoptix-app.desktop \
-      --replace 'Exec=AppRun' "Exec=$out/bin/${pname}"
+      --replace 'Exec=AppRun' "Exec=$out/bin/${pname} --"
+
+    # Add udev rules
     mkdir -p $out/lib/udev/rules.d
     ln -s ${udevRules} $out/lib/udev/rules.d/99-tprogrammer.rules
   '';


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This update is required because the autoupdater prevents the app from
running without being updated (which is not possible because it is a
store path).
So this updates the app and patches out the updater (essentially it
never thinks it needs to update, even though it prints on the command
line that it should).

Also fix the desktop item.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
