### PR TITLE
fstar: 0.9.6.0 -> 2021.07.31

### DIFF
--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -1,36 +1,66 @@
 { lib, stdenv, fetchFromGitHub, z3, ocamlPackages, makeWrapper, installShellFiles }:
 
+let
+  # FStar requires sedlex < 2.4
+  # see https://github.com/FStarLang/FStar/issues/2343
+  sedlex-2_3 = ocamlPackages.sedlex_2.overrideAttrs (_: rec {
+    pname = "sedlex";
+    version = "2.3";
+    src = fetchFromGitHub {
+       owner = "ocaml-community";
+       repo = "sedlex";
+       rev = "v${version}";
+       sha256 = "WXUXUuIaBUrFPQOKtZ7dgDZYdpEVnoJck0dkrCi8g0c=";
+    };
+  });
+in
+
 stdenv.mkDerivation rec {
   pname = "fstar";
-  version = "0.9.6.0";
+  version = "2021.07.31";
 
   src = fetchFromGitHub {
     owner = "FStarLang";
     repo = "FStar";
     rev = "v${version}";
-    sha256 = "0wix7l229afkn6c6sk4nwkfq0nznsiqdkds4ixi2yyf72immwmmb";
+    sha256 = "KZTmphpt8nYpOd8EReAZ6iIkS4uY3ZziKQ3A70BL/90=";
   };
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
-  buildInputs = with ocamlPackages; [
-    z3 ocaml findlib batteries menhir menhirLib stdint
-    zarith camlp4 yojson pprint
-    ulex ocaml-migrate-parsetree process ppx_deriving ppx_deriving_yojson ocamlbuild
-  ];
+  buildInputs = [
+    z3
+  ] ++ (with ocamlPackages; [
+    ocaml
+    findlib
+    ocamlbuild
+    batteries
+    zarith
+    stdint
+    yojson
+    fileutils
+    menhir
+    menhirLib
+    pprint
+    sedlex-2_3
+    ppxlib
+    ppx_deriving
+    ppx_deriving_yojson
+    process
+  ]);
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  preBuild = ''
-    patchShebangs src/tools
-    patchShebangs bin
+  buildFlags = [ "libs" ];
+
+  postPatch = ''
+    patchShebangs ulib/gen_mllib.sh
+    substituteInPlace src/ocaml-output/Makefile --replace '$(COMMIT)' 'v${version}'
   '';
-  buildFlags = [ "-C" "src/ocaml-output" ];
 
   preInstall = ''
     mkdir -p $out/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib/fstarlib
   '';
-  installFlags = [ "-C" "src/ocaml-output" ];
   postInstall = ''
     wrapProgram $out/bin/fstar.exe --prefix PATH ":" "${z3}/bin"
     installShellCompletion --bash .completion/bash/fstar.exe.bash

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11501,9 +11501,7 @@ with pkgs;
 
   fsharp = callPackage ../development/compilers/fsharp { };
 
-  fstar = callPackage ../development/compilers/fstar {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_07;
-  };
+  fstar = callPackage ../development/compilers/fstar { };
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
 


### PR DESCRIPTION
###### Motivation for this change

FStar is outdated (>3 years behind the official repository).

Closes #131542

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
