### PR TITLE
nixos/airsonic: make path to war file and jre configurable

### DIFF
--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -82,6 +82,25 @@ in {
         '';
       };
 
+      jre = mkOption {
+        type = types.package;
+        default = pkgs.jre8;
+        defaultText = "pkgs.jre8";
+        description = ''
+          jre package to use.
+
+          Airsonic only supports Java 8, airsonic-advanced requires at least
+          Java 11.
+        '';
+      };
+
+      war = mkOption {
+        type = types.path;
+        default = "${pkgs.airsonic}/webapps/airsonic.war";
+        defaultText = "\${pkgs.airsonic}/webapps/airsonic.war";
+        description = "Airsonic war file to use.";
+      };
+
       jvmOptions = mkOption {
         description = ''
           Extra command line options for the JVM running AirSonic.
@@ -118,7 +137,7 @@ in {
       '';
       serviceConfig = {
         ExecStart = ''
-          ${pkgs.jre8}/bin/java -Xmx${toString cfg.maxMemory}m \
+          ${cfg.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
           -Dairsonic.home=${cfg.home} \
           -Dserver.address=${cfg.listenAddress} \
           -Dserver.port=${toString cfg.port} \
@@ -128,7 +147,7 @@ in {
             "-Dserver.use-forward-headers=true"} \
           ${toString cfg.jvmOptions} \
           -verbose:gc \
-          -jar ${pkgs.airsonic}/webapps/airsonic.war
+          -jar ${cfg.war}
         '';
         Restart = "always";
         User = "airsonic";

--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -85,9 +85,9 @@ in {
       jre = mkOption {
         type = types.package;
         default = pkgs.jre8;
-        defaultText = "pkgs.jre8";
+        defaultText = literalExample "pkgs.jre8";
         description = ''
-          jre package to use.
+          JRE package to use.
 
           Airsonic only supports Java 8, airsonic-advanced requires at least
           Java 11.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[airsonic](https://github.com/airsonic/airsonic) has stopped development. This should make the transition to [airsonic-advanced](https://github.com/airsonic-advanced/airsonic-advanced/) easier.

###### Things done

Added configuration options:
- services.airsonic.jre
- services.airsonic.war

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
