### PR TITLE
fossil: 2.15.1 -> 2.16

### DIFF
--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -2,11 +2,10 @@
 , installShellFiles
 , tcl
 , libiconv
-, fetchurl
+, fetchzip
 , zlib
 , openssl
 , readline
-, sqlite
 , ed
 , which
 , tcllib
@@ -15,25 +14,24 @@
 
 stdenv.mkDerivation rec {
   pname = "fossil";
-  version = "2.15.1";
+  version = "2.16";
 
-  src = fetchurl {
-    url = "https://www.fossil-scm.org/index.html/uv/fossil-src-${version}.tar.gz";
-    name = "${pname}-${version}.tar.gz";
-    sha256 = "sha256-gNJ5I8ZjsqLHEPiujNVJhi4E+MBChXBidMNK48jKF9E=";
+  src = fetchzip {
+    url = "https://fossil-scm.org/home/tarball/version-${version}/fossil-${version}.tar.gz";
+    sha256 = "0jxnc3zkza3mc40sb6q0f8bfl2wpxhcmdgr5kv56sbryf8xn2dhr";
+    name = "${pname}-${version}-src";
   };
 
   nativeBuildInputs = [ installShellFiles tcl tcllib ];
 
-  buildInputs = [ zlib openssl readline sqlite which ed ]
+  buildInputs = [ zlib openssl readline which ed ]
     ++ lib.optional stdenv.isDarwin libiconv;
 
   enableParallelBuilding = true;
 
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
-  configureFlags = [ "--disable-internal-sqlite" ]
-    ++ lib.optional withJson "--json";
+  configureFlags = lib.optional withJson "--json";
 
   preBuild = ''
     export USER=nonexistent-but-specified-user


### PR DESCRIPTION
fixes: CVE-2021-36377
fixes: #132117

Update source url to match upstream.

Use fetchzip instead of fetchurl to protect against potential changes
in the src sha256; upstream now generates the src tar.gz dynamically.

Update to use embedded version of sqlite, as fossil 2.16 requires a
deserialize feature missing in current nixpkgs master. Using the
embedded sqlite fixes this issue now and should prevent future
recurrence.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Security fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
