### PR TITLE
WIP: bluespec: unstable-2021.03.29 -> 2021.07

### DIFF
--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -1,66 +1,30 @@
-{ lib, stdenv
-, fetchFromGitHub
-, fetchpatch
-, autoconf
-, automake
-, fontconfig
-, gmp-static
-, gperf
-, libX11
-, libpoly
-, perl
-, flex
-, bison
-, pkg-config
-, itktcl
-, incrtcl
-, tcl
-, tk
-, verilog
-, xorg
-, yices
-, zlib
-, ghc
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoconf, automake, fontconfig
+, gmp-static, gperf, libX11, libpoly, perl, flex, bison, pkg-config, itktcl
+, incrtcl, tcl, tk, verilog, xorg, yices, zlib, ghc, asciidoctor, tex # docs
+, dejagnu, gnum4, time, tcsh # check
+, longTests ? false # WIP
 }:
 
 let
-  ghcWithPackages = ghc.withPackages (g: (with g; [old-time regex-compat syb split ]));
+  ghcWithPackages =
+    ghc.withPackages (g: (with g; [ old-time regex-compat syb split ]));
+
 in stdenv.mkDerivation rec {
   pname = "bluespec";
-  version = "unstable-2021.03.29";
+  version = "2021.07";
 
   src = fetchFromGitHub {
-      owner  = "B-Lang-org";
-      repo   = "bsc";
-      rev    = "00185f7960bd1bd5554a1167be9f37e1f18ac454";
-      sha256 = "1bcdhql4cla137d8xr8m2h21dyxv0jpjpalpr5mgj2jxqfsmkbrn";
-    };
+    owner = "B-Lang-org";
+    repo = "bsc";
+    rev = version;
+    sha256 = "0gw8wyp65lpkyfhv3laazz9qypdl8qkp1j7cqp0gv11592a9p5qw";
+  };
 
   enableParallelBuilding = true;
 
+  outputs = [ "out" "doc" ];
+
   patches = [ ./libstp_stub_makefile.patch ];
-
-  buildInputs = yices.buildInputs ++ [
-    zlib
-    tcl tk
-    libX11 # tcltk
-    xorg.libXft
-    fontconfig
-  ];
-
-  nativeBuildInputs = [
-    automake autoconf
-    perl
-    flex
-    bison
-    pkg-config
-    ghcWithPackages
-  ];
-
-  checkInputs = [
-    verilog
-  ];
-
 
   postUnpack = ''
     mkdir -p $sourceRoot/src/vendor/yices/v2.6/yices2
@@ -70,34 +34,90 @@ in stdenv.mkDerivation rec {
   '';
 
   preBuild = ''
+    # XXX: remove
+    set -x
+
     patchShebangs \
       src/Verilog/copy_module.pl \
       src/comp/update-build-version.sh \
       src/comp/update-build-system.sh \
-      src/comp/wrapper.sh
+      src/comp/wrapper.sh \
+
+    # patchShebangs doesn't catch these. 
+    substituteInPlace \
+        testsuite/findfailures.csh \
+        --replace '/bin/tcsh' "${tcsh}/bin/tcsh" \
+        --replace '/bin/csh' "${tcsh}/bin/tcsh"
+
+    substituteInPlace \
+        testsuite/test_list.sh \
+        --replace '/bin/tcsh' "${tcsh}/bin/tcsh" \
+        --replace '/bin/csh' "${tcsh}/bin/tcsh"
 
     substituteInPlace src/comp/Makefile \
       --replace 'BINDDIR' 'BINDIR' \
       --replace 'install-bsc install-bluetcl' 'install-bsc install-bluetcl $(UTILEXES) install-utils'
+
     # allow running bsc to bootstrap
     export LD_LIBRARY_PATH=/build/source/inst/lib/SAT
   '';
 
+  buildInputs = yices.buildInputs ++ [
+    fontconfig
+    libX11 # tcltk
+    tcl
+    tk
+    xorg.libXft
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    automake
+    autoconf
+    asciidoctor
+    bison
+    flex
+    ghcWithPackages
+    perl
+    pkg-config
+    tcsh
+    tex
+  ];
+
   makeFlags = [
+    "release"
     "NO_DEPS_CHECKS=1" # skip the subrepo check (this deriviation uses yices.src instead of the subrepo)
     "NOGIT=1" # https://github.com/B-Lang-org/bsc/issues/12
     "LDCONFIG=ldconfig" # https://github.com/B-Lang-org/bsc/pull/43
     "STP_STUB=1"
   ];
 
-  installPhase = "mv inst $out";
-
   doCheck = true;
+
+  checkInputs = [ dejagnu gnum4 verilog perl time ];
+
+  checkTarget = if longTests then "check-suite" else "check-smoke";
+
+  checkFlags = [
+    "SYSTEMCTEST=0" # no SystemC support yet. Patches welcome!
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    mv inst/bin $out
+    mv inst/lib $out
+
+    # fragile, I know.. 
+    mkdir -p $doc/share/doc/bsc
+    mv inst/README $doc/share/doc/bsc 
+    mv inst/ReleaseNotes.* $doc/share/doc/bsc
+    mv inst/doc/*.pdf $doc/share/doc/bsc
+  '';
 
   meta = {
     description = "Toolchain for the Bluespec Hardware Definition Language";
-    homepage    = "https://github.com/B-Lang-org/bsc";
-    license     = lib.licenses.bsd3;
+    homepage = "https://github.com/B-Lang-org/bsc";
+    license = lib.licenses.bsd3;
     platforms = [ "x86_64-linux" ];
     # darwin fails at https://github.com/B-Lang-org/bsc/pull/35#issuecomment-583731562
     # aarch64 fails, as GHC fails with "ghc: could not execute: opt"

--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
       src/Verilog/copy_module.pl \
       src/comp/update-build-version.sh \
       src/comp/update-build-system.sh \
-      src/comp/wrapper.sh 
+      src/comp/wrapper.sh
 
     substituteInPlace src/comp/Makefile \
       --replace 'BINDDIR' 'BINDIR' \

--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -94,7 +94,7 @@ in stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  checkInputs = [ 
+  checkInputs = [
     gmp-static
     verilog
   ];

--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -1,11 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoconf, automake, fontconfig
-, gmp-static, gperf, libX11, libpoly, perl, flex, bison, pkg-config, itktcl
-, incrtcl, tcl, tk, verilog, xorg, yices, zlib, ghc, asciidoctor, tex # docs
-}:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, fontconfig
+, libX11
+, perl
+, flex
+, bison
+, pkg-config
+, tcl
+, tk
+, xorg
+, yices
+, zlib
+, ghc
+, gmp-static
+, verilog
+, asciidoctor
+, tex }:
 
 let
-  ghcWithPackages =
-    ghc.withPackages (g: (with g; [ old-time regex-compat syb split ]));
+  ghcWithPackages = ghc.withPackages (g: (with g; [ old-time regex-compat syb split ]));
 
 in stdenv.mkDerivation rec {
   pname = "bluespec";
@@ -74,6 +90,13 @@ in stdenv.mkDerivation rec {
     "NOGIT=1" # https://github.com/B-Lang-org/bsc/issues/12
     "LDCONFIG=ldconfig" # https://github.com/B-Lang-org/bsc/pull/43
     "STP_STUB=1"
+  ];
+
+  doCheck = true;
+
+  checkInputs = [ 
+    gmp-static
+    verilog
   ];
 
   checkTarget = "check-smoke";

--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
       src/comp/update-build-system.sh \
       src/comp/wrapper.sh \
 
-    # patchShebangs doesn't catch these. 
+    # patchShebangs doesn't catch these.
     substituteInPlace \
         testsuite/findfailures.csh \
         --replace '/bin/tcsh' "${tcsh}/bin/tcsh" \
@@ -107,9 +107,9 @@ in stdenv.mkDerivation rec {
     mv inst/bin $out
     mv inst/lib $out
 
-    # fragile, I know.. 
+    # fragile, I know..
     mkdir -p $doc/share/doc/bsc
-    mv inst/README $doc/share/doc/bsc 
+    mv inst/README $doc/share/doc/bsc
     mv inst/ReleaseNotes.* $doc/share/doc/bsc
     mv inst/doc/*.pdf $doc/share/doc/bsc
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10794,6 +10794,7 @@ with pkgs;
 
   bluespec = callPackage ../development/compilers/bluespec {
     gmp-static = gmp.override { withStatic = true; };
+    tex = texlive.combined.scheme-full;
   };
 
   cakelisp = callPackage ../development/compilers/cakelisp { };


### PR DESCRIPTION
###### Motivation for this change

There is finally a bsc release! Let's use it. 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Things todo

This isn't quite done yet -- the [testsuite](https://github.com/B-Lang-org/bsc-testsuite) got merged into this repo, and I haven't quite got it working yet -- `longTests` is still WIP, but the smoke tests still work. 