### PR TITLE
uxn: init at 2021-08-26-c6c31aa

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5012,6 +5012,12 @@
     githubId = 705123;
     name = "Jan Tojnar";
   };
+  jtrees = {
+    email = "me@jtrees.io";
+    github = "jtrees";
+    githubId = 5802758;
+    name = "Joshua Trees";
+  };
   juaningan = {
     email = "juaningan@gmail.com";
     github = "juaningan";

--- a/pkgs/misc/uxn/default.nix
+++ b/pkgs/misc/uxn/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     description = "An assembler and emulator for the Uxn stack-machine";
     homepage = "https://wiki.xxiivv.com/site/uxn.html";
     licence = licenses.mit;
+    maintainers = [ maintainers.jtrees ];
   };
 }

--- a/pkgs/misc/uxn/default.nix
+++ b/pkgs/misc/uxn/default.nix
@@ -1,0 +1,49 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  pname = "uxn";
+  version = "2021-08-26-c6c31aa";
+
+  src = fetchFromSourcehut {
+    owner = "~rabbits";
+    repo = pname;
+    rev = "c6c31aa81546ac2348efd4031e3130ca22e9d9a0";
+    sha256 = "0r3qpx4cwbd9plp4y0yk14ys3impm31d47sa93d4n7vr4j7p7aim";
+  };
+
+  buildInputs = [ SDL2 ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    CFLAGS="-std=c89 -Wall -Wno-unknown-pragmas -DNDEBUG -Os -g0 -s"
+    UXNEMU_LDFLAGS="$(sdl2-config --cflags --libs)"
+
+    mkdir bin
+    cc $CFLAGS src/uxnasm.c -o bin/uxnasm
+    cc $CFLAGS src/uxn-fast.c src/devices/ppu.c src/devices/apu.c src/uxnemu.c $UXNEMU_LDFLAGS -o bin/uxnemu
+    cc $CFLAGS src/uxn-fast.c src/uxncli.c -o bin/uxncli
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+
+    cp ./bin/uxnemu "$out/bin/"
+    cp ./bin/uxnasm "$out/bin/"
+    cp ./bin/uxncli "$out/bin/"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An assembler and emulator for the Uxn stack-machine";
+    homepage = "https://wiki.xxiivv.com/site/uxn.html";
+    licence = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31141,6 +31141,8 @@ in
 
   unixcw = callPackage ../applications/radio/unixcw { };
 
+  uxn = callPackage ../misc/uxn { };
+
   vault = callPackage ../tools/security/vault { };
 
   vault-bin = callPackage ../tools/security/vault/vault-bin.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding uxn.

Closes #134541.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).