### PR TITLE
purescript: 0.14.3 -> 0.14.4

### DIFF
--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -18,19 +18,19 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "purescript";
-  version = "0.14.3";
+  version = "0.14.4";
 
   src =
     if stdenv.isDarwin
     then
     fetchurl {
       url = "https://github.com/${pname}/${pname}/releases/download/v${version}/macos.tar.gz";
-      sha256 = "1ipksp6kx3h030xf1y3y30gazrdz893pklanwak27hbqfy3ckssj";
+      sha256 = "0m6zwb5f890d025zpn006qr8cky6zhjycap5az9zh6h47jfbrcf9";
     }
     else
     fetchurl {
       url = "https://github.com/${pname}/${pname}/releases/download/v${version}/linux64.tar.gz";
-      sha256 = "158jyjpfgd84gbwpxqj41mvpy0fmb1d1iqq2h42sc7041v2f38p0";
+      sha256 = "0hgsh6l52z873b2zk3llvqik18ifika48lmr71qyhlqf250ng9m0";
     };
 
 

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -20,6 +20,7 @@ in stdenv.mkDerivation rec {
   pname = "purescript";
   version = "0.14.4";
 
+  # These hashes can be updated automatically by running the ./update.sh script.
   src =
     if stdenv.isDarwin
     then
@@ -51,8 +52,11 @@ in stdenv.mkDerivation rec {
     $PURS --bash-completion-script $PURS > $out/share/bash-completion/completions/purs-completion.bash
   '';
 
-  passthru.tests = {
-    minimal-module = pkgs.callPackage ./test-minimal-module {};
+  passthru = {
+    updateScript = ./update.sh;
+    tests = {
+      minimal-module = pkgs.callPackage ./test-minimal-module {};
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/compilers/purescript/purescript/update.sh
+++ b/pkgs/development/compilers/purescript/purescript/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq -I nixpkgs=.
+#!nix-shell -i bash -p curl gnused jq -I nixpkgs=.
 #
 # This script will update the purescript derivation to the latest version.
 

--- a/pkgs/development/compilers/purescript/purescript/update.sh
+++ b/pkgs/development/compilers/purescript/purescript/update.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq -I nixpkgs=.
+#
+# This script will update the purescript derivation to the latest version.
+
+set -eo pipefail
+
+# This is the directory of this update.sh script.
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+purescript_derivation_file="${script_dir}/default.nix"
+
+# This is the current revision of PureScript in Nixpkgs.
+old_version="$(sed -En 's/.*\bversion = "(.*?)".*/\1/p' "$purescript_derivation_file")"
+
+# This is the latest release version of PureScript on GitHub.
+new_version=$(curl --silent "https://api.github.com/repos/purescript/purescript/releases" | jq '.[0].tag_name' --raw-output | sed -e 's/v//')
+
+echo "Updating purescript from old version v${old_version} to new version v${new_version}."
+echo
+
+echo "Fetching both old and new release tarballs for Darwin and Linux in order to confirm hashes."
+echo
+old_linux_version_hash="$(nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v${old_version}/linux64.tar.gz")"
+echo "v${old_version} linux tarball hash (current version): $old_linux_version_hash"
+new_linux_version_hash="$(nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v${new_version}/linux64.tar.gz")"
+echo "v${new_version} linux tarball hash: $new_linux_version_hash"
+old_darwin_version_hash="$(nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v${old_version}/macos.tar.gz")"
+echo "v${old_version} darwin tarball hash (current version): $old_darwin_version_hash"
+new_darwin_version_hash="$(nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v${new_version}/macos.tar.gz")"
+echo "v${new_version} darwin tarball hash: $new_darwin_version_hash"
+echo
+
+echo "Replacing version and hashes in ${purescript_derivation_file}."
+sed -i -e "s/${old_linux_version_hash}/${new_linux_version_hash}/" "$purescript_derivation_file"
+sed -i -e "s/${old_darwin_version_hash}/${new_darwin_version_hash}/" "$purescript_derivation_file"
+sed -i -e "s/${old_version}/${new_version}/" "$purescript_derivation_file"
+echo
+
+echo "Finished.  Make sure you run the following commands to confirm PureScript builds correctly:"
+echo ' - `nix build -L -f ./. purescript`'
+echo ' - `nix build -L -f ./. purescript.passthru.tests.minimal-module`'
+echo ' - `sudo nix build -L -f ./. spago.passthru.tests --option sandbox relaxed`'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bumps PureScript from 0.14.3 to 0.14.4: https://github.com/purescript/purescript/releases/tag/v0.14.4

I've also added an `updateScript` to make these updates easier in the future.  This should hopefully also cause the ryantm bot to do some of these updates if I ever forget.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
