### PR TITLE
vector: 0.15.2 -> 0.16.1

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -53,7 +53,16 @@ rustPlatform.buildRustPackage rec {
   # dev dependency includes httpmock which depends on iashc which depends on curl-sys with http2 feature enabled
   # compilation fails because of a missing http2 include
   doCheck = !stdenv.isDarwin;
-  checkPhase = "TZDIR=${tzdata}/share/zoneinfo cargo test --no-default-features --features ${lib.concatStringsSep "," features} -- --test-threads 1";
+  # healthcheck_grafana_cloud is trying to make a network access
+  # test_stream_errors is flaky on linux-aarch64
+  checkPhase = ''
+    TZDIR=${tzdata}/share/zoneinfo cargo test \
+      --no-default-features \
+      --features ${lib.concatStringsSep "," features} \
+      -- --test-threads 1 \
+      --skip=sinks::loki::tests::healthcheck_grafana_cloud \
+      --skip=kubernetes::api_watcher::tests::test_stream_errors
+  '';
 
   # recent overhauls of DNS support in 0.9 mean that we try to resolve
   # vector.dev during the checkPhase, which obviously isn't going to work.

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -28,16 +28,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "vector";
-  version = "0.15.2";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "timberio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-u/KHiny9o/q74dh/w3cShAb6oEkMxNaTMF2lOFx+1po=";
+    sha256 = "sha256-xLlVM4K5yDur2jhrninZL6foFWq935u6mZXUbtQofsE=";
   };
 
-  cargoSha256 = "sha256-wUNF+810Yh4hPQzraWo2mDi8KSmRKp9Z9D+4kwKQ+IU=";
+  cargoSha256 = "sha256-mIUmYDSPCIvuZDK/5HHH3mf5Yc8D5wnhGUvgsuXrAFQ=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]
     ++ lib.optionals stdenv.isDarwin [ Security libiconv coreutils CoreServices ];

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -28,16 +28,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "vector";
-  version = "0.16.0";
+  version = "0.16.1";
 
   src = fetchFromGitHub {
     owner = "timberio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-xLlVM4K5yDur2jhrninZL6foFWq935u6mZXUbtQofsE=";
+    sha256 = "sha256-10e0cWt6XW8msNR/RXbaOpdwTAlRLm6jVvDed905rho=";
   };
 
-  cargoSha256 = "sha256-mIUmYDSPCIvuZDK/5HHH3mf5Yc8D5wnhGUvgsuXrAFQ=";
+  cargoSha256 = "sha256-ezQ/tX/uKzJprLQt2xIUZwGuUOmuRmTO+gPsf3MLEv8=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]
     ++ lib.optionals stdenv.isDarwin [ Security libiconv coreutils CoreServices ];


### PR DESCRIPTION
###### Motivation for this change

upstream update. 
There are basically still no release notes so you have to read through this diff
https://github.com/timberio/vector/commit/9e4174dbcd98988cb9419362cbdc82d514b012fd

The things to notice
- wasm transform is deprecated in this release (in case someone is using it)
- They have a new version for vector source and sink (opt in in this release)

the update was pretty smooth, that's a good sign in my opinion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
