### PR TITLE
python3Packages.anybadge: init at 1.7.0

### DIFF
--- a/pkgs/development/python-modules/anybadge/default.nix
+++ b/pkgs/development/python-modules/anybadge/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, buildPythonPackage, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "anybadge";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "jongracecox";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1d02fnig04zlrhfqqcf4505vy4p51whl2ifilnx3mkhis9lcwrmr";
+  };
+
+  # setup.py reads its version from the TRAVIS_TAG environment variable
+  TRAVIS_TAG = "v${version}";
+
+  pythonImportsCheck = [ "anybadge" ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "A Python project for generating badges for your projects, with a focus on simplicity and flexibility";
+    license = licenses.mit;
+    homepage = "https://github.com/jongracecox/anybadge";
+    maintainers = [ maintainers.fabiangd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13170,6 +13170,8 @@ with pkgs;
 
   ameba = callPackage ../development/tools/ameba { };
 
+  anybadge = with python3Packages; toPythonApplication anybadge;
+
   augeas = callPackage ../tools/system/augeas { };
 
   inherit (callPackage ../tools/admin/ansible { })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -477,6 +477,8 @@ in {
 
   anyascii = callPackage ../development/python-modules/anyascii { };
 
+  anybadge = callPackage ../development/python-modules/anybadge { };
+
   anyio = callPackage ../development/python-modules/anyio { };
 
   anyjson = callPackage ../development/python-modules/anyjson { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Addition of `anybadge` as a Python package and Python application. This tool is neat in the context of custom CI/CD where you want to generate a badge based on the results of i.e. lint or coverage runs.    

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
