### PR TITLE
weechatScripts.edit: init at 1.0.2

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -3,6 +3,8 @@
 {
   colorize_nicks = callPackage ./colorize_nicks { };
 
+  edit = callPackage ./edit { };
+
   multiline = callPackage ./multiline {
     inherit (perlPackages) PodParser;
   };

--- a/pkgs/applications/networking/irc/weechat/scripts/edit/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/edit/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, weechat }:
+
+stdenv.mkDerivation {
+  pname = "edit-weechat";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "keith";
+    repo = "edit-weechat";
+    rev = "1.0.2";
+    sha256 = "1s42r0l0xkhlp6rbc23cm4vlda91il6cg53w33hqfhd2wz91s66w";
+  };
+
+  dontBuild = true;
+
+  passthru.scripts = [ "edit.py" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D edit.py $out/share/edit.py
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit (weechat.meta) platforms;
+    description = "This simple weechat plugin allows you to compose messages in your $EDITOR.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ eraserhd ];
+  };
+}

--- a/pkgs/applications/networking/irc/weechat/scripts/edit/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/edit/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, weechat }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "edit-weechat";
   version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "keith";
     repo = "edit-weechat";
-    rev = "1.0.2";
+    rev = version;
     sha256 = "1s42r0l0xkhlp6rbc23cm4vlda91il6cg53w33hqfhd2wz91s66w";
   };
 


### PR DESCRIPTION
###### Motivation for this change

New package

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
