### PR TITLE
minder: 1.11.3 -> 1.13.1

### DIFF
--- a/pkgs/applications/misc/minder/default.nix
+++ b/pkgs/applications/misc/minder/default.nix
@@ -1,24 +1,62 @@
-{ lib, stdenv, fetchFromGitHub
-, pkg-config, meson, ninja, python3
-, wrapGAppsHook, vala, shared-mime-info
-, cairo, pantheon, glib, gtk3, libxml2, libgee, libarchive
-, discount, gtksourceview3
+{ lib
+, stdenv
+, fetchFromGitHub
+, desktop-file-utils
+, meson
+, ninja
+, pkg-config
+, python3
+, shared-mime-info
+, vala
+, wrapGAppsHook
+, cairo
+, discount
+, glib
+, gtk3
+, gtksourceview4
 , hicolor-icon-theme # for setup-hook
+, libarchive
+, libgee
+, libhandy
+, libxml2
+, pantheon
 }:
 
 stdenv.mkDerivation rec {
   pname = "minder";
-  version = "1.11.3";
+  version = "1.13.1";
 
   src = fetchFromGitHub {
     owner = "phase1geo";
     repo = pname;
     rev = version;
-    sha256 = "137kyf82n5a2v0cm9q02rhv8rmbjgnj60h64prq90h0d42prj3gd";
+    sha256 = "07mq595c1vxwsnwkr2zdci0r06yhs75ph2db09mc63k5fjvi8rya";
   };
 
-  nativeBuildInputs = [ pkg-config meson ninja python3 wrapGAppsHook vala shared-mime-info ];
-  buildInputs = [ cairo pantheon.granite glib gtk3 libxml2 libgee libarchive hicolor-icon-theme discount gtksourceview3 ];
+  nativeBuildInputs = [
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    python3
+    shared-mime-info
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    cairo
+    discount
+    glib
+    gtk3
+    gtksourceview4
+    hicolor-icon-theme
+    libarchive
+    libgee
+    libhandy
+    libxml2
+    pantheon.granite
+  ];
 
   postPatch = ''
     chmod +x meson/post_install.py
@@ -32,11 +70,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Mind-mapping application for Elementary OS";
+    description = "Mind-mapping application for elementary OS";
     homepage = "https://github.com/phase1geo/Minder";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ dtzWill ];
+    maintainers = with maintainers; [ dtzWill ] ++ teams.pantheon.members;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

- https://github.com/phase1geo/Minder/releases/tag/1.13.1
- https://github.com/phase1geo/Minder/compare/1.11.3...1.13.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
