### PR TITLE
cisco-packet-tracer: init at 7.3.1 and 8.0.1

### DIFF
--- a/pkgs/applications/networking/cisco-packet-tracer/7.nix
+++ b/pkgs/applications/networking/cisco-packet-tracer/7.nix
@@ -1,0 +1,90 @@
+{ stdenv
+, lib
+, buildFHSUserEnvBubblewrap
+, callPackage
+, copyDesktopItems
+, dpkg
+, lndir
+, makeDesktopItem
+, makeWrapper
+, requireFile
+}:
+
+let
+  version = "7.3.1";
+
+  ptFiles = stdenv.mkDerivation {
+    name = "PacketTracer7drv";
+    inherit version;
+
+    dontUnpack = true;
+    src = requireFile {
+      name = "PacketTracer_${builtins.replaceStrings ["."] [""] version}_amd64.deb";
+      sha256 = "c39802d15dd61d00ba27fb8c116da45fd8562ab4b49996555ad66b88deace27f";
+      url = "https://www.netacad.com";
+    };
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+
+    installPhase = ''
+      dpkg-deb -x $src $out
+      makeWrapper "$out/opt/pt/bin/PacketTracer7" "$out/bin/packettracer7" \
+          --prefix LD_LIBRARY_PATH : "$out/opt/pt/bin"
+    '';
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "cisco-pt7.desktop";
+    desktopName = "Cisco Packet Tracer 7";
+    icon = "${ptFiles}/opt/pt/art/app.png";
+    exec = "packettracer7 %f";
+    mimeType = "application/x-pkt;application/x-pka;application/x-pkz;";
+  };
+
+  fhs = buildFHSUserEnvBubblewrap {
+    name = "packettracer7";
+    runScript = "${ptFiles}/bin/packettracer7";
+
+    targetPkgs = pkgs: with pkgs; [
+      alsa-lib
+      dbus
+      expat
+      fontconfig
+      glib
+      libglvnd
+      libpulseaudio
+      libudev0-shim
+      libxkbcommon
+      libxml2
+      libxslt
+      nspr
+      nss
+      xorg.libICE
+      xorg.libSM
+      xorg.libX11
+      xorg.libXScrnSaver
+    ];
+  };
+in stdenv.mkDerivation {
+  pname = "ciscoPacketTracer7";
+  inherit version;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir $out
+    ${lndir}/bin/lndir -silent ${fhs} $out
+  '';
+
+  desktopItems = [ desktopItem ];
+
+  nativeBuildInputs = [ copyDesktopItems ];
+
+  meta = with lib; {
+    description = "Network simulation tool from Cisco";
+    homepage = "https://www.netacad.com/courses/packet-tracer";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ lucasew ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/cisco-packet-tracer/8.nix
+++ b/pkgs/applications/networking/cisco-packet-tracer/8.nix
@@ -1,0 +1,131 @@
+{ stdenv
+, lib
+, alsa-lib
+, autoPatchelfHook
+, buildFHSUserEnvBubblewrap
+, callPackage
+, copyDesktopItems
+, dbus
+, dpkg
+, expat
+, fontconfig
+, glib
+, libdrm
+, libglvnd
+, libpulseaudio
+, libudev0-shim
+, libxkbcommon
+, libxml2
+, libxslt
+, lndir
+, makeDesktopItem
+, makeWrapper
+, nspr
+, nss
+, requireFile
+, xorg
+}:
+
+let
+  version = "8.0.1";
+
+  ptFiles = stdenv.mkDerivation {
+    name = "PacketTracer8Drv";
+    inherit version;
+
+    dontUnpack = true;
+    src = requireFile {
+      name = "CiscoPacketTracer_${builtins.replaceStrings ["."] [""] version}_Ubuntu_64bit.deb";
+      sha256 = "77a25351b016faed7c78959819c16c7013caa89c6b1872cb888cd96edd259140";
+      url = "https://www.netacad.com";
+    };
+
+    nativeBuildInputs = [
+      alsa-lib
+      autoPatchelfHook
+      dbus
+      dpkg
+      expat
+      fontconfig
+      glib
+      libdrm
+      libglvnd
+      libpulseaudio
+      libudev0-shim
+      libxkbcommon
+      libxml2
+      libxslt
+      makeWrapper
+      nspr
+      nss
+    ] ++ (with xorg; [
+      libICE
+      libSM
+      libX11
+      libxcb
+      libXcomposite
+      libXcursor
+      libXdamage
+      libXext
+      libXfixes
+      libXi
+      libXrandr
+      libXrender
+      libXScrnSaver
+      xcbutilimage
+      xcbutilkeysyms
+      xcbutilrenderutil
+      xcbutilwm
+    ]);
+
+    installPhase = ''
+      dpkg-deb -x $src $out
+      chmod 755 "$out"
+      makeWrapper "$out/opt/pt/bin/PacketTracer" "$out/bin/packettracer" \
+        --prefix LD_LIBRARY_PATH : "$out/opt/pt/bin"
+
+      # Keep source archive cached, to avoid re-downloading
+      ln -s $src $out/usr/share/
+    '';
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "cisco-pt8.desktop";
+    desktopName = "Cisco Packet Tracer 8";
+    icon = "${ptFiles}/opt/pt/art/app.png";
+    exec = "packettracer8 %f";
+    mimeType = "application/x-pkt;application/x-pka;application/x-pkz;";
+  };
+
+  fhs = buildFHSUserEnvBubblewrap {
+    name = "packettracer8";
+    runScript = "${ptFiles}/bin/packettracer";
+    targetPkgs = pkgs: [ libudev0-shim ];
+
+    extraInstallCommands = ''
+      mkdir -p "$out/share/applications"
+      cp "${desktopItem}"/share/applications/* "$out/share/applications/"
+    '';
+  };
+in stdenv.mkDerivation {
+  pname = "ciscoPacketTracer8";
+  inherit version;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir $out
+    ${lndir}/bin/lndir -silent ${fhs} $out
+  '';
+
+  desktopItems = [ desktopItem ];
+  nativeBuildInputs = [ copyDesktopItems ];
+
+  meta = with lib; {
+    description = "Network simulation tool from Cisco";
+    homepage = "https://www.netacad.com/courses/packet-tracer";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ lucasew ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24078,6 +24078,10 @@ with pkgs;
 
   clapper = callPackage ../applications/video/clapper { };
 
+  ciscoPacketTracer7 = callPackage ../applications/networking/cisco-packet-tracer/7.nix { };
+
+  ciscoPacketTracer8 = callPackage ../applications/networking/cisco-packet-tracer/8.nix { };
+
   claws-mail-gtk2 = callPackage ../applications/networking/mailreaders/claws-mail {
     inherit (xorg) libSM;
     useGtk3 = false;


### PR DESCRIPTION
This PR is ready for merge

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
People need Cisco Packet Tracer for uni assignments. I've added both 7.x and 8.x versions because both are incompatible and the 8.x cause some problems to people that can require everyone working on the 7.x version.

###### Things done
- Added cisco-packet-tracer7 at 7.3.1
- Added cisco-packet-tracer8 at 8.0.1
- Credits to people that sent code to start from in gists on nixpkgs issues, in special @buckley310 that posted his Cisco 8 code that I stolen to adapt for my needs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
