### PR TITLE
coqPackages.serapi: patch to fix COQPATH issue

### DIFF
--- a/pkgs/development/coq-modules/serapi/8.10.0+0.7.2.patch
+++ b/pkgs/development/coq-modules/serapi/8.10.0+0.7.2.patch
@@ -1,0 +1,34 @@
+diff --git a/serapi/serapi_paths.ml b/serapi/serapi_paths.ml
+index 17cbb98..1fd85a0 100644
+--- a/serapi/serapi_paths.ml
++++ b/serapi/serapi_paths.ml
+@@ -23,10 +23,10 @@
+ let coq_loadpath_default ~implicit ~coq_path =
+   let open Mltop in
+   let mk_path prefix = coq_path ^ "/" ^ prefix in
+-  let mk_lp ~ml ~root ~dir ~implicit =
++  let mk_lp ~ml ~root ~dir ~implicit ~absolute =
+     { recursive = true;
+       path_spec = VoPath {
+-          unix_path = mk_path dir;
++          unix_path = if absolute then dir else mk_path dir;
+           coq_path  = root;
+           has_ml    = ml;
+           implicit;
+@@ -35,10 +35,12 @@ let coq_loadpath_default ~implicit ~coq_path =
+   (* in 8.8 we can use Libnames.default_* *)
+   let coq_root     = Names.DirPath.make [Libnames.coq_root] in
+   let default_root = Libnames.default_root_prefix in
+-  [mk_lp ~ml:AddRecML ~root:coq_root     ~implicit       ~dir:"plugins";
+-   mk_lp ~ml:AddNoML  ~root:coq_root     ~implicit       ~dir:"theories";
+-   mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir:"user-contrib";
+-  ]
++  [mk_lp ~ml:AddRecML ~root:coq_root     ~implicit       ~dir:"plugins" ~absolute:false;
++   mk_lp ~ml:AddNoML  ~root:coq_root     ~implicit       ~dir:"theories" ~absolute:false;
++   mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir:"user-contrib" ~absolute:false;
++  ] @
++  List.map (fun dir -> mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir ~absolute:true)
++    Envars.coqpath
+ 
+ (******************************************************************************)
+ (* Generate a module name given a file                                        *)

--- a/pkgs/development/coq-modules/serapi/8.11.0+0.11.1.patch
+++ b/pkgs/development/coq-modules/serapi/8.11.0+0.11.1.patch
@@ -1,0 +1,33 @@
+diff --git a/serapi/serapi_paths.ml b/serapi/serapi_paths.ml
+index a9c5074..eed92e3 100644
+--- a/serapi/serapi_paths.ml
++++ b/serapi/serapi_paths.ml
+@@ -23,10 +23,10 @@
+ let coq_loadpath_default ~implicit ~coq_path =
+   let open Loadpath in
+   let mk_path prefix = coq_path ^ "/" ^ prefix in
+-  let mk_lp ~ml ~root ~dir ~implicit =
++  let mk_lp ~ml ~root ~dir ~implicit ~absolute =
+     { recursive = true;
+       path_spec = VoPath {
+-          unix_path = mk_path dir;
++          unix_path = if absolute then dir else mk_path dir;
+           coq_path  = root;
+           has_ml    = ml;
+           implicit;
+@@ -35,11 +35,11 @@ let coq_loadpath_default ~implicit ~coq_path =
+   (* in 8.8 we can use Libnames.default_* *)
+   let coq_root     = Names.DirPath.make [Libnames.coq_root] in
+   let default_root = Libnames.default_root_prefix in
+-  [mk_lp ~ml:AddRecML ~root:coq_root     ~implicit       ~dir:"plugins";
+-   mk_lp ~ml:AddNoML  ~root:coq_root     ~implicit       ~dir:"theories";
+-   mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir:"user-contrib";
++  [mk_lp ~ml:AddRecML ~root:coq_root     ~implicit       ~dir:"plugins" ~absolute:false;
++   mk_lp ~ml:AddNoML  ~root:coq_root     ~implicit       ~dir:"theories" ~absolute:false;
++   mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir:"user-contrib" ~absolute:false;
+   ] @
+-  List.map (fun dir -> mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir)
++  List.map (fun dir -> mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir ~absolute:true)
+     Envars.coqpath
+ 
+ (******************************************************************************)

--- a/pkgs/development/coq-modules/serapi/8.12.0+0.12.1.patch
+++ b/pkgs/development/coq-modules/serapi/8.12.0+0.12.1.patch
@@ -1,0 +1,29 @@
+diff --git a/serapi/serapi_paths.ml b/serapi/serapi_paths.ml
+index b71fa60..0bec8c2 100644
+--- a/serapi/serapi_paths.ml
++++ b/serapi/serapi_paths.ml
+@@ -24,8 +24,8 @@ let coq_loadpath_default ~implicit ~coq_path =
+   let open Loadpath in
+   let mk_path prefix = coq_path ^ "/" ^ prefix in
+   (* let mk_ml = () in *)
+-  let mk_vo ~has_ml ~coq_path ~dir ~implicit =
+-    { unix_path = mk_path dir
++  let mk_vo ~has_ml ~coq_path ~dir ~implicit ~absolute =
++    { unix_path = if absolute then dir else mk_path dir
+     ; coq_path
+     ; has_ml
+     ; recursive = true
+@@ -40,10 +40,10 @@ let coq_loadpath_default ~implicit ~coq_path =
+     List.map fst plugins_dirs
+   in
+   ml_paths ,
+-  [ mk_vo ~has_ml:false ~coq_path:coq_root     ~implicit       ~dir:"theories"
+-  ; mk_vo ~has_ml:true  ~coq_path:default_root ~implicit:false ~dir:"user-contrib";
++  [ mk_vo ~has_ml:false ~coq_path:coq_root     ~implicit       ~dir:"theories" ~absolute:false
++  ; mk_vo ~has_ml:true  ~coq_path:default_root ~implicit:false ~dir:"user-contrib" ~absolute:false;
+   ] @
+-  List.map (fun dir -> mk_vo ~has_ml:true ~coq_path:default_root ~implicit:false ~dir)
++  List.map (fun dir -> mk_vo ~has_ml:true ~coq_path:default_root ~implicit:false ~dir ~absolute:true)
+     Envars.coqpath
+ 
+ (******************************************************************************)

--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -75,4 +75,19 @@ in
         }.tbz";
     sha256 = release."${version}".sha256;
   };
+
+  patches =
+    if version == "8.10.0+0.7.2"
+    then [
+      ./8.10.0+0.7.2.patch
+    ]
+    else if version == "8.11.0+0.11.1"
+    then [
+      ./8.11.0+0.11.1.patch
+    ]
+    else if version == "8.12.0+0.12.1" || version == "8.13.0+0.13.0"
+    then [
+      ./8.12.0+0.12.1.patch
+    ]
+    else [];
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
SerAPI was interpreting paths as relative to the Coq root.
The patch has been accepted by the maintainer (see https://github.com/ejgallego/coq-serapi/pull/249).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Largely tested in https://github.com/coq-community/hydra-battles.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
