### PR TITLE
nordic: unstable-2021-06-04 -> unstable-2021-08-13

### DIFF
--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -2,70 +2,70 @@
 
 stdenv.mkDerivation rec {
   pname = "nordic";
-  version = "unstable-2021-06-04";
+  version = "unstable-2021-08-13";
 
   srcs = [
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "9a98c05f4d4f6c9e701ac20b0bf5c18284ad0015";
-      sha256 = "0ghgr7fr7anm8hdq6n46xhkjxydqkr0qlk1q7mdg08j43f0yra7b";
+      rev = "937ca200e8148a61c73228030ec260abecc27fb2";
+      sha256 = "0h7z7jh5p0916i9lx4n94r6vbydafnikdi6d9p4djvpyhn5nizgy";
       name = "Nordic";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "90ce6f539735af1f231c4fa07708cef602e1c8a2";
-      sha256 = "1g6sz7ifpc8jf4iplcsmihqhjdc7yp5xygw8584n122jmh8mak47";
+      rev = "e736846a130be7907e977b16d0b3a0ab19631015";
+      sha256 = "0dv7z31zw1r3iac5bvwapf9lm99y5l0xfzaw93hn8msh10w5crx8";
       name = "Nordic-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "529cdb86b4d4474a67a56eb9377e3c7907b452db";
-      sha256 = "06li44i5wh4h06fbhvjf5cjma5czjdgnwvm79d8hg6vmi2101b0a";
+      rev = "8ff12077f28e25f4e57f055a51e5e3b9b1bf53fd";
+      sha256 = "082k0na39qb97kbvc15g3mdfh8d8ricql84i4wdjy3rjfbfwq0pl";
       name = "Nordic-darker";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "1d16f37de315c298a6c3d79a552ed6f18cbb7fb4";
-      sha256 = "0nxzygnysg4ciib337vay0qcc80hpryjnclwjwjzj51i95366k25";
+      rev = "8c422e4bfdf5680ff323938f49f411680154d3d6";
+      sha256 = "1w540zlmsxpwa455wpxy1dpgv2fjr36xwjqbyc8x4y0ya0qfify0";
       name = "Nordic-darker-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "78a30080bc50ee88c23d393049306ef1925bcdb8";
-      sha256 = "10w4815fcf3pd24ar7jp0wcdiwn3zzrdj2p6fqlgx26biz7kf3iv";
+      rev = "ce31d794fe1c6b72d3cff2e9513e08ddce014118";
+      sha256 = "09d41wllr9hgxshgvpgngx9rlg8pvx5aqgkk5q8jra4jz2a92fhq";
       name = "Nordic-bluish-accent";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "e4363da8d457e8b14f6e4340979225db92d34aa9";
-      sha256 = "1sjw2hvg4jgxqzgqhqixq216a7vv5licbc8ii1rsz88ycafsbr7j";
+      rev = "8ca4fe244c31775effacc77f0a25ae10c6bee60c";
+      sha256 = "1cby8wmaqdqpd9c40wiy7i9wmrazwfhb3h818hg0ni7yfcm2fr58";
       name = "Nordic-bluish-accent-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "a38fd7d440309573947d3e53ea3ed295cf027ce7";
-      sha256 = "1r6hz0m0y7c1d0ka1x9cd47r0jvpgkld6x3gf2b7w7yvqpmh6a44";
+      rev = "a2d1c633ac2bfe261e8f612c8af14af0311c7f67";
+      sha256 = "05llvix671i6128vbr3jiik8mipaab7bn0v9i89ydwyfhw822n7v";
       name = "Nordic-Polar";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "b86d43c48bcac57c49d891b967311fd90f6d4bcd";
-      sha256 = "0c725kf5ql42zrqk6dwk6i7wyrhr3gddipvhy6692nv0dszqm0ml";
+      rev = "62a1702a17e7ea96e9b692832d68a0a7f26aabb6";
+      sha256 = "0r1qn1rj322b44h15hcfbx79hhmb1m4pkv2fpdsn3s2klcxwr1ql";
       name = "Nordic-Polar-standard-buttons";
     })
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to unstable-2021-08-13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
