### PR TITLE
lens: 4.2.4 -> 5.1.3

### DIFF
--- a/pkgs/applications/networking/cluster/lens/default.nix
+++ b/pkgs/applications/networking/cluster/lens/default.nix
@@ -2,12 +2,13 @@
 
 let
   pname = "lens";
-  version = "4.2.4";
+  version = "5.1.3";
+  build = "${version}-latest.20210722.1";
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "https://github.com/lensapp/lens/releases/download/v${version}/Lens-${version}.x86_64.AppImage";
-    sha256 = "0fzhv8brwwl1ihx6jqq4pi77489hr6f9hpppqq3n8d2imjsqgvlw";
+    url = "https://api.k8slens.dev/binaries/Lens-${build}.x86_64.AppImage";
+    sha256 = "1iwwyqpn1x1m8n22f99snlhcbcr65i4przx697hlbpmnm40dw7q9";
     name="${pname}.AppImage";
   };
 
@@ -22,12 +23,12 @@ in appimageTools.wrapType2 {
     ''
       mv $out/bin/${name} $out/bin/${pname}
 
-      install -m 444 -D ${appimageContents}/kontena-lens.desktop $out/share/applications/${pname}.desktop
-      install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/kontena-lens.png \
-        $out/share/icons/hicolor/512x512/apps/${pname}.png
+      install -m 444 -D ${appimageContents}/lens.desktop $out/share/applications/${pname}.desktop
+      install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/lens.png \
+         $out/share/icons/hicolor/512x512/apps/${pname}.png
 
       substituteInPlace $out/share/applications/${pname}.desktop \
-        --replace 'Icon=kontena-lens' 'Icon=${pname}' \
+        --replace 'Icon=lens' 'Icon=${pname}' \
         --replace 'Exec=AppRun' 'Exec=${pname}'
     '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Version bump.
- Lens does no longer ships its AppImages via GitHub. The new URL also contains some more detailed build tag, indicating a date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
