### PR TITLE
python39Packages.*: various cleanups

### DIFF
--- a/pkgs/development/python-modules/aioprocessing/default.nix
+++ b/pkgs/development/python-modules/aioprocessing/default.nix
@@ -1,13 +1,13 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pythonAtLeast
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aioprocessing";
   version = "1.1.0";
-  disabled = !(pythonAtLeast "3.4");
+  disabled = pythonOlder "3.4";
 
   src = fetchPypi {
     inherit pname version;
@@ -16,6 +16,8 @@ buildPythonPackage rec {
 
   # Tests aren't included in pypi package
   doCheck = false;
+
+  pythonImportsCheck = [ "aioprocessing" ];
 
   meta = {
     description = "A library that integrates the multiprocessing module with asyncio";

--- a/pkgs/development/python-modules/inform/default.nix
+++ b/pkgs/development/python-modules/inform/default.nix
@@ -2,8 +2,6 @@
 , arrow
 , six
 , hypothesis
-, pytest
-, pytest-runner
 , pytestCheckHook
 }:
 
@@ -18,13 +16,18 @@ buildPythonPackage rec {
     sha256 = "114cyff00j9r7qm2ld4w1a4kklr5gx570vk67p56gpr2553dkmly";
   };
 
-  nativeBuildInputs = [ pytest-runner ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest-runner>=2.0" ""
+  '';
+
   propagatedBuildInputs = [ arrow six ];
 
-  checkInputs = [ pytest hypothesis ];
-  checkPhase = ''
+  checkInputs = [ pytestCheckHook hypothesis ];
+  preCheck = ''
     patchShebangs test.doctests.py test.inform.py
-    ./test.doctests.py && ./test.inform.py && pytest
+    ./test.doctests.py
+    ./test.inform.py
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/jupyter-repo2docker/default.nix
+++ b/pkgs/development/python-modules/jupyter-repo2docker/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonAtLeast
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
 , docker
 , escapism
 , jinja2
@@ -14,7 +14,7 @@
 buildPythonPackage rec {
   version = "2021.3.0";
   pname = "jupyter-repo2docker";
-  disabled = !(pythonAtLeast "3.4");
+  disabled = pythonOlder "3.4";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
