### PR TITLE
lib/trivial: Optimize pipe, showWarnings and toHexString

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -58,9 +58,7 @@ rec {
      of the next function, and the last function returns the
      final value.
   */
-  pipe = val: functions:
-    let reverseApply = x: f: f x;
-    in builtins.foldl' reverseApply val functions;
+  pipe = builtins.foldl' (x: f: f x);
   /* note please don’t add a function like `compose = flip pipe`.
      This would confuse users, because the order of the functions
      in the list is not clear. With pipe, it’s obvious that it
@@ -308,7 +306,7 @@ rec {
 
   info = msg: builtins.trace "INFO: ${msg}";
 
-  showWarnings = warnings: res: lib.foldr (w: x: warn w x) res warnings;
+  showWarnings = warnings: res: builtins.foldl' warn res warnings;
 
   ## Function annotations
 
@@ -355,21 +353,8 @@ rec {
      toHexString 250 => "FA"
   */
   toHexString = i:
-    let
-      toHexDigit = d:
-        if d < 10
-        then toString d
-        else
-          {
-            "10" = "A";
-            "11" = "B";
-            "12" = "C";
-            "13" = "D";
-            "14" = "E";
-            "15" = "F";
-          }.${toString d};
-    in
-      lib.concatMapStrings toHexDigit (toBaseDigits 16 i);
+    lib.concatMapStrings
+      (builtins.elemAt [ "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "A" "B" "C" "D" "E" "F" ]) (toBaseDigits 16 i);
 
   /* `toBaseDigits base i` converts the positive integer i to a list of its
      digits in the given base. For example:


### PR DESCRIPTION
- pipe: Reduce arguments of pipe away as it is applied in order
  to builtins.foldl'. Inline definition of reverseApply as
  it forces a thunk allocation without any benefits.
- showWarnings: Use builtins.foldl' instead of foldr as builtins.trace
  already enforce strictness. This should be optimal even
  though two extra envs are allocated to flip arguments
  for warn, as builtins.foldl' is iterative underneath.
- toHexString: Index elements in a preallocated lookup table
  as opposed to indexing an attribute set. Attribute identifiers
  can not be raw numbers, so toString must be used which harm performance
  as a single character string must be allocated for each element in
  the base digits array. elemAt avoids the conversion from int to
  string.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is a small step in improving evaluation performance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
