### PR TITLE
[staging] elfutils: 0.182 -> 0.185, cleanup

### DIFF
--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, autoreconfHook, musl-fts
-, musl-obstack, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, musl-fts
+, musl-obstack, m4, zlib, zstd, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs
 , argp-standalone
 , enableDebuginfod ? false, sqlite, curl, libmicrohttpd_0_9_70, libarchive
 }:
@@ -7,11 +7,11 @@
 # TODO: Look at the hardcoded paths to kernel, modules etc.
 stdenv.mkDerivation rec {
   pname = "elfutils";
-  version = "0.182";
+  version = "0.185";
 
   src = fetchurl {
     url = "https://sourceware.org/elfutils/ftp/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "7MQGkU7fM18Lf8CE6+bEYMTW1Rdb/dZojBx42RRriFg=";
+    sha256 = "sha256-3I0+dKsglGXn9Wjhs7uaWhQvhlbitX0QBJpz2irmtaY=";
   };
 
   patches = [
@@ -28,42 +28,28 @@ stdenv.mkDerivation rec {
       sha256 = "8D1wPcdgAkE/TNBOgsHaeTZYhd9l+9TrZg8d5C7kG6k=";
     })
     (fetchpatch {
-      name = "musl-fts-obstack.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-fts-obstack.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
-      sha256 = "3lbC0UtscTIJgT7kOXnnjWrpPAVt2PYMbW+uJK6K350=";
-    })
-    (fetchpatch {
       name = "musl-macros.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-macros.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
       sha256 = "tp6O1TRsTAMsFe8vw3LMENT/vAu6OmyA8+pzgThHeA8=";
-    })
-    (fetchpatch {
-      name = "musl-qsort_r.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-qsort_r.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
-      sha256 = "FPWCkdtFT3zw8aNnz0Jz5Vmu8B/mRfNgfhbM/ej7d8M=";
-    })
-    (fetchpatch {
-      name = "musl-strerror_r.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-strerror_r.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
-      sha256 = "QF6YwWkcT12dZHKzfqFgxy/1fkIllo0AAosbV0sM5PU=";
     })
     (fetchpatch {
       name = "musl-strndupa.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-strndupa.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
       sha256 = "sha256-7daehJj1t0wPtQzTv+/Rpuqqs5Ng/EYnZzrcf2o/Lb0=";
     })
-  ] ++ lib.optional stdenv.hostPlatform.isMusl [ ./musl-error_h.patch ];
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [ ./musl-error_h.patch ];
+
+  postPatch = ''
+    patchShebangs tests/*.sh
+  '';
 
   outputs = [ "bin" "dev" "out" "man" ];
-
-  hardeningDisable = [ "format" ];
 
   # We need bzip2 in NativeInputs because otherwise we can't unpack the src,
   # as the host-bzip2 will be in the path.
   nativeBuildInputs = [ m4 bison flex gettext bzip2 ]
-    ++ lib.optional stdenv.hostPlatform.isMusl autoreconfHook
-    ++ lib.optional (enableDebuginfod || stdenv.hostPlatform.isMusl) pkg-config;
-  buildInputs = [ zlib bzip2 xz ]
+    ++ lib.optional enableDebuginfod pkg-config;
+  buildInputs = [ zlib zstd bzip2 xz ]
     ++ lib.optionals stdenv.hostPlatform.isMusl [
     argp-standalone
     musl-fts
@@ -77,22 +63,24 @@ stdenv.mkDerivation rec {
 
   propagatedNativeBuildInputs = [ setupDebugInfoDirs ];
 
-  preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
-    NIX_CFLAGS_COMPILE+=" -Wno-null-dereference"
-  '';
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.hostPlatform.isMusl [
+    "-Wno-null-dereference"
+  ];
 
   configureFlags = [
     "--program-prefix=eu-" # prevent collisions with binutils
     "--enable-deterministic-archives"
-  ] ++ lib.optionals (!enableDebuginfod) [
-    "--disable-libdebuginfod"
-    "--disable-debuginfod"
+    (lib.enableFeature enableDebuginfod "libdebuginfod")
+    (lib.enableFeature enableDebuginfod "debuginfod")
   ];
 
   enableParallelBuilding = true;
 
-  doCheck = false; # fails 3 out of 174 tests
-  doInstallCheck = false; # fails 70 out of 174 tests
+  # Backtrace unwinding tests rely on glibc-internal symbol names.
+  # Musl provides slightly different forms and fails.
+  # Let's disable tests there until musl support is fully upstreamed.
+  doCheck = !stdenv.hostPlatform.isMusl;
+  doInstallCheck = !stdenv.hostPlatform.isMusl;
 
   meta = with lib; {
     homepage = "https://sourceware.org/elfutils/";
@@ -101,6 +89,6 @@ stdenv.mkDerivation rec {
     # licenses are GPL2 or LGPL3+ for libraries, GPL3+ for bins,
     # but since this package isn't split that way, all three are listed.
     license = with licenses; [ gpl2Only lgpl3Plus gpl3Plus ];
-    maintainers = [ maintainers.eelco ];
+    maintainers = with maintainers; [ eelco r-burns ];
   };
 }


### PR DESCRIPTION
Remove obsolete musl patches & musl-specific autoreconfHook
(same as https://git.alpinelinux.org/aports/commit/main/elfutils?id=a8779348058ef0f42d31c814d2792ccdc8062007)

cc @baloo for debuginfod testing against #112455 (still builds, but you might want to check it still works as well)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
