### PR TITLE
ocamlPackages.ocsigen-toolkit: 2.7.0 → 2.12.2

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -5,26 +5,26 @@
 stdenv.mkDerivation rec {
  pname = "ocsigen-toolkit";
  name = "ocaml${ocaml.version}-${pname}-${version}";
- version = "2.7.0";
+ version = "2.12.2";
 
  propagatedBuildInputs = [ calendar js_of_ocaml-ppx_deriving_json eliom ];
  buildInputs = [ ocaml findlib opaline ];
 
- installPhase =
-  ''
+ installPhase = ''
+    runHook preInstall
+    mkdir -p $OCAMLFIND_DESTDIR
     export OCAMLPATH=$out/lib/ocaml/${ocaml.version}/site-lib/:$OCAMLPATH
     make install
     opaline -prefix $out
+    runHook postInstall
   '';
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = pname;
     rev = version;
-    sha256 = "0jan5779nc0jf993hmvfii15ralcs20sm4mcnqwqrnhjbq6f6zpk";
+    sha256 = "1fqrh7wrzs76qj3nvmxqy76pzqvsja2dwzqxyl8rkh5jg676vmqy";
   };
-
-  createFindlibDestdir = true;
 
   meta = {
     homepage = "http://ocsigen.org/ocsigen-toolkit/";


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
