### PR TITLE
epmd: add ipv6 assert

### DIFF
--- a/nixos/modules/services/networking/epmd.nix
+++ b/nixos/modules/services/networking/epmd.nix
@@ -4,9 +4,7 @@ with lib;
 
 let
   cfg = config.services.epmd;
-
 in
-
 {
   ###### interface
   options.services.epmd = {
@@ -27,16 +25,31 @@ in
         an Erlang runtime that is already installed for other purposes.
       '';
     };
+    listenStream = mkOption
+      {
+        type = types.str;
+        default = null;
+        description = ''
+          the listenStream used by the systemd socket.
+          see https://www.freedesktop.org/software/systemd/man/systemd.socket.html#ListenStream= for more informations.
+          use this to change the port epmd will run on.
+          if not defined, epmd will use "[::]:4369"
+        '';
+      };
   };
 
   ###### implementation
   config = mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.listenStream == null -> config.networking.enableIPv6;
+      message = "epmd listens by default on ipv6, enable ipv6 or change config.services.epmd.listenStream";
+    }];
     systemd.sockets.epmd = rec {
       description = "Erlang Port Mapper Daemon Activation Socket";
       wantedBy = [ "sockets.target" ];
       before = wantedBy;
       socketConfig = {
-        ListenStream = "4369";
+        ListenStream = if cfg.listenStream != null then cfg.listenStream else "[::]:4369";
         Accept = "false";
       };
     };


### PR DESCRIPTION
###### Motivation for this change

epmd listens by default on ipv6, this adds an assert that ipv6 is enabled on the machine.
In case ipv6 is not enabled, this adds another option where you can define the listenStream (systemd's way of defining the ip and port to listen on).

I still have one question. epmd is started with the `-systemd` flag. 
I couldn't find any mention of that flag in the docs https://erlang.org/doc/man/epmd.html
I wonder if this has been removed. The logs don't say anything. If it was removed, there would have been a deprecation notice ? If anybody knows, it might be nice to add a comment on that execStart line.
@dlesl perhaps you know ? (no worries if you are busy)

Please note, that if you enable the epmd service after you have an elixir or erlang app running, the activation will fail. Every erlang or elixir release will attempt to start epmd if it doesn't find it. So if you want to enable epmd.
- check if it is already running `ps -fe | grep epmd`
- kill it if it is `sudo pkill epmd`
- then you can do a `nixos-rebuild switch ...`

Some context. I ran into this while doing some tests for rabbitmq which enables the epmd service. Using epmd in a separate service makes sense (since any erlang/elixir application will rely on it). However the problem is that ideally you need to disable starting epmd in each of the application. It's usually not straightforward. For elixir apps, you need to add a `vm.args` with `-start_epmd false`. Needless to say, there will probably be some conflicts if people have an already running elixir/application and later on they decide to enable rabbitmq.

@NixOS/beam could be interesting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
