### PR TITLE
prometheus-junos-exporter: init at 0.9.10

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -36,6 +36,7 @@ let
     "influxdb"
     "json"
     "jitsi"
+    "junos"
     "kea"
     "keylight"
     "knot"

--- a/nixos/modules/services/monitoring/prometheus/exporters/junos.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/junos.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, options }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.junos;
+  configFile = pkgs.writeText "junos-exporter.yaml" (builtins.toJSON {
+    devices = cfg.devices;
+    features = {} // (
+      lib.genAttrs cfg.enabledFeatures (x: true) //
+      lib.genAttrs cfg.disabledFeatures (x: false)
+    );
+  });
+in
+{
+  port = 9326;
+  extraOpts = {
+    devices = mkOption {
+      type = types.listOf types.attrs;
+      default = [ ];
+      example = literalExample ''
+        [
+          {
+            host = "router1";
+            username = "user";
+            password = "password";
+          }
+        ]
+      '';
+      description = ''
+        List of JunOS devices
+
+        Check the official documentation for the corresponding YAML
+        settings that can all be used here: <link xlink:href="https://github.com/czerwonk/junos_exporter#config-file" />
+      '';
+    };
+
+    enabledFeatures = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "environment" "bgp" ];
+      description = ''
+        Features to enable. The features listed here are enabled in addition to the default ones.
+      '';
+    };
+
+    disabledFeatures = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "environment" "bgp" ];
+      description = ''
+        Features to disable. The features listed here are disabled in addition to the default ones.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      DynamicUser = false;
+      RuntimeDirectory = "prometheus-junos-exporter";
+      ExecStart = ''
+        ${pkgs.prometheus-junos-exporter}/bin/junos_exporter \
+          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+          --config.file ${configFile} ${concatStringsSep " " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/servers/monitoring/prometheus/junos-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/junos-exporter.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub, net-snmp, nixosTests }:
+
+buildGoModule rec {
+  pname = "junos_exporter";
+  version = "0.9.10";
+
+  src = fetchFromGitHub {
+    owner = "czerwonk";
+    repo = "junos_exporter";
+    rev = version;
+    sha256 = "0yi8yxwgcc129yi29w6mq03yri2n3aa5fcg578ly2krnqs55x624";
+  };
+
+  vendorSha256 = "082cj25jfrkjihs76i1zdbfyb2096ihkdasw04w5008ab51j9016";
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Exporter for metrics from devices running JunOS (via SSH)";
+    homepage = "https://github.com/czerwonk/junos_exporter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ arezvov ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20393,6 +20393,7 @@ with pkgs;
   prometheus-jitsi-exporter = callPackage ../servers/monitoring/prometheus/jitsi-exporter.nix { };
   prometheus-jmx-httpserver = callPackage ../servers/monitoring/prometheus/jmx-httpserver.nix {  };
   prometheus-json-exporter = callPackage ../servers/monitoring/prometheus/json-exporter.nix { };
+  prometheus-junos-exporter = callPackage ../servers/monitoring/prometheus/junos-exporter.nix { };
   prometheus-kea-exporter = callPackage ../servers/monitoring/prometheus/kea-exporter.nix { };
   prometheus-keylight-exporter = callPackage ../servers/monitoring/prometheus/keylight-exporter.nix { };
   prometheus-knot-exporter = callPackage ../servers/monitoring/prometheus/knot-exporter.nix { };


### PR DESCRIPTION
What about tests... I can't add tests because I need some JunOS device for gathering metrics. 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
