### PR TITLE
D compiler update

### DIFF
--- a/pkgs/applications/science/biology/sambamba/default.nix
+++ b/pkgs/applications/science/biology/sambamba/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   pname = "sambamba";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "biod";
     repo = "sambamba";
     rev = "v${version}";
-    sha256 = "sha256:0kx5a0fmvv9ldz2hnh7qavgf7711kqc73zxf51k4cca4hr58zxr9";
+    sha256 = "0f4qngnys2zjb0ri54k6kxqnssg938mnnscs4z9713hjn41rk7yd";
     fetchSubmodules = true;
   };
 
   patches = [
-    # Fixes hardcoded gcc, making clang build possible.
+    # make ldc 1.27.1 compatible
     (fetchpatch {
-      url = "https://github.com/biod/sambamba/commit/c50a1c91e1ba062635467f197139bf6784e9be15.patch";
-      sha256 = "1y0vlybmb9wpg4z1nca7m96mk9hxmvd3yrg7w8rxscj45hcqvf8q";
+      url = "https://github.com/biod/sambamba/pull/480/commits/b5c80feb62683d24ec0529f685a1d7a36962a1d4.patch";
+      sha256 = "0yr9baxqbhyb4scwcwczk77z8gazhkl60jllhz9dnrb7p5qsvs7r";
     })
   ];
 

--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -1,26 +1,25 @@
 { stdenv, lib, fetchFromGitHub
 , makeWrapper, unzip, which, writeTextFile
-, curl, tzdata, gdb, darwin, git, callPackage
+, curl, tzdata, gdb, Foundation, git, callPackage
 , targetPackages, fetchpatch, bash
-, dmdBootstrap ? callPackage ./bootstrap.nix { }
-, HOST_DMD ? "${dmdBootstrap}/bin/dmd"
-, version ? "2.095.1"
-, dmdSha256 ? "sha256:0faca1y42a1h16aml4lb7z118mh9k9fjx3xlw3ki5f1h3ln91xhk"
-, druntimeSha256 ? "sha256:0ad4pa5llr9m9wqbvfv4yrcra4zz9qxlh5kx43mrv48f9bcxm2ha"
-, phobosSha256 ? "sha256:04w6jw4izix2vbw62j13wvz6q3pi7vivxnmxqj0g8904j5g0cxjl"
+, HOST_DMD? "${callPackage ./bootstrap.nix { }}/bin/dmd"
+, version? "2.097.2"
+, dmdSha256? "16ldkk32y7ln82n7g2ym5d1xf3vly3i31hf8600cpvimf6yhr6kb"
+, druntimeSha256? "1sayg6ia85jln8g28vb4m124c27lgbkd6xzg9gblss8ardb8dsp1"
+, phobosSha256? "0czg13h65b6qwhk9ibya21z3iv3fpk3rsjr3zbcrpc2spqjknfw5"
 }:
 
 let
-
   dmdConfFile = writeTextFile {
-      name = "dmd.conf";
-      text = (lib.generators.toINI {} {
-        Environment = {
-          DFLAGS = ''-I@out@/include/dmd -L-L@out@/lib -fPIC ${lib.optionalString (!targetPackages.stdenv.cc.isClang) "-L--export-dynamic"}'';
-        };
-      });
+    name = "dmd.conf";
+    text = (lib.generators.toINI {} {
+      Environment = {
+        DFLAGS = ''-I@out@/include/dmd -L-L@out@/lib -fPIC ${lib.optionalString (!targetPackages.stdenv.cc.isClang) "-L--export-dynamic"}'';
+      };
+    });
   };
 
+  bits = builtins.toString stdenv.hostPlatform.parsed.cpu.bits;
 in
 
 stdenv.mkDerivation rec {
@@ -30,27 +29,27 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   srcs = [
-  (fetchFromGitHub {
-    owner = "dlang";
-    repo = "dmd";
-    rev = "v${version}";
-    sha256 = dmdSha256;
-    name = "dmd";
-  })
-  (fetchFromGitHub {
-    owner = "dlang";
-    repo = "druntime";
-    rev = "v${version}";
-    sha256 = druntimeSha256;
-    name = "druntime";
-  })
-  (fetchFromGitHub {
-    owner = "dlang";
-    repo = "phobos";
-    rev = "v${version}";
-    sha256 = phobosSha256;
-    name = "phobos";
-  })
+    (fetchFromGitHub {
+      owner = "dlang";
+      repo = "dmd";
+      rev = "v${version}";
+      sha256 = dmdSha256;
+      name = "dmd";
+    })
+    (fetchFromGitHub {
+      owner = "dlang";
+      repo = "druntime";
+      rev = "v${version}";
+      sha256 = druntimeSha256;
+      name = "druntime";
+    })
+    (fetchFromGitHub {
+      owner = "dlang";
+      repo = "phobos";
+      rev = "v${version}";
+      sha256 = phobosSha256;
+      name = "phobos";
+    })
   ];
 
   sourceRoot = ".";
@@ -58,60 +57,72 @@ stdenv.mkDerivation rec {
   # https://issues.dlang.org/show_bug.cgi?id=19553
   hardeningDisable = [ "fortify" ];
 
-  postUnpack = ''
-      patchShebangs .
+  # Not using patches option to make it easy to patch, for example, dmd and
+  # Phobos at same time if that's required
+  patchPhase =
+  lib.optionalString (builtins.compareVersions version "2.092.1" <= 0) ''
+    patch -p1 -F3 --directory=druntime -i ${(fetchpatch {
+      url = "https://github.com/dlang/druntime/commit/438990def7e377ca1f87b6d28246673bb38022ab.patch";
+      sha256 = "0nxzkrd1rzj44l83j7jj90yz2cv01na8vn9d116ijnm85jl007b4";
+    })}
+
+  '' + postPatch;
+
+  postPatch =
+  ''
+    patchShebangs .
+
+  '' + lib.optionalString (version == "2.092.1") ''
+    rm dmd/test/dshell/test6952.d
+  '' + lib.optionalString (builtins.compareVersions "2.092.1" version < 0) ''
+    substituteInPlace dmd/test/dshell/test6952.d --replace "/usr/bin/env bash" "${bash}/bin/bash"
+
+  '' + ''
+    rm dmd/test/runnable/gdb1.d
+    rm dmd/test/runnable/gdb10311.d
+    rm dmd/test/runnable/gdb14225.d
+    rm dmd/test/runnable/gdb14276.d
+    rm dmd/test/runnable/gdb14313.d
+    rm dmd/test/runnable/gdb14330.d
+    rm dmd/test/runnable/gdb15729.sh
+    rm dmd/test/runnable/gdb4149.d
+    rm dmd/test/runnable/gdb4181.d
+
+  '' + lib.optionalString stdenv.isLinux ''
+    substituteInPlace phobos/std/socket.d --replace "assert(ih.addrList[0] == 0x7F_00_00_01);" ""
+  '' + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace phobos/std/socket.d --replace "foreach (name; names)" "names = []; foreach (name; names)"
   '';
 
-  postPatch = ''
-      substituteInPlace dmd/test/dshell/test6952.d --replace "/usr/bin/env bash" "${bash}/bin/bash"
+  nativeBuildInputs = [ makeWrapper unzip which git ];
 
-      rm dmd/test/runnable/gdb1.d
-      rm dmd/test/runnable/gdb10311.d
-      rm dmd/test/runnable/gdb14225.d
-      rm dmd/test/runnable/gdb14276.d
-      rm dmd/test/runnable/gdb14313.d
-      rm dmd/test/runnable/gdb14330.d
-      rm dmd/test/runnable/gdb15729.sh
-      rm dmd/test/runnable/gdb4149.d
-      rm dmd/test/runnable/gdb4181.d
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-      substituteInPlace phobos/std/socket.d --replace "assert(ih.addrList[0] == 0x7F_00_00_01);" ""
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace phobos/std/socket.d --replace "foreach (name; names)" "names = []; foreach (name; names)"
-  '';
+  buildInputs = [ gdb curl tzdata ]
+    ++ lib.optional stdenv.isDarwin [ Foundation gdb ];
 
-  nativeBuildInputs = [ makeWrapper unzip which gdb git ]
 
-  ++ lib.optional stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [
-    Foundation
-  ]);
-
-  buildInputs = [ curl tzdata ];
-
-  bits = builtins.toString stdenv.hostPlatform.parsed.cpu.bits;
-  osname = if stdenv.hostPlatform.isDarwin then
+  osname = if stdenv.isDarwin then
     "osx"
   else
     stdenv.hostPlatform.parsed.kernel.name;
-  top = "$(echo $NIX_BUILD_TOP)";
+  top = "$NIX_BUILD_TOP";
   pathToDmd = "${top}/dmd/generated/${osname}/release/${bits}/dmd";
 
-  # Buid and install are based on http://wiki.dlang.org/Building_DMD
+  # Build and install are based on http://wiki.dlang.org/Building_DMD
   buildPhase = ''
-      cd dmd
-      make -j$NIX_BUILD_CORES -f posix.mak INSTALL_DIR=$out BUILD=release ENABLE_RELEASE=1 PIC=1 HOST_DMD=${HOST_DMD}
-      cd ../druntime
-      make -j$NIX_BUILD_CORES -f posix.mak BUILD=release ENABLE_RELEASE=1 PIC=1 INSTALL_DIR=$out DMD=${pathToDmd}
-      cd ../phobos
-      echo ${tzdata}/share/zoneinfo/ > TZDatabaseDirFile
-      echo ${curl.out}/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} > LibcurlPathFile
-      make -j$NIX_BUILD_CORES -f posix.mak BUILD=release ENABLE_RELEASE=1 PIC=1 INSTALL_DIR=$out DMD=${pathToDmd} DFLAGS="-version=TZDatabaseDir -version=LibcurlPath -J$(pwd)"
-      cd ..
+    cd dmd
+    make -j$NIX_BUILD_CORES -f posix.mak INSTALL_DIR=$out BUILD=release ENABLE_RELEASE=1 PIC=1 HOST_DMD=${HOST_DMD}
+    cd ../druntime
+    make -j$NIX_BUILD_CORES -f posix.mak BUILD=release ENABLE_RELEASE=1 PIC=1 INSTALL_DIR=$out DMD=${pathToDmd}
+    cd ../phobos
+    echo ${tzdata}/share/zoneinfo/ > TZDatabaseDirFile
+    echo ${curl.out}/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} > LibcurlPathFile
+    make -j$NIX_BUILD_CORES -f posix.mak BUILD=release ENABLE_RELEASE=1 PIC=1 INSTALL_DIR=$out DMD=${pathToDmd} DFLAGS="-version=TZDatabaseDir -version=LibcurlPath -J$(pwd)"
+    cd ..
   '';
 
   doCheck = true;
+
+  # many tests are disbled because they are failing
 
   # NOTE: Purity check is disabled for checkPhase because it doesn't fare well
   # with the DMD linker. See https://github.com/NixOS/nixpkgs/issues/97420
@@ -132,43 +143,42 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-      cd dmd
-      mkdir $out
-      mkdir $out/bin
-      cp ${pathToDmd} $out/bin
+    cd dmd
+    mkdir $out
+    mkdir $out/bin
+    cp ${pathToDmd} $out/bin
 
-      mkdir -p $out/share/man/man1
-      mkdir -p $out/share/man/man5
-      cp -r docs/man/man1/* $out/share/man/man1/
-      cp -r docs/man/man5/* $out/share/man/man5/
+    mkdir -p $out/share/man/man1
+    mkdir -p $out/share/man/man5
+    cp -r docs/man/man1/* $out/share/man/man1/
+    cp -r docs/man/man5/* $out/share/man/man5/
 
-      cd ../druntime
-      mkdir $out/include
-      mkdir $out/include/dmd
-      cp -r import/* $out/include/dmd
+    cd ../druntime
+    mkdir $out/include
+    mkdir $out/include/dmd
+    cp -r import/* $out/include/dmd
 
-      cd ../phobos
-      mkdir $out/lib
-      cp generated/${osname}/release/${bits}/libphobos2.* $out/lib
+    cd ../phobos
+    mkdir $out/lib
+    cp generated/${osname}/release/${bits}/libphobos2.* $out/lib
 
-      cp -r std $out/include/dmd
-      cp -r etc $out/include/dmd
+    cp -r std $out/include/dmd
+    cp -r etc $out/include/dmd
 
-      wrapProgram $out/bin/dmd \
-          --prefix PATH ":" "${targetPackages.stdenv.cc}/bin" \
-          --set-default CC "${targetPackages.stdenv.cc}/bin/cc"
+    wrapProgram $out/bin/dmd \
+      --prefix PATH ":" "${targetPackages.stdenv.cc}/bin" \
+      --set-default CC "${targetPackages.stdenv.cc}/bin/cc"
 
-      substitute ${dmdConfFile} "$out/bin/dmd.conf" --subst-var out
+    substitute ${dmdConfFile} "$out/bin/dmd.conf" --subst-var out
   '';
 
   meta = with lib; {
     description = "Official reference compiler for the D language";
-    homepage = "http://dlang.org/";
+    homepage = "https://dlang.org/";
     # Everything is now Boost licensed, even the backend.
     # https://github.com/dlang/dmd/pull/6680
     license = licenses.boost;
     maintainers = with maintainers; [ ThomasMader lionello ];
     platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
-    # many tests are failing
   };
 }

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "1.25.1";
-  ldcSha256 = "sha256-DjcW/pknvpEmTR/eXEEHECb2xEJic16evaU4CJthLUA=";
+  version = "1.27.1";
+  ldcSha256 = "1775001ba6n8w46ln530kb5r66vs935ingnppgddq8wqnc0gbj4k";
 }

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -27,6 +27,11 @@ in stdenv.mkDerivation rec {
       url = "https://github.com/gtkd-developers/GtkD/commit/a9db09117ab27127ca4c3b8d2f308fae483a9199.patch";
       sha256 = "0ngyqifw1kandc1vk01kms3z65pcisfd75q7z09rml96glhfzjd6";
     })
+    # Fix breakage with dmd ldc 1.26 and newer
+    (fetchpatch {
+      url = "https://github.com/gtkd-developers/GtkD/commit/323ff96c648882eaca2faee170bd9e90c6e1e9c3.patch";
+      sha256 = "1rhyi0isl6fl5i6fgsinvgq6v72xq7c6sajrxcsnmrzpvw91il3d";
+    })
   ];
 
   prePatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4066,7 +4066,9 @@ in
 
   dleyna-server = callPackage ../development/libraries/dleyna-server { };
 
-  dmd = callPackage ../development/compilers/dmd { };
+  dmd = callPackage ../development/compilers/dmd {
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  };
 
   dmg2img = callPackage ../tools/misc/dmg2img { };
 


### PR DESCRIPTION
dmd 2.095.1 -> 2.097.2
ldc 1.25.1 -> 1.27.1

###### Motivation for this change

In #127932 I wanted to make DMD support multiple versions, but that was decided against. However, the pull request was also a regular compiler update and gathered a lot miscellaneous improvements from @SuperSandro2000 . This PR is including those, but without the multi-version scheme. I left the existing version dependencies on the build script though, because @lionello mentioned he wants the user to be able to override the versions himself.

@ThomasMader mentioned he wants DMD and LDC to be based on the same frontend, so I decided to increment LDC too,

###### Things done

Test-compiled and ran a hello world with both compilers

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).