### PR TITLE
inferno: init at 0.10.6

### DIFF
--- a/pkgs/development/tools/inferno/default.nix
+++ b/pkgs/development/tools/inferno/default.nix
@@ -1,0 +1,31 @@
+{ fetchCrate, lib, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "inferno";
+  version = "0.10.6";
+
+  # github version doesn't have a Cargo.lock
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "1pn3ask36mv8byd62xhm8bjv59k12i1s533jgb5syml64w1cnn12";
+  };
+
+  cargoSha256 = "0w5w9pyv34x0iy9knr79491kb9bgbcagh6251pq72mv4pvx0axip";
+
+  # these tests depend on a patched version of flamegraph which is included in
+  # the github repository as a submodule, but absent from the crates version
+  checkFlags = [
+    "--skip=collapse::dtrace::tests::test_collapse_multi_dtrace"
+    "--skip=collapse::dtrace::tests::test_collapse_multi_dtrace_simple"
+    "--skip=collapse::perf::tests::test_collapse_multi_perf"
+    "--skip=collapse::perf::tests::test_collapse_multi_perf_simple"
+  ];
+
+  meta = with lib; {
+    description = "A port of parts of the flamegraph toolkit to Rust";
+    homepage = "https://github.com/jonhoo/inferno";
+    changelog = "https://github.com/jonhoo/inferno/blob/v${version}/CHANGELOG.md";
+    license = licenses.cddl;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6082,6 +6082,8 @@ with pkgs;
 
   inetutils = callPackage ../tools/networking/inetutils { };
 
+  inferno = callPackage ../development/tools/inferno { };
+
   inform6 = callPackage ../development/compilers/inform6 { };
 
   inform7 = callPackage ../development/compilers/inform7 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Inferno is a port of parts of the flamegraph toolkit to Rust, with the aim of improving the performance of the original flamegraph tools

https://github.com/jonhoo/inferno

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
