### PR TITLE
merkaartor: 0.18.4 → 0.19.0

### DIFF
--- a/pkgs/applications/misc/merkaartor/default.nix
+++ b/pkgs/applications/misc/merkaartor/default.nix
@@ -2,14 +2,13 @@
 , lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , qmake
 , qttools
 , qttranslations
 , gdal
 , proj
 , qtsvg
-, qtwebkit
+, qtwebengine
 , withGeoimage ? true, exiv2
 , withGpsdlib ? (!stdenv.isDarwin), gpsd
 , withLibproxy ? false, libproxy
@@ -18,31 +17,18 @@
 
 mkDerivation rec {
   pname = "merkaartor";
-  version = "0.18.4";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";
     repo = "merkaartor";
     rev = version;
-    sha256 = "vwO4/a7YF9KbpxcFGTFCdG6SfwEyhISlEtcA+rMebUA=";
+    sha256 = "sha256-Gx+gnVbSY8JnG03kO5vVQNlSZRl/hrKTdDbh7lyIMbA=";
   };
-
-  patches = [
-    # Fix build with Qt 5.15 (missing QPainterPath include)
-    (fetchpatch {
-      url = "https://github.com/openstreetmap/merkaartor/commit/e72553a7ea2c7ba0634cc3afcd27a9f7cfef089c.patch";
-      sha256 = "NAisplnS3xHSlRpX+fH15NpbaD+uM57OCsTYGKlIR7U=";
-    })
-    # Added a condition to use the new timespec_t on gpsd APIs >= 9
-    (fetchpatch {
-      url = "https://github.com/openstreetmap/merkaartor/commit/13b358fa7899bb34e277b32a4c0d92833050f2c6.patch";
-      sha256 = "129fpjm7illz7ngx3shps5ivrxwf14apw55842xhskwwb0rf5szb";
-    })
-  ];
 
   nativeBuildInputs = [ qmake qttools ];
 
-  buildInputs = [ gdal proj qtsvg qtwebkit ]
+  buildInputs = [ gdal proj qtsvg qtwebengine ]
     ++ lib.optional withGeoimage exiv2
     ++ lib.optional withGpsdlib gpsd
     ++ lib.optional withLibproxy libproxy
@@ -52,8 +38,10 @@ mkDerivation rec {
     lrelease src/src.pro
   '';
 
-  qmakeFlags = [ "TRANSDIR_SYSTEM=${qttranslations}/translations" ]
-    ++ lib.optional withGeoimage "GEOIMAGE=1"
+  qmakeFlags = [
+    "TRANSDIR_SYSTEM=${qttranslations}/translations"
+    "USEWEBENGINE=1"
+  ] ++ lib.optional withGeoimage "GEOIMAGE=1"
     ++ lib.optional withGpsdlib "GPSDLIB=1"
     ++ lib.optional withLibproxy "LIBPROXY=1"
     ++ lib.optional withZbar "ZBAR=1";


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://github.com/openstreetmap/merkaartor/releases/tag/0.19.0)
* qtwebkit -> qtwebengine (#53079)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
