### PR TITLE
intel-gpu-tools: 1.25 -> 1.26

### DIFF
--- a/pkgs/development/tools/misc/intel-gpu-tools/default.nix
+++ b/pkgs/development/tools/misc/intel-gpu-tools/default.nix
@@ -1,37 +1,85 @@
-{ lib, stdenv, fetchurl, pkg-config, libdrm, libpciaccess, cairo, xorgproto, udev
-, libX11, libXext, libXv, libXrandr, glib, bison, libunwind, python3, kmod
-, procps, utilmacros, gtk-doc, openssl, peg, elfutils
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, libdrm
+, libpciaccess
+, cairo
+, xorgproto
+, udev
+, libX11
+, libXext
+, libXv
+, libXrandr
+, glib
+, bison
+, libunwind
+, python3
+, kmod
+, procps
+, utilmacros
+, gtk-doc
+, docbook_xsl
+, openssl
+, peg
+, elfutils
+, meson
+, ninja
+, valgrind
+, xmlrpc_c
+, gsl
+, alsa-lib
+, curl
+, json_c
+, liboping
+, flex
+, docutils
 }:
 
 stdenv.mkDerivation rec {
   pname = "intel-gpu-tools";
-  version = "1.25";
+  version = "1.26";
 
   src = fetchurl {
     url = "https://xorg.freedesktop.org/archive/individual/app/igt-gpu-tools-${version}.tar.xz";
-    sha256 = "04fx7xclhick3k7fyk9c4mn8mxzf1253j1r0hrvj9sl40j7lsia0";
+    sha256 = "1dwvxh1yplsh1a7h3gpp40g91v12cfxy6yy99s1v9yr2kwxikm1n";
   };
 
-  nativeBuildInputs = [ pkg-config utilmacros ];
-  buildInputs = [ libdrm libpciaccess cairo xorgproto udev libX11 kmod
-    libXext libXv libXrandr glib bison libunwind python3 procps
-    gtk-doc openssl peg elfutils ];
+  nativeBuildInputs = [ pkg-config utilmacros meson ninja flex bison gtk-doc docutils docbook_xsl ];
+  buildInputs = [
+    libdrm
+    libpciaccess
+    cairo
+    xorgproto
+    udev
+    libX11
+    kmod
+    libXext
+    libXv
+    libXrandr
+    glib
+    libunwind
+    python3
+    procps
+    openssl
+    peg
+    elfutils
+    valgrind
+    xmlrpc_c
+    gsl
+    alsa-lib
+    curl
+    json_c
+    liboping
+  ];
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=array-bounds" ];
 
   preConfigure = ''
-    ./autogen.sh
+    patchShebangs tests man
   '';
 
-  preBuild = ''
-    patchShebangs tests
-
-    patchShebangs debugger/system_routine/pre_cpp.py
-    substituteInPlace tools/Makefile.am --replace '$(CAIRO_CFLAGS)' '$(CAIRO_CFLAGS) $(GLIB_CFLAGS)'
-    substituteInPlace tests/Makefile.am --replace '$(CAIRO_CFLAGS)' '$(CAIRO_CFLAGS) $(GLIB_CFLAGS)'
-  '';
-
-  enableParallelBuilding = true;
+  hardeningDisable = [ "bindnow" ];
 
   meta = with lib; {
     homepage = "https://01.org/linuxgraphics/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A new version of `intel-gpu-tools` was released. The previously supported autotools-based build system was removed in favour of meson.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
