### PR TITLE
nodePackages.prisma: init at 2.30.0

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -267,6 +267,18 @@ let
       meta.mainProgram = "postcss";
     };
 
+    prisma = super.prisma.override {
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postInstall = with pkgs; ''
+        wrapProgram "$out/bin/prisma" \
+          --prefix PRISMA_MIGRATION_ENGINE_BINARY : "${prisma-engines}/bin/migration-engine" \
+          --prefix PRISMA_QUERY_ENGINE_BINARY : "${prisma-engines}/bin/query-engine" \
+          --prefix PRISMA_QUERY_ENGINE_LIBRARY : "${lib.getLib prisma-engines}/libquery_engine.so.node"
+          --prefix PRISMA_INTROSPECTION_ENGINE_BINARY : "${prisma-engines}/bin/introspection-engine" \
+          --prefix PRISMA_FMT_BINARY : "${prisma-engines}/bin/prisma-fmt"
+      '';
+    };
+
     pulp = super.pulp.override {
       # tries to install purescript
       npmFlags = "--ignore-scripts";

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -205,6 +205,7 @@
 , "postcss-cli"
 , "prettier"
 , "prettier-plugin-toml"
+, "prisma"
 , "pscid"
 , "pulp"
 , "purescript-language-server"

--- a/pkgs/development/tools/database/prisma-engines/default.nix
+++ b/pkgs/development/tools/database/prisma-engines/default.nix
@@ -1,0 +1,61 @@
+{ fetchFromGitHub
+, lib
+, openssl
+, pkg-config
+, protobuf
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "prisma-engines";
+  version = "2.30.2";
+
+  src = fetchFromGitHub {
+    owner = "prisma";
+    repo = "prisma-engines";
+    rev = version;
+    sha256 = "sha256-i4r+TRC8454awbqe35Kg3M9xN2NnP8Sbd/dITtm9MDg=";
+  };
+
+  cargoPatches = [
+    # Remove test from compilation targets:
+    # they add time to an already long compilation and some fail out-of-the-box.
+    ./no_tests.patch
+  ];
+
+  # Use system openssl.
+  OPENSSL_NO_VENDOR = 1;
+
+  cargoSha256 = "sha256-BldEj8+tzY0dIA/fdrPLsFn3ZdfoGq6GsomCUhQBoLM=";
+
+  outputs = [ "out" "lib" "bin" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl protobuf ];
+
+  preBuild = ''
+    export OPENSSL_DIR=${lib.getDev openssl}
+    export OPENSSL_LIB_DIR=${openssl.out}/lib
+
+    export PROTOC=${protobuf}/bin/protoc
+    export PROTOC_INCLUDE="${protobuf}/include";
+
+    export SQLITE_MAX_VARIABLE_NUMBER=250000
+    export SQLITE_MAX_EXPR_DEPTH=10000
+  '';
+
+  postInstall = ''
+    cp target/release/libquery_engine.so $out/lib/libquery_engine.so.node
+  '';
+
+  # Tests are long to compile
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A collection of engines that power the core stack for Prisma";
+    homepage = "https://www.prisma.io/";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/development/tools/database/prisma-engines/no_tests.patch
+++ b/pkgs/development/tools/database/prisma-engines/no_tests.patch
@@ -1,0 +1,459 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 1070c7a30..310f7302f 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -479,18 +479,6 @@ version = "1.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+ 
+-[[package]]
+-name = "bitvec"
+-version = "0.19.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+-dependencies = [
+- "funty",
+- "radium",
+- "tap",
+- "wyz",
+-]
+-
+ [[package]]
+ name = "block-buffer"
+ version = "0.7.3"
+@@ -706,19 +694,6 @@ dependencies = [
+  "wasm-bindgen",
+ ]
+ 
+-[[package]]
+-name = "console"
+-version = "0.14.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+-dependencies = [
+- "encode_unicode",
+- "lazy_static",
+- "libc",
+- "terminal_size",
+- "winapi",
+-]
+-
+ [[package]]
+ name = "const_fn"
+ version = "0.4.5"
+@@ -1011,24 +986,12 @@ dependencies = [
+  "uuid",
+ ]
+ 
+-[[package]]
+-name = "dtoa"
+-version = "0.4.8"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+-
+ [[package]]
+ name = "either"
+ version = "1.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+ 
+-[[package]]
+-name = "encode_unicode"
+-version = "0.3.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+-
+ [[package]]
+ name = "encoding"
+ version = "0.2.33"
+@@ -1114,18 +1077,6 @@ dependencies = [
+  "syn",
+ ]
+ 
+-[[package]]
+-name = "enum_dispatch"
+-version = "0.3.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8946e241a7774d5327d92749c50806f275f57d031d2229ecbfd65469a8ad338e"
+-dependencies = [
+- "once_cell",
+- "proc-macro2",
+- "quote",
+- "syn",
+-]
+-
+ [[package]]
+ name = "enumflags2"
+ version = "0.7.1"
+@@ -1261,12 +1212,6 @@ dependencies = [
+  "percent-encoding",
+ ]
+ 
+-[[package]]
+-name = "funty"
+-version = "1.1.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+-
+ [[package]]
+ name = "futures"
+ version = "0.3.13"
+@@ -1573,15 +1518,6 @@ dependencies = [
+  "winapi",
+ ]
+ 
+-[[package]]
+-name = "html-escape"
+-version = "0.2.7"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d64794b2265e97e459334ed47a7b7369ce8e8ee3d3450c0c363a0b563fc92233"
+-dependencies = [
+- "utf8-width",
+-]
+-
+ [[package]]
+ name = "http"
+ version = "0.2.3"
+@@ -1744,21 +1680,6 @@ version = "0.2.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+ 
+-[[package]]
+-name = "insta"
+-version = "1.7.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c4a1b21a2971cea49ca4613c0e9fe8225ecaf5de64090fddc6002284726e9244"
+-dependencies = [
+- "console",
+- "lazy_static",
+- "serde",
+- "serde_json",
+- "serde_yaml",
+- "similar",
+- "uuid",
+-]
+-
+ [[package]]
+ name = "instant"
+ version = "0.1.9"
+@@ -1804,34 +1725,6 @@ dependencies = [
+  "user-facing-errors",
+ ]
+ 
+-[[package]]
+-name = "introspection-engine-tests"
+-version = "0.1.0"
+-dependencies = [
+- "barrel",
+- "datamodel",
+- "datamodel-connector",
+- "enumflags2",
+- "expect-test",
+- "indoc",
+- "introspection-connector",
+- "introspection-core",
+- "migration-connector",
+- "pretty_assertions",
+- "quaint",
+- "serde_json",
+- "sql-datamodel-connector",
+- "sql-introspection-connector",
+- "sql-migration-connector",
+- "sql-schema-describer",
+- "test-macros",
+- "test-setup",
+- "tokio",
+- "tracing",
+- "tracing-futures",
+- "user-facing-errors",
+-]
+-
+ [[package]]
+ name = "ipconfig"
+ version = "0.2.2"
+@@ -2178,39 +2071,6 @@ dependencies = [
+  "user-facing-errors",
+ ]
+ 
+-[[package]]
+-name = "migration-engine-tests"
+-version = "0.1.0"
+-dependencies = [
+- "bigdecimal",
+- "chrono",
+- "connection-string",
+- "datamodel",
+- "datamodel-connector",
+- "enumflags2",
+- "expect-test",
+- "indoc",
+- "migration-connector",
+- "migration-core",
+- "once_cell",
+- "pretty_assertions",
+- "prisma-value",
+- "quaint",
+- "serde",
+- "serde_json",
+- "sql-datamodel-connector",
+- "sql-migration-connector",
+- "sql-schema-describer",
+- "tempfile",
+- "test-macros",
+- "test-setup",
+- "tokio",
+- "tracing",
+- "tracing-futures",
+- "url",
+- "user-facing-errors",
+-]
+-
+ [[package]]
+ name = "mime"
+ version = "0.3.16"
+@@ -2517,19 +2377,6 @@ dependencies = [
+  "socket2 0.4.0",
+ ]
+ 
+-[[package]]
+-name = "nom"
+-version = "6.1.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+-dependencies = [
+- "bitvec",
+- "funty",
+- "lexical-core",
+- "memchr",
+- "version_check",
+-]
+-
+ [[package]]
+ name = "ntapi"
+ version = "0.3.6"
+@@ -2773,18 +2620,6 @@ dependencies = [
+  "winapi",
+ ]
+ 
+-[[package]]
+-name = "parse-hyperlinks"
+-version = "0.19.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9dfd153802fdbad158c1dfa2c5df806a86955ae6e07758af642a4faaa03310ff"
+-dependencies = [
+- "html-escape",
+- "nom",
+- "percent-encoding",
+- "thiserror",
+-]
+-
+ [[package]]
+ name = "pbkdf2"
+ version = "0.7.5"
+@@ -3388,72 +3223,6 @@ dependencies = [
+  "user-facing-errors",
+ ]
+ 
+-[[package]]
+-name = "query-engine-tests"
+-version = "0.1.0"
+-dependencies = [
+- "anyhow",
+- "base64 0.13.0",
+- "chrono",
+- "colored",
+- "datamodel-connector",
+- "indoc",
+- "insta",
+- "prisma-value",
+- "query-test-macros",
+- "query-tests-setup",
+- "serde_json",
+- "tokio",
+- "tracing",
+- "tracing-futures",
+- "uuid",
+-]
+-
+-[[package]]
+-name = "query-test-macros"
+-version = "0.1.0"
+-dependencies = [
+- "darling",
+- "indoc",
+- "itertools 0.10.0",
+- "proc-macro2",
+- "query-tests-setup",
+- "quote",
+- "syn",
+-]
+-
+-[[package]]
+-name = "query-tests-setup"
+-version = "0.1.0"
+-dependencies = [
+- "async-trait",
+- "colored",
+- "datamodel",
+- "datamodel-connector",
+- "enum_dispatch",
+- "enumflags2",
+- "indoc",
+- "itertools 0.10.0",
+- "lazy_static",
+- "migration-core",
+- "mongodb-datamodel-connector",
+- "nom",
+- "parse-hyperlinks",
+- "prisma-models",
+- "query-core",
+- "regex",
+- "request-handlers",
+- "serde",
+- "serde_json",
+- "sql-datamodel-connector",
+- "thiserror",
+- "tokio",
+- "tracing",
+- "tracing-error",
+- "tracing-futures",
+- "tracing-subscriber",
+-]
+-
+ [[package]]
+ name = "quick-error"
+ version = "1.2.3"
+@@ -3469,12 +3238,6 @@ dependencies = [
+  "proc-macro2",
+ ]
+ 
+-[[package]]
+-name = "radium"
+-version = "0.5.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+-
+ [[package]]
+ name = "rand"
+ version = "0.7.3"
+@@ -3922,18 +3685,6 @@ dependencies = [
+  "syn",
+ ]
+ 
+-[[package]]
+-name = "serde_yaml"
+-version = "0.8.17"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+-dependencies = [
+- "dtoa",
+- "linked-hash-map",
+- "serde",
+- "yaml-rust",
+-]
+-
+ [[package]]
+ name = "serial_test"
+ version = "0.5.1"
+@@ -4028,12 +3779,6 @@ dependencies = [
+  "libc",
+ ]
+ 
+-[[package]]
+-name = "similar"
+-version = "1.3.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
+-
+ [[package]]
+ name = "simple-mutex"
+ version = "1.1.5"
+@@ -4372,12 +4117,6 @@ version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+ 
+-[[package]]
+-name = "tap"
+-version = "1.0.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+-
+ [[package]]
+ name = "tempfile"
+ version = "3.2.0"
+@@ -4392,16 +4131,6 @@ dependencies = [
+  "winapi",
+ ]
+ 
+-[[package]]
+-name = "terminal_size"
+-version = "0.1.16"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
+-dependencies = [
+- "libc",
+- "winapi",
+-]
+-
+ [[package]]
+ name = "test-cli"
+ version = "0.1.0"
+@@ -5094,12 +4823,6 @@ dependencies = [
+  "user-facing-error-macros",
+ ]
+ 
+-[[package]]
+-name = "utf8-width"
+-version = "0.1.4"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
+-
+ [[package]]
+ name = "uuid"
+ version = "0.8.2"
+@@ -5361,18 +5084,3 @@ checksum = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
+ dependencies = [
+  "winapi",
+ ]
+-
+-[[package]]
+-name = "wyz"
+-version = "0.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+-
+-[[package]]
+-name = "yaml-rust"
+-version = "0.4.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+-dependencies = [
+- "linked-hash-map",
+-]
+diff --git a/Cargo.toml b/Cargo.toml
+index 2411986ea..2eb2bb82d 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -3,7 +3,6 @@ members = [
+   "introspection-engine/connectors/introspection-connector",
+   "introspection-engine/connectors/sql-introspection-connector",
+   "introspection-engine/core",
+-  "introspection-engine/introspection-engine-tests",
+   "libs/datamodel/connectors/datamodel-connector",
+   "libs/datamodel/connectors/sql-datamodel-connector",
+   "libs/datamodel/connectors/mongodb-datamodel-connector",
+@@ -12,14 +11,12 @@ members = [
+   "migration-engine/connectors/sql-migration-connector",
+   "migration-engine/connectors/mongodb-migration-connector",
+   "migration-engine/core",
+-  "migration-engine/migration-engine-tests",
+   "query-engine/connectors/query-connector",
+   "query-engine/connectors/sql-query-connector",
+   "query-engine/connectors/mongodb-query-connector",
+   "query-engine/core",
+   "query-engine/query-engine",
+   "query-engine/query-engine-node-api",
+-  "query-engine/connector-test-kit-rs/query-engine-tests",
+   "query-engine/request-handlers",
+   "prisma-fmt",
+   "libs/datamodel/core",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -302,6 +302,8 @@ with pkgs;
 
   mix2nix = callPackage ../development/tools/mix2nix/default.nix { };
 
+  prisma-engines = callPackage ../development/tools/database/prisma-engines { };
+
   proto-contrib = callPackage ../development/tools/proto-contrib {};
 
   protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};


### PR DESCRIPTION
###### Motivation for this change

Allow to use `prisma`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
