### PR TITLE
openipmi: fix collectd assertion

### DIFF
--- a/pkgs/tools/system/openipmi/default.nix
+++ b/pkgs/tools/system/openipmi/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "05wpkn74nxqp5p6sa2yaf2ajrh8b0gfkb7y4r86lnigz4rvz6lkh";
   };
 
+  patches = [
+    # fix assertion when used as a library in collectd
+    # taken from https://sourceforge.net/p/openipmi/code/ci/d613d279dbce2d5e4594f6fed39653d83af0d99b/
+    ./fix-collectd-assertion.diff
+  ];
+
   buildInputs = [ ncurses popt python3 readline ];
 
   outputs = [ "out" "lib" "dev" "man" ];

--- a/pkgs/tools/system/openipmi/fix-collectd-assertion.diff
+++ b/pkgs/tools/system/openipmi/fix-collectd-assertion.diff
@@ -1,0 +1,11 @@
+--- a/unix/posix_thread_os_hnd.c
++++ b/unix/posix_thread_os_hnd.c
+@@ -140,8 +140,6 @@
+     fd_data->data_ready = data_ready;
+     fd_data->handler = handler;
+     fd_data->freed = freed;
+-    sel_set_fd_write_handler(posix_sel, fd, SEL_FD_HANDLER_DISABLED);
+-    sel_set_fd_except_handler(posix_sel, fd, SEL_FD_HANDLER_DISABLED);
+     rv = sel_set_fd_handlers(posix_sel, fd, fd_data, fd_handler, NULL, NULL,
+ 			     free_fd_data);
+     if (rv) {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
