### PR TITLE
qownnotes: 21.7.4 -> 21.8.12

### DIFF
--- a/pkgs/applications/office/qownnotes/default.nix
+++ b/pkgs/applications/office/qownnotes/default.nix
@@ -1,7 +1,6 @@
-{ mkDerivation, lib, stdenv, fetchurl,
-qmake, qttools, qtbase, qtsvg, qtdeclarative, qtxmlpatterns, qtwebsockets,
-qtx11extras,
-qtwayland
+{ mkDerivation, lib, stdenv, fetchurl
+, qmake, qttools, qtbase, qtsvg, qtdeclarative, qtxmlpatterns, qtwebsockets
+, qtx11extras, qtwayland
 }:
 
 mkDerivation rec {

--- a/pkgs/applications/office/qownnotes/default.nix
+++ b/pkgs/applications/office/qownnotes/default.nix
@@ -1,15 +1,18 @@
-{ mkDerivation, lib, stdenv, fetchurl, qmake, qttools, qtbase, qtsvg, qtdeclarative, qtxmlpatterns, qtwebsockets, qtx11extras
-, qtwayland }:
+{ mkDerivation, lib, stdenv, fetchurl,
+qmake, qttools, qtbase, qtsvg, qtdeclarative, qtxmlpatterns, qtwebsockets,
+qtx11extras,
+qtwayland
+}:
 
 mkDerivation rec {
   pname = "qownnotes";
-  version = "21.7.4";
+  version = "21.8.12";
 
   src = fetchurl {
     url = "https://download.tuxfamily.org/${pname}/src/${pname}-${version}.tar.xz";
     # Fetch the checksum of current version with curl:
     # curl https://download.tuxfamily.org/qownnotes/src/qownnotes-<version>.tar.xz.sha256
-    sha256 = "3957dc623b419582ef7ccc5cb04b8f97bed4e96e8ecc2e99bef9dca7ce255b8e";
+    sha256 = "85fbfb6288411ed585de85dd2cfcf3b3308eb4634824b96c5842d091da4cd476";
   };
 
   nativeBuildInputs = [ qmake qttools ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update QOwnNotes to version 21.8.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
