### PR TITLE
uxn: init at 0.0.0+unstable=2021-08-27

### DIFF
--- a/pkgs/misc/emulators/uxn/default.nix
+++ b/pkgs/misc/emulators/uxn/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, SDL2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "uxn";
+  version = "0.0.0+unstable=2021-08-30";
+
+  src = fetchFromSourcehut {
+    owner = "~rabbits";
+    repo = pname;
+    rev = "a2e40d9d10c11ef48f4f93d0dc86f5085b4263ce";
+    hash = "sha256-/hxDYi814nQydm2iQk4NID4vpJ3BcBcM6NdL0iuZk5M=";
+  };
+
+  buildInputs = [
+    SDL2
+  ];
+
+  dontConfigure = true;
+
+  # It is easier to emulate build.sh script
+  buildPhase = ''
+    runHook preBuild
+
+    cc -std=c89 -Wall -Wno-unknown-pragmas src/uxnasm.c -o uxnasm
+    cc -std=c89 -Wall -Wno-unknown-pragmas src/uxn.c src/uxncli.c -o uxncli
+    cc -std=c89 -Wall -Wno-unknown-pragmas src/uxn.c src/devices/ppu.c \
+       src/devices/apu.c src/uxnemu.c $(sdl2-config --cflags --libs) -o uxnemu
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/bin/ $out/share/${pname}/
+
+    cp uxnasm uxncli uxnemu $out/bin/
+    cp -r projects $out/share/${pname}/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://wiki.xxiivv.com/site/uxn.html";
+    description = "An assembler and emulator for the Uxn stack machine";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -228,6 +228,8 @@ with pkgs;
 
   cen64 = callPackage ../misc/emulators/cen64 { };
 
+  uxn = callPackage ../misc/emulators/uxn { };
+
   cereal = callPackage ../development/libraries/cereal { };
 
   cewl = callPackage ../tools/security/cewl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
