### PR TITLE
python3Packages.protonup: init at 0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3621,6 +3621,12 @@
       fingerprint = "2F93 661D AC17 EA98 A104  F780 ECC7 55EE 583C 1672";
     }];
   };
+  flexagoon = {
+    email = "flexagoon@pm.me";
+    github = "flexagoon";
+    githubId = 66178592;
+    name = "Pavel Zolotarevskiy";
+  };
   flexw = {
     email = "felix.weilbach@t-online.de";
     github = "FlexW";

--- a/pkgs/development/python-modules/protonup/default.nix
+++ b/pkgs/development/python-modules/protonup/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, pythonOlder, fetchPypi, requests, configparser }:
+
+buildPythonPackage rec {
+  pname = "protonup";
+  version = "0.1.4";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0z5q0s9h51w2bqm9lkafml14g13v2dgm4nm9x06v7nxqc9msmyyy";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "argparse" ""
+  '';
+
+  propagatedBuildInputs = [ requests configparser ];
+
+  doCheck = false; # protonup does not have any tests
+  pythonImportsCheck = [ "protonup" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/AUNaseef/protonup";
+    description = "CLI program and API to automate the installation and update of GloriousEggroll's Proton-GE";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ flexagoon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29869,6 +29869,8 @@ with pkgs;
     inherit (gnome) zenity;
   };
 
+  protonup = with python3Packages; toPythonApplication protonup;
+
   sdlpop = callPackage ../games/sdlpop { };
 
   stepmania = callPackage ../games/stepmania {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5696,6 +5696,8 @@ in {
 
   protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };
 
+  protonup = callPackage ../development/python-modules/protonup { };
+
   prov = callPackage ../development/python-modules/prov { };
 
   prox-tv = callPackage ../development/python-modules/prox-tv { };


### PR DESCRIPTION
###### Motivation for this change
Protonup is a cli utility to easily install and update GloriousEgroll's fork of Proton
https://github.com/AUNaseef/protonup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
