### PR TITLE
treewide: remove ma27 from the maintainer-list of a few packages

### DIFF
--- a/nixos/tests/graylog.nix
+++ b/nixos/tests/graylog.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "graylog";
-  meta.maintainers = with lib.maintainers; [ ma27 ];
+  meta.maintainers = with lib.maintainers; [ ];
 
   machine = { pkgs, ... }: {
     virtualisation.memorySize = 4096;

--- a/nixos/tests/nexus.nix
+++ b/nixos/tests/nexus.nix
@@ -6,7 +6,7 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "nexus";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ ironpinguin ma27 ];
+    maintainers = [ ironpinguin ];
   };
 
   nodes = {

--- a/nixos/tests/xautolock.nix
+++ b/nixos/tests/xautolock.nix
@@ -4,7 +4,7 @@ with lib;
 
 {
   name = "xautolock";
-  meta.maintainers = with pkgs.lib.maintainers; [ ma27 ];
+  meta.maintainers = with pkgs.lib.maintainers; [ ];
 
   nodes.machine = {
     imports = [ ./common/x11.nix ./common/user-account.nix ];

--- a/nixos/tests/xss-lock.nix
+++ b/nixos/tests/xss-lock.nix
@@ -4,7 +4,7 @@ with lib;
 
 {
   name = "xss-lock";
-  meta.maintainers = with pkgs.lib.maintainers; [ ma27 ];
+  meta.maintainers = with pkgs.lib.maintainers; [ ];
 
   nodes = {
     simple = {

--- a/nixos/tests/yabar.nix
+++ b/nixos/tests/yabar.nix
@@ -5,7 +5,7 @@ with lib;
 {
   name = "yabar";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ ma27 ];
+    maintainers = [ ];
   };
 
   machine = {

--- a/pkgs/applications/misc/taizen/default.nix
+++ b/pkgs/applications/misc/taizen/default.nix
@@ -20,6 +20,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://crates.io/crates/taizen";
     license = licenses.mit;
     description = "curses based mediawiki browser";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/misc/xmind/default.nix
+++ b/pkgs/applications/misc/xmind/default.nix
@@ -87,6 +87,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.xmind.net/";
     license = licenses.unfree;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ michalrus ma27 ];
+    maintainers = with maintainers; [ michalrus ];
   };
 }

--- a/pkgs/applications/video/avidemux/default.nix
+++ b/pkgs/applications/video/avidemux/default.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://fixounet.free.fr/avidemux/";
     description = "Free video editor designed for simple video editing tasks";
-    maintainers = with maintainers; [ abbradar ma27 ];
+    maintainers = with maintainers; [ abbradar ];
     # "CPU not supported" errors on AArch64
     platforms = [ "i686-linux" "x86_64-linux" ];
     license = licenses.gpl2;

--- a/pkgs/applications/video/xscast/default.nix
+++ b/pkgs/applications/video/xscast/default.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/KeyboardFire/xscast";
     license = licenses.mit;
     description = "Screencasts of windows with list of keystrokes overlayed";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/howard-hinnant-date/default.nix
+++ b/pkgs/development/libraries/howard-hinnant-date/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     description = "A date and time library based on the C++11/14/17 <chrono> header";
     homepage = "https://github.com/HowardHinnant/date";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/libelfin/default.nix
+++ b/pkgs/development/libraries/libelfin/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/aclements/libelfin/";
     license = licenses.mit;
     description = "C++11 ELF/DWARF parser";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/fs-s3fs/default.nix
+++ b/pkgs/development/python-modules/fs-s3fs/default.nix
@@ -18,6 +18,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.org/project/fs-s3fs/";
     license = licenses.mit;
     description = "Amazon S3 filesystem for PyFilesystem2";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/nose-cov/default.nix
+++ b/pkgs/development/python-modules/nose-cov/default.nix
@@ -15,6 +15,6 @@ buildPythonPackage rec {
     homepage = "https://pypi.org/project/nose-cov/";
     license = licenses.mit;
     description = "This plugin produces coverage reports. It also supports coverage of subprocesses.";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/parameterized/default.nix
+++ b/pkgs/development/python-modules/parameterized/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "Parameterized testing with any Python test framework";
     homepage = "https://github.com/wolever/parameterized";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pybase64/default.nix
+++ b/pkgs/development/python-modules/pybase64/default.nix
@@ -24,6 +24,6 @@ buildPythonPackage rec {
     description = "Fast Base64 encoding/decoding";
     homepage = "https://github.com/mayeut/pybase64";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/todoist/default.nix
+++ b/pkgs/development/python-modules/todoist/default.nix
@@ -17,6 +17,6 @@ buildPythonPackage rec {
     description = "The official Todoist Python API library";
     homepage = "https://todoist-python.readthedocs.io/en/latest/";
     license = licenses.mit;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/database/shmig/default.nix
+++ b/pkgs/development/tools/database/shmig/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     description = "Minimalistic database migration tool with MySQL, PostgreSQL and SQLite support";
     homepage = "https://github.com/mbucc/shmig";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -43,6 +43,6 @@ rustPlatform.buildRustPackage rec {
     description = "A utility intended to provide Rust code completion for editors and IDEs";
     homepage = "https://github.com/racer-rust/racer";
     license = licenses.mit;
-    maintainers = with maintainers; [ jagajaga ma27 ];
+    maintainers = with maintainers; [ jagajaga ];
   };
 }

--- a/pkgs/tools/graphics/nifskope/default.nix
+++ b/pkgs/tools/graphics/nifskope/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "http://niftools.sourceforge.net/wiki/NifSkope";
     description = "A tool for analyzing and editing NetImmerse/Gamebryo '*.nif' files";
-    maintainers = with maintainers; [ eelco ma27 ];
+    maintainers = with maintainers; [ eelco ];
     platforms = platforms.linux;
     license = licenses.bsd3;
   };

--- a/pkgs/tools/misc/peep/default.nix
+++ b/pkgs/tools/misc/peep/default.nix
@@ -18,6 +18,6 @@ rustPlatform.buildRustPackage rec {
     description = "The CLI text viewer tool that works like less command on small pane within the terminal window";
     license = licenses.mit;
     homepage = "https://github.com/ryochack/peep";
-    maintainers = with maintainers; [ ma27 ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/misc/thefuck/default.nix
+++ b/pkgs/tools/misc/thefuck/default.nix
@@ -22,6 +22,6 @@ buildPythonApplication rec {
     homepage = "https://github.com/nvbn/thefuck";
     description = "Magnificent app which corrects your previous console command";
     license = licenses.mit;
-    maintainers = with maintainers; [ ma27 SuperSandro2000 ];
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
These are all packages that I stopped using and hence just create noise
in my inbox for each change affecting them and let's face it, while I
still enjoy contributing to nixpkgs, it doesn't really make sense to be
listed there if I can't do much anyways.

Each of these packages can be taken over by someone or removed if
people think that's reasonable.

Of course, if other maintainers face issues, I can answer some questions
if needed & possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
