### PR TITLE
wordpress: allow updating builtin themes and plugins

### DIFF
--- a/pkgs/servers/web-apps/wordpress/default.nix
+++ b/pkgs/servers/web-apps/wordpress/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchurl, nixosTests }:
+{ lib
+, stdenv
+, fetchurl
+, nixosTests
+, wordpressPackages
+, wpThemes ? [ wordpressPackages.themes.twentynineteen wordpressPackages.themes.twentytwenty wordpressPackages.themes.twentytwentyone ]
+, wpPlugins ? [ wordpressPackages.plugins.akismet wordpressPackages.plugins.hello-dolly ]
+}:
 
 stdenv.mkDerivation rec {
   pname = "wordpress";
@@ -12,17 +19,23 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/share/wordpress
     cp -r . $out/share/wordpress
+    rm -r $out/share/wordpress/wp-content/plugins/*
+    rm -r $out/share/wordpress/wp-content/themes/*
+    ${lib.concatMapStringsSep "\n" (theme: "cp -r ${theme} $out/share/wordpress/wp-content/themes/${theme.passthru.wpName or theme.pname}") wpThemes}
+    ${lib.concatMapStringsSep "\n" (plugin: "cp -r ${plugin} $out/share/wordpress/wp-content/plugins/${plugin.passthru.wpName or plugin.pname}") wpPlugins}
   '';
 
   passthru.tests = {
     inherit (nixosTests) wordpress;
   };
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://wordpress.org";
     description = "WordPress is open source software you can use to create a beautiful website, blog, or app";
     license = [ licenses.gpl2 ];
-    maintainers = [ maintainers.basvandijk ];
+    maintainers = with maintainers; [ basvandijk ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/web-apps/wordpress/themes-and-plugins/default.nix
+++ b/pkgs/servers/web-apps/wordpress/themes-and-plugins/default.nix
@@ -1,0 +1,120 @@
+# Source: https://git.helsinki.tools/helsinki-systems/wp4nix/-/blob/master/default.nix
+# Licensed under: MIT
+# Slightly modified
+{ lib, newScope, plugins, themes, languages, pluginLanguages, themeLanguages }:
+
+let packages = self:
+  let
+    generatedJson = {
+      inherit plugins themes languages pluginLanguages themeLanguages;
+    };
+
+  in {
+    # Create a generic WordPress package. Most arguments are just passed
+    # to `mkDerivation`. The version is automatically filtered for weird characters.
+    mkWordpressDerivation = self.callPackage ({ stdenvNoCC, lib, filterWPString, gettext, wp-cli }:
+      { type, pname, version, ... }@args:
+        assert lib.any (x: x == type) [ "plugin" "theme" "language" "pluginLanguage" "themeLanguage" ];
+        stdenvNoCC.mkDerivation ({
+          pname = "wordpress-${type}-${pname}";
+          version = filterWPString version;
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+            cp -R ./. $out
+            runHook postInstall
+          '';
+
+          passthru = {
+            wpName = pname;
+          } // (args.passthru or {});
+        } // lib.optionalAttrs (type == "language" || type == "pluginLanguage" || type == "themeLanguage") {
+          nativeBuildInputs = [ gettext wp-cli ];
+          dontBuild = false;
+          buildPhase = ''
+            runHook preBuild
+
+            find -name '*.po' -print0 | while IFS= read -d "" -r po; do
+              msgfmt -o $(basename "$po" .po).mo "$po"
+            done
+            wp i18n make-json .
+            rm *.po
+
+            runHook postBuild
+          '';
+        } // removeAttrs args [ "type" "pname" "version" "passthru" ])) {};
+
+    # Create a derivation from the official wordpress.org packages.
+    # This takes the type, the pname and the data generated from the go tool.
+    mkOfficialWordpressDerivation = self.callPackage ({ mkWordpressDerivation, fetchWordpress }:
+      { type, pname, data }:
+      mkWordpressDerivation {
+        inherit type pname;
+        version = data.version;
+
+        src = fetchWordpress type data;
+      }) {};
+
+    # Filter out all characters that might occur in a version string but that that are not allowed
+    # in store paths.
+    filterWPString = builtins.replaceStrings [ " " "," "/" "&" ";" ''"'' "'" "$" ":" "(" ")" "[" "]" "{" "}" "|" "*" "\t" ] [ "_" "." "." "" "" "" "" "" "" "" "" "" "" "" "" "-" "" "" ];
+
+    # Fetch a package from the official wordpress.org SVN.
+    # The data supplied is the data straight from the go tool.
+    fetchWordpress = self.callPackage ({ fetchsvn }: type: data: fetchsvn {
+      inherit (data) rev sha256;
+      url = if type == "plugin" || type == "theme" then
+        "https://" + type + "s.svn.wordpress.org/" + data.path
+      else if type == "language" then
+        "https://i18n.svn.wordpress.org/core/" + data.version + "/" + data.path
+      else if type == "pluginLanguage" then
+        "https://i18n.svn.wordpress.org/plugins/" + data.path
+      else if type == "themeLanguage" then
+        "https://i18n.svn.wordpress.org/themes/" + data.path
+      else
+        throw "fetchWordpress: invalid package type ${type}";
+    }) {};
+
+  } // lib.mapAttrs (type: pkgs: lib.makeExtensible (_: lib.mapAttrs (pname: data: self.mkOfficialWordpressDerivation { type = lib.removeSuffix "s" type; inherit pname data; }) pkgs)) generatedJson;
+
+# This creates an extensible scope and immediately extends it with our custom
+# package overrides.
+in (lib.makeExtensible (_: (lib.makeScope newScope packages))).extend (selfWP: superWP: {
+
+  plugins = superWP.plugins.extend (selfPlugins: superPlugins: {
+    # Fix the plugin caching store paths
+    visualcomposer = superPlugins.visualcomposer.overrideAttrs (oA: {
+      postInstall = ''
+        ${oA.postInstall or ""}
+        rm -r $out/cache
+      '';
+    });
+
+    # Add nix syntax support
+    prismatic = superWP.callPackage ({ fetchurl }: superPlugins.prismatic.overrideAttrs (oA: {
+      postInstall = ''
+        ${oA.postInstall or ""}
+
+        cp ${fetchurl {
+          url = "https://raw.githubusercontent.com/PrismJS/prism/v1.25.0/components/prism-nix.js";
+          sha256 = "1ajw7pdnppgyar3v42nraxm0f4rzyqb5fw75ych8q3x94v4klgc7";
+        }} $out/lib/prism/js/lang-nix.js
+
+        # Allow loading the js
+        substituteInPlace $out/inc/resources-enqueue.php \
+          --replace "'lang-none'," "'lang-none', 'lang-nix'," \
+          --replace "'language-none'," "'language-none', 'language-nix',"
+
+        # Add the language into the editor
+        sed -i "/Language\.\./a { label : 'Nix', value : 'nix' }," $out/js/blocks-prism.js
+        sed -i "/Language\.\./a { label : 'Nix', value : 'nix' }," $out/js/buttons-prism.js
+      '';
+    })) {};
+  });
+
+  #themes = superWP.plugins.extend (selfThemes: superThemes: {
+  #});
+})

--- a/pkgs/servers/web-apps/wordpress/themes-and-plugins/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/themes-and-plugins/plugins.json
@@ -1,0 +1,14 @@
+{
+  "akismet": {
+    "path": "akismet/tags/4.2.1",
+    "rev": "2608000",
+    "sha256": "05sis4s8lax56j52kl9ih6f4kp2qjk39y5mkdq9z35mp3zsj89ap",
+    "version": "4.2.1"
+  },
+  "hello-dolly": {
+    "path": "hello-dolly/tags/1.7.2",
+    "rev": "2599640",
+    "sha256": "0sd7s3fmc5yky6gaiqxkbdfl0bj5bmvxfyc9v5a4wmgnlbsnd7db",
+    "version": "1.7.2"
+  }
+}

--- a/pkgs/servers/web-apps/wordpress/themes-and-plugins/themes.json
+++ b/pkgs/servers/web-apps/wordpress/themes-and-plugins/themes.json
@@ -1,0 +1,20 @@
+{
+  "twentynineteen": {
+    "path": "twentynineteen/2.1",
+    "rev": "151906",
+    "sha256": "014159rmh8l4qyl195ds8dywbv1apz6dxkvanc0i29njazd9lfhm",
+    "version": "2.1"
+  },
+  "twentytwenty": {
+    "path": "twentytwenty/1.8",
+    "rev": "151907",
+    "sha256": "0h0s3irgsjbls56rsdhlj170s6jr13d1d2al378asvlnjln126rz",
+    "version": "1.8"
+  },
+  "twentytwentyone": {
+    "path": "twentytwentyone/1.4",
+    "rev": "151908",
+    "sha256": "09gjm1nim2r0mb728pxrlsia3yjwf79zn3s02dd4cnq73ja07yx6",
+    "version": "1.4"
+  }
+}

--- a/pkgs/servers/web-apps/wordpress/update.sh
+++ b/pkgs/servers/web-apps/wordpress/update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts jq wp4nix
+
+set -eu -o pipefail
+
+version=$(curl --globoff "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+update-source-version wordpress $version
+
+# cd /tmp
+# curl https://wordpress.org/latest.tar.gz | tar xzf -
+# ls wordpress/wp-content/themes/  # update the command below with that
+# ls wordpress/wp-content/plugins/ # update the command below with that
+
+cd pkgs/servers/web-apps/wordpress/themes-and-plugins
+WP_VERSION=5.8 WORKERS=1 wp4nix -t twentynineteen,twentytwenty,twentytwentyone -p akismet,hello-dolly
+rm *.log languages.json pluginLanguages.json themeLanguages.json
+cd ../../../../..

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36158,6 +36158,14 @@ with pkgs;
 
   wordpress = callPackage ../servers/web-apps/wordpress { };
 
+  wordpressPackages = callPackage ../servers/web-apps/wordpress/themes-and-plugins {
+    plugins = lib.importJSON ../servers/web-apps/wordpress/themes-and-plugins/plugins.json;
+    themes = lib.importJSON ../servers/web-apps/wordpress/themes-and-plugins/themes.json;
+    languages = lib.importJSON ../servers/web-apps/wordpress/themes-and-plugins/languages.json;
+    pluginLanguages = lib.importJSON ../servers/web-apps/wordpress/themes-and-plugins/pluginLanguages.json;
+    themeLanguages = lib.importJSON ../servers/web-apps/wordpress/themes-and-plugins/themeLanguages.json;
+  };
+
   wprecon = callPackage ../tools/security/wprecon { };
 
   wraith = callPackage ../applications/networking/irc/wraith { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
To my knowledge it is currently not possible to update the themes and plugins that are shipped with wordpress by default.

**Also when migrating to the new method you fix the issue that you may lose theme/plugin settings on updates because the settings are stored based on the directory name and it changes as it contained the version.**

###### Things done
Split off https://github.com/NixOS/nixpkgs/pull/96910

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
