### PR TITLE
howard-hinnant-date: unstable-2020-03-09 -> 3.0.1

### DIFF
--- a/pkgs/development/libraries/howard-hinnant-date/default.nix
+++ b/pkgs/development/libraries/howard-hinnant-date/default.nix
@@ -1,20 +1,23 @@
-{ lib, stdenv, fetchFromGitHub, cmake, curl, tzdata, fetchpatch, substituteAll }:
+{ lib, stdenv, fetchFromGitHub, cmake, tzdata, fetchpatch, substituteAll }:
 
 stdenv.mkDerivation rec {
-  pname = "howard-hinnant-date-unstable";
-  version = "2020-03-09";
+  pname = "howard-hinnant-date";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "HowardHinnant";
     repo = "date";
-    rev = "4c1968b8f038483037cadfdbad3215ce21d934bb";
-    sha256 = "0dywrf18v1znfnz0gdxgi2ydax466zq34gc1vvg2k7vq17a30wq3";
+    rev = "v${version}";
+    sha256 = "1qk7pgnk0bpinja28104qha6f7r1xwh5dy3gra7vjkqwl0jdwa35";
   };
 
   patches = [
+    # Add pkg-config file
+    # https://github.com/HowardHinnant/date/pull/538
     (fetchpatch {
-      url = "https://github.com/HowardHinnant/date/commit/e56b2dce7e89a92e1b9b35caa13b3e938c4cedea.patch";
-      sha256 = "0m3qbhq7kmm9qa3jm6d2px7c1dxdj5k9lffgdvqnrwmhxwj1p9n2";
+      name = "output-date-pc-for-pkg-config.patch";
+      url = "https://git.alpinelinux.org/aports/plain/community/date/538-output-date-pc-for-pkg-config.patch?id=11f6b4d4206b0648182e7b41cd57dcc9ccea0728";
+      sha256 = "1ma0586jsd89jgwbmd2qlvlc8pshs1pc4zk5drgxi3qvp8ai1154";
     })
     # Without this patch, this library will drop a `tzdata` directory into
     # `~/Downloads` if it cannot find `/usr/share/zoneinfo`. Make the path it
@@ -26,7 +29,6 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ curl ];
 
   cmakeFlags = [
     "-DBUILD_TZ_LIB=true"
@@ -41,6 +43,6 @@ stdenv.mkDerivation rec {
     description = "A date and time library based on the C++11/14/17 <chrono> header";
     homepage = "https://github.com/HowardHinnant/date";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ r-burns ];
   };
 }


### PR DESCRIPTION
* use updated pkg-config patch from alpine ports
* remove unused curl build input

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
