### PR TITLE
nixos/pounce: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4897,6 +4897,16 @@
     githubId = 372912;
     name = "Justin Bedő";
   };
+  jbellerb = {
+    email = "jbellerb@vt.edu";
+    github = "jbellerb";
+    githubId = 25756846;
+    name = "Jared Beller";
+    keys = [{
+      longkeyid = "rsa4096/044B207F4820E3AE";
+      fingerprint = "0D26 C33F 8A6F 273F EFD1  CC56 044B 207F 4820 E3AE";
+    }];
+  };
   jbgi = {
     email = "jb@giraudeau.info";
     github = "jbgi";

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -171,8 +171,6 @@
           <link linkend="opt-services.isso.enable">isso</link>
         </para>
       </listitem>
-    </itemizedlist>
-    <itemizedlist spacing="compact">
       <listitem>
         <para>
           <link xlink:href="https://www.navidrome.org/">navidrome</link>,
@@ -181,8 +179,6 @@
           <link linkend="opt-services.navidrome.enable">navidrome</link>.
         </para>
       </listitem>
-    </itemizedlist>
-    <itemizedlist>
       <listitem>
         <para>
           <link xlink:href="https://docs.fluidd.xyz/">fluidd</link>, a
@@ -219,6 +215,13 @@
           <link xlink:href="https://nats.io/">nats</link>, a high
           performance cloud and edge messaging system. Available as
           <link linkend="opt-services.nats.enable">services.nats</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://git.causal.agency/pounce/about/">pounce</link>,
+          a multi-client, TLS-only IRC bouncer. Available as
+          <link linkend="opt-services.pounce.enable">services.pounce</link>.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -54,7 +54,7 @@ pt-services.clipcat.enable).
 - [isso](https://posativ.org/isso/), a commenting server similar to Disqus.
   Available as [isso](#opt-services.isso.enable)
 
-* [navidrome](https://www.navidrome.org/), a personal music streaming server with
+- [navidrome](https://www.navidrome.org/), a personal music streaming server with
 subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable).
 
 - [fluidd](https://docs.fluidd.xyz/), a Klipper web interface for managing 3d printers using moonraker. Available as [fluidd](#opt-services.fluidd.enable).
@@ -66,6 +66,8 @@ subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable
 - [soju](https://sr.ht/~emersion/soju), a user-friendly IRC bouncer. Available as [services.soju](options.html#opt-services.soju.enable).
 
 - [nats](https://nats.io/), a high performance cloud and edge messaging system. Available as [services.nats](#opt-services.nats.enable).
+
+- [pounce](https://git.causal.agency/pounce/about/), a multi-client, TLS-only IRC bouncer. Available as [services.pounce](#opt-services.pounce.enable).
 
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -801,6 +801,7 @@
   ./services/networking/pixiecore.nix
   ./services/networking/pleroma.nix
   ./services/networking/polipo.nix
+  ./services/networking/pounce.nix
   ./services/networking/powerdns.nix
   ./services/networking/pdns-recursor.nix
   ./services/networking/pppd.nix

--- a/nixos/modules/services/networking/pounce.nix
+++ b/nixos/modules/services/networking/pounce.nix
@@ -1,0 +1,209 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.pounce;
+
+  defaultUser = "pounce";
+
+  settingsFormat = {
+    type = types.attrsOf (types.nullOr
+      (types.oneOf [ types.bool types.int types.str ]));
+    generate = name: value:
+      let
+        mkKeyValue = k: v:
+          if true == v then k
+          else if false == v then "#${k}"
+          else lib.generators.mkKeyValueDefault {} " = " k v;
+        mkKeyValueList = values:
+          lib.generators.toKeyValue { inherit mkKeyValue; } values;
+      in pkgs.writeText name (mkKeyValueList value);
+  };
+
+in {
+  options.services.pounce = {
+    enable = mkEnableOption "Pounce IRC bouncer with the Calico dispatcher";
+
+    user = mkOption {
+      type = types.str;
+      default = defaultUser;
+      description = ''
+        User account under which Pounce runs. If not specified, a default user
+        will be created.
+      '';
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/pounce";
+      description = ''
+        Directory where each Pounce instance's UNIX-domain socket is stored for
+        Calico to route to. Certificates can also be stored here.
+      '';
+    };
+
+    certDir = mkOption {
+      type = types.str;
+      default = "/var/lib/pounce/certs";
+      example = "/etc/letsencrypt/live";
+      description = ''
+        Directory where each Pounce instance's TLS sertificates and private
+        keys are stored. Each instance should have a folder in the certbot
+        format: a <literal>fullchain.pem</literal> and
+        <literal>privkey.pem</literal> in a folder with the full domain name of
+        the instance (ex: <literal>libera.example.org/</literal>). Self-signed
+        certificates will be generated in this folder if
+        <option>services.pounce.generateCerts</option> is true.
+      '';
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "localhost";
+      example = "example.org";
+      description = ''
+        Base domain name for Calico to listen at. Each instance will be at a
+        subdomain of this.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 6697;
+      description = ''
+        Port for Calico to listen on.
+      '';
+    };
+
+    generateCerts = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Generate a self-signed TLS certificate in the certificate directory.
+        If you would like to use <command>certbot</command> instead, generate
+        certificates for each instance like this:
+        <literal>certbot certonly -d libera.example.org</literal>.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Open port in the firewall for Calico.
+      '';
+    };
+
+    timeout = mkOption {
+      type = types.ints.positive;
+      default = 1000;
+      description = ''
+        Timeout parameter (in milliseconds) for Calico to close a connection
+        if no <literal>ClientHello</literal> message is sent.
+      '';
+    };
+
+    networks = mkOption {
+      type = types.attrsOf settingsFormat.type;
+      default = {};
+      example = {
+        libera = {
+          host = "irc.libera.chat";
+          port = 6697;
+          sasl-plain = "testname:password";
+          join = "#nixos,#nixos-dev";
+        };
+      };
+      description = ''
+        Attribute set of Pounce configurations. For information on the Pounce
+        configuration format, see the
+        <link xlink:href="https://git.causal.agency/pounce/about/pounce.1">pounce(1)</link>
+        manual page.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services = mkMerge [
+      {
+        calico = {
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network.target" ];
+
+          description = "Calico dispatcher for Pounce IRC bouncer.";
+
+          serviceConfig = {
+            User = cfg.user;
+            Group = cfg.user;
+            RuntimeDirectory = "pounce";
+            ExecStart = ''
+              ${pkgs.pounce}/bin/calico \
+                -H ${cfg.host} -P ${toString cfg.port} \
+                -t ${toString cfg.timeout} ${cfg.dataDir}
+            '';
+            Restart = "always";
+            ExecStartPre = ''
+              +${pkgs.bash}/bin/bash -c '\
+                mkdir -p ${cfg.dataDir} && \
+                chown ${cfg.user}:${cfg.user} ${cfg.dataDir} && \
+                chmod 700 ${cfg.dataDir}'
+            '';
+          };
+        };
+      }
+
+      (mapAttrs' (name: value: nameValuePair "pounce-${name}" {
+        wantedBy = [ "multi-user.target" ];
+        bindsTo = [ "calico.service" ];
+        after = [ "calico.service" ];
+
+        description = "Pounce IRC bouncer for the ${name} network.";
+
+        serviceConfig = {
+          User = cfg.user;
+          Group = cfg.user;
+          RuntimeDirectory = "pounce";
+          ExecStart = ''
+            ${pkgs.pounce}/bin/pounce \
+              -C ${cfg.certDir}/${name}.${cfg.host}/fullchain.pem \
+              -K ${cfg.certDir}/${name}.${cfg.host}/privkey.pem \
+              -U ${cfg.dataDir} -H ${name}.${cfg.host} \
+              ${settingsFormat.generate "${name}.cfg" value}
+          '';
+          Restart = "always";
+        };
+        preStart = ''
+          mkdir -p ${cfg.certDir}/${name}.${cfg.host}
+
+          if ${boolToString cfg.generateCerts}; then
+            if [ ! -f ${cfg.certDir}/${name}.${cfg.host}/fullchain.pem ] || \
+               [ ! -f ${cfg.certDir}/${name}.${cfg.host}/privkey.pem ]; then
+              ${pkgs.libressl}/bin/openssl req -x509 -newkey rsa:4096 \
+                -out ${cfg.certDir}/${name}.${cfg.host}/fullchain.pem \
+                -keyout ${cfg.certDir}/${name}.${cfg.host}/privkey.pem \
+                -nodes -sha256 -days 36500 -subj "/CN=${name}.${cfg.host}"
+            fi
+          fi
+        '';
+      }) cfg.networks)
+    ];
+
+    users = optionalAttrs (cfg.user == defaultUser) {
+      users.${defaultUser} = {
+        group = defaultUser;
+        isSystemUser = true;
+      };
+
+      groups.${defaultUser} = { };
+    };
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+    environment.systemPackages = [ pkgs.pounce ];
+  };
+
+  meta = {
+    doc = ./pounce.xml;
+    maintainers = [ lib.maintainers.jbellerb ];
+  };
+}

--- a/nixos/modules/services/networking/pounce.xml
+++ b/nixos/modules/services/networking/pounce.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" xml:id="module-services-networking-pounce">
+  <title>Pounce</title>
+  <para>
+    <link xlink:href="https://git.causal.agency/pounce/about/">Pounce</link>
+    is a multi-client, TLS-only IRC bouncer. Pounce includes the
+    <link xlink:href="https://git.causal.agency/pounce/about/calico.1">Calico</link>
+    dispatcher for serving multiple networks over a single port.
+  </para>
+  <section xml:id="module-services-networking-pounce-quick-start">
+    <title>Basic Usage</title>
+    <para>
+      To support connecting to multiple networks, Pounce will always be
+      configured to serve through Calico. Due to this, each network's
+      bouncer is served at a subdomain of
+      <link linkend="opt-services.pounce.host">services.pounce.host</link>.
+    </para>
+    <para>
+      A complete list of Pounce's options is availiable in the
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1">pounce(1)</link>
+      manual page. For additional notes about connecting to various popular
+      networks, see Pounce's
+      <link xlink:href="https://git.causal.agency/pounce/about/QUIRKS.7">QUIRKS(7)</link>
+      document.
+    </para>
+    <para>
+      Pounce must be served over TLS. By default, this module will generate a
+      self-signed certificate valid for 100 years. To disable this, set
+      <link linkend="opt-services.pounce.generateCerts">services.pounce.generateCerts</link>
+      to <literal>false</literal> and point
+      <link linkend="opt-services.pounce.certDir">services.pounce.certDir</link>
+      to a folder containing TLS certificates in the certbot format (a
+      <literal>fullchain.pem</literal> and <literal>privkey.pem</literal> in a
+      folder named the full domain name of the instance). Certificates can be
+      generated with certbot using <command>certbot certonly -d ...</command>,
+      or using NixOS's built-in ACME module.
+    </para>
+    <para>
+      Below is an example configuration which joins #nixos and #nixos-chat on
+      Libera Chat and #ascii.town on tilde.chat. The bouncer for Libera Chat can
+      be reached at <literal>libera.irc.example.org/6697</literal> and the
+      bouncer for tilde.chat is at <literal>tilde.irc.example.org/6697</literal>.
+      Libera Chat is additionally configured to connect with CertFP using a
+      certificate stored at <literal>/var/lib/pounce/certfp/libera.pem</literal>.
+      This certificate can be generated with
+      <literal>pounce -g /var/lib/pounce/certfp/libera.pem</literal>.
+      <programlisting>
+services.pounce = {
+  <link linkend="opt-services.pounce.enable">enable</link> = true;
+  <link linkend="opt-services.pounce.host">host</link> = "irc.example.org";
+  <link linkend="opt-services.pounce.openFirewall">openFirewall</link> = true;
+  <link linkend="opt-services.pounce.networks">networks</link> = {
+    libera = {
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1#host">host</link> = "irc.libera.chat";
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1#port">port</link> = 6697; # This is the default port. This field can be ommitted.
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1#nick">nick</link> = "...";
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1#client-cert">client-cert</link> = "/var/lib/pounce/certfp/libera.pem";
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1#sasl-external">sasl-external</link> = true;
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1#join">join</link> = "#nixos,#nixos-chat";
+    };
+    tilde = {
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1#host">host</link> = "irc.tilde.chat";
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1#nick">nick</link> = "...";
+      <link xlink:href="https://git.causal.agency/pounce/about/pounce.1#join">join</link> = "#ascii.town";
+    };
+  };
+};</programlisting>
+    </para>
+  </section>
+</chapter>

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -32,6 +32,9 @@ let
     # removing ./configure pre-config.
     preConfigure = ''
       rm configure
+      substituteInPlace CMakeLists.txt \
+        --replace 'exec_prefix \''${prefix}' "exec_prefix ${placeholder "bin"}" \
+        --replace 'libdir      \''${exec_prefix}' 'libdir \''${prefix}'
     '';
 
     inherit patches;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR adds a module for the Pounce IRC bouncer. This module's usage is loosely based on the ZNC module and similarly uses a custom generator to support all possible configuration options. Calico, Pounce's built-in dispatcher, is used to support hosting bouncers for multiple networks over the same port. Usage is documented in a new manual entry.

In addition to the new module, a small patch for LibreSSL was included to fix the generated .pc files so that exec_prefix actually points to the OpenSSL binary (instead of a nonexistent bin folder in the main LibreSSL library derivation). This fixes a longstanding issue in the Pounce package where a few tasks, such as certificate generation, fail because it can't find OpenSSL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
