### PR TITLE
goimapnotify: 2.0 -> 2.3.2

### DIFF
--- a/pkgs/tools/networking/goimapnotify/default.nix
+++ b/pkgs/tools/networking/goimapnotify/default.nix
@@ -1,23 +1,23 @@
-{ buildGoPackage, fetchFromGitLab, lib, runtimeShell }:
+{ buildGoModule, fetchFromGitLab, lib, runtimeShell }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "goimapnotify";
-  version = "2.0";
-
-  goPackagePath = "gitlab.com/shackra/goimapnotify";
+  version = "2.3.2";
 
   src = fetchFromGitLab {
     owner = "shackra";
     repo = "goimapnotify";
     rev = version;
-    sha256 = "1d42gd3m2rkvy985d181dbcm5i3f7xsg2z8z6s4bpvw24pfnzs42";
+    sha256 = "sha256-pkpdIkabxz9bu0LnyU1/wu1qqPc/pQqCn8tePc2fIfg=";
   };
 
-  postPatch = ''
-    substituteInPlace command.go --replace '"sh"' '"${runtimeShell}"'
-  '';
+  vendorSha256 = "sha256-4+2p/7BAEk+1V0TII9Q2O2YNX0rvBiw2Ss7k1dsvUbk=";
 
-  goDeps = ./deps.nix;
+  postPatch = ''
+    for f in command.go command_test.go; do
+      substituteInPlace $f --replace '"sh"' '"${runtimeShell}"'
+    done
+  '';
 
   meta = with lib; {
     description =


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
