### PR TITLE
Fetcher testing

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -1,8 +1,16 @@
 # Fetchers {#chap-pkgs-fetchers}
 
-When using Nix, you will frequently need to download source code and other files from the internet. Nixpkgs comes with a few helper functions that allow you to fetch fixed-output derivations in a structured way.
+When using Nix, you will frequently need to download source code and other files from the internet. For this purpose, Nix provides the [_fixed output derivation_](https://nixos.org/manual/nix/stable/#fixed-output-drvs) feature and Nixpkgs provides various functions that implement the actual fetching from various protocols and services.
 
-The two fetcher primitives are `fetchurl` and `fetchzip`. Both of these have two required arguments, a URL and a hash. The hash is typically `sha256`, although many more hash algorithms are supported. Nixpkgs contributors are currently recommended to use `sha256`. This hash will be used by Nix to identify your source. A typical usage of fetchurl is provided below.
+## Caveats
+
+Because fixed output derivations are _identified_ by their hash, a common mistake is to update a fetcher's URL or a version parameter, without updating the hash. **This will cause the old contents to be used.** So remember to always invalidate the hash argument.
+
+Similarly, a change to the implementation of a fetcher may cause a fixed output derivation to fail, but isn't caught by tests because the supposed output is already in the store or cache. So when testing a fetcher, always make sure to `nix-store --delete` the output and pay attention to the log, in case deletion was prevented by a garbage collection root.
+
+## `fetchurl` and `fetchzip` {#fetchurl}
+
+Two basic fetchers are `fetchurl` and `fetchzip`. Both of these have two required arguments, a URL and a hash. The hash is typically `sha256`, although many more hash algorithms are supported. Nixpkgs contributors are currently recommended to use `sha256`. This hash will be used by Nix to identify your source. A typical usage of fetchurl is provided below.
 
 ```nix
 { stdenv, fetchurl }:
@@ -20,7 +28,7 @@ The main difference between `fetchurl` and `fetchzip` is in how they store the c
 
 `fetchpatch` works very similarly to `fetchurl` with the same arguments expected. It expects patch files as a source and performs normalization on them before computing the checksum. For example it will remove comments or other unstable parts that are sometimes added by version control systems and can change over time.
 
-Other fetcher functions allow you to add source code directly from a VCS such as subversion or git. These are mostly straightforward nambes based on the name of the command used with the VCS system. Because they give you a working repository, they act most like `fetchzip`.
+Most other fetchers return a directory rather than a single file.
 
 ## `fetchsvn` {#fetchsvn}
 

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -6,7 +6,7 @@ When using Nix, you will frequently need to download source code and other files
 
 Because fixed output derivations are _identified_ by their hash, a common mistake is to update a fetcher's URL or a version parameter, without updating the hash. **This will cause the old contents to be used.** So remember to always invalidate the hash argument.
 
-For those who develop and maintain fetcheres, a similar problem arises with changes to the implementation of a fetcher. These may cause a fixed output derivation to fail, but won't normally be caught by tests because the supposed output is already in the store or cache. For the purpose of testing, you can use a trick that is embodied by the `invalidateFetcherByDrvHash` function. It uses the derivation `name` to create a unique output path per fetcher implementation, defeating the caching precisely where it would be harmful.
+For those who develop and maintain fetcheres, a similar problem arises with changes to the implementation of a fetcher. These may cause a fixed output derivation to fail, but won't normally be caught by tests because the supposed output is already in the store or cache. For the purpose of testing, you can use a trick that is embodied by the [`invalidateFetcherByDrvHash`](#sec-pkgs-invalidateFetcherByDrvHash) function. It uses the derivation `name` to create a unique output path per fetcher implementation, defeating the caching precisely where it would be harmful.
 
 ## `fetchurl` and `fetchzip` {#fetchurl}
 

--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -6,7 +6,7 @@ When using Nix, you will frequently need to download source code and other files
 
 Because fixed output derivations are _identified_ by their hash, a common mistake is to update a fetcher's URL or a version parameter, without updating the hash. **This will cause the old contents to be used.** So remember to always invalidate the hash argument.
 
-Similarly, a change to the implementation of a fetcher may cause a fixed output derivation to fail, but isn't caught by tests because the supposed output is already in the store or cache. So when testing a fetcher, always make sure to `nix-store --delete` the output and pay attention to the log, in case deletion was prevented by a garbage collection root.
+For those who develop and maintain fetcheres, a similar problem arises with changes to the implementation of a fetcher. These may cause a fixed output derivation to fail, but won't normally be caught by tests because the supposed output is already in the store or cache. For the purpose of testing, you can use a trick that is embodied by the `invalidateFetcherByDrvHash` function. It uses the derivation `name` to create a unique output path per fetcher implementation, defeating the caching precisely where it would be harmful.
 
 ## `fetchurl` and `fetchzip` {#fetchurl}
 

--- a/doc/builders/special.xml
+++ b/doc/builders/special.xml
@@ -7,4 +7,5 @@
  </para>
  <xi:include href="special/fhs-environments.section.xml" />
  <xi:include href="special/mkshell.section.xml" />
+ <xi:include href="special/invalidateFetcherByDrvHash.section.xml" />
 </chapter>

--- a/doc/builders/special/invalidateFetcherByDrvHash.section.md
+++ b/doc/builders/special/invalidateFetcherByDrvHash.section.md
@@ -1,0 +1,31 @@
+
+## `invalidateFetcherByDrvHash` {#sec-pkgs-invalidateFetcherByDrvHash}
+
+Use the derivation hash to invalidate the output via name, for testing.
+
+Type: `(a@{ name, ... } -> Derivation) -> a -> Derivation`
+
+Normally, fixed output derivations can and should be cached by their output
+hash only, but for testing we want to re-fetch everytime the fetcher changes.
+
+Changes to the fetcher become apparent in the drvPath, which is a hash of
+how to fetch, rather than a fixed store path.
+By inserting this hash into the name, we can make sure to re-run the fetcher
+every time the fetcher changes.
+
+This relies on the assumption that Nix isn't clever enough to reuse its
+database of local store contents to optimize fetching.
+
+You might notice that the "salted" name derives from the normal invocation,
+not the final derivation. `invalidateFetcherByDrvHash` has to invoke the fetcher
+function twice: once to get a derivation hash, and again to produce the final
+fixed output derivation.
+
+Example:
+
+    tests.fetchgit = invalidateFetcherByDrvHash fetchgit {
+      name = "nix-source";
+      url = "https://github.com/NixOS/nix";
+      rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+      sha256 = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+    };

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -1,0 +1,10 @@
+{ invalidateFetcherByDrvHash, fetchgit, ... }:
+
+{
+  simple = invalidateFetcherByDrvHash fetchgit {
+    name = "nix-source";
+    url = "https://github.com/NixOS/nix";
+    rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+    sha256 = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -614,35 +614,8 @@ with pkgs;
 
   installShellFiles = callPackage ../build-support/install-shell-files {};
 
-  /*
-    Use the derivation hash to invalidate the output via name, for testing
-    purposes.
-
-    Type: (a@{ name, ... } -> Derivation) -> a -> Derivation
-
-    Normally, fixed output derivations can and should be cached by their output
-    hash only, but for testing we want to re-fetch everytime the fetcher changes.
-
-    Changes to the fetcher become apparent in the drvPath, which is a hash of
-    how to fetch, rather than a fixed store path.
-    By inserting this hash into the name, we can make sure to re-run the fetcher
-    every time the fetcher changes.
-
-    This relies on the assumption that Nix isn't clever enough to reuse its
-    database of local store contents to optimize fetching.
-
-    Note that the "salt" derives from a different drv than the final fetcher
-    drv. This is necessary, because it can not be defined recursively.
-
-    Example:
-
-      tests.fetchgit = invalidateFetcherByDrvHash fetchgit {
-        name = "nix-source";
-        url = "https://github.com/NixOS/nix";
-        rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
-        sha256 = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
-      };
-  */
+  # See doc/builders/special/invalidateFetcherByDrvHash.section.md or
+  # https://nixos.org/manual/nixpkgs/unstable/#sec-pkgs-invalidateFetcherByDrvHash
   invalidateFetcherByDrvHash = f: args:
     let
       drvPath = (f args).drvPath;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -594,6 +594,42 @@ with pkgs;
 
   installShellFiles = callPackage ../build-support/install-shell-files {};
 
+  /*
+    Use the derivation hash to invalidate the output via name, for testing
+    purposes.
+
+    Type: (a@{ name, ... } -> Derivation) -> a -> Derivation
+
+    Normally, fixed output derivations can and should be cached by their output
+    hash only, but for testing we want to re-fetch everytime the fetcher changes.
+
+    Changes to the fetcher become apparent in the drvPath, which is a hash of
+    how to fetch, rather than a fixed store path.
+    By inserting this hash into the name, we can make sure to re-run the fetcher
+    every time the fetcher changes.
+
+    This relies on the assumption that Nix isn't clever enough to reuse its
+    database of local store contents to optimize fetching.
+
+    Note that the "salt" derives from a different drv than the final fetcher
+    drv. This is necessary, because it can not be defined recursively.
+
+    Example:
+
+      tests.fetchgit = invalidateFetcherByDrvHash fetchgit {
+        name = "nix-source";
+        url = "https://github.com/NixOS/nix";
+        rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+        sha256 = "sha256-7DszvbCNTjpzGRmpIVAWXk20P0/XTrWZ79KSOGLrUWY=";
+      };
+  */
+  invalidateFetcherByDrvHash = f: args:
+    let
+      drvPath = (f args).drvPath;
+      # It's safe to discard the context, because we don't access the path.
+      salt = builtins.unsafeDiscardStringContext (lib.substring 0 12 (baseNameOf drvPath));
+    in f (args // { name = "${args.name or "source"}-salted-${salt}"; });
+
   lazydocker = callPackage ../tools/misc/lazydocker { };
 
   ld-is-cc-hook = makeSetupHook { name = "ld-is-cc-hook"; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -441,10 +441,12 @@ with pkgs;
 
   fetchfossil = callPackage ../build-support/fetchfossil { };
 
-  fetchgit = callPackage ../build-support/fetchgit {
+  fetchgit = (callPackage ../build-support/fetchgit {
     git = buildPackages.gitMinimal;
     cacert = buildPackages.cacert;
     git-lfs = buildPackages.git-lfs;
+  }) // { # fetchgit is a function, so we use // instead of passthru.
+    tests = callPackages ../build-support/fetchgit/tests.nix {};
   };
 
   fetchgitLocal = callPackage ../build-support/fetchgitlocal { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -119,24 +119,6 @@ with pkgs;
     callTest = t: t.test;
   };
 
-  ### Traversal for package tests
-
-  # Whereas most tests can be run with `nix-build -A my-package.tests`, this
-  # does not work for tests on a __functor attrset.
-  # TODO: enable these on hydra.nixos.org?
-  packageTests = let
-    getTests = attrs:
-      if builtins.typeOf attrs != "set"
-      then {}
-      else if lib.isDerivation attrs
-        then lib.recurseIntoAttrs attrs.tests or {}
-        else if attrs?__functor
-        then lib.recurseIntoAttrs attrs.tests or {}
-        else lib.mapAttrs (k: if k == "recurseForDerivations" then v: v else getTests) attrs;
-    in
-      getTests pkgs;
-
-
   ### BUILD SUPPORT
 
   auditBlasHook = makeSetupHook


### PR DESCRIPTION
###### Motivation for this change

Make maintenance easier on the fetchers and avoid problems.

The `packageTests` attribute will serve two purposes:
 - for ofborg: allow it to build tests in a __functor attrset like `fetchgit`
 - for hydra, potentially, build the package tests. Enabling these is not part of this PR.

Closes #133739

Refs #128749 #135881 or really all of [topic: fetch](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen++label%3A%226.topic%3A+fetch%22+)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
