### PR TITLE
ssldump: 1.1 -> 1.4

### DIFF
--- a/pkgs/tools/networking/ssldump/default.nix
+++ b/pkgs/tools/networking/ssldump/default.nix
@@ -1,30 +1,52 @@
-{ lib, stdenv, fetchFromGitHub, openssl, libpcap }:
+{ lib
+, stdenv
+, autoreconfHook
+, fetchFromGitHub
+, json_c
+, libnet
+, libpcap
+, openssl
+}:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "ssldump";
-  version = "1.1";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "adulau";
     repo = "ssldump";
-    rev = "7491b9851505acff95b2c68097e9b9f630d418dc";
-    sha256 = "1j3rln86khdnc98v50hclvqaq83a24c1rfzbcbajkbfpr4yxpnpd";
+    rev = "v${version}";
+    sha256 = "1xnlfqsl93nxbcv4x4xsgxa6mnhcx37hijrpdb7vzla6q7xvg8qr";
   };
 
-  buildInputs = [ libpcap openssl ];
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    json_c
+    libnet
+    libpcap
+    openssl
+  ];
+
   prePatch = ''
     sed -i -e 's|#include.*net/bpf.h|#include <pcap/bpf.h>|' \
       base/pcap-snoop.c
   '';
-  configureFlags = [ "--with-pcap-lib=${libpcap}/lib"
-                     "--with-pcap-inc=${libpcap}/include"
-                     "--with-openssl-lib=${openssl}/lib"
-                     "--with-openssl-inc=${openssl}/include" ];
-  meta = {
+
+  configureFlags = [
+    "--with-pcap-lib=${libpcap}/lib"
+    "--with-pcap-inc=${libpcap}/include"
+    "--with-openssl-lib=${openssl}/lib"
+    "--with-openssl-inc=${openssl}/include"
+  ];
+
+  meta = with lib; {
     description = "An SSLv3/TLS network protocol analyzer";
     homepage = "http://ssldump.sourceforge.net";
     license = "BSD-style";
-    maintainers = with lib.maintainers; [ aycanirican ];
-    platforms = lib.platforms.linux;
+    maintainers = with maintainers; [ aycanirican ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.4

Change log: https://github.com/adulau/ssldump/blob/master/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
