### PR TITLE
cinny: init at 1.6.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/cinny/default.nix
+++ b/pkgs/applications/networking/instant-messengers/cinny/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchurl, writeText, jq, conf ? {} }:
+
+let
+  configOverrides = writeText "cinny-config-overrides.json" (builtins.toJSON conf);
+in stdenv.mkDerivation rec {
+  pname = "cinny";
+  version = "1.6.1";
+
+  src = fetchurl {
+    url = "https://github.com/ajbura/cinny/releases/download/v${version}/cinny-v${version}.tar.gz";
+    sha256 = "sha256-RJpLK16bedpqo/JJf3atpiuL5spHJNowomcusjZtEWA=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/
+    cp -R . $out/
+    ${jq}/bin/jq -s '.[0] * .[1]' "config.json" "${configOverrides}" > "$out/config.json"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Yet another Matrix client for the web";
+    homepage = "https://cinny.in/";
+    maintainers = with maintainers; [ abbe ];
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2473,6 +2473,8 @@ with pkgs;
 
   cht-sh = callPackage ../tools/misc/cht.sh { };
 
+  cinny = callPackage ../applications/networking/instant-messengers/cinny {};
+
   ckbcomp = callPackage ../tools/X11/ckbcomp { };
 
   clac = callPackage ../tools/misc/clac {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Cinny is a web client for Matrix, and would like it to be available to nixpkgs. The derivation is architecture independent similar to `element-web`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
