### PR TITLE
prowlarr: init at 0.1.1.978

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5144,6 +5144,12 @@
     githubId = 117874;
     name = "Jeroen de Haas";
   };
+  jdreaver = {
+    email = "johndreaver@gmail.com";
+    github = "jdreaver";
+    githubId = 1253071;
+    name = "David Reaver";
+  };
   jduan = {
     name = "Jingjing Duan";
     email = "duanjingjing@gmail.com";

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -271,6 +271,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://wiki.servarr.com/prowlarr">prowlarr</link>,
+          an indexer manager/proxy built on the popular arr .net/reactjs
+          base stack
+          <link linkend="opt-services.prowlarr.enable">services.prowlarr</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://sr.ht/~emersion/soju">soju</link>, a
           user-friendly IRC bouncer. Available as
           <link xlink:href="options.html#opt-services.soju.enable">services.soju</link>.

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -82,6 +82,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [postfixadmin](https://postfixadmin.sourceforge.io/), a web based virtual user administration interface for Postfix mail servers. Available as [postfixadmin](#opt-services.postfixadmin.enable).
 
+- [prowlarr](https://wiki.servarr.com/prowlarr), an indexer manager/proxy built on the popular arr .net/reactjs base stack [services.prowlarr](#opt-services.prowlarr.enable).
+
 - [soju](https://sr.ht/~emersion/soju), a user-friendly IRC bouncer. Available as [services.soju](options.html#opt-services.soju.enable).
 
 - [nats](https://nats.io/), a high performance cloud and edge messaging system. Available as [services.nats](#opt-services.nats.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -571,6 +571,7 @@
   ./services/misc/plex.nix
   ./services/misc/plikd.nix
   ./services/misc/podgrab.nix
+  ./services/misc/prowlarr.nix
   ./services/misc/tautulli.nix
   ./services/misc/pinnwand.nix
   ./services/misc/pykms.nix

--- a/nixos/modules/services/misc/prowlarr.nix
+++ b/nixos/modules/services/misc/prowlarr.nix
@@ -1,0 +1,41 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.prowlarr;
+
+in
+{
+  options = {
+    services.prowlarr = {
+      enable = mkEnableOption "Prowlarr";
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Open ports in the firewall for the Prowlarr web interface.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.prowlarr = {
+      description = "Prowlarr";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        DynamicUser = true;
+        StateDirectory = "prowlarr";
+        ExecStart = "${pkgs.prowlarr}/bin/Prowlarr -nobrowser -data=/var/lib/prowlarr";
+        Restart = "on-failure";
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ 9696 ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -375,6 +375,7 @@ in
   prosody = handleTest ./xmpp/prosody.nix {};
   prosodyMysql = handleTest ./xmpp/prosody-mysql.nix {};
   proxy = handleTest ./proxy.nix {};
+  prowlarr = handleTest ./prowlarr.nix {};
   pt2-clone = handleTest ./pt2-clone.nix {};
   qboot = handleTestOn ["x86_64-linux" "i686-linux"] ./qboot.nix {};
   quorum = handleTest ./quorum.nix {};

--- a/nixos/tests/prowlarr.nix
+++ b/nixos/tests/prowlarr.nix
@@ -1,0 +1,18 @@
+import ./make-test-python.nix ({ lib, ... }:
+
+with lib;
+
+{
+  name = "prowlarr";
+  meta.maintainers = with maintainers; [ jdreaver ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    { services.prowlarr.enable = true; };
+
+  testScript = ''
+    machine.wait_for_unit("prowlarr.service")
+    machine.wait_for_open_port("9696")
+    machine.succeed("curl --fail http://localhost:9696/")
+  '';
+})

--- a/pkgs/servers/prowlarr/default.nix
+++ b/pkgs/servers/prowlarr/default.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, makeWrapper, icu, dotnetCorePackages, openssl, nixosTests }:
+
+let
+  os =
+    if stdenv.isDarwin then
+      "osx"
+    else if stdenv.isLinux then
+      "linux"
+    else
+      throw "Not supported on ${stdenv.hostPlatform.system}.";
+
+  arch = {
+    x86_64-linux = "x64";
+    aarch64-linux = "arm64";
+    x86_64-darwin = "x64";
+  }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  hash = {
+    x64-linux_hash = "sha256-9DoqyotXAUha2TMSgDIot5PD8ABpfZ8gsshS1ypr5SY=";
+    arm64-linux_hash = "sha256-r22c70OuevRsF8gOHZOkkhlRtoD4nsTHnXF82elQIF8=";
+    x64-osx_hash = "sha256-6jVM4iSGT7tpagocI/1nuBPVvAegfFqsCfrz2fPKCI4=";
+  }."${arch}-${os}_hash";
+
+in stdenv.mkDerivation rec {
+  pname = "prowlarr";
+  version = "0.1.1.978";
+
+  src = fetchurl {
+    url = "https://github.com/Prowlarr/Prowlarr/releases/download/v${version}/Prowlarr.develop.${version}.${os}-core-${arch}.tar.gz";
+    sha256 = hash;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/${pname}-${version}}
+    cp -r * $out/share/${pname}-${version}/.
+
+    makeWrapper "${dotnetCorePackages.netcore_3_1}/bin/dotnet" $out/bin/Prowlarr \
+      --add-flags "$out/share/${pname}-${version}/Prowlarr.dll" \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
+        curl sqlite libmediainfo mono openssl icu ]}
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = ./update.sh;
+  };
+
+  meta = with lib; {
+    description = "An indexer manager/proxy built on the popular arr .net/reactjs base stack";
+    homepage = "https://wiki.servarr.com/prowlarr";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ jdreaver ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/servers/prowlarr/default.nix
+++ b/pkgs/servers/prowlarr/default.nix
@@ -48,6 +48,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = ./update.sh;
+    tests.smoke-test = nixosTests.prowlarr;
   };
 
   meta = with lib; {

--- a/pkgs/servers/prowlarr/update.sh
+++ b/pkgs/servers/prowlarr/update.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused nix-prefetch jq
+
+set -eou pipefail
+
+dirname="$(dirname "$0")"
+
+updateHash()
+{
+    version=$1
+    arch=$2
+    os=$3
+
+    hashKey="${arch}-${os}_hash"
+
+    url="https://github.com/Prowlarr/Prowlarr/releases/download/v$version/Prowlarr.develop.$version.$os-core-$arch.tar.gz"
+    hash=$(nix-prefetch-url --type sha256 $url)
+    sriHash="$(nix hash to-sri --type sha256 $hash)"
+
+    sed -i "s|$hashKey = \"[a-zA-Z0-9\/+-=]*\";|$hashKey = \"$sriHash\";|g" "$dirname/default.nix"
+}
+
+updateVersion()
+{
+    sed -i "s/version = \"[0-9.]*\";/version = \"$1\";/g" "$dirname/default.nix"
+}
+
+currentVersion=$(cd $dirname && nix eval --raw -f ../../.. prowlarr.version)
+
+# N.B. Prowlarr is still in development, so
+# https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest
+# returns nothing. Once this endpoint returns something, we should use
+# it. Until then, we use jq to sort releases (N.B. the "sort_by(. |
+# split(".") | map(tonumber))" incantation is to sort the version
+# number properly and not as a string).
+
+# latestTag=$(curl https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest | jq -r ".tag_name")
+# latestVersion="$(expr $latestTag : 'v\(.*\)')"
+latestVersion=$(curl https://api.github.com/repos/Prowlarr/Prowlarr/git/refs/tags | jq '. | map(.ref | sub("refs/tags/v";"")) | sort_by(. | split(".") | map(tonumber)) | .[-1]' -r)
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "Prowlarr is up-to-date: ${currentVersion}"
+    exit 0
+fi
+
+updateVersion $latestVersion
+
+updateHash $latestVersion x64 linux
+updateHash $latestVersion arm64 linux
+updateHash $latestVersion x64 osx

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8633,6 +8633,8 @@ with pkgs;
 
   openmodelica = recurseIntoAttrs (callPackage ../applications/science/misc/openmodelica {});
 
+  prowlarr = callPackage ../servers/prowlarr { };
+
   qarte = libsForQt5.callPackage ../applications/video/qarte { };
 
   qlcplus = libsForQt5.callPackage ../applications/misc/qlcplus { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/135887

This PR adds a new package and NixOS service for [Prowlarr](https://wiki.servarr.com/prowlarr). This is an indexer similar to `jackett` (which is already in nixpkgs), but is newer and more well-integrated with the *arr ecosystem (e.g. `radarr` and `sonarr`, which are also already in `nixpkgs`).

I mostly copied the config from `radarr` and fixed the `prowlarr`-specific bits. In particular, the `update.sh` script had to be modified because the releases are not official releases yet, so we have to specify the version we want to use.

**This is my first significant `nixpkgs` PR.** I've updated the versions of packages before, but I've never added a new service from scratch. I would think anyone who is a maintainer for `radarr` could/should review this. I'm also happy to add myself as a maintainer for this package, but I'm not sure what the protocol on that is.

I used this `nixpkgs` fork and enabled `prowlarr` in my home server's NixOS config, and it worked flawlessly, so this has basically been tested end-to-end.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
