### PR TITLE
treewide: lib.concatStrings (lib.intersperse ...) -> lib.concatStringsSep …

### DIFF
--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -84,7 +84,7 @@ with builtins; buildDotnetPackage rec {
   # after loading. It is brought into plugins bin/ directory using
   # buildEnv in the plugin derivation. Wrapper below makes sure it
   # is found and does not pollute output path.
-  binPaths = lib.concatStrings (lib.intersperse ":" (map (x: x + "/bin") plugins));
+  binPaths = lib.concatStringsSep ":" (map (x: x + "/bin") plugins);
 
   dynlibPath = lib.makeLibraryPath [ gtk2 ];
 

--- a/pkgs/applications/video/vdr/wrapper.nix
+++ b/pkgs/applications/video/vdr/wrapper.nix
@@ -24,7 +24,7 @@ in symlinkJoin {
     inherit license homepage;
     description = description
     + " (with plugins: "
-    + lib.concatStrings (lib.intersperse ", " (map (x: ""+x.name) plugins))
+    + lib.concatStringsSep ", " (map (x: ""+x.name) plugins)
     + ")";
   };
 }

--- a/pkgs/desktops/xfce/core/thunar/wrapper.nix
+++ b/pkgs/desktops/xfce/core/thunar/wrapper.nix
@@ -36,6 +36,6 @@ symlinkJoin {
 
     description = thunar.meta.description + optionalString
       (0 != length thunarPlugins)
-      " (with plugins: ${concatStrings (intersperse ", " (map (x: x.name) thunarPlugins))})";
+      " (with plugins: ${concatStringsSep  ", " (map (x: x.name) thunarPlugins)})";
   };
 }

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -133,7 +133,7 @@ let
       "--with-system-zlib"
       "--enable-static"
       "--enable-languages=${
-        lib.concatStrings (lib.intersperse ","
+        lib.concatStringsSep ","
           (  lib.optional langC        "c"
           ++ lib.optional langCC       "c++"
           ++ lib.optional langD        "d"
@@ -146,7 +146,6 @@ let
           ++ lib.optionals crossDarwin [ "objc" "obj-c++" ]
           ++ lib.optional langJit      "jit"
           )
-        )
       }"
     ]
 

--- a/pkgs/misc/emulators/retroarch/wrapper.nix
+++ b/pkgs/misc/emulators/retroarch/wrapper.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     inherit license homepage platforms maintainers;
     description = description
                   + " (with cores: "
-                  + lib.concatStrings (lib.intersperse ", " (map (x: ""+x.name) cores))
+                  + lib.concatStringsSep ", " (map (x: ""+x.name) cores)
                   + ")";
   };
 }

--- a/pkgs/tools/graphics/diagrams-builder/default.nix
+++ b/pkgs/tools/graphics/diagrams-builder/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   buildCommand = with lib;
-    concatStrings (intersperse "\n" (map exeWrapper backends));
+    concatStringsSep "\n" (map exeWrapper backends);
 
   # Will be faster to build the wrapper locally then to fetch it from a binary cache.
   preferLocalBuild = true;


### PR DESCRIPTION
Update all usage of lib.concatStrings (lib.intersperse ...) to
lib.concatStringsSep. This produces the same result as per https://github.com/NixOS/nixpkgs/pull/135843,
however it yields a performance benefit on Nix versions that
support the builtins.concatStringsSep primop.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The `concatStrings (intersperse ...)` effectively produces an intermediate result(which has to be strict) of what `builtins.concatStringsSep` does internally then proceeds to concatenate it using `concatStringsSep` using an empty string as the separator, this is wasteful on Nix versions with support for `builtins.concatStringsSep` which can inline this iteratively without an intermediate result.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
