### PR TITLE
Add espeak-ng support to brltty

### DIFF
--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -2,6 +2,7 @@
 , tcl, acl, kmod, coreutils, shadow, util-linux, udev
 , alsaSupport ? stdenv.isLinux, alsa-lib
 , systemdSupport ? stdenv.isLinux, systemd
+, espeak-ngSupport ? true, espeak-ng
 }:
 
 stdenv.mkDerivation rec {
@@ -13,10 +14,12 @@ stdenv.mkDerivation rec {
     sha256 = "14psxwlvgyi2fj1zh8rfykyjcjaya8xa7yg574bxd8y8n49n8hvb";
   };
 
-  nativeBuildInputs = [ pkg-config python3.pkgs.cython tcl ];
-  buildInputs = [ bluez ]
+  nativeBuildInputs = [ pkg-config python3.pkgs.cython tcl ]
+    ++ lib.optional espeak-ngSupport espeak-ng;
+  buildInputs = [ bluez espeak-ng ]
     ++ lib.optional alsaSupport alsa-lib
-    ++ lib.optional systemdSupport systemd;
+    ++ lib.optional systemdSupport systemd
+    ++ lib.optional espeak-ngSupport espeak-ng;
 
   meta = {
     description = "Access software for a blind person using a braille display";
@@ -46,7 +49,10 @@ stdenv.mkDerivation rec {
     "--with-writable-directory=/run/brltty"
     "--with-updatable-directory=/var/lib/brltty"
     "--with-api-socket-path=/var/lib/BrlAPI"
-  ];
+  ] ++ lib.optional espeak-ngSupport [
+      "--with-espeak_ng=$espeak-ng"
+      "--with-speech-driver=en"
+    ];
   installFlags = [ "install-systemd" "install-udev" "install-polkit" ];
 
   preConfigure = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
