### PR TITLE
virtualbox: fix audio driver loading

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -97,6 +97,7 @@ in stdenv.mkDerivation {
     # Temporary workaround for broken build
     # https://www.virtualbox.org/pipermail/vbox-dev/2021-July/015670.html
     ./fix-configure-pkgconfig-qt.patch
+    # https://github.com/NixOS/nixpkgs/issues/123851
     ./fix-audio-driver-loading.patch
   ];
 

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -97,6 +97,7 @@ in stdenv.mkDerivation {
     # Temporary workaround for broken build
     # https://www.virtualbox.org/pipermail/vbox-dev/2021-July/015670.html
     ./fix-configure-pkgconfig-qt.patch
+    ./fix-audio-driver-loading.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/virtualization/virtualbox/fix-audio-driver-loading.patch
+++ b/pkgs/applications/virtualization/virtualbox/fix-audio-driver-loading.patch
@@ -1,0 +1,26 @@
+diff --git a/src/VBox/Devices/Audio/DrvHostAudioAlsaStubs.cpp b/src/VBox/Devices/Audio/DrvHostAudioAlsaStubs.cpp
+index cfcb0abbf..2ce564f6f 100644
+--- a/src/VBox/Devices/Audio/DrvHostAudioAlsaStubs.cpp
++++ b/src/VBox/Devices/Audio/DrvHostAudioAlsaStubs.cpp
+@@ -258,7 +258,7 @@ static DECLCALLBACK(int32_t) drvHostAudioAlsaLibInitOnce(void *pvUser)
+     LogFlowFunc(("\n"));
+ 
+     RTLDRMOD hMod = NIL_RTLDRMOD;
+-    int rc = RTLdrLoadSystemEx(VBOX_ALSA_LIB, RTLDRLOAD_FLAGS_NO_UNLOAD, &hMod);
++    int rc = RTLdrLoad(VBOX_ALSA_LIB, &hMod);
+     if (RT_SUCCESS(rc))
+     {
+         for (uintptr_t i = 0; i < RT_ELEMENTS(SharedFuncs); i++)
+diff --git a/src/VBox/Devices/Audio/DrvHostAudioPulseAudioStubs.cpp b/src/VBox/Devices/Audio/DrvHostAudioPulseAudioStubs.cpp
+index a17fc93f9..148f5c39a 100644
+--- a/src/VBox/Devices/Audio/DrvHostAudioPulseAudioStubs.cpp
++++ b/src/VBox/Devices/Audio/DrvHostAudioPulseAudioStubs.cpp
+@@ -332,7 +332,7 @@ static DECLCALLBACK(int32_t) drvHostAudioPulseLibInitOnce(void *pvUser)
+     LogFlowFunc(("\n"));
+ 
+     RTLDRMOD hMod = NIL_RTLDRMOD;
+-    int rc = RTLdrLoadSystemEx(VBOX_PULSE_LIB, RTLDRLOAD_FLAGS_NO_UNLOAD, &hMod);
++    int rc = RTLdrLoad(VBOX_PULSE_LIB, &hMod);
+     if (RT_SUCCESS(rc))
+     {
+         for (unsigned i = 0; i < RT_ELEMENTS(g_aImportedFunctions); i++)


### PR DESCRIPTION
fixes #123851

patch by @jcumming

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note: I couldn't run the tests because the build for `VirtualBox-GuestAdditions-6.1.26-5.10.60` fails with:

```
  CC [M]  /build/install/src/vboxguest-6.1.26/vboxguest/common/math/gcc/qdivrem.o
In file included from /build/install/src/vboxguest-6.1.26/vboxguest/combined-os-specific.c:30:
/build/install/src/vboxguest-6.1.26/vboxguest/r0drv/linux/alloc-r0drv-linux.c: In function 'rtR0MemAllocEx':
/build/install/src/vboxguest-6.1.26/vboxguest/r0drv/linux/alloc-r0drv-linux.c:272:27: error: too many arguments to function '__vmalloc'
  272 |         pHdr = (PRTMEMHDR)__vmalloc(cb + sizeof(*pHdr), GFP_KERNEL | __GFP_HIGHMEM | __GFP_NOWARN, MY_PAGE_KERNEL_EXEC);
      |                           ^~~~~~~~~
In file included from /nix/store/iqv8g1m0xl18hc26cq0ik8kgqdfvzxxm-linux-5.10.60-dev/lib/modules/5.10.60/source/include/asm-generic/io.h:911,
                 from /nix/store/iqv8g1m0xl18hc26cq0ik8kgqdfvzxxm-linux-5.10.60-dev/lib/modules/5.10.60/source/arch/x86/include/asm/io.h:375,
                 from /nix/store/iqv8g1m0xl18hc26cq0ik8kgqdfvzxxm-linux-5.10.60-dev/lib/modules/5.10.60/source/include/linux/io.h:13,
                 from /nix/store/iqv8g1m0xl18hc26cq0ik8kgqdfvzxxm-linux-5.10.60-dev/lib/modules/5.10.60/source/include/linux/pci.h:39,
                 from /build/install/src/vboxguest-6.1.26/vboxguest/r0drv/linux/the-linux-kernel.h:135,
                 from /build/install/src/vboxguest-6.1.26/vboxguest/combined-os-specific.c:28:
/nix/store/iqv8g1m0xl18hc26cq0ik8kgqdfvzxxm-linux-5.10.60-dev/lib/modules/5.10.60/source/include/linux/vmalloc.h:107:14: note: declared here
  107 | extern void *__vmalloc(unsigned long size, gfp_t gfp_mask);
      |              ^~~~~~~~~
```