### PR TITLE
gnome.baobab: use strictDeps

### DIFF
--- a/pkgs/desktops/gnome/core/baobab/default.nix
+++ b/pkgs/desktops/gnome/core/baobab/default.nix
@@ -27,25 +27,30 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    desktop-file-utils
+    gettext
+    glib
+    itstool
+    libxml2
     meson
     ninja
     pkg-config
-    vala
-    gettext
-    itstool
-    libxml2
-    desktop-file-utils
-    wrapGAppsHook
     python3
+    vala
+    wrapGAppsHook
+    # Prevents “error: Package `libhandy-1' not found in specified Vala API
+    # directories or GObject-Introspection GIR directories”, even though it
+    # should only be a runtime dependency.
+    libhandy
   ];
 
   buildInputs = [
     gtk3
     libhandy
     glib
-    gnome.adwaita-icon-theme
   ];
 
+  strictDeps = true;
   doCheck = true;
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
