### PR TITLE
llvmPackages/update.sh: Support LLVM 13+

### DIFF
--- a/pkgs/development/compilers/llvm/update.sh
+++ b/pkgs/development/compilers/llvm/update.sh
@@ -19,19 +19,26 @@ sed -Ei \
   "$FILE"
 
 readonly ATTRSET="llvmPackages_$VERSION_MAJOR"
-readonly SOURCES=(
-  "clang-unwrapped.src"
-  "compiler-rt.src"
-  "clang-unwrapped.clang-tools-extra_src"
-  "libcxx.src"
-  "libcxxabi.src"
-  "libunwind.src"
-  "lld.src"
-  "lldb.src"
-  "llvm.src"
-  "llvm.polly_src"
-  "openmp.src"
-)
+
+if [ "$VERSION_MAJOR" -ge "13" ]; then
+  readonly SOURCES=(
+    "llvm.src"
+  )
+else
+  readonly SOURCES=(
+    "clang-unwrapped.src"
+    "compiler-rt.src"
+    "clang-unwrapped.clang-tools-extra_src"
+    "libcxx.src"
+    "libcxxabi.src"
+    "libunwind.src"
+    "lld.src"
+    "lldb.src"
+    "llvm.src"
+    "llvm.polly_src"
+    "openmp.src"
+  )
+fi
 
 for SOURCE in "${SOURCES[@]}"; do
   echo "Updating the hash of $SOURCE:"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
