### PR TITLE
lib/strings: __toString attrs considered strings

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -23,7 +23,6 @@ rec {
     isList
     isAttrs
     isPath
-    isString
     match
     parseDrvName
     readFile
@@ -912,10 +911,13 @@ rec {
      string interpolations and in most functions that expect a string.
    */
   isStringLike = x:
-    isString x ||
+    builtins.isString x ||
     isPath x ||
     x ? outPath ||
     x ? __toString;
+
+  /* Check whether something can be used as a string */
+  isString = isStringLike;
 
   /* Check whether a value is a store path.
 


### PR DESCRIPTION
Unlike values that must be explicitly converted to strings, attrsets containing a `__toString` function can be used anywhere as strings.

Most `isCoercibleToString` types require conversion via either `"${x}"` or `toString x` (which are different operators with different behaviours, is "coerce" in this context referring to a specific op?). Attrsets containing `{ __toString = self: "x"; }` however are unique in that they act more like functors; they will be automatically coerced when used in place of a string. Also like strings, `toString x == "${x}"`

###### Motivation for this change

My particular motivation here is to be able to use these attrsets as values for `types.str` and similar options in nixos modules, in much the same way that nixpkgs expands the definition of `isFunction` to include functors.

Not sure if this would be controversial/discouraged but figured it was worth throwing out there, so...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
