### PR TITLE
chromium: Move the version helper functions into default.nix

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -1,4 +1,7 @@
-{ lib, mkChromiumDerivation, channel, enableWideVine, ungoogled }:
+{ lib, mkChromiumDerivation
+, channel, chromiumVersionAtLeast
+, enableWideVine, ungoogled
+}:
 
 with lib;
 
@@ -16,8 +19,8 @@ mkChromiumDerivation (base: rec {
     cp -v "$buildPath/"*.so "$buildPath/"*.pak "$buildPath/"*.bin "$libExecPath/"
     cp -v "$buildPath/icudtl.dat" "$libExecPath/"
     cp -vLR "$buildPath/locales" "$buildPath/resources" "$libExecPath/"
-    ${lib.optionalString (channel != "dev") ''cp -v "$buildPath/crashpad_handler" "$libExecPath/"''}
-    ${lib.optionalString (channel == "dev") ''cp -v "$buildPath/chrome_crashpad_handler" "$libExecPath/"''}
+    ${lib.optionalString (!chromiumVersionAtLeast "94") ''cp -v "$buildPath/crashpad_handler" "$libExecPath/"''}
+    ${lib.optionalString (chromiumVersionAtLeast "94") ''cp -v "$buildPath/chrome_crashpad_handler" "$libExecPath/"''}
     cp -v "$buildPath/chrome" "$libExecPath/$packageName"
 
     # Swiftshader

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, fetchurl, fetchpatch
 # Channel data:
 , channel, upstream-info
+# Helper functions:
+, chromiumVersionAtLeast, versionRange
 
 # Native build inputs:
 , ninja, pkg-config
@@ -105,18 +107,6 @@ let
   buildType = "Release";
   buildPath = "out/${buildType}";
   libExecPath = "$out/libexec/${packageName}";
-
-  warnObsoleteVersionConditional = min-version: result:
-    let ungoogled-version = (importJSON ./upstream-info.json).ungoogled-chromium.version;
-    in warnIf (versionAtLeast ungoogled-version min-version) "chromium: ungoogled version ${ungoogled-version} is newer than a conditional bounded at ${min-version}. You can safely delete it."
-      result;
-  chromiumVersionAtLeast = min-version:
-    let result = versionAtLeast upstream-info.version min-version;
-    in  warnObsoleteVersionConditional min-version result;
-  versionRange = min-version: upto-version:
-    let inherit (upstream-info) version;
-        result = versionAtLeast version min-version && versionOlder version upto-version;
-    in warnObsoleteVersionConditional upto-version result;
 
   ungoogler = ungoogled-chromium {
     inherit (upstream-info.deps.ungoogled-patches) rev sha256;


### PR DESCRIPTION
Those functions can be required anywhere in the Nix expressions for
Chromium and therefore they should be defined in default.nix and
inherited where necessary.

This fixes the chromiumBeta build which failed because I forgot to
update the channel conditional when the beta channel advanced to M94.
This is exactly why the version based conditionals should be used
everywhere.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Note: This change should only affect `chromiumBeta`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
