### PR TITLE
nixos/gnome: enable platform integration for Qt

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1088,6 +1088,15 @@ Superuser created successfully.
           but instead use more of the YAML-specific syntax.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          GNOME desktop environment now enables
+          <literal>QGnomePlatform</literal> as the Qt platform theme,
+          which should avoid crashes when opening file chooser dialogs
+          in Qt apps by using XDG desktop portal. Additionally, it will
+          make the apps fit better visually.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -311,3 +311,5 @@ To be able to access the web UI this port needs to be opened in the firewall.
 - Nginx will use the value of `sslTrustedCertificate` if provided for a virtual host, even if `enableACME` is set. This is useful for providers not using the same certificate to sign OCSP responses and server certificates.
 
 - `lib.formats.yaml`'s `generate` will not generate JSON anymore, but instead use more of the YAML-specific syntax.
+
+- GNOME desktop environment now enables `QGnomePlatform` as the Qt platform theme, which should avoid crashes when opening file chooser dialogs in Qt apps by using XDG desktop portal. Additionally, it will make the apps fit better visually.

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -372,6 +372,13 @@ in
       xdg.portal.enable = true;
       xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
 
+      # Harmonize Qt5 application style and also make them use the portal for file chooser dialog.
+      qt5 = {
+        enable = mkDefault true;
+        platformTheme = mkDefault "gnome";
+        style = mkDefault "adwaita";
+      };
+
       networking.networkmanager.enable = mkDefault true;
 
       services.xserver.updateDbusEnvironment = true;

--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -2,12 +2,12 @@
 , lib
 , fetchFromGitHub
 , nix-update-script
+, cmake
 , pkg-config
-, gtk3
+, adwaita-qt
 , glib
+, gtk3
 , qtbase
-, qmake
-, qtx11extras
 , pantheon
 , substituteAll
 , gsettings-desktop-schemas
@@ -15,13 +15,13 @@
 
 mkDerivation rec {
   pname = "qgnomeplatform";
-  version = "0.6.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "FedoraQt";
     repo = "QGnomePlatform";
     rev = version;
-    sha256 = "1mwqg2zk0sfjq54vz2jjahbgi5sxw8rb71h6mgg459wp99mhlqi0";
+    sha256 = "C/n8i5j0UWfxhP10c4j89U+LrpPozXnam4fIPYMXZAA=";
   };
 
   patches = [
@@ -33,24 +33,21 @@ mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    cmake
     pkg-config
-    qmake
   ];
 
   buildInputs = [
+    adwaita-qt
     glib
     gtk3
     qtbase
-    qtx11extras
   ];
 
-  postPatch = ''
-    # Fix plugin dir
-    substituteInPlace decoration/decoration.pro \
-      --replace "\$\$[QT_INSTALL_PLUGINS]" "$out/$qtPluginPrefix"
-    substituteInPlace theme/theme.pro \
-      --replace "\$\$[QT_INSTALL_PLUGINS]" "$out/$qtPluginPrefix"
-  '';
+  cmakeFlags = [
+    "-DGLIB_SCHEMAS_DIR=${glib.getSchemaPath gsettings-desktop-schemas}"
+    "-DQT_PLUGINS_DIR=${placeholder "out"}/${qtbase.qtPluginPrefix}"
+  ];
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/development/libraries/qgnomeplatform/hardcode-gsettings.patch
+++ b/pkgs/development/libraries/qgnomeplatform/hardcode-gsettings.patch
@@ -1,13 +1,14 @@
-diff --git a/common/gnomehintssettings.cpp b/common/gnomehintssettings.cpp
-index 9860e57..40fa6ec 100644
---- a/common/gnomehintssettings.cpp
-+++ b/common/gnomehintssettings.cpp
-@@ -80,9 +80,17 @@ void gtkMessageHandler(const gchar *log_domain,
- GnomeHintsSettings::GnomeHintsSettings()
-     : QObject(0)
+diff --git a/src/common/gnomesettings.cpp b/src/common/gnomesettings.cpp
+index 717cc9b..ee255ea 100644
+--- a/src/common/gnomesettings.cpp
++++ b/src/common/gnomesettings.cpp
+@@ -150,10 +150,18 @@ GnomeSettingsPrivate::GnomeSettingsPrivate(QObject *parent)
+     : GnomeSettings(parent)
      , m_usePortal(checkUsePortalSupport())
+     , m_canUseFileChooserPortal(!m_usePortal)
 -    , m_gnomeDesktopSettings(g_settings_new("org.gnome.desktop.wm.preferences"))
 -    , m_settings(g_settings_new("org.gnome.desktop.interface"))
+     , m_fallbackFont(new QFont(QLatin1String("Sans"), 10))
  {
 +    g_autoptr(GSettingsSchemaSource) schemaSource = nullptr;
 +    g_autoptr(GSettingsSchema) gnomeDesktopSchema = nullptr;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18499,7 +18499,7 @@ with pkgs;
 
   qrupdate = callPackage ../development/libraries/qrupdate { };
 
-  qgnomeplatform =  libsForQt514.callPackage ../development/libraries/qgnomeplatform { };
+  qgnomeplatform = libsForQt5.callPackage ../development/libraries/qgnomeplatform { };
 
   randomx = callPackage ../development/libraries/randomx { };
 


### PR DESCRIPTION
###### Motivation for this change

Qt links against GTK to be able to use native GTK file chooser in GTK-oriented DEs. However, GTK expects a specific environment, which means the application needs to be wrapped to prevent crashes when file chooser is opened in some environments.

This patch bypasses the need for wrapping Qt applications with GTK-related environment since the file chooser dialogue will now come from a separate process (instantiated by the XDG desktop portal via D-Bus).

In the future, we could remove the GTK dependency from Qt to fix the crashes on non-{GNOME,Pantheon} environments. Then, users would be able to choose between non-native Qt dialogue or native one facilitated by XDG portals (e.g. through setting `QT_QPA_PLATFORMTHEME` to either `qgnomeplatform`, or `xdgdesktopportal`).

One disadvantage is adding a Qt dependency to GNOME, even for people who might not use any Qt apps. But they can easily just add `qt5.enable = false;` to their NixOS configuration.

The configuration is also presumably less battle tested than plain Qt with its first-party GTK integration. But it is backed by Fedora and used by Manjaro GNOME so it cannot be that bad.

Lastly, I worry about ABI compatibility of the platform modules with apps installed from different Nixpkgs revision.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Confirmed that `QT_QPA_PLATFORMTHEME=qgnomeplatform QT_STYLE_OVERRIDE=adwaita calibre` follows the theme and file chooser uses portal.
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
