### PR TITLE
dwz: init at 0.14

### DIFF
--- a/pkgs/development/tools/misc/dwz/default.nix
+++ b/pkgs/development/tools/misc/dwz/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cmake, elfutils }:
+{ lib, stdenv, fetchurl, elfutils }:
 
 stdenv.mkDerivation rec {
   pname = "dwz";

--- a/pkgs/development/tools/misc/dwz/default.nix
+++ b/pkgs/development/tools/misc/dwz/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     description = "DWARF optimization and duplicate removal tool";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ jbcrail ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/tools/misc/dwz/default.nix
+++ b/pkgs/development/tools/misc/dwz/default.nix
@@ -12,8 +12,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ elfutils ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out/bin"
     cp dwz "$out/bin"
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/dwz/default.nix
+++ b/pkgs/development/tools/misc/dwz/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://sourceware.org/dwz/";
     description = "DWARF optimization and duplicate removal tool";
-    license = licenses.gpl3;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ jbcrail ];
     platforms = platforms.all;
   };

--- a/pkgs/development/tools/misc/dwz/default.nix
+++ b/pkgs/development/tools/misc/dwz/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl, cmake, elfutils }:
+
+stdenv.mkDerivation rec {
+  pname = "dwz";
+  version = "0.14";
+
+  src = fetchurl {
+    url = "https://www.sourceware.org/ftp/${pname}/releases/${pname}-${version}.tar.gz";
+    sha256 = "07qdvzfk4mvbqj5z3aff7vc195dxqn1mi27w2dzs1w2zhymnw01k";
+  };
+
+  nativeBuildInputs = [ elfutils ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp dwz "$out/bin"
+  '';
+
+  meta = with lib; {
+    homepage = "https://sourceware.org/dwz/";
+    description = "DWARF optimization and duplicate removal tool";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jbcrail ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/misc/dwz/default.nix
+++ b/pkgs/development/tools/misc/dwz/default.nix
@@ -11,14 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ elfutils ];
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p "$out/bin"
-    cp dwz "$out/bin"
-
-    runHook postInstall
-  '';
+  makeFlags = [ "prefix=${placeholder "out"}" ];
 
   meta = with lib; {
     homepage = "https://sourceware.org/dwz/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13745,6 +13745,8 @@ with pkgs;
 
   drush = callPackage ../development/tools/misc/drush { };
 
+  dwz = callPackage ../development/tools/misc/dwz { };
+
   easypdkprog = callPackage ../development/embedded/easypdkprog { };
 
   editorconfig-checker = callPackage ../development/tools/misc/editorconfig-checker { };


### PR DESCRIPTION
###### Motivation for this change

Add [dwz](https://sourceware.org/dwz/), a DWARF optimization and duplicate removal tool.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
