### PR TITLE
orc: disable failing test suite on armv7l

### DIFF
--- a/pkgs/development/compilers/orc/default.nix
+++ b/pkgs/development/compilers/orc/default.nix
@@ -12,6 +12,11 @@ in stdenv.mkDerivation rec {
     sha256 = "1w0qmyj3v9sb2g7ff39pp38b9850y9hyy0bag26ifrby5f7ksvm6";
   };
 
+  postPatch = lib.optionalString stdenv.isAarch32 ''
+    # https://gitlab.freedesktop.org/gstreamer/orc/-/issues/20
+    sed -i '/exec_opcodes_sys/d' testsuite/meson.build
+  '';
+
   outputs = [ "out" "dev" ]
      ++ optional buildDevDoc "devdoc"
   ;


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv7l-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
