### PR TITLE
root.tests.roottest: init

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, callPackage
 , fetchurl
 , makeWrapper
 , cmake
@@ -154,6 +155,9 @@ stdenv.mkDerivation rec {
   '';
 
   setupHook = ./setup-hook.sh;
+
+  passthru = { inherit python; };
+  passthru.tests.roottest = callPackage ./roottest.nix { };
 
   meta = with lib; {
     homepage = "https://root.cern.ch/";

--- a/pkgs/applications/science/misc/root/roottest.nix
+++ b/pkgs/applications/science/misc/root/roottest.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gtest
+, lz4
+, root
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "roottest";
+  inherit (root) version;
+
+  src = fetchFromGitHub {
+    owner = "root-project";
+    repo = "roottest";
+    rev = "v" + builtins.replaceStrings [ "." ] [ "-" ] version;
+    hash = "sha256-qiHoE1y8lCqRWSxuphViFT+RepZnMjK/8bk9jZJSPZk=";
+  };
+
+  dontInstall = true;
+
+  postPatch = ''
+    substituteInPlace cmake/modules/SearchInstalledSoftwareRoottest.cmake \
+      --replace 'if(NOT TARGET gtest)' 'if(FALSE)'
+    substituteInPlace python/CMakeLists.txt \
+      --replace "find_python_module(pytest REQUIRED)" "" \
+      --replace "if (PY_PYTEST_FOUND)" "if (TRUE)"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ gtest lz4 root root.python root.python.pkgs.pytest zstd ];
+
+  cmakeFlags = lib.optionals stdenv.isDarwin [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # https://github.com/NixOS/nixpkgs/pull/108496
+    "-DCMAKE_DISABLE_FIND_PACKAGE_Python2=TRUE"
+  ];
+
+  postBuild = ''
+    touch "$out"
+  '';
+
+  meta = with lib; {
+    homepage = "https://root.cern.ch/";
+    description = "The ROOT test suite";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.veprbl ];
+    license = licenses.lgpl21;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Why not

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
