### PR TITLE
abuild: init at 3.7.0

### DIFF
--- a/pkgs/development/tools/abuild/default.nix
+++ b/pkgs/development/tools/abuild/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, pkg-config
+, openssl
+, zlib
+, busybox
+}:
+
+stdenv.mkDerivation rec {
+  pname = "abuild";
+  version = "3.7.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.alpinelinux.org";
+    owner = "alpine";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xsik9hyzzq861bi922sb5r8c6r4wpnpxz5kd30i9f20vvfpp5jx";
+  };
+
+  buildInputs = [
+    openssl
+    zlib
+    busybox
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  patchPhase = ''
+    substituteInPlace ./Makefile \
+      --replace 'chmod 4555' '#chmod 4555'
+  '';
+
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+    "CFLAGS=-Wno-error"
+  ];
+
+  installFlags = [
+    "sysconfdir=${placeholder "out"}/etc"
+  ];
+
+  meta = with lib; {
+    description = "Alpine Linux build tools";
+    homepage = "https://gitlab.alpinelinux.org/alpine/abuild";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ onny ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/tools/admin/stripe-cli/default.nix
+++ b/pkgs/tools/admin/stripe-cli/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "stripe-cli";
-  version = "1.5.12";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "stripe";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-eMxukwaJqsXL0+Euvk5mM+pcAsT3GsF9filuyRL4tXg=";
+    sha256 = "sha256-CO+2BpMIUSaOhdia75zDGR4RZQSaxY05Z6TOKxBlKIw=";
   };
 
-  vendorSha256 = "sha256-e7EZ5o30vDpS904/R1y7/Mds7HxQNmsIftrnc1Bj2bc=";
+  vendorSha256 = "sha256-LOSHoEP0YRjfHav3MXSYPPrrjX6/ItxeVMOihRx0DTQ=";
 
   subPackages = [
     "cmd/stripe"

--- a/pkgs/tools/admin/stripe-cli/default.nix
+++ b/pkgs/tools/admin/stripe-cli/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "stripe-cli";
-  version = "1.7.0";
+  version = "1.5.12";
 
   src = fetchFromGitHub {
     owner = "stripe";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-CO+2BpMIUSaOhdia75zDGR4RZQSaxY05Z6TOKxBlKIw=";
+    sha256 = "sha256-eMxukwaJqsXL0+Euvk5mM+pcAsT3GsF9filuyRL4tXg=";
   };
 
-  vendorSha256 = "sha256-LOSHoEP0YRjfHav3MXSYPPrrjX6/ItxeVMOihRx0DTQ=";
+  vendorSha256 = "sha256-e7EZ5o30vDpS904/R1y7/Mds7HxQNmsIftrnc1Bj2bc=";
 
   subPackages = [
     "cmd/stripe"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13169,6 +13169,8 @@ with pkgs;
 
   abi-dumper = callPackage ../development/tools/misc/abi-dumper { };
 
+  abuild = callPackage ../development/tools/abuild { };
+
   adtool = callPackage ../tools/admin/adtool { };
 
   inherit (callPackage ../development/tools/alloy {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This pull request adds Alpine Linux abuild tool. With it one could build and package APKBUILD files in NixOS without any problems.

I'm still having some issues with patchShebangs in case of `bin/abuild` which uses `ash` as interpreter. Also the `chmod` command of `make install` doesn't seem to work, so the binaries are not executable yet :(

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
