### PR TITLE
nixos/paperless-ng: Fix /proc access for service

### DIFF
--- a/nixos/modules/services/misc/paperless-ng.nix
+++ b/nixos/modules/services/misc/paperless-ng.nix
@@ -48,7 +48,6 @@ let
     # PrivateNetwork = true;
     PrivateTmp = true;
     PrivateUsers = true;
-    ProcSubset = "pid";
     ProtectClock = true;
     # Breaks if the home dir of the user is in /home
     # Also does not add much value in combination with the TemporaryFileSystem.
@@ -61,6 +60,8 @@ let
     ProtectKernelModules = true;
     ProtectKernelTunables = true;
     ProtectProc = "invisible";
+    # django-q reads /proc/stat for CPU and memory information
+    ProcSubset = "all";
     RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
     RestrictNamespaces = true;
     RestrictRealtime = true;

--- a/nixos/modules/services/misc/paperless-ng.nix
+++ b/nixos/modules/services/misc/paperless-ng.nix
@@ -236,9 +236,7 @@ in
       '';
     };
 
-    # Password copying can't be implemented as a privileged preStart script
-    # in 'paperless-ng-server' because 'defaultServiceConfig' limits the filesystem
-    # paths accessible by the service.
+    # Reading the user-provided password file requires root access
     systemd.services.paperless-ng-copy-password = mkIf (cfg.passwordFile != null) {
       requiredBy = [ "paperless-ng-server.service" ];
       before = [ "paperless-ng-server.service" ];

--- a/nixos/tests/paperless-ng.nix
+++ b/nixos/tests/paperless-ng.nix
@@ -12,9 +12,11 @@ import ./make-test-python.nix ({ lib, ... }: {
   };
 
   testScript = ''
+    import json
+
     machine.wait_for_unit("paperless-ng-consumer.service")
 
-    with subtest("Create test doc"):
+    with subtest("Add a document via the file system"):
         machine.succeed(
             "convert -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 -fill black "
             "-annotate +5+20 'hello world 16-10-2005' /var/lib/paperless/consume/doc.png"
@@ -25,7 +27,7 @@ import ./make-test-python.nix ({ lib, ... }: {
         # Wait until server accepts connections
         machine.wait_until_succeeds("curl -fs localhost:28981")
 
-    with subtest("Create web test doc"):
+    with subtest("Add a document via the web interface"):
         machine.succeed(
             "convert -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 -fill black "
             "-annotate +5+20 'hello web 16-10-2005' /tmp/webdoc.png"
@@ -36,11 +38,8 @@ import ./make-test-python.nix ({ lib, ... }: {
         machine.wait_until_succeeds(
             "(($(curl -u admin:admin -fs localhost:28981/api/documents/ | jq .count) == 2))"
         )
-        assert "2005-10-16" in machine.succeed(
-            "curl -u admin:admin -fs localhost:28981/api/documents/ | jq '.results | .[0] | .created'"
-        )
-        assert "2005-10-16" in machine.succeed(
-            "curl -u admin:admin -fs localhost:28981/api/documents/ | jq '.results | .[1] | .created'"
-        )
+        docs = json.loads(machine.succeed("curl -u admin:admin -fs localhost:28981/api/documents/"))['results']
+        assert "2005-10-16" in docs[0]['created']
+        assert "2005-10-16" in docs[1]['created']
   '';
 })


### PR DESCRIPTION
Commit `nixos/paperless-ng: fix /proc access for service` fixes the following non critical error which can be triggered by running the test:
```
paperless-ng[1014]: Traceback (most recent call last):
paperless-ng[1014]:   File "/nix/store/sy7x6pr0kykqxjiq1jc6l2vyv712pd5c-python3.9-psutil-5.8.0/lib/python3.9/site-packages/psutil/_common.py", line 403, in wrapper
paperless-ng[1014]:     return cache[key]
paperless-ng[1014]: KeyError: (('/proc',), frozenset())
paperless-ng[1014]: During handling of the above exception, another exception occurred:
...
paperless-ng[1014]: FileNotFoundError: [Errno 2] No such file or directory: '/proc/stat'
```

cc @flakebi @em0lar

###### Things done
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change