### PR TITLE
akku: init at 1.1.0

### DIFF
--- a/pkgs/tools/package-management/akku/default.nix
+++ b/pkgs/tools/package-management/akku/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchFromGitLab, autoreconfHook, pkg-config, guile, curl, substituteAll }:
+
+stdenv.mkDerivation rec {
+  pname = "akku";
+  version = "1.1.0";
+
+  src = fetchFromGitLab {
+    owner = "akkuscm";
+    repo = "akku";
+    rev = "v${version}";
+    sha256 = "1pi18aamg1fd6f9ynfl7zx92052xzf0zwmhi2pwcwjs1kbah19f5";
+  };
+
+  patches = [
+    # substitute libcurl path
+    (substituteAll {
+      src = ./hardcode-libcurl.patch;
+      libcurl = "${curl.out}/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  buildInputs = [ guile ];
+
+  # Use a dummy package index to boostrap Akku
+  preBuild = ''
+    touch bootstrap.db
+  '';
+
+  makeFlags = [ "GUILE_AUTO_COMPILE=0" ];
+
+  meta = with lib; {
+    homepage = "https://akkuscm.org/";
+    description = "Language package manager for Scheme";
+    changelog = "https://gitlab.com/akkuscm/akku/-/raw/v${version}/NEWS.md";
+    platforms = platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ marsam ];
+  };
+}

--- a/pkgs/tools/package-management/akku/hardcode-libcurl.patch
+++ b/pkgs/tools/package-management/akku/hardcode-libcurl.patch
@@ -1,0 +1,18 @@
+--- old/private/http.scm
++++ new/private/http.scm
+@@ -101,14 +101,7 @@
+                  ;; shouldn't, but it's an old issue.
+                  (log/error "Could not load libcurl. Please install the curl development(!) package.")
+                  (exit 1)))
+-          (case (os-name)
+-            ((darwin) (set! libcurl (open-shared-object "libcurl.dylib")))
+-            ((msys) (set! libcurl (open-shared-object "msys-curl-4")))
+-            (else
+-             (guard (exn
+-                     (else
+-                      (set! libcurl (open-shared-object "libcurl.so.3"))))
+-               (set! libcurl (open-shared-object "libcurl.so.4"))))))
++          (set! libcurl (open-shared-object "@libcurl@")))
+         (letrec ()
+           (define %curl_global_init (foreign-procedure libcurl int curl_global_init (long)))
+           (call %curl_global_init #b11)))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -865,6 +865,8 @@ with pkgs;
     inherit (plasma5Packages) kdialog;
   };
 
+  akku = callPackage ../tools/package-management/akku { };
+
   albert = libsForQt5.callPackage ../applications/misc/albert {};
 
   arch-install-scripts = callPackage ../tools/misc/arch-install-scripts {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add https://akkuscm.org/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
