### PR TITLE
[WIP] Qt 5.15 static build, help needed

### DIFF
--- a/pkgs/build-support/setup-hooks/meson-shlibs-to-static.sh
+++ b/pkgs/build-support/setup-hooks/meson-shlibs-to-static.sh
@@ -1,0 +1,21 @@
+preConfigurePhases+=" mesonShlibsToStaticPhase"
+
+mesonShlibsToStaticPhase() {
+    runHook preMesonShlibsToStatic
+	replaceMesonFunction() {
+		foundFiles=$(find . -name "meson.build" -exec grep -El "	* *$1 *\(" {} \;)
+		for mesonFile in $foundFiles
+		do
+			echo "$mesonFile";
+			cp "$mesonFile" "$mesonFile.tmp_file_mesonShlibsToStaticPhase"
+			sed -i -E "s=(	* *)$1( *)\(=\1$2(\2=g" "$mesonFile";
+			echo -n "[meson-shlibs-to-static] applied patch : "
+			diff -u "$mesonFile.tmp_file_mesonShlibsToStaticPhase" "$mesonFile" || echo ""
+			rm -f "$mesonFile.tmp_file_mesonShlibsToStaticPhase"
+		done
+	}
+	replaceMesonFunction "shared_library" "static_library"
+	replaceMesonFunction "shared_module" "static_library"
+
+    runHook postMesonShlibsToStatic
+}

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -36,7 +36,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ libdaemon dbus glib expat libiconv libevent ]
-    ++ (with perlPackages; [ perl XMLParser ])
+  ++ lib.optionals (!stdenv.hostPlatform.isStatic)
+      (with perlPackages; [ perl XMLParser ])
     ++ (lib.optional gtk3Support gtk3)
     ++ (lib.optional qt4Support qt4)
     ++ (lib.optional qt5Support qt5);

--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
     sha256 = "646e6c5a9a185faa4cea796d378a1ba8e1148dbb197ca6605f95986a25af2752";
   };
 
-  outputs = [ "bin" "dev" "out" "man" "devdoc" ];
+  outputs = [ "bin" "dev" "out" ] ++
+   lib.optionals (!stdenv.hostPlatform.isStatic) ["man" "devdoc" ];
   # Not normally useful docs.
   outputInfo = "devdoc";
   outputDoc  = "devdoc";
@@ -61,7 +62,7 @@ stdenv.mkDerivation rec {
     "--with-guile-site-dir=\${out}/share/guile/site"
     "--with-guile-site-ccache-dir=\${out}/share/guile/site"
     "--with-guile-extension-dir=\${out}/share/guile/site"
-  ];
+  ] ++ lib.optionals stdenv.hostPlatform.isStatic [ "--disable-tests" "--disable-doc" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libdeflate/default.nix
+++ b/pkgs/development/libraries/libdeflate/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fixDarwinDylibNames }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   pname = "libdeflate";
@@ -10,6 +10,15 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1hnn1yd9s5h92xs72y73izak47kdz070kxkw3kyz2d3az6brfdgh";
   };
+  # Waiting for PR https://github.com/ebiggers/libdeflate/pull/135
+  patches = lib.optional stdenv.hostPlatform.isStatic
+  (fetchpatch {
+    url = "https://github.com/ebiggers/libdeflate/pull/135/commits/030310477a9ec82a264f4009c9f3acf195a1af8a.patch";
+    sha256 = "0wlqj0qbvp2b60a4mngkjhh5qwygfi5caayb4y5i2a8lpal4dsxf";
+  });
+  makeFlags = lib.optional stdenv.hostPlatform.isStatic [
+    "DONTBUILD_SHARED_LIBS=1"
+  ];
 
   postPatch = ''
     substituteInPlace Makefile --replace /usr/local $out

--- a/pkgs/development/libraries/libglvnd/nm-path-option.patch
+++ b/pkgs/development/libraries/libglvnd/nm-path-option.patch
@@ -1,0 +1,25 @@
+diff -ur a/meson.build b/meson.build
+--- a/meson.build	2021-07-28 15:08:35.490095306 +0200
++++ b/meson.build	2021-07-28 15:26:30.108102819 +0200
+@@ -37,7 +37,7 @@
+ cc = meson.get_compiler('c')
+ prog_py = import('python').find_installation()
+ files_symbols_check = files('bin/symbols-check.py')
+-prog_nm = find_program('nm')
++prog_nm = find_program(get_option('nm-path'))
+ 
+ message('Host CPU family: @0@'.format(host_machine.cpu_family()))
+ message('Host CPU: @0@'.format(host_machine.cpu()))
+diff -ur a/meson_options.txt b/meson_options.txt
+--- a/meson_options.txt	2021-07-28 15:08:35.490095306 +0200
++++ b/meson_options.txt	2021-07-28 15:26:50.876044187 +0200
+@@ -80,3 +80,9 @@
+   type : 'feature',
+   description : 'Allow vendor libraries to patch OpenGL entrypoint functions.'
+ )
++option(
++  'nm-path',
++  type : 'string',
++  description : 'path to nm',
++  value : 'nm'
++)

--- a/pkgs/development/libraries/libudev-zero/default.nix
+++ b/pkgs/development/libraries/libudev-zero/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libudev-zero";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "illiliti";
+    repo = "libudev-zero";
+    rev = version;
+    sha256 = "10xsrak2y7biplqrs9628adwv9ac91qp0a3v4wcplw6ff8j6d5wc";
+  };
+
+  patches = lib.optional (stdenv.hostPlatform.isStatic)
+  ./static-build-makefile.patch;
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Daemonless, musl-compatible replacement for libudev";
+    license = licenses.isc;
+    homepage = "https://github.com/illiliti/libudev-zero";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libudev-zero/static-build-makefile.patch
+++ b/pkgs/development/libraries/libudev-zero/static-build-makefile.patch
@@ -1,0 +1,60 @@
+diff --color -ur a/Makefile b/Makefile
+--- a/Makefile	2021-08-24 19:30:13.431978875 +0200
++++ b/Makefile	2021-08-24 19:31:52.540742338 +0200
+@@ -5,10 +5,10 @@
+ LIBDIR = ${PREFIX}/lib
+ INCLUDEDIR = ${PREFIX}/include
+ PKGCONFIGDIR = ${LIBDIR}/pkgconfig
+-XCFLAGS = ${CPPFLAGS} ${CFLAGS} -std=c99 -fPIC -pthread -D_XOPEN_SOURCE=700 \
++XCFLAGS = ${CPPFLAGS} ${CFLAGS} -std=c99 -pthread -D_XOPEN_SOURCE=700 \
+ 		  -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wstrict-prototypes \
+ 		  -Wno-unused-parameter
+-XLDFLAGS = ${LDFLAGS} -shared -Wl,-soname,libudev.so.1
++XLDFLAGS = ${LDFLAGS}
+ XARFLAGS = -rc
+ 
+ OBJ = \
+@@ -18,7 +18,7 @@
+ 	  udev_monitor.o \
+ 	  udev_enumerate.o
+ 
+-all: libudev.so.1 libudev.a
++all: libudev.a
+ 
+ .c.o:
+ 	${CC} ${XCFLAGS} -c -o $@ $<
+@@ -26,9 +26,6 @@
+ libudev.a: ${OBJ}
+ 	${AR} ${XARFLAGS} $@ ${OBJ}
+ 
+-libudev.so.1: ${OBJ}
+-	${CC} ${XCFLAGS} -o $@ ${OBJ} ${XLDFLAGS}
+-
+ libudev.pc: libudev.pc.in
+ 	libdir="${LIBDIR}"; \
+ 	if [ "$${libdir#${PREFIX}}" != "$$libdir" ]; then \
+@@ -45,22 +42,18 @@
+ 		-e 's|@VERSION@|243|g' \
+ 		libudev.pc.in > libudev.pc
+ 
+-install: libudev.so.1 libudev.a libudev.pc
++install: libudev.a libudev.pc
+ 	mkdir -p         ${DESTDIR}${INCLUDEDIR} ${DESTDIR}${LIBDIR} ${DESTDIR}${PKGCONFIGDIR}
+ 	cp -f udev.h  	 ${DESTDIR}${INCLUDEDIR}/libudev.h
+ 	cp -f libudev.a  ${DESTDIR}${LIBDIR}/libudev.a
+-	cp -f libudev.so.1 ${DESTDIR}${LIBDIR}/libudev.so.1
+-	ln -fs libudev.so.1 ${DESTDIR}${LIBDIR}/libudev.so
+ 	cp -f libudev.pc ${DESTDIR}${PKGCONFIGDIR}/libudev.pc
+ 
+ uninstall:
+ 	rm -f ${DESTDIR}${LIBDIR}/libudev.a \
+-          ${DESTDIR}${LIBDIR}/libudev.so \
+-          ${DESTDIR}${LIBDIR}/libudev.so.1 \
+           ${DESTDIR}${PKGCONFIGDIR}/libudev.pc \
+           ${DESTDIR}${INCLUDEDIR}/libudev.h
+ 
+ clean:
+-	rm -f libudev.so.1 libudev.a libudev.pc ${OBJ}
++	rm -f libudev.a libudev.pc ${OBJ}
+ 
+ .PHONY: all clean install uninstall

--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, which
-, gettext, libffi, libiconv, libtasn1, bash-completion
+, gettext, libffi, libiconv, libtasn1, bash-completion, mesonShlibsToStaticHook
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
   # at the same time, libtasn1 in buildInputs provides the libasn1 library
   # to link against for the target platform.
   # hence, libtasn1 is required in both native and build inputs.
-  nativeBuildInputs = [ meson ninja pkg-config which libtasn1 ];
+  nativeBuildInputs = [ meson ninja pkg-config which libtasn1 ] ++
+    lib.optional (stdenv.hostPlatform.isStatic) [ mesonShlibsToStaticHook ];
   buildInputs = [ gettext libffi libiconv libtasn1 ];
   propagatedBuildInputs = [ bash-completion ];
 

--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, which
-, gettext, libffi, libiconv, libtasn1
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, which
+, gettext, libffi, libiconv, libtasn1, bash-completion
 }:
 
 stdenv.mkDerivation rec {
@@ -21,17 +21,15 @@ stdenv.mkDerivation rec {
   # at the same time, libtasn1 in buildInputs provides the libasn1 library
   # to link against for the target platform.
   # hence, libtasn1 is required in both native and build inputs.
-  nativeBuildInputs = [ autoreconfHook pkg-config which libtasn1 ];
+  nativeBuildInputs = [ meson ninja pkg-config which libtasn1 ];
   buildInputs = [ gettext libffi libiconv libtasn1 ];
+  propagatedBuildInputs = [ bash-completion ];
 
-  autoreconfPhase = ''
-    NOCONFIGURE=1 ./autogen.sh
-  '';
-
-  configureFlags = [
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
-    "--with-trust-paths=/etc/ssl/certs/ca-certificates.crt"
+  mesonFlags = [
+    "-Dsystem_config=/etc"
+    "-Dtrust_paths=/etc/ssl/certs/ca-certificates.crt"
+    "-Dsystemd=disabled"
+    "-Dbashcompdir=${placeholder "out"}/share/bash-completion/completions"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -111,7 +111,8 @@ let
         url = "https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=patch;h=049e14870c13235cd066758f29c42dc96c1ccdf8";
         sha256 = "1cb2hwi859hds0fa2cbap014qaa7mah9p0rcxcm2cvj2ybl33qfc";
       })
-    ];
+    ] ++ lib.optional (stdenv.hostPlatform.isStatic)
+          ./qtbase.patch.d/qtbase-fix-static-build.patch;
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];

--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/qtbase-fix-static-build.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/qtbase-fix-static-build.patch
@@ -1,6 +1,15 @@
 diff --color -ur a/src/corelib/configure.json b/src/corelib/configure.json
 --- a/src/corelib/configure.json	2020-10-27 09:02:11.000000000 +0100
-+++ b/src/corelib/configure.json	2021-09-01 12:38:32.310356819 +0200
++++ b/src/corelib/configure.json	2021-09-03 20:03:11.321616009 +0200
+@@ -114,7 +114,7 @@
+                     "condition": "config.win32 && !features.shared"
+                 },
+                 { "libs": "-licuin -licuuc -licudt", "condition": "config.win32 && features.shared" },
+-                { "libs": "-licui18n -licuuc -licudata", "condition": "!config.win32" }
++                { "libs": "-licui18n -licuuc -licudata -lc++ -lc++abi", "condition": "!config.win32" }
+             ],
+             "use": [
+                 { "lib": "libdl", "condition": "features.dlopen" }
 @@ -155,7 +155,7 @@
              "headers": [ "atomic", "cstdint" ],
              "sources": [
@@ -12,7 +21,7 @@ diff --color -ur a/src/corelib/configure.json b/src/corelib/configure.json
          "librt": {
 diff --color -ur a/src/gui/configure.json b/src/gui/configure.json
 --- a/src/gui/configure.json	2020-10-27 09:02:11.000000000 +0100
-+++ b/src/gui/configure.json	2021-09-01 12:38:32.311356857 +0200
++++ b/src/gui/configure.json	2021-09-03 20:02:40.542485289 +0200
 @@ -303,7 +303,7 @@
              },
              "headers": "harfbuzz/hb.h",
@@ -44,7 +53,7 @@ diff --color -ur a/src/gui/configure.json b/src/gui/configure.json
          "xcb_icccm": {
 diff --color -ur a/src/plugins/sqldrivers/configure.json b/src/plugins/sqldrivers/configure.json
 --- a/src/plugins/sqldrivers/configure.json	2020-10-27 09:02:11.000000000 +0100
-+++ b/src/plugins/sqldrivers/configure.json	2021-09-01 13:50:06.943343623 +0200
++++ b/src/plugins/sqldrivers/configure.json	2021-09-03 20:02:40.543485293 +0200
 @@ -71,7 +71,7 @@
                  { "type": "mysqlConfig", "query": "--libs", "cleanlibs": true },
                  { "type": "mysqlConfig", "query": "--libs_r", "cleanlibs": false },
@@ -65,7 +74,7 @@ diff --color -ur a/src/plugins/sqldrivers/configure.json b/src/plugins/sqldriver
          "tds": {
 diff --color -ur a/src/printsupport/configure.json b/src/printsupport/configure.json
 --- a/src/printsupport/configure.json	2020-10-27 09:02:11.000000000 +0100
-+++ b/src/printsupport/configure.json	2021-09-01 12:38:32.313356933 +0200
++++ b/src/printsupport/configure.json	2021-09-03 20:02:40.544485297 +0200
 @@ -21,7 +21,7 @@
              },
              "headers": "cups/cups.h",

--- a/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/qtbase-fix-static-build.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/qtbase-fix-static-build.patch
@@ -1,0 +1,77 @@
+diff --color -ur a/src/corelib/configure.json b/src/corelib/configure.json
+--- a/src/corelib/configure.json	2020-10-27 09:02:11.000000000 +0100
++++ b/src/corelib/configure.json	2021-09-01 12:38:32.310356819 +0200
+@@ -155,7 +155,7 @@
+             "headers": [ "atomic", "cstdint" ],
+             "sources": [
+                 "",
+-                "-latomic"
++                "-latomic -lc++"
+             ]
+         },
+         "librt": {
+diff --color -ur a/src/gui/configure.json b/src/gui/configure.json
+--- a/src/gui/configure.json	2020-10-27 09:02:11.000000000 +0100
++++ b/src/gui/configure.json	2021-09-01 12:38:32.311356857 +0200
+@@ -303,7 +303,7 @@
+             },
+             "headers": "harfbuzz/hb.h",
+             "sources": [
+-                "-lharfbuzz"
++                "-lharfbuzz -lgraphite2"
+             ]
+         },
+         "imf": {
+@@ -446,7 +446,8 @@
+             ],
+             "sources": [
+                 { "type": "pkgConfig", "args": "gl", "condition": "!config.darwin" },
+-                { "type": "makeSpec", "spec": "OPENGL" }
++                { "type": "makeSpec", "spec": "OPENGL" },
++				"-lGLdispatch"
+             ]
+         },
+         "opengl_es2": {
+@@ -588,8 +589,7 @@
+             },
+             "headers": "xcb/xcb.h",
+             "sources": [
+-                { "type": "pkgConfig", "args": "xcb >= 1.11" },
+-                "-lxcb"
++                "-lxcb -lXau -lXdmcp"
+             ]
+         },
+         "xcb_icccm": {
+diff --color -ur a/src/plugins/sqldrivers/configure.json b/src/plugins/sqldrivers/configure.json
+--- a/src/plugins/sqldrivers/configure.json	2020-10-27 09:02:11.000000000 +0100
++++ b/src/plugins/sqldrivers/configure.json	2021-09-01 13:50:06.943343623 +0200
+@@ -71,7 +71,7 @@
+                 { "type": "mysqlConfig", "query": "--libs", "cleanlibs": true },
+                 { "type": "mysqlConfig", "query": "--libs_r", "cleanlibs": false },
+                 { "type": "mysqlConfig", "query": "--libs", "cleanlibs": false },
+-                { "libs": "-lmysqlclient_r", "condition": "!config.win32" },
++                { "libs": "-lmysqlclient_r -lssl -lcrypto -lz", "condition": "!config.win32" },
+                 { "libs": "-llibmariadb", "condition": "config.win32" },
+                 { "libs": "-llibmysql", "condition": "config.win32" },
+                 { "libs": "-lmariadb", "condition": "!config.win32" },
+@@ -91,7 +91,7 @@
+                 { "type": "pkgConfig", "args": "libpq" },
+                 { "type": "psqlConfig" },
+                 { "type": "psqlEnv", "libs": "-llibpq -lws2_32 -ladvapi32", "condition": "config.win32" },
+-                { "type": "psqlEnv", "libs": "-lpq", "condition": "!config.win32" }
++                { "libs": "-lpq -lssl -lcrypto -lpgcommon -lpgport", "condition": "!config.win32" }
+             ]
+         },
+         "tds": {
+diff --color -ur a/src/printsupport/configure.json b/src/printsupport/configure.json
+--- a/src/printsupport/configure.json	2020-10-27 09:02:11.000000000 +0100
++++ b/src/printsupport/configure.json	2021-09-01 12:38:32.313356933 +0200
+@@ -21,7 +21,7 @@
+             },
+             "headers": "cups/cups.h",
+             "sources": [
+-                "-lcups"
++                "-lcups -lz -lavahi-client -lavahi-common -ldbus-1 -lgnutls -lunistring -lp11-kit -lffi -lhogweed -lgmp -lnettle -ltasn1"
+             ]
+         }
+     },

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -7,6 +7,8 @@ qtModule {
   outputs = [ "out" "dev" "bin" ];
   preConfigure = ''
     NIX_CFLAGS_COMPILE+=" -DNIXPKGS_QML2_IMPORT_PREFIX=\"$qtQmlPrefix\""
+  '' + lib.optionalString stdenv.hostPlatform.isStatic + ''
+    NIX_LDFLAGS+=" -lc++ -lc++abi -lXdmcp -lXau -lexpat -lbz2"
   '';
   configureFlags = lib.optionals (lib.versionAtLeast qtbase.version "5.11.0") [ "-qml-debug" ];
   devTools = [

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -1,6 +1,6 @@
 { qtModule, stdenv, lib, qtbase, qtdeclarative }:
 
-qtModule {
+qtModule ({
   pname = "qttools";
   qtInputs = [ qtbase qtdeclarative ];
   outputs = [ "out" "dev" "bin" ];
@@ -39,4 +39,8 @@ qtModule {
   NIX_CFLAGS_COMPILE = lib.optional stdenv.isDarwin ''-DNIXPKGS_QMLIMPORTSCANNER="${qtdeclarative.dev}/bin/qmlimportscanner"'';
 
   setupHook = ../hooks/qttools-setup-hook.sh;
-}
+} // lib.optionalAttrs stdenv.hostPlatform.isStatic {
+  preConfigure = ''
+    NIX_LDFLAGS+=" -lXdmcp -lXau -lexpat -lbz2"
+  '';
+})

--- a/pkgs/development/python-modules/pyudev/default.nix
+++ b/pkgs/development/python-modules/pyudev/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchPypi, buildPythonPackage
-, six, systemd, pytest, mock, hypothesis, docutils
+, six, udev, pytest, mock, hypothesis, docutils
 }:
 
 buildPythonPackage rec {
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace src/pyudev/_ctypeslib/utils.py \
-      --replace "find_library(name)" "'${lib.getLib systemd}/lib/libudev.so'"
+      --replace "find_library(name)" "'${lib.getLib udev}/lib/libudev.so'"
     '';
 
   checkInputs = [ pytest mock hypothesis docutils ];

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -57,6 +57,12 @@ python3.pkgs.buildPythonApplication rec {
     # unsandboxed non-NixOS builds, see:
     # https://github.com/NixOS/nixpkgs/issues/86131#issuecomment-711051774
     ./boost-Do-not-add-system-paths-on-nix.patch
+
+    # This allows statically built derivations to use
+    # NIX_MESON_DEPENDENCY_STATIC = true which will force meson
+    # to link all dependencies statically (as if all calls to meson's
+    # dependency function were made with the static: true option.
+    ./nix-force-dependency-static.patch
   ];
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/development/tools/build-managers/meson/nix-force-dependency-static.patch
+++ b/pkgs/development/tools/build-managers/meson/nix-force-dependency-static.patch
@@ -1,0 +1,17 @@
+Seulement dans b: :
+diff --color -ur a/mesonbuild/dependencies/base.py b/mesonbuild/dependencies/base.py
+--- a/mesonbuild/dependencies/base.py	2021-02-01 21:35:16.000000000 +0100
++++ b/mesonbuild/dependencies/base.py	2021-08-21 19:17:34.680964003 +0200
+@@ -339,7 +339,11 @@
+             self.version_reqs = [self.version_reqs]
+         self.required = kwargs.get('required', True)
+         self.silent = kwargs.get('silent', False)
+-        self.static = kwargs.get('static', False)
++        if 'NIX_MESON_DEPENDENCY_STATIC' in os.environ:
++            self.static = True
++            mlog.log("Forcing static building on typename ", type_name)
++        else:
++            self.static = kwargs.get('static', False)
+         if not isinstance(self.static, bool):
+             raise DependencyException('Static keyword must be boolean')
+         # Is this dependency to be run on the build platform?

--- a/pkgs/os-specific/linux/libselinux/fix-static-build.patch
+++ b/pkgs/os-specific/linux/libselinux/fix-static-build.patch
@@ -1,0 +1,105 @@
+diff --color -ur a/src/Makefile b/src/Makefile
+--- a/src/Makefile	2019-11-28 13:46:48.000000000 +0100
++++ b/src/Makefile	2021-08-21 20:18:42.554513955 +0200
+@@ -32,7 +32,7 @@
+ endif
+ 
+ LIBA=libselinux.a 
+-TARGET=libselinux.so
++# TARGET=libselinux.so
+ LIBPC=libselinux.pc
+ SWIGIF= selinuxswig_python.i selinuxswig_python_exception.i
+ SWIGRUBYIF= selinuxswig_ruby.i
+@@ -44,7 +44,7 @@
+ SWIGSO=$(PYPREFIX)_selinux.so
+ SWIGFILES=$(SWIGSO) $(SWIGPYOUT)
+ SWIGRUBYSO=$(RUBYPREFIX)_selinux.so
+-LIBSO=$(TARGET).$(LIBVERSION)
++# LIBSO=$(TARGET).$(LIBVERSION)
+ AUDIT2WHYLOBJ=$(PYPREFIX)audit2why.lo
+ AUDIT2WHYSO=$(PYPREFIX)audit2why.so
+ 
+@@ -127,7 +127,7 @@
+ 
+ SWIGRUBY = swig -Wall -ruby -o $(SWIGRUBYCOUT) -outdir ./ $(DISABLE_FLAGS)
+ 
+-all: $(LIBA) $(LIBSO) $(LIBPC)
++all: $(LIBA) $(LIBPC)
+ 
+ pywrap: all selinuxswig_python_exception.i
+ 	CFLAGS="$(CFLAGS) $(SWIG_CFLAGS)" $(PYTHON) setup.py build_ext
+@@ -144,9 +144,9 @@
+ 	$(AR) rcs $@ $^
+ 	$(RANLIB) $@
+ 
+-$(LIBSO): $(LOBJS)
+-	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ $^ $(PCRE_LDLIBS) $(FTS_LDLIBS) -ldl -Wl,$(LD_SONAME_FLAGS)
+-	ln -sf $@ $(TARGET)
++# $(LIBSO): $(LOBJS)
++	# $(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ $^ $(PCRE_LDLIBS) $(FTS_LDLIBS) -ldl -Wl,$(LD_SONAME_FLAGS)
++	# ln -sf $@ $(TARGET)
+ 
+ $(LIBPC): $(LIBPC).in ../VERSION
+ 	sed -e 's/@VERSION@/$(VERSION)/; s:@prefix@:$(PREFIX):; s:@libdir@:$(LIBDIR):; s:@includedir@:$(INCLUDEDIR):; s:@PCRE_MODULE@:$(PCRE_MODULE):' < $< > $@
+@@ -167,10 +167,10 @@
+ 	test -d $(DESTDIR)$(LIBDIR) || install -m 755 -d $(DESTDIR)$(LIBDIR)
+ 	install -m 644 $(LIBA) $(DESTDIR)$(LIBDIR)
+ 	test -d $(DESTDIR)$(SHLIBDIR) || install -m 755 -d $(DESTDIR)$(SHLIBDIR)
+-	install -m 755 $(LIBSO) $(DESTDIR)$(SHLIBDIR)
++	# install -m 755 $(LIBSO) $(DESTDIR)$(SHLIBDIR)
+ 	test -d $(DESTDIR)$(LIBDIR)/pkgconfig || install -m 755 -d $(DESTDIR)$(LIBDIR)/pkgconfig
+ 	install -m 644 $(LIBPC) $(DESTDIR)$(LIBDIR)/pkgconfig
+-	ln -sf --relative $(DESTDIR)$(SHLIBDIR)/$(LIBSO) $(DESTDIR)$(LIBDIR)/$(TARGET)
++	# ln -sf --relative $(DESTDIR)$(SHLIBDIR)/$(LIBSO) $(DESTDIR)$(LIBDIR)/$(TARGET)
+ 
+ install-pywrap: pywrap
+ 	$(PYTHON) setup.py install --prefix=$(PREFIX) `test -n "$(DESTDIR)" && echo --root $(DESTDIR)`
+@@ -181,8 +181,8 @@
+ 	test -d $(DESTDIR)$(RUBYINSTALL) || install -m 755 -d $(DESTDIR)$(RUBYINSTALL) 
+ 	install -m 755 $(SWIGRUBYSO) $(DESTDIR)$(RUBYINSTALL)/selinux.so
+ 
+-relabel:
+-	/sbin/restorecon $(DESTDIR)$(SHLIBDIR)/$(LIBSO)
++# relabel:
++	# /sbin/restorecon $(DESTDIR)$(SHLIBDIR)/$(LIBSO)
+ 
+ clean-pywrap:
+ 	-rm -f $(SWIGLOBJ) $(SWIGSO) $(AUDIT2WHYLOBJ) $(AUDIT2WHYSO)
+@@ -192,8 +192,8 @@
+ clean-rubywrap:
+ 	-rm -f $(SWIGRUBYLOBJ) $(SWIGRUBYSO)
+ 
+-clean: clean-pywrap clean-rubywrap
+-	-rm -f $(LIBPC) $(OBJS) $(LOBJS) $(LIBA) $(LIBSO) $(TARGET) *.o *.lo *~
++# clean: clean-pywrap clean-rubywrap
++# 	-rm -f $(LIBPC) $(OBJS) $(LOBJS) $(LIBA) $(LIBSO) $(TARGET) *.o *.lo *~
+ 
+ distclean: clean
+ 	rm -f $(GENERATED) $(SWIGFILES)
+diff --color -ur a/utils/Makefile b/utils/Makefile
+--- a/utils/Makefile	2019-11-28 13:46:48.000000000 +0100
++++ b/utils/Makefile	2021-08-21 20:23:09.154510931 +0200
+@@ -43,10 +43,11 @@
+ override LDFLAGS += -L../../libsepol/src -undefined dynamic_lookup
+ endif
+ 
+-override CFLAGS += -I../include -D_GNU_SOURCE $(DISABLE_FLAGS) $(PCRE_CFLAGS)
+-override LDFLAGS += -L../src
+-override LDLIBS += -lselinux
+ PCRE_LDLIBS ?= -lpcre
++FTS_LDLIBS ?= -lfts
++override CFLAGS += -I../include -D_GNU_SOURCE $(DISABLE_FLAGS) $(PCRE_CFLAGS)
++override LDFLAGS += -L../src 
++override LDLIBS += -lselinux $(PCRE_LDLIBS) $(FTS_LDLIBS)
+ 
+ ifeq ($(ANDROID_HOST),y)
+ TARGETS=sefcontext_compile
+@@ -54,7 +55,7 @@
+ TARGETS=$(patsubst %.c,%,$(sort $(wildcard *.c)))
+ endif
+ 
+-sefcontext_compile: LDLIBS += $(PCRE_LDLIBS) ../src/libselinux.a -lsepol
++sefcontext_compile: LDLIBS += ../src/libselinux.a -lsepol
+ 
+ sefcontext_compile: sefcontext_compile.o ../src/regex.o
+ 

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -31,6 +31,14 @@ stdenv.mkDerivation {
     substituteInPlace mariadb_config/mariadb_config.c.in \
       --replace '-I%s/@INSTALL_INCLUDEDIR@' "-I$dev/include" \
       --replace '-L%s/@INSTALL_LIBDIR@' "-L$out/lib/mariadb"
+
+  '' + lib.optionalString stdenv.hostPlatform.isStatic ''
+    # Disables all dynamic plugins
+    substituteInPlace cmake/plugins.cmake \
+      --replace 'if(''${CC_PLUGIN_DEFAULT} STREQUAL "DYNAMIC")' 'if(''${CC_PLUGIN_DEFAULT} STREQUAL "INVALID")'
+    # Force building static libraries
+    substituteInPlace libmariadb/CMakeLists.txt \
+      --replace 'libmariadb SHARED' 'libmariadb STATIC'
   '';
 
   # The cmake setup-hook uses $out/lib by default, this is not the case here.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22193,6 +22193,8 @@ with pkgs;
 
   eudev = callPackage ../os-specific/linux/eudev { util-linux = util-linuxMinimal; };
 
+  libudev-zero = callPackage ../development/libraries/libudev-zero { };
+
   libudev0-shim = callPackage ../os-specific/linux/libudev0-shim { };
 
   udisks1 = callPackage ../os-specific/linux/udisks/1-default.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -132,6 +132,13 @@ with pkgs;
       ../build-support/setup-hooks/autoreconf.sh
   ) { };
 
+  mesonShlibsToStaticHook = callPackage (
+      { makeSetupHook }:
+      makeSetupHook
+        { deps = []; }
+        ../build-support/setup-hooks/meson-shlibs-to-static.sh
+  ) { };
+
   autoreconfHook264 = autoreconfHook.override {
     autoconf = autoconf264;
     automake = automake111x;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7335,7 +7335,7 @@ in {
     };
 
   pyudev = callPackage ../development/python-modules/pyudev {
-    inherit (pkgs) systemd;
+    inherit (pkgs) udev;
   };
 
   pyunbound = callPackage ../tools/networking/unbound/python.nix { };

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -129,6 +129,13 @@ in rec {
     nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ super.mesonShlibsToStaticHook ];
   });
 
+  gdk-pixbuf = super.gdk-pixbuf.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      super.mesonShlibsToStaticHook
+    ];
+  });
+
   glib = super.glib.overrideAttrs (old: {
     NIX_MESON_DEPENDENCY_STATIC = true;
   });

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -150,6 +150,10 @@ in rec {
     ];
   });
 
+  libxkbcommon = super.libxkbcommon.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+  });
+
   ocaml-ng = self.lib.mapAttrs (_: set:
     if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
   ) super.ocaml-ng;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -114,4 +114,12 @@ in {
     # it doesn’t like the --disable-shared flag
     stdenv = super.stdenv;
   };
+
+  wayland = super.wayland.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    postPatch = (old.postPatch or "") + ''
+      substituteInPlace meson.build \
+        --replace "subdir('tests')" ""
+    '';
+  });
 }

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -209,6 +209,27 @@ in rec {
     NIX_LDFLAGS = " -lglib-2.0 -lpcre";
   });
 
+  gtk3 = (super.gtk3.override {
+    trackerSupport = false;
+    withGtkDoc = false;
+    # Symbol overlap between wayland and libXcursor
+    waylandSupport = false;
+    wayland = null;
+    wayland-protocols = null;
+  }).overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      super.pkg-config
+      super.mesonShlibsToStaticHook
+      gdk-pixbuf
+    ];
+    mesonFlags = (old.mesonFlags or []) ++ [
+      "-Dintrospection=false"
+      "-Dwayland_backend=false"
+    ];
+    NIX_CFLAGS_COMPILE = "-DG_LOG_DOMAIN=\"\"\"\"";
+  });
+
   harfbuzz = super.harfbuzz.overrideAttrs (old: {
     NIX_MESON_DEPENDENCY_STATIC = true;
     nativeBuildInputs = (old.nativeBuildInputs or []) ++ [

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -93,6 +93,19 @@ in {
     gssSupport = false;
   };
 
+  libselinux = (super.libselinux.override {
+    fts = super.musl-fts;
+    enablePython = false;
+  }).overrideAttrs (old: {
+    patches = (old.patches or []) ++ [
+      # Patch to disable shared libraries, a cleaner way
+      # would be to fork this to use meson which is much
+      # easier to tweak for static builds using NIX_MESON_DEPENDENCY_STATIC
+      # and/or the mesonShlibsToStaticHook
+      ../os-specific/linux/libselinux/fix-static-build.patch
+    ];
+  });
+
   ocaml-ng = self.lib.mapAttrs (_: set:
     if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
   ) super.ocaml-ng;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -97,6 +97,10 @@ in {
     NIX_MESON_DEPENDENCY_STATIC = true;
   });
 
+  json-glib = super.json-glib.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+  });
+
   libselinux = (super.libselinux.override {
     fts = super.musl-fts;
     enablePython = false;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -77,7 +77,7 @@ self: super: let
       });
     };
 
-in {
+in rec {
   stdenv = foldl (flip id) super.stdenv staticAdapters;
 
   boost = super.boost.override {
@@ -129,6 +129,11 @@ in {
     # it doesn’t like the --disable-shared flag
     stdenv = super.stdenv;
   };
+
+  shared-mime-info = super.shared-mime-info.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    buildInputs = (old.buildInputs or []) ++ [ zlib ];
+  });
 
   zlib = super.zlib.override {
     # Don’t use new stdenv zlib because

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -214,6 +214,13 @@ in rec {
     ];
   });
 
+  libwacom = super.libwacom.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      super.mesonShlibsToStaticHook
+    ];
+  });
+
   libxkbcommon = super.libxkbcommon.overrideAttrs (old: {
     NIX_MESON_DEPENDENCY_STATIC = true;
   });

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -214,6 +214,14 @@ in rec {
     ];
   });
 
+  libsoup = super.libsoup.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      super.mesonShlibsToStaticHook
+    ];
+    NIX_LDFLAGS = (old.NIX_LDFLAGS or "") + " -lidn2 -lunistring";
+  });
+
   libwacom = super.libwacom.overrideAttrs (old: {
     NIX_MESON_DEPENDENCY_STATIC = true;
     nativeBuildInputs = (old.nativeBuildInputs or []) ++ [

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -98,6 +98,25 @@ in rec {
     stdenv = super.stdenv;
   };
 
+  cups = super.cups.overrideAttrs (old: {
+    # Proper use of pkg-config --static is a better way to do this
+    # the right way, keeping the order correct manually is a pain
+    NIX_LDFLAGS = let
+      libs = [
+        "-lavahi-common"
+        "-ldbus-1"
+        "-lunistring"
+        "-lgnutls"
+        "-lp11-kit"
+        "-lffi"
+        "-ltasn1"
+        "-lhogweed"
+        "-lnettle"
+        "-lgmp"
+      ];
+    in " ${super.lib.concatStringsSep " " libs}";
+  });
+
   curl = super.curl.override {
     # brotli doesn't build static (Mar. 2021)
     brotliSupport = false;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -80,6 +80,14 @@ self: super: let
 in rec {
   stdenv = foldl (flip id) super.stdenv staticAdapters;
 
+  at-spi2-atk = super.at-spi2-atk.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      super.mesonShlibsToStaticHook
+    ];
+    NIX_CFLAGS_COMPILE = "-DG_LOG_DOMAIN=\"\"\"\"";
+  });
+
   at-spi2-core = super.at-spi2-core.overrideAttrs (old: {
     NIX_MESON_DEPENDENCY_STATIC = true;
     nativeBuildInputs = (old.nativeBuildInputs or []) ++ [

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -80,6 +80,13 @@ self: super: let
 in rec {
   stdenv = foldl (flip id) super.stdenv staticAdapters;
 
+  at-spi2-core = super.at-spi2-core.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      super.mesonShlibsToStaticHook
+    ];
+  });
+
   avahi = super.avahi.overrideAttrs (old: {
     buildInputs = (old.buildInputs or []) ++ [ super.musl ];
     nativeBuildInputs = (old.nativeBuildInputs or []) ++

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -178,6 +178,13 @@ in rec {
     '';
   });
 
+  pango = super.pango.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      super.mesonShlibsToStaticHook
+    ];
+  });
+
   perl = super.perl.override {
     # Don’t use new stdenv zlib because
     # it doesn’t like the --disable-shared flag

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -194,6 +194,13 @@ in rec {
     NIX_MESON_DEPENDENCY_STATIC = true;
   });
 
+  libinput = super.libinput.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      super.mesonShlibsToStaticHook
+    ];
+  });
+
   libselinux = (super.libselinux.override {
     fts = super.musl-fts;
     enablePython = false;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -140,6 +140,13 @@ in rec {
     NIX_MESON_DEPENDENCY_STATIC = true;
   });
 
+  harfbuzz = super.harfbuzz.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+      super.mesonShlibsToStaticHook
+    ];
+  });
+
   json-glib = super.json-glib.overrideAttrs (old: {
     NIX_MESON_DEPENDENCY_STATIC = true;
   });

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -105,6 +105,11 @@ in rec {
     gssSupport = false;
   };
 
+  dconf = super.dconf.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+    nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ super.mesonShlibsToStaticHook ];
+  });
+
   glib = super.glib.overrideAttrs (old: {
     NIX_MESON_DEPENDENCY_STATIC = true;
   });

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -97,6 +97,12 @@ in {
     if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
   ) super.ocaml-ng;
 
+  p11-kit = super.p11-kit.overrideAttrs (old: {
+    postPatch = (old.postPatch or "") + ''
+      sed -i '/install_data(pkcs11_conf_example/,+1d' p11-kit/meson.build
+    '';
+  });
+
   perl = super.perl.override {
     # Don’t use new stdenv zlib because
     # it doesn’t like the --disable-shared flag

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -196,6 +196,9 @@ in rec {
     buildInputs = (old.buildInputs or []) ++ [ zlib ];
   });
 
+  udev = super.libudev-zero;
+  systemdMinimal = udev;
+
   zlib = super.zlib.override {
     # Don’t use new stdenv zlib because
     # it doesn’t like the --disable-shared flag

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -93,6 +93,10 @@ in {
     gssSupport = false;
   };
 
+  glib = super.glib.overrideAttrs (old: {
+    NIX_MESON_DEPENDENCY_STATIC = true;
+  });
+
   libselinux = (super.libselinux.override {
     fts = super.musl-fts;
     enablePython = false;


### PR DESCRIPTION
###### Motivation for this change
I think it's useful to have static builds for a few reasons : 
 - debugging
 - easily shipping standalone binaries to other linux distros
 - avoiding runtime dependencies
 - reducing startup time

###### Things done

I managed to get `pkgsStatic.libsForQt515.qtbase` build successfully.
~~But I couldn't get `pkgsStatic.libsForQt515.qtsvg` to build against it.~~ Fixed !

The goal of this is to get at least one simple Qt Gui app to build statically.

The guidelines I tried to follow for this contribution are : 
 -  to use the least amount of patches (preferring sedding and other postPatch tricks to regular patches) because I consider them as technical debt
 - to interfer the least with the non static derivations using `stdenv.hostPlatform.isStatic` conditional extensively or only adding an override in `pkgs/top-level/static.nix`

##### Changes made

 - p11-kit: using meson instead of autotools (no maintainers in the meta ?)
 - mesonShlibsToStaticHook: a preconfigure setup hook that replaces all shared_library calls to static_library calls in meson.build files
 - dbus: use autoreconfHook instead of relying on provided configure script, it's much easier to patch an M4 script rather than patching a configure script @NixOS/freedesktop 
 - libglvnd-meson: same as libglvnd but built with meson @primeos 
 - NIX_MESON_DEPENDENCY_STATIC: a patch to meson that allows to force static linking of all dependencies if this environment variable is set. It seemed easier to do it like this rather than using a preconfigure setup hook like mesonShlibsToStaticHook which would try to force the `static: true` kwarg on all dependency() function calls (probably impossible to get write with a sed, it might be possible with some tools like beautifulsoup though)
 - libselinux: had to patch the Makefile to disable shared libs building @Phreedom 
 - libudev-zero: systemd is too much work to get to build with musl-libc and qtbase really only depends on udev, so I've overriden pkgsStatic.udev to point to this "daemonless" implementation: https://github.com/illiliti/libudev-zero (used by Alpine OS) @andir  @edolstra  @flokli  @Kloenk 
 - systemdMinimal: also made systemdMinimal point to libudev-zero, this is probably not good and should be fixed by replacing every use of systemdMinimal with the use of udev when really only the latter one is needed.
 - at-spi2-atk: not sure why but G_LOG_DOMAIN isn't defined and thus the static build crashes, fixed it with NIX_CFLAGS_COMPILE setting it to an empty string. I don't know if there is a specific NIX environment variable for such C preprocessor defines. @NixOS/gnome 
 - postgresql: couldn't make it build statically, it's a C library that uses libicuuc which is a c++ library. c++ specific symbols are needed when linking against libicuuc which aren't easy to provide to gcc. I think linking with (libc++,libc++abi) or libstdc++ might fix it, help is needed there. Meanwhile, I've disabled it's static build but I think that we shouldn't merge this PR until postgresql builds.
 - gobject-introspection: had to disable the build of python bindings because they involve building shared libraries which is impossible to do with the "-static" flag enforced by the static adapter. Maybe this could be fixed by using super.stdenv or cleaning NIX_CFLAGS_COMPILE before building the bindings. But I think this would require to rebuild some stuff with -fPIC. @NixOS/gnome 
 - gtk3: since the gobject-introspection's python bindings aren't built, I had to disable introspection, @NixOS/gnome 
 - pyudev: replaced systemd dependency with udev.
 - qtbase: had to patch a few configure.json files to have it find the dependencies and link all the needed ones. I also had to make it build with clang, against libc++ and libc++abi as it seems like llvm toolchains are easier to use when building statically. This required that I also build libicuuc with the same compiler runtime libs. Finally, the postInstall and fixup phase aren't passing when building statically. This is unfortunate since debugging this requires to wait for the whole build to finish. I separated the build in two stages to temporairly work on those phases to make them work but help is needed to properly figure out what's going wrong. @NixOS/qt-kde 

 ~~And while `pkgsStatic.libsForQt515.qtbase` builds successfully, it doesn't seem to work, `pkgsStatic.libsForQt515.qtsvg` doesn't build against it. This PR shouldn't be merge until both `pkgsStatic.postgresql` and `pkgsStatic.libsForQt515.qtsvg` build successfully.~~ Fixed !

## Status
I can build a simple Qt app of mine statically !

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
