### PR TITLE
nixos-install-tools: Fix handling of the -I flag

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -102,6 +102,14 @@ done
 
 # Get the path of the NixOS configuration file.
 if [[ -z $NIXOS_CONFIG ]]; then
+    for ((i = 0; i < ${#extraBuildFlags[@]}; i++)); do
+        if [[ ${extraBuildFlags[$i]} == nixos-config=*  ]]; then
+            IFS="=" read -r -a arr <<< "${extraBuildFlags[$i]}";
+            NIXOS_CONFIG=${arr[1]};
+        fi;
+    done
+fi
+if [[ -z $NIXOS_CONFIG ]]; then
     NIXOS_CONFIG=$mountPoint/etc/nixos/configuration.nix
 fi
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Propose to fix a bug in nixos-install(8) in which the `-I nixos-config=/path/to/configuration.nix` command line argument gets ignored. Resolves #131975

The proposed change alters the handling of the `nixos-config=...` definition as follows (written in pseudo code):

```
if NIXOS_CONFIG is empty; then
    if `-I nixos-config=/path/to/configuration.nix`; then
        NIXOS_CONFIG=/path/to/configuration.nix
    fi
fi
if NIXOS_CONFIG is empty; then
    NIXOS_CONFIG=$mountPoint/etc/nixos/configuration.nix
fi
```

One open question remains: Which definition of `nixos-config=...` should take precedence if one would call the script with both `NIXOS_CONFIG=...` and `-I nixos-config=...`, i.e.
```
NIXOS_CONFIG=/path/to/configuration.nix nixos-install -I nixos-config=/path/to/other/configuration.nix
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
