### PR TITLE
kakoune: 2020.09.01 -> 2021.08.28

### DIFF
--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, asciidoc, docbook_xsl, libxslt, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, pkg-config }:
 
 with lib;
 
@@ -12,17 +12,11 @@ stdenv.mkDerivation rec {
     sha256 = "13kc68vkrzg89khir6ayyxgbnmz16dhippcnw09hhzxivf5ayzpy";
   };
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ asciidoc docbook_xsl libxslt ];
   makeFlags = [ "debug=no" ];
-
-  postPatch = ''
-    export PREFIX=$out
-    cd src
-    sed -ie 's#--no-xmllint#--no-xmllint --xsltproc-opts="--nonet"#g' Makefile
-  '';
 
   preConfigure = ''
     export version="v${version}"
+    export PREFIX=$out
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -1,18 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, ncurses, asciidoc, docbook_xsl, libxslt, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, asciidoc, docbook_xsl, libxslt, pkg-config }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   pname = "kakoune-unwrapped";
-  version = "2020.09.01";
+  version = "2021.08.28";
   src = fetchFromGitHub {
     repo = "kakoune";
     owner = "mawww";
     rev = "v${version}";
-    sha256 = "091qzk0qs7hql0q51hix99srgma35mhdnjfd5ncfba1bmc1h8x5i";
+    sha256 = "13kc68vkrzg89khir6ayyxgbnmz16dhippcnw09hhzxivf5ayzpy";
   };
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ncurses asciidoc docbook_xsl libxslt ];
+  buildInputs = [ asciidoc docbook_xsl libxslt ];
   makeFlags = [ "debug=no" ];
 
   postPatch = ''

--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config }:
+{ lib, stdenv, fetchFromGitHub }:
 
 with lib;
 
@@ -11,12 +11,10 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "13kc68vkrzg89khir6ayyxgbnmz16dhippcnw09hhzxivf5ayzpy";
   };
-  nativeBuildInputs = [ pkg-config ];
-  makeFlags = [ "debug=no" ];
+  makeFlags = [ "debug=no" "PREFIX=${placeholder "out"}" ];
 
   preConfigure = ''
     export version="v${version}"
-    export PREFIX=$out
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bringing kakoune up-to-date.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Additional Notes

ncurses was removed as a dependency upstream:

https://github.com/mawww/kakoune/releases/tag/v2021.08.28

@vrthra 