### PR TITLE
silver-searcher: add meta.mainProgram

### DIFF
--- a/pkgs/tools/text/silver-searcher/default.nix
+++ b/pkgs/tools/text/silver-searcher/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ggreer/the_silver_searcher/";
     description = "A code-searching tool similar to ack, but faster";
     maintainers = with maintainers; [ madjar ];
+    mainProgram = "ag";
     platforms = platforms.all;
     license = licenses.asl20;
   };


### PR DESCRIPTION
###### Motivation for this change
Support `nix run`

###### Things done
added meta.mainProgram value

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

