### PR TITLE
python3Packages.poetry*: use native namespaces

### DIFF
--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -54,6 +54,9 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "poetry.core" ];
 
+  # allow for package to use pep420's native namespaces
+  pythonNamespaces = [ "poetry" ];
+
   meta = with lib; {
     description = "Core utilities for Poetry";
     homepage = "https://github.com/python-poetry/poetry-core/";

--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -99,6 +99,9 @@ buildPythonPackage rec {
     })
   ];
 
+  # allow for package to use pep420's native namespaces
+  pythonNamespaces = [ "poetry" ];
+
   meta = with lib; {
     homepage = "https://python-poetry.org/";
     description = "Python dependency management and packaging made easy";


### PR DESCRIPTION
###### Motivation for this change
Follow up to: https://github.com/python-poetry/poetry/issues/2800

Upstream doesn't want to kill python2 support, but I do.
This does allow for python3 (and by extension, nixpkgs) to use these packages when located at different store paths.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
