### PR TITLE
elk7: 7.5.1 -> 7.10.2

### DIFF
--- a/pkgs/development/tools/misc/kibana/7.x.nix
+++ b/pkgs/development/tools/misc/kibana/7.x.nix
@@ -19,12 +19,12 @@ let
   shas =
     if enableUnfree
     then {
-      x86_64-linux = "1wq4fc2fifkg1qz7nxdfb4yi2biay8cgdz7kl5k0p37sxn0sbkja";
-      x86_64-darwin = "06346kj7bv49py49pmmnmh8m24322m88v1af19909pj9cxgd0p6v";
+      x86_64-linux = "sha256-lTPBppKm51zgKSQtSdO0PgZ/aomvaStwqwYYGNPY4Bo=";
+      x86_64-darwin = "sha256-d7xHmoASiywDlZCJX/CfUX1VIi4iOcDrqvK0su54MJc=";
     }
     else {
-      x86_64-linux = "0ygpmcm6wdcnvw8azwqc5257lyic7yw31rqvm2pw3afhpha62lpj";
-      x86_64-darwin = "0xy81g0bhxp47p29kkkh5llfzqkzqzr5dk50ap2hy0hjw33ld6g1";
+      x86_64-linux = "sha256-+pkKpiXBpLHs72KKNtMJbqipw6eu5XC1xu/iLFCHGRQ=";
+      x86_64-darwin = "sha256-CyJ5iRXaPgXO2lyy+E24OcGtb9V3e1gMZRIu25bVyzk=";
     };
 
 in

--- a/pkgs/development/tools/misc/kibana/7.x.nix
+++ b/pkgs/development/tools/misc/kibana/7.x.nix
@@ -1,6 +1,7 @@
 { elk7Version
 , enableUnfree ? true
-, lib, stdenv
+, lib
+, stdenv
 , makeWrapper
 , fetchurl
 , nodejs-10_x
@@ -18,15 +19,16 @@ let
   shas =
     if enableUnfree
     then {
-      x86_64-linux  = "1wq4fc2fifkg1qz7nxdfb4yi2biay8cgdz7kl5k0p37sxn0sbkja";
+      x86_64-linux = "1wq4fc2fifkg1qz7nxdfb4yi2biay8cgdz7kl5k0p37sxn0sbkja";
       x86_64-darwin = "06346kj7bv49py49pmmnmh8m24322m88v1af19909pj9cxgd0p6v";
     }
     else {
-      x86_64-linux  = "0ygpmcm6wdcnvw8azwqc5257lyic7yw31rqvm2pw3afhpha62lpj";
+      x86_64-linux = "0ygpmcm6wdcnvw8azwqc5257lyic7yw31rqvm2pw3afhpha62lpj";
       x86_64-darwin = "0xy81g0bhxp47p29kkkh5llfzqkzqzr5dk50ap2hy0hjw33ld6g1";
     };
 
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   name = "kibana-${optionalString (!enableUnfree) "oss-"}${version}";
   version = elk7Version;
 

--- a/pkgs/development/tools/misc/kibana/7.x.nix
+++ b/pkgs/development/tools/misc/kibana/7.x.nix
@@ -4,14 +4,14 @@
 , stdenv
 , makeWrapper
 , fetchurl
-, nodejs-10_x
+, nodejs-14_x
 , coreutils
 , which
 }:
 
 with lib;
 let
-  nodejs = nodejs-10_x;
+  nodejs = nodejs-14_x;
   inherit (builtins) elemAt;
   info = splitString "-" stdenv.hostPlatform.system;
   arch = elemAt info 0;

--- a/pkgs/development/tools/misc/kibana/7.x.nix
+++ b/pkgs/development/tools/misc/kibana/7.x.nix
@@ -29,11 +29,11 @@ let
 
 in
 stdenv.mkDerivation rec {
-  name = "kibana-${optionalString (!enableUnfree) "oss-"}${version}";
+  pname = "kibana${optionalString (!enableUnfree) "-oss"}";
   version = elk7Version;
 
   src = fetchurl {
-    url = "https://artifacts.elastic.co/downloads/kibana/${name}-${plat}-${arch}.tar.gz";
+    url = "https://artifacts.elastic.co/downloads/kibana/${pname}-${version}-${plat}-${arch}.tar.gz";
     sha256 = shas.${stdenv.hostPlatform.system} or (throw "Unknown architecture");
   };
 

--- a/pkgs/misc/logging/beats/7.x.nix
+++ b/pkgs/misc/logging/beats/7.x.nix
@@ -1,30 +1,31 @@
 { lib, fetchFromGitHub, elk7Version, buildGoPackage, libpcap, nixosTests, systemd }:
 
-let beat = package : extraArgs : buildGoPackage (rec {
-      name = "${package}-${version}";
-      version = elk7Version;
+let beat = package: extraArgs: buildGoPackage (rec {
+  name = "${package}-${version}";
+  version = elk7Version;
 
-      src = fetchFromGitHub {
-        owner = "elastic";
-        repo = "beats";
-        rev = "v${version}";
-        sha256 = "192ygz3ppfah8d2b811x67jfqhcr5ivz7qh4vwrd729rjfr0bbgb";
-      };
+  src = fetchFromGitHub {
+    owner = "elastic";
+    repo = "beats";
+    rev = "v${version}";
+    sha256 = "192ygz3ppfah8d2b811x67jfqhcr5ivz7qh4vwrd729rjfr0bbgb";
+  };
 
-      goPackagePath = "github.com/elastic/beats";
+  goPackagePath = "github.com/elastic/beats";
 
-      subPackages = [ package ];
+  subPackages = [ package ];
 
-      meta = with lib; {
-        homepage = "https://www.elastic.co/products/beats";
-        license = licenses.asl20;
-        maintainers = with maintainers; [ fadenb basvandijk ];
-        platforms = platforms.linux;
-      };
-    } // extraArgs);
-in rec {
-  filebeat7   = beat "filebeat"   {meta.description = "Lightweight shipper for logfiles";};
-  heartbeat7  = beat "heartbeat"  {meta.description = "Lightweight shipper for uptime monitoring";};
+  meta = with lib; {
+    homepage = "https://www.elastic.co/products/beats";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fadenb basvandijk ];
+    platforms = platforms.linux;
+  };
+} // extraArgs);
+in
+rec {
+  filebeat7 = beat "filebeat" { meta.description = "Lightweight shipper for logfiles"; };
+  heartbeat7 = beat "heartbeat" { meta.description = "Lightweight shipper for uptime monitoring"; };
   metricbeat7 = beat "metricbeat" {
     meta.description = "Lightweight shipper for metrics";
     passthru.tests =
@@ -46,14 +47,15 @@ in rec {
       PostgreSQL, Redis or Thrift and correlate the messages into transactions.
     '';
   };
-  journalbeat7  = beat "journalbeat" {
+  journalbeat7 = beat "journalbeat" {
     meta.description = ''
       Journalbeat is an open source data collector to read and forward
       journal entries from Linuxes with systemd.
     '';
     buildInputs = [ systemd.dev ];
-    postFixup = let libPath = lib.makeLibraryPath [ (lib.getLib systemd) ]; in ''
-      patchelf --set-rpath ${libPath} "$out/bin/journalbeat"
-    '';
+    postFixup = let libPath = lib.makeLibraryPath [ (lib.getLib systemd) ]; in
+      ''
+        patchelf --set-rpath ${libPath} "$out/bin/journalbeat"
+      '';
   };
 }

--- a/pkgs/misc/logging/beats/7.x.nix
+++ b/pkgs/misc/logging/beats/7.x.nix
@@ -8,7 +8,7 @@ let beat = package: extraArgs: buildGoPackage (rec {
     owner = "elastic";
     repo = "beats";
     rev = "v${version}";
-    sha256 = "192ygz3ppfah8d2b811x67jfqhcr5ivz7qh4vwrd729rjfr0bbgb";
+    sha256 = "sha256-zr0a0LBR4G9okS2pUixDYtYZ0yCp4G6j08jx/zlIKOA=";
   };
 
   goPackagePath = "github.com/elastic/beats";

--- a/pkgs/misc/logging/beats/7.x.nix
+++ b/pkgs/misc/logging/beats/7.x.nix
@@ -1,7 +1,7 @@
-{ lib, fetchFromGitHub, elk7Version, buildGoPackage, libpcap, nixosTests, systemd }:
+{ lib, fetchFromGitHub, elk7Version, buildGoModule, libpcap, nixosTests, systemd }:
 
-let beat = package: extraArgs: buildGoPackage (rec {
-  name = "${package}-${version}";
+let beat = package: extraArgs: buildGoModule (rec {
+  pname = package;
   version = elk7Version;
 
   src = fetchFromGitHub {
@@ -11,7 +11,7 @@ let beat = package: extraArgs: buildGoPackage (rec {
     sha256 = "sha256-zr0a0LBR4G9okS2pUixDYtYZ0yCp4G6j08jx/zlIKOA=";
   };
 
-  goPackagePath = "github.com/elastic/beats";
+  vendorSha256 = "sha256-xmw432vY1T2EixkDcXdGrnMdc8fYOI4R2lEjbkav3JQ=";
 
   subPackages = [ package ];
 

--- a/pkgs/servers/search/elasticsearch/7.x.nix
+++ b/pkgs/servers/search/elasticsearch/7.x.nix
@@ -20,12 +20,12 @@ let
   shas =
     if enableUnfree
     then {
-      x86_64-linux = "1s27bzx5y8vcd95qrw6av3fhyxb45219x9ahwaxa2cygmbpighrp";
-      x86_64-darwin = "1ia3byir3i5qaarmcaysrg3dhnxjmxnf0m0kzyf61g9aiy87gb7q";
+      x86_64-linux = "sha256-O3rjtvXyJI+kRBqiz2U2OMkCIQj4E+AIHaE8N4o14R4=";
+      x86_64-darwin = "sha256-AwuY2yMxf+v7U5/KD3Cf+Hv6ijjySEyj6pzF3RCsg24=";
     }
     else {
-      x86_64-linux = "005i7d7ag10qkn7bkx7md50iihvcvc84hay2j94wvsm7yghhbmi3";
-      x86_64-darwin = "01f81720rbzdqc0g1xymhz2lflldfbnb0rh7mpki99pss28vj9sh";
+      x86_64-linux = "sha256-cJrdkFIFgAI6wfQh34Z8yFuLrOCOKzgOsWZhU3S/3NQ=";
+      x86_64-darwin = "sha256-OhMVOdXei9D9cH+O5tBhdKvZ05TsImjMqUUsucRyWMo=";
     };
 in
 stdenv.mkDerivation (rec {

--- a/pkgs/servers/search/elasticsearch/7.x.nix
+++ b/pkgs/servers/search/elasticsearch/7.x.nix
@@ -1,10 +1,13 @@
 { elk7Version
 , enableUnfree ? true
-, lib, stdenv
+, lib
+, stdenv
 , fetchurl
 , makeWrapper
 , jre_headless
-, util-linux, gnugrep, coreutils
+, util-linux
+, gnugrep
+, coreutils
 , autoPatchelfHook
 , zlib
 }:
@@ -17,11 +20,11 @@ let
   shas =
     if enableUnfree
     then {
-      x86_64-linux  = "1s27bzx5y8vcd95qrw6av3fhyxb45219x9ahwaxa2cygmbpighrp";
+      x86_64-linux = "1s27bzx5y8vcd95qrw6av3fhyxb45219x9ahwaxa2cygmbpighrp";
       x86_64-darwin = "1ia3byir3i5qaarmcaysrg3dhnxjmxnf0m0kzyf61g9aiy87gb7q";
     }
     else {
-      x86_64-linux  = "005i7d7ag10qkn7bkx7md50iihvcvc84hay2j94wvsm7yghhbmi3";
+      x86_64-linux = "005i7d7ag10qkn7bkx7md50iihvcvc84hay2j94wvsm7yghhbmi3";
       x86_64-darwin = "01f81720rbzdqc0g1xymhz2lflldfbnb0rh7mpki99pss28vj9sh";
     };
 in
@@ -48,7 +51,7 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jre_headless util-linux ]
-             ++ optional enableUnfree zlib;
+    ++ optional enableUnfree zlib;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -37,7 +37,7 @@ in
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${version}.zip";
       sha256 =
-        if version == "7.5.1" then "0v6ynbk34g7pl9cwy8ga8bk1my18jb6pc3pqbjl8p93w38219vi6"
+        if version == "7.10.2" then "sha256-HXNJy8WPExPeh5afjdLEFg+0WX0LYI/kvvaLGVUke5E="
         else if version == "6.8.3" then "0vbaqyj0lfy3ijl1c9h92b0nh605h5mjs57bk2zhycdvbw5sx2lv"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -54,7 +54,7 @@ in
     src = fetchurl {
       url = "https://github.com/vhyza/elasticsearch-${pluginName}/releases/download/v${version}/elasticsearch-${pluginName}-${version}-plugin.zip";
       sha256 =
-        if version == "7.5.1" then "0js8b9a9ma797448m3sy92qxbwziix8gkcka7hf17dqrb9k29v61"
+        if version == "7.10.2" then "sha256-mW4YNZ20qatyfHCDAmod/gVmkPYh15NrsYPgiBy1/T8="
         else if version == "6.8.3" then "12bshvp01pp2lgwd0cn9l58axg8gdimsh4g9wfllxi1bdpv4cy53"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -71,7 +71,7 @@ in
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${version}.zip";
       sha256 =
-        if version == "7.5.1" then "0znmbdf99bli4kvyb3vxr5x48yb6n64nl38gpa63iqsv3nlbi0hp"
+        if version == "7.10.2" then "sha256-PjA/pwoulkD2d6sHKqzcYxQpb1aS68/l047z5JTcV3Y="
         else if version == "6.8.3" then "0ggdhf7w50bxsffmcznrjy14b578fps0f8arg3v54qvj94v9jc37"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -88,7 +88,7 @@ in
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${version}.zip";
       sha256 =
-        if version == "7.5.1" then "09wl2bpng4xx384xns960rymnm64b5zn2cb1sp25n85pd0isp4p2"
+        if version == "7.10.2" then "sha256-yvxSkVyZDWeu7rcxxq1+IVsljZQKgWEURiXY9qycK1s="
         else if version == "6.8.3" then "0pmffz761dqjpvmkl7i7xsyw1iyyspqpddxp89rjsznfc9pak5im"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -105,7 +105,7 @@ in
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${version}.zip";
       sha256 =
-        if version == "7.5.1" then "0hhwxkjlkw1yv5sp6pdn5k1y8bdv4mnmb6nby1z4367mig6rm8v9"
+        if version == "7.10.2" then "sha256-yOMiYJ2c/mcLDcTA99YrpQBiEBAa/mLtTqJlqTJ5tBc="
         else if version == "6.8.3" then "0kfr4i2rcwinjn31xrc2piicasjanaqcgnbif9xc7lnak2nnzmll"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -122,7 +122,7 @@ in
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${esVersion}.zip";
       sha256 =
-        if version == "7.5.1" then "1j1rgbha5lh0a02h55zqc5qn0mvvi16l2m5r8lmaswp97px056v9"
+        if version == "7.10.2" then "sha256-fN2RQsY9OACE71pIw87XVJo4c3sUu/6gf/6wUt7ZNIE="
         else if version == "6.8.3" then "1mm6hj2m1db68n81rzsvlw6nisflr5ikzk5zv9nmk0z641n5vh1x"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -139,7 +139,7 @@ in
     src = fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${esVersion}.zip";
       sha256 =
-        if version == "7.5.1" then "15g438zpxrcmsgddwmk3sccy92ha90cyq9c61kcw1q84wfi0a7jl"
+        if version == "7.10.2" then "sha256-JdWt5LzSbs0MIEuLJIE1ceTnNeTYI5Jt2N0Xj7OBO6g="
         else if version == "6.8.3" then "1s2klpvnhpkrk53p64zbga3b66czi7h1a13f58kfn2cn0zfavnbk"
         else throw "unsupported version ${version} for plugin ${pluginName}";
     };
@@ -158,13 +158,15 @@ in
       pluginName = "search-guard";
       version =
         # https://docs.search-guard.com/latest/search-guard-versions
-        if esVersion == "7.5.1" then "${esVersion}-38.0.0"
+        if esVersion == "7.10.2" then "7.10.1-49.3.0"
         else if esVersion == "6.8.3" then "${esVersion}-25.5"
         else throw "unsupported version ${esVersion} for plugin ${pluginName}";
       src = fetchurl {
-        url = "mirror://maven/com/floragunn/${pluginName}-${majorVersion}/${version}/${pluginName}-${majorVersion}-${version}.zip";
+        url =
+          if version == "7.10.1-49.3.0" then "https://maven.search-guard.com/search-guard-suite-release/com/floragunn/search-guard-suite-plugin/${version}/search-guard-suite-plugin-${version}.zip"
+          else "mirror://maven/com/floragunn/${pluginName}-${majorVersion}/${version}/${pluginName}-${majorVersion}-${version}.zip";
         sha256 =
-          if version == "7.5.1-38.0.0" then "1a1wp9wrmz6ji2rnpk0b9jqnp86w0w0z8sb48giyc1gzcy1ra9yh"
+          if version == "7.10.1-49.3.0" then "sha256-vKH2+c+7WlncgljrvYH9lAqQTKzg9l0ABZ23Q/xdoK4="
           else if version == "6.8.3-25.5" then "0a7ys9qinc0fjyka03cx9rv0pm7wnvslk234zv5vrphkrj52s1cb"
           else throw "unsupported version ${version} for plugin ${pluginName}";
       };

--- a/pkgs/tools/misc/logstash/7.x.nix
+++ b/pkgs/tools/misc/logstash/7.x.nix
@@ -11,15 +11,16 @@
 with lib;
 
 let this = stdenv.mkDerivation rec {
-  version = elk7Version;
+  # FIXME 7.10 is not available on the mirror
+  version = "7.9.3";
   name = "logstash-${optionalString (!enableUnfree) "oss-"}${version}";
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
     sha256 =
       if enableUnfree
-      then "01l6alwgsq6yf0z9d08i0hi8g708nph1vm78nl4xbpg8h964bybj"
-      else "0nlwgaw6rmhp5b68zpp1pzsjs30b0bjzdg8f7xy6rarpk338s8yb";
+      then "sha256-YM17/LqsMLH15YZp+0pqbEUzmAcCUpIwWT7o+MJN1QE="
+      else "sha256-5HEs/2bi8m64P0R8aHGgyFJCqiFxs1aBF59Wzg9STCM=";
   };
 
   dontBuild = true;

--- a/pkgs/tools/misc/logstash/7.x.nix
+++ b/pkgs/tools/misc/logstash/7.x.nix
@@ -1,6 +1,7 @@
 { elk7Version
 , enableUnfree ? true
-, lib, stdenv
+, lib
+, stdenv
 , fetchurl
 , makeWrapper
 , nixosTests
@@ -21,13 +22,14 @@ let this = stdenv.mkDerivation rec {
       else "0nlwgaw6rmhp5b68zpp1pzsjs30b0bjzdg8f7xy6rarpk338s8yb";
   };
 
-  dontBuild         = true;
-  dontPatchELF      = true;
-  dontStrip         = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
   dontPatchShebangs = true;
 
   buildInputs = [
-    makeWrapper jre
+    makeWrapper
+    jre
   ];
 
   installPhase = ''
@@ -48,9 +50,9 @@ let this = stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Logstash is a data pipeline that helps you process logs and other event data from a variety of systems";
-    homepage    = "https://www.elastic.co/products/logstash";
-    license     = if enableUnfree then licenses.elastic else licenses.asl20;
-    platforms   = platforms.unix;
+    homepage = "https://www.elastic.co/products/logstash";
+    license = if enableUnfree then licenses.elastic else licenses.asl20;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ wjlroe offline basvandijk ];
   };
   passthru.tests =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4616,7 +4616,7 @@ with pkgs;
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
   # When updating make sure to update all plugins or they will break!
   elk6Version = "6.8.3";
-  elk7Version = "7.5.1";
+  elk7Version = "7.10.2";
 
   elasticsearch6 = callPackage ../servers/search/elasticsearch/6.x.nix {
     util-linux = util-linuxMinimal;
@@ -4629,12 +4629,12 @@ with pkgs;
   };
   elasticsearch7 = callPackage ../servers/search/elasticsearch/7.x.nix {
     util-linux = util-linuxMinimal;
-    jre_headless = jre8_headless; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
+    jre_headless = jdk11_headless; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
   elasticsearch7-oss = callPackage ../servers/search/elasticsearch/7.x.nix {
     enableUnfree = false;
     util-linux = util-linuxMinimal;
-    jre_headless = jre8_headless; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
+    jre_headless = jdk11_headless; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
   elasticsearch = elasticsearch6;
   elasticsearch-oss = elasticsearch6-oss;


### PR DESCRIPTION
###### Motivation for this change

upstream change.

There is one weird thing with logstash, the version is not available for some reason. I've opened an issue upstream.
https://github.com/elastic/logstash/issues/13176

I still feel we should upgrade, and we can just fix logstash when upstream solves the issue.

the nixpkgs-fmt commits are optional. If you feel strongly against them, I'm happy to remove them.

I haven't updated the linux sha256 yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
