### PR TITLE
fritzing: 0.9.6 -> unstable-2021-09-22

### DIFF
--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , lib
 , fetchFromGitHub
+, fetchpatch
 , qmake
 , pkg-config
 , qtbase
@@ -9,6 +10,7 @@
 , qtserialport
 , boost
 , libgit2
+, quazip
 }:
 
 let
@@ -20,6 +22,13 @@ let
   # SHA256 of the fritzing-parts HEAD on the master branch,
   # which contains the latest stable parts definitions
   partsSha = "6f04697be286768bc9e4d64f8707e8e40cbcafcb";
+
+  parts = fetchFromGitHub {
+    owner = "fritzing";
+    repo = "fritzing-parts";
+    rev = partsSha;
+    sha256 = "1f4w0hz44n4iw1rc5vhcgzvlji54rf4yr8bvzkqv99hn2xf5pjgs";
+  };
 in
 
 mkDerivation rec {
@@ -33,21 +42,22 @@ mkDerivation rec {
     sha256 = "083nz7vj7a334575smjry6257535h68gglh8a381xxa36dw96aqs";
   };
 
-  parts = fetchFromGitHub {
-    owner = pname;
-    repo = "fritzing-parts";
-    name = "fritzing-parts";
-    rev = partsSha;
-    sha256 = "1f4w0hz44n4iw1rc5vhcgzvlji54rf4yr8bvzkqv99hn2xf5pjgs";
-  };
-
-  buildInputs = [ qtbase qtsvg qtserialport boost libgit2 ];
+  buildInputs = [ qtbase qtsvg qtserialport boost libgit2 quazip ];
   nativeBuildInputs = [ qmake pkg-config qttools ];
+
+  patches = [
+    # Add support for QuaZip 1.x
+    (fetchpatch {
+      url = "https://github.com/fritzing/fritzing-app/commit/ef83ebd9113266bb31b3604e3e9d0332bb48c999.patch";
+      sha256 = "sha256-J43E6iBRIVbsuuo82gPk3Q7tyLhNkuuyYwtH8hUfcPU=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace phoenix.pro \
       --replace 'LIBGIT_STATIC = true' 'LIBGIT_STATIC = false'
 
+    #TODO: Do not hardcode SHA.
     substituteInPlace src/fapplication.cpp \
       --replace 'PartsChecker::getSha(dir.absolutePath());' '"${partsSha}";'
 
@@ -55,15 +65,19 @@ mkDerivation rec {
     cp -a ${parts}/* parts/
   '';
 
+  qmakeFlags = [
+    "phoenix.pro"
+    "DEFINES=QUAZIP_INSTALLED"
+    "DEFINES+=QUAZIP_1X"
+  ];
+
   postFixup = ''
     # generate the parts.db file
     QT_QPA_PLATFORM=offscreen "$out/bin/Fritzing" \
       -db "$out/share/fritzing/parts/parts.db" \
-      -pp "$out/fritzing/parts" \
+      -pp "$out/share/fritzing/parts" \
       -folder "$out/share/fritzing"
   '';
-
-  qmakeFlags = [ "phoenix.pro" ];
 
   meta = with lib; {
     description = "An open source prototyping tool for Arduino-based projects";

--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -83,7 +83,7 @@ mkDerivation rec {
     description = "An open source prototyping tool for Arduino-based projects";
     homepage = "https://fritzing.org/";
     license = with licenses; [ gpl3 cc-by-sa-30 ];
-    maintainers = with maintainers; [ robberer ];
+    maintainers = with maintainers; [ robberer musfay ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -14,32 +14,27 @@
 }:
 
 let
-  # build number corresponding to a release, has no further relation
-  # see https://github.com/fritzing/fritzing-app/releases/tag/CD-498
-  # fritzingBuild = "498";
-  # version 0.9.6 is properly tagged, hope it continues
-
   # SHA256 of the fritzing-parts HEAD on the master branch,
   # which contains the latest stable parts definitions
-  partsSha = "6f04697be286768bc9e4d64f8707e8e40cbcafcb";
+  partsSha = "640fa25650211afccd369f960375ade8ec3e8653";
 
   parts = fetchFromGitHub {
     owner = "fritzing";
     repo = "fritzing-parts";
     rev = partsSha;
-    sha256 = "1f4w0hz44n4iw1rc5vhcgzvlji54rf4yr8bvzkqv99hn2xf5pjgs";
+    sha256 = "sha256-4S65eX4LCnXCFQAOxmdvr8d0nAgTWcJooE2SpLYpcXI=";
   };
 in
 
 mkDerivation rec {
   pname = "fritzing";
-  version = "0.9.6";
+  version = "unstable-2021-09-22";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = "fritzing-app";
-    rev = version;
-    sha256 = "083nz7vj7a334575smjry6257535h68gglh8a381xxa36dw96aqs";
+    rev = "f0af53a9077f7cdecef31d231b85d8307de415d4";
+    sha256 = "sha256-fF38DrBoeZ0aKwVMNyYMPWa5rFPbIVXRARZT+eRat5Q=";
   };
 
   buildInputs = [ qtbase qtsvg qtserialport boost libgit2 quazip ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Vendored quazip is outdated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
