### PR TITLE
python39Packages.cli-helpers: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/cli-helpers/default.nix
+++ b/pkgs/development/python-modules/cli-helpers/default.nix
@@ -1,37 +1,37 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27
-, backports_csv
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
 , configobj
 , mock
-, pytest
+, pytestCheckHook
 , tabulate
-, terminaltables
 , wcwidth
 }:
 
 buildPythonPackage rec {
   pname = "cli_helpers";
-  version = "2.1.0";
+  version = "2.2.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "dd6f164310f7d86fa3da1f82043a9c784e44a02ad49be932a80624261e56979b";
+  # PyPi only carries py3 wheel
+  src = fetchFromGitHub {
+    owner = "dbcli";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19npq8snc3ycbjapqdjp7274rcj9rszf1c7iyp346rclb6w6ay6j";
   };
 
   propagatedBuildInputs = [
     configobj
-    terminaltables
     tabulate
     wcwidth
-  ] ++ (lib.optionals isPy27 [ backports_csv ]);
+  ];
 
-  # namespace collision between backport.csv and backports.configparser
-  doCheck = !isPy27;
+  disabled = pythonOlder "3.6";
 
-  checkInputs = [ pytest mock ];
+  checkInputs = [ pytestCheckHook mock ];
 
-  checkPhase = ''
-    py.test
-  '';
+  pythonImportsCheck = [ "cli_helpers" ];
 
   meta = with lib; {
     description = "Python helpers for common CLI tasks";
@@ -56,7 +56,8 @@ buildPythonPackage rec {
       Read the documentation at http://cli-helpers.rtfd.io
     '';
     homepage = "https://cli-helpers.readthedocs.io/en/stable/";
-    license = licenses.bsd3 ;
+    license = licenses.bsd3;
+    changelog = "https://github.com/dbcli/cli_helpers/raw/v${version}/CHANGELOG";
     maintainers = [ maintainers.kalbasit ];
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/dbcli/cli_helpers/raw/v2.2.0/CHANGELOG


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
