### PR TITLE
terraform-providers: Update alicloud to v1.133.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -33,11 +33,13 @@
     "version": "0.7.1"
   },
   "alicloud": {
-    "owner": "terraform-providers",
+    "owner": "aliyun",
+    "provider-source-address": "registry.terraform.io/aliyun/alicloud",
     "repo": "terraform-provider-alicloud",
-    "rev": "v1.86.0",
-    "sha256": "1hbv9ah7fd173sapwgsbg7790piwxw9zx90wfj5vz5b96ggbg28d",
-    "version": "1.86.0"
+    "rev": "v1.133.0",
+    "sha256": "1f8hrvvlmjiw9kh11vv1w9yrq3pw2x7zxpawpfpr1913bq0jcpfw",
+    "vendorSha256": null,
+    "version": "1.133.0"
   },
   "archive": {
     "owner": "hashicorp",


### PR DESCRIPTION
###### Motivation for this change

The alicloud provider move to aliyun/alicloud, update to the latest
version.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
