### PR TITLE
Ocaml lsp improvements

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -31,9 +31,17 @@ buildDunePackage rec {
   useDune2 = true;
   minimumOCamlVersion = "4.06";
 
-  buildInputs = [ yojson stdlib-shims ocaml-syntax-shims ];
+  buildInputs =
+    if lib.versionAtLeast version "1.7.0" then
+      [ ]
+    else
+      [ yojson stdlib-shims ocaml-syntax-shims ];
 
-  propagatedBuildInputs = [ ppx_yojson_conv_lib result ];
+  propagatedBuildInputs =
+    if lib.versionAtLeast version "1.7.0" then
+      [ ]
+    else
+      [ ppx_yojson_conv_lib result ];
 
   meta = with lib; {
     description = "Jsonrpc protocol implementation in OCaml";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -9,6 +9,7 @@
 , octavius
 , dune-build-info
 , uutf
+, re
 , pp
 , csexp
 , cmdliner
@@ -32,22 +33,24 @@ buildDunePackage rec {
     rm -r ocaml-lsp-server/vendor/{octavius,uutf,omd,cmdliner}
   '';
 
-  buildInputs = [
-    cppo
-    ppx_yojson_conv_lib
-    ocaml-syntax-shims
-    octavius
-    dune-build-info
-    omd
-    cmdliner
-  ] ++ lib.optional (lib.versionAtLeast jsonrpc.version "1.7.0") pp;
+  buildInputs =
+    if lib.versionAtLeast version "1.7.0" then
+      [ pp re ppx_yojson_conv_lib octavius dune-build-info omd cmdliner ]
+    else
+      [ cppo
+        ppx_yojson_conv_lib
+        ocaml-syntax-shims
+        octavius
+        dune-build-info
+        omd
+        cmdliner
+      ];
 
   propagatedBuildInputs = [
     csexp
     jsonrpc
-    stdlib-shims
     uutf
-  ];
+  ] ++ lib.optional (lib.versionOlder version "1.7.0") stdlib-shims;
 
   meta = jsonrpc.meta // {
     description = "LSP protocol implementation in OCaml";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -14,11 +14,15 @@
 , cmdliner
 }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "lsp";
   inherit (jsonrpc) version src;
   useDune2 = true;
-  minimumOCamlVersion = "4.06";
+  minimumOCamlVersion =
+    if lib.versionAtLeast version "1.7.0" then
+      "4.12"
+    else
+      "4.06";
 
   # unvendor some (not all) dependencies.
   # They are vendored by upstream only because it is then easier to install


### PR DESCRIPTION
###### Motivation for this change

specify the dependencies of ocamllsp and jsonrpc more accurately

###### Things done

* Dropped unnecessary dependencies for jsonrpc 1.7.0
* Fixed the minimum OCaml version for ocamllsp 1.7.0
* Fixed the set of dependencies ofr ocamllsp 1.7.0

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
