### PR TITLE
bwm_ng: 0.6.1 -> 0.6.3

### DIFF
--- a/pkgs/tools/networking/bwm-ng/default.nix
+++ b/pkgs/tools/networking/bwm-ng/default.nix
@@ -1,79 +1,42 @@
-{ writeText, lib, stdenv, fetchurl, ncurses }:
+{ lib
+, stdenv
+, autoreconfHook
+, fetchurl
+, ncurses
+}:
 
-let
-  version = "0.6.1";
-in
 stdenv.mkDerivation rec {
   pname = "bwm-ng";
-  inherit version;
+  version = "0.6.3";
 
   src = fetchurl {
     url = "https://www.gropp.org/bwm-ng/${pname}-${version}.tar.gz";
-    sha256 = "1w0dwpjjm9pqi613i8glxrgca3rdyqyp3xydzagzr5ndc34z6z02";
+    sha256 = "0ikzyvnb73msm9n7ripg1dsw9av1i0c7q2hi2173xsj8zyv559f1";
   };
 
-  buildInputs = [ ncurses ];
-
-  # gcc7 has some issues with inline functions
-  patches = [
-    (writeText "gcc7.patch"
-    ''
-    --- a/src/bwm-ng.c
-    +++ b/src/bwm-ng.c
-    @@ -27,5 +27,5 @@
-     /* handle interrupt signal */
-     void sigint(int sig) FUNCATTR_NORETURN;
-    -inline void init(void);
-    +static inline void init(void);
-
-     /* clear stuff and exit */
-    --- a/src/options.c
-    +++ b/src/options.c
-    @@ -35,5 +35,5 @@
-     inline int str2output_type(char *optarg);
-     #endif
-    -inline int str2out_method(char *optarg);
-    +static inline int str2out_method(char *optarg);
-     inline int str2in_method(char *optarg);
-
-    '')
+  nativeBuildInputs = [
+    autoreconfHook
   ];
 
-
-  # This code uses inline in the gnu89 sense: see http://clang.llvm.org/compatibility.html#inline
-  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-std=gnu89";
+  buildInputs = [
+    ncurses
+  ];
 
   meta = with lib; {
     description = "A small and simple console-based live network and disk io bandwidth monitor";
     homepage = "http://www.gropp.org/?id=projects&sub=bwm-ng";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.unix;
-
+    maintainers = with maintainers; [ ];
     longDescription = ''
-        Features
-
-            supports /proc/net/dev, netstat, getifaddr, sysctl, kstat, /proc/diskstats /proc/partitions, IOKit, devstat and libstatgrab
-            unlimited number of interfaces/devices supported
-            interfaces/devices are added or removed dynamically from list
-            white-/blacklist of interfaces/devices
-            output of KB/s, Kb/s, packets, errors, average, max and total sum
-            output in curses, plain console, CSV or HTML
-            configfile
-
-        Short list of changes since 0.5 (for full list read changelog):
-
-            curses2 output, a nice bar chart
-            disk input for bsd/macosx/linux/solaris
-            win32 network bandwidth support
-            moved to autotools
-            alot fixes
-
-        Info
-        This was influenced by the old bwm util written by Barney (barney@freewill.tzo.com) which had some issues with faster interfaces and was very simple. Since i had almost all code done anyway for other projects, i decided to create my own version.
-
-        I actually don't know if netstat input is useful at all. I saw this elsewhere, so i added it. Its target is "netstat 1.42 (2001-04-15)" linux or Free/Open/netBSD. If there are other formats i would be happy to add them.
-
-        (from homepage)
+      bwm-ng supports:
+       - /proc/net/dev, netstat, getifaddr, sysctl, kstat, /proc/diskstats /proc/partitions, IOKit,
+         devstat and libstatgrab
+       - unlimited number of interfaces/devices
+       - interfaces/devices are added or removed dynamically from list
+       - white-/blacklist of interfaces/devices
+       - output of KB/s, Kb/s, packets, errors, average, max and total sum
+       - output in curses, plain console, CSV or HTML
     '';
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.6.3

Change log:
- https://github.com/vgropp/bwm-ng/releases/tag/v0.6.3
- https://github.com/vgropp/bwm-ng/releases/tag/v0.6.2

Other changes:
- `nixpkgs-fmt`
- Clarify license
- Remove change log from `longDescription`
- `inline` issue seems to be resolved -> patch removed 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
