### PR TITLE
ipcalc: 0.41 -> 1.0.1

### DIFF
--- a/pkgs/tools/networking/ipcalc/default.nix
+++ b/pkgs/tools/networking/ipcalc/default.nix
@@ -1,20 +1,38 @@
-{lib, stdenv, fetchurl, perl}:
+{ lib
+, stdenv
+, fetchFromGitLab
+, glib
+, meson
+, ninja
+, libmaxminddb
+, pkg-config
+, ronn
+}:
+
 stdenv.mkDerivation rec {
   pname = "ipcalc";
-  version = "0.41";
-  src = fetchurl {
-    url = "http://jodies.de/ipcalc-archive/${pname}-${version}.tar.gz";
-    sha256 = "dda9c571ce3369e5b6b06e92790434b54bec1f2b03f1c9df054c0988aa4e2e8a";
+  version = "1.0.1";
+
+  src = fetchFromGitLab {
+    owner = "ipcalc";
+    repo = "ipcalc";
+    rev = version;
+    sha256 = "0qg516jv94dlk0qj0bj5y1dd0i31ziqcjd6m00w8xp5wl97bj2ji";
   };
-  buildInputs = [perl];
-  installPhase = ''
-    mkdir -p $out/bin
-    cp ipcalc $out/bin
-  '';
-  meta = {
+
+  nativeBuildInputs = [
+    glib
+    meson
+    ninja
+    pkg-config
+    libmaxminddb
+    ronn
+  ];
+
+  meta = with lib; {
     description = "Simple IP network calculator";
-    homepage = "http://jodies.de/ipcalc";
-    license = lib.licenses.gpl2Plus;
-    platforms = lib.platforms.all;
+    homepage = "https://gitlab.com/ipcalc/ipcalc";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.0.1

Change log: https://gitlab.com/ipcalc/ipcalc/-/blob/master/NEWS

- Uses now `mason`
- Ran `nixpkgs-fmt`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
