### PR TITLE
grilo: add patch for CVE-2021-39365

### DIFF
--- a/pkgs/development/libraries/grilo/default.nix
+++ b/pkgs/development/libraries/grilo/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, gettext, vala, glib, liboauth, gtk3
+{ lib, stdenv, fetchurl, fetchpatch, meson, ninja, pkg-config, gettext, vala, glib, liboauth, gtk3
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43
 , libxml2, gnome, gobject-introspection, libsoup, totem-pl-parser }:
 
@@ -15,6 +15,14 @@ in stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0ywjvh7xw4ql1q4fvl0q5n06n08pga1g1nc9l7c3x5214gr3fj6i";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-39365.patch";
+      url = "https://gitlab.gnome.org/GNOME/grilo/-/commit/cd2472e506dafb1bb8ae510e34ad4797f63e263e.patch";
+      sha256 = "1i1p21vlms43iawg4dl1dibnpsbnkx27kcfvllnx76q07bfrpwzm";
+    })
+  ];
 
   setupHook = ./setup-hook.sh;
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-39365

There are references in the patch to CVE-2016-20011 because it's essentially the same issue in a different application.

Looks like these issues should stop happening sooner or later because libsoup is changing its default https://gitlab.gnome.org/GNOME/libsoup/-/issues/228

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
