### PR TITLE
epmd: provide default listenStream

### DIFF
--- a/nixos/modules/services/networking/epmd.nix
+++ b/nixos/modules/services/networking/epmd.nix
@@ -28,7 +28,7 @@ in
     listenStream = mkOption
       {
         type = types.str;
-        default = null;
+        default = "[::]:4369";
         description = ''
           the listenStream used by the systemd socket.
           see https://www.freedesktop.org/software/systemd/man/systemd.socket.html#ListenStream= for more informations.
@@ -41,7 +41,7 @@ in
   ###### implementation
   config = mkIf cfg.enable {
     assertions = [{
-      assertion = cfg.listenStream == null -> config.networking.enableIPv6;
+      assertion = cfg.listenStream == "[::]:4369" -> config.networking.enableIPv6;
       message = "epmd listens by default on ipv6, enable ipv6 or change config.services.epmd.listenStream";
     }];
     systemd.sockets.epmd = rec {
@@ -49,7 +49,7 @@ in
       wantedBy = [ "sockets.target" ];
       before = wantedBy;
       socketConfig = {
-        ListenStream = if cfg.listenStream != null then cfg.listenStream else "[::]:4369";
+        ListenStream = cfg.listenStream;
         Accept = "false";
       };
     };


### PR DESCRIPTION
###### Motivation for this change

there should be a default port for the epmd socket.
my previous PR adding an assertion was using a null default. In retrospect it's not a good solutions to not have a sane default.
https://github.com/NixOS/nixpkgs/pull/135867

@NixOS/beam this might be interesting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
