### PR TITLE
linuxPackages.vhba: 20190831 -> 20210418

### DIFF
--- a/pkgs/misc/emulators/cdemu/analyzer.nix
+++ b/pkgs/misc/emulators/cdemu/analyzer.nix
@@ -1,9 +1,9 @@
 { callPackage, makeWrapper, gobject-introspection, cmake
 , python3Packages, gtk3, glib, libxml2, gnuplot, gnome, gdk-pixbuf, librsvg, intltool, libmirage }:
 let pkg = import ./base.nix {
-  version = "3.2.3";
+  version = "3.2.5";
   pkgName = "image-analyzer";
-  pkgSha256 = "17yfjmf65s77214qassz6l01cjcni4cv06nzfsm7qrzw172fmci4";
+  pkgSha256 = "00906lky0z1m0bdqnjmzxgcb19dzvljhddhh42lixyr53sjp94cc";
 };
 in callPackage pkg {
   buildInputs = [ glib gtk3 libxml2 gnuplot libmirage makeWrapper

--- a/pkgs/misc/emulators/cdemu/base.nix
+++ b/pkgs/misc/emulators/cdemu/base.nix
@@ -1,11 +1,10 @@
 { pkgName, version, pkgSha256 }:
 { lib, stdenv, fetchurl, cmake, pkg-config, buildInputs, drvParams ? {} }:
 let name = "${pkgName}-${version}";
-    ext = if lib.versionAtLeast version "3.2.5" then ".xz" else ".bz2";
 in stdenv.mkDerivation ({
   inherit name buildInputs;
   src = fetchurl {
-    url = "mirror://sourceforge/cdemu/${name}.tar${ext}";
+    url = "mirror://sourceforge/cdemu/${name}.tar.xz";
     sha256 = pkgSha256;
   };
   nativeBuildInputs = [ pkg-config cmake ];

--- a/pkgs/misc/emulators/cdemu/base.nix
+++ b/pkgs/misc/emulators/cdemu/base.nix
@@ -1,10 +1,11 @@
 { pkgName, version, pkgSha256 }:
 { lib, stdenv, fetchurl, cmake, pkg-config, buildInputs, drvParams ? {} }:
 let name = "${pkgName}-${version}";
+    ext = if lib.versionAtLeast version "3.2.5" then ".xz" else ".bz2";
 in stdenv.mkDerivation ({
   inherit name buildInputs;
   src = fetchurl {
-    url = "mirror://sourceforge/cdemu/${name}.tar.bz2";
+    url = "mirror://sourceforge/cdemu/${name}.tar${ext}";
     sha256 = pkgSha256;
   };
   nativeBuildInputs = [ pkg-config cmake ];
@@ -29,7 +30,7 @@ in stdenv.mkDerivation ({
 
       Optical media emulated by CDemu can be mounted within Linux. Automounting is also allowed.
     '';
-    homepage = "http://cdemu.sourceforge.net/";
+    homepage = "https://cdemu.sourceforge.io/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with lib.maintainers; [ bendlas ];

--- a/pkgs/misc/emulators/cdemu/client.nix
+++ b/pkgs/misc/emulators/cdemu/client.nix
@@ -1,8 +1,8 @@
 { callPackage, python3Packages, intltool, makeWrapper }:
 let pkg = import ./base.nix {
-  version = "3.2.3";
+  version = "3.2.5";
   pkgName = "cdemu-client";
-  pkgSha256 = "1bvc2m63fx03rbp3ihgl2n7k24lwg5ydwkmr84gsjfcxp46q10zq";
+  pkgSha256 = "1prrdhv0ia0axc6b73crszqzh802wlkihz6d100yvg7wbgmqabd7";
 };
 in callPackage pkg {
   buildInputs = [ python3Packages.python python3Packages.dbus-python python3Packages.pygobject3

--- a/pkgs/misc/emulators/cdemu/daemon.nix
+++ b/pkgs/misc/emulators/cdemu/daemon.nix
@@ -1,8 +1,8 @@
 { callPackage, glib, libao, intltool, libmirage }:
 let pkg = import ./base.nix {
-  version = "3.2.3";
+  version = "3.2.5";
   pkgName = "cdemu-daemon";
-  pkgSha256 = "022xzgwmncswb9md71w3ly3mjkdfc93lbij2llp2jamq8grxjjxr";
+  pkgSha256 = "16g6fv1lxkdmbsy6zh5sj54dvgwvm900fd18aq609yg8jnqm644d";
 };
 in callPackage pkg {
   buildInputs = [ glib libao libmirage intltool ];

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -2,9 +2,9 @@
 , python3Packages, gtk3, glib, libnotify, intltool, gnome, gdk-pixbuf, librsvg }:
 let
   pkg = import ./base.nix {
-    version = "3.2.3";
+    version = "3.2.5";
     pkgName = "gcdemu";
-    pkgSha256 = "19vy1awha8s7cfja3a6npaf3rfy3pl3cbsh4vd609q9jz4v4lyg4";
+    pkgSha256 = "1nvpbq4mz8caw91q5ny9gf206g9bypavxws9nxyfcanfkc4zfkl4";
   };
   inherit (python3Packages) python pygobject3;
 in callPackage pkg {

--- a/pkgs/misc/emulators/cdemu/libmirage.nix
+++ b/pkgs/misc/emulators/cdemu/libmirage.nix
@@ -3,9 +3,9 @@
 , pcre, util-linux, libselinux, libsepol }:
 
 let pkg = import ./base.nix {
-  version = "3.2.3";
+  version = "3.2.5";
   pkgName = "libmirage";
-  pkgSha256 = "08mfvqyk3833ksfd47i4j3ppmrw5ry219km6h7lywdh9hm9x14yf";
+  pkgSha256 = "0f8i2ha44rykkk3ac2q8zsw3y1zckw6qnf6zvkyrj3qqbzhrf3fm";
 };
 in callPackage pkg {
   buildInputs = [ glib libsndfile zlib bzip2 xz libsamplerate intltool ];

--- a/pkgs/misc/emulators/cdemu/vhba.nix
+++ b/pkgs/misc/emulators/cdemu/vhba.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "vhba";
-  version = "20190831";
+  version = "20210418";
 
   src  = fetchurl {
-    url = "mirror://sourceforge/cdemu/vhba-module-${version}.tar.bz2";
-    sha256 = "1ybbk6l06n0y11n5wnfmvdz0baizmq55l458ywimghdyz0n7g0ws";
+    url = "mirror://sourceforge/cdemu/vhba-module-${version}.tar.xz";
+    sha256 = "119zgav6caialmf3hr096wkf72l9h76sqc9w5dhx26kj4yp85g8q";
   };
 
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" "INSTALL_MOD_PATH=$(out)" ];
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Provides a Virtual (SCSI) HBA";
-    homepage = "http://cdemu.sourceforge.net/about/vhba/";
+    homepage = "https://cdemu.sourceforge.io/about/vhba/";
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ bendlas ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Noticed this was out of date while checking out-of-tree module compatibility with Linux 5.14.  All I've done with the update is test that it builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
