### PR TITLE
linuxPackages.akvcam: 1.2.0 -> 1.2.2

### DIFF
--- a/pkgs/os-specific/linux/akvcam/default.nix
+++ b/pkgs/os-specific/linux/akvcam/default.nix
@@ -1,32 +1,32 @@
-{ lib, stdenv, fetchFromGitHub, kernel, qmake }:
+{ lib, stdenv, fetchFromGitHub, kernel }:
 
 stdenv.mkDerivation rec {
   pname = "akvcam";
-  version = "1.2.0";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "webcamoid";
     repo = "akvcam";
     rev = version;
-    sha256 = "0r5xg7pz0wl6pq5029rpzm9fn978vq0md31xjkp2amny7rrgxw72";
+    sha256 = "1f0vjia2d7zj3y5c63lx1r537bdjx6821yxy29ilbrvsbjq2szj8";
   };
+  sourceRoot = "source/src";
 
-  nativeBuildInputs = [ qmake ];
-  dontWrapQtApps = true;
-
-  qmakeFlags = [
+  makeFlags = [
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 
   installPhase = ''
-    install -m644 -b -D src/akvcam.ko $out/lib/modules/${kernel.modDirVersion}/akvcam.ko
+    install -m644 -b -D akvcam.ko $out/lib/modules/${kernel.modDirVersion}/akvcam.ko
   '';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Virtual camera driver for Linux";
     homepage = "https://github.com/webcamoid/akvcam";
     maintainers = with maintainers; [ freezeboy ];
     platforms = platforms.linux;
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21339,9 +21339,7 @@ with pkgs;
 
     acpi_call = callPackage ../os-specific/linux/acpi-call {};
 
-    akvcam = callPackage ../os-specific/linux/akvcam {
-      inherit (qt5) qmake;
-    };
+    akvcam = callPackage ../os-specific/linux/akvcam { };
 
     amdgpu-pro = callPackage ../os-specific/linux/amdgpu-pro { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I noticed that this was out of date while checking compatibility with out-of-tree modules Linux 5.14.  All I've done with this update is check that it builds.

The qmake-based build didn't seem to work any more, but there's a
Kbuild-based build system available anyway, so let's just switch to
that and save a dependency.

Also clarify license.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
