### PR TITLE
obinskit: 1.1.4 -> 1.1.8

### DIFF
--- a/pkgs/applications/misc/obinskit/default.nix
+++ b/pkgs/applications/misc/obinskit/default.nix
@@ -4,7 +4,7 @@
 , libxkbcommon
 , systemd
 , xorg
-, electron_3
+, electron_11
 , makeWrapper
 , makeDesktopItem
 }:
@@ -17,15 +17,15 @@ let
     genericName = "Obinskit keyboard configurator";
     categories = "Utility";
   };
-  electron = electron_3;
+  electron = electron_11;
 in
 stdenv.mkDerivation rec {
   pname = "obinskit";
-  version = "1.1.4";
+  version = "1.1.8";
 
   src = fetchurl {
     url = "http://releases.obins.net/occ/linux/tar/ObinsKit_${version}_x64.tar.gz";
-    sha256 = "0q422rmfn4k4ww1qlgrwdmxz4l10dxkd6piynbcw5cr4i5icnh2l";
+    sha256 = "MgasbgexOdscQrUte/6OzCSrc74RvaBq44oHplQA/Gc=";
   };
 
   unpackPhase = "tar -xzf $src";
@@ -51,12 +51,12 @@ stdenv.mkDerivation rec {
   postFixup = ''
     makeWrapper ${electron}/bin/electron $out/bin/${pname} \
       --add-flags $out/opt/obinskit/resources/app.asar \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib libxkbcommon (lib.getLib systemd) xorg.libXt ]}"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib libxkbcommon (lib.getLib systemd) xorg.libXt xorg.libXtst ]}"
   '';
 
   meta = with lib; {
     description = "Graphical configurator for Anne Pro and Anne Pro II keyboards";
-    homepage = "http://en.obins.net/obinskit/"; # https is broken
+    homepage = "https://www.hexcore.xyz/obinskit";
     license = licenses.unfree;
     maintainers = with maintainers; [ shou ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
Updated to the latest release of Obinskit, namely version 1.1.8.
One caveat is that the new electron version requires that the program is run with a `--no-sandbox` flag when executed as the root user which, on my machine, is necessary for accessing `/dev/*` devices.
I have successfully tested:
- updating the keyboard firmware
- changed the key layout, lightning profiles, and edited/installed new macros

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Most recent build of Obinskit includes features such as factory reset and other [bug fixes](https://www.hexcore.xyz/obinskit/releases).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
