### PR TITLE
linuxPackages.isgx: 2.11 -> 2.14

### DIFF
--- a/pkgs/os-specific/linux/isgx/default.nix
+++ b/pkgs/os-specific/linux/isgx/default.nix
@@ -1,28 +1,15 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, kernel, kernelAtLeast }:
+{ stdenv, lib, fetchFromGitHub, kernel, kernelAtLeast }:
 
 stdenv.mkDerivation rec {
   name = "isgx-${version}-${kernel.version}";
-  version = "2.11";
+  version = "2.14";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-sgx-driver";
-    rev = "sgx_driver_${version}";
-    hash = "sha256-zZ0FgCx63LCNmvQ909O27v/o4+93gefhgEE/oDr/bHw=";
+    rev = "sgx_diver_${version}"; # Typo is upstream's.
+    sha256 = "0kbbf2inaywp44lm8ig26mkb36jq3smsln0yp6kmrirdwc3c53mi";
   };
-
-  patches = [
-    # Fixes build with kernel >= 5.8
-    (fetchpatch {
-      url = "https://github.com/intel/linux-sgx-driver/commit/276c5c6a064d22358542f5e0aa96b1c0ace5d695.patch";
-      sha256 = "sha256-PmchqYENIbnJ51G/tkdap/g20LUrJEoQ4rDtqy6hj24=";
-    })
-    # Fixes detection with kernel >= 5.11
-    (fetchpatch {
-      url = "https://github.com/intel/linux-sgx-driver/commit/ed2c256929962db1a8805db53bed09bb8f2f4de3.patch";
-      sha256 = "sha256-MRbgS4U8FTCP1J1n+rhsvbXxKDytfl6B7YlT9Izq05U=";
-    })
-  ];
 
   hardeningDisable = [ "pic" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I noticed this was out of date while checking out-of-tree modules for compatibility with Linux 5.14.  All I've done with this update is test that it builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
