### PR TITLE
stalonetray: 0.8.3 -> 0.8.4

### DIFF
--- a/pkgs/applications/window-managers/stalonetray/default.nix
+++ b/pkgs/applications/window-managers/stalonetray/default.nix
@@ -1,29 +1,51 @@
-{ lib, stdenv, fetchurl, libX11, xorgproto }:
+{ autoreconfHook
+, docbook_xml_dtd_44
+, docbook-xsl-ns
+, fetchFromGitHub
+, lib
+, libX11
+, libXpm
+, libxslt
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
   pname = "stalonetray";
-  version = "0.8.3";
+  version = "0.8.4";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/stalonetray/${pname}-${version}.tar.bz2";
-    sha256 = "0k7xnpdb6dvx25d67v0crlr32cdnzykdsi9j889njiididc8lm1n";
+  src = fetchFromGitHub {
+    owner = "kolbusa";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-grxPqSYPLUstLIOKqzMActaSQ2ftYrjbalfR4HcPDRY=";
   };
 
-  buildInputs = [ libX11 xorgproto ];
+  preConfigure =
+    let
+      db_root = "${docbook-xsl-ns}/share/xml/docbook-xsl-ns";
+      ac_str = "AC_SUBST(DOCBOOK_ROOT)";
+      ac_str_sub = "DOCBOOK_ROOT=${db_root}; ${ac_str}";
+    in
+      ''
+        substituteInPlace configure.ac --replace '${ac_str}' '${ac_str_sub}'
+      '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    docbook-xsl-ns
+    docbook_xml_dtd_44
+    libX11
+    libXpm
+    libxslt
+  ];
 
   hardeningDisable = [ "format" ];
 
   meta = with lib; {
     description = "Stand alone tray";
-    homepage = "http://stalonetray.sourceforge.net";
-    license = licenses.gpl2;
+    homepage = "https://github.com/kolbusa/stalonetray";
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ raskin ];
-  };
-
-  passthru = {
-    updateInfo = {
-      downloadPage = "https://sourceforge.net/projects/stalonetray/files/";
-    };
   };
 }


### PR DESCRIPTION
This update is quite involved for a minor version update.

1. I had to change the source from Sourceforge to Github.

2. I manually specify the autoconf pre-configuration steps. This seems to be
necessary, but is there a better, more canonical way?

3. I had to add the docbook dependency and tinker around with substitutions,
because the original files would pull sources from an online repository. Please
have a look!

Thanks for your comments.

Cheers.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
