### PR TITLE
linuxPackages.system76*: updates

### DIFF
--- a/pkgs/os-specific/linux/system76-acpi/default.nix
+++ b/pkgs/os-specific/linux/system76-acpi/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 let
-  version = "1.0.1";
-  sha256 = "0jmm9h607f7k20yassm6af9mh5l00yih5248wwv4i05bd68yw3p5";
+  version = "1.0.2";
+  sha256 = "1i7zjn5cdv9h00fgjg46b8yrz4d3dqvfr25g3f13967ycy58m48h";
 in
 stdenv.mkDerivation {
   name = "system76-acpi-module-${version}-${kernel.version}";
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     maintainers = [ maintainers.khumba ];
     license = [ licenses.gpl2Only ];
     platforms = [ "i686-linux" "x86_64-linux" ];
-    broken = versionOlder kernel.version "4.14";
+    broken = kernel.kernelOlder "5.2";
     description = "System76 ACPI Driver (DKMS)";
     homepage = "https://github.com/pop-os/system76-acpi-dkms";
     longDescription = ''

--- a/pkgs/os-specific/linux/system76/default.nix
+++ b/pkgs/os-specific/linux/system76/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 let
-  version = "1.0.9";
-  sha256 = "0i4825y2vd679kdjv30ifzj1i1066d3x37z4lgk39hx16993k162";
+  version = "1.0.12";
+  sha256 = "0k098zkxa8spj5rbmzpndxs0cf5i2n22g3ym6kq4j43kvs18x6c7";
 in
 stdenv.mkDerivation {
   name = "system76-module-${version}-${kernel.version}";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I noticed that these were out of date while checking out-of-tree modules for compatibility with Linux 5.14.  All I've done with these updates is test that they build.

`linuxPackages.system76-power` is also outdated, but https://github.com/NixOS/nixpkgs/pull/135171 is already open to update that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
