### PR TITLE
xonotic: support user statistics reporting

### DIFF
--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -6,6 +6,8 @@
   libX11, libGLU, libGL, libXpm, libXext, libXxf86vm, alsa-lib
 , # sdl
   SDL2
+, # blind
+  gmp
 
 , withSDL ? true
 , withGLX ? false
@@ -63,7 +65,7 @@ let
     };
 
     nativeBuildInputs = [ unzip ];
-    buildInputs = [ libjpeg zlib libvorbis curl ]
+    buildInputs = [ libjpeg zlib libvorbis curl gmp ]
       ++ lib.optional withGLX [ libX11.dev libGLU.dev libGL.dev libXpm.dev libXext.dev libXxf86vm.dev alsa-lib.dev ]
       ++ lib.optional withSDL [ SDL2.dev ];
 
@@ -74,17 +76,27 @@ let
 
     dontStrip = target != "release";
 
-    buildPhase = lib.optionalString withDedicated ''
+    postConfigure = ''
+      pushd ../d0_blind_id
+      ./configure $configureFlags
+      popd
+    '';
+
+    buildPhase = (lib.optionalString withDedicated ''
       make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES sv-${target}
     '' + lib.optionalString withGLX ''
       make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES cl-${target}
     '' + lib.optionalString withSDL ''
       make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES sdl-${target}
+    '') + ''
+      pushd ../d0_blind_id
+      make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES
+      popd
     '';
 
     enableParallelBuilding = true;
 
-    installPhase = ''
+    installPhase = (''
       for size in 16x16 24x24 32x32 48x48 64x64 72x72 96x96 128x128 192x192 256x256 512x512 1024x1024 scalable; do
         install -Dm644 ../../misc/logos/xonotic_icon.svg \
           $out/share/icons/hicolor/$size/xonotic.svg
@@ -95,6 +107,10 @@ let
       install -Dm755 darkplaces-glx "$out/bin/xonotic-glx"
     '' + lib.optionalString withSDL ''
       install -Dm755 darkplaces-sdl "$out/bin/xonotic-sdl"
+    '') + ''
+      pushd ../d0_blind_id
+      make install
+      popd
     '';
 
     # Xonotic needs to find libcurl.so at runtime for map downloads
@@ -121,10 +137,10 @@ in rec {
   xonotic-data = fetchzip {
     name = "xonotic-data";
     url = "https://dl.xonotic.org/xonotic-${version}.zip";
-    sha256 = "1ygkh0v68y4sd1w5vpk8dgb65h5jm599hwszdfgjp3ax4d3ml81x";
+    sha256 = "15caj11v9hhr7w55w3rs1rspblzr9lg1crqivbn9pyyq0rif8cpl";
     extraPostFetch = ''
       cd $out
-      rm -rf $(ls | grep -v "^data$")
+      rm -rf $(ls | grep -v "^data$" | grep -v "^key_0.d0pk$")
     '';
     meta.hydraPlatforms = [];
     passthru.version = version;
@@ -156,7 +172,7 @@ in rec {
     copyDesktopItems
   '' + ''
     for binary in $out/bin/xonotic-*; do
-      wrapProgram $binary --add-flags "-basedir ${xonotic-data}"
+      wrapProgram $binary --add-flags "-basedir ${xonotic-data}" --prefix LD_LIBRARY_PATH : "${xonotic-unwrapped}/lib"
     done
   '');
 }


### PR DESCRIPTION
Xonotic supports (opt-in) tracking of user statistics. For staistics to
be trackable each player needs a unique identifier that is based on some
cryptographic identity. For that to work we need to build the "blind"
library and provide it do xonotic during runtime.

The official xonotic releases ship with the public key of some sort of
central trust authority and thus we must retain that file within our
data package as well.

Before this commit the crypto_* commands in the ingame console weren't
available. With this commit you should be able to execute "crypto_keys"
commands as show below.

  $ crypto_keys
  0: public key key_0.d0pk (fingerprint: Xon//KssdlzGkFKdnnN4sgg8H+koTbBn5JTi37BAW1Q=)
     private ID key_0.d0si (public key fingerprint: 9piqrk8ajAPRc3BnSbkac5GA+yL3dOwh53BhyrfmVlI=)

Once the above command works you have to configure your player profile
to allow tracking (if you want) via the Multiplayer -> Profile dialog.
In the top right-hand corner there will be checkboxes to control the
level of tracking that you are opting in to.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Played the game and got my records recognized on the server :-) 
