### PR TITLE
apr: add patch for CVE-2021-35940

### DIFF
--- a/pkgs/development/libraries/apr/default.nix
+++ b/pkgs/development/libraries/apr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, autoreconfHook }:
+{ lib, stdenv, fetchurl, fetchpatch, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "apr";
@@ -9,7 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "1spp6r2a3xcl5yajm9safhzyilsdzgagc2dadif8x6z9nbq4iqg2";
   };
 
-  patches = lib.optionals stdenv.isDarwin [ ./is-this-a-compiler-bug.patch ];
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-35940.patch";
+      url = "https://dist.apache.org/repos/dist/release/apr/patches/apr-1.7.0-CVE-2021-35940.patch";
+      sha256 = "1qd511dyqa1b7bj89iihrlbaavbzl6yyblqginghmcnhw8adymbs";
+      # convince fetchpatch to restore missing `a/`, `b/` to paths
+      extraPrefix = "";
+    })
+  ] ++ lib.optionals stdenv.isDarwin [ ./is-this-a-compiler-bug.patch ];
 
   # This test needs the net
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-35940

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
