### PR TITLE
tcl.mkTclDerivation: fix cross

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, callPackage, makeSetupHook, makeWrapper
+{ lib, stdenv, callPackage, makeSetupHook
 
 # Version specific stuff
 , release, version, src
@@ -51,9 +51,9 @@ let
         inherit release version;
         libPrefix = "tcl${release}";
         libdir = "lib/${libPrefix}";
-        tclPackageHook = callPackage ({}: makeSetupHook {
+        tclPackageHook = callPackage ({ buildPackages }: makeSetupHook {
           name = "tcl-package-hook";
-          deps = [ makeWrapper ];
+          deps = [ buildPackages.makeWrapper ];
         } ./tcl-package-hook.sh) {};
       };
     };

--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -39,8 +39,8 @@ let
     "addTclConfigureFlags" "checkPhase" "checkInputs" "doCheck"
   ]) // {
 
-    buildInputs = buildInputs ++ [ makeWrapper tcl.tclPackageHook ];
-    nativeBuildInputs = nativeBuildInputs ++ [ tcl ];
+    buildInputs = buildInputs ++ [ tcl.tclPackageHook ];
+    nativeBuildInputs = nativeBuildInputs ++ [ makeWrapper tcl ];
     propagatedBuildInputs = propagatedBuildInputs ++ [ tcl ];
 
     TCLSH = "${getBin tcl}/bin/tclsh";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This makes it possible to cross-compile e.g. tk.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
