### PR TITLE
oauth2l: init at 1.2.2

### DIFF
--- a/pkgs/tools/security/oauth2l/default.nix
+++ b/pkgs/tools/security/oauth2l/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoModule, fetchFromGitHub, ... }:
+
+buildGoModule rec {
+  pname = "oauth2l";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "sha256-HOUy+F4WCZE9NA9Z9uIENTOTv+F9iHQmeNIvH8YCPSk=";
+  };
+
+  vendorSha256 = null;
+
+  # the test suite's use of runtime.Caller(0) to find relative file paths is incompatible with -trimpath
+  allowGoReference = true;
+
+  # as it's a utility that drops files in your homedir, it needs writable home.
+  preCheck = ''
+    # failed to read configuration:  mkdir /homeless-shelter: permission denied
+    export HOME=$TMPDIR
+  '';
+
+  meta = {
+    description = "A tool for working with Google OAuth 2.0";
+    homepage = "https://github.com/google/oauth2l";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ pjjw ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20095,6 +20095,8 @@ with pkgs;
     buildGoModule = buildGo115Module;
   };
 
+  oauth2l = callPackage ../tools/security/oauth2l { };
+
   openbgpd = callPackage ../servers/openbgpd { };
 
   openafs_1_8 = callPackage ../servers/openafs/1.8 { tsmbac = null; ncurses = null; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The desire to use this tool in a development workflow.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
