### PR TITLE
vala_0_48: 0.48.18 -> 0.48.19, vala_0_50: 0.50.9 -> 0.50.10, vala_0_52: 0.52.4 -> 0.52.5

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -121,8 +121,8 @@ in rec {
   };
 
   vala_0_50 = generic {
-    version = "0.50.9";
-    sha256 = "0w5ngs90rq7vy21nqfq8drqyb33kxm17j161qvakwpsbjsidv1mn";
+    version = "0.50.10";
+    sha256 = "sha256-vnIf8/AYHqttM+zKzygfZvMI+qHl5VTwj99nFZpFlRU=";
   };
 
   vala_0_52 = generic {

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -116,8 +116,8 @@ in rec {
   };
 
   vala_0_48 = generic {
-    version = "0.48.18";
-    sha256 = "1pbz4nyrrf9wp8rp953sczx545s4g0h5mars9ynkn788dzs2h3wy";
+    version = "0.48.19";
+    sha256 = "sha256-gLdlijfZhE/NG0Mdr8WATeYWpYGW5PHxGeWyrraLSgE=";
   };
 
   vala_0_50 = generic {

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -126,8 +126,8 @@ in rec {
   };
 
   vala_0_52 = generic {
-    version = "0.52.4";
-    sha256 = "0cfz3xshc9azxx4fn25x9gadnph6jvf1r2wzd7p5krk0a4755ppc";
+    version = "0.52.5";
+    sha256 = "sha256-hKG7MSs+Xcrkt7JcRVmNN14stpIzzvtZoV0jUMdr3ZE=";
   };
 
   vala = vala_0_52;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I don't think any of the changes are majorly concerning. I've tested building vala but not everything GNOME.

```
Vala 0.48.19
============
 * Various improvements and bug fixes:
  - codegen:
    + Allow null to initialize non-null struct inside initializer list [#594]
    + Implementing GLib.Source.prepare/check is optional since 2.36
    + Fix variadic constructors for compact classes and structs [#1195]
    + Use detroy_value() for delete statement [#1201]
    + Fix params-array in constructor for struct [#1202]
  - vala:
    + Rely on DataType.to_qualified_string() for error-types [#1206]
    + Disallow resize() for constant arrays [#944]
  - Recognize multiple valid CCode.gir_namespace/_version in VAPI files [#1189]
  - Slightly improve source_reference for get_dup_func_expression()
  - girwriter:
    + Respect GIR.name for constants, errordomains and delegates [#1196]
    + Add explicit writable attribute to all field elements
    + Fix position of "result" parameter for struct constructor
    + Write missing c:type attribute of compact class record
  - girparser: Add support for "final" class attribute
  - tests/girwriter: Add missing [Flags] annotation
  - testrunner: Add support for girwriter tests
  - docs: Update bootstrap instructions in README.md

 * Bindings:
  - glib-2.0: Add Uri.to_string/to_string_partial() (since 2.66)
  - gobject-2.0: Fix the Closure.invoke() signature
```

```
Vala 0.50.10
============
 * Various improvements and bug fixes:
  - codegen:
    + Allow null to initialize non-null struct inside initializer list [#594]
    + Implementing GLib.Source.prepare/check is optional since 2.36
    + Fix variadic constructors for compact classes and structs [#1195]
    + Use detroy_value() for delete statement [#1201]
    + Fix params-array in constructor for struct [#1202]
  - vala:
    + Rely on DataType.to_qualified_string() for error-types [#1206]
    + Disallow resize() for constant arrays [#944]
  - Recognize multiple valid CCode.gir_namespace/_version in VAPI files [#1189]
  - Slightly improve source_reference for get_dup_func_expression()
  - girwriter:
    + Respect GIR.name for constants, errordomains and delegates [#1196]
    + Add explicit writable attribute to all field elements
    + Fix position of "result" parameter for struct constructor
    + Write missing c:type attribute of compact class record
  - girparser: Add support for "final" class attribute
  - tests/girwriter: Add missing [Flags] annotation
  - testrunner: Add support for girwriter tests
  - docs: Update bootstrap instructions in README.md

 * Bindings:
  - glib-2.0: Add Uri.to_string/to_string_partial() (since 2.66)
  - gobject-2.0: Fix the Closure.invoke() signature
```

```
Vala 0.52.5
===========
 * Various improvements and bug fixes:
  - codegen:
    + Allow null to initialize non-null struct inside initializer list [#594]
    + Implementing GLib.Source.prepare/check is optional since 2.36
    + Fix variadic constructors for compact classes and structs [#1195]
    + Use detroy_value() for delete statement [#1201]
    + Fix params-array in constructor for struct [#1202]
  - vala:
    + Rely on DataType.to_qualified_string() for error-types [#1206]
    + Disallow resize() for constant arrays [#944]
  - Recognize multiple valid CCode.gir_namespace/_version in VAPI files [#1189]
  - Slightly improve source_reference for get_dup_func_expression()
  - girwriter:
    + Respect GIR.name for constants, errordomains and delegates [#1196]
    + Add explicit writable attribute to all field elements
    + Fix position of "result" parameter for struct constructor
    + Write missing c:type attribute of compact class record
  - girparser: Add support for "final" class attribute
  - tests/girwriter: Add missing [Flags] annotation
  - testrunner: Add support for girwriter tests
  - docs: Update bootstrap instructions in README.md

 * Bindings:
  - Partly revert "gstreamer: Update from 1.19.0+ git master" [#1210]
  - glib-2.0: expected_type and return value of VariantDict.lookup_value()
    is nullable
  - glib-2.0: Add Uri.to_string/to_string_partial() (since 2.66)
  - gobject-2.0: Fix the Closure.invoke() signature
  - gstreamer: Update from 1.19.0+ git master
  - gtk4: Update to 4.3.2+04f3c805
  - linux: Substitute linux/if.h with net/if.h
  - linux: Fix some bindings errors
  - linux: Fix i2c-dev constants
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
