### PR TITLE
glib: 2.68.3 -> 2.68.4

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -45,11 +45,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "glib";
-  version = "2.68.3";
+  version = "2.68.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0f1iprj7v0b5wn9njj39dkl25g6filfs7i4ybk20jq821k1a7qg7";
+    sha256 = "sha256-Yv0GHQinVJJhfmJac+LAXiWfgxrLuOH4ucgfI/eZOjs=";
   };
 
   patches = optionals stdenv.isDarwin [


### PR DESCRIPTION
- https://gitlab.gnome.org/GNOME/glib/-/releases/2.68.4

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Changelog looks safe IMO.

```
Overview of changes in GLib 2.68.4
==================================

* Bugs fixed:
 - #2454 Read past the end of buffer in g_win32_package_parser_enum_packages
 - !2158 Backport !2155 “glocalfilemonitor: Avoid a deadlock on finalization” to glib-2-68
 - !2175 Backport !2174 “data-to-c.py: generate new-line at the end of the file” to glib-2-68
 - !2183 Backport !2180 “correctly use 3 parameters for close_range” to glib-2-68
 - !2186 Backport !2185 “glocalfile: Fix the global trash dir detection” to glib-2-68
 - !2209 Backport !2208 “g_string_replace: Don't replace empty string more than once per location” to glib-2-68
 - !2220 Backport GWin32AppInfo fixes to glib-2-68

* Translation updates:
 - Chinese (China)
 - Chinese (Taiwan)
 - Occitan (post 1500)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
