### PR TITLE
libe57format: 2.1 -> 2.2.0

### DIFF
--- a/pkgs/development/libraries/libe57format/default.nix
+++ b/pkgs/development/libraries/libe57format/default.nix
@@ -5,20 +5,17 @@
   boost,
   xercesc,
   icu,
-
-  dos2unix,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
   pname = "libe57format";
-  version = "2.1";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "asmaloney";
     repo = "libE57Format";
     rev = "v${version}";
-    sha256 = "05z955q68wjbd9gc5fw32nqg69xc82n2x75j5vchxzkgnn3adcpi";
+    sha256 = "15l23spjvak5h3n7aj3ggy0c3cwcg8mvnc9jlbd9yc2ra43bx7bp";
   };
 
   nativeBuildInputs = [
@@ -35,31 +32,6 @@ stdenv.mkDerivation rec {
     # due to the way that libe57format's CMake config is written.
     xercesc
   ];
-
-  # TODO: Remove CMake patching when https://github.com/asmaloney/libE57Format/pull/60 is available.
-
-  # GNU patch cannot patch `CMakeLists.txt` that has CRLF endings,
-  # see https://unix.stackexchange.com/questions/239364/how-to-fix-hunk-1-failed-at-1-different-line-endings-message/243748#243748
-  # so convert it first.
-  prePatch = ''
-    ${dos2unix}/bin/dos2unix CMakeLists.txt
-  '';
-  patches = [
-    (fetchpatch {
-      name = "libE57Format-cmake-Fix-config-filename.patch";
-      url = "https://github.com/asmaloney/libE57Format/commit/279d8d6b60ee65fb276cdbeed74ac58770a286f9.patch";
-      sha256 = "0fbf92hs1c7yl169i7zlbaj9yhrd1yg3pjf0wsqjlh8mr5m6rp14";
-    })
-  ];
-  # It appears that while the patch has
-  #     diff --git a/cmake/E57Format-config.cmake b/cmake/e57format-config.cmake
-  #     similarity index 100%
-  #     rename from cmake/E57Format-config.cmake
-  #     rename to cmake/e57format-config.cmake
-  # GNU patch doesn't interpret that.
-  postPatch = ''
-    mv cmake/E57Format-config.cmake cmake/e57format-config.cmake
-  '';
 
   # The build system by default builds ONLY static libraries, and with
   # `-DE57_BUILD_SHARED=ON` builds ONLY shared libraries, see:
@@ -79,7 +51,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Library for reading & writing the E57 file format (fork of E57RefImpl)";
+    description = "Library for reading & writing the E57 file format";
     homepage = "https://github.com/asmaloney/libE57Format";
     license = licenses.boost;
     maintainers = with maintainers; [ chpatrick nh2 ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/asmaloney/libE57Format/releases/tag/v2.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).