### PR TITLE
nvidia-x11: improve support for clang-built kernel

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -143,6 +143,15 @@ in
       '';
     };
 
+    hardware.nvidia.nvidiaSettings = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to add nvidia-settings, NVIDIA's GUI configuration tool, to
+        systemPackages.
+      '';
+    };
+
     hardware.nvidia.nvidiaPersistenced = mkOption {
       default = false;
       type = types.bool;
@@ -279,7 +288,8 @@ in
     hardware.opengl.extraPackages = optional offloadCfg.enable nvidia_x11.out;
     hardware.opengl.extraPackages32 = optional offloadCfg.enable nvidia_x11.lib32;
 
-    environment.systemPackages = [ nvidia_x11.bin nvidia_x11.settings ]
+    environment.systemPackages = [ nvidia_x11.bin ]
+      ++ optionals nvidiaSettings [ nvidia_x11.settings ]
       ++ optionals nvidiaPersistencedEnabled [ nvidia_x11.persistenced ];
 
     systemd.packages = optional cfg.powerManagement.enable nvidia_x11.out;

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -17,10 +17,8 @@ buildPhase() {
         # Create the module.
         echo "Building linux driver against kernel: $kernel";
         cd kernel
-        sysSrc=$(echo $kernel/lib/modules/$kernelVersion/source)
-        sysOut=$(echo $kernel/lib/modules/$kernelVersion/build)
         unset src # used by the nv makefile
-        make IGNORE_PREEMPT_RT_PRESENCE=1 NV_BUILD_SUPPORTS_HMM=1 SYSSRC=$sysSrc SYSOUT=$sysOut module -j$NIX_BUILD_CORES
+        make $makeFlags -j $NIX_BUILD_CORES module
 
         cd ..
     fi

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -75,6 +75,8 @@ let
     kernel = if libsOnly then null else kernel.dev;
     kernelVersion = if libsOnly then null else kernel.modDirVersion;
 
+    makeFlags = optionals (!libsOnly) kernel.makeFlags;
+
     hardeningDisable = [ "pic" "format" ];
 
     dontStrip = true;

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -75,7 +75,12 @@ let
     kernel = if libsOnly then null else kernel.dev;
     kernelVersion = if libsOnly then null else kernel.modDirVersion;
 
-    makeFlags = optionals (!libsOnly) kernel.makeFlags;
+    makeFlags = optionals (!libsOnly) (kernel.makeFlags ++ [
+      "IGNORE_PREEMPT_RT_PRESENCE=1"
+      "NV_BUILD_SUPPORTS_HMM=1"
+      "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
+      "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    ]);
 
     hardeningDisable = [ "pic" "format" ];
 

--- a/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ m4 ];
   buildInputs = [ libtirpc ];
 
+  inherit (nvidia_x11) makeFlags;
+
   installFlags = [ "PREFIX=$(out)" ];
 
   postFixup = ''

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation {
   preBuild = ''
     if [ -e src/libXNVCtrl/libXNVCtrl.a ]; then
       ( cd src/libXNVCtrl
-        make
+        make $makeFlags
       )
     fi
   '';

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -24,7 +24,7 @@ let
       cd src/libXNVCtrl
     '';
 
-    makeFlags = [
+    makeFlags = nvidia_x11.makeFlags ++ [
       "OUTPUTDIR=." # src/libXNVCtrl
     ];
 
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
              ++ lib.optionals withGtk3 [ gtk3 librsvg wrapGAppsHook ];
 
   enableParallelBuilding = true;
-  makeFlags = [ "NV_USE_BUNDLED_LIBJANSSON=0" ];
+  makeFlags = nvidia_x11.makeFlags ++ [ "NV_USE_BUNDLED_LIBJANSSON=0" ];
   installFlags = [ "PREFIX=$(out)" ];
 
   postPatch = lib.optionalString nvidia_x11.useProfiles ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This patchset does two things to enable nvidia support in clang-built kernels
with NixOS:

1. Allow the user to not install nvidia-settings. It is useless in headless
   settings and makes building with clang a lot more difficult.
2. Propagates the kernel's `makeFlags` throughout the nvidia driver and
   associated packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
