### PR TITLE
pkgsMerge: automatic buildEnv's with chained packages

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -33,6 +33,7 @@ in
   ### Deprecated aliases - for backward compatibility
 
 mapAliases ({
+  "+" = pkgsMerge;
   PPSSPP = ppsspp; # added 2017-10-01
   QmidiNet = qmidinet;  # added 2016-05-22
   accounts-qt = libsForQt5.accounts-qt; # added 2015-12-19

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -253,6 +253,22 @@ let
         gcc.abi = "elfv2";
       };
     });
+
+    pkgsMerge = let
+      gen = name: paths: self.buildEnv {
+        inherit name paths;
+        ignoreCollisions = true;
+        meta.mainProgram = let last = self.lib.last paths;
+          in last.meta.mainProgram or (builtins.parseDrvName last.name).name;
+
+        # Use lists not attrsets because order matters
+        passthru = builtins.mapAttrs (n: v:
+          gen (if builtins.length paths > 5
+            then "merged-environment"
+            else name + "-${n}") (paths ++ [v])
+        ) self;
+      };
+      in gen "merged" [];
   };
 
   # The complete chain of package set builders, applied from top to bottom.


### PR DESCRIPTION
###### Motivation for this change
```
nix shell nixpkgs#hello nixpkgs#cowsay nixpkgs#dash -c dash -c 'hello|cowsay'
```
is awkward and repetitive. Especially if trying to use a flake not in the registry (eg: a github flake URI). This also doesn't look very nice in a shebang (https://github.com/NixOS/nix/pull/5189). The idea is to utilize syntax similar to https://github.com/DavHau/mach-nix and https://nixery.dev/. This change makes it easy to make a buildEnv by chaining together packages. 

```
nix shell nixpkgs#pkgsMerge.hello.cowsay.dash -c dash -c 'hello|cowsay'
``` 

###### Things done

Added an adapter alongside other `pkgs*` which recursively places all of top-level packages into the passthru of a buildEnv derivation. As one traverses through the passthru's, the paths are collected and incorporated into a buildEnv.

design decisions to think about:
- Name? pkgsMerge, pkgsEnv?
- Should order matter? When used with `nix run` we must pick either first or last item.
- Use first or last item's `mainProgram` value? Currently this uses the last item in the list. 
- Alias? "+" is convenient, but probably a bit too much overloading?
- `nix run nixpkgs#pkgsMerge.hello.cowsay.bash` doesn't work as expected due to PATH not being set for the program. This could be fixed in Nix pretty easily by setting the PATH to the `merged-environment/bin` itself around [here](https://github.com/NixOS/nix/blob/master/src/nix/run.cc#L176)
- does not work with non-top level derivations (eg: python, but we have mach-nix for that!)

This also works as an independent [flake](https://github.com/tomberek/-)! So it could just remain a quirky flake and not integrated into Nixpkgs.
```
nix shell github:tomberek/-#pkgsMerge.hello.cowsay.dash -c dash -c 'hello|cowsay'
```

### TODO
- [ ] get feedback
- [ ] finalize design
- [ ] docs
- [ ] `nix run` fixes

[![asciicast](https://asciinema.org/a/txZ2dZLbZS6ze3tGCtzseJTWv.svg)](https://asciinema.org/a/txZ2dZLbZS6ze3tGCtzseJTWv)