### PR TITLE
Fix interaction between appendOverlays and otherPackageSets

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -15,7 +15,7 @@
   # Utility functions, could just import but passing in for efficiency
   lib
 
-, # Use to reevaluate Nixpkgs; a dirty hack that should be removed
+, # Use to reevaluate Nixpkgs
   nixpkgsFun
 
   ## Other parameters
@@ -218,7 +218,7 @@ let
     appendOverlays = extraOverlays:
       if extraOverlays == []
       then self
-      else import ./stage.nix (args // { overlays = args.overlays ++ extraOverlays; });
+      else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
 
     # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
     #       of allocations. DO NOT USE THIS IN NIXPKGS.


### PR DESCRIPTION
The comment

    a dirty hack that should be removed

has led me to believe that nixpkgsFun isn't the right solution,
but bypassing it is worse, because it creates a second, inner
overriding mechanism that doesn't pass its changes to the old,
outer overriding mechanism.

Before this change:

    nix-repl> ((import <nixpkgs> {}).appendOverlays([(f: s: { foobarbaz = "ok"; })])).foobarbaz
    "ok"

    nix-repl> ((import <nixpkgs> {}).appendOverlays([(f: s: { foobarbaz = "ok"; })])).pkgsCross.aarch64-multiplatform.foobarbaz
    error: attribute 'foobarbaz' missing

           at «string»:1:1:

                1| ((import <nixpkgs> {}).appendOverlays([(f: s: { foobarbaz = "ok"; })])).pkgsCross.aarch64-multiplatform.foobarbaz
                 | ^
                2|

After this change:

    nix-repl> ((import ./. {}).appendOverlays([(f: s: { foobarbaz = "ok"; })])).pkgsCross.aarch64-multiplatform.foobarbaz
    "ok"

Thanks to @samueldr for discovering this problem.

The bug was introduced with the introduction of `appendOverlays` itself: https://github.com/NixOS/nixpkgs/pull/47430

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
