### PR TITLE
nixUnstable: pre20210802_47e96bb -> pre20210830_50a3586

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -240,13 +240,13 @@ in rec {
     #    git diff OLD..NEW -- $(find . -name \*.nix | grep -v test)
     pname = "nix";
     version = "2.4${suffix}";
-    suffix = "pre20210830_${lib.substring 0 7 src.rev}";
+    suffix = "pre20210831_${lib.substring 0 7 src.rev}";
 
     src = fetchFromGitHub {
-      owner = "NixOS";
+      owner = "hercules-ci";
       repo = "nix";
-      rev = "50a35860ee9237d341948437c5f70a7f0987d393";
-      sha256 = "sha256-eljjEPJdLK3aDskF7qX4YM/6KCq+w9nr+IKhrKW/AIQ=";
+      rev = "5d51df2fbe005ae37714541bb13e037e6fe28a81";
+      sha256 = "sha256:0dxz40wjbb851k2j3hixxvvk2z0ykyjhdpyry25cba6r289c560j";
     };
 
     boehmgc = boehmgc_nixUnstable;

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -232,15 +232,21 @@ in rec {
   });
 
   nixUnstable = lib.lowPrio (callPackage common rec {
+    # Update checklist
+    #  - version
+    #  - date
+    #  - src rev/sha256
+    #  - changes in upstream packaging
+    #    git diff OLD..NEW -- $(find . -name \*.nix | grep -v test)
     pname = "nix";
     version = "2.4${suffix}";
-    suffix = "pre20210802_47e96bb";
+    suffix = "pre20210830_${lib.substring 0 7 src.rev}";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "47e96bb533f8cacc171bec9b688b134de31a48a9";
-      sha256 = "sha256-vwj1fAGn3Pl9Vr/qSL+oDxuwbRzEdI3dsEg6o3xTmWg=";
+      rev = "50a35860ee9237d341948437c5f70a7f0987d393";
+      sha256 = "sha256-eljjEPJdLK3aDskF7qX4YM/6KCq+w9nr+IKhrKW/AIQ=";
     };
 
     boehmgc = boehmgc_nixUnstable;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Deliver recent fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
