### PR TITLE
logstash: fix passthru.tests

### DIFF
--- a/pkgs/tools/misc/logstash/7.x.nix
+++ b/pkgs/tools/misc/logstash/7.x.nix
@@ -24,54 +24,55 @@ let
       x86_64-linux = "sha256-jiV2yGPwPgZ5plo3ftImVDLSOsk/XBzFkeeALSObLhU=";
       x86_64-darwin = "sha256-UYG+GGr23eAc2GgNX/mXaGU0WKMjiQMPpD1wUvAVz0A=";
     };
+  this = stdenv.mkDerivation rec {
+    version = elk7Version;
+    pname = "logstash${optionalString (!enableUnfree) "-oss"}";
+
+    src = fetchurl {
+      url = "https://artifacts.elastic.co/downloads/logstash/${pname}-${version}-${plat}-${arch}.tar.gz";
+      sha256 = shas.${stdenv.hostPlatform.system} or (throw "Unknown architecture");
+    };
+
+    dontBuild = true;
+    dontPatchELF = true;
+    dontStrip = true;
+    dontPatchShebangs = true;
+
+    buildInputs = [
+      makeWrapper
+      jre
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r {Gemfile*,modules,vendor,lib,bin,config,data,logstash-core,logstash-core-plugin-api} $out
+
+      patchShebangs $out/bin/logstash
+      patchShebangs $out/bin/logstash-plugin
+
+      wrapProgram $out/bin/logstash \
+         --set JAVA_HOME "${jre}"
+
+      wrapProgram $out/bin/logstash-plugin \
+         --set JAVA_HOME "${jre}"
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "Logstash is a data pipeline that helps you process logs and other event data from a variety of systems";
+      homepage = "https://www.elastic.co/products/logstash";
+      license = if enableUnfree then licenses.elastic else licenses.asl20;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ wjlroe offline basvandijk ];
+    };
+    passthru.tests =
+      optionalAttrs (!enableUnfree) (
+        assert this.drvPath == nixosTests.elk.ELK-7.elkPackages.logstash.drvPath;
+        {
+          elk = nixosTests.elk.ELK-7;
+        }
+      );
+  };
 in
-stdenv.mkDerivation rec {
-  version = elk7Version;
-  pname = "logstash${optionalString (!enableUnfree) "-oss"}";
-
-  src = fetchurl {
-    url = "https://artifacts.elastic.co/downloads/logstash/${pname}-${version}-${plat}-${arch}.tar.gz";
-    sha256 = shas.${stdenv.hostPlatform.system} or (throw "Unknown architecture");
-  };
-
-  dontBuild = true;
-  dontPatchELF = true;
-  dontStrip = true;
-  dontPatchShebangs = true;
-
-  buildInputs = [
-    makeWrapper
-    jre
-  ];
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out
-    cp -r {Gemfile*,modules,vendor,lib,bin,config,data,logstash-core,logstash-core-plugin-api} $out
-
-    patchShebangs $out/bin/logstash
-    patchShebangs $out/bin/logstash-plugin
-
-    wrapProgram $out/bin/logstash \
-       --set JAVA_HOME "${jre}"
-
-    wrapProgram $out/bin/logstash-plugin \
-       --set JAVA_HOME "${jre}"
-    runHook postInstall
-  '';
-
-  meta = with lib; {
-    description = "Logstash is a data pipeline that helps you process logs and other event data from a variety of systems";
-    homepage = "https://www.elastic.co/products/logstash";
-    license = if enableUnfree then licenses.elastic else licenses.asl20;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ wjlroe offline basvandijk ];
-  };
-  passthru.tests =
-    optionalAttrs (!enableUnfree) (
-      assert this.drvPath == nixosTests.elk.ELK-7.elkPackages.logstash.drvPath;
-      {
-        elk = nixosTests.elk.ELK-7;
-      }
-    );
-}
+this


### PR DESCRIPTION
###### Motivation for this change

hydra failure on master https://hydra.nixos.org/build/151770288/nixlog/1 for the tarball job

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
