### PR TITLE
elixir_ls: add update script

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -76,7 +76,7 @@ let
         debugInfo = true;
       };
 
-      elixir_ls = callPackage ./elixir_ls.nix { inherit elixir fetchMixDeps mixRelease; };
+      elixir_ls = callPackage ./elixir-ls { inherit elixir fetchMixDeps mixRelease; };
 
       lfe = lfe_1_3;
       lfe_1_3 = lib'.callLFE ../interpreters/lfe/1.3.nix { inherit erlang buildRebar3 buildHex; };

--- a/pkgs/development/beam-modules/elixir-ls/default.nix
+++ b/pkgs/development/beam-modules/elixir-ls/default.nix
@@ -68,4 +68,5 @@ mixRelease rec {
     platforms = platforms.unix;
     maintainers = teams.beam.members;
   };
+  passthru.updateScript = ./update.sh;
 }

--- a/pkgs/development/beam-modules/elixir-ls/update.sh
+++ b/pkgs/development/beam-modules/elixir-ls/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i oil -p jq sd nix-prefetch-github ripgrep
+
+# TODO set to `verbose` or `extdebug` once implemented in oil
+shopt --set xtrace
+
+var directory = $(dirname $0 | xargs realpath)
+var owner = "elixir-lsp"
+var repo = "elixir-ls"
+var latest_rev = $(curl -q https://api.github.com/repos/${owner}/${repo}/releases/latest | \
+  jq -r '.tag_name')
+var latest_version = $(echo $latest_rev | sd 'v' '')
+var current_version = $(nix-instantiate -A elixir_ls.version --eval --json | jq -r)
+if ("$latest_version" == "$current_version") {
+  echo "elixir-ls is already up-to-date"
+  return 0
+} else {
+  var tarball_meta = $(nix-prefetch-github $owner $repo --rev "$latest_rev")
+  var tarball_hash = "sha256-$(echo $tarball_meta | jq -r '.sha256')"
+  var sha256s = $(rg '"sha256-.+"' $directory/default.nix | sd '.+"(.+)";' '$1' )
+  echo $sha256s | read --line :github_sha256
+  echo $sha256s | tail -n 1 | read --line :old_mix_sha256
+  sd 'version = ".+"' "version = \"$latest_version\"" "$directory/default.nix"
+  sd "sha256 = \"$github_sha256\"" "sha256 = \"$tarball_hash\"" "$directory/default.nix"
+  sd "sha256 = \"$old_mix_sha256\"" "sha256 = \"\"" "$directory/default.nix"
+
+  var new_mix_hash = $(nix-build -A elixir_ls.mixFodDeps 2>&1 | \
+    tail -n 1 | \
+    sd '\s+got:\s+' '')
+
+  sd "sha256 = \"\"" "sha256 = \"$new_mix_hash\"" "$directory/default.nix"
+}


### PR DESCRIPTION
###### Motivation for this change

add an update script for elixir_ls

@NixOS/beam might be interested.

I used this occasion to experiment with [oilshell](oilshell.org/). I'm open to criticism if people are against it. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
