### PR TITLE
pylint-exit: init at 1.2.0

### DIFF
--- a/pkgs/development/tools/pylint-exit/default.nix
+++ b/pkgs/development/tools/pylint-exit/default.nix
@@ -1,0 +1,36 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+with python3Packages; buildPythonApplication rec {
+  pname = "pylint-exit";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "jongracecox";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hwfny48g394visa3xd15425fsw596r3lhkfhswpjrdk2mnk3cny";
+  };
+
+  # Converting the shebang manually as it is not picked up by patchShebangs
+  postPatch = ''
+    substituteInPlace pylint_exit.py \
+      --replace "#!/usr/local/bin/python" "#!${python.interpreter}"
+  '';
+
+  # See https://github.com/jongracecox/pylint-exit/pull/7
+  buildInputs = [ m2r ];
+
+  # setup.py reads its version from the TRAVIS_TAG environment variable
+  TRAVIS_TAG = version;
+
+  checkPhase = ''
+    ${python.interpreter} -m doctest pylint_exit.py
+  '';
+
+  meta = with lib; {
+    description = "Utility to handle pylint exit codes in an OS-friendly way";
+    license = licenses.mit;
+    homepage = "https://github.com/jongracecox/pylint-exit";
+    maintainers = [ maintainers.fabiangd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14941,6 +14941,8 @@ with pkgs;
 
   pycritty = with python3Packages; toPythonApplication pycritty;
 
+  pylint-exit = callPackage ../development/tools/pylint-exit { };
+
   qtcreator = libsForQt5.callPackage ../development/tools/qtcreator {
     inherit (linuxPackages) perf;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The python linter package `pylint` usually returns non-zero exit code even on successful linting runs. This PR adds `pylint-exit`, a small utility to decode bit-encoded `pylint` exit codes, which is very helpful in a CI context. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
