### PR TITLE
rhash: 1.4.1 -> 1.4.2

### DIFF
--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -1,23 +1,28 @@
-{ lib, stdenv, fetchFromGitHub, which
+{ lib
+, stdenv
+, fetchFromGitHub
+, which
 , enableStatic ? stdenv.hostPlatform.isStatic
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.1";
+  version = "1.4.2";
   pname = "rhash";
 
   src = fetchFromGitHub {
     owner = "rhash";
     repo = "RHash";
     rev = "v${version}";
-    sha256 = "sha256-kmi1FtJYPBUdMfJlzEsQkTwcYB99isP3yzH1EYlk54g=";
+    sha256 = "sha256-HkDgWwHoRWCNtWyfP4sj3veEd+KT5J7yL4J4Z/hJcrE=";
   };
 
   nativeBuildInputs = [ which ];
 
   # configure script is not autotools-based, doesn't support these options
   dontAddStaticConfigureFlags = true;
+
   configurePlatforms = [ ];
+
   configureFlags = [
     "--ar=${stdenv.cc.targetPrefix}ar"
     (lib.enableFeature enableStatic "static")
@@ -28,14 +33,18 @@ stdenv.mkDerivation rec {
 
   checkTarget = "test-full";
 
-  installTargets = [ "install" "install-lib-headers" ]
-    ++ lib.optional (!enableStatic) "install-lib-so-link";
+  installTargets = [
+    "install"
+    "install-lib-headers"
+  ] ++ lib.optional (!enableStatic) [
+    "install-lib-so-link"
+  ];
 
   meta = with lib; {
     homepage = "http://rhash.sourceforge.net/";
     description = "Console utility and library for computing and verifying hash sums of files";
     license = licenses.bsd0;
     platforms = platforms.all;
-    maintainers = [ maintainers.andrewrk ];
+    maintainers = with maintainers; [ andrewrk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.4.2

Change log: https://github.com/rhash/RHash/releases/tag/v1.4.2

- Ran `nixpkgs-fmt`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
