### PR TITLE
ell: 0.42 -> 0.43, iwd: 1.16 -> 1.17

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ell";
-  version = "0.42";
+  version = "0.43";
 
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/libs/${pname}/${pname}.git";
     rev = version;
-    sha256 = "sha256-GgQhSzVqGCpljWewtevCc9rpkks7devRNp5TN+5JNN4=";
+    sha256 = "sha256-ttKFKV8spxnkFpZHV4Dn9BxJdjxYLWYrHY+qq6uAOlg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -8,16 +8,17 @@
 , readline
 , openssl
 , python3Packages
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   pname = "iwd";
-  version = "1.16";
+  version = "1.17";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git";
     rev = version;
-    sha256 = "sha256-Nu6vb5UOJ/KgmJZM4bMKwLpOoKMLcnZPYCqFBQjuCYY=";
+    sha256 = "sha256-uWWdKjxctz8fdiIkSiuOYNcZPhxEWDXaA8QPLnd/I9c=";
   };
 
   outputs = [ "out" "man" ]
@@ -54,6 +55,14 @@ stdenv.mkDerivation rec {
     "--with-systemd-modloaddir=${placeholder "out"}/etc/modules-load.d/" # maybe
     "--with-systemd-unitdir=${placeholder "out"}/lib/systemd/system/"
     "--with-systemd-networkdir=${placeholder "out"}/lib/systemd/network/"
+  ];
+
+  patches = [
+    # Fix failure in test-eapol. Remove when bumping to 1.18
+    (fetchpatch {
+      url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git/patch/?id=ed10b00afa3f4c087b46d7ba0b60a47bd05d8b39";
+      sha256 = "0n8ixrbfh428ajncakcb9kd2n4fw82kw9sfskn1d9ny0lrg39nvg";
+    })
   ];
 
   postUnpack = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
iwd
```
ver 1.17:
	Fix issue with sending additional and vendor IEs.
	Fix issue with IE ordering for 802.11-2020 support.
	Fix issue with frequency update on channel switch events.
	Fix issue with drivers and handling of IF_OPER_UP setting.
```

ell
```
ver 0.43:
	Add support for DHCP Rapid Commit feature.
	Add support for DHCP authoritative mode feature.
```

`ofono` and `bluez` still build and seem to work. I had to include one post-1.17 commit to fix a test failure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
