### PR TITLE
git-branchless: add support for Darwin builds

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7445,6 +7445,16 @@
     name = "Maxim Schuwalow";
     email = "maxim.schuwalow@gmail.com";
   };
+  msfjarvis = {
+    github = "msfjarvis";
+    githubId = 3348378;
+    name = "Harsh Shandilya";
+    email = "nixos@msfjarvis.dev";
+    keys = [{
+      longkeyid = "rsa4096/0xB7843F823355E9B9";
+      fingerprint = "8F87 050B 0F9C B841 1515  7399 B784 3F82 3355 E9B9";
+    }];
+  };
   msiedlarek = {
     email = "mikolaj@siedlarek.pl";
     github = "msiedlarek";

--- a/pkgs/applications/version-management/git-and-tools/git-branchless/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-branchless/default.nix
@@ -52,6 +52,6 @@ rustPlatform.buildRustPackage rec {
     description = "A suite of tools to help you visualize, navigate, manipulate, and repair your commit history";
     homepage = "https://github.com/arxanas/git-branchless";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nh2 ];
+    maintainers = with maintainers; [ msfjarvis nh2 ];
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-branchless/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-branchless/default.nix
@@ -2,9 +2,13 @@
 
 , coreutils
 , git
+, libiconv
 , ncurses
 , rustPlatform
 , sqlite
+, stdenv
+, Security
+, SystemConfiguration
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -33,6 +37,10 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     ncurses
     sqlite
+  ] ++ lib.optionals (stdenv.isDarwin) [
+    Security
+    SystemConfiguration
+    libiconv
   ];
 
   preCheck = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5255,7 +5255,9 @@ with pkgs;
 
   git-big-picture = callPackage ../applications/version-management/git-and-tools/git-big-picture { };
 
-  git-branchless = callPackage ../applications/version-management/git-and-tools/git-branchless { };
+  git-branchless = callPackage ../applications/version-management/git-and-tools/git-branchless {
+    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
+  };
 
   inherit (haskellPackages) git-brunch;
 


### PR DESCRIPTION
###### Motivation for this change

- Adds dependencies required to build and run tests successfully on Darwin
- Includes myself as a co-maintainer for the package

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
