### PR TITLE
neo4j: 3.5.14 -> 4.3.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -311,3 +311,5 @@ To be able to access the web UI this port needs to be opened in the firewall.
 - Nginx will use the value of `sslTrustedCertificate` if provided for a virtual host, even if `enableACME` is set. This is useful for providers not using the same certificate to sign OCSP responses and server certificates.
 
 - `lib.formats.yaml`'s `generate` will not generate JSON anymore, but instead use more of the YAML-specific syntax.
+
+- Neo4j was updated from version 3 to version 4. See this [migration guide](https://neo4j.com/docs/upgrade-migration-guide/current/) on how to migrate your Neo4j instance.

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -36,7 +36,7 @@ let
     # General
     dbms.allow_upgrade=${boolToString cfg.allowUpgrade}
     dbms.default_listen_address=${cfg.defaultListenAddress}
-    dbms.read_only=${boolToString cfg.readOnly}
+    dbms.databases.default_to_read_only=${boolToString cfg.readOnly}
     ${optionalString (cfg.workerCount > 0) ''
       dbms.threads.worker_count=${toString cfg.workerCount}
     ''}
@@ -59,6 +59,7 @@ let
     ${optionalString (cfg.http.enable) ''
       dbms.connector.http.enabled=${boolToString cfg.https.enable}
       dbms.connector.http.listen_address=${cfg.http.listenAddress}
+      dbms.connector.http.advertised_address=${cfg.http.listenAddress}
     ''}
     ${optionalString (!cfg.http.enable) ''
       # It is not possible to disable the HTTP connector. To fully prevent
@@ -71,10 +72,12 @@ let
     # HTTPS Connector
     dbms.connector.https.enabled=${boolToString cfg.https.enable}
     dbms.connector.https.listen_address=${cfg.https.listenAddress}
+    dbms.connector.https.advertised_address=${cfg.https.listenAddress}
 
     # BOLT Connector
     dbms.connector.bolt.enabled=${boolToString cfg.bolt.enable}
     dbms.connector.bolt.listen_address=${cfg.bolt.listenAddress}
+    dbms.connector.bolt.advertised_address=${cfg.bolt.listenAddress}
     dbms.connector.bolt.tls_level=${cfg.bolt.tlsLevel}
 
     # SSL Policies

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -50,7 +50,6 @@ let
    ''}
 
     # Directories (read and write)
-    dbms.directories.home=${cfg.directories.home}
     dbms.directories.data=${cfg.directories.data}
     dbms.directories.logs=${cfg.directories.home}/logs
     dbms.directories.run=${cfg.directories.home}/run

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -652,6 +652,6 @@ in {
     };
 
   meta = {
-    maintainers = with lib.maintainers; [ patternspandemic jonringer ];
+    maintainers = with lib.maintainers; [ patternspandemic jonringer erictapen ];
   };
 }

--- a/nixos/tests/neo4j.nix
+++ b/nixos/tests/neo4j.nix
@@ -7,6 +7,9 @@ import ./make-test-python.nix {
 
       {
         services.neo4j.enable = true;
+        # require tls certs to be available
+        services.neo4j.https.enable = false;
+        services.neo4j.bolt.enable = false;
       };
   };
 

--- a/nixos/tests/neo4j.nix
+++ b/nixos/tests/neo4j.nix
@@ -19,7 +19,7 @@ import ./make-test-python.nix {
   testScript = ''
     start_all()
 
-    server.wait_for_unit("neo4j")
+    server.wait_for_unit("neo4j.service")
     server.wait_for_open_port(7474)
     server.succeed("curl -f http://localhost:7474/")
   '';

--- a/nixos/tests/neo4j.nix
+++ b/nixos/tests/neo4j.nix
@@ -6,7 +6,7 @@ import ./make-test-python.nix {
       { ... }:
 
       {
-	# virtualisation.memorySize = 4096;
+	virtualisation.memorySize = 4096;
 	virtualisation.diskSize = 1024;
 
         services.neo4j.enable = true;

--- a/nixos/tests/neo4j.nix
+++ b/nixos/tests/neo4j.nix
@@ -2,10 +2,13 @@ import ./make-test-python.nix {
   name = "neo4j";
 
   nodes = {
-    master =
+    server =
       { ... }:
 
       {
+	# virtualisation.memorySize = 4096;
+	virtualisation.diskSize = 1024;
+
         services.neo4j.enable = true;
         # require tls certs to be available
         services.neo4j.https.enable = false;
@@ -16,8 +19,8 @@ import ./make-test-python.nix {
   testScript = ''
     start_all()
 
-    master.wait_for_unit("neo4j")
-    master.wait_for_open_port(7474)
-    master.succeed("curl -f http://localhost:7474/")
+    server.wait_for_unit("neo4j")
+    server.wait_for_open_port(7474)
+    server.succeed("curl -f http://localhost:7474/")
   '';
 }

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A highly scalable, robust (fully ACID) native graph database";
-    homepage = "http://www.neo4j.org/";
+    homepage = "https://neo4j.com/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ jonringer offline ];
     platforms = platforms.unix;

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeWrapper, openjdk11, which, gawk }:
+{ stdenv, lib, fetchurl, nixosTests, makeWrapper, openjdk11, which, gawk }:
 
 stdenv.mkDerivation rec {
   pname = "neo4j";
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     # user will be asked to change password on first login
     $out/bin/neo4j-admin set-initial-password neo4j
   '';
+
+  passthru.tests.nixos = nixosTests.neo4j;
 
   meta = with lib; {
     description = "A highly scalable, robust (fully ACID) native graph database";

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "neo4j";
-  version = "4.1.1";
+  version = "4.3.3";
 
   src = fetchurl {
     url = "https://neo4j.com/artifact.php?name=neo4j-community-${version}-unix.tar.gz";
-    sha256 = "0w8jgbk1fxwivjvasj5l63123wrsz4yfnbwpn78dyh7c1d93lrjg";
+    sha256 = "sha256-uzllwY5hPuc48Hrxx8jamFujyoAlBUzmYmY3bG1PcGU=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/nosql/neo4j/default.nix
+++ b/pkgs/servers/nosql/neo4j/default.nix
@@ -1,14 +1,12 @@
-{ lib, stdenv, fetchurl, makeWrapper, jre, which, gawk }:
-
-with lib;
+{ stdenv, lib, fetchurl, makeWrapper, openjdk11, which, gawk }:
 
 stdenv.mkDerivation rec {
   pname = "neo4j";
-  version = "3.5.14";
+  version = "4.1.1";
 
   src = fetchurl {
     url = "https://neo4j.com/artifact.php?name=neo4j-community-${version}-unix.tar.gz";
-    sha256 = "1zjb6cgk2lpzx6pq1cs5fh65in6b5ccpl1cgfiglgpjc948mnhzv";
+    sha256 = "0w8jgbk1fxwivjvasj5l63123wrsz4yfnbwpn78dyh7c1d93lrjg";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -18,21 +16,25 @@ stdenv.mkDerivation rec {
     cp -R * "$out/share/neo4j"
 
     mkdir -p "$out/bin"
-    for NEO4J_SCRIPT in neo4j neo4j-admin neo4j-import cypher-shell
+    for NEO4J_SCRIPT in neo4j neo4j-admin cypher-shell
     do
+        chmod +x "$out/share/neo4j/bin/$NEO4J_SCRIPT"
         makeWrapper "$out/share/neo4j/bin/$NEO4J_SCRIPT" \
             "$out/bin/$NEO4J_SCRIPT" \
-            --prefix PATH : "${lib.makeBinPath [ jre which gawk ]}" \
-            --set JAVA_HOME "${jre}"
+            --prefix PATH : "${lib.makeBinPath [ openjdk11 which gawk ]}" \
+            --set JAVA_HOME "${openjdk11}"
     done
+
+    patchShebangs $out/share/neo4j/bin/neo4j-admin
+    # user will be asked to change password on first login
+    $out/bin/neo4j-admin set-initial-password neo4j
   '';
 
   meta = with lib; {
     description = "A highly scalable, robust (fully ACID) native graph database";
     homepage = "http://www.neo4j.org/";
     license = licenses.gpl3;
-
-    maintainers = [ maintainers.offline ];
-    platforms = lib.platforms.unix;
+    maintainers = with maintainers; [ jonringer offline ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20318,9 +20318,7 @@ with pkgs;
 
   check_systemd = callPackage ../servers/monitoring/nagios/plugins/check_systemd.nix { };
 
-  neo4j = callPackage ../servers/nosql/neo4j {
-    jre = jre8_headless;
-  };
+  neo4j = callPackage ../servers/nosql/neo4j { };
 
   neo4j-desktop = callPackage ../applications/misc/neo4j-desktop { };
 


### PR DESCRIPTION
This is a rebase and continuation of https://github.com/NixOS/nixpkgs/pull/98443.

Running in the NixOS test the DB doesn't start up, so this is definetly not mergable yet.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
