### PR TITLE
pulumi-bin: make ld_library_path editing optional

### DIFF
--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -4,6 +4,8 @@ with lib;
 
 let
   data = import ./data.nix {};
+  wrap = stdenv.isLinux && !preserveLdLibraryPath;
+
 in stdenv.mkDerivation {
   pname = "pulumi";
   version = data.version;
@@ -17,11 +19,11 @@ in stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     cp * $out/bin/
-  '' + optionalString (stdenv.isLinux && !preserveLdLibraryPath) pres''
+  '' + optionalString wrap ''
     wrapProgram $out/bin/pulumi --set LD_LIBRARY_PATH "${stdenv.cc.cc.lib}/lib"
   '';
 
-  nativeBuildInputs = optionals stdenv.isLinux [ autoPatchelfHook makeWrapper ];
+  nativeBuildInputs = optionals wrap [ autoPatchelfHook makeWrapper ];
 
   meta = {
     homepage = "https://pulumi.io/";

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, autoPatchelfHook, makeWrapper }:
+{ lib, stdenv, fetchurl, autoPatchelfHook, makeWrapper, preserveLdLibraryPath ? false }:
 
 with lib;
 
@@ -17,7 +17,7 @@ in stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     cp * $out/bin/
-  '' + optionalString stdenv.isLinux ''
+  '' + optionalString (stdenv.isLinux && !preserveLdLibraryPath) pres''
     wrapProgram $out/bin/pulumi --set LD_LIBRARY_PATH "${stdenv.cc.cc.lib}/lib"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The change provides an option that enables users to use Pulumi more seamlessly in the following situation:

- OS: Linux
- VirtualEnv: none (remove `venv` option from Pulumi.yaml)
- Language: Python
- Python dependencies installed via Nix (e.g. `pkgs.python3Packages.grpcio`)

There is a set of issues with how Pulumi and virtual environments interact, which I believe was the reason to introduce LD_LIBRARY_PATH override in the first place in this code.

# Context

The typical process structure for using Pulumi is as follows:

```
pulumi 
  |
  +--- pulumi-language-python
                |
                +----- [venv/]?python __main__.py
```

The user's program in `__main__.py` depends on Python packages must notably Pulumi SDK, and transitively depends on `grpcio` package. If Pulumi is configured with `venv` support it automatically starts a virtual environment and installs the contents of `requirements.txt` into that environment. 

Without custom LD_LIBRARY_PATH, this automatically created `venv` may be broken as it cannot load `gprcio`, which may be linked against the wrong native dependencies compared to the base system. This is why I believe the LD_LIBRARY_PATH override was introduced, which propagates from pulumi top process and is inherited by the python subprocess.

Consider however that it is not a complete solution. Users who want to interact with their program outside of running `pulumi` binary, for example to unit test the program, will run into errors anyway, as they are not aware they need to set LD_LIBRARY_PATH.  Moreover, if any additional dependencies come in they might start conflicting on LD_LIBRARY_PATH choices. 

When a user encounters this breakage, one way forward that may be expected to work, is opting out of venvs and letting Nix manage the environment. After all grpcio Python package is in nixpkgs and it works. However, as of today such uses of Pulumi do not work when the baked in LD_LIBRARY_PATH from pulumi-bin definition conflicts with the grpcio the user installs into her environment.

# Alternatives

I'm open to alternatives on how to best manage the problem, to recommend to Pulumi+Nix+Python users. https://nixos.wiki/wiki/Python mentions `buildFHSUserEnv` I have not fully investigated yet:

> Installing packages with pip that need to compile code or use C libraries will sometimes fail due to not finding dependencies in the expected places. In that case you can use buildFHSUserEnv to make yourself a sandbox that appears like a more typical Linux install. For example if you were working with machine learning code you could use:




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
