### PR TITLE
neovim: allow extra Lua packages

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -50,6 +50,8 @@ in
 
     dontFixCmake = true;
 
+    inherit lua;
+
     buildInputs = [
       gperf
       libtermkey

--- a/pkgs/applications/editors/neovim/tests.nix
+++ b/pkgs/applications/editors/neovim/tests.nix
@@ -132,4 +132,15 @@ rec {
     extraName = "-pathogen";
     configure.pathogen.pluginNames = [ "vim-nix" ];
   };
+
+  nvimWithLuaPackages = wrapNeovim2 "with-lua-packages" (makeNeovimConfig {
+    extraLuaPackages = ps: [ps.mpack];
+    customRC = ''
+      lua require("mpack")
+    '';
+  });
+
+  nvim_with_lua_packages = runTest nvimWithLuaPackages ''
+    ${nvimWithLuaPackages}/bin/nvim -n -i NONE --noplugin -es
+  '';
 })

--- a/pkgs/applications/editors/neovim/tests.nix
+++ b/pkgs/applications/editors/neovim/tests.nix
@@ -141,6 +141,6 @@ rec {
   });
 
   nvim_with_lua_packages = runTest nvimWithLuaPackages ''
-    ${nvimWithLuaPackages}/bin/nvim -n -i NONE --noplugin -es
+    ${nvimWithLuaPackages}/bin/nvim -i NONE --noplugin -es
   '';
 })

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -28,6 +28,8 @@ let
     , extraPython3Packages ? (_: [ ])
     , withNodeJs ? false
     , withRuby ? true
+    /* the function you would have passed to lua.withPackages */
+    , extraLuaPackages ? (_: [ ])
 
     # expects a list of plugin configuration
     # expects { plugin=far-vim; config = "let g:far#source='rg'"; optional = false; }
@@ -76,6 +78,8 @@ let
         ++ (extraPython3Packages ps)
         ++ (lib.concatMap (f: f ps) pluginPython3Packages));
 
+      lua = neovim-unwrapped.lua;
+      luaEnv = lua.withPackages(ps: extraLuaPackages ps);
 
       # Mapping a boolean argument to a key that tells us whether to add or not to
       # add to nvim's 'embedded rc' this:
@@ -110,6 +114,9 @@ let
           "--set" "GEM_HOME" "${rubyEnv}/${rubyEnv.ruby.gemPath}"
         ] ++ lib.optionals (binPath != "") [
           "--suffix" "PATH" ":" binPath
+        ] ++ lib.optionals (luaEnv != null) [
+          "--prefix" "LUA_PATH" ";" "${luaEnv}/share/lua/${lua.luaversion}/?.lua"
+          "--prefix" "LUA_CPATH" ";" "${luaEnv}/lib/lua/${lua.luaversion}/?.so"
         ];
 
 
@@ -123,6 +130,7 @@ let
       inherit neovimRcContent;
       inherit manifestRc;
       inherit python3Env;
+      inherit luaEnv;
       inherit withNodeJs;
     } // lib.optionalAttrs withRuby {
       inherit rubyEnv;
@@ -143,6 +151,8 @@ let
     , extraPythonPackages ? (_: [])
     /* the function you would have passed to python.withPackages */
     , withPython3 ? true,  extraPython3Packages ? (_: [])
+    /* the function you would have passed to lua.withPackages */
+    , extraLuaPackages ? (_: [])
     , withNodeJs ? false
     , withRuby ? true
     , vimAlias ? false
@@ -159,6 +169,7 @@ let
       res = makeNeovimConfig {
         inherit withPython3;
         extraPython3Packages = compatFun extraPython3Packages;
+        inherit extraLuaPackages;
         inherit withNodeJs withRuby viAlias vimAlias;
         inherit configure;
         inherit extraName;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Users can already specify additional Python, Ruby, and Node. This change allows
users to specify Lua packages as well.

I am marking this as a draft because I would love some input from other maintainers. I am not sure this is the best way to implement this, though I did the best I could with the Nix knowledge I have. In particular, I don't like that the `lua` parameter now has to be specified for both `neovim-unwrapped` as well as `neovimUtils`, but I'm not sure how to get around that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
