### PR TITLE
cataclysm-dda: 0.F-1 -> 0.F-2

### DIFF
--- a/pkgs/games/cataclysm-dda/stable.nix
+++ b/pkgs/games/cataclysm-dda/stable.nix
@@ -10,17 +10,17 @@ let
   };
 
   self = common.overrideAttrs (common: rec {
-    version = "0.F-1";
+    version = "0.F-2";
 
     src = fetchFromGitHub {
       owner = "CleverRaven";
       repo = "Cataclysm-DDA";
       rev = version;
-      sha256 = "sha256-bVIln8cLZ15qXpW5iB8Odqk0OQbNLLM8OiKybTzARA0=";
+      sha256 = "sha256-8AZOrO/Wxui+LqAZo8hURktMTycecIgOONUJmE3M+vM=";
     };
 
     makeFlags = common.makeFlags ++ [
-      # Makefile declares version as 0.F, even under 0.F-1
+      # Makefile declares version as 0.F, even under 0.F-2
       "VERSION=${version}"
     ];
 


### PR DESCRIPTION
###### Motivation for this change
Another bugfix release: https://github.com/CleverRaven/Cataclysm-DDA/releases/tag/0.F-2

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
