### PR TITLE
ell: backport test fixes on kernel without AF_ALG

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchgit
+, fetchpatch
 , autoreconfHook
 , pkg-config
 , dbus
@@ -16,6 +17,18 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-GgQhSzVqGCpljWewtevCc9rpkks7devRNp5TN+5JNN4=";
   };
+  patches = [
+    (fetchpatch {
+      name = "fix-test-cipher-without-AF_ALG-kernel.patch";
+      url = "https://git.kernel.org/pub/scm/libs/ell/ell.git/patch/?id=6b18c5d0128fbb8cea19a4622429a75ed992ba69";
+      sha256 = "sha256-yg8RtQ26V+pr44MH7JN2GypFiHmEbdF5AeJabqRAVZw=";
+    })
+    (fetchpatch {
+      name = "fix-test-uuid-without-AF_ALG-kernel.patch";
+      url = "https://git.kernel.org/pub/scm/libs/ell/ell.git/patch/?id=093c8122c7aa3543c89fa8f5056660903ad241d1";
+      sha256 = "sha256-iShbf3lhFES537deCk21FixN+uzJUGXB31JukTHH6zk=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
###### Motivation for this change

Fix test failure on host kernel without `AF_ALG` support.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
