### PR TITLE
darktile: init at 0.0.10

### DIFF
--- a/pkgs/applications/terminal-emulators/darktile/default.nix
+++ b/pkgs/applications/terminal-emulators/darktile/default.nix
@@ -2,10 +2,8 @@
 , buildGoModule
 , fetchFromGitHub
 , lib
-
 , go
 , pkg-config
-
 , libX11
 , libXcursor
 , libXrandr
@@ -13,7 +11,8 @@
 , libXi
 , libXext
 , libXxf86vm
-, libGL }:
+, libGL
+}:
 
 stdenv.mkDerivation rec {
   pname = "darktile";

--- a/pkgs/applications/terminal-emulators/darktile/default.nix
+++ b/pkgs/applications/terminal-emulators/darktile/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, buildGoModule
+, fetchFromGitHub
+, lib
+
+, go
+, pkg-config
+
+, libX11
+, libXcursor
+, libXrandr
+, libXinerama
+, libXi
+, libXext
+, libXxf86vm
+, libGL }:
+
+stdenv.mkDerivation rec {
+  pname = "darktile";
+  version = "0.0.10";
+
+  src = fetchFromGitHub {
+    owner = "liamg";
+    repo = "darktile";
+    rev = "v${version}";
+    sha256 = "0pdj4yv3qrq56gb67p85ara3g8qrzw5ha787bl2ls4vcx85q7303";
+  };
+
+  nativeBuildInputs = [ go pkg-config ];
+
+  buildInputs = [
+    libX11
+    libXcursor
+    libXrandr
+    libXinerama
+    libXi
+    libXext
+    libXxf86vm
+    libGL
+  ];
+
+  postPatch = ''
+    substituteInPlace scripts/build.sh \
+      --replace "bash" "sh"
+  '';
+
+  postConfigure = ''
+    export GOPATH=$TMP/go
+  '';
+
+  makeFlags = [ "HOME=$TMP" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 darktile -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A GPU rendered terminal emulator designed for tiling window managers";
+    homepage = "https://github.com/liamg/darktile";
+    downloadPage = "https://github.com/liamg/darktile/releases";
+    changelog = "https://github.com/liamg/darktile/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ flexagoon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -938,6 +938,8 @@ with pkgs;
     inherit (lxqt) qtermwidget;
   };
 
+  darktile = callPackage ../applications/terminal-emulators/darktile { };
+
   eterm = callPackage ../applications/terminal-emulators/eterm { };
 
   evilvte = callPackage ../applications/terminal-emulators/evilvte (config.evilvte or {});


### PR DESCRIPTION
###### Motivation for this change
Darktile is a GPU rendered terminal emulator designed for tiling window managers.
https://github.com/liamg/darktile

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
