### PR TITLE
omnisharp-roslyn: 1.37.12 -> 1.37.15

### DIFF
--- a/pkgs/development/tools/omnisharp-roslyn/create-deps.sh
+++ b/pkgs/development/tools/omnisharp-roslyn/create-deps.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p msbuild -p jq -p xmlstarlet -p curl
+#!nix-shell -I nixpkgs=../../../../.. -i bash -p msbuild dotnet-sdk_3 jq xmlstarlet curl
 set -euo pipefail
 
 cat << EOL
@@ -20,7 +20,6 @@ mapfile -t repos < <(
 
 msbuild -t:restore -p:Configuration=Release -p:RestorePackagesPath="$tmpdir" \
         -p:RestoreNoCache=true -p:RestoreForce=true \
-        -p:NuGetPackageVersion=5.9.1-rc.8 \
         src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj >&2
 
 cd "$tmpdir"

--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -66,26 +66,23 @@ let
 in stdenv.mkDerivation rec {
 
   pname = "omnisharp-roslyn";
-  version = "1.37.12";
+  version = "1.37.15";
 
   src = fetchFromGitHub {
     owner = "OmniSharp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0gyy49v3pslr0l0q6h8hzah4s0iwkhkyckyrj3g2cg08w20b10gw";
+    sha256 = "070wqs667si3f78fy6w4rrfm8qncnabg0yckjhll0yv1pzbj9q42";
   };
 
   nativeBuildInputs = [ makeWrapper msbuild ];
 
-  # NuGetPackageVersion is overridden to be to be compatible with msbuild 16.10,
-  # it needs to be kept in sync with ./create-deps.sh
   buildPhase = ''
     runHook preBuild
 
     HOME=$(pwd)/fake-home msbuild -r \
       -p:Configuration=Release \
       -p:RestoreConfigFile=${nuget-config} \
-      -p:NuGetPackageVersion=5.9.1-rc.8 \
       src/OmniSharp.Stdio.Driver/OmniSharp.Stdio.Driver.csproj
 
     runHook postBuild

--- a/pkgs/development/tools/omnisharp-roslyn/deps.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/deps.nix
@@ -49,10 +49,10 @@
   }
   {
     name = "mcmaster.extensions.commandlineutils";
-    version = "2.2.4";
+    version = "3.1.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/mcmaster.extensions.commandlineutils/2.2.4/mcmaster.extensions.commandlineutils.2.2.4.nupkg";
-      sha256 = "0hy45iacm9zlrj6p2j2i2gkbs4k52mncnlnjvwgh6b6523p9msfy";
+      url = "https://api.nuget.org/v3-flatcontainer/mcmaster.extensions.commandlineutils/3.1.0/mcmaster.extensions.commandlineutils.3.1.0.nupkg";
+      sha256 = "075n1mfsxwz514r94l8i3ax0wp43c3xb4f9w25a96h6xxnj0k2hd";
     };
   }
   {
@@ -85,6 +85,14 @@
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/messagepack.annotations/2.1.152/messagepack.annotations.2.1.152.nupkg";
       sha256 = "196swfxaz7l26hiyfv1mix0y80amhlq48krc4g5p9894wx1az3c3";
+    };
+  }
+  {
+    name = "microsoft.aspnetcore.app.ref";
+    version = "3.1.10";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.ref/3.1.10/microsoft.aspnetcore.app.ref.3.1.10.nupkg";
+      sha256 = "0xn4zh7shvijqlr03fqsmps6gz856isd9bg9rk4z2c4599ggal77";
     };
   }
   {
@@ -177,82 +185,82 @@
   }
   {
     name = "microsoft.codeanalysis.common";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.common/4.0.0-2.21322.50/microsoft.codeanalysis.common.4.0.0-2.21322.50.nupkg";
-      sha256 = "1j9yl7m0lr03fjklzjyiac1lrgs8541frqmi4xlldn8a2sx3h97x";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.common/4.0.0-4.21427.11/microsoft.codeanalysis.common.4.0.0-4.21427.11.nupkg";
+      sha256 = "15q6a2z3ms2vyrfk4y7biniygy0brr3ddb8mn700zg4sl84vphcz";
     };
   }
   {
     name = "microsoft.codeanalysis.csharp";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp/4.0.0-2.21322.50/microsoft.codeanalysis.csharp.4.0.0-2.21322.50.nupkg";
-      sha256 = "1mmcl4rj3n1q7zh1n9b9ph3lvm8i51sdm87q3sgiczv2pxrihzs6";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp/4.0.0-4.21427.11/microsoft.codeanalysis.csharp.4.0.0-4.21427.11.nupkg";
+      sha256 = "0x3l774higkpbbk4f1naf57c039g8qvvdvb3963m7g54qn4zhvdh";
     };
   }
   {
     name = "microsoft.codeanalysis.csharp.features";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp.features/4.0.0-2.21322.50/microsoft.codeanalysis.csharp.features.4.0.0-2.21322.50.nupkg";
-      sha256 = "11pzbswlznz71m248c1p4fi4i3zzvpc4a71px9j2lhnm57zy2lvy";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp.features/4.0.0-4.21427.11/microsoft.codeanalysis.csharp.features.4.0.0-4.21427.11.nupkg";
+      sha256 = "0w0wrssv0ix4z9609a34k6a5kc4p85gy76p676fdg6hyf6pzd78m";
     };
   }
   {
     name = "microsoft.codeanalysis.csharp.scripting";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp.scripting/4.0.0-2.21322.50/microsoft.codeanalysis.csharp.scripting.4.0.0-2.21322.50.nupkg";
-      sha256 = "0piiyg1l27cy6s4ii80phrdsyhl8zvwbj9aljqkg53gki520x19p";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp.scripting/4.0.0-4.21427.11/microsoft.codeanalysis.csharp.scripting.4.0.0-4.21427.11.nupkg";
+      sha256 = "0lmfbkxqp8p52wg2lsyxpavabk318s6ci02cxzgmxydc2pd9r70v";
     };
   }
   {
     name = "microsoft.codeanalysis.csharp.workspaces";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp.workspaces/4.0.0-2.21322.50/microsoft.codeanalysis.csharp.workspaces.4.0.0-2.21322.50.nupkg";
-      sha256 = "0q6jkgjh1dylmjx8a79ighgbai1jr2fhls9m7khi87anzc3wdcl2";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.csharp.workspaces/4.0.0-4.21427.11/microsoft.codeanalysis.csharp.workspaces.4.0.0-4.21427.11.nupkg";
+      sha256 = "0j5c9v4nfahvnasz895czk1cp46b2d98px1gdar2ik9c5630vxwi";
     };
   }
   {
     name = "microsoft.codeanalysis.externalaccess.omnisharp";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.externalaccess.omnisharp/4.0.0-2.21322.50/microsoft.codeanalysis.externalaccess.omnisharp.4.0.0-2.21322.50.nupkg";
-      sha256 = "1rv5qsj8lsfqxdzd6zazrzwzaxwmj6szd9hv2ckbb4lypkn8ifs8";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.externalaccess.omnisharp/4.0.0-4.21427.11/microsoft.codeanalysis.externalaccess.omnisharp.4.0.0-4.21427.11.nupkg";
+      sha256 = "0qy8xiv1j8awmbbgy16b2y9rhymxhx8kcmfylhxi1ryqql4mrpg2";
     };
   }
   {
     name = "microsoft.codeanalysis.externalaccess.omnisharp.csharp";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.externalaccess.omnisharp.csharp/4.0.0-2.21322.50/microsoft.codeanalysis.externalaccess.omnisharp.csharp.4.0.0-2.21322.50.nupkg";
-      sha256 = "0ygp7hnm6mn9khh6z573avhvbcx5459fmyz4z657dx9p2v1f0fs0";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.externalaccess.omnisharp.csharp/4.0.0-4.21427.11/microsoft.codeanalysis.externalaccess.omnisharp.csharp.4.0.0-4.21427.11.nupkg";
+      sha256 = "0mp1gkfdrdjcryqdj76ilpmjh0w8z4h313djjplcawwk76369mnc";
     };
   }
   {
     name = "microsoft.codeanalysis.features";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.features/4.0.0-2.21322.50/microsoft.codeanalysis.features.4.0.0-2.21322.50.nupkg";
-      sha256 = "1grkql2wcqsqlmqnfchw6wxynwpz4x9wgqd00zpc1g04z9lqimq6";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.features/4.0.0-4.21427.11/microsoft.codeanalysis.features.4.0.0-4.21427.11.nupkg";
+      sha256 = "03vclmmxch3jrjamr9lg899s9wsfxw9yf53p9yfwvcr8wml4cwpz";
     };
   }
   {
     name = "microsoft.codeanalysis.scripting.common";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.scripting.common/4.0.0-2.21322.50/microsoft.codeanalysis.scripting.common.4.0.0-2.21322.50.nupkg";
-      sha256 = "1c14bg99ywxdvlp5zc08ijc030rxmpb3171kz2z6f5kr02vf296x";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.scripting.common/4.0.0-4.21427.11/microsoft.codeanalysis.scripting.common.4.0.0-4.21427.11.nupkg";
+      sha256 = "15fkbw651v9lliqdmg1k61dqzasrssahyhrhwg24m111rgh86fbn";
     };
   }
   {
     name = "microsoft.codeanalysis.workspaces.common";
-    version = "4.0.0-2.21322.50";
+    version = "4.0.0-4.21427.11";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.workspaces.common/4.0.0-2.21322.50/microsoft.codeanalysis.workspaces.common.4.0.0-2.21322.50.nupkg";
-      sha256 = "1c0m5pg156x8zh50x7rp25p8cn09gbv50wpbz2p1nc5ff5dyavf5";
+      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/microsoft.codeanalysis.workspaces.common/4.0.0-4.21427.11/microsoft.codeanalysis.workspaces.common.4.0.0-4.21427.11.nupkg";
+      sha256 = "0k4qjkkg4mllizialzm463ssm3faqcqjnw19kbcnrzm5cd72i7cy";
     };
   }
   {
@@ -544,35 +552,11 @@
     };
   }
   {
-    name = "microsoft.netcore.app";
-    version = "2.1.0";
+    name = "microsoft.netcore.app.ref";
+    version = "3.1.0";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app/2.1.0/microsoft.netcore.app.2.1.0.nupkg";
-      sha256 = "1qgw6njwz30l5cwkvgf2fbsjqkc9vy0w3939c24iabmvjnzjr6a4";
-    };
-  }
-  {
-    name = "microsoft.netcore.dotnetapphost";
-    version = "2.1.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.dotnetapphost/2.1.0/microsoft.netcore.dotnetapphost.2.1.0.nupkg";
-      sha256 = "10hnhkix2av0c7djp2q88pw407m8gk3im4r06x762a3cs6f2jprd";
-    };
-  }
-  {
-    name = "microsoft.netcore.dotnethostpolicy";
-    version = "2.1.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.dotnethostpolicy/2.1.0/microsoft.netcore.dotnethostpolicy.2.1.0.nupkg";
-      sha256 = "1xh8ij7zyfkrk20rgpwqs00mxdy2qiwr7qar2xk397zk2bh2d90n";
-    };
-  }
-  {
-    name = "microsoft.netcore.dotnethostresolver";
-    version = "2.1.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.dotnethostresolver/2.1.0/microsoft.netcore.dotnethostresolver.2.1.0.nupkg";
-      sha256 = "1384k3cg4sjcn3hyalcm43fhmlfj5pnywpzd9zpgc4jsr2c16x76";
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.ref/3.1.0/microsoft.netcore.app.ref.3.1.0.nupkg";
+      sha256 = "08svsiilx9spvjamcnjswv0dlpdrgryhr3asdz7cvnl914gjzq4y";
     };
   }
   {
@@ -597,14 +581,6 @@
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.0.0/microsoft.netcore.platforms.2.0.0.nupkg";
       sha256 = "1fk2fk2639i7nzy58m9dvpdnzql4vb8yl8vr19r2fp8lmj9w2jr0";
-    };
-  }
-  {
-    name = "microsoft.netcore.platforms";
-    version = "2.1.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.1.0/microsoft.netcore.platforms.2.1.0.nupkg";
-      sha256 = "0nmdnkmwyxj8cp746hs9an57zspqlmqdm55b00i7yk8a22s6akxz";
     };
   }
   {
@@ -637,14 +613,6 @@
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.1.0/microsoft.netcore.targets.1.1.0.nupkg";
       sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
-    };
-  }
-  {
-    name = "microsoft.netcore.targets";
-    version = "2.1.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/2.1.0/microsoft.netcore.targets.2.1.0.nupkg";
-      sha256 = "1dav8x5551nwdqfigxf9zfsml5l9lakg86x38s9dvps81xs5d9zq";
     };
   }
   {
@@ -705,10 +673,10 @@
   }
   {
     name = "microsoft.visualstudio.debugger.contracts";
-    version = "17.2.0-beta.21262.1";
+    version = "17.2.0-beta.21417.1";
     src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/microsoft.visualstudio.debugger.contracts/17.2.0-beta.21262.1/microsoft.visualstudio.debugger.contracts.17.2.0-beta.21262.1.nupkg";
-      sha256 = "148gb4k28fch1rhh6kr82dajl7qnvjxvkxvc8igy7zra70nvbx74";
+      url = "https://pkgs.dev.azure.com/azure-public/3ccf6661-f8ce-4e8a-bb2e-eff943ddd3c7/_packaging/78665e4c-b767-412b-9804-2b1ef7a48b8a/nuget/v3/flat2/microsoft.visualstudio.debugger.contracts/17.2.0-beta.21417.1/microsoft.visualstudio.debugger.contracts.17.2.0-beta.21417.1.nupkg";
+      sha256 = "14v8d0hp6p1jn4i6b12r6vx4cvxycpb37a0zh0amz0qkg4afr12d";
     };
   }
   {
@@ -784,6 +752,14 @@
     };
   }
   {
+    name = "microsoft.win32.systemevents";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/4.7.0/microsoft.win32.systemevents.4.7.0.nupkg";
+      sha256 = "0pjll2a62hc576hd4wgyasva0lp733yllmk54n37svz5ac7nfz0q";
+    };
+  }
+  {
     name = "nerdbank.streams";
     version = "2.6.81";
     src = fetchurl {
@@ -833,6 +809,14 @@
   }
   {
     name = "nuget.common";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.common/5.10.0/nuget.common.5.10.0.nupkg";
+      sha256 = "0qy6blgppgvxpfcricmvva3qzddk18dza5vy851jrbqshvf9g7kx";
+    };
+  }
+  {
+    name = "nuget.common";
     version = "5.2.0";
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/nuget.common/5.2.0/nuget.common.5.2.0.nupkg";
@@ -840,11 +824,11 @@
     };
   }
   {
-    name = "nuget.common";
-    version = "5.9.1-rc.8";
+    name = "nuget.configuration";
+    version = "5.10.0";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.common/5.9.1-rc.8/nuget.common.5.9.1-rc.8.nupkg";
-      sha256 = "056b1h4fvik6z2qc2s6qzz0s4acbipc50af14fbr7hd9h2fxya4c";
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.configuration/5.10.0/nuget.configuration.5.10.0.nupkg";
+      sha256 = "0xb1n94lrwa6k83i9xcsq68202086p2gj74gzlbhlvb8c2pw6lbb";
     };
   }
   {
@@ -856,11 +840,11 @@
     };
   }
   {
-    name = "nuget.configuration";
-    version = "5.9.1-rc.8";
+    name = "nuget.dependencyresolver.core";
+    version = "5.10.0";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.configuration/5.9.1-rc.8/nuget.configuration.5.9.1-rc.8.nupkg";
-      sha256 = "0x8vigf0sfp6kf1i98xcr4k84vci596x16hmajdm0zgv3p1w2kvk";
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.dependencyresolver.core/5.10.0/nuget.dependencyresolver.core.5.10.0.nupkg";
+      sha256 = "0dhhclm281ihpfsjzxw34l6zlw49nwzyjiynkmsbcj9icfkp3y4r";
     };
   }
   {
@@ -869,14 +853,6 @@
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/nuget.dependencyresolver.core/5.2.0/nuget.dependencyresolver.core.5.2.0.nupkg";
       sha256 = "156yjfsk9pzqviiwy69lxfqf61yyj4hn4vdgfcbqvw4d567i150r";
-    };
-  }
-  {
-    name = "nuget.dependencyresolver.core";
-    version = "5.9.1-rc.8";
-    src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.dependencyresolver.core/5.9.1-rc.8/nuget.dependencyresolver.core.5.9.1-rc.8.nupkg";
-      sha256 = "1q9a97s1z3a6fb4p82ag2lqnzl53895prbqwlbvckdw9c3rpz3gc";
     };
   }
   {
@@ -889,6 +865,14 @@
   }
   {
     name = "nuget.frameworks";
+    version = "5.10.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.frameworks/5.10.0/nuget.frameworks.5.10.0.nupkg";
+      sha256 = "0gb6n8rg2jpjp52icgpb3wjdfs3qllh5vbcz8hbcix3l7dncy3v2";
+    };
+  }
+  {
+    name = "nuget.frameworks";
     version = "5.2.0";
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/nuget.frameworks/5.2.0/nuget.frameworks.5.2.0.nupkg";
@@ -896,11 +880,11 @@
     };
   }
   {
-    name = "nuget.frameworks";
-    version = "5.9.1-rc.8";
+    name = "nuget.librarymodel";
+    version = "5.10.0";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.frameworks/5.9.1-rc.8/nuget.frameworks.5.9.1-rc.8.nupkg";
-      sha256 = "1n3mp9ns79yq4dwgj7h2av3b485mzgsw0qlj8z7p47krwlzp5hiv";
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.librarymodel/5.10.0/nuget.librarymodel.5.10.0.nupkg";
+      sha256 = "0b6mmq2mqfr06ypc772dmcd8bz55gkyfrgn0j3nrgkcdww4fzf9q";
     };
   }
   {
@@ -912,11 +896,11 @@
     };
   }
   {
-    name = "nuget.librarymodel";
-    version = "5.9.1-rc.8";
+    name = "nuget.packaging";
+    version = "5.10.0";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.librarymodel/5.9.1-rc.8/nuget.librarymodel.5.9.1-rc.8.nupkg";
-      sha256 = "0sy8422c94wcg8ka85lnawq26mpixl79avk9m6y44lshrpga5v4v";
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.packaging/5.10.0/nuget.packaging.5.10.0.nupkg";
+      sha256 = "11g0v061axhp0nisclq5cm2mc92d69z92giz9l40ih478c5nishw";
     };
   }
   {
@@ -928,19 +912,19 @@
     };
   }
   {
-    name = "nuget.packaging";
-    version = "5.9.1-rc.8";
+    name = "nuget.packaging.core";
+    version = "5.10.0";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.packaging/5.9.1-rc.8/nuget.packaging.5.9.1-rc.8.nupkg";
-      sha256 = "0x9c3v741nn6m2xgidna88fa4xj5avhv6asj73hqv4pzpdprlrhv";
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.packaging.core/5.10.0/nuget.packaging.core.5.10.0.nupkg";
+      sha256 = "1frxwwl583qwsj84rjgvd7il6icgxzxxps6yng75qx8ppf99dsr6";
     };
   }
   {
-    name = "nuget.packaging.core";
-    version = "5.9.1-rc.8";
+    name = "nuget.projectmodel";
+    version = "5.10.0";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.packaging.core/5.9.1-rc.8/nuget.packaging.core.5.9.1-rc.8.nupkg";
-      sha256 = "0vsaixmla4zh277xpn5ngbmi2f52hb26aqzr0z9l4a3mlpi4l5nx";
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.projectmodel/5.10.0/nuget.projectmodel.5.10.0.nupkg";
+      sha256 = "1cqg319n986wciskrqsfawfhqp1d7a7i2qjd0qplpckyw8msng2i";
     };
   }
   {
@@ -952,11 +936,11 @@
     };
   }
   {
-    name = "nuget.projectmodel";
-    version = "5.9.1-rc.8";
+    name = "nuget.protocol";
+    version = "5.10.0";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.projectmodel/5.9.1-rc.8/nuget.projectmodel.5.9.1-rc.8.nupkg";
-      sha256 = "1xjh7isw467nkc7dkfj3wlw69vi2cns66z152jrzjdmxmia3i3pv";
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.protocol/5.10.0/nuget.protocol.5.10.0.nupkg";
+      sha256 = "0cs9qp169zx6g2w5bzrlhxv0q1i8mb8dxlb2nkiq7pkvah86rxkc";
     };
   }
   {
@@ -968,11 +952,11 @@
     };
   }
   {
-    name = "nuget.protocol";
-    version = "5.9.1-rc.8";
+    name = "nuget.versioning";
+    version = "5.10.0";
     src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.protocol/5.9.1-rc.8/nuget.protocol.5.9.1-rc.8.nupkg";
-      sha256 = "1rnrxzaciqhhgwd4by0dhkvfrm1h161vvmkvlcwaz2589sqq2dzq";
+      url = "https://api.nuget.org/v3-flatcontainer/nuget.versioning/5.10.0/nuget.versioning.5.10.0.nupkg";
+      sha256 = "10vvw6vjpx0c26rlxh7dnpyp4prahn25717ccd8bzkjmyzhm90cs";
     };
   }
   {
@@ -981,14 +965,6 @@
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/nuget.versioning/5.2.0/nuget.versioning.5.2.0.nupkg";
       sha256 = "08ay8bhddj9yiq6h9lk814l65fpx5gh1iprkl7pcp78g57a6k45k";
-    };
-  }
-  {
-    name = "nuget.versioning";
-    version = "5.9.1-rc.8";
-    src = fetchurl {
-      url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d1622942-d16f-48e5-bc83-96f4539e7601/nuget/v3/flat2/nuget.versioning/5.9.1-rc.8/nuget.versioning.5.9.1-rc.8.nupkg";
-      sha256 = "1vv7z122ilsk2rsvjm6j3hpifb45g8wa1mgnq1kwi9k8b2dbb6vv";
     };
   }
   {
@@ -1405,6 +1381,22 @@
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg";
       sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
+    };
+  }
+  {
+    name = "system.drawing.common";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.drawing.common/4.7.0/system.drawing.common.4.7.0.nupkg";
+      sha256 = "0yfw7cpl54mgfcylvlpvrl0c8r1b0zca6p7r3rcwkvqy23xqcyhg";
+    };
+  }
+  {
+    name = "system.formats.asn1";
+    version = "5.0.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.formats.asn1/5.0.0/system.formats.asn1.5.0.0.nupkg";
+      sha256 = "1axc8z0839yvqi2cb63l73l6d9j6wd20lsbdymwddz9hvrsgfwpn";
     };
   }
   {
@@ -2233,18 +2225,18 @@
   }
   {
     name = "system.valuetuple";
-    version = "4.4.0";
-    src = fetchurl {
-      url = "https://api.nuget.org/v3-flatcontainer/system.valuetuple/4.4.0/system.valuetuple.4.4.0.nupkg";
-      sha256 = "1wydfgszs00yxga57sam66vzv9fshk2pw7gim57saplsnkfliaif";
-    };
-  }
-  {
-    name = "system.valuetuple";
     version = "4.5.0";
     src = fetchurl {
       url = "https://api.nuget.org/v3-flatcontainer/system.valuetuple/4.5.0/system.valuetuple.4.5.0.nupkg";
       sha256 = "00k8ja51d0f9wrq4vv5z2jhq8hy31kac2rg0rv06prylcybzl8cy";
+    };
+  }
+  {
+    name = "system.windows.extensions";
+    version = "4.7.0";
+    src = fetchurl {
+      url = "https://api.nuget.org/v3-flatcontainer/system.windows.extensions/4.7.0/system.windows.extensions.4.7.0.nupkg";
+      sha256 = "11dmyx3j0jafjx5r9mkj1v4w2a4rzrdn8fgwm2d1g7fs1ayqcvy9";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change

New upstream [release](https://github.com/OmniSharp/omnisharp-roslyn/releases/tag/v1.37.15)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

FTR, I had to tweak the create-deps.sh script since I first ran into this error:

```
/nix/store/866b8j8nqrqqyk4r03sjjxbw49fqbhk5-msbuild-16.8+xamarinxplat.2020.07.30.15.02/lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(127,5): error NETSDK1045: The current .NET SDK does not support targeting .NET Core 3.1.  Either target .NET Core 3.0 or lower, or use a version of the .NET SDK that supports .NET Core 3.1. [/home/claudio/nixpkgs/pkgs/development/tools/omnisharp-roslyn/omnisharp-roslyn/src/OmniSharp.Shared/OmniSharp.Shared.csproj]
```