### PR TITLE
cowpatty: 4.6 -> 4.8

### DIFF
--- a/pkgs/tools/security/cowpatty/default.nix
+++ b/pkgs/tools/security/cowpatty/default.nix
@@ -1,26 +1,48 @@
-{ lib, stdenv, fetchurl, openssl, libpcap
+{ lib
+, stdenv
+, clang
+, fetchFromGitHub
+, installShellFiles
+, openssl
+, libpcap
 }:
-
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "cowpatty";
-  version = "4.6";
+  version = "4.8";
 
-  buildInputs = [ openssl libpcap ];
-
-  src = fetchurl {
-    url = "http://www.willhackforsushi.com/code/cowpatty/${version}/${pname}-${version}.tgz";
-    sha256 = "1hivh3bq2maxvqzwfw06fr7h8bbpvxzah6mpibh3wb85wl9w2gyd";
+  src = fetchFromGitHub {
+    owner = "joswr1ght";
+    repo = pname;
+    rev = version;
+    sha256 = "0fvwwghhd7wsx0lw2dj9rdsjnirawnq3c6silzvhi0yfnzn5fs0s";
   };
 
-  installPhase = "make DESTDIR=$out BINDIR=/bin install";
+  nativeBuildInputs = [
+    clang
+    installShellFiles
+  ];
 
-  meta = {
+  buildInputs = [
+    openssl
+    libpcap
+  ];
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "BINDIR=/bin"
+  ];
+
+  postInstall = ''
+    installManPage cowpatty.1
+    installManPage genpmk.1
+  '';
+
+  meta = with lib; {
     description = "Offline dictionary attack against WPA/WPA2 networks";
-    license = licenses.gpl2;
-    homepage = "https://www.willhackforsushi.com/?page_id=50";
-    maintainers = with maintainers; [ nico202 ];
+    homepage = "https://github.com/joswr1ght/cowpatty";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nico202 fab ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 4.8

Change log: https://github.com/joswr1ght/cowpatty/releases/tag/4.8

- Add man pages
- Update license and homepage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
