### PR TITLE
Revert "zfsUnstable: 2.1.0 -> unstable-2021-08-30"

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -210,14 +210,13 @@ in {
 
   zfsUnstable = common {
     # check the release notes for compatible kernels
-    kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.15";
+    kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.14";
     latestCompatibleLinuxPackages = linuxPackages_5_13;
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "unstable-2021-08-30";
-    rev = "3b89d9518df2c7fd747e349873a3d4d498beb20e";
+    version = "2.1.0";
 
-    sha256 = "sha256-wVbjpVrPQmhJmMqdGUf0IwlCIoOsT7Zfj5lxSKcOsgg=";
+    sha256 = "sha256-YdY4SStXZGBBdAHdM3R/unco7ztxI3s0/buPSNSeh5o=";
 
     isUnstable = true;
   };


### PR DESCRIPTION
From the documentation of `boot.zfs.enableUnstable`:

> The version will have already *passed an extensive test suite*, but it is more likely to hit an undiscovered bug compared to running a released version of ZFS on Linux.

(emphasis mine)

However, this specific version [*fails*](https://github.com/openzfs/zfs/runs/3467198842) the test suite. I also don't think we have [ever bumped zfsUnstable to a non-release and non-rc version](https://github.com/zhaofengli/nixpkgs/commits/0046ed37e1ed4010c68f9d1562853b63318f89a0/pkgs/os-specific/linux/zfs/default.nix). Therefore we should revert this before it hits a channel.