### PR TITLE
[DRAFT] Add librewolf

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -1,6 +1,8 @@
 { pname, version, meta, updateScript ? null
 , binaryName ? "firefox", application ? "browser"
-, src, unpackPhase ? null, patches ? []
+, src, unpackPhase ? null, postUnpack ? null, patches ? []
+, allowOfficialBranding ? true
+, extraLib ? null
 , extraNativeBuildInputs ? [], extraConfigureFlags ? [], extraMakeFlags ? [], tests ? [] }:
 
 { lib, stdenv, pkg-config, pango, perl, python3, zip
@@ -69,7 +71,7 @@
 # > Therefor, as long as you keep the patch queue sane and you don't alter
 # > the experience of Firefox users, you won't have any issues using the
 # > official branding.
-, enableOfficialBranding ? true
+, enableOfficialBranding ? allowOfficialBranding
 }:
 
 assert stdenv.cc.libc or null != null;
@@ -132,7 +134,7 @@ buildStdenv.mkDerivation ({
   name = "${pname}-unwrapped-${version}";
   inherit version;
 
-  inherit src unpackPhase meta;
+  inherit src unpackPhase postUnpack meta;
 
   patches = [
   ] ++
@@ -364,6 +366,7 @@ buildStdenv.mkDerivation ({
     inherit version;
     inherit alsaSupport;
     inherit pipewireSupport;
+    inherit extraLib;
     inherit nspr;
     inherit ffmpegSupport;
     inherit gssSupport;

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, callPackage, fetchurl, fetchpatch, nixosTests }:
+{ stdenv, lib, callPackage, fetchurl, fetchFromGitLab, fetchpatch, nixosTests }:
 
 let
   common = opts: callPackage (import ./common.nix opts) {};
@@ -77,6 +77,101 @@ rec {
     updateScript = callPackage ./update.nix {
       attrPath = "firefox-esr-78-unwrapped";
       versionSuffix = "esr";
+    };
+  };
+
+  librewolf = let
+    inherit (builtins) attrNames filter readDir;
+    inherit (lib) hasSuffix;
+    lwRelease = "1";
+    lwPatchesTag = "v${firefox.version}-${lwRelease}";
+    lwSettingsTag = "1.6";
+    lwPatches = fetchFromGitLab {
+      group = "librewolf-community";
+      owner = "browser";
+      repo = "common";
+      rev = lwPatchesTag;
+      sha256 = "Uzm3wYewVyFOKHnXAw28bOuCHTR/kiHQvQpLG7a1Xhw=";
+    };
+    lwSettings = fetchFromGitLab {
+      owner = "librewolf-community";
+      repo = "settings";
+      rev = lwSettingsTag;
+      sha256 = "lG8OmDUkkaG9imCj6H/aqEVCca8AG4PW3A9LKQ2x3b8=";
+    };
+  in common rec {
+    pname = "librewolf";
+    version = firefox.version;
+    src = firefox.src;
+
+    # TODO: Maybe force override this in extraConfigureFlags and
+    #       extraMakeFlags instead of modifying `common.nix`.
+    allowOfficialBranding = false;
+    binaryName = "librewolf";
+
+    # Adapted from
+    # https://gitlab.com/librewolf-community/browser/arch/-/blob/master/PKGBUILD#L48
+    # for now; except for --disable-updater and --enable-release.
+    #
+    # None of these are set by the `common` function, but most of
+    # these are integral to what librewolf does (disable telemetry and
+    # pre-installed addons ala pocket, as well as the actual
+    # branding).
+    #
+    # It'd be nice if this were more centralized, see
+    # https://gitlab.com/librewolf-community/browser/common/-/issues/37
+    extraConfigureFlags = [
+      "--enable-hardening"
+      "--enable-rust-simd"
+      "--enable-update-channel=release"
+      "--with-app-name=librewolf"
+      "--with-app-basename=LibreWolf"
+      "--with-branding=browser/branding/librewolf"
+      "--with-distribution-id=io.gitlab.librewolf-community"
+      "--with-unsigned-addon-scopes=app,system"
+      "--allow-addon-sideload"
+      "--disable-crashreporter"
+    ];
+    extraMakeFlags = [
+      "MOZ_REQUIRE_SIGNING=0"
+      "MOZ_CRASHREPORTER=0"
+      "MOZ_DATA_REPORTING=0"
+      "MOZ_SERVICES_HEALTHREPORT=0"
+      "MOZ_TELEMETRY_REPORTING=0"
+    ];
+
+    postUnpack = ''
+      cp -r ${lwPatches}/source_files/browser "$sourceRoot"
+      chmod -R u+w "$sourceRoot/browser"
+    '';
+
+    patches = let
+      readSubdir = subdir:
+        filter (hasSuffix ".patch")
+        (map (path: "${lwPatches}/${subdir}/${path}")
+          (attrNames (readDir "${lwPatches}/${subdir}")));
+    in (readSubdir "patches") ++ (readSubdir "patches/sed-patches") ++ [
+      # An additional patch to fix a wayland compilation issue
+      # that librewolf tickles out
+      (fetchpatch {
+        name = "fix-wayland-build.patch";
+        sha256 = "sha256-LcWx1PvUHvGf6ArNIYkAd2ucbqFbf7pw+VKATjok8wo=";
+        url =
+          "https://aur.archlinux.org/cgit/aur.git/plain/fix-wayland-build.patch?h=c6dd893ec36daa57e80759ed364b55c51c1ea5ea";
+      })
+    ];
+
+    extraLib = lwSettings;
+
+    meta = {
+      description =
+        "A fork of Firefox, focused on privacy, security and freedom.";
+      homepage = "https://librewolf-community.gitlab.io/";
+      # maintainers = with lib.maintainers; [ tlater ];
+      platforms = lib.platforms.unix;
+      badPlatforms = lib.platforms.darwin;
+      broken = stdenv.buildPlatform.is32bit;
+      license = lib.licenses.mpl20;
     };
   };
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -143,14 +143,12 @@ rec {
     postUnpack = ''
       cp -r ${lwPatches}/source_files/browser "$sourceRoot"
       chmod -R u+w "$sourceRoot/browser"
+
+      # Apply the librewolf patches to create our source tree
+      find '${lwPatches}/patches' -name '*.patch' -printf 'applying patch %p\n' -exec patch -p1 {} \;
     '';
 
-    patches = let
-      readSubdir = subdir:
-        filter (hasSuffix ".patch")
-        (map (path: "${lwPatches}/${subdir}/${path}")
-          (attrNames (readDir "${lwPatches}/${subdir}")));
-    in (readSubdir "patches") ++ (readSubdir "patches/sed-patches") ++ [
+    patches = [
       # An additional patch to fix a wayland compilation issue
       # that librewolf tickles out
       (fetchpatch {

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -41,6 +41,9 @@ let
     # https://github.com/mozilla/policy-templates#enterprisepoliciesenabled
     , extraPolicies ? {}
     , libName ? "firefox" # Important for tor package or the like
+    # For forks (distributions?) that set policies and other
+    # configuration in usr/lib
+    , extraLib ? browser.extraLib or null
     , nixExtensions ? null
     }:
 
@@ -340,13 +343,13 @@ let
         #   END EXTRA PREF CHANGES  #
         #                           #
         #############################
-      '' + lib.optionalString (! (isNull browser.extraLib)) ''
+      '' + lib.optionalString (! (isNull extraLib)) ''
         # additional files included from forks; ensure policies.json,
         # prefs and mozilla.cfg are still set up correctly.
         #
         # TODO: This is a band-aid for librewolf, we should design the
         # whole wrapper better for this use case.
-        cp -r ${browser.extraLib}/* "$out/lib/${libName}/"
+        cp -r ${extraLib}/* "$out/lib/${libName}/"
       '';
 
       preferLocalBuild = true;

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -328,7 +328,7 @@ let
         # preparing for autoconfig
         mkdir -p "$out/lib/${libName}/defaults/pref"
 
-        echo 'pref("general.config.filename", "mozilla.cfg");' > "$out/lib/${libName}/defaults/pref/autoconfig.js"
+        echo 'pref("general.config.filename", "librewolf.cfg");' > "$out/lib/${libName}/defaults/pref/autoconfig.js"
         echo 'pref("general.config.obscure_value", 0);' >> "$out/lib/${libName}/defaults/pref/autoconfig.js"
 
         cat > "$out/lib/${libName}/mozilla.cfg" < ${mozillaCfg}

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -340,6 +340,13 @@ let
         #   END EXTRA PREF CHANGES  #
         #                           #
         #############################
+      '' + lib.optionalString (! (isNull browser.extraLib)) ''
+        # additional files included from forks; ensure policies.json,
+        # prefs and mozilla.cfg are still set up correctly.
+        #
+        # TODO: This is a band-aid for librewolf, we should design the
+        # whole wrapper better for this use case.
+        cp -r ${browser.extraLib}/* "$out/lib/${libName}/"
       '';
 
       preferLocalBuild = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24681,6 +24681,8 @@ with pkgs;
   firefox-wayland = wrapFirefox firefox-unwrapped { forceWayland = true; };
   firefox-esr-78 = wrapFirefox firefox-esr-78-unwrapped { };
   firefox-esr-91 = wrapFirefox firefox-esr-91-unwrapped { };
+  librewolf-unwrapped = firefoxPackages.librewolf;
+  librewolf = wrapFirefox librewolf-unwrapped { libName = "librewolf"; };
 
   firefox-esr = firefox-esr-78;
   firefox-esr-unwrapped = firefoxPackages.firefox-esr-78;


### PR DESCRIPTION
###### Motivation for this change

#94918

And also the fact that I just found pocket re-enabled without asking Firefox to do so :|

###### Things done

This is an attempt to package Librewolf as another Firefox package, in contrast with the approach taken for #132992. It *mostly* should work exactly like a Firefox package, just with some additional patches on top, so it *almost* fits into the current Firefox packaging environment, but there are a few snags of course.

This is still very much a draft, to see what this *could* look like. Mainly asking for review of the approach; there are a few things I am unsure about or that are still missing.

Namely:

- [x] Actual testing of whether this works beyond the compilation looking ok - builds take ages...
- [ ] Update script
- [x] Applying a nested directory of patches correctly
  - I've done this with ugly hacking around `builtins.readDir`, for future update convenience, but this doesn't cover new subdirectories or suchlike. Is there a better generic function for this purpose?
- [ ] Official branding disable-toggle from the package side
  - This is currently a bit ugly in my implementation
- [ ] `/usr/lib` settings in the wrapper
  - This is generally awkward, but even more so if Firefox supplies defaults.
- [ ] Maintainership status
  - I've not read up on how to do that, I am not currently a maintainer, so can't add myself

I have done none of the formalities yet either:

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
