### PR TITLE
python3Packages.certauth: init at 1.3.0

### DIFF
--- a/pkgs/development/python-modules/certauth/default.nix
+++ b/pkgs/development/python-modules/certauth/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyopenssl
+, tldextract
+, pytestCheckHook
+, pytest-cov
+}:
+
+buildPythonPackage rec {
+  pname = "certauth";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ikreymer";
+    repo = "certauth";
+    rev = "ad2bae5d40a9e45519fc1f2cd7678174bbc55b3d"; # Repo has no git tags
+    sha256 = "sha256-Rso5N0jb9k7bdorjPIUMNiZZPnzwbkxFNiTpsJ9pco0=";
+  };
+
+  propagatedBuildInputs = [
+    pyopenssl
+    tldextract
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-cov
+  ];
+
+  pythonImportsCheck = [ "certauth" ];
+
+  meta = with lib; {
+    description = "Simple CertificateAuthority and host certificate creation, useful for man-in-the-middle HTTPS proxy";
+    homepage = "https://github.com/ikreymer/certauth";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1373,6 +1373,8 @@ in {
 
   cert-chain-resolver = callPackage ../development/python-modules/cert-chain-resolver { };
 
+  certauth = callPackage ../development/python-modules/certauth { };
+
   certbot = callPackage ../development/python-modules/certbot { };
 
   certbot-dns-cloudflare = callPackage ../development/python-modules/certbot-dns-cloudflare { };


### PR DESCRIPTION
###### Motivation for this change
This is a dependency of wsgiprox, which plan to add in the future.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).