### PR TITLE
octoprint.python.pkgs.ender3v2tempfix: init at unstable-2021-04-27

### DIFF
--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -147,6 +147,25 @@ in {
     };
   };
 
+  ender3v2tempfix = buildPlugin rec {
+    pname = "OctoPrintPlugin-ender3v2tempfix";
+    version = "unstable-2021-04-27";
+
+    src = fetchFromGitHub {
+      owner = "SimplyPrint";
+      repo = "OctoPrint-Creality2xTemperatureReportingFix";
+      rev = "2c4183b6a0242a24ebf646d7ac717cd7a2db2bcf";
+      sha256 = "03bc2zbffw4ksk8if90kxhs3179nbhb4xikp4f0adm3lrnvxkd3s";
+    };
+
+    meta = with lib; {
+      description = "Fixes the double temperature reporting from the Creality Ender-3 v2 printer";
+      homepage = "https://github.com/SimplyPrint/OctoPrint-Creality2xTemperatureReportingFix";
+      license = licenses.mit;
+      maintainers = with maintainers; [ illustris ];
+    };
+  };
+
   gcodeeditor = buildPlugin rec {
     pname = "GcodeEditor";
     version = "0.2.12";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- using octoprint with certain Creality printers requires the temperature reporting fix plugin
- octolapse is a popular plugin for octoprint

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
