### PR TITLE
caddy: build with default go and fix tests

### DIFF
--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -50,57 +50,58 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         };
       };
     };
+  };
 
-    testScript = { nodes, ... }:
-      let
-        etagSystem = "${nodes.webserver.config.system.build.toplevel}/specialisation/etag";
-        justReloadSystem = "${nodes.webserver.config.system.build.toplevel}/specialisation/config-reload";
-        multipleConfigs = "${nodes.webserver.config.system.build.toplevel}/specialisation/multiple-configs";
-      in
-      ''
-        url = "http://localhost/example.html"
-        webserver.wait_for_unit("caddy")
-        webserver.wait_for_open_port("80")
-
-
-        def check_etag(url):
-            etag = webserver.succeed(
-                "curl --fail -v '{}' 2>&1 | sed -n -e \"s/^< [Ee][Tt][Aa][Gg]: *//p\"".format(
-                    url
-                )
-            )
-            etag = etag.replace("\r\n", " ")
-            http_code = webserver.succeed(
-                "curl --fail --silent --show-error -o /dev/null -w \"%{{http_code}}\" --head -H 'If-None-Match: {}' {}".format(
-                    etag, url
-                )
-            )
-            assert int(http_code) == 304, "HTTP code is {}, expected 304".format(http_code)
-            return etag
+  testScript = { nodes, ... }:
+    let
+      etagSystem = "${nodes.webserver.config.system.build.toplevel}/specialisation/etag";
+      justReloadSystem = "${nodes.webserver.config.system.build.toplevel}/specialisation/config-reload";
+      multipleConfigs = "${nodes.webserver.config.system.build.toplevel}/specialisation/multiple-configs";
+    in
+    ''
+      url = "http://localhost/example.html"
+      webserver.wait_for_unit("caddy")
+      webserver.wait_for_open_port("80")
 
 
-        with subtest("check ETag if serving Nix store paths"):
-            old_etag = check_etag(url)
-            webserver.succeed(
-                "${etagSystem}/bin/switch-to-configuration test >&2"
-            )
-            webserver.sleep(1)
-            new_etag = check_etag(url)
-            assert old_etag != new_etag, "Old ETag {} is the same as {}".format(
-                old_etag, new_etag
-            )
+      def check_etag(url):
+          etag = webserver.succeed(
+              "curl --fail -v '{}' 2>&1 | sed -n -e \"s/^< [Ee][Tt][Aa][Gg]: *//p\"".format(
+                  url
+              )
+          )
+          etag = etag.replace("\r\n", " ")
+          http_code = webserver.succeed(
+              "curl --fail --silent --show-error -o /dev/null -w \"%{{http_code}}\" --head -H 'If-None-Match: {}' {}".format(
+                  etag, url
+              )
+          )
+          assert int(http_code) == 304, "HTTP code is {}, expected 304".format(http_code)
+          return etag
 
-        with subtest("config is reloaded on nixos-rebuild switch"):
-            webserver.succeed(
-                "${justReloadSystem}/bin/switch-to-configuration test >&2"
-            )
-            webserver.wait_for_open_port("8080")
 
-        with subtest("multiple configs are correctly merged"):
-            webserver.succeed(
-                "${multipleConfigs}/bin/switch-to-configuration test >&2"
-            )
-            webserver.wait_for_open_port("8080")
-            webserver.wait_for_open_port("8081")
-      '';
-  })
+      with subtest("check ETag if serving Nix store paths"):
+          old_etag = check_etag(url)
+          webserver.succeed(
+              "${etagSystem}/bin/switch-to-configuration test >&2"
+          )
+          webserver.sleep(1)
+          new_etag = check_etag(url)
+          assert old_etag != new_etag, "Old ETag {} is the same as {}".format(
+              old_etag, new_etag
+          )
+
+      with subtest("config is reloaded on nixos-rebuild switch"):
+          webserver.succeed(
+              "${justReloadSystem}/bin/switch-to-configuration test >&2"
+          )
+          webserver.wait_for_open_port("8080")
+
+      with subtest("multiple configs are correctly merged"):
+          webserver.succeed(
+              "${multipleConfigs}/bin/switch-to-configuration test >&2"
+          )
+          webserver.wait_for_open_port("8080")
+          webserver.wait_for_open_port("8081")
+    '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2180,9 +2180,7 @@ with pkgs;
     '';
   });
 
-  caddy = callPackage ../servers/caddy {
-    buildGoModule = buildGo115Module;
-  };
+  caddy = callPackage ../servers/caddy { };
 
   traefik = callPackage ../servers/traefik { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
As of version 2.4.4, caddy no longer requires go 1.15 to build (and one of its dependencies fails to build on that), we may drop the param and build caddy with default go.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
