### PR TITLE
poetry2conda: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/poetry-semver/default.nix
+++ b/pkgs/development/python-modules/poetry-semver/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "poetry-semver";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-2Am2Eqons5vy0PydMbT0gJsOlyZGxfGc+kbHJbdjiBA=";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "A semantic versioning library for Python.";
+    homepage = "https://github.com/python-poetry/semver";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/development/python-modules/poetry2conda/default.nix
+++ b/pkgs/development/python-modules/poetry2conda/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, pytest-mock
+, pytestCheckHook
+, toml
+, poetry
+, poetry-semver
+, pyyaml
+}:
+
+buildPythonApplication rec {
+  pname = "poetry2conda";
+  version = "0.3.0";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "dojeda";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-UqNoEGgStvqtxhYwExk7wO4SvATaM2kGaFbB5ViJa7U=";
+  };
+
+  nativeBuildInputs = [ poetry ];
+
+  propagatedBuildInputs = [
+    poetry-semver
+    toml
+  ];
+
+  checkInputs = [
+    pytest-mock
+    pytestCheckHook
+    pyyaml
+  ];
+
+  meta = with lib; {
+    description = "A script to convert a Python project declared on a pyproject.toml to a conda environment";
+    homepage = "https://github.com/dojeda/poetry2conda";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12939,6 +12939,8 @@ with pkgs;
     inherit pkgs lib;
   };
 
+  poetry2conda = python3Packages.callPackage ../development/python-modules/poetry2conda { };
+
   pipenv = callPackage ../development/tools/pipenv {};
 
   pipewire = callPackage ../development/libraries/pipewire {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5566,6 +5566,8 @@ in {
 
   poetry-core = callPackage ../development/python-modules/poetry-core { };
 
+  poetry-semver = callPackage ../development/python-modules/poetry-semver { };
+
   poezio = callPackage ../applications/networking/instant-messengers/poezio { };
 
   polib = callPackage ../development/python-modules/polib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5568,6 +5568,8 @@ in {
 
   poetry-semver = callPackage ../development/python-modules/poetry-semver { };
 
+  poetry2conda = callPackage ../development/python-modules/poetry2conda { };
+
   poezio = callPackage ../applications/networking/instant-messengers/poezio { };
 
   polib = callPackage ../development/python-modules/polib { };


### PR DESCRIPTION
- poetry-semver: init at 0.1.0
- poetry2conda: init at 0.3.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds poetry2conda and a necessary dependency poetry-semver to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
