### PR TITLE
figma: init at 0.8.1

### DIFF
--- a/pkgs/applications/graphics/figma/default.nix
+++ b/pkgs/applications/graphics/figma/default.nix
@@ -4,7 +4,6 @@
 , fonts ? [ ]
 }:
 
-with pkgs;
 let
   version = "0.8.1";
   # Figma executable.

--- a/pkgs/applications/graphics/figma/default.nix
+++ b/pkgs/applications/graphics/figma/default.nix
@@ -11,9 +11,8 @@ let
   figma-exec = stdenv.mkDerivation rec {
     inherit version;
     pname = "figma-exec";
-    src = pkgs.fetchurl {
-      url =
-        "https://github.com/Figma-Linux/figma-linux/releases/download/v${version}/figma-linux_${version}_linux_amd64.zip";
+    src = fetchurl {
+      url = "https://github.com/Figma-Linux/figma-linux/releases/download/v${version}/figma-linux_${version}_linux_amd64.zip";
       sha256 = "sha256-LqcjFLQeEQx/3HFy0mPoIynFy704omYVxv42IsY7s8k=";
     };
     buildInputs = [ unzip ];

--- a/pkgs/applications/graphics/figma/default.nix
+++ b/pkgs/applications/graphics/figma/default.nix
@@ -110,8 +110,8 @@ let
   };
 
 in stdenv.mkDerivation {
+  pname = "figma";
   inherit version;
-  name = "figma";
   src = builtins.path { path = ./.; };
   nativeBuildInputs = [ figma-fhs ];
   installPhase = ''

--- a/pkgs/applications/graphics/figma/default.nix
+++ b/pkgs/applications/graphics/figma/default.nix
@@ -1,7 +1,8 @@
 { pkgs, lib
 # Specify any font packages to include
 # e.g. figma.override { fonts = [ noto-fonts fira-code ]; }
-, fonts ? [ ], ... }:
+, fonts ? [ ]
+}:
 
 with pkgs;
 let

--- a/pkgs/applications/graphics/figma/default.nix
+++ b/pkgs/applications/graphics/figma/default.nix
@@ -1,0 +1,133 @@
+{ pkgs, lib
+# Specify any font packages to include
+# e.g. figma.override { fonts = [ noto-fonts fira-code ]; }
+, fonts ? [ ], ... }:
+
+with pkgs;
+let
+  version = "0.8.1";
+  # Figma executable.
+  # Currently won't run outside of FHS even with autopatching - needs help.
+  figma-exec = stdenv.mkDerivation rec {
+    inherit version;
+    pname = "figma-exec";
+    src = pkgs.fetchurl {
+      url =
+        "https://github.com/Figma-Linux/figma-linux/releases/download/v${version}/figma-linux_${version}_linux_amd64.zip";
+      sha256 = "sha256-LqcjFLQeEQx/3HFy0mPoIynFy704omYVxv42IsY7s8k=";
+    };
+    buildInputs = [ unzip ];
+    unpackPhase = ''
+      runHook preUnpack
+      mkdir output
+      unzip $src -d output
+      runHook postUnpack
+    '';
+    installPhase = ''
+      APPDIR=$out/etc/figma-linux
+      # Copy application to etc
+      mkdir -p $out/etc/figma-linux
+      cp -r output/. $APPDIR
+
+      # Add icons
+      for size in 24 36 48 64 72 96 128 192 256 384 512; do
+        mkdir -p "$out/share/icons/hicolor/''${size}x''${size}/apps"
+        cp -rf "$APPDIR/icons/''${size}x''${size}.png" "$out/share/icons/hicolor/''${size}x''${size}/apps/figma-linux.png"
+      done
+      mkdir -p "$out/share/icons/hicolor/scalable/apps"
+      cp -rf "$APPDIR/icons/scalable.svg" "$out/share/icons/hicolor/scalable/apps/figma-linux.svg"
+
+      # Copy fonts
+      mkdir -p $out/share/fonts
+      ${lib.concatMapStringsSep "\n"
+      (f: "cp -r ${f}/share/fonts/. $out/share/fonts/") fonts}
+
+      # Link binary
+      mkdir -p $out/bin
+      ln -s $out/etc/figma-linux/figma-linux $out/bin/figma
+
+      # Link desktop item
+      mkdir -p $out/share/applications
+      ln -s ${desktopItem}/share/applications/* $out/share/applications
+    '';
+    desktopItem = makeDesktopItem {
+      name = "Figma";
+      exec = "figma";
+      icon = "figma-linux";
+      desktopName = "Figma";
+      genericName = "Vector Graphics Designer";
+      comment = "Unofficial desktop application for linux";
+      type = "Application";
+      categories = "Graphics;";
+      mimeType = "application/figma;x-scheme-handler/figma;";
+      extraDesktopEntries = { StartupWMClass = "figma-linux"; };
+    };
+  };
+  figma-fhs = buildFHSUserEnv {
+    name = "figma-fhs";
+    targetPkgs = pkgs: [
+      figma-exec
+      alsaLib
+      at_spi2_atk
+      at_spi2_core
+      atk
+      avahi
+      brotli
+      cairo
+      cups
+      dbus
+      expat
+      freetype
+      pango
+      gcc
+      glib
+      glibc
+      gdk_pixbuf
+      gtk3
+      icu
+      libxkbcommon
+      mesa
+      ffmpeg
+      libdrm
+      libGL
+      nss_3_53
+      nspr
+      udev
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libX11
+      xorg.libXau
+      xorg.libxcb
+      xorg.libXcomposite
+      xorg.libXdmcp
+      xorg.libXfixes
+      xorg.libXrender
+      xorg.libXrandr
+      xorg.libxshmfence
+      wayland
+    ];
+    runScript = "figma";
+  };
+
+in stdenv.mkDerivation {
+  inherit version;
+  name = "figma";
+  src = builtins.path { path = ./.; };
+  nativeBuildInputs = [ figma-fhs ];
+  installPhase = ''
+    # Add binary link
+    mkdir -p $out/bin
+    cp -r ${figma-fhs}/bin/figma-fhs $out/bin/figma
+
+    # Link icons + desktop items
+    mkdir -p $out/share
+    cp -r ${figma-exec}/share/. $out/share
+  '';
+  meta = with lib; {
+    description = "unofficial Electron-based Figma desktop app for Linux";
+    homepage = "https://github.com/Figma-Linux/figma-linux";
+    # While the container application is GPL-2.0,
+    # Figma itself (running in the application) is nonFree.
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -455,6 +455,8 @@ with pkgs;
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  figma = callPackage ../applications/graphics/figma {};
+
   find-cursor = callPackage ../tools/X11/find-cursor { };
 
   flare-floss = callPackage ../tools/security/flare-floss { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [Figma](https://www.figma.com/) built from [figma-linux](https://github.com/Figma-Linux/figma-linux) client.

There are features not available in the browser version of Figma such as custom font support hence the need for a native client.

###### Notes

 - Originally was building this from source - can provide that version if that could help add support for more platforms+architectures
 -  Whether building from source or with prebuilt binaries, I wasn't able to get this working without using FHS [(forum discussion here)](https://discourse.nixos.org/t/could-use-some-help-packaging-a-binary/14801). **Would appreciate any help.**
 - See  code comments regarding licensing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
