### PR TITLE
numix-solarized-gtk-theme: 20210522 -> 20210831

### DIFF
--- a/pkgs/data/themes/numix-solarized/default.nix
+++ b/pkgs/data/themes/numix-solarized/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "numix-solarized-gtk-theme";
-  version = "20210522";
+  version = "20210831";
 
   src = fetchFromGitHub {
     owner = "Ferdi265";
     repo = pname;
     rev = version;
-    sha256 = "0hin73fmfir4w1z0j87k5hahhf2blhcq4r7gf89gz4slnl18cvjh";
+    sha256 = "1q8qhpw0hfv625sm626zp4vbz2106b0g5m11ygk87s6kbxrfg6lr";
   };
 
   nativeBuildInputs = [ python3 sassc glib gdk-pixbuf inkscape ];
@@ -24,7 +24,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    for theme in *.colors; do
+    for theme in colors/*.colors; do
+      theme="''${theme##*/}"
       make THEME="''${theme/.colors/}" install
     done
     runHook postInstall


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [20210831](https://github.com/Ferdi265/numix-solarized-gtk-theme/releases/tag/20210831)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
