### PR TITLE
frei0r-plugins: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/development/libraries/frei0r/default.nix
+++ b/pkgs/development/libraries/frei0r/default.nix
@@ -1,16 +1,26 @@
-{ lib, stdenv, fetchurl, autoconf, cairo, opencv, pkg-config }:
+{ lib, stdenv, fetchurl, fetchpatch, cairo, cmake, opencv, pcre, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "frei0r-plugins";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "https://files.dyne.org/frei0r/releases/${pname}-${version}.tar.gz";
-    sha256 = "0pji26fpd0dqrx1akyhqi6729s394irl73dacnyxk58ijqq4dhp0";
+    hash = "sha256-Gx/48Pm8I+7XJOlOmnwdjwJEv+M0JLtP5o5kYMCIUjo=";
   };
 
-  nativeBuildInputs = [ autoconf pkg-config ];
-  buildInputs = [ cairo opencv ];
+  # A PR to add support for OpenCV 4 was merged in May 2020. This
+  # patch can be removed when a release beyond 1.7.0 is issued.
+  patches = [
+    (fetchpatch {
+      name = "opencv4-support.patch";
+      url = "https://github.com/dyne/frei0r/commit/c0c8eed79fc8abe6c9881a53d7391efb526a3064.patch";
+      sha256 = "sha256-qxUAui4EEBEj8M/SoyMUkj//KegMTTT6FTBDC/Chxz4=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cairo opencv pcre ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     for f in $out/lib/frei0r-1/*.so* ; do


### PR DESCRIPTION
- Switched the build from autoconf to cmake as this build path
receives more attention by upstream developers.

- Include a PR that adds OpenCV 4 compatibility to better fit with nixpkgs. This
is not a recent PR, but no releases have been made in quite some time.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Use new frei0r plugins in kdenlive.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
