### PR TITLE
intensity-normalization: init at 2.0.1

### DIFF
--- a/pkgs/applications/science/biology/intensity-normalization/default.nix
+++ b/pkgs/applications/science/biology/intensity-normalization/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pytestCheckHook
+, matplotlib
+, nibabel
+, numpy
+, scikit-fuzzy
+, scikitimage
+, scikit-learn
+, scipy
+, statsmodels
+}:
+
+buildPythonPackage rec {
+  pname = "intensity-normalization";
+  version = "2.0.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1c6inlhpxarvkniq8j5j2pgl32dmggn14s8c3c0xx15j7cg90413";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "pytest-runner" ""
+  '';
+
+  checkInputs = [ pytestCheckHook ];
+  propagatedBuildInputs = [
+    matplotlib
+    nibabel
+    numpy
+    scikit-fuzzy
+    scikitimage
+    scikit-learn
+    scipy
+    statsmodels
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/jcreinhold/intensity-normalization";
+    description = "MRI intensity normalization tools";
+    maintainers = with maintainers; [ bcdarwin ];
+    license = licenses.asl20;
+  };
+
+}

--- a/pkgs/development/python-modules/scikit-fuzzy/default.nix
+++ b/pkgs/development/python-modules/scikit-fuzzy/default.nix
@@ -12,18 +12,21 @@
 
 buildPythonPackage rec {
   pname = "scikit-fuzzy";
-  version = "unstable-2020-10-03";
+  version = "unstable-2021-03-31";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "eecf303b701e3efacdc9b9066207ef605d4facaa";
-    sha256 = "18dl0017iqwc7446hqgabhibgjwdakhmycpis6zpvvkkv4ip5062";
+    rev = "92ad3c382ac19707086204ac6cdf6e81353345a7";
+    sha256 = "0q89p385nsg3lymlsqm3mw6y45vgrk6w9p30igbm59b7r9mkgdj8";
   };
 
   propagatedBuildInputs = [ networkx numpy scipy ];
   checkInputs = [ matplotlib nose pytestCheckHook ];
+
+  # test error: "ValueError: could not convert string to float: '2.6.2'"
+  disabledTestPaths = [ "skfuzzy/control/tests/test_controlsystem.py" ];
 
   meta = with lib; {
     homepage = "https://github.com/scikit-fuzzy/scikit-fuzzy";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2957,6 +2957,12 @@ with pkgs;
 
   inklecate = callPackage ../development/compilers/inklecate {};
 
+  intensity-normalization = callPackage ../applications/science/biology/intensity-normalization {
+    inherit (python3Packages)
+      buildPythonPackage fetchPypi pythonOlder pytestCheckHook
+      matplotlib nibabel numpy scikit-fuzzy scikitimage scikit-learn scipy statsmodels;
+  };
+
   interactsh = callPackage ../tools/misc/interactsh { };
 
   interlock = callPackage ../servers/interlock {};


### PR DESCRIPTION
python3Packages.scikit-fuzzy: unstable-2020-10-03 -> unstable-2021-03-31

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)  [Note: some binaries raise `ImportError` due to the missing optional dependency `antspy`.]
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
