### PR TITLE
qv2ray: 2.6.3 -> 2.7.0

### DIFF
--- a/pkgs/applications/networking/qv2ray/default.nix
+++ b/pkgs/applications/networking/qv2ray/default.nix
@@ -1,10 +1,11 @@
 { lib
+, stdenv
 , mkDerivation
 , fetchFromGitHub
 , qmake
 , qttools
 , cmake
-, clang
+, clang_8
 , grpc
 , protobuf
 , openssl
@@ -13,19 +14,25 @@
 , abseil-cpp
 , libGL
 , zlib
+, curl
 }:
 
 mkDerivation rec {
   pname = "qv2ray";
-  version = "2.6.3";
+  version = "2.7.0";
 
   src = fetchFromGitHub {
     owner = "Qv2ray";
     repo = "Qv2ray";
     rev = "v${version}";
-    sha256 = "sha256-zf3IlpRbZGDZMEny0jp7S+kWtcE1Z10U9GzKC0W0mZI=";
+    sha256 = "sha256-afFTGX/zrnwq/p5p1kj+ANU4WeN7jNq3ieeW+c+GO5M=";
     fetchSubmodules = true;
   };
+
+  patchPhase = lib.optionals stdenv.isDarwin ''
+    substituteInPlace cmake/platforms/macos.cmake \
+      --replace \''${QV2RAY_QtX_DIR}/../../../bin/macdeployqt macdeployqt
+  '';
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
@@ -50,10 +57,14 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    clang
+
+    # The default clang_7 will result in reproducible ICE.
+    clang_8
+
     pkg-config
     qmake
     qttools
+    curl
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Qv2ray repo was archived, this is the final version.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
