### PR TITLE
monit: 5.27.2 -> 5.29.0; format

### DIFF
--- a/pkgs/tools/system/monit/default.nix
+++ b/pkgs/tools/system/monit/default.nix
@@ -1,17 +1,22 @@
-{ lib, stdenv
-, fetchurl, bison, flex
+{ lib
+, stdenv
+, fetchurl
+, bison
+, flex
 , zlib
-, usePAM ? stdenv.hostPlatform.isLinux, pam
-, useSSL ? true, openssl
+, usePAM ? stdenv.hostPlatform.isLinux
+, pam
+, useSSL ? true
+, openssl
 }:
 
 stdenv.mkDerivation rec {
   pname = "monit";
-  version = "5.27.2";
+  version = "5.29.0";
 
   src = fetchurl {
     url = "${meta.homepage}dist/monit-${version}.tar.gz";
-    sha256 = "sha256-2ICceNXcHtenujKlpVxRFIVRMsxNpIBfjTqvjPRuqkw=";
+    sha256 = "sha256-9mXm3R8mp0tWgomah3k0Fn3islguBIZS7PA2MYR3iF8=";
   };
 
   nativeBuildInputs = [ bison flex ];
@@ -22,10 +27,10 @@ stdenv.mkDerivation rec {
   configureFlags = [
     (lib.withFeature usePAM "pam")
   ] ++ (if useSSL then [
-      "--with-ssl-incl-dir=${openssl.dev}/include"
-      "--with-ssl-lib-dir=${openssl.out}/lib"
-    ] else [
-      "--without-ssl"
+    "--with-ssl-incl-dir=${openssl.dev}/include"
+    "--with-ssl-lib-dir=${openssl.out}/lib"
+  ] else [
+    "--without-ssl"
   ]) ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     # will need to check both these are true for musl
     "libmonit_cv_setjmp_available=yes"
@@ -33,7 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    homepage = "http://mmonit.com/monit/";
+    homepage = "https://mmonit.com/monit/";
     description = "Monitoring system";
     license = lib.licenses.agpl3;
     maintainers = with lib.maintainers; [ raskin wmertens ryantm ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

new version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

