### PR TITLE
Vim remove share/runtime/NAME prefix from the installed folder

### DIFF
--- a/pkgs/applications/editors/neovim/tests.nix
+++ b/pkgs/applications/editors/neovim/tests.nix
@@ -84,6 +84,13 @@ rec {
     viAlias = true;
   };
 
+  nvim_with_plug = neovim.override {
+    extraName = "-with-plug";
+    configure.plug.plugins = with pkgs.vimPlugins; [
+      vim-go
+    ];
+  };
+
   # nixpkgs should detect that no wrapping is necessary
   nvimShouldntWrap = wrapNeovim2 "-should-not-wrap" nvimAutoDisableWrap;
 

--- a/pkgs/applications/editors/vim/vimacs.nix
+++ b/pkgs/applications/editors/vim/vimacs.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildCommand = ''
     mkdir -p "$out"/bin
-    cp "${vimPlugins.vimacs}"/share/vim-plugins/vimacs/bin/vim $out/bin/vimacs
+    cp "${vimPlugins.vimacs}"/bin/vim $out/bin/vimacs
     substituteInPlace "$out"/bin/vimacs \
       --replace '-vim}' '-@bin@/bin/vim}' \
       --replace '-gvim}' '-@bin@/bin/vim -g}' \

--- a/pkgs/misc/vim-plugins/build-vim-plugin.nix
+++ b/pkgs/misc/vim-plugins/build-vim-plugin.nix
@@ -19,7 +19,7 @@ rec {
     buildPhase ? "",
     preInstall ? "",
     postInstall ? "",
-    path ? lib.getName name,
+    path ? ".",
     addonInfo ? null,
     ...
   }:

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -99,10 +99,10 @@ self: super: {
     # The linked ruby code shows generates the required '.clang_complete' for cmake based projects
     # https://gist.github.com/Mic92/135e83803ed29162817fce4098dec144
     preFixup = ''
-      substituteInPlace "$out"/share/vim-plugins/clang_complete/plugin/clang_complete.vim \
+      substituteInPlace "$out"/plugin/clang_complete.vim \
         --replace "let g:clang_library_path = '' + "''" + ''" "let g:clang_library_path='${llvmPackages.libclang.lib}/lib/libclang.so'"
 
-      substituteInPlace "$out"/share/vim-plugins/clang_complete/plugin/libclang.py \
+      substituteInPlace "$out"/plugin/libclang.py \
         --replace "/usr/lib/clang" "${llvmPackages.clang.cc}/lib/clang"
     '';
   });
@@ -110,7 +110,7 @@ self: super: {
   clighter8 = super.clighter8.overrideAttrs (old: {
     preFixup = ''
       sed "/^let g:clighter8_libclang_path/s|')$|${llvmPackages.clang.cc.lib}/lib/libclang.so')|" \
-        -i "$out"/share/vim-plugins/clighter8/plugin/clighter8.vim
+        -i "$out"/plugin/clighter8.vim
     '';
   });
 
@@ -203,7 +203,7 @@ self: super: {
 
   direnv-vim = super.direnv-vim.overrideAttrs (oa: {
     preFixup = oa.preFixup or "" + ''
-      substituteInPlace $out/share/vim-plugins/direnv.vim/autoload/direnv.vim \
+      substituteInPlace $out/autoload/direnv.vim \
         --replace "let s:direnv_cmd = get(g:, 'direnv_cmd', 'direnv')" \
           "let s:direnv_cmd = get(g:, 'direnv_cmd', '${lib.getBin direnv}/bin/direnv')"
     '';
@@ -354,7 +354,7 @@ self: super: {
       propagatedBuildInputs = [ LanguageClient-neovim-bin ];
 
       preFixup = ''
-        substituteInPlace "$out"/share/vim-plugins/LanguageClient-neovim/autoload/LanguageClient.vim \
+        substituteInPlace "$out"/autoload/LanguageClient.vim \
           --replace "let l:path = s:root . '/bin/'" "let l:path = '${LanguageClient-neovim-bin}' . '/bin/'"
       '';
     };
@@ -387,9 +387,9 @@ self: super: {
 
   minimap-vim = super.minimap-vim.overrideAttrs (old: {
     preFixup = ''
-      substituteInPlace $out/share/vim-plugins/minimap.vim/plugin/minimap.vim \
+      substituteInPlace $out/plugin/minimap.vim \
         --replace "code-minimap" "${code-minimap}/bin/code-minimap"
-      substituteInPlace $out/share/vim-plugins/minimap.vim/bin/minimap_generator.sh \
+      substituteInPlace $out/bin/minimap_generator.sh \
         --replace "code-minimap" "${code-minimap}/bin/code-minimap"
     '';
   });
@@ -691,7 +691,7 @@ self: super: {
 
   vim-dasht = super.vim-dasht.overrideAttrs (old: {
     preFixup = ''
-      substituteInPlace $out/share/vim-plugins/vim-dasht/autoload/dasht.vim \
+      substituteInPlace $out/autoload/dasht.vim \
         --replace "['dasht']" "['${dasht}/bin/dasht']"
     '';
   });
@@ -795,7 +795,7 @@ self: super: {
     in
     super.vim-markdown-composer.overrideAttrs (oldAttrs: rec {
       preFixup = ''
-        substituteInPlace "$out"/share/vim-plugins/vim-markdown-composer/after/ftplugin/markdown/composer.vim \
+        substituteInPlace "$out"/after/ftplugin/markdown/composer.vim \
           --replace "let l:args = [s:plugin_root . '/target/release/markdown-composer']" \
           "let l:args = ['${vim-markdown-composer-bin}/bin/markdown-composer']"
       '';

--- a/pkgs/misc/vim-plugins/vim-gen-doc-hook.sh
+++ b/pkgs/misc/vim-plugins/vim-gen-doc-hook.sh
@@ -7,7 +7,6 @@ vimPluginGenTags() {
 
     target="$out/@rtpPath@/$pname"
     mkdir -p $out/@rtpPath@
-    cp -r . $target
 
     # build help tags
     if [ -d "$target/doc" ]; then

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -185,7 +185,7 @@ let
       else (lib.optional (x ? name) x.name)
             ++ (x.names or []);
 
-  rtpPath = "share/vim-plugins";
+  rtpPath = ".";
 
   nativeImpl = packages:
   (let
@@ -196,13 +196,14 @@ let
       ln -sf ${plugin}/${plugin.pname}-${plugin.version}-rocks/${plugin.pname}/${plugin.version}/* $out/pack/${packageName}/${dir}/${plugin.pname}/
     '';
 
-    linkVimlPlugin = pluginPath: packageName: dir:
-      "ln -sf ${pluginPath}/${rtpPath}/* $out/pack/${packageName}/${dir}";
+    linkVimlPlugin = plugin: packageName: dir: ''
+      mkdir -p $out/pack/${packageName}/${dir}/${plugin.pname}
+      ln -sf ${plugin}/${rtpPath}/* $out/pack/${packageName}/${dir}/${plugin.pname}
+    '';
 
-      # (builtins.trace pluginPath )
-      link = pluginPath: if hasLuaModule pluginPath
-        then linkLuaPlugin pluginPath
-        else linkVimlPlugin pluginPath;
+    link = pluginPath: if hasLuaModule pluginPath
+      then linkLuaPlugin pluginPath
+      else linkVimlPlugin pluginPath;
 
     packageLinks = (packageName: {start ? [], opt ? []}:
     let


### PR DESCRIPTION
###### Motivation for this change

When looking into plugin issues, there is a hierarchy of 3 folders `share/runtime/<PKG_NAME>` for no reason ? just makes debugging harder as well as paths longer when patching.

This passes nixpkgs-review.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
