### PR TITLE
buildFhsUserenv: inherit mounts from parent namespace

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/chrootenv/chrootenv.c
+++ b/pkgs/build-support/build-fhs-userenv/chrootenv/chrootenv.c
@@ -122,7 +122,7 @@ int main(gint argc, gchar **argv) {
     }
 
     // hide all mounts we do from the parent
-    fail_if(mount(0, "/", 0, MS_PRIVATE | MS_REC, 0));
+    fail_if(mount(0, "/", 0, MS_SLAVE | MS_REC, 0));
 
     if (uid != 0) {
       spit("/proc/self/setgroups", "deny");


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Since #125804 FHSUserEnvs don't inherit new mounts from the parent namespace, breaking autofs mounts.

This also likely fixes #122685

If you have an autofs mount on your system, running an FHSUserEnv will give the following error if the real mount doesn't happen to be mounted at this instant:
```
** (process:3339): ERROR **: 01:34:44.237: bind_mount: mount(source, target, NULL, MS_BIND | MS_REC, NULL): Too many levels of symbolic links
fish: Job 1, 'fhsenv' terminated by signal SIGTRAP (Trace or breakpoint trap)
```
This is because the automount daemon can only create the new mount in the parent namespace, and the child process will get the `ELOOP` error. Source: https://www.kernel.org/doc/html/latest/filesystems/autofs.html#autofs-name-spaces-and-shared-mounts

###### Things done

Change `MS_PRIVATE` to `MS_SLAVE` in `chrootenv.c`
This way new mounts will be inherited, but will not leak new mounts to the parent like before.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
