### PR TITLE
syncserver: 1.8.0 → 1.9.1

### DIFF
--- a/pkgs/development/python-modules/venusian/1.2.0.nix
+++ b/pkgs/development/python-modules/venusian/1.2.0.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pytest-cov
+, syncserver
+}:
+
+buildPythonPackage rec {
+  pname = "venusian";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06842b7242b1039c0c28f6feef29016e7e7dd3caaeb476a193acf737db31ee38";
+  };
+
+  checkInputs = [ pytest pytest-cov ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "A library for deferring decorator actions";
+    homepage = "https://pylonsproject.org/";
+    license = licenses.bsd0;
+    maintainers = syncserver.maintainers;
+  };
+}

--- a/pkgs/servers/syncserver/default.nix
+++ b/pkgs/servers/syncserver/default.nix
@@ -14,27 +14,44 @@ let
           sha256 = "1vvymhf6ydc885ygqiqpa39xr9v302i1l6nzirjnczqy9llyqvpj";
         };
       });
+
+      pyramid = super.pyramid.overridePythonAttrs (oldAttrs: {
+        # Depends on webtest, which is not supported on Python 2.
+        checkInputs = [];
+        doCheck = false;
+      });
     };
   };
 
 # buildPythonPackage is necessary for syncserver to work with gunicorn or paster scripts
 in python.pkgs.buildPythonPackage rec {
   pname = "syncserver";
-  version = "1.8.0";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "mozilla-services";
     repo = "syncserver";
     rev = version;
-    sha256 = "0hxjns9hz7a8r87iqr1yfvny4vwj1rlhwcf8bh7j6lsf92mkmgy8";
+    sha256 = "0s13pbzjldpiyz6hgw5djwnwd8q7dai6c28vrb1vqanxhrfm1rwb";
   };
 
   # There are no tests
   doCheck = false;
 
   propagatedBuildInputs = with python.pkgs; [
-    cornice gunicorn pyramid requests simplejson sqlalchemy mozsvc tokenserver
-    serversyncstorage configparser
+    cornice
+    gunicorn
+    pyramid
+    requests
+    sqlalchemy
+    configparser
+    mozsvc
+    futures
+    soupsieve
+    umemcache
+    tokenserver
+    serversyncstorage
+    google-cloud-spanner
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -652,6 +652,8 @@ with self; with super; {
 
   wxPython = self.wxPython30;
 
+  venusian = callPackage ../development/python-modules/venusian/1.2.0.nix { };
+
   vcrpy = callPackage ../development/python-modules/vcrpy/3.nix { };
 
   xcaplib = callPackage ../development/python-modules/xcaplib { };


### PR DESCRIPTION
This is work in progress attempt at fixing Firefox sync server. The latest version claims to support Python 3 but unfortunately, many of its dependencies don’t (e.g. mozsvc [depends](https://github.com/mozilla-services/mozservices/issues/41) on umemcached, which has been abandoned). But we cannot simply use Python 2 because the versions of some dependencies in Nixpkgs no longer support that. That means we need to re-introduce them to `python2Packages`.

Previous effort to remove this package: https://github.com/NixOS/nixpkgs/pull/74725
