### PR TITLE
_1password-gui: 8.1.1 -> 8.2.0

### DIFF
--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , makeWrapper
-, alsaLib
+, alsa-lib
 , at-spi2-atk
 , at-spi2-core
 , atk
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   installPhase =
     let rpath = lib.makeLibraryPath [
-      alsaLib
+      alsa-lib
       at-spi2-atk
       at-spi2-core
       atk
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
     description = "Multi-platform password manager";
     homepage = "https://1password.com/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ timstott savannidgerinel jcdickinson ];
+    maintainers = with maintainers; [ timstott savannidgerinel ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , makeWrapper
-, alsa-lib
+, alsaLib
 , at-spi2-atk
 , at-spi2-core
 , atk
@@ -33,11 +33,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "8.1.1";
+  version = "8.2.0";
 
   src = fetchurl {
     url = "https://downloads.1password.com/linux/tar/stable/x86_64/1password-${version}.x64.tar.gz";
-    sha256 = "0y39sfhj9xrgprh01i9apzfkqzm6pdhjc8x59x5p5djjjvxbcwmy";
+    sha256 = "517813056c8ad4d32a865b0ecd20613ce3e268b1cefdd28bb74921aaf6ded7c2";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   installPhase =
     let rpath = lib.makeLibraryPath [
-      alsa-lib
+      alsaLib
       at-spi2-atk
       at-spi2-core
       atk
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
     description = "Multi-platform password manager";
     homepage = "https://1password.com/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ timstott savannidgerinel ];
+    maintainers = with maintainers; [ timstott savannidgerinel jcdickinson ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
Bump version and hash. `alsa-lib` needed to be updated to `alsaLib`.

###### Motivation for this change

The 8.1.1 version of 1password has a hard expiration date.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
