### PR TITLE
ran: init at 0.1.6

### DIFF
--- a/pkgs/servers/http/ran/default.nix
+++ b/pkgs/servers/http/ran/default.nix
@@ -1,0 +1,47 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, runCommand
+, ran
+, curl
+}:
+
+buildGoModule rec {
+  pname = "ran";
+  version = "0.1.6";
+  src = fetchFromGitHub {
+    owner = "m3ng9i";
+    repo = "ran";
+    rev = "v${version}";
+    hash = "sha256-iMvUvzr/jaTNdgHQFuoJNJnnkx2XHIUUlrPWyTlreEw=";
+  };
+
+  vendorSha256 = "sha256-ObroruWWNilHIclqNvbEaa7vwk+1zMzDKbjlVs7Fito=";
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-X" "main._version_=v${version}"
+    "-X" "main._branch_=master"
+  ];
+
+  passthru.tests = {
+    simple = runCommand "ran-test" { } ''
+      echo hello world > index.html
+      ${ran}/bin/ran &
+      # Allow ran to fully initialize
+      sleep 1
+      [ "$(${curl}/bin/curl 127.0.0.1:8080)" == "hello world" ]
+      kill %1
+      ${ran}/bin/ran --version > $out
+    '';
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/m3ng9i/ran";
+    description = "Ran is a simple web server for serving static files";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tomberek ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14364,6 +14364,8 @@ with pkgs;
     lua = lua5;
   } // (config.radare or {}));
 
+  ran = callPackage ../servers/http/ran { };
+
   retry = callPackage ../tools/system/retry { };
 
   rizin = pkgs.callPackage ../development/tools/analysis/rizin { };


### PR DESCRIPTION
###### Motivation for this change
I keep building it manually to use it as a quick/simple webserver.

###### Things done
Standard Go packaging. Copied some bits from pomerium

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
 - [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).