### PR TITLE
Update SILE to 0.11.0, bump Lua Penlight and Cassowary

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -75,7 +75,7 @@ mediator_lua,,,,,,
 mpack,,,,,,
 moonscript,,,,,,arobyn
 nvim-client,https://github.com/neovim/lua-client.git,,,,,
-penlight,https://github.com/Tieske/Penlight.git,,,,,
+penlight,https://github.com/lunarmodules/Penlight.git,,,,,alerque
 plenary.nvim,https://github.com/nvim-lua/plenary.nvim.git,,,,lua5_1,
 rapidjson,https://github.com/xpol/lua-rapidjson.git,,,,,
 readline,,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -160,10 +160,10 @@ busted = buildLuarocksPackage {
 
 cassowary = buildLuarocksPackage {
   pname = "cassowary";
-  version = "2.3.1-1";
+  version = "2.3.1-2";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/cassowary-2.3.1-1.rockspec";
-    sha256 = "1rgs0rmlmhghml0gi4dn0rg2iq7rqnn8w8dcy9r3qsbkpyylbajc";
+    url    = "https://luarocks.org/cassowary-2.3.1-2.rockspec";
+    sha256 = "04y882f9ai1jhk0zwla2g0fvl56a75rwnxhsl9r3m0qa5i0ia1i5";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/sile-typesetter/cassowary.lua",
@@ -171,7 +171,7 @@ cassowary = buildLuarocksPackage {
   "date": "2021-07-19T14:37:34+03:00",
   "path": "/nix/store/rzsbr6gqg8vhchl24ma3p1h4slhk0xp7-cassowary.lua",
   "sha256": "1r668qcvd2a1rx17xp7ajp5wjhyvh2fwn0c60xmw0mnarjb5w1pq",
-  "fetchSubmodules": true,
+  "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false
 }
@@ -179,6 +179,10 @@ cassowary = buildLuarocksPackage {
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua penlight ];
+  checkInputs = [ busted ];
+  # Avoid circular dependency issue with busted / penlight, see:
+  # https://github.com/NixOS/nixpkgs/pull/136453/files#r700982255
+  doCheck = false;
 
   meta = {
     homepage = "https://github.com/sile-typesetter/cassowary.lua";

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1957,15 +1957,18 @@ nvim-client = buildLuarocksPackage {
 
 penlight = buildLuarocksPackage {
   pname = "penlight";
-  version = "dev-1";
-
+  version = "1.11.0-1";
+  knownRockspec = (fetchurl {
+    url    = "https://luarocks.org/penlight-1.11.0-1.rockspec";
+    sha256 = "1sjhnywvamyi9fadhra5pw2an1rhy2hk2byfxmr3n5wi0xrqv004";
+  }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/lunarmodules/penlight.git",
   "rev": "e3712f00fae09a166dd62540b677600165d5bcd7",
   "date": "2021-08-18T21:37:47+02:00",
   "path": "/nix/store/i70ndw8qhvcm828ifb3vyj08y22xp0ka-penlight",
   "sha256": "19n9xqkb4hlak0k7hamk4ixwjvyxslsnyh1zjazdzrl8n736xhkl",
-  "fetchSubmodules": true,
+  "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false
 }
@@ -1973,12 +1976,13 @@ penlight = buildLuarocksPackage {
 
   disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua luafilesystem ];
-  checkInputs = [ busted busted ];
+  checkInputs = [ busted ];
   doCheck = false;
 
   meta = {
     homepage = "https://lunarmodules.github.io/penlight";
     description = "Lua utility libraries loosely based on the Python standard libraries";
+    maintainers = with lib.maintainers; [ alerque ];
     license.fullName = "MIT/X11";
   };
 };

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -3,9 +3,8 @@
 , fetchurl
 , makeWrapper
 , pkg-config
-, autoconf
-, automake
 , poppler_utils
+, gitMinimal
 , harfbuzz
 , icu
 , fontconfig
@@ -39,11 +38,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.10.15";
+  version = "0.11.1";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "0p1w3s6j34qi93aycqmqggfm277n90z90nlmm1j3qizxxwq5gda9";
+    sha256 = "06bx94zx6skhizk2bbrid82sldwgxfycvjh6zx1zy1xz8gajgrm3";
   };
 
   configureFlags = [
@@ -52,8 +51,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    autoconf
-    automake
+    gitMinimal
     pkg-config
     makeWrapper
   ];
@@ -70,7 +68,9 @@ stdenv.mkDerivation rec {
     poppler_utils
   ];
 
-  preConfigure = lib.optionalString stdenv.isDarwin ''
+  preConfigure = ''
+    patchShebangs build-aux/*.sh
+  '' + lib.optionalString stdenv.isDarwin ''
     sed -i -e 's|@import AppKit;|#import <AppKit/AppKit.h>|' src/macfonts.m
   '';
 
@@ -108,7 +108,8 @@ stdenv.mkDerivation rec {
       technologies and borrowing some ideas from graphical systems
       such as InDesign.
     '';
-    homepage = "https://sile-typesetter.org/";
+    homepage = "https://sile-typesetter.org";
+    changelog = "https://github.com/sile-typesetter/sile/raw/v${version}/CHANGELOG.md";
     platforms = platforms.unix;
     broken = stdenv.isDarwin;   # https://github.com/NixOS/nixpkgs/issues/23018
     maintainers = with maintainers; [ doronbehar alerque ];


### PR DESCRIPTION
- lua-cassowary: 2.3.1-1 → 2.3.1-2
- lua-penlight: dev-1 → 1.11.0-1
- sile: 0.10.15 → 0.11.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
