### PR TITLE
gixy: use toPythonApplication

### DIFF
--- a/pkgs/development/python-modules/gixy/default.nix
+++ b/pkgs/development/python-modules/gixy/default.nix
@@ -1,11 +1,19 @@
-{ lib, fetchFromGitHub, python3 }:
+{ lib, fetchFromGitHub, buildPythonPackage
+, pythonAtLeast
+, isPy27
+, nose
+, cached-property
+, configargparse
+, jinja2
+, pyparsing
+, six }:
 
-python3.pkgs.buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "gixy";
   version = "0.1.20";
 
   # package is only compatible with python 2.7 and 3.5+
-  disabled = with python3.pkgs; !(pythonAtLeast "3.5" || isPy27);
+  disabled = !(pythonAtLeast "3.5" || isPy27);
 
   # fetching from GitHub because the PyPi source is missing the tests
   src = fetchFromGitHub {
@@ -19,13 +27,15 @@ python3.pkgs.buildPythonApplication rec {
     sed -ie '/argparse/d' setup.py
   '';
 
-  propagatedBuildInputs = with python3.pkgs; [
+  checkInputs = [
+    nose
+  ];
+
+  propagatedBuildInputs = [
     cached-property
     configargparse
-    pyparsing
     jinja2
-    nose
-    setuptools
+    pyparsing
     six
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2833,7 +2833,7 @@ with pkgs;
 
   gitjacker = callPackage ../tools/security/gitjacker { };
 
-  gixy = callPackage ../tools/admin/gixy { };
+  gixy = with python3Packages; toPythonApplication gixy;
 
   glpaper = callPackage ../development/tools/glpaper { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2949,6 +2949,8 @@ in {
 
   git-sweep = callPackage ../development/python-modules/git-sweep { };
 
+  gixy = callPackage ../development/python-modules/gixy { };
+
   glances-api = callPackage ../development/python-modules/glances-api { };
 
   glasgow = callPackage ../development/python-modules/glasgow { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This fixes python issues in nix-shell when using non-default python version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [X] `nixosTests.nginx`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
