### PR TITLE
NTFS-3G and PROGS security fixes update

### DIFF
--- a/pkgs/tools/filesystems/ntfs-3g/default.nix
+++ b/pkgs/tools/filesystems/ntfs-3g/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with lib; {
-    homepage = "https://www.tuxera.com/community/open-source-ntfs-3g/";
+    homepage = "https://github.com/tuxera/ntfs-3g";
     description = "FUSE-based NTFS driver with full write support";
     maintainers = with maintainers; [ dezgeg ];
     platforms = with platforms; darwin ++ linux;

--- a/pkgs/tools/filesystems/ntfs-3g/default.nix
+++ b/pkgs/tools/filesystems/ntfs-3g/default.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation rec {
   pname = "ntfs3g";
-  version = "2017.3.23";
+  version = "2021.8.22";
 
   outputs = [ "out" "dev" "man" "doc" ];
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://tuxera.com/opensource/ntfs-3g_ntfsprogs-${version}.tgz";
-    sha256 = "1mb228p80hv97pgk3myyvgp975r9mxq56c6bdn1n24kngcfh4niy";
+    sha256 = "55b883aa05d94b2ec746ef3966cb41e66bed6db99f22ddd41d1b8b94bb202efb";
   };
 
   patchPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Security vulnerabilities were identified in the open source NTFS-3G and NTFSPROGS software. These vulnerabilities were confirmed and resolved.
CVEs: CVE-2021-33285, CVE-2021-35269, CVE-2021-35268, CVE-2021-33289, CVE-2021-33286, CVE-2021-35266, CVE-2021-33287, CVE-2021-35267, CVE-2021-39251, CVE-2021-39252, CVE-2021-39253, CVE-2021-39254, CVE-2021-39255, CVE-2021-39256, CVE-2021-39257, CVE-2021-39258, CVE-2021-39259, CVE-2021-39260, CVE-2021-39261, CVE-2021-39262, CVE-2021-39263
More information here: https://github.com/tuxera/ntfs-3g/security/advisories/GHSA-q759-8j5v-q5jp

- The project was also migrated to GitHub, so the homepage needs an update.

###### Things done
The NTFS-3G and progs version updated to 2021.8.22.
Changelog and the source available here: https://github.com/tuxera/ntfs-3g/releases/tag/2021.8.22

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
