### PR TITLE
comfortaa: 3.101 -> 2021-07-29

### DIFF
--- a/pkgs/data/fonts/comfortaa/default.nix
+++ b/pkgs/data/fonts/comfortaa/default.nix
@@ -1,13 +1,13 @@
 { lib, fetchFromGitHub }:
 
 let
-  version = "3.101";
+  version = "2021-07-29";
 in fetchFromGitHub rec {
   name = "comfortaa-${version}";
 
   owner = "googlefonts";
   repo = "comfortaa";
-  rev = version;
+  rev = "2a87ac6f6ea3495150bfa00d0c0fb53dd0a2f11b";
 
   postFetch = ''
     tar -xf $downloadedFile --strip=1
@@ -16,7 +16,7 @@ in fetchFromGitHub rec {
     cp FONTLOG.txt README.md $out/share/doc/comfortaa
   '';
 
-  sha256 = "06jhdrfzl01ma085bp354g002ypmkbp6a51jn1lsj77zfj2mfmfc";
+  sha256 = "12ad7qy11q49iv9h3l2d7x7y7kf0hxbqhclb92bzwig8dzly9n2k";
 
   meta = with lib; {
     homepage = "http://aajohan.deviantart.com/art/Comfortaa-font-105395949";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I believe there was some sort of font issue in the release that messed up some characters (i.e. `8`) which I don't see with this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
