### PR TITLE
pythonPackages.stestr: init 3.2.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonApplication, fetchPypi
 , installShellFiles, pbr
-, flake8, mock, pycodestyle, pylint, tox
+, flake8, mock, pycodestyle, pylint, tox, stestr
 , nix-update-script
 , testVersion, git-machete
 }:
@@ -16,10 +16,7 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ installShellFiles pbr ];
 
-  # TODO: Add missing check inputs (2019-11-22):
-  # - stestr
-  doCheck = false;
-  checkInputs = [ flake8 mock pycodestyle pylint tox ];
+  checkInputs = [ flake8 mock pycodestyle pylint tox stestr ];
 
   postInstall = ''
       installShellCompletion --bash --name git-machete completion/git-machete.completion.bash

--- a/pkgs/development/python-modules/stestr/default.nix
+++ b/pkgs/development/python-modules/stestr/default.nix
@@ -1,0 +1,45 @@
+{ lib, buildPythonPackage, fetchPypi, callPackage
+, future, pbr, cliff, subunit, fixtures, testtools, pyyaml, voluptuous
+#, coverage, ddt, doc8, openstack-hacking, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "stestr";
+  version = "3.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fb492cbdf3d3fdd6812645804efc84a99a68bb60dd7705f15c1a2949c8172bc4";
+  };
+
+  propagatedBuildInputs = [
+    future
+    pbr
+    cliff
+    subunit
+    fixtures
+    testtools
+    pyyaml
+    voluptuous
+  ];
+
+  # FIXME: Tests disabled until "openstack-hacking" is merged.
+  # checkInputs = [
+  #   coverage
+  #   ddt
+  #   doc8
+  #   (openstack-hacking.overridePythonAttrs (oldAttrs: rec { doCheck = false; }))
+  #   sphinx
+  # ];
+  checkPhase = ''
+    $out/bin/stestr --version | grep ${version} > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "A parallel Python test runner built around subunit";
+    downloadPage = "https://pypi.org/project/stestr/";
+    homepage = "https://github.com/mtreinish/stestr/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8489,6 +8489,8 @@ in {
 
   stem = callPackage ../development/python-modules/stem { };
 
+  stestr = callPackage ../development/python-modules/stestr { };
+
   stevedore = callPackage ../development/python-modules/stevedore { };
 
   stm32loader = callPackage ../development/python-modules/stm32loader { };


### PR DESCRIPTION
* pythonPackages.stestr: init 3.2.0
* git-machete: fixes tests

Tests are disabled until `openstack-hacking` is merged (I expect to do so eventually).

I have fixed `git-manchete` to show this works.