### PR TITLE
nixos/etc: make sure local "source" files are imported to the store

### DIFF
--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -6,7 +6,9 @@ with lib;
 
 let
 
-  etc' = filter (f: f.enable) (attrValues config.environment.etc);
+  # if the source is a local file, it should be imported to the store
+  localToStore = mapAttrs (name: value: if name == "source" then "${value}" else value);
+  etc' = map localToStore (filter (f: f.enable) (attrValues config.environment.etc));
 
   etc = pkgs.runCommandLocal "etc" {
     # This is needed for the systemd module


### PR DESCRIPTION
###### Motivation for this change

The treatment of the "source" parameter changed
with eb7120dc79966d5ed168321fd213de38de13a2b1, breaking stuff.

Before that commit, the source parameter was converted to a
string by implicit coercion, which would copy the file to the
store and yield an string containing the store path. Now, by
the virtue of escapeShellArg, toString is called explicitly on
that path, which will yield an string containing the absolute
path of the file.

This commit restores the old behavior.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Tested that the resulting `/etc/` looks fine on NixOS
