### PR TITLE
python3Packages.datasette-publish-fly: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/datasette-publish-fly/default.nix
+++ b/pkgs/development/python-modules/datasette-publish-fly/default.nix
@@ -2,7 +2,6 @@
 , fetchFromGitHub
 , lib
 , datasette
-, flyctl
 , pytestCheckHook
 , pytest-asyncio
 , sqlite-utils

--- a/pkgs/development/python-modules/datasette-publish-fly/default.nix
+++ b/pkgs/development/python-modules/datasette-publish-fly/default.nix
@@ -1,0 +1,34 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, datasette
+, flyctl
+, pytestCheckHook
+, pytest-asyncio
+, sqlite-utils
+}:
+
+buildPythonPackage rec {
+  pname = "datasette-publish-fly";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = pname;
+    rev = version;
+    sha256 = "0wy7lqigjk76c3jw1chrzrn8gva3jzh1q5sbbb54xaa20w8c29da";
+  };
+
+  propagatedBuildInputs = [ datasette ];
+
+  checkInputs = [ pytestCheckHook pytest-asyncio sqlite-utils ];
+
+  pythonImportsCheck = [ "datasette_publish_fly" ];
+
+  meta = with lib; {
+    description = "Datasette plugin for publishing data using Fly";
+    homepage = "https://datasette.io/plugins/datasette-publish-fly";
+    license = licenses.asl20;
+    maintainers = [ maintainers.MostAwesomeDude ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1846,6 +1846,8 @@ in {
 
   datasette-template-sql = callPackage ../development/python-modules/datasette-template-sql { };
 
+  datasette-publish-fly = callPackage ../development/python-modules/datasette-publish-fly { };
+
   datashader = callPackage ../development/python-modules/datashader {
     dask = self.dask.override { withExtraComplete = true; };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See #129072, as it's the same sort of plugin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
