### PR TITLE
pythonPackages.zc_buildout: 2.13.4 -> 3.0.0b2

### DIFF
--- a/pkgs/development/python-modules/buildout/default.nix
+++ b/pkgs/development/python-modules/buildout/default.nix
@@ -1,18 +1,42 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchFromGitHub
+, setuptools, pip, wheel
+# , zope_testing, manuel, zope_bobo, zdaemon, zope_zc_zdaemonrecipe, zope_zc_recipe_deployment
+}:
 
 buildPythonPackage rec {
-  pname = "zc.buildout";
-  version = "2.13.4";
+  pname = "zc_buildout";
+  version = "3.0.0b2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b978b2f9317b317ee4191f78fcc4f05b1ac41bdaaae47f0956f14c8285feef63";
+  src = fetchFromGitHub {
+    owner = "buildout";
+    repo = "buildout";
+    rev = version;
+    sha256 = "01sj09xx5kmkzynhq1xd8ahn6xqybfi8lrqjqr5lr45aaxjk2pid";
   };
 
+  propagatedBuildInputs = [
+    setuptools
+    pip
+    wheel
+  ];
+
+  # checkInputs = [
+  #   zope_testing
+  #   manuel
+  #   zope_bobo
+  #   zdaemon
+  #   #zope_zc_zdaemonrecipe # Missing package & Blocked on `zc.recipe.egg`.
+  #   (zope_zc_recipe_deployment.overridePythonAttrs (oldAttrs: rec { doCheck = false; }))
+  # ];
+  checkPhase = ''
+    $out/bin/buildout --version | grep ${version} > /dev/null
+  '';
+
   meta = with lib; {
-    homepage = "http://www.buildout.org";
     description = "A software build and configuration system";
+    downloadPage = "https://github.com/buildout/buildout";
+    homepage = "https://www.buildout.org";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ superherointj ];
   };
 }

--- a/pkgs/development/python-modules/check-python-versions/default.nix
+++ b/pkgs/development/python-modules/check-python-versions/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchPypi
+, pyyaml
+, coverage, flake8, mypy, types-pyyaml, isort, check-manifest, check-python-versions
+}:
+
+buildPythonPackage rec {
+  pname = "check-python-versions";
+  version = "0.18.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6cc06a5ccc0b9efd8e3c9cbce0b3d6bf4aed3b78f22b9c66f90c4774008c04bf";
+  };
+
+  propagatedBuildInputs = [
+    pyyaml
+  ];
+
+  checkInputs = [
+    coverage
+    flake8
+    mypy
+    types-pyyaml
+    isort
+    check-manifest
+    (check-python-versions.overridePythonAttrs (oldAttrs: rec { doCheck = false; }))
+  ];
+
+  meta = with lib; {
+    description = "Check that supported Python versions in a setup.py match tox.ini, .travis.yml and a bunch of other files";
+    downloadPage = "https://pypi.org/project/check-python-versions/";
+    homepage = "https://github.com/mgedmin/check-python-versions/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/python-modules/coverage-python-version/default.nix
+++ b/pkgs/development/python-modules/coverage-python-version/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchzip
+, setuptools, pytest, twine, wheel, coverage
+}:
+
+buildPythonPackage rec {
+  pname = "coverage-python-version";
+  version = "0.2.0";
+
+  src = fetchzip {
+    url = "https://github.com/jayclassless/coverage_python_version/archive/refs/tags/${version}.zip";
+    sha256 = "0ip13n75qxjqy3v9nsmw3xg62nxbgwf435pavvmkk7cgwgqjscss";
+  };
+
+  propagatedBuildInputs = [
+    # from pyproject.toml
+    setuptools
+    # from requirements.txt
+    pytest
+    twine
+    wheel
+    # from setup.py
+    coverage
+  ];
+
+  meta = with lib; {
+    description = "A coverage.py plugin to facilitate exclusions based on Python version ";
+    downloadPage = "https://pypi.org/project/coverage-python-version/";
+    homepage = "https://github.com/jayclassless/coverage_python_version";
+    license = licenses.mit;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/python-modules/types-pyyaml/default.nix
+++ b/pkgs/development/python-modules/types-pyyaml/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "types-pyyaml";
+  version = "5.4.10";
+
+  src = fetchPypi {
+    pname = "types-PyYAML";
+    inherit version;
+    sha256 = "1d9e431e9f1f78a65ea957c558535a3b15ad67ea4912bce48a6c1b613dcf81ad";
+  };
+
+  meta = with lib; {
+    description = "Typing stubs for PyYAML";
+    longDescription = ''
+      This is a PEP 561 type stub package for the PyYAML package. It can be used by type-checking tools like mypy, PyCharm, pytype etc. to check code that uses PyYAML. The source for this package can be found at https://github.com/python/typeshed/tree/master/stubs/PyYAML. All fixes for types and metadata should be contributed there.
+    '';
+    downloadPage = "https://pypi.org/project/types-PyYAML/";
+    homepage = "https://github.com/python/typeshed/tree/master/stubs/PyYAML";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/python-modules/zope_bobo/default.nix
+++ b/pkgs/development/python-modules/zope_bobo/default.nix
@@ -1,0 +1,48 @@
+{ lib, buildPythonPackage, fetchPypi
+, webob, six
+, zope_bobodoctestumentation, setuptools, zc_buildout, flake8, check-manifest, check-python-versions, coverage, coverage-python-version, zope_testrunner
+}:
+
+buildPythonPackage rec {
+  pname = "zope_bobo";
+  version = "2.4.0";
+
+  src = fetchPypi {
+    pname = "bobo";
+    inherit version;
+    sha256 = "993711b05f4db31829fb85288be95d8d75228fa48987bda812ab54219490e3b3";
+  };
+
+  propagatedBuildInputs = [
+    webob
+    six
+  ];
+
+  checkInputs = [
+    zope_bobodoctestumentation
+    setuptools
+    (zc_buildout.overridePythonAttrs (oldAttrs: rec { doCheck = false; }))
+    flake8
+    check-manifest
+    check-python-versions
+    coverage
+    coverage-python-version
+    zope_testrunner
+  ];
+  checkPhase = ''
+    runHook preCheck
+    zope-testrunner --test-path=src
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "bobo" "boboserver" ];
+
+  meta = with lib; {
+    description = "A light-weight framework for creating WSGI web applications.";
+    longDescription = "Provides mapping URLs to objects and calling objects to generate HTTP responses.";
+    downloadPage = "https://pypi.org/project/bobo/";
+    homepage = "https://github.com/zopefoundation/bobo/";
+    license = licenses.zpl21;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/python-modules/zope_bobodoctestumentation/default.nix
+++ b/pkgs/development/python-modules/zope_bobodoctestumentation/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi
+, manuel, six, webtest, zope_testing
+}:
+
+buildPythonPackage rec {
+  pname = "zope_bobodoctestumentation";
+  version = "2.2.0";
+
+  src = fetchPypi {
+    pname = "bobodoctestumentation";
+    inherit version;
+    sha256 = "ad61cd5753c58351940dfdc9713d4c188bf51f7bd793626f82e6f1f93f328195";
+  };
+
+  propagatedBuildInputs = [
+    manuel
+    six
+    webtest
+    zope_testing
+  ];
+
+  meta = with lib; {
+    description = "Bobo tests and documentation";
+    downloadPage = "https://pypi.org/project/bobodoctestumentation/";
+    homepage = "https://github.com/zopefoundation/bobo/tree/master/bobodoctestumentation";
+    license = licenses.zpl21;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/python-modules/zope_zc_recipe_deployment/default.nix
+++ b/pkgs/development/python-modules/zope_zc_recipe_deployment/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchPypi
+, setuptools, six
+, zc_buildout, zope_testing, zope_testrunner
+}:
+
+buildPythonPackage rec {
+  pname = "zope_zc_recipe_deployment";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    pname = "zc.recipe.deployment";
+    inherit version;
+    sha256 = "003f7ef6c099cfdd9c4f11b00ec03343bd4ded947f131e8c666d0be966a59803";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    six
+  ];
+
+  checkInputs = [
+    zc_buildout
+    zope_testing
+    zope_testrunner
+  ];
+
+  meta = with lib; {
+    description = "ZC Buildout recipe for Unix deployments";
+    downloadPage = "https://pypi.org/project/zc.recipe.deployment/";
+    homepage = "https://github.com/zopefoundation/zc.recipe.deployment";
+    license = licenses.zpl21;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/python-modules/zope_zc_zdaemonrecipe/default.nix
+++ b/pkgs/development/python-modules/zope_zc_zdaemonrecipe/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchPypi
+, setuptools, zc_buildout, zconfig/*, zope_zc_recipe_egg */
+, six, zdaemon, zope_testing, zope_testrunner
+}:
+
+buildPythonPackage rec {
+  pname = "zope_zc_zdaemonrecipe";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    pname = "zc.zdaemonrecipe";
+    inherit version;
+    sha256 = "e89693f40655164c818f04ff7e70d858eae809598a0afea406f201d025722b43";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    zc_buildout
+    #zope_zc_recipe_egg # `zc.recipe.egg` is broken!
+    zconfig
+  ];
+
+  checkInputs = [
+    six
+    zdaemon
+    zope_testing
+    zope_testrunner
+  ];
+
+  meta = with lib; {
+    broken = true;
+    description = "ZC Buildout recipe for zdaemon scripts";
+    downloadPage = "https://pypi.org/project/zc.zdaemonrecipe";
+    homepage = "https://github.com/zopefoundation/zc.zdaemonrecipe";
+    license = licenses.zpl21;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9036,6 +9036,8 @@ in {
 
   types-pytz = callPackage ../development/python-modules/types-pytz { };
 
+  types-pyyaml = callPackage ../development/python-modules/types-pyyaml { };
+
   types-requests = callPackage ../development/python-modules/types-requests { };
 
   typesentry = callPackage ../development/python-modules/typesentry { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1427,6 +1427,8 @@ in {
 
   check-manifest = callPackage ../development/python-modules/check-manifest { };
 
+  check-python-versions = callPackage ../development/python-modules/check-python-versions { };
+
   cheetah3 = callPackage ../development/python-modules/cheetah3 { };
 
   cheroot = callPackage ../development/python-modules/cheroot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9760,6 +9760,8 @@ in {
 
   zope_zc_recipe_deployment = callPackage ../development/python-modules/zope_zc_recipe_deployment { };
 
+  zope_zc_zdaemonrecipe = callPackage ../development/python-modules/zope_zc_zdaemonrecipe { };
+
   zopfli = callPackage ../development/python-modules/zopfli { };
 
   zstandard = callPackage ../development/python-modules/zstandard { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9706,6 +9706,10 @@ in {
 
   zodbpickle = callPackage ../development/python-modules/zodbpickle { };
 
+  zope_bobo = callPackage ../development/python-modules/zope_bobo { };
+
+  zope_bobodoctestumentation = callPackage ../development/python-modules/zope_bobodoctestumentation { };
+
   zope_broken = callPackage ../development/python-modules/zope_broken { };
 
   zope_component = callPackage ../development/python-modules/zope_component { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1683,6 +1683,8 @@ in {
 
   coverage = callPackage ../development/python-modules/coverage { };
 
+  coverage-python-version = callPackage ../development/python-modules/coverage-python-version { };
+
   coveralls = callPackage ../development/python-modules/coveralls { };
 
   cozy = callPackage ../development/python-modules/cozy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9758,6 +9758,8 @@ in {
 
   zope_testrunner = callPackage ../development/python-modules/zope_testrunner { };
 
+  zope_zc_recipe_deployment = callPackage ../development/python-modules/zope_zc_recipe_deployment { };
+
   zopfli = callPackage ../development/python-modules/zopfli { };
 
   zstandard = callPackage ../development/python-modules/zstandard { };


### PR DESCRIPTION
Upgrade necessary because `setuptools` was upgraded to 54.2.0 and current `buildout` does not work with setuptools >52, see issue: https://github.com/buildout/buildout/issues/543

This is affecting downstream packages like [martian](https://pypi.org/project/martian/). See #136516 

---

On fixing tests:

My effort to fix `zc_buildout` tests failed. Because `zc_buildout` depends on `zope_zc_zdaemonrecipe` which depends on `zc.recipe.egg` which is broken!

7 python packages were ported in the process.
* Upstream all 6 *working* packages? [They are here in this PR.]
  * zope_bobo: init 2.4.0
  * zope_bobodoctestumentation: init 2.2.0
  * check-python-versions: init 0.18.1
  * coverage-python-version: init 0.2.0
  * types-pyyaml: init 5.4.10
  * zope_zc_recipe_deployment: init 1.3.0

* `zope_zc_zdaemonrecipe` is broken. Upstream to mark it as broken? (I wouldn't have wasted time if I knew it was broken.)