### PR TITLE
saleae-logic-2: 2.3.33 -> 2.3.37 + add lib dependencies

### DIFF
--- a/pkgs/development/tools/misc/saleae-logic-2/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic-2/default.nix
@@ -1,10 +1,10 @@
 { lib, fetchurl, appimageTools, gtk3 }:
 let
   name = "saleae-logic-2";
-  version = "2.3.33";
+  version = "2.3.37";
   src = fetchurl {
     url = "https://downloads.saleae.com/logic2/Logic-${version}-master.AppImage";
-    sha256 = "09vypl03gj58byk963flskzkhl4qrd9qw1kh0sywbqnzbzvj5cgm";
+    sha256 = "0jclzd4s1r6h2p1r0vhmzz3jnwpp7d41g70lcamrsxidxrmm8d45";
   };
 in
 appimageTools.wrapType2 {

--- a/pkgs/development/tools/misc/saleae-logic-2/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic-2/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, appimageTools }:
+{ lib, fetchurl, appimageTools, gtk3 }:
 let
   name = "saleae-logic-2";
   version = "2.3.33";
@@ -11,11 +11,47 @@ appimageTools.wrapType2 {
   inherit name src;
 
   extraInstallCommands =
-    let appimageContents = appimageTools.extractType2 { inherit name src; }; in
-    ''
-      mkdir -p $out/etc/udev/rules.d
-      cp ${appimageContents}/resources/linux/99-SaleaeLogic.rules $out/etc/udev/rules.d/
-    '';
+    let
+      appimageContents = appimageTools.extractType2 { inherit name src; };
+    in
+      ''
+        mkdir -p $out/etc/udev/rules.d
+        cp ${appimageContents}/resources/linux/99-SaleaeLogic.rules $out/etc/udev/rules.d/
+      '';
+
+  profile = ''
+    export XDG_DATA_DIRS="${gtk3}/share/gsettings-schemas/${gtk3.name}''${XDG_DATA_DIRS:+:"''$XDG_DATA_DIRS"}"
+  '';
+
+  extraPkgs = pkgs: with pkgs; [
+    wget
+    unzip
+    glib
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXtst
+    nss
+    nspr
+    dbus
+    gdk-pixbuf
+    gtk3
+    pango
+    atk
+    cairo
+    expat
+    xorg.libXrandr
+    xorg.libXScrnSaver
+    alsa-lib
+    at-spi2-core
+    cups
+  ];
 
   meta = with lib; {
     homepage = "https://www.saleae.com/";


### PR DESCRIPTION
###### Motivation for this change

The Saleae Logic 2 package's appimage was missing some library dependecies that caused it to crash when trying to interact with the system, e.g., trying to open or save a file using a file picker dialog box.

This PR adds the dependencies needed. I inspected the dependencies using `ldd` to determine what was needed, and have been using the app built from this derivation for more than a week without encountering issues.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
