### PR TITLE
mylvmbackup: init at 0.16

### DIFF
--- a/pkgs/tools/backup/mylvmbackup/default.nix
+++ b/pkgs/tools/backup/mylvmbackup/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchurl
+, perlPackages
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mylvmbackup";
+  version = "0.16";
+
+  src = fetchurl {
+    url = "${meta.homepage}/${pname}-${version}.tar.gz";
+    sha256 = "sha256-vb7M3EPIrxIz6jUwm241fzaEz2czqdCObrFgSOSgJRU=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ perlPackages.perl ];
+
+  dontConfigure = true;
+
+  postPatch = ''
+    patchShebangs mylvmbackup
+    substituteInPlace Makefile \
+      --replace "prefix = /usr/local" "prefix = ${builtins.placeholder "out"}" \
+      --replace "sysconfdir = /etc" "sysconfdir = ${builtins.placeholder "out"}/etc" \
+      --replace "/usr/bin/install" "install"
+  '';
+
+  postInstall = ''
+    wrapProgram "$out/bin/mylvmbackup" \
+      --prefix PERL5LIB : "${perlPackages.makePerlPath (
+    with perlPackages; [
+      ConfigIniFiles
+      DBDmysql
+      DBI
+      TimeDate
+      FileCopyRecursive
+    ]
+  )}"
+  '';
+
+  meta = {
+    homepage = "https://www.lenzg.net/mylvmbackup/";
+    description = "a tool for quickly creating full physical backups of a MySQL server's data files";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ ryantm ];
+    platforms = with lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7319,6 +7319,8 @@ with pkgs;
 
   mydumper = callPackage ../tools/backup/mydumper { };
 
+  mylvmbackup = callPackage ../tools/backup/mylvmbackup { };
+
   mysql2pgsql = callPackage ../tools/misc/mysql2pgsql { };
 
   mysqltuner = callPackage ../tools/misc/mysqltuner { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I use this Perl script to backup my mysql instances quickly.

###### Things done

* ran nixpkgs-hammering and nixpkgs-fmt

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
