### PR TITLE
rofi: 1.6.1 -> 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1318,6 +1318,12 @@
     githubId = 7346933;
     name = "betaboon";
   };
+  bew = {
+    email = "benoit.dechezelles@gmail.com";
+    github = "bew";
+    githubId = 9730330;
+    name = "Benoit de Chezelles";
+  };
   bfortz = {
     email = "bernard.fortz@gmail.com";
     github = "bfortz";

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1104,6 +1104,16 @@ Superuser created successfully.
           make the apps fit better visually.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>rofi</literal> has been updated from
+          <quote>1.6.1</quote> to <quote>1.7.0</quote>, one important
+          thing is the removal of the old xresources based configuration
+          setup. Read more
+          <link xlink:href="https://github.com/davatorium/rofi/blob/cb12e6fc058f4a0f4f/Changelog#L1">in
+          rofi’s changelog</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -316,3 +316,5 @@ To be able to access the web UI this port needs to be opened in the firewall.
 - `lib.formats.yaml`'s `generate` will not generate JSON anymore, but instead use more of the YAML-specific syntax.
 
 - GNOME desktop environment now enables `QGnomePlatform` as the Qt platform theme, which should avoid crashes when opening file chooser dialogs in Qt apps by using XDG desktop portal. Additionally, it will make the apps fit better visually.
+
+- `rofi` has been updated from '1.6.1' to '1.7.0', one important thing is the removal of the old xresources based configuration setup. Read more [in rofi's changelog](https://github.com/davatorium/rofi/blob/cb12e6fc058f4a0f4f/Changelog#L1).

--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -1,16 +1,35 @@
-{ stdenv, lib, fetchurl
-, autoreconfHook, pkg-config, libxkbcommon, pango, which, git
-, cairo, libxcb, xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification
-, bison, flex, librsvg, check
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, libxkbcommon
+, pango
+, which
+, git
+, cairo
+, libxcb
+, xcbutil
+, xcbutilwm
+, xcbutilxrm
+, xcb-util-cursor
+, libstartup_notification
+, bison
+, flex
+, librsvg
+, check
 }:
 
 stdenv.mkDerivation rec {
   pname = "rofi-unwrapped";
-  version = "1.6.1";
+  version = "1.7.0";
 
-  src = fetchurl {
-    url = "https://github.com/davatorium/rofi/releases/download/${version}/rofi-${version}.tar.gz";
-    sha256 = "04glljqbf9ckkc6x6fv4x1gqmy468n1agya0kd8rxdvz24wzf7cd";
+  src = fetchFromGitHub {
+    owner = "davatorium";
+    repo = "rofi";
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "03wdy56b3g8p2czb0qydrddyyhj3x037pirnhyqr5qbfczb9a63v";
   };
 
   preConfigure = ''
@@ -20,8 +39,22 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ libxkbcommon pango cairo git bison flex librsvg check
-    libstartup_notification libxcb xcbutil xcbutilwm xcbutilxrm which
+  buildInputs = [
+    libxkbcommon
+    pango
+    cairo
+    git
+    bison
+    flex
+    librsvg
+    check
+    libstartup_notification
+    libxcb
+    xcbutil
+    xcbutilwm
+    xcbutilxrm
+    xcb-util-cursor
+    which
   ];
 
   doCheck = false;
@@ -30,7 +63,7 @@ stdenv.mkDerivation rec {
     description = "Window switcher, run dialog and dmenu replacement";
     homepage = "https://github.com/davatorium/rofi";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ bew ];
     platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

:warning: This is my first contribution here :) :warning: 

###### Motivation for this change

The rofi package was not up to date :smiley: 

This PR adds a new dependancy on `xcb-util-cursor` which is now needed for the build. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).