### PR TITLE
megapixels: Fix schema compilation

### DIFF
--- a/pkgs/applications/graphics/megapixels/default.nix
+++ b/pkgs/applications/graphics/megapixels/default.nix
@@ -4,6 +4,7 @@
 , meson
 , ninja
 , pkg-config
+, glib
 , wrapGAppsHook
 , epoxy
 , gtk4
@@ -35,13 +36,23 @@ stdenv.mkDerivation rec {
     sha256 = "0jnfzwvq58p4ksyifma10i158r2fb7fv72ymibgcxbnx596xpjb2";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config wrapGAppsHook ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    glib
+    wrapGAppsHook
+  ];
 
   buildInputs = [
     epoxy
     gtk4
     zbar
   ];
+
+  postInstall = ''
+    glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
 
   preFixup = optionalString (tiffSupport || jpgSupport) ''
     gappsWrapperArgs+=(


### PR DESCRIPTION
###### Motivation for this change
https://todo.sr.ht/~martijnbraam/Megapixels/59

> > Is it intended that the schemas are not compiled anymore, or is that a regression? Is it up to the packagers to compile the schemas now, e.g. by running glib-compile-schemas ourselves, like shown in this comment: https://github.com/NixOS/nixpkgs/pull/132814#issuecomment-907863298?
> 
> It seems most distro's have a hook in the glib package that automatically recompiles the schemas when a package pushes new schemas.

We don't have such a hook (afaik?) so we need to manually compile the schemas.

CC @Mindavi who reported the missing schemas in https://github.com/NixOS/nixpkgs/pull/132814#issuecomment-907823954

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
