### PR TITLE
octoprint.python.pkgs.octolapse: init at 0.4.1

### DIFF
--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -420,6 +420,27 @@ in
     };
   };
 
+  octolapse = buildPlugin rec {
+    pname = "Octolapse";
+    version = "0.4.1";
+
+    src = fetchFromGitHub {
+      owner = "FormerLurker";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "13q20g7brabplc198jh67lk65rn140r8217iak9b2jy3in8fggv4";
+    };
+
+    propagatedBuildInputs = with super; [ awesome-slugify setuptools pillow sarge six psutil file_read_backwards ];
+
+    meta = with lib; {
+      description = "Stabilized timelapses for Octoprint";
+      homepage = "https://github.com/FormerLurker/OctoLapse";
+      license = licenses.agpl3Plus;
+      maintainers = with maintainers; [ illustris j0hax ];
+    };
+  };
+
   octoprint-dashboard = buildPlugin rec {
     pname = "OctoPrint-Dashboard";
     version = "1.18.3";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -431,7 +431,10 @@ in
       sha256 = "13q20g7brabplc198jh67lk65rn140r8217iak9b2jy3in8fggv4";
     };
 
-    propagatedBuildInputs = with super; [ awesome-slugify setuptools pillow sarge six psutil file_read_backwards ];
+    # Test fails due to code executed on import, see #136513
+    #pythonImportsCheck = [ "octoprint_octolapse" ];
+
+    propagatedBuildInputs = with super; [ awesome-slugify setuptools pillow sarge six psutil file-read-backwards ];
 
     meta = with lib; {
       description = "Stabilized timelapses for Octoprint";

--- a/pkgs/development/python-modules/file-read-backwards/default.nix
+++ b/pkgs/development/python-modules/file-read-backwards/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, mock }:
+
+buildPythonPackage rec {
+  pname = "file-read-backwards";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    pname = "file_read_backwards";
+    inherit version;
+    sha256 = "fd50d9089b412147ea3c6027e2ad905f977002db2918cf315d64eed23d6d6eb8";
+  };
+
+  checkInputs = [ mock ];
+  pythonImportsCheck = [ "file_read_backwards" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/RobinNil/file_read_backwards";
+    description = "Memory efficient way of reading files line-by-line from the end of file";
+    license = licenses.mit;
+    maintainers = with maintainers; [ j0hax ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2796,6 +2796,8 @@ in {
 
   fields = callPackage ../development/python-modules/fields { };
 
+  file-read-backwards = callPackage ../development/python-modules/file-read-backwards { };
+
   filebrowser_safe = callPackage ../development/python-modules/filebrowser_safe { };
 
   filebytes = callPackage ../development/python-modules/filebytes { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package the popular Octolapse plugin along with an additional python dependency

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
