### PR TITLE
emacsMacport: apply patch-mac in prePatch instead of postPatch

### DIFF
--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     tar xzfv $hiresSrc --strip 1 -C $sourceRoot
   '';
 
-  postPatch = ''
+  prePatch = ''
     patch -p1 < patch-mac
     substituteInPlace lisp/international/mule-cmds.el \
       --replace /usr/share/locale ${gettext}/share/locale


### PR DESCRIPTION
This allows the normal patch phase to operate on the source with the Mac
patches already applied, so you can use the regular "patches" attribute to
apply patches to Mac-specific files.

###### Motivation for this change

I wanted to write a personal override to apply a patch to `macterm.c` -- a file that only exists *after* `patch -p1 <patch-mac` happens -- and I was mildly annoyed that I couldn't just do it with the normal `patches` mechanism.

This is minor, as it was very easy to make this change in my own override, but `prePatch` seems more appropriate for this step anyway.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
