### PR TITLE
pythonPackages.martian: init 1.4

### DIFF
--- a/pkgs/development/python-modules/martian/default.nix
+++ b/pkgs/development/python-modules/martian/default.nix
@@ -1,0 +1,45 @@
+{ lib, buildPythonPackage, fetchPypi, callPackage
+, setuptools, zc_buildout, zope_interface, six
+# tox, zope_testing, zope_testrunner, coverage#, zc_recipe_testrunner
+}:
+
+buildPythonPackage rec {
+  pname = "martian";
+  version = "1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b4b48f3004f9b30789ef4fba7bb5748ff0522a80d9906b78e61fa7d1ae060883";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    zc_buildout
+    zope_interface
+    six
+  ];
+
+  # checkInputs = [
+  #   #zc_recipe_testrunner # Missing dependency blocked on 'zc.recipe.egg'
+  #   zope_testing
+  #   tox
+  #   coverage
+  #   zope_testrunner
+  # ];
+  # checkPhase = ''
+  #   runHook preCheck
+  #   zope-testrunner --test-path=src []
+  #   runHook postCheck
+  # '';
+  doCheck = false;
+
+  pythonImportsCheck = [ "martian" ];
+
+  meta = with lib; {
+    description = "A library to embed configuration information in Python code";
+    downloadPage = "https://pypi.org/project/martian/";
+    homepage = "https://github.com/zopefoundation/martian";
+    license = licenses.zpl21;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4413,6 +4413,8 @@ in {
 
   marshmallow-sqlalchemy = callPackage ../development/python-modules/marshmallow-sqlalchemy { };
 
+  martian = callPackage ../development/python-modules/martian { };
+
   mask-rcnn = callPackage ../development/python-modules/mask-rcnn { };
 
   mastodon-py = callPackage ../development/python-modules/mastodon-py { };


### PR DESCRIPTION
pythonPackages.martian: init 1.4

Review & merge `zc_buildout` (https://github.com/NixOS/nixpkgs/pull/136491) before this.

`martian` *tests are blocked* on `zc_recipe_testrunner` which is blocked on `zc.recipe.egg`.
My hopes of fixing tests here are gone. Unless you know a solution to `zc.recipe.egg` issue.