### PR TITLE
gnome-todo: patch build race away

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-todo/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-todo/default.nix
@@ -33,6 +33,14 @@ stdenv.mkDerivation rec {
     sha256 = "1r94880d4khbjhhfnhaba3y3d4hv2bri82rzfzxn27s5iybpqras";
   };
 
+  patches = [
+    # fix build race bug https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=257667
+    (fetchpatch {
+      url = "https://cgit.freebsd.org/ports/patch/?id=a4faaf6cf7835014b5f69a337b544ea4ee7f9655";
+      sha256 = "sha256-IMBfqtrqBw3DdmJG0qchZFR6Am1PICMnM5P6BcS8oqI=";
+    })
+  ];
+
   nativeBuildInputs = [
     meson
     ninja


### PR DESCRIPTION

###### Motivation for this change

Only sometimes on a server with 12 cpu cores I get the below error

Seems like a parallel build race

```
error: builder for '/nix/store/xrwjhd1cbh7172chmxnc10nv02kszb3l-gnome-todo-40.0.drv' failed with exit code 1;
       last 10 log lines:
       > build flags: -j12 -l12
       > [27/214] Compiling C object src/plugins/libplugins.a.p/all-tasks-panel_gtd-all-tasks-panel.c.oks-panel-resources.c.o
       > FAILED: src/plugins/libplugins.a.p/all-tasks-panel_gtd-all-tasks-panel.c.o
       > gcc -Isrc/plugins/libplugins.a.p -Isrc/plugins -I../src/plugins -I../src/animation -I../src/core -Isrc/gui -I../src/gui -I../src/models -Isrc -I../src -Isrc/plugins/all-tasks-panel -Isrc/plugins/background -Isrc/plugins/dark-theme -Isrc/plugins/eds -Isrc/plugins/inbox-panel -Isrc/plugins/next-week-panel -Isrc/plugins/night-light -Isrc/plugins/peace -Isrc/plugins/task-lists-workspace -Isrc/plugins/today-panel -Isrc/plugins/welcome -I/nix/store/ifrd1cxpxqx8iwmnc57z4hrxhln01rbw-glib-2.68.3-dev/include/glib-2.0 -I/nix/store/94iv84rv2d1cl0fk1l1mkmmbnxg7fyzz-glib-2.68.3/lib/glib-2.0/include -I/nix/store/ifrd1cxpxqx8iwmnc57z4hrxhln01rbw-glib-2.68.3-dev/include -I/nix/store/lbjfdhiar0b3qz48kw07gs1mni27kfv9-gtk4-4.2.1-dev/include/gtk-4.0 -I/nix/store/7i0zq8rd4wadxy3r0b18ga3cmc793gr8-cairo-1.16.0-dev/include/cairo -I/nix/store/i3jmkg9hwb9ss6c8mwlwxvqpldl2px6q-freetype-2.11.0-dev/include/freetype2 -I/nix/store/i3jmkg9hwb9ss6c8mwlwxvqpldl2px6q-freetype-2.11.0-dev/include -I/nix/store/avwgxwkdxal2gir7pznb4k65xxnkv9kx-gdk-pixbuf-2.42.6-dev/include/gdk-pixbuf-2.0 -I/nix/store/ajak80hbfrrppykc8mj4jxc9wh5ndybz-graphene-1.10.6/include/graphene-1.0 -I/nix/store/ajak80hbfrrppykc8mj4jxc9wh5ndybz-graphene-1.10.6/lib/graphene-1.0/include -I/nix/store/gpvwn9wl6x4cg8jfr2njj7cxyk8zk6v0-pango-1.48.5-dev/include/pango-1.0 -I/nix/store/q2hi3bjmacy1wjvm758fd0cd29vl1d7k-harfbuzz-2.8.2-dev/include/harfbuzz -I/nix/store/c1z9373m42wv2d0wj5qmdac72sayf37n-vulkan-headers-1.2.182.0/include -I/nix/store/yphqc4kynppqmasmysxjpzzgv552psq9-libadwaita-1.0.0-alpha.1-dev/include/libadwaita-1 -I/nix/store/9zwmk1fvrrbw5vdp5591ca8nq4f1v4al-gnome-online-accounts-3.40.0-dev/include/goa-1.0 -I/nix/store/jg655mm6pldbk7k3wnixn7dp41ga1920-gnome-online-accounts-3.40.0/lib/goa-1.0/include -I/nix/store/pnv64z2syqg3hv9yjs41wprn5dw8cx54-libpeas-1.30.0-dev/include/libpeas-1.0 -I/nix/store/wyn9sba9cklqi5ddk0p34n0rqzpjpz4p-gobject-introspection-1.68.0-dev/include/gobject-introspection-1.0 -I/nix/store/nbf745slz7241fl5gxcljd6lf6higf6x-libportal-0.4-dev/include -I/nix/store/mi6l0a0lcirlvnri7n05a6jvrlyyan1k-evolution-data-server-3.40.4-dev/include/evolution-data-server -I/nix/store/38l3kxa7h95nr7c8ipsxw9ww2x2lbg6s-libsecret-0.20.4-dev/include/libsecret-1 -I/nix/store/bzad4zrz48nxp23dhcvwy0hzrb51xyk8-libical-3.0.10-dev/include -I/nix/store/30hpnxn445n7ja8nx78rimhjzy73pmz9-libsoup-2.72.0-dev/include/libsoup-2.4 -I/nix/store/q8xy99la4sn3ak4h4l0gram0k3d1j2q6-libxml2-2.9.12-dev/include/libxml2 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -DHAVE_CONFIG_H -fPIC -pthread -mfpmath=sse -msse -msse2 -mfpmath=sse -msse -msse2 -MD -MQ src/plugins/libplugins.a.p/all-tasks-panel_gtd-all-tasks-panel.c.o -MF src/plugins/libplugins.a.p/all-tasks-panel_gtd-all-tasks-panel.c.o.d -o src/plugins/libplugins.a.p/all-tasks-panel_gtd-all-tasks-panel.c.o -c ../src/plugins/all-tasks-panel/gtd-all-tasks-panel.c
       > In file included from ../src/plugins/all-tasks-panel/gtd-all-tasks-panel.c:26:
       > ../src/gnome-todo.h:24:10: fatal error: gtd-enum-types.h: No such file or directory
       >    24 | #include "gtd-enum-types.h"
       >       |          ^~~~~~~~~~~~~~~~~~
       > compilation terminated.
       > ninja: build stopped: subcommand failed.
```
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
