### PR TITLE
chatty: 0.3.2 -> 0.3.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatty/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatty/default.nix
@@ -24,14 +24,14 @@
 
 stdenv.mkDerivation rec {
   pname = "chatty";
-  version = "0.3.2";
+  version = "0.3.4";
 
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "chatty";
     rev = "v${version}";
-    sha256 = "sha256-/l8hysfBmXLbs2COIVjdr2JC1qX/c66DqOm2Gyqb9s8=";
+    sha256 = "0910f5bw75ph576gxbsd6ysdwnlk4ysdp0pml2i3mjqpcbkqfs3w";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
https://source.puri.sm/Librem5/chatty/-/tags/v0.3.4

Changelog: https://source.puri.sm/Librem5/chatty/-/commit/7cbabfb1f6a1b0f63c683cd6430fe95bb313c199 .

Tested to work on my Pinephone with https://source.puri.sm/Librem5/purple-mm-sms.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
