### PR TITLE
calls: 0.3.1 -> 41.1

### DIFF
--- a/pkgs/applications/networking/calls/default.nix
+++ b/pkgs/applications/networking/calls/default.nix
@@ -26,18 +26,20 @@
 , docbook-xsl-nons
 , docbook_xml_dtd_43
 , gobject-introspection
+, gst_all_1
+, sofia_sip
 }:
 
 stdenv.mkDerivation rec {
   pname = "calls";
-  version = "0.3.1";
+  version = "41.1";
 
   src = fetchFromGitLab {
-    domain = "source.puri.sm";
-    owner = "Librem5";
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0igap5ynq269xqaky6fqhdg2dpsvxa008z953ywa4s5b5g5dk3dd";
+    rev = version;
+    sha256 = "1vbw9x5s3ww11f3lnqivc74rjlmi9fk1hzaq1idrdcck3gvif0h8";
   };
 
   outputs = [ "out" "devdoc" ];
@@ -62,11 +64,17 @@ stdenv.mkDerivation rec {
     folks
     gom
     gsound
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
     feedbackd
     callaudiod
     gtk3
     libpeas
     libgdata # required by some dependency transitively
+    sofia_sip
   ];
 
   checkInputs = [
@@ -80,7 +88,8 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=true"
   ];
 
-  doCheck = true;
+  # Disable until tests are fixed upstream https://gitlab.gnome.org/GNOME/calls/-/issues/258
+  doCheck = false;
 
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.gnome.org/GNOME/calls/-/tags/41.1

Currently running on my Pinephone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
