### PR TITLE
video/cast-control: init at 0.11.4

### DIFF
--- a/pkgs/applications/video/cast_control/default.nix
+++ b/pkgs/applications/video/cast_control/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, python3
+}:
+with python3.pkgs; buildPythonApplication rec {
+  pname = "cast_control";
+  version = "0.11.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gsznsd9w8pvbrny0x41wsblgllknvrhcrz3qg1jn7f98phkixas";
+  };
+
+  # No tests included
+  #doCheck = false;
+
+  propagatedBuildInputs = [
+    aiopath
+    appdirs
+    click
+    daemons
+    mpris-server
+    PyChromecast
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/alexdelorenzo/cast_control/";
+    description = "Control Chromecasts from Linux and D-Bus";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ tomfitzhenry ];
+  };
+}

--- a/pkgs/development/python-modules/aiofile/default.nix
+++ b/pkgs/development/python-modules/aiofile/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchPypi, buildPythonPackage, caio }:
+
+buildPythonPackage rec {
+  pname = "aiofile";
+  version = "3.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hcjgx8bxhkc30i45w8qsbyp2pqzqsmci3aa69xf3fp3zjw3i3q6";
+  };
+
+  propagatedBuildInputs = [
+    caio
+  ];
+
+  # no tests available
+  #doCheck = false;
+  #pythonImportsCheck = [ "pychromecast" ];
+
+  meta = with lib; {
+    description = "Real asynchronous file operations with asyncio support.";
+    homepage    = "https://github.com/mosquito/aiofile";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/aiopath/default.nix
+++ b/pkgs/development/python-modules/aiopath/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchPypi, buildPythonPackage, aiofile, anyio, typing-extensions }:
+
+buildPythonPackage rec {
+  pname = "aiopath";
+  version = "0.5.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r0xnba1vz3iyrqkhkrckkrphnzblvsms9pvk8krm2q9vl0r8byy";
+  };
+
+  propagatedBuildInputs = [
+    aiofile
+    anyio
+    typing-extensions
+  ];
+
+  # no tests available
+  #doCheck = false;
+  #pythonImportsCheck = [ "pychromecast" ];
+
+  meta = with lib; {
+    description = "Async pathlib for Python";
+    homepage    = "https://github.com/alexdelorenzo/aiopath";
+    license     = licenses.lgpl3Only;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/caio/default.nix
+++ b/pkgs/development/python-modules/caio/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "caio";
+  version = "0.9.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0h3a7agljnkrg4aaia3rwz58mxgzl5mcdb68r75avfmq130b0iif";
+  };
+
+  # no tests available
+  #doCheck = false;
+  #pythonImportsCheck = [ "" ];
+
+  meta = with lib; {
+    description = "Asynchronous file IO for Linux POSIX and Windows.";
+    homepage    = "https://github.com/mosquito/caio";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/daemons/default.nix
+++ b/pkgs/development/python-modules/daemons/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "daemons";
+  version = "1.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0cvyhrna1djpcjp957f46lpzgzxxpp4mhm12xhg8q3cf9pcv3nip";
+  };
+
+  # no tests available
+  #doCheck = false;
+  #pythonImportsCheck = [ "pychromecast" ];
+
+  meta = with lib; {
+    description = "Well behaved unix daemons for every occasion.";
+    homepage    = "https://github.com/kevinconway/daemons";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/mpris-server/default.nix
+++ b/pkgs/development/python-modules/mpris-server/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchPypi, buildPythonPackage, emoji, pygobject3, unidecode, typing-extensions, pydbus }:
+
+buildPythonPackage rec {
+  pname = "mpris_server";
+  version = "0.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wgipcp53nz5klr0cgi0gz2bsnyhz3jmxkmbg1kd8cnf8zrwqyd7";
+  };
+
+  propagatedBuildInputs = [
+    emoji
+    pydbus
+    pygobject3
+    typing-extensions
+    unidecode
+  ];
+
+  # no tests available
+  #doCheck = false;
+  #pythonImportsCheck = [ "pychromecast" ];
+
+  meta = with lib; {
+    description = "Publish a MediaPlayer2 MPRIS device to D-Bus.";
+    homepage    = "https://github.com/alexdelorenzo/mpris_server/";
+    license     = licenses.agpl3Plus;
+    maintainers = with maintainers; [ tomfitzhenry ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -217,6 +217,8 @@ with pkgs;
 
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
+  cast_control = callPackage ../applications/video/cast_control { };
+
   castget = callPackage ../applications/networking/feedreaders/castget { };
 
   castxml = callPackage ../development/tools/castxml {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4664,6 +4664,8 @@ in {
 
   mpmath = callPackage ../development/python-modules/mpmath { };
 
+  mpris-server = callPackage ../development/python-modules/mpris-server { };
+
   mpv = callPackage ../development/python-modules/mpv {
     inherit (pkgs) mpv;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -339,6 +339,8 @@ in {
 
   aionotion = callPackage ../development/python-modules/aionotion { };
 
+  aiopath = callPackage ../development/python-modules/aiopath { };
+
   aiopg = callPackage ../development/python-modules/aiopg { };
 
   aioprocessing = callPackage ../development/python-modules/aioprocessing { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1792,6 +1792,8 @@ in {
 
   dacite = callPackage ../development/python-modules/dacite { };
 
+  daemons = callPackage ../development/python-modules/daemons { };
+
   daemonize = callPackage ../development/python-modules/daemonize { };
 
   daemonocle = callPackage ../development/python-modules/daemonocle { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -271,6 +271,8 @@ in {
 
   aioextensions = callPackage ../development/python-modules/aioextensions { };
 
+  aiofile = callPackage ../development/python-modules/aiofile { };
+  
   aiofiles = callPackage ../development/python-modules/aiofiles { };
 
   aioflo = callPackage ../development/python-modules/aioflo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1303,6 +1303,8 @@ in {
     inherit (self) python numpy boost;
   });
 
+  caio = callPackage ../development/python-modules/caio { };
+
   cairocffi = callPackage ../development/python-modules/cairocffi { };
 
   cairosvg = callPackage ../development/python-modules/cairosvg { };


### PR DESCRIPTION
###### Motivation for this change
Add https://github.com/alexdelorenzo/cast_control , a daemon to control Chromecast via the Freedesktop MPRIS standard.

This allows Pinephone/Phosh users to pause/play Chromecasts.

WIP.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
