### PR TITLE
python3Packages.dpath: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/development/python-modules/dpath/default.nix
+++ b/pkgs/development/python-modules/dpath/default.nix
@@ -1,24 +1,38 @@
-{ lib, fetchPypi, buildPythonPackage, isPy27
-, mock, pytestCheckHook, nose, hypothesis
+{ lib
+, buildPythonPackage
+, fetchPypi
+, hypothesis
+, isPy27
+, mock
+, nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "dpath";
-  version = "2.0.1";
+  version = "2.0.2";
+
   disabled = isPy27; # uses python3 imports
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bea06b5f4ff620a28dfc9848cf4d6b2bfeed34238edeb8ebe815c433b54eb1fa";
+    sha256 = "sha256-BA2+ShAeG2sbZenaJYU08PCwrgCjsf0tWS/oV5/4N64=";
   };
 
   # use pytest as nosetests hangs
-  checkInputs = [ mock nose pytestCheckHook hypothesis ];
+  checkInputs = [
+    hypothesis
+    mock
+    nose
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "dpath" ];
 
   meta = with lib; {
+    description = "Python library for accessing and searching dictionaries via /slashed/paths ala xpath";
     homepage = "https://github.com/akesterson/dpath-python";
-    license = [ licenses.mit ];
-    description = "A python library for accessing and searching dictionaries via /slashed/paths ala xpath";
-    maintainers = [ maintainers.mmlb ];
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ mmlb ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.2

Change log: https://github.com/dpath-maintainers/dpath-python/releases/tag/v2.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
