### PR TITLE
domoticz: 2020.2 -> 2021.1

### DIFF
--- a/pkgs/servers/domoticz/default.nix
+++ b/pkgs/servers/domoticz/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv,
-  fetchzip,
+  fetchFromGitHub,
   makeWrapper,
   cmake,
   python3,
@@ -17,29 +17,17 @@
   cereal
 }:
 
-let
-  version = "2020.2";
-  minizip = "f5282643091dc1b33546bb8d8b3c23d78fdba231";
-
-  domoticz-src = fetchzip {
-    url = "https://github.com/domoticz/domoticz/archive/${version}.tar.gz";
-    sha256 = "1b4pkw9qp7f5r995vm4xdnpbwi9vxjyzbnk63bmy1xkvbhshm0g3";
-  };
-
-  minizip-src = fetchzip {
-    url = "https://github.com/domoticz/minizip/archive/${minizip}.tar.gz";
-    sha256 = "1vddrzm4pwl14bms91fs3mbqqjhcxrmpx9a68b6nfbs20xmpnsny";
-  };
-in
 stdenv.mkDerivation rec {
   pname = "domoticz";
-  inherit version;
+  version = "2021.1";
 
-  src = domoticz-src;
-
-  postUnpack = ''
-    cp -r ${minizip-src}/* $sourceRoot/extern/minizip
-  '';
+  src = fetchFromGitHub {
+    owner = "domoticz";
+    repo = pname;
+    rev = version;
+    sha256 = "03s1fx2ilhiq47p99c6iln1fi0rhdcxxsrv1zaww7f7bc744vzbk";
+    fetchSubmodules = true;
+  };
 
   buildInputs = [
     openssl


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix the package build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>domoticz</li>
  </ul>
</details>
