### PR TITLE
treewide: move gfortran to nativeBuildInputs

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -61,6 +61,7 @@ mkDerivation rec {
     ninja
     pkg-config
     pyside2-tools
+    gfortran
     wrapQtAppsHook
   ];
 
@@ -69,7 +70,6 @@ mkDerivation rec {
     boost
     coin3d
     eigen
-    gfortran
     gts
     hdf5
     libGLU

--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -27,9 +27,15 @@ in stdenv.mkDerivation {
     ./openblasPath.patch
   ];
 
-  nativeBuildInputs = [ perl cmake texlive.combined.scheme-minimal makeWrapper ];
-  buildInputs = [
+  nativeBuildInputs = [
+    perl
     gfortran
+    cmake
+    texlive.combined.scheme-minimal
+    makeWrapper
+  ];
+
+  buildInputs = [
     openblas
     hdf5-cpp
     python

--- a/pkgs/applications/science/chemistry/quantum-espresso/default.nix
+++ b/pkgs/applications/science/chemistry/quantum-espresso/default.nix
@@ -21,10 +21,12 @@ stdenv.mkDerivation rec {
     patchShebangs configure
   '';
 
-  buildInputs = [ fftw blas lapack gfortran ]
+  nativeBuildInputs = [ gfortran ];
+
+  buildInputs = [ fftw blas lapack ]
     ++ (lib.optionals useMpi [ mpi ]);
 
-configureFlags = if useMpi then [ "LD=${mpi}/bin/mpif90" ] else [ "LD=${gfortran}/bin/gfortran" ];
+  configureFlags = if useMpi then [ "LD=${mpi}/bin/mpif90" ] else [ "LD=${gfortran}/bin/gfortran" ];
 
   makeFlags = [ "all" ];
 

--- a/pkgs/applications/science/chemistry/siesta/default.nix
+++ b/pkgs/applications/science/chemistry/siesta/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation {
     inherit mpi;
   };
 
-  buildInputs = [ blas lapack gfortran ]
+  nativeBuildInputs = [ gfortran ];
+
+  buildInputs = [ blas lapack ]
     ++ lib.optionals useMpi [ mpi scalapack ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/science/math/csdp/default.nix
+++ b/pkgs/applications/science/math/csdp/default.nix
@@ -8,7 +8,9 @@ stdenv.mkDerivation {
     sha256 = "1f9ql6cjy2gwiyc51ylfan24v1ca9sjajxkbhszlds1lqmma8n05";
   };
 
-  buildInputs = [ blas gfortran.cc.lib lapack ];
+  nativeBuildInputs = [ gfortran ];
+
+  buildInputs = [ blas lapack ];
 
   postPatch = ''
     substituteInPlace Makefile --replace /usr/local/bin $out/bin

--- a/pkgs/applications/science/math/jags/default.nix
+++ b/pkgs/applications/science/math/jags/default.nix
@@ -6,7 +6,11 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/mcmc-jags/${name}.tar.gz";
     sha256 = "1z3icccg2ic56vmhyrpinlsvpq7kcaflk1731rgpvz9bk1bxvica";
   };
-  buildInputs = [gfortran blas lapack];
+
+  nativeBuildInputs = [ gfortran ];
+
+  buildInputs = [ blas lapack ];
+
   configureFlags = [ "--with-blas=-lblas" "--with-lapack=-llapack" ];
 
   meta = with lib; {

--- a/pkgs/applications/science/math/scilab/default.nix
+++ b/pkgs/applications/science/math/scilab/default.nix
@@ -19,11 +19,12 @@ stdenv.mkDerivation rec {
     sha256 = "1adk6jqlj7i3gjklvlf1j3il1nb22axnp4rvwl314an62siih0sc";
   };
 
-  buildInputs = [gfortran ncurses]
-  ++ lib.optionals withGtk [gtk2]
-  ++ lib.optionals withOCaml [ocaml]
-  ++ lib.optional withX xlibsWrapper
-  ;
+  nativeBuildInputs = [ gfortran ];
+
+  buildInputs = [ ncurses ]
+    ++ lib.optionals withGtk [ gtk2 ]
+    ++ lib.optionals withOCaml [ ocaml ]
+    ++ lib.optional withX xlibsWrapper;
 
 
 /*

--- a/pkgs/applications/science/molecular-dynamics/dl-poly-classic/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/dl-poly-classic/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation {
     sha256 = "1r76zvln3bwycxlmqday0sqzv5j260y7mdh66as2aqny6jzd5ld7";
   };
 
-  buildInputs = [ mpi gfortran ];
+  nativeBuildInputs = [ gfortran ];
+
+  buildInputs = [ mpi ];
 
   configurePhase = ''
     cd source

--- a/pkgs/applications/science/physics/elmerfem/default.nix
+++ b/pkgs/applications/science/physics/elmerfem/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  nativeBuildInputs = [ cmake pkg-config git ];
-  buildInputs = [ gfortran mpi blas liblapack qt4 qwt6_qt4 ];
+  nativeBuildInputs = [ cmake gfortran pkg-config git ];
+  buildInputs = [ mpi blas liblapack qt4 qwt6_qt4 ];
 
   preConfigure = ''
     patchShebangs ./

--- a/pkgs/applications/science/physics/sherpa/default.nix
+++ b/pkgs/applications/science/physics/sherpa/default.nix
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
     sed -ie '/sys\/sysctl.h/d' ATOOLS/Org/Run_Parameter.C
   '';
 
-  buildInputs = [ gfortran sqlite lhapdf rivet ];
+
+  nativeBuildInputs = [ gfortran ];
+
+  buildInputs = [ sqlite lhapdf rivet ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -370,9 +370,11 @@ in rec {
                 ./009_remove_signedness_verifier.patch ./010_mx_substratevm.py
               ];
 
+    nativeBuildInputs = [ gfortran ];
+
     buildInputs = [ mx zlib.dev mercurial jvmci8 git llvm clang
                     python27withPackages icu ruby bzip2 which
-                    readline bzip2 xz pcre curl ed gfortran
+                    readline bzip2 xz pcre curl ed
                   ]  ++ lib.optional stdenv.isDarwin [
                     CoreFoundation gcc.cc.lib libiconv perl openssl
                   ];

--- a/pkgs/development/libraries/eccodes/default.nix
+++ b/pkgs/development/libraries/eccodes/default.nix
@@ -17,13 +17,13 @@ stdenv.mkDerivation rec {
     substituteInPlace cmake/FindOpenJPEG.cmake --replace openjpeg-2.1 ${openjpeg.incDir}
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake gfortran ];
 
   buildInputs = [ netcdf
                   openjpeg
                   libpng
-                  gfortran
                 ];
+
   propagatedBuildInputs = optionals enablePython [
                   pythonPackages.python
                   pythonPackages.numpy

--- a/pkgs/development/libraries/globalarrays/default.nix
+++ b/pkgs/development/libraries/globalarrays/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0bky91ncz6vy0011ps9prsnq9f4a5s5xwr23kkmi39xzg0417mnd";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ mpi blas gfortran openssh ];
+  nativeBuildInputs = [ autoreconfHook gfortran ];
+  buildInputs = [ mpi blas openssh ];
 
   preConfigure = ''
     configureFlagsArray+=( "--enable-i8" \

--- a/pkgs/development/libraries/libxc/default.nix
+++ b/pkgs/development/libraries/libxc/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cy3x2zn1bldc5i0rzislfbc8h4nqgds445jkfqjv0d1shvdy0zn";
   };
 
-  buildInputs = [ gfortran ];
-  nativeBuildInputs = [ perl cmake ];
+  nativeBuildInputs = [ perl cmake gfortran ];
 
   preConfigure = ''
     patchShebangs ./

--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation  rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ perl gfortran openssh hwloc ]
+  nativeBuildInputs = [ gfortran ];
+  buildInputs = [ perl openssh hwloc ]
     ++ lib.optional (!stdenv.isDarwin) ch4backend;
 
   doCheck = true;

--- a/pkgs/development/libraries/mvapich/default.nix
+++ b/pkgs/development/libraries/mvapich/default.nix
@@ -21,13 +21,12 @@ stdenv.mkDerivation rec {
     sha256 = "0jd28vy9ivl3rcpkxmhw73b6krzm0pd9jps8asw92wa00lm2z9mk";
   };
 
-  nativeBuildInputs = [ pkg-config bison makeWrapper ];
+  nativeBuildInputs = [ pkg-config bison makeWrapper gfortran ];
   propagatedBuildInputs = [ numactl rdma-core zlib opensm ];
   buildInputs = with lib; [
     numactl
     libxml2
     perl
-    gfortran
     openssh
     hwloc
   ] ++ optionals (network == "infiniband") [ rdma-core opensm ]

--- a/pkgs/development/libraries/netcdf-fortran/default.nix
+++ b/pkgs/development/libraries/netcdf-fortran/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "00qwg4v250yg8kxp68srrnvfbfim241fnlm071p9ila2mihk8r01";
   };
 
-  buildInputs = [ netcdf hdf5 curl gfortran ];
+  nativeBuildInputs = [ gfortran ];
+  buildInputs = [ netcdf hdf5 curl ];
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -46,14 +46,14 @@ in stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ zlib ]
-    ++ lib.optionals fortranSupport [ gfortran ]
     ++ lib.optionals stdenv.isLinux [ libnl numactl pmix ucx ]
     ++ lib.optionals cudaSupport [ cudatoolkit ]
     ++ [ libevent hwloc ]
     ++ lib.optional (stdenv.isLinux || stdenv.isFreeBSD) rdma-core
     ++ lib.optional fabricSupport [ libpsm2 libfabric ];
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ perl ]
+    ++ lib.optionals fortranSupport [ gfortran ];
 
   configureFlags = lib.optional (!cudaSupport) "--disable-mca-dso"
     ++ lib.optional (!fortranSupport) "--disable-mpi-fortran"

--- a/pkgs/development/libraries/physics/applgrid/default.nix
+++ b/pkgs/development/libraries/physics/applgrid/default.nix
@@ -9,8 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1yw9wrk3vjv84kd3j4s1scfhinirknwk6xq0hvj7x2srx3h93q9p";
   };
 
+  nativeBuildInputs = [ gfortran ];
+
   # For some reason zlib was only needed after bump to gfortran8
-  buildInputs = [ gfortran hoppet lhapdf root5 zlib ];
+  buildInputs = [ hoppet lhapdf root5 zlib ];
 
   patches = [
     ./bad_code.patch

--- a/pkgs/development/libraries/physics/herwig/default.nix
+++ b/pkgs/development/libraries/physics/herwig/default.nix
@@ -9,9 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "10y3fb33zsinr0z3hzap9rsbcqhy1yjqnv4b4vz21g7mdlw6pq2k";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ autoconf automake libtool gfortran ];
 
-  buildInputs = [ boost fastjet gfortran gsl thepeg zlib ]
+  buildInputs = [ boost fastjet gsl thepeg zlib ]
     # There is a bug that requires for default PDF's to be present during the build
     ++ (with lhapdf.pdf_sets; [ CT14lo CT14nlo ]);
 

--- a/pkgs/development/libraries/physics/hoppet/default.nix
+++ b/pkgs/development/libraries/physics/hoppet/default.nix
@@ -9,8 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0j7437rh4xxbfzmkjr22ry34xm266gijzj6mvrq193fcsfzipzdz";
   };
 
-  buildInputs = [ gfortran ];
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ perl gfortran  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/physics/mela/default.nix
+++ b/pkgs/development/libraries/physics/mela/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "01sgd4mwx4n58x95brphp4dskqkkx8434bvsr38r5drg9na5nc9y";
   };
 
-  buildInputs = [ gfortran ];
+  nativeBuildInputs = [ gfortran ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/qrupdate/default.nix
+++ b/pkgs/development/libraries/qrupdate/default.nix
@@ -42,9 +42,7 @@ stdenv.mkDerivation rec {
 
   installTargets = lib.optionals stdenv.isDarwin [ "install-staticlib" "install-shlib" ];
 
-  buildInputs = [ gfortran ];
-
-  nativeBuildInputs = [ which ];
+  nativeBuildInputs = [ which gfortran ];
 
   meta = with lib; {
     description = "Library for fast updating of qr and cholesky decompositions";

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -22,9 +22,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake gfortran ];
   buildInputs = assert (blas.isILP64 == lapack.isILP64); [
-    gfortran
     blas
     lapack
     eigen

--- a/pkgs/development/libraries/science/math/blas/default.nix
+++ b/pkgs/development/libraries/science/math/blas/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-LjYNmcm9yEB6YYiMQKqFP7QhlCDruCZNtIbLiGBGirM=";
   };
 
-  buildInputs = [ gfortran ];
+  nativeBuildInputs = [ gfortran ];
 
   configurePhase = ''
     echo >make.inc  "SHELL = ${stdenv.shell}"

--- a/pkgs/development/libraries/science/math/cholmod-extra/default.nix
+++ b/pkgs/development/libraries/science/math/cholmod-extra/default.nix
@@ -10,7 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0hz1lfp0zaarvl0dv0zgp337hyd8np41kmdpz5rr3fc6yzw7vmkg";
   };
 
-  buildInputs = [ suitesparse gfortran blas lapack ];
+  nativeBuildInputs = [ gfortran ];
+  buildInputs = [ suitesparse blas lapack ];
 
   makeFlags = [
     "BLAS=-lcblas"

--- a/pkgs/development/libraries/science/math/clblas/default.nix
+++ b/pkgs/development/libraries/science/math/clblas/default.nix
@@ -35,9 +35,8 @@ stdenv.mkDerivation rec {
      "-DBUILD_TEST=OFF"
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake gfortran ];
   buildInputs = [
-    gfortran
     blas
     python3
     boost

--- a/pkgs/development/libraries/science/math/ipopt/default.nix
+++ b/pkgs/development/libraries/science/math/ipopt/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
     "--with-lapack-lib=-llapack"
   ];
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [ unzip gfortran ];
 
-  buildInputs = [ gfortran blas lapack ];
+  buildInputs = [ blas lapack ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1c10d18gj3kvpmyv5q246x35hjxaqn4ygy1cygaydhyxnm4klzdj";
   };
 
-  nativeBuildInputs = [ cmake openssh ];
-  buildInputs = [ mpi gfortran blas lapack ];
+  nativeBuildInputs = [ cmake openssh gfortran ];
+  buildInputs = [ mpi blas lapack ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/science/math/spooles/default.nix
+++ b/pkgs/development/libraries/science/math/spooles/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, gfortran, perl }:
+{ lib, stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
   pname = "spooles";

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-SNp7qoFS3bIq7RsC2C0du0+/6iKs9nY0ARqgMDoQCkM=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake gfortran ];
 
   buildInputs = [
     python
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
     ++ lib.optionals (lapackSupport)
     # Check that the same index size is used for both libraries
     (assert (blas.isILP64 == lapack.isILP64); [
-      gfortran
       blas
       lapack
     ])

--- a/pkgs/development/python-modules/scikit-learn/0.20.nix
+++ b/pkgs/development/python-modules/scikit-learn/0.20.nix
@@ -16,7 +16,8 @@ buildPythonPackage rec {
     sha256 = "1z3w2c50dwwa297j88pr16pyrjysagsvdj7vrlq40q8777rs7a6z";
   };
 
-  buildInputs = [ pillow gfortran glibcLocales ];
+  nativeBuildInputs = [ gfortran ];
+  buildInputs = [ pillow glibcLocales ];
   propagatedBuildInputs = [ numpy scipy numpy.blas ];
   checkInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/scikit-learn/default.nix
+++ b/pkgs/development/python-modules/scikit-learn/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
 
   buildInputs = [
     pillow
-    gfortran
     glibcLocales
   ] ++ lib.optionals stdenv.cc.isClang [
     llvmPackages.openmp
@@ -46,6 +45,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     cython
+    gfortran
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -34,10 +34,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ removeReferencesTo ];
+  nativeBuildInputs = [ removeReferencesTo ]
+    ++ optional (gfortran != null) gfortran;
 
   buildInputs = []
-    ++ optional (gfortran != null) gfortran
     ++ optional (szip != null) szip
     ++ optional javaSupport jdk;
 


### PR DESCRIPTION
###### Motivation for this change
A lot of packages have `gfortran` compiler in `buildInputs`. This is historical baggage because  a few years back it would only work if `gfortran` was in `buildInputs`. This problem has been long fixed and `gfortran` now belongs into `nativeBuildInputs` like all other build-time utilities.  

###### Things done
`nixpkgs-review` did not recover any errors related to this PR.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
