### PR TITLE
llvmPackages_13: Fix the build on AArch64

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11973,6 +11973,8 @@ with pkgs;
     inherit (stdenvAdapters) overrideCC;
     buildLlvmTools = buildPackages.llvmPackages_13.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_13.libraries;
+  } // lib.optionalAttrs (stdenv.targetPlatform.isAarch64) {
+    stdenv = gcc10Stdenv;
   } // lib.optionalAttrs (stdenv.hostPlatform.isi686 && buildPackages.stdenv.cc.isGNU) {
     stdenv = gcc7Stdenv;
   }));


### PR DESCRIPTION
The compiler-rt build was failing with:
/build/source/compiler-rt/build/lib/fuzzer/libcxx_fuzzer_aarch64/include/c++/v1/__config:1065:41: error: a destructor cannot be 'constexpr'
 1065 | #  define _LIBCPP_CONSTEXPR_AFTER_CXX17 constexpr
      |                                         ^~~~~~~~~
make[5]: *** [cxx/src/CMakeFiles/cxx_static.dir/build.make:303: cxx/src/CMakeFiles/cxx_static.dir/optional.cpp.o] Error 1
make[2]: *** [lib/fuzzer/CMakeFiles/libcxx_fuzzer_aarch64-build.dir/build.make:80: lib/fuzzer/libcxx_fuzzer_aarch64-stamps/libcxx_fuzzer_aarch64-build] Error 2

See:
- https://hydra.nixos.org/job/nixpkgs/trunk/llvmPackages_13.compiler-rt.aarch64-linux/all
- https://hydra.nixos.org/log/nlcppawcbnpff23mdxxk6ianrwp8p7j7-compiler-rt-libc-13.0.0-rc2.drv

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
