### PR TITLE
[21.05] Backport the required commits for the Chromium M93 update

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -16,7 +16,8 @@ mkChromiumDerivation (base: rec {
     cp -v "$buildPath/"*.so "$buildPath/"*.pak "$buildPath/"*.bin "$libExecPath/"
     cp -v "$buildPath/icudtl.dat" "$libExecPath/"
     cp -vLR "$buildPath/locales" "$buildPath/resources" "$libExecPath/"
-    cp -v "$buildPath/crashpad_handler" "$libExecPath/"
+    ${lib.optionalString (channel != "dev") ''cp -v "$buildPath/crashpad_handler" "$libExecPath/"''}
+    ${lib.optionalString (channel == "dev") ''cp -v "$buildPath/chrome_crashpad_handler" "$libExecPath/"''}
     cp -v "$buildPath/chrome" "$libExecPath/$packageName"
 
     # Swiftshader

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -1,4 +1,7 @@
-{ lib, mkChromiumDerivation, channel, enableWideVine, ungoogled }:
+{ lib, mkChromiumDerivation
+, channel, chromiumVersionAtLeast
+, enableWideVine, ungoogled
+}:
 
 with lib;
 
@@ -16,8 +19,8 @@ mkChromiumDerivation (base: rec {
     cp -v "$buildPath/"*.so "$buildPath/"*.pak "$buildPath/"*.bin "$libExecPath/"
     cp -v "$buildPath/icudtl.dat" "$libExecPath/"
     cp -vLR "$buildPath/locales" "$buildPath/resources" "$libExecPath/"
-    ${lib.optionalString (channel != "dev") ''cp -v "$buildPath/crashpad_handler" "$libExecPath/"''}
-    ${lib.optionalString (channel == "dev") ''cp -v "$buildPath/chrome_crashpad_handler" "$libExecPath/"''}
+    ${lib.optionalString (!chromiumVersionAtLeast "94") ''cp -v "$buildPath/crashpad_handler" "$libExecPath/"''}
+    ${lib.optionalString (chromiumVersionAtLeast "94") ''cp -v "$buildPath/chrome_crashpad_handler" "$libExecPath/"''}
     cp -v "$buildPath/chrome" "$libExecPath/$packageName"
 
     # Swiftshader

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, fetchurl, fetchpatch
 # Channel data:
 , channel, upstream-info
+# Helper functions:
+, chromiumVersionAtLeast, versionRange
 
 # Native build inputs:
 , ninja, pkg-config
@@ -105,18 +107,6 @@ let
   buildType = "Release";
   buildPath = "out/${buildType}";
   libExecPath = "$out/libexec/${packageName}";
-
-  warnObsoleteVersionConditional = min-version: result:
-    let ungoogled-version = (importJSON ./upstream-info.json).ungoogled-chromium.version;
-    in warnIf (versionAtLeast ungoogled-version min-version) "chromium: ungoogled version ${ungoogled-version} is newer than a conditional bounded at ${min-version}. You can safely delete it."
-      result;
-  chromiumVersionAtLeast = min-version:
-    let result = versionAtLeast upstream-info.version min-version;
-    in  warnObsoleteVersionConditional min-version result;
-  versionRange = min-version: upto-version:
-    let inherit (upstream-info) version;
-        result = versionAtLeast version min-version && versionOlder version upto-version;
-    in warnObsoleteVersionConditional upto-version result;
 
   ungoogler = ungoogled-chromium {
     inherit (upstream-info.deps.ungoogled-patches) rev sha256;

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -171,14 +171,6 @@ let
       ./patches/widevine-79.patch
       # Fix the build by adding a missing dependency (s. https://crbug.com/1197837):
       ./patches/fix-missing-atspi2-dependency.patch
-    ] ++ lib.optionals (chromiumVersionAtLeast "93") [
-      # We need to revert this patch to build M93 with LLVM 12.
-      (githubPatch {
-        # Reland "Replace 'blacklist' with 'ignorelist' in ./tools/msan/."
-        commit = "9d080c0934b848ee4a05013c78641e612fcc1e03";
-        sha256 = "1bxdhxmiy6h4acq26lq43x2mxx6rawmfmlgsh5j7w8kyhkw5af0c";
-        revert = true;
-      })
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -1,40 +1,49 @@
-{ stdenv, lib, llvmPackages, gnChromium, ninja, which, nodejs, fetchpatch, fetchurl
+{ stdenv, lib, fetchurl, fetchpatch
+# Channel data:
+, channel, upstream-info
 
-# default dependencies
-, gnutar, bzip2, flac, speex, libopus
+# Native build inputs:
+, ninja, pkg-config
+, python2, python3, perl
+, gnutar, which
+, llvmPackages
+# postPatch:
+, pkgsBuildHost
+# configurePhase:
+, gnChromium
+
+# Build inputs:
+, libpng
+, bzip2, flac, speex, libopus
 , libevent, expat, libjpeg, snappy
-, libpng, libcap
-, xdg-utils, yasm, nasm, minizip, libwebp
-, libusb1, pciutils, nss, re2
-
-, python2, python3, perl, pkg-config
-, nspr, systemd, libkrb5
+, libcap
+, xdg-utils, minizip, libwebp
+, libusb1, re2
+, ffmpeg, libxslt, libxml2
+, nasm
+, nspr, nss, systemd
 , util-linux, alsa-lib
-, bison, gperf
+, bison, gperf, libkrb5
 , glib, gtk3, dbus-glib
-, glibc
 , libXScrnSaver, libXcursor, libXtst, libxshmfence, libGLU, libGL
-, protobuf, speechd, libXdamage, cups
-, ffmpeg, libxslt, libxml2, at-spi2-core
-, jre8
+, mesa
+, pciutils, protobuf, speechd, libXdamage, at-spi2-core
 , pipewire
 , libva
-, libdrm, wayland, mesa, libxkbcommon # Ozone
+, libdrm, wayland, libxkbcommon # Ozone
 , curl
+# postPatch:
+, glibc # gconv + locale
 
-# optional dependencies
-, libgcrypt ? null # gnomeSupport || cupsSupport
-
-# package customization
+# Package customization:
 , gnomeSupport ? false, gnome2 ? null
 , gnomeKeyringSupport ? false, libgnome-keyring3 ? null
+, cupsSupport ? true, cups ? null
 , proprietaryCodecs ? true
-, cupsSupport ? true
 , pulseSupport ? false, libpulseaudio ? null
 , ungoogled ? false, ungoogled-chromium
-
-, channel
-, upstream-info
+# Optional dependencies:
+, libgcrypt ? null # gnomeSupport || cupsSupport
 }:
 
 buildFun:
@@ -91,17 +100,6 @@ let
     withCustomModes = true;
   };
 
-  defaultDependencies = [
-    (libpng.override { apngSupport = false; }) # https://bugs.chromium.org/p/chromium/issues/detail?id=752403
-    bzip2 flac speex opusWithCustomModes
-    libevent expat libjpeg snappy
-    libcap
-    xdg-utils minizip libwebp
-    libusb1 re2
-    ffmpeg libxslt libxml2
-    nasm
-  ];
-
   # build paths and release info
   packageName = extraAttrs.packageName or extraAttrs.name;
   buildType = "Release";
@@ -136,12 +134,20 @@ let
 
     nativeBuildInputs = [
       ninja pkg-config
-      python2WithPackages python3WithPackages perl nodejs
+      python2WithPackages python3WithPackages perl
       gnutar which
       llvmPackages.bintools
     ];
 
-    buildInputs = defaultDependencies ++ [
+    buildInputs = [
+      (libpng.override { apngSupport = false; }) # https://bugs.chromium.org/p/chromium/issues/detail?id=752403
+      bzip2 flac speex opusWithCustomModes
+      libevent expat libjpeg snappy
+      libcap
+      xdg-utils minizip libwebp
+      libusb1 re2
+      ffmpeg libxslt libxml2
+      nasm
       nspr nss systemd
       util-linux alsa-lib
       bison gperf libkrb5
@@ -153,14 +159,16 @@ let
       libva
       libdrm wayland mesa.drivers libxkbcommon
       curl
-    ] ++ optional gnomeKeyringSupport libgnome-keyring3
-      ++ optionals gnomeSupport [ gnome2.GConf libgcrypt ]
+    ] ++ optionals gnomeSupport [ gnome2.GConf libgcrypt ]
+      ++ optional gnomeKeyringSupport libgnome-keyring3
       ++ optionals cupsSupport [ libgcrypt cups ]
       ++ optional pulseSupport libpulseaudio;
 
     patches = [
-      ./patches/no-build-timestamps.patch # Optional patch to use SOURCE_DATE_EPOCH in compute_build_timestamp.py (should be upstreamed)
-      ./patches/widevine-79.patch # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags
+      # Optional patch to use SOURCE_DATE_EPOCH in compute_build_timestamp.py (should be upstreamed):
+      ./patches/no-build-timestamps.patch
+      # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags:
+      ./patches/widevine-79.patch
       # Fix the build by adding a missing dependency (s. https://crbug.com/1197837):
       ./patches/fix-missing-atspi2-dependency.patch
     ] ++ lib.optionals (chromiumVersionAtLeast "93") [
@@ -226,8 +234,8 @@ let
       patchShebangs .
       # Link to our own Node.js and Java (required during the build):
       mkdir -p third_party/node/linux/node-linux-x64/bin
-      ln -s "$(command -v node)" third_party/node/linux/node-linux-x64/bin/node
-      ln -s "${jre8}/bin/java" third_party/jdk/current/bin/
+      ln -s "${pkgsBuildHost.nodejs}/bin/node" third_party/node/linux/node-linux-x64/bin/node
+      ln -s "${pkgsBuildHost.jre8}/bin/java" third_party/jdk/current/bin/
 
       # Allow building against system libraries in official builds
       sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' tools/generate_shim_headers/generate_shim_headers.py
@@ -259,9 +267,9 @@ let
       google_api_key = "AIzaSyDGi15Zwl11UNe6Y-5XW_upsfyw31qwZPI";
 
       # Optional features:
-      use_cups = cupsSupport;
       use_gio = gnomeSupport;
       use_gnome_keyring = gnomeKeyringSupport;
+      use_cups = cupsSupport;
 
       # Feature overrides:
       # Native Client support was deprecated in 2020 and support will end in June 2021:

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -169,6 +169,7 @@ let
       ./patches/no-build-timestamps.patch
       # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags:
       ./patches/widevine-79.patch
+    ] ++ lib.optionals (versionRange "91" "94") [
       # Fix the build by adding a missing dependency (s. https://crbug.com/1197837):
       ./patches/fix-missing-atspi2-dependency.patch
     ];

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -243,15 +243,28 @@ let
 
     gnFlags = mkGnFlags ({
       # Main build and toolchain settings:
+      # Create an official and optimized release build (only official builds
+      # should be distributed to users, as non-official builds are intended for
+      # development and may not be configured appropriately for production,
+      # e.g. unsafe developer builds have developer-friendly features that may
+      # weaken or disable security measures like sandboxing or ASLR):
       is_official_build = true;
+      # Build Chromium using the system toolchain (for Linux distributions):
       custom_toolchain = "//build/toolchain/linux/unbundle:default";
       host_toolchain = "//build/toolchain/linux/unbundle:default";
+      # Don't build against a sysroot image downloaded from Cloud Storage:
       use_sysroot = false;
+      # The default value is hardcoded instead of using pkg-config:
       system_wayland_scanner_path = "${wayland}/bin/wayland-scanner";
+      # Because we use a different toolchain / compiler version:
       treat_warnings_as_errors = false;
+      # We aren't compiling with Chrome's Clang (would enable Chrome-specific
+      # plugins for enforcing coding guidelines, etc.):
       clang_use_chrome_plugins = false;
-      blink_symbol_level = 0;
+      # Disable symbols (they would negatively affect the performance of the
+      # build since the symbols are large and dealing with them is slow):
       symbol_level = 0;
+      blink_symbol_level = 0;
 
       # Google API key, see: https://www.chromium.org/developers/how-tos/api-keys
       # Note: The API key is for NixOS/nixpkgs use ONLY.

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -252,7 +252,6 @@ let
       clang_use_chrome_plugins = false;
       blink_symbol_level = 0;
       symbol_level = 0;
-      fieldtrial_testing_like_official_build = true;
 
       # Google API key, see: https://www.chromium.org/developers/how-tos/api-keys
       # Note: The API key is for NixOS/nixpkgs use ONLY.
@@ -273,6 +272,10 @@ let
       enable_widevine = true;
       # Provides the enable-webrtc-pipewire-capturer flag to support Wayland screen capture:
       rtc_use_pipewire = true;
+    } // optionalAttrs (!chromiumVersionAtLeast "94") {
+      fieldtrial_testing_like_official_build = true;
+    } // optionalAttrs (chromiumVersionAtLeast "94") {
+      disable_fieldtrial_testing_config = true;
     } // optionalAttrs proprietaryCodecs {
       # enable support for the H.264 codec
       proprietary_codecs = true;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,5 +1,5 @@
 { newScope, config, stdenv, fetchurl, makeWrapper
-, llvmPackages_11, llvmPackages_12, ed, gnugrep, coreutils, xdg-utils
+, llvmPackages_12, llvmPackages_13, ed, gnugrep, coreutils, xdg-utils
 , glib, gtk3, gnome, gsettings-desktop-schemas, gn, fetchgit
 , libva, pipewire, wayland
 , gcc, nspr, nss, runCommand
@@ -19,7 +19,7 @@
 }:
 
 let
-  llvmPackages = llvmPackages_11;
+  llvmPackages = llvmPackages_12;
   stdenv = llvmPackages.stdenv;
 
   callPackage = newScope chromium;
@@ -38,9 +38,9 @@ let
           inherit (upstream-info.deps.gn) url rev sha256;
         };
       });
-    } // lib.optionalAttrs (lib.versionAtLeast upstream-info.version "90") {
-      llvmPackages = llvmPackages_12;
-      stdenv = llvmPackages_12.stdenv;
+    } // lib.optionalAttrs (lib.versionAtLeast upstream-info.version "94") rec {
+      llvmPackages = llvmPackages_13;
+      stdenv = llvmPackages.stdenv;
     });
 
     browser = callPackage ./browser.nix { inherit channel enableWideVine ungoogled; };

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -38,7 +38,7 @@ let
           inherit (upstream-info.deps.gn) url rev sha256;
         };
       });
-    } // lib.optionalAttrs (lib.versionAtLeast upstream-info.version "94") rec {
+    } // lib.optionalAttrs (lib.versionAtLeast upstream-info.version "93") rec {
       llvmPackages = llvmPackages_13;
       stdenv = llvmPackages.stdenv;
     });

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "93.0.4577.25",
-    "sha256": "09v7wyy9xwrpzmsa030j8jjww30jps3lbvlq4bzppdg04fk6rbsn",
-    "sha256bin64": "1l86aqym4dxsrp81ppv5cwyki4wnh7cpqy4dw88kdxgqbiwwii27",
+    "version": "93.0.4577.42",
+    "sha256": "180lywcimhlcwbxmn37814hd96bqnqrp3whbzv6ln3hwca2da4hl",
+    "sha256bin64": "19px9h9vf9p2ipirv8ryaxvhfkls0nfiw7jz1d4h61r3r6ay5fc4",
     "deps": {
       "gn": {
         "version": "2021-07-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "94.0.4595.0",
-    "sha256": "0ksd7vqpbiplbg2xpm566z7p7qp57r27a3pk6ss1qz8v18490092",
-    "sha256bin64": "1kibyhgwcgby3hnhjdg2vrgbj4dvvbicqlcj4id9761zw1jhz8r4",
+    "version": "94.0.4603.0",
+    "sha256": "1mhb7y7mhjbi5m79izcqvc6pjmgxvlk9vvr273k29gr2zq2m2fv3",
+    "sha256bin64": "1rqprc2vkyygwwwjk25xa2av30bqbx5dzs6nwhnzsdqwic5wdbbz",
     "deps": {
       "gn": {
         "version": "2021-07-31",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "93.0.4577.18",
-    "sha256": "1h1ppyizj5vbnrv11iy9vlcpcv8mgb9r8m2zmz6vp7q1ch6w0w4x",
-    "sha256bin64": "1s5qj0pd79qbchq3awhxc86l9vmi6304z7sd9ls9f8q138789cha",
+    "version": "93.0.4577.25",
+    "sha256": "09v7wyy9xwrpzmsa030j8jjww30jps3lbvlq4bzppdg04fk6rbsn",
+    "sha256bin64": "1l86aqym4dxsrp81ppv5cwyki4wnh7cpqy4dw88kdxgqbiwwii27",
     "deps": {
       "gn": {
         "version": "2021-07-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "94.0.4606.12",
-    "sha256": "1yv34wahg1f0l35kvlm3x17wvqdg8yyzmjj6naz2lnl5qai89zr8",
-    "sha256bin64": "19z9yzj6ig5ym8f9zzs8b4yixkspc0x62sz526r39803pbgs7s7i",
+    "version": "94.0.4606.20",
+    "sha256": "0wp9fdw7jkrzhaz8dils7k1ssd6v7kkiz4y9l81s37xxi3xj1drg",
+    "sha256bin64": "059rn0jj2cajrxx57gmr0ndkgixgfqazb73rxbprqj4857w4d5da",
     "deps": {
       "gn": {
         "version": "2021-08-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,15 +18,15 @@
     }
   },
   "beta": {
-    "version": "93.0.4577.58",
-    "sha256": "1i9ygy99lg9h0qyl46c02id9d1ig3brkvr8va0blpf7h8pg9251s",
-    "sha256bin64": "16cyn74sxz8lwdyb7x3z115czk9xvs67bb2bbnhrhnaszhhrzs4j",
+    "version": "94.0.4606.20",
+    "sha256": "0wp9fdw7jkrzhaz8dils7k1ssd6v7kkiz4y9l81s37xxi3xj1drg",
+    "sha256bin64": "0ahc09qv78vmx72kqhjj2lwcniqn9q73vkc1b9lyv184ai3269sq",
     "deps": {
       "gn": {
-        "version": "2021-07-08",
+        "version": "2021-08-11",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "24e2f7df92641de0351a96096fb2c490b2436bb8",
-        "sha256": "1lwkyhfhw0zd7daqz466n7x5cddf0danr799h4jg3s0yvd4galjl"
+        "rev": "69ec4fca1fa69ddadae13f9e6b7507efa0675263",
+        "sha256": "031znmkbm504iim5jvg3gmazj4qnkfc7zg8aymjsij18fhf7piz0"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "94.0.4603.0",
-    "sha256": "1mhb7y7mhjbi5m79izcqvc6pjmgxvlk9vvr273k29gr2zq2m2fv3",
-    "sha256bin64": "1rqprc2vkyygwwwjk25xa2av30bqbx5dzs6nwhnzsdqwic5wdbbz",
+    "version": "94.0.4606.12",
+    "sha256": "1yv34wahg1f0l35kvlm3x17wvqdg8yyzmjj6naz2lnl5qai89zr8",
+    "sha256bin64": "19z9yzj6ig5ym8f9zzs8b4yixkspc0x62sz526r39803pbgs7s7i",
     "deps": {
       "gn": {
-        "version": "2021-07-31",
+        "version": "2021-08-11",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "eea3906f0e2a8d3622080127d2005ff214d51383",
-        "sha256": "1wc969jrivb502c45wdcbgh0c5888nqxla05is9bimkrk9rqppw3"
+        "rev": "69ec4fca1fa69ddadae13f9e6b7507efa0675263",
+        "sha256": "031znmkbm504iim5jvg3gmazj4qnkfc7zg8aymjsij18fhf7piz0"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "95.0.4621.4",
-    "sha256": "06fgdyg3bychqhf31fikk7s4qp3rc7hmsvm6p2bj9ascd6kzjzx8",
-    "sha256bin64": "1bvkdrc7cznb9xrnld642qj3z7vbyin9xbq0pp6kqva4gck41cyn",
+    "version": "95.0.4628.3",
+    "sha256": "04r2db9kl77lp4jyyj01pc70jkxrifbnz5hic4r91lf8m2gf1fa3",
+    "sha256bin64": "1ssf8jdk6gn2mrnyvgz2c9nkk70rsidd5y26w2kx3s0cllfr7d96",
     "deps": {
       "gn": {
         "version": "2021-08-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "94.0.4606.20",
-    "sha256": "0wp9fdw7jkrzhaz8dils7k1ssd6v7kkiz4y9l81s37xxi3xj1drg",
-    "sha256bin64": "059rn0jj2cajrxx57gmr0ndkgixgfqazb73rxbprqj4857w4d5da",
+    "version": "95.0.4621.4",
+    "sha256": "06fgdyg3bychqhf31fikk7s4qp3rc7hmsvm6p2bj9ascd6kzjzx8",
+    "sha256bin64": "1bvkdrc7cznb9xrnld642qj3z7vbyin9xbq0pp6kqva4gck41cyn",
     "deps": {
       "gn": {
         "version": "2021-08-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "94.0.4606.20",
-    "sha256": "0wp9fdw7jkrzhaz8dils7k1ssd6v7kkiz4y9l81s37xxi3xj1drg",
-    "sha256bin64": "0ahc09qv78vmx72kqhjj2lwcniqn9q73vkc1b9lyv184ai3269sq",
+    "version": "94.0.4606.31",
+    "sha256": "1f5hk2acd9lj88m2acz8ik85fh5h3giz65p19dpfg92zsyly54nf",
+    "sha256bin64": "1ypf9j51a4kmx27x3s9izzbd2r094idz194gwhbdly75l1x8hk4z",
     "deps": {
       "gn": {
         "version": "2021-08-11",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "93.0.4577.42",
-    "sha256": "180lywcimhlcwbxmn37814hd96bqnqrp3whbzv6ln3hwca2da4hl",
-    "sha256bin64": "19px9h9vf9p2ipirv8ryaxvhfkls0nfiw7jz1d4h61r3r6ay5fc4",
+    "version": "93.0.4577.51",
+    "sha256": "0b3mx5ns4pbrwc7s2iz8ffv8lhay6p9gj0dnsd1qzxgqwgrv37h5",
+    "sha256bin64": "1b8ypv14c5ky789dm17czv4yf7v21lwhnf2ygkdzryvd3i056nsz",
     "deps": {
       "gn": {
         "version": "2021-07-08",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "93.0.4577.51",
-    "sha256": "0b3mx5ns4pbrwc7s2iz8ffv8lhay6p9gj0dnsd1qzxgqwgrv37h5",
-    "sha256bin64": "1b8ypv14c5ky789dm17czv4yf7v21lwhnf2ygkdzryvd3i056nsz",
+    "version": "93.0.4577.58",
+    "sha256": "1i9ygy99lg9h0qyl46c02id9d1ig3brkvr8va0blpf7h8pg9251s",
+    "sha256bin64": "16cyn74sxz8lwdyb7x3z115czk9xvs67bb2bbnhrhnaszhhrzs4j",
     "deps": {
       "gn": {
         "version": "2021-07-08",

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -75,6 +75,10 @@ let
 
   suffix = if channel != "stable" then "-" + channel else "";
 
+  crashpadHandlerBinary = if lib.versionAtLeast version "94"
+    then "chrome_crashpad_handler"
+    else "crashpad_handler";
+
 in stdenv.mkDerivation {
   inherit version;
 
@@ -146,7 +150,7 @@ in stdenv.mkDerivation {
       --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
       --add-flags ${escapeShellArg commandLineArgs}
 
-    for elf in $out/share/google/$appname/{chrome,chrome-sandbox,crashpad_handler,nacl_helper}; do
+    for elf in $out/share/google/$appname/{chrome,chrome-sandbox,${crashpadHandlerBinary},nacl_helper}; do
       patchelf --set-rpath $rpath $elf
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $elf
     done


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

After this only the actual update is missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
