### PR TITLE
fftw: add optional AVX/FMA optimization flags

### DIFF
--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -1,4 +1,15 @@
-{ fetchurl, stdenv, lib, gfortran, llvmPackages ? null, precision ? "double", perl }:
+{ fetchurl
+, stdenv
+, lib
+, gfortran
+, perl
+, llvmPackages ? null
+, precision ? "double"
+, enableAvx ? stdenv.hostPlatform.avxSupport
+, enableAvx2 ? stdenv.hostPlatform.avx2Support
+, enableAvx512 ? stdenv.hostPlatform.avx512Support
+, enableFma ? stdenv.hostPlatform.fmaSupport
+}:
 
 with lib;
 
@@ -40,6 +51,10 @@ stdenv.mkDerivation {
     # all x86_64 have sse2
     # however, not all float sizes fit
     ++ optional (stdenv.isx86_64 && (precision == "single" || precision == "double") )  "--enable-sse2"
+    ++ optional enableAvx "--enable-avx"
+    ++ optional enableAvx2 "--enable-avx2"
+    ++ optional enableAvx512 "--enable-avx512"
+    ++ optional enableFma "--enable-fma"
     ++ [ "--enable-openmp" ]
     # doc generation causes Fortran wrapper generation which hard-codes gcc
     ++ optional (!withDoc) "--disable-doc";


### PR DESCRIPTION
###### Motivation for this change
Allow turning on AVX related configure options via simple override.

In the current setting, it does not cause any rebuilds. Build with these flags activated have been extensively tested here: https://github.com/markuskowa/NixOS-QChem/blob/f98737b583894438491444b2dcd002b0e5945752/nixpkgs-opt.nix#L8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
