### PR TITLE
brave: add support for command line arguments

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -41,6 +41,7 @@
 , zlib
 , xdg-utils
 , wrapGAppsHook
+, commandLineArgs ? ""
 }:
 
 let
@@ -154,6 +155,11 @@ stdenv.mkDerivation rec {
       ln -sf ${xdg-utils}/bin/xdg-mime $out/opt/brave.com/brave/xdg-mime
 
       runHook postInstall
+  '';
+
+  preFixup = ''
+    # Add command line args to wrapGApp.
+    gappsWrapperArgs+=(--add-flags ${lib.escapeShellArg commandLineArgs})
   '';
 
   installCheckPhase = ''


### PR DESCRIPTION
Add formal argument `commandLineArgs` to the brave derivation and append it
to the `gappsWrapperArgs` expected by the `wrapGAppsHook`. This adds some
flexibility to the wrapper creation of brave, and aligns with customization
avalible in other chromium derivation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Switches are ubiquitous in chromium distributions, they are used to toggle flags, features, prefs and settings.  Though all of the configurations mentioned can be enabled through the browser itself, a majority are automatically persistent across restarts and may be deprecated or changed which makes debugging and tracking configurations diffucult. Switches have all the capabilities of other configuration interfaces can be used for virtually any purpose, while being ephemeral which aligns with reproducibility aspects with Nix (i.e any number of transformation of switches ending with the same command line should exhibit the same behavior)

Users can still set configurations dynamically through the browser, but the addition of the `commandLineArgs` parameter allows users to pass switches to the brave wrapper itself without creating another derivation which just overwrites the wrapper using `symlinkJoin` or `buildEnv`.

Note I use switches here to refer to a subset of arguments prefixed with '-', '--' or '/' in line with [definition by the chromium authors](https://chromium.googlesource.com/chromium/src/+/main/base/command_line.h#5). Other arguments do not benefits as much from this change as they should usually be managed imperatively by the user.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
