### PR TITLE
shadowenv: 2.0.4 -> 2.0.5

### DIFF
--- a/pkgs/tools/misc/shadowenv/default.nix
+++ b/pkgs/tools/misc/shadowenv/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "shadowenv";
-  version = "2.0.4";
+  version = "2.0.5";
 
   src = fetchFromGitHub {
     owner = "Shopify";
     repo = pname;
     rev = version;
-    sha256 = "sha256-BXCIb91EOpu/GUVvmFZbycuWYAS1n5Sxg5OiYx5rlPA=";
+    sha256 = "sha256-MPky0ZB7yfl/gOPThx1BpRoTgvY7mkLaoqnvGKPvSPo=";
   };
 
-  cargoSha256 = "sha256-Hn+128ZQljTroebDQBBNynSq7WTZLpB5sdA2Gz54pOU=";
+  cargoSha256 = "sha256-reVw8YkKi+EMDk0Bva2Ugp72VhAYB6axHonkr9Kdos4=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
###### Motivation for this change
Keep package up to date

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
