### PR TITLE
vimPlugins: split helptag generation into a hook

### DIFF
--- a/pkgs/misc/vim-plugins/build-vim-plugin.nix
+++ b/pkgs/misc/vim-plugins/build-vim-plugin.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
-, rtpPath ? "share/vim-plugins"
+, rtpPath
 , vim
+, vimGenDocHook
 }:
 
 rec {
@@ -25,6 +26,7 @@ rec {
     addRtp "${rtpPath}/${path}" attrs (stdenv.mkDerivation (attrs // {
       name = namePrefix + name;
 
+      nativeBuildInputs = attrs.nativeBuildInputs or [] ++ [ vimGenDocHook ];
       inherit unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;
 
       installPhase = ''
@@ -33,21 +35,6 @@ rec {
         target=$out/${rtpPath}/${path}
         mkdir -p $out/${rtpPath}
         cp -r . $target
-
-        # build help tags
-        if [ -d "$target/doc" ]; then
-          echo "Building help tags"
-          if ! ${vim}/bin/vim -N -u NONE -i NONE -n -E -s -V1 -c "helptags $target/doc" +quit!; then
-            echo "Failed to build help tags!"
-            exit 1
-          fi
-        else
-          echo "No docs available"
-        fi
-
-        if [ -n "$addonInfo" ]; then
-          echo "$addonInfo" > $target/addon-info.json
-        fi
 
         runHook postInstall
       '';

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -3,7 +3,7 @@
 
 let
 
-  inherit (vimUtils.override {inherit vim;}) buildVimPluginFrom2Nix;
+  inherit (vimUtils.override {inherit vim;}) buildVimPluginFrom2Nix vimGenDocHook;
 
   inherit (lib) extends;
 
@@ -11,6 +11,8 @@ let
     # Convert derivation to a vim plugin.
     toVimPlugin = drv:
       drv.overrideAttrs(oldAttrs: {
+
+        nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [ vimGenDocHook ];
         passthru = (oldAttrs.passthru or {}) // {
           vimPlugin = true;
         };

--- a/pkgs/misc/vim-plugins/update-shell.nix
+++ b/pkgs/misc/vim-plugins/update-shell.nix
@@ -1,0 +1,13 @@
+{ nixpkgs ? import ../../.. { } }:
+with nixpkgs;
+let
+  pyEnv = python3.withPackages(ps: [ ps.GitPython ]);
+in
+mkShell {
+  packages = [
+    bash
+    pyEnv
+    nix-prefetch-scripts
+  ];
+}
+

--- a/pkgs/misc/vim-plugins/update.py
+++ b/pkgs/misc/vim-plugins/update.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p nix-prefetch-git -p python3 -p python3Packages.GitPython nix -i python3
+#!nix-shell update-shell.nix -i python3
+
 
 # format:
 # $ nix run nixpkgs.python3Packages.black -c black update.py

--- a/pkgs/misc/vim-plugins/vim-gen-doc-hook.sh
+++ b/pkgs/misc/vim-plugins/vim-gen-doc-hook.sh
@@ -1,0 +1,31 @@
+echo "Sourcing vim-gen-doc-hook"
+
+# the doc folder is copied via the copy_directories entry of the rockspec
+# in the folder gitsigns.nvim-scm-1-rocks/gitsigns.nvim/scm-1
+vimPluginGenTags() {
+    echo "Executing vimPluginGenTags"
+
+    target="$out/@rtpPath@/$pname"
+    mkdir -p $out/@rtpPath@
+    cp -r . $target
+
+    # build help tags
+    if [ -d "$target/doc" ]; then
+        echo "Building help tags"
+        if ! @vimBinary@ -N -u NONE -i NONE -n -E -s -V1 -c "helptags $target/doc" +quit!; then
+        echo "Failed to build help tags!"
+        exit 1
+        fi
+    else
+        echo "No docs available"
+    fi
+
+    if [ -n "$addonInfo" ]; then
+        echo "$addonInfo" > $target/addon-info.json
+    fi
+
+    echo "Finished executing vimPluginInstallPhase"
+}
+
+preFixupHooks+=(vimPluginGenTags)
+

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub, runtimeShell
 , hasLuaModule
 , python3
+, callPackage, makeSetupHook
 }:
 
 /*
@@ -485,7 +486,18 @@ rec {
     '';
   };
 
-  inherit (import ./build-vim-plugin.nix { inherit lib stdenv rtpPath vim; }) buildVimPlugin buildVimPluginFrom2Nix;
+  vimGenDocHook = callPackage ({ vim }:
+    makeSetupHook {
+      name = "vim-gen-doc-hook";
+      deps = [ vim ];
+      substitutions = {
+        vimBinary = "${vim}/bin/vim";
+        inherit rtpPath;
+      };
+    } ./vim-gen-doc-hook.sh) {};
+
+  inherit (import ./build-vim-plugin.nix { inherit lib stdenv rtpPath vim vimGenDocHook; })
+    buildVimPlugin buildVimPluginFrom2Nix;
 
   # used to figure out which python dependencies etc. neovim needs
   requiredPlugins = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Generating the tags via a hook improves composition as the hook can be used for lua modules too (some neovim plugins are now lua modules too).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
