### PR TITLE
zsh: fix TZ= completion

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation {
     sha256 = "09yyaadq738zlrnlh1hd3ycj1mv3q5hh4xl1ank70mjnqm6bbi6w";
   };
 
+  patches = [
+    # fix location of timezone data for TZ= completion
+    ./tz_completion.patch
+  ];
+
   buildInputs = [ ncurses pcre ];
 
   configureFlags = [

--- a/pkgs/shells/zsh/tz_completion.patch
+++ b/pkgs/shells/zsh/tz_completion.patch
@@ -1,0 +1,14 @@
+On NixOS, timezone data is located at /etc/zoneinfo
+diff --git a/Completion/Unix/Type/_time_zone b/Completion/Unix/Type/_time_zone
+index cd924bbc7..5d683291b 100644
+--- a/Completion/Unix/Type/_time_zone
++++ b/Completion/Unix/Type/_time_zone
+@@ -3,7 +3,7 @@
+ local expl
+ 
+ if (( ! $+_zoneinfo_dirs )); then
+-  _zoneinfo_dirs=( /usr/{share,lib,share/lib}/{zoneinfo*,locale/TZ}(/) )
++  _zoneinfo_dirs=( /etc/zoneinfo /usr/{share,lib,share/lib}/{zoneinfo*,locale/TZ}(/) )
+ fi
+ 
+ _wanted time-zones expl 'time zone' _files -W _zoneinfo_dirs "$@" -


### PR DESCRIPTION
###### Motivation for this change

make `TZ=<tab>` work

cc @Ekleog 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
