### PR TITLE
scilla: 20210118 -> 1.1.1

### DIFF
--- a/pkgs/tools/security/scilla/default.nix
+++ b/pkgs/tools/security/scilla/default.nix
@@ -5,17 +5,16 @@
 
 buildGoModule rec {
   pname = "scilla";
-  version = "20210118-${lib.strings.substring 0 7 rev}";
-  rev = "74dd81492fef92b95765df1d0f629276a146a5a4";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "edoardottt";
     repo = pname;
-    inherit rev;
-    sha256 = "10qvaigfarljydfb9vx2fb9nk293j4g9w2h9mr8xw6adbvl0qr9q";
+    rev = "v${version}";
+    sha256 = "sha256-xg8qnpYRdSGaFkjmQLbjMFIU419ASEHtFA8h8ads/50=";
   };
 
-  vendorSha256 = "04wqsl4269gc3r6l9srqhcq19zarnyyab8k1shj3w6lkfcc61z25";
+  vendorSha256 = "sha256-PFfzlqBuasTNeCNnu5GiGyQzBQkbe83q1EqCsWTor18=";
 
   meta = with lib; {
     description = "Information gathering tool for DNS, ports and more";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.1.1

Change log: https://github.com/edoardottt/scilla/releases/tag/v1.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
