### PR TITLE
nmap-formatter: init at 0.2.1

### DIFF
--- a/pkgs/tools/security/nmap-formatter/default.nix
+++ b/pkgs/tools/security/nmap-formatter/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "nmap-formatter";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "vdjagilev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1r8l7ajcb436b60ir6xgy53wafk6rw1cil326yg6mhcngz9sazbk";
+  };
+
+  vendorSha256 = "0c1b4iw28qj8iq55lg32xqw69jjdv5ial495j0gz68s17kydbwhb";
+
+  postPatch = ''
+    # Fix hard-coded release
+    substituteInPlace cmd/root.go \
+      --replace "0.2.0" "${version}"
+  '';
+
+  meta = with lib; {
+    description = "Tool that allows you to convert nmap output";
+    homepage = "https://github.com/vdjagilev/nmap-formatter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7576,6 +7576,8 @@ with pkgs;
     graphicalSupport = true;
   };
 
+  nmap-formatter = callPackage ../tools/security/nmap-formatter { };
+
   nmapsi4 = libsForQt514.callPackage ../tools/security/nmap/qt.nix { };
 
   nnn = callPackage ../applications/misc/nnn { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool that allows you to convert nmap output

https://github.com/vdjagilev/nmap-formatter

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
