### PR TITLE
buf: 0.52.0 -> 0.54.1

### DIFF
--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -9,15 +9,15 @@
 
 buildGoModule rec {
   pname = "buf";
-  version = "0.52.0";
+  version = "0.54.1";
 
   src = fetchFromGitHub {
     owner = "bufbuild";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-WFL+ztFR8kV6cRY1Ax2TheH+xpA58CLnW69jDpMhe3M=";
+    sha256 = "sha256-v8n1K2YrN8o4IPA2u6Sg5zsOM08nppg29vlU6ycMj9U=";
   };
-  vendorSha256 = "sha256-vbphThpEYDDm1iipcY0QXhKKuLSD87sAxiIUi7SfrAc=";
+  vendorSha256 = "sha256-WLQ8Bw/UgRVTFEKpDbv6VZkMHQm2tgxekH3J7Sd5vC8=";
 
   patches = [
     # Skip a test that requires networking to be available to work.

--- a/pkgs/development/tools/buf/skip_test_requiring_dotgit.patch
+++ b/pkgs/development/tools/buf/skip_test_requiring_dotgit.patch
@@ -1,14 +1,14 @@
-diff --git a/internal/buf/cmd/buf/workspace_test.go b/internal/buf/cmd/buf/workspace_test.go
-index e051690..8887837 100644
---- a/internal/buf/cmd/buf/workspace_test.go
-+++ b/internal/buf/cmd/buf/workspace_test.go
-@@ -335,6 +335,9 @@ func TestWorkspaceNestedArchive(t *testing.T) {
+diff --git a/private/buf/cmd/buf/workspace_test.go b/private/buf/cmd/buf/workspace_test.go
+index 25e33dd..f593beb 100644
+--- a/private/buf/cmd/buf/workspace_test.go
++++ b/private/buf/cmd/buf/workspace_test.go
+@@ -340,6 +340,9 @@ func TestWorkspaceNestedArchive(t *testing.T) {
  }
  
  func TestWorkspaceGit(t *testing.T) {
 +	// Requires .git directory which we do not retain due to
 +	// `leaveDotGit` non-determinism
 +	t.Skip()
+ 	t.Skip("skip until the move to private/buf is merged")
  	// Directory paths specified as a git reference within a workspace.
  	t.Parallel()
- 	testRunStdout(

--- a/pkgs/development/tools/buf/skip_test_requiring_network.patch
+++ b/pkgs/development/tools/buf/skip_test_requiring_network.patch
@@ -1,8 +1,8 @@
-diff --git a/internal/buf/internal/buftesting/buftesting.go b/internal/buf/internal/buftesting/buftesting.go
-index dc8da0c..70ad299 100644
---- a/internal/buf/internal/buftesting/buftesting.go
-+++ b/internal/buf/internal/buftesting/buftesting.go
-@@ -100,6 +100,10 @@ func RunActualProtoc(
+diff --git a/private/bufpkg/buftesting/buftesting.go b/private/bufpkg/buftesting/buftesting.go
+index 82b3ec4..ef8263a 100644
+--- a/private/bufpkg/buftesting/buftesting.go
++++ b/private/bufpkg/buftesting/buftesting.go
+@@ -99,6 +99,10 @@ func RunActualProtoc(
  
  // GetGoogleapisDirPath gets the path to a clone of googleapis.
  func GetGoogleapisDirPath(t *testing.T, buftestingDirPath string) string {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates `buf`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
