### PR TITLE
python3Packages.scikit-learn-extra: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/scikit-learn-extra/default.nix
+++ b/pkgs/development/python-modules/scikit-learn-extra/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, numpy
+, cython
+, scipy
+, scikit-learn
+, matplotlib
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "scikit-learn-extra";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "scikit-learn-contrib";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "09v7a9jdycdrlqq349m1gbn8ppzv1bl5g3l72k6ywsx2xb01qw13";
+  };
+
+  nativeBuildInputs = [ numpy cython ];
+  propagatedBuildInputs = [ numpy scipy scikit-learn ];
+  checkInputs = [ matplotlib pytestCheckHook ];
+
+  preCheck = ''
+    # Remove the package in the build dir, because Python defaults to it and
+    # ignores the one in Nix store with cythonized modules.
+    rm -r sklearn_extra
+  '';
+
+  pytestFlagsArray = [ "--pyargs sklearn_extra" ];
+  disabledTestPaths = [
+    "benchmarks"
+    "examples"
+    "doc"
+  ];
+  disabledTests = [
+    "build"   # needs network connection
+  ];
+
+  # Check packages with cythonized modules
+  pythonImportsCheck = [
+    "sklearn_extra"
+    "sklearn_extra.cluster"
+    "sklearn_extra.robust"
+    "sklearn_extra.utils"
+  ];
+
+  meta = {
+    description = "A set of tools for scikit-learn";
+    homepage = "https://github.com/scikit-learn-contrib/scikit-learn-extra";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ yl3dy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7950,6 +7950,8 @@ in {
     inherit (pkgs) gfortran glibcLocales;
   };
 
+  scikit-learn-extra = callPackage ../development/python-modules/scikit-learn-extra { };
+
   scikit-optimize = callPackage ../development/python-modules/scikit-optimize { };
 
   scikits-odes = callPackage ../development/python-modules/scikits-odes { };


### PR DESCRIPTION
###### Motivation for this change

Scikit-learn-extra contains additional algorithms for scikit-learn, like K-medoid clusterization.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
