### PR TITLE
python3Packages.setuptools-scm: 6.0.1 -> 6.3.1, enable tests

### DIFF
--- a/pkgs/development/python-modules/setuptools-scm/default.nix
+++ b/pkgs/development/python-modules/setuptools-scm/default.nix
@@ -1,29 +1,36 @@
-{ lib, buildPythonPackage, fetchPypi, toml, tomli }:
+{ buildPythonPackage
+, callPackage
+, fetchPypi
+, packaging
+, tomli
+, lib
+}:
 
 buildPythonPackage rec {
   pname = "setuptools-scm";
-  # don't update to 6.1.0 or 6.2.0, releases were pulled because of regression
-  # https://github.com/pypa/setuptools_scm/issues/615
-  version = "6.0.1";
+  version = "6.3.1";
 
   src = fetchPypi {
     pname = "setuptools_scm";
     inherit version;
-    sha256 = "sha256-0ZJaacsH6bKUFqJ1ufrbAJojwUis6QWy+yIGSabBjpI=";
+    sha256 = "sha256-D2omORKxN5jAKLmicdka873g5CeECRx5fezMOtOn9ZY=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "tomli~=1.0.0" "tomli>=1.0.0"
-  '';
+  propagatedBuildInputs = [
+    packaging
+    tomli
+  ];
 
-  # TODO: figure out why both toml and tomli are needed when only tomli is listed in setuptools-scm
-  # if not both are listed some packages like zipp silently fallback to a 0.0.0 version number and break version pins in other packages
-  propagatedBuildInputs = [ toml tomli ];
+  pythonImportsCheck = [
+    "setuptools_scm"
+  ];
 
-  # Requires pytest, circular dependency
+  # check in passhtru.tests.pytest to escape infinite recursion on pytest
   doCheck = false;
-  pythonImportsCheck = [ "setuptools_scm" ];
+
+  passthru.tests = {
+    pytest = callPackage ./tests.nix { };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/pypa/setuptools_scm/";

--- a/pkgs/development/python-modules/setuptools-scm/tests.nix
+++ b/pkgs/development/python-modules/setuptools-scm/tests.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, setuptools-scm
+, pytestCheckHook
+, git
+, mercurial
+, pip
+, virtualenv
+}:
+
+buildPythonPackage rec {
+  pname = "setuptools-scm-tests";
+  inherit (setuptools-scm) version;
+
+  src = setuptools-scm.src;
+
+  dontBuild = true;
+  dontInstall = true;
+
+  checkInputs = [
+    pytestCheckHook
+    setuptools-scm
+    pip
+    virtualenv
+    git
+    mercurial
+  ];
+
+  disabledTests = [
+    # network access
+    "test_pip_download"
+  ];
+}

--- a/pkgs/development/tools/poetry2nix/poetry2nix/mk-poetry-dep.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/mk-poetry-dep.nix
@@ -96,6 +96,9 @@ pythonPackages.callPackage
         "setuptools_scm"
         "setuptools-scm"
         "toml" # Toml is an extra for setuptools-scm
+        "packaging"
+        "six"
+        "pyparsing"
       ];
       baseBuildInputs = lib.optional (! lib.elem name skipSetupToolsSCM) pythonPackages.setuptools-scm;
       format = if isDirectory || isGit || isUrl then "pyproject" else fileInfo.format;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/pypa/setuptools_scm/issues/615 was resolved, let's update and get some tests going.

Verified that zipp builds and has correct version number.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
