### PR TITLE
aws-sdk-cpp: disabale parallel checking

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -64,10 +64,10 @@ stdenv.mkDerivation rec {
   # fix build with gcc9, can be removed after bumping to current version
   NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
 
-  preConfigure = ''
-    rm aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
-    rm aws-cpp-sdk-core-tests/aws/client/AWSClientTest.cpp
-  '';
+  # aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
+  # aws-cpp-sdk-core-tests/aws/client/AWSClientTest.cpp
+  # seem to have a datarace
+  enableParallelChecking = false;
 
   postFixupHooks = [
     # This bodge is necessary so that the file that the generated -config.cmake file


### PR DESCRIPTION
data races suspected in
aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
and
aws-cpp-sdk-core-tests/aws/client/AWSClientTest.cpp


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
