### PR TITLE
python3Packages.markdown-it-py: use pythonImportsCheck instead of pytestImportsCheck

### DIFF
--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     pytest-regressions
     pytestCheckHook
   ];
-  pytestImportsCheck = [ "markdown_it" ];
+  pythonImportsCheck = [ "markdown_it" ];
 
   meta = with lib; {
     description = "Markdown parser done right";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The correct option is `pythonImportsCheck` according to the [official docs](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/python.section.md#using-pythonimportscheck-using-pythonimportscheck). The `pytestImportsCheck` is not used anywhere else in nixpkgs. 

I have no idea why `pytestImportsCheck` doesn't error. Perhaps that should also be investigated?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
