### PR TITLE
inconsolata: revert to working unstable version

### DIFF
--- a/pkgs/data/fonts/inconsolata/default.nix
+++ b/pkgs/data/fonts/inconsolata/default.nix
@@ -1,12 +1,18 @@
-{ lib, stdenv, google-fonts }:
+{ lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
   pname = "inconsolata";
+  version = "unstable-2021-01-19";
 
-  inherit (google-fonts) src version;
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "fonts";
+    rev = "f113126dc4b9b1473d9354a86129c9d7b837aa1a";
+    sha256 = "0safw5prpa63mqcyfw3gr3a535w4c9hg5ayw5pkppiwil7n3pyxs";
+  };
 
   installPhase = ''
-    install -m644 --target $out/share/fonts/truetype/inconsolata -D $src/ofl/inconsolata/static/*.ttf
+    install -m644 --target $out/share/fonts/truetype/inconsolata -D $src/ofl/inconsolata/*.ttf
   '';
 
   meta = with lib; {


### PR DESCRIPTION
An update to an unstable version of google-fonts broke the Inconsolata
monospace font in programs that use xft such as urxvt. This patch reverts
some inconsolata back to a working version.

Alternative to #130209

See also:

googlefonts/Inconsolata#42
https://discourse.nixos.org/t/how-to-fix-broken-inconsolata-font-in-urxvt-on-21-05/13437

cc @jakubgs @06kellyjac @petabyteboy @tu-maurice

Signed-off-by: William Casarin <jb55@jb55.com>