### PR TITLE
base16-shell-preview: 0.3.0 -> 1.0.0

### DIFF
--- a/pkgs/misc/base16-shell-preview/default.nix
+++ b/pkgs/misc/base16-shell-preview/default.nix
@@ -2,12 +2,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "base16-shell-preview";
-  version = "0.3.0";
+  version = "1.0.0";
 
   src = python3Packages.fetchPypi {
     inherit version;
     pname = "base16_shell_preview";
-    sha256 = "0x2fbicrcqgf2dl7dqzm14dz08vjjziabaaw33wah3v9wv4rw7jq";
+    sha256 = "098f3z81g3acgcrisipz0nh17n9kx7ld6h8dg26qz3nx31pngsxd";
   };
 
   # No tests


### PR DESCRIPTION
###### Motivation for this change

0.3.0 is years out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
