### PR TITLE
cudatoolkit_11_{3,4}: init at 11.{3,4}.1

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -1,13 +1,15 @@
-{ lib
-, callPackage
+{ callPackage
 , fetchurl
 , gcc7
 , gcc9
+, gcc10
+, lib
 }:
 
 let
   common = callPackage ./common.nix;
-in rec {
+in
+rec {
   cudatoolkit_10_0 = common {
     version = "10.0.130";
     url = "https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_410.48_linux";
@@ -54,6 +56,20 @@ in rec {
     url = "https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run";
     sha256 = "sha256-HamMuJfMX1inRFpKZspPaSaGdwbLOvWKZpzc2Nw9F8g=";
     gcc = gcc9;
+  };
+
+  cudatoolkit_11_3 = common {
+    version = "11.3.1";
+    url = "https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run";
+    sha256 = "0d19pwcqin76scbw1s5kgj8n0z1p4v1hyfldqmamilyfxycfm4xd";
+    gcc = gcc9;
+  };
+
+  cudatoolkit_11_4 = common {
+    version = "11.4.1";
+    url = "https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux.run";
+    sha256 = "0180pb1zfajb9l6blr467xkx01yp3snfwm2xix8x52crf6d36v6x";
+    gcc = gcc10; # can bump to 11 along with stdenv.cc
   };
 
   cudatoolkit_11 = cudatoolkit_11_2;

--- a/pkgs/development/libraries/science/math/cutensor/default.nix
+++ b/pkgs/development/libraries/science/math/cutensor/default.nix
@@ -41,5 +41,5 @@ rec {
     cudatoolkit = cudatoolkit_11_4;
   };
 
-  cutensor_cudatoolkit_11 = cutensor_cudatoolkit_11_4;
+  cutensor_cudatoolkit_11 = cutensor_cudatoolkit_11_2;
 }

--- a/pkgs/development/libraries/science/math/cutensor/default.nix
+++ b/pkgs/development/libraries/science/math/cutensor/default.nix
@@ -1,6 +1,6 @@
 { callPackage
 , cudatoolkit_10_1, cudatoolkit_10_2
-, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2
+, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2, cudatoolkit_11_3, cudatoolkit_11_4
 }:
 
 rec {
@@ -33,5 +33,13 @@ rec {
     cudatoolkit = cudatoolkit_11_2;
   };
 
-  cutensor_cudatoolkit_11 = cutensor_cudatoolkit_11_2;
+  cutensor_cudatoolkit_11_3 = cutensor_cudatoolkit_11_0.override {
+    cudatoolkit = cudatoolkit_11_3;
+  };
+
+  cutensor_cudatoolkit_11_4 = cutensor_cudatoolkit_11_0.override {
+    cudatoolkit = cudatoolkit_11_4;
+  };
+
+  cutensor_cudatoolkit_11 = cutensor_cudatoolkit_11_4;
 }

--- a/pkgs/test/cuda/cuda-library-samples/default.nix
+++ b/pkgs/test/cuda/cuda-library-samples/default.nix
@@ -1,8 +1,8 @@
 { callPackage
 , cudatoolkit_10_1, cudatoolkit_10_2
-, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2
+, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2, cudatoolkit_11_3, cudatoolkit_11_4
 , cutensor_cudatoolkit_10_1, cutensor_cudatoolkit_10_2
-, cutensor_cudatoolkit_11_0, cutensor_cudatoolkit_11_1, cutensor_cudatoolkit_11_2
+, cutensor_cudatoolkit_11_0, cutensor_cudatoolkit_11_1, cutensor_cudatoolkit_11_2, cutensor_cudatoolkit_11_3, cutensor_cudatoolkit_11_4
 }:
 
 rec {
@@ -37,6 +37,16 @@ rec {
     cutensor_cudatoolkit = cutensor_cudatoolkit_11_2;
   };
 
+  cuda-library-samples_cudatoolkit_11_3 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_3;
+    cutensor_cudatoolkit = cutensor_cudatoolkit_11_3;
+  };
+
+  cuda-library-samples_cudatoolkit_11_4 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_4;
+    cutensor_cudatoolkit = cutensor_cudatoolkit_11_4;
+  };
+
   cuda-library-samples_cudatoolkit_11 =
-    cuda-library-samples_cudatoolkit_11_2;
+    cuda-library-samples_cudatoolkit_11_4;
 }

--- a/pkgs/test/cuda/cuda-samples/default.nix
+++ b/pkgs/test/cuda/cuda-samples/default.nix
@@ -1,6 +1,6 @@
 { callPackage
 , cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2
-, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2
+, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2, cudatoolkit_11_3, cudatoolkit_11_4
 }:
 
 rec {
@@ -40,5 +40,15 @@ rec {
     sha256 = "1p1qjvfbm28l933mmnln02rqrf0cy9kbpsyb488d1haiqzvrazl1";
   };
 
-  cuda-samples_cudatoolkit_11 = cuda-samples_cudatoolkit_11_2;
+  cuda-samples_cudatoolkit_11_3 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_3;
+    sha256 = "0kbibb6pgz8j5iq6284axcnmycaha9bw8qlmdp6yfwmnahq1v0yz";
+  };
+
+  cuda-samples_cudatoolkit_11_4 = callPackage ./generic.nix {
+    cudatoolkit = cudatoolkit_11_4;
+    sha256 = "082dkk5y34wyvjgj2p5j1d00rk8xaxb9z0mhvz16bd469r1bw2qk";
+  };
+
+  cuda-samples_cudatoolkit_11 = cuda-samples_cudatoolkit_11_4;
 }

--- a/pkgs/test/cuda/cuda-samples/generic.nix
+++ b/pkgs/test/cuda/cuda-samples/generic.nix
@@ -1,6 +1,11 @@
-{ lib, stdenv, fetchFromGitHub
-, pkg-config, addOpenGLRunpath
-, sha256, cudatoolkit
+{ addOpenGLRunpath
+, cudatoolkit
+, fetchFromGitHub
+, fetchpatch
+, lib
+, pkg-config
+, sha256
+, stdenv
 }:
 
 let
@@ -21,6 +26,14 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config addOpenGLRunpath ];
 
   buildInputs = [ cudatoolkit ];
+
+  # See https://github.com/NVIDIA/cuda-samples/issues/75.
+  patches = lib.optionals (version == "11.3") [
+    (fetchpatch {
+      url = "https://github.com/NVIDIA/cuda-samples/commit/5c3ec60faeb7a3c4ad9372c99114d7bb922fda8d.patch";
+      sha256 = "sha256:15bydf59scmfnldz5yawbjacdxafi50ahgpzq93zlc5xsac5sz6i";
+    })
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/test/cuda/default.nix
+++ b/pkgs/test/cuda/default.nix
@@ -10,7 +10,9 @@ rec {
     cuda-samples_cudatoolkit_11
     cuda-samples_cudatoolkit_11_0
     cuda-samples_cudatoolkit_11_1
-    cuda-samples_cudatoolkit_11_2;
+    cuda-samples_cudatoolkit_11_2
+    cuda-samples_cudatoolkit_11_3
+    cuda-samples_cudatoolkit_11_4;
 
   cuda-library-samplesPackages = callPackage ./cuda-library-samples { };
   inherit (cuda-library-samplesPackages)
@@ -20,5 +22,7 @@ rec {
     cuda-library-samples_cudatoolkit_11
     cuda-library-samples_cudatoolkit_11_0
     cuda-library-samples_cudatoolkit_11_1
-    cuda-library-samples_cudatoolkit_11_2;
+    cuda-library-samples_cudatoolkit_11_2
+    cuda-library-samples_cudatoolkit_11_3
+    cuda-library-samples_cudatoolkit_11_4;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4111,7 +4111,9 @@ with pkgs;
     cudatoolkit_11
     cudatoolkit_11_0
     cudatoolkit_11_1
-    cudatoolkit_11_2;
+    cudatoolkit_11_2
+    cudatoolkit_11_3
+    cudatoolkit_11_4;
 
   cudatoolkit = cudatoolkit_10;
 
@@ -4136,7 +4138,9 @@ with pkgs;
     cutensor_cudatoolkit_11
     cutensor_cudatoolkit_11_0
     cutensor_cudatoolkit_11_1
-    cutensor_cudatoolkit_11_2;
+    cutensor_cudatoolkit_11_2
+    cutensor_cudatoolkit_11_3
+    cutensor_cudatoolkit_11_4;
 
   cutensor = cutensor_cudatoolkit_10;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add derivations for the latest CUDA toolkit releases.

GCC versions were selected based on the official documentation 
* 11.3: https://docs.nvidia.com/cuda/archive/11.3.1/cuda-installation-guide-linux/index.html#system-requirements
* 11.4: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements

I have built both derivations and tested that they run `nvidia-smi` successfully.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
