### PR TITLE
telescope: 0.4.1 -> 0.5.1

### DIFF
--- a/pkgs/applications/networking/browsers/telescope/default.nix
+++ b/pkgs/applications/networking/browsers/telescope/default.nix
@@ -1,23 +1,27 @@
 { stdenv
 , lib
-, fetchurl
+, fetchFromGitHub
 , pkg-config
 , bison
 , libevent
 , libressl
 , ncurses
+, autoreconfHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "telescope";
-  version = "0.4.1";
+  version = "0.5.1";
 
-  src = fetchurl {
-    url = "https://github.com/omar-polo/telescope/releases/download/${version}/telescope-${version}.tar.gz";
-    sha256 = "086zps4nslv5isfw1b5gvms7vp3fglm7x1a6ks0h0wxarzj350bl";
+  src = fetchFromGitHub {
+    owner = "omar-polo";
+    repo = pname;
+    rev = version;
+    sha256 = "0dd09r7b2gm9nv1q67yq4zk9f4v0fwqr5lw51crki9ii82gmj2h8";
   };
 
   nativeBuildInputs = [
+    autoreconfHook
     pkg-config
     bison
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
