### PR TITLE
publicsuffix-list: 2019-05-24 -> 2021-09-03

### DIFF
--- a/pkgs/data/misc/publicsuffix-list/default.nix
+++ b/pkgs/data/misc/publicsuffix-list/default.nix
@@ -2,13 +2,13 @@
 
 let
   pname = "publicsuffix-list";
-  version = "2019-05-24";
+  version = "2021-09-03";
 in fetchFromGitHub {
   name = "${pname}-${version}";
   owner = "publicsuffix";
   repo = "list";
-  rev = "a1db0e898956e126de65be1a5e977fbbbbeebe33";
-  sha256 = "092153w2jr7nx28p9wc9k6b5azi9c39ghnqfnfiwfzv1j8jm3znq";
+  rev = "2533d032871e1ef1f410fc0754b848d4587c8021";
+  hash = "sha256-Q8uIXM1CMu8dlWcVoL17M1XRGu3kG7Y7jpx0oHQh+2I=";
 
   postFetch = ''
     tar xf $downloadedFile --strip=1

--- a/pkgs/data/misc/publicsuffix-list/default.nix
+++ b/pkgs/data/misc/publicsuffix-list/default.nix
@@ -8,7 +8,7 @@ in fetchFromGitHub {
   owner = "publicsuffix";
   repo = "list";
   rev = "2533d032871e1ef1f410fc0754b848d4587c8021";
-  hash = "sha256-Q8uIXM1CMu8dlWcVoL17M1XRGu3kG7Y7jpx0oHQh+2I=";
+  sha256 = "sha256-Q8uIXM1CMu8dlWcVoL17M1XRGu3kG7Y7jpx0oHQh+2I=";
 
   postFetch = ''
     tar xf $downloadedFile --strip=1


### PR DESCRIPTION
###### Motivation for this change

The publicsuffix-list data file in Nix is pretty out of date. Trying to fix this long-term with occasional updates is probably not all that great (vs. keeping it up-to-date on the target machine by refetching), but this is definitely the easiest way to get another update in.

###### Things done

I have tested building the package on Ubuntu. I have not done a full recompilation of all packages depending on this package because a) it's an update to a single data file and b) it affects a ton of reverse dependencies.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
