### PR TITLE
[21.05] thunderbird-91: patch for #134433

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/91/D124361.diff
+++ b/pkgs/applications/networking/mailreaders/thunderbird/91/D124361.diff
@@ -1,0 +1,22 @@
+diff --git a/comm/mail/config/mozconfigs/common b/comm/mail/config/mozconfigs/common
+--- a/comm/mail/config/mozconfigs/common
++++ b/comm/mail/config/mozconfigs/common
+@@ -1,6 +1,3 @@
+ ac_add_options --enable-application=comm/mail
+ 
+-# Disable enforcing that add-ons are signed by the trusted root.
+-MOZ_REQUIRE_SIGNING=
+-
+ . "$topsrcdir/build/mozconfig.common.override"
+diff --git a/comm/mail/moz.configure b/comm/mail/moz.configure
+--- a/comm/mail/moz.configure
++++ b/comm/mail/moz.configure
+@@ -12,6 +12,7 @@
+ imply_option("MOZ_CRASHREPORTER_URL", "https://crash-reports.thunderbird.net/")
+ 
+ imply_option("--enable-default-browser-agent", False)
++imply_option("MOZ_REQUIRE_SIGNING", False)
+ 
+ 
+ @depends(target_is_windows, target_is_linux)
+

--- a/pkgs/applications/networking/mailreaders/thunderbird/91/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/91/default.nix
@@ -11,6 +11,12 @@ callPackage (import ../../../browsers/firefox/common.nix rec {
   };
   patches = [
     ./no-buildconfig-90.patch
+
+    # There is a bug in Thunderbird 91 where add-ons are required
+    # to be signed when the build is run with default settings.
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1727113
+    # https://phabricator.services.mozilla.com/D124361
+    ./D124361.diff
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/136567

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
