### PR TITLE
nixos/etc: Force the source path to a string with context

### DIFF
--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -55,7 +55,7 @@ let
     mkdir -p "$out/etc"
     ${concatMapStringsSep "\n" (etcEntry: escapeShellArgs [
       "makeEtcEntry"
-      etcEntry.source
+      "${etcEntry.source}"
       etcEntry.target
       etcEntry.mode
       etcEntry.user


### PR DESCRIPTION
###### Motivation for this change

With this change we ensure that the source path is always within the nix
store if passed as a `path` type. This used to work until refactored in
eb7120d where the path was converted to a string (implicitly).

This caused previously working configurations that propagated files in
/etc/ with files from the local (build time) filesystem to break. They
did now contain the absolute path to the files on the build host.

This surfaced in the initrd-networking-sshd test case where the ssh key
wasn't deployed onto the hosts again. If we want to  intentionally
change this behavior we should provide an alternative, proper warnings
and a changelog entry.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
 - [x] ran the  initrd-network-ssh test before (failed) and afterwards (succeeded).