### PR TITLE
fetchipfs: support api/v0/get

### DIFF
--- a/pkgs/build-support/fetchipfs/builder.sh
+++ b/pkgs/build-support/fetchipfs/builder.sh
@@ -7,15 +7,17 @@ source $stdenv/setup
 
 set -o noglob
 
+# we handle retries manually, since curl does also retry on http 500
+[ -z "$retryCount" ] && retryCount=2
+
 curl="curl            \
  --location           \
  --max-redirs 20      \
- --retry 2            \
+ --retry 0            \
  --disable-epsv       \
  --cookie-jar cookies \
  --insecure           \
  --speed-time 5       \
- -#                   \
  --fail               \
  $curlOpts            \
  $NIX_CURL_FLAGS"
@@ -28,9 +30,9 @@ finish() {
 
 ipfs_add() {
     if curl --retry 0 --head --silent "localhost:5001" > /dev/null; then
-        echo "[0m[01;36m=IPFS=[0m add $ipfs"
+        echo "fetchipfs: add $ipfs"
         tar --owner=root --group=root -cWf "source.tar" $(echo *)
-        res=$(curl -# -F "file=@source.tar" "localhost:5001/api/v0/tar/add" | sed 's/.*"Hash":"\(.*\)".*/\1/')
+        res=$(curl -X POST -# -F "file=@source.tar" "localhost:5001/api/v0/tar/add" | sed 's/.*"Hash":"\(.*\)".*/\1/')
         if [ $ipfs != $res ]; then
             echo "\`ipfs tar add' results in $res when $ipfs is expected"
             exit 1
@@ -44,27 +46,63 @@ echo
 mkdir download
 cd download
 
-if curl --retry 0 --head --silent "localhost:5001" > /dev/null; then
+if curl -X POST --retry 0 --head --silent "localhost:5001" > /dev/null; then
     curlexit=18;
-    echo "[0m[01;36m=IPFS=[0m get $ipfs"
-    # if we get error code 18, resume partial download
-    while [ $curlexit -eq 18 ]; do
+    echo "fetchipfs: get $ipfs"
+    api_path_tar="tar/cat?"
+    api_path_get="get?archive=true&compress=false&"
+    api_path="$api_path_tar"
+
+    retry_step=0
+    for (( loop_step = 1; ; loop_step++ )); do
+        if (( $loop_step % 50 == 0 )); then
+            # debug infinite loop: show progress every 50 steps
+            echo "fetchipfs: loop step $loop_step"
+        fi
+
         # keep this inside an if statement, since on failure it doesn't abort the script
-        if $curl -C - "http://localhost:5001/api/v0/tar/cat?arg=$ipfs" --output "$ipfs.tar"; then
+        if http_code=$($curl -s -w "%{http_code}" -X POST -C - "http://localhost:5001/api/v0/${api_path}arg=$ipfs" --output "$ipfs.tar")
+        then
+            sleep 0.5 # WORKAROUND tar: time stamp is 0.2 s in the future https://github.com/ipfs/go-ipfs/issues/8406
             unpackFile "$ipfs.tar"
             rm "$ipfs.tar"
-            set +o noglob
-            mv $(echo *) "$out"
+            if [[ "$api_path" == "$api_path_tar" ]]; then
+                mkdir -p "$out"
+                set +o noglob # enable glob
+                set -o dotglob # also glob hidden files
+                mv * "$out"
+            else
+                mv "$ipfs" "$out"
+            fi
             finish
         else
-            curlexit=$?;
+            curlexit=$?
+
+            if [[ $curlexit == 18 ]]; then
+                # continue partial download (curl -C -)
+                continue
+            fi
+
+            if [[ "$http_code" == 500 && "$api_path" == "$api_path_tar" ]]; then
+                # change api method
+                api_path="$api_path_get"
+                continue
+            fi
+
+            retry_step=$(($retry_step + 1))
+            if (( $retry_step > $retryCount )); then
+                echo "fetchipfs: retry end"
+                break
+            fi
+
+            echo "fetchipfs: retry $retry_step"
         fi
     done
 fi
 
 if test -n "$url"; then
     curlexit=18;
-    echo "Downloading $url"
+    echo "fetchipfs: download $url"
     while [ $curlexit -eq 18 ]; do
         # keep this inside an if statement, since on failure it doesn't abort the script
         if $curl "$url" -O; then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
the old fetchipfs only works, when the object is an "IPFS tarchive"

when the object is a directory, the [api method `tar/cat`](https://docs.ipfs.io/reference/http/api/#api-v0-tar-cat) fails:

```
curl -X POST "http://localhost:5001/api/v0/tar/cat?arg=bafybeiflkjt66aetfgcrgvv75izymd5kc47g6luepqmfq6zsf5w6ueth6y"
# {"Message":"not an IPFS tarchive","Code":0,"Type":"error"}

curl -s -w "%{http_code}" -o /dev/null -X POST "http://localhost:5001/api/v0/tar/cat?arg=bafybeiflkjt66aetfgcrgvv75izymd5kc47g6luepqmfq6zsf5w6ueth6y"
# 500
```

instead, we must use the [api method `get`](https://docs.ipfs.io/reference/http/api/#api-v0-get)

```
curl -o output.tar -X POST "http://localhost:5001/api/v0/get?archive=true&compress=false&arg=bafybeiflkjt66aetfgcrgvv75izymd5kc47g6luepqmfq6zsf5w6ueth6y"
```

this patch will also

* send POST requests to the ipfs api, since GET is no longer supported
* use manual retries, since curl would also retry on http 500 = wrong api method
* add a workaround for https://github.com/ipfs/go-ipfs/issues/8406

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### test

```nix
# fetchipfs-test.nix
# nix-build -E 'with import <nixpkgs> { }; callPackage ./fetchipfs-test.nix { }'
{ curl, stdenv }:
let
  fetchipfs = import ./fetchipfs { inherit curl stdenv; };
in
fetchipfs {
  # ipfs-desktop/assets/webui = 20 megabyte
  ipfs = "bafybeiflkjt66aetfgcrgvv75izymd5kc47g6luepqmfq6zsf5w6ueth6y";
  sha256 = "0p8w97j6rxnackm14p9npbra5a82irdb50i80qjc0pfpzjk781dm";
}
```

### todo

* test with other ipfs objects
* test the retry loop
* support fetching from public gateways = https://ipfs.io/api/v0/ etc
* allow to add a human-readable name as suffix to store path
* in the store path, always add the prefix `ipfs-` before the ipfs hash, so its easier to find ipfs objects in the store

