### PR TITLE
stdenv: simplify nix_build_core guess

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -660,15 +660,10 @@ export NIX_INDENT_MAKE=1
 # means that we're supposed to try and auto-detect the number of
 # available CPU cores at run-time.
 
-if [ -z "${NIX_BUILD_CORES:-}" ]; then
-  NIX_BUILD_CORES="1"
-elif (( NIX_BUILD_CORES <= 0 )); then
-  NIX_BUILD_CORES=$(nproc 2>/dev/null || true)
-  if expr >/dev/null 2>&1 "$NIX_BUILD_CORES" : "^[0-9][0-9]*$"; then
-    :
-  else
-    NIX_BUILD_CORES="1"
-  fi
+NIX_BUILD_CORES="${NIX_BUILD_CORES:-1}"
+if ((NIX_BUILD_CORES <= 0)); then
+  guess=$(nproc 2>/dev/null || true)
+  ((NIX_BUILD_CORES = guess <= 0 ? 1 : guess))
 fi
 export NIX_BUILD_CORES
 


### PR DESCRIPTION

###### Motivation for this change

- rely on a bash builtin rather than the external exp
- simplify the logic

This can be tested with the following script
```
NIX_BUILD_CORES=4
NIX_BUILD_CORES="${NIX_BUILD_CORES:-1}"
if ((NIX_BUILD_CORES <= 0 )); then
  GUESS=$(nproc 2>/dev/null || true)
  NUMERIC_GUESS="${GUESS//[^0-9]/}"
  NIX_BUILD_CORES="${NUMERIC_GUESS:-1}"
fi
echo $NIX_BUILD_CORES
```
replace the first assignement with potential initial values.
4, 1, 0, -1, abcd
all lead to the correct NIX_BUILD_CORES value.

I know this doesn't matter in the grand scheme of things, just trying in case people agree.


@7c6f434c you've been kind enough to review some bash before.
@andersk you've been very knowledgeable about shell

No worries if you don't have time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
