### PR TITLE
surge-XT: init at unstable-2021-11-7

### DIFF
--- a/pkgs/applications/audio/surge-XT/default.nix
+++ b/pkgs/applications/audio/surge-XT/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, cairo, libxkbcommon, xcbutilcursor, xcbutilkeysyms, xcbutil, libXrandr, libXinerama, libXcursor, alsa-lib, libjack2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "surge-XT";
+  version = "unstable-2021-11-07";
+
+  src = fetchFromGitHub {
+    owner = "surge-synthesizer";
+    repo = "surge";
+    rev = "ed93833eb44b177c977e3a7b878ffdd9bf9f24e5";
+    sha256 = "0b164659ksl6h5nn7jja5zccx2mwzibqs6b7hg8l98gpcy9fi5r2";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cairo libxkbcommon xcbutilcursor xcbutilkeysyms xcbutil libXrandr libXinerama libXcursor alsa-lib libjack2 ];
+
+  installPhase = ''
+    cd ..
+    cmake --build build --config Release --target install
+  '';
+
+  doInstallCheck = false;
+
+  meta = with lib; {
+    description = "LV2 & VST3 synthesizer plug-in (previously released as Vember Audio Surge)";
+    homepage = "https://surge-synthesizer.github.io";
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ magnetophon orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28124,6 +28124,8 @@ with pkgs;
     git = gitMinimal;
   };
 
+  surge-XT = callPackage ../applications/audio/surge-XT { };
+
   survex = callPackage ../applications/misc/survex {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
