### PR TITLE
stdenv: fix build times

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -121,14 +121,12 @@ exitHandler() {
     set +e
 
     if [ -n "${showBuildStats:-}" ]; then
-        times > "$NIX_BUILD_TOP/.times"
-        local -a times=($(cat "$NIX_BUILD_TOP/.times"))
-        # Print the following statistics:
-        # - user time for the shell
-        # - system time for the shell
-        # - user time for all child processes
-        # - system time for all child processes
-        echo "build time elapsed: " "${times[@]}"
+        read -r -d '' -a buildTimes < <(times)
+        echo "build times:"
+        echo "user time for the shell             ${buildTimes[0]}"
+        echo "system time for the shell           ${buildTimes[1]}"
+        echo "user time for all child processes   ${buildTimes[2]}"
+        echo "system time for all child processes ${buildTimes[3]}"
     fi
 
     if (( "$exitCode" != 0 )); then


### PR DESCRIPTION
###### Motivation for this change

This is not a major concern, but there are two problems with the code
- it uses cat instead of built in file redirection
- There is a shellcheck warning on unclear array semantics

This can be tested with the small script
```
buildTimes=()
while read -r line; do
    echo "$line"
    buildTimes+=("$line")
done < <(times) > .times
echo "build time elapsed: " "${buildTimes[@]}"
```

@7c6f434c you've been kind enough to review some bash before.
@andersk you've been very knowledgeable about shell

No worries if you don't have time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
