### PR TITLE
nixos: nix.sshServe: add write option

### DIFF
--- a/nixos/modules/services/misc/nix-ssh-serve.nix
+++ b/nixos/modules/services/misc/nix-ssh-serve.nix
@@ -4,7 +4,7 @@ with lib;
 let cfg = config.nix.sshServe;
     command =
       if cfg.protocol == "ssh"
-        then "nix-store --serve"
+        then "nix-store --serve ${lib.optionalString cfg.write "--write"}"
       else "nix-daemon --stdio";
 in {
   options = {
@@ -15,6 +15,12 @@ in {
         type = types.bool;
         default = false;
         description = "Whether to enable serving the Nix store as a remote store via SSH.";
+      };
+
+      write = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable writing to the Nix store as a remote store via SSH. Note: the sshServe user is named nix-ssh and is not a trusted-user. nix-ssh should be added to the nix.trustedUsers option in most use cases, such as allowing remote building of derivations.";
       };
 
       keys = mkOption {


### PR DESCRIPTION
(NOTE: opening this for @MatthewCroughan)

Adds the ability to provide the --write flag in addition to the --serve flag via a new option, services.sshServe.write.

A user can now share their system as a remote builder with friends easily as
follows:

```nix
{
  nix = {
    sshServe = {
      enable = true;
      write = true;
      keys = ["ssh-dss AAAAB3NzaC1k... alice@example.org"];
    };
  };
}
```

###### Motivation for this change

A use-case for the user is to include the `--write` flag in addition to the `--serve` flag.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (a remote builder was added and tested)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
