### PR TITLE
hylafaxplus: 7.0.3 -> 7.0.4

### DIFF
--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -30,8 +30,8 @@
 let
 
   pname = "hylafaxplus";
-  version = "7.0.3";
-  sha256 = "139iwcwrn9i5lragxi33ilzah72w59wg4midfjjgx5cly3ah0iy4";
+  version = "7.0.4";
+  sha256 = "1y4b178rxa4ivxm8cnypnnyc8db7cjqyyzy60hiw215x4cyyj4i5";
 
   configSite = substituteAll {
     name = "${pname}-config.site";

--- a/pkgs/servers/hylafaxplus/libtiff-4.patch
+++ b/pkgs/servers/hylafaxplus/libtiff-4.patch
@@ -2,11 +2,11 @@ https://bugs.gentoo.org/706154
 --- a/configure
 +++ b/configure
 @@ -2583,7 +2583,7 @@ EOF
- 				echo '#define TIFFSTRIPBYTECOUNTS uint32'
+ 				echo '#define TIFFSTRIPBYTECOUNTS uint32_t'
  				echo '#define TIFFVERSION TIFF_VERSION'
  				echo '#define TIFFHEADER TIFFHeader';;
--		4.[01])		tiff_runlen_t="uint32"
-+		4.[0-9])	tiff_runlen_t="uint32"
- 				tiff_offset_t="uint64"
- 				echo '#define TIFFSTRIPBYTECOUNTS uint64'
+-		4.[0123])	tiff_runlen_t="uint32_t"
++		4.[0-9])	tiff_runlen_t="uint32_t"
+ 				tiff_offset_t="uint64_t"
+ 				echo '#define TIFFSTRIPBYTECOUNTS uint64_t'
  				echo '#define TIFFVERSION TIFF_VERSION_CLASSIC'


### PR DESCRIPTION
###### Motivation for this change

Update hylafaxplus to the newest version.

Release notes: https://hylafax.sourceforge.io/news/7.0.4.php

Also adapt the libitff patch (see commit for details):

- hylafaxplus now accepts libtiff 4.0, 4.1, 4.2, 4.3
- variable types around the patched line changed

Notifying recent hylafaxplus nixpkgs contributor @ajs124: Maybe you can test and/or review this pull request, if you can spare the time.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested:

- sending and receiving faxes works as expected
- sending txt and pdf files works as expected
- `sendfax` options `-d`, `-i`, `-S`, `-h` work as expected
- `faxstat` options `-s`, `-r` work as expected
- sending to a busy, an unresponsive, and a non-fax phone line produce the expected error messages
- tested with iaxmodem (and asterisk), tested with conexant-1.0-compatible modem
- not tested email notification, but notification scripts are called
- not tested other features (polling, pager messages, SSLFax)
