### PR TITLE
mautrix-facebook: init at 0.3.1

### DIFF
--- a/pkgs/servers/mautrix-facebook/default.nix
+++ b/pkgs/servers/mautrix-facebook/default.nix
@@ -1,4 +1,5 @@
-{ fetchFromGitHub
+{ enableSystemd ? stdenv.isLinux
+, fetchFromGitHub
 , lib
 , python3
 , stdenv
@@ -29,7 +30,7 @@ python3.pkgs.buildPythonPackage rec {
     ruamel_yaml
     unpaddedbase64
     yarl
-  ];
+  ] ++ lib.optional enableSystemd systemd;
 
   doCheck = false;
 

--- a/pkgs/servers/mautrix-facebook/default.nix
+++ b/pkgs/servers/mautrix-facebook/default.nix
@@ -1,0 +1,57 @@
+{ fetchFromGitHub
+, lib
+, python3
+, stdenv
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "mautrix-facebook";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "mautrix";
+    repo = "facebook";
+    rev = "v${version}";
+    sha256 = "0m7nznx3z6cg4wgvjybdivx22ifxcdri4i8501yibsri0jnpf0y2";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    CommonMark
+    aiohttp
+    asyncpg
+    mautrix
+    paho-mqtt
+    pillow
+    prometheus-client
+    pycryptodome
+    python-olm
+    python_magic
+    ruamel_yaml
+    unpaddedbase64
+    yarl
+  ];
+
+  doCheck = false;
+
+  postPatch = ''
+    sed -ie 's/^asyncpg.*/asyncpg>=0.20/' requirements.txt
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+
+    cat <<-END >$out/bin/mautrix-facebook
+    #!/bin/sh
+    PYTHONPATH="$PYTHONPATH" exec ${python3}/bin/python -m mautrix_facebook "\$@"
+    END
+    chmod +x $out/bin/mautrix-facebook
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/mautrix/facebook";
+    description = "A Matrix-Facebook Messenger puppeting bridge";
+    license = licenses.agpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kevincox ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6624,6 +6624,8 @@ with pkgs;
 
   matrix-corporal = callPackage ../servers/matrix-corporal { };
 
+  mautrix-facebook = callPackage ../servers/mautrix-facebook { };
+
   mautrix-signal = recurseIntoAttrs (callPackage ../servers/mautrix-signal { });
 
   mautrix-telegram = recurseIntoAttrs (callPackage ../servers/mautrix-telegram { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
