### PR TITLE
Update vcsh to 2.x

### DIFF
--- a/pkgs/applications/version-management/vcsh/default.nix
+++ b/pkgs/applications/version-management/vcsh/default.nix
@@ -1,26 +1,38 @@
-{ lib, stdenv, fetchFromGitHub, which, git, ronn, perlPackages }:
+{ lib, stdenv
+, fetchurl
+, makeWrapper
+, pkg-config
+, git
+, perlPackages
+}:
 
-stdenv.mkDerivation {
-  version = "1.20170915";       # date of commit we're pulling
+stdenv.mkDerivation rec {
   pname = "vcsh";
+  version = "2.0.2";
 
-  src = fetchFromGitHub {
-    owner = "RichiH";
-    repo = "vcsh";
-    rev = "eadb8df6aa71a76e5be36492edcadb118bd862ac";
-    sha256 = "1wfzp8167lcq6akdpbi8fikjv0z3h1i5minh3423dljc04q0klm1";
+  src = fetchurl {
+    url = "https://github.com/RichiH/vcsh/releases/download/v${version}/${pname}-${version}.tar.xz";
+    sha256 = "0qdd4f6rm5rhnym9f114pcj9vafhjjpg962c4g420rn78fxhpz1z";
   };
 
-  buildInputs = [ which git ronn ]
-    ++ (with perlPackages; [ perl ShellCommand TestMost TestDifferences TestDeep TestException TestWarn ]);
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
 
-  installPhase = "make install PREFIX=$out";
+  buildInputs = [ git ];
+
+  checkInputs = []
+    ++ (with perlPackages; [ perl ShellCommand TestMost ]);
+
+  outputs = [ "out" "doc" "man" ];
 
   meta = with lib; {
     description = "Version Control System for $HOME";
     homepage = "https://github.com/RichiH/vcsh";
+    changelog = "https://github.com/RichiH/vcsh/blob/v${version}/changelog";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = with maintainers; [ ttuegel alerque ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
This is rather a shot in the dark. I'm the one that did the work upstream overhauling the build system between 1.x and 2.x so I know what happened there, but I don't know if this packaging is anything like correct.

The major change is that we switched from a home-grown makefile to a regular autotools build with a configure that checks for dependencies and system paths, and a `make install` that puts it all in standardized locations. All standard things like `--prefix` when configuring and `DESTDIR` when installing should would as expected now.

Additionally there are bash and zsh completions that should get installed, but I don't know if this build recipe will handle that or not.

@ttuegel I'm available for questions, and by all means if this doesn't get close feel free to nuke this and handle it however is proper.

###### Motivation for this change

Upstream release:

https://github.com/RichiH/vcsh/releases/tag/v2.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
