### PR TITLE
xmrig: etc ability to add config.json through package overrides

### DIFF
--- a/pkgs/applications/misc/xmrig/default.nix
+++ b/pkgs/applications/misc/xmrig/default.nix
@@ -1,7 +1,14 @@
 { stdenv, lib, fetchFromGitHub, cmake, libuv, libmicrohttpd, openssl, hwloc
+, writeText
+, configFile ? null
 , donateLevel ? 0
 }:
 
+let
+  configFileWriteCommand = if configFile != null then ''
+    echo "${configFile}" > $out/bin/config.json
+  '' else "";
+in
 stdenv.mkDerivation rec {
   pname = "xmrig";
   version = "6.14.0";
@@ -25,7 +32,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -vD xmrig $out/bin/xmrig
-  '';
+  '' + configFileWriteCommand;
 
   meta = with lib; {
     description = "Monero (XMR) CPU miner";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

By default xmrig looks for a config file in the nix-store. This change makes it possible to override configFile argument which will write the `config.json` file.

I am still new to nix and nixpkgs and I do not know if this is the desired way to make this work, please let me know if should be done in some other way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
