### PR TITLE
[21.05] inetutils: add patch for CVE-2021-40491

### DIFF
--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, ncurses, perl, help2man
+{ stdenv, lib, fetchurl, fetchpatch, ncurses, perl, help2man
 , apparmorRulesFromClosure
 }:
 
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
   outputs = ["out" "apparmor"];
 
   patches = [
+    (fetchpatch {
+      name = "CVE-2021-40491.patch";
+      url = "https://git.savannah.gnu.org/cgit/inetutils.git/patch/?id=58cb043b190fd04effdaea7c9403416b436e50dd";
+      excludes = [ "NEWS" ];
+      sha256 = "0001ij7493x14f05zfjk11x1x0363sbbxh08nnfv226pmbaxzbkn";
+    })
     ./whois-Update-Canadian-TLD-server.patch
     ./service-name.patch
     # https://git.congatec.com/yocto/meta-openembedded/commit/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-40491

Fixed in master in #136473

Patch assumed valid because this is the first change `ftp.c` has seen since 2.0, and all the involved interfaces are standard socket structures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
