### PR TITLE
atkinson-hyperlegible: init at unstable-2021-04-29

### DIFF
--- a/pkgs/data/fonts/atkinson-hyperlegible/default.nix
+++ b/pkgs/data/fonts/atkinson-hyperlegible/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub }:
+
+let
+  pname = "atkinson-hyperlegible";
+  version = "unstable-2021-04-29";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+
+  owner = "googlefonts";
+  repo = "atkinson-hyperlegible";
+  rev = "1cb311624b2ddf88e9e37873999d165a8cd28b46";
+  sha256 = "sha256-urSTqC3rfDRM8IMG+edwKEe7NPiTuDZph3heGHzLDks=";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -Dm644 -t $out/share/fonts/opentype fonts/otf/*
+  '';
+
+  meta = with lib; {
+    description = "Typeface designed to offer greater legibility and readability for low vision readers";
+    homepage = "https://brailleinstitute.org/freefont";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ zhaofengli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -173,6 +173,8 @@ with pkgs;
 
   antsimulator = callPackage ../games/antsimulator { };
 
+  atkinson-hyperlegible = callPackage ../data/fonts/atkinson-hyperlegible { };
+
   atuin = callPackage ../tools/misc/atuin {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A typeface designed to offer greater legibility and readability for low vision readers.

[Homepage](https://brailleinstitute.org/freefont)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
