### PR TITLE
taoup: init at 1.1.14

### DIFF
--- a/pkgs/tools/misc/taoup/cachefile.patch
+++ b/pkgs/tools/misc/taoup/cachefile.patch
@@ -1,0 +1,35 @@
+--- a/taoup-fortune	2021-09-05 12:16:23.408295791 +0800
++++ b/taoup-fortune	2021-09-05 13:02:52.286440200 +0800
+@@ -5,31 +5,9 @@
+ #        - https://github.com/matheuss/parrotsay
+ #        - https://github.com/busyloop/lolcat
+ #        - https://github.com/sckott/cowsay (enhanced version)
+-dir=`dirname "${BASH_SOURCE[0]}"`
+-
+-# USER ALERT!!! @ronjouch complained about execution speed at https://github.com/globalcitizen/taoup/issues/11 
+-#  ... therefore we add caching ... therefore first ensure we have an up to date cache via one of ...
+-# md5sum
+-if [ `which md5sum 2>/dev/null` ]; then
+- MD5SUM=`md5sum ${dir}/taoup | cut -d ' ' -f1`
+-# md5
+-elif [ `which md5 2>/dev/null` ]; then
+- MD5SUM=`md5 -q ${dir}/taoup | cut -d ' ' -f1`
+-# openssl
+-elif [ `which openssl 2>/dev/null` ]; then
+- MD5SUM=`cat ${dir}/taoup | openssl md5 | grep -o '[[:xdigit:]][[:xdigit:]]*$' |cut -d '=' -f2- |cut -c 2-`
+-# ruby
+-elif [ `which ruby 2>/dev/null` ]; then
+- MD5SUM=`ruby -rdigest/md5 -e"puts Digest::MD5.file'${dir}/taoup'"`
+-fi
+ 
+ # determine cachefile name
+-cachefile=${dir}/.taoup-fortune.cache.${MD5SUM}
+-
+-# create if necessary
+-if [ ! -r $cachefile ]; then
+- ${dir}/taoup $@ >${cachefile}
+-fi
++cachefile=@out@/lib/taoup/cache
+ 
+ # handle all classes of society
+ if [ `which cowsay 2>/dev/null` ]; then

--- a/pkgs/tools/misc/taoup/default.nix
+++ b/pkgs/tools/misc/taoup/default.nix
@@ -1,0 +1,62 @@
+{ lib, stdenv, fetchFromGitHub, ruby, bash, ncurses }:
+let
+  rubyEnv = ruby.withPackages (ps: with ps; [ ansi ]);
+in
+stdenv.mkDerivation rec {
+  pname = "taoup";
+  version = "1.1.14";
+
+  src = fetchFromGitHub {
+    owner = "globalcitizen";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1gs6f66fg1l504riw481nvyw7cchbr3qjks4mkj2qb3s9147ad8j";
+  };
+
+  buildInputs = [ rubyEnv bash ncurses ];
+
+  patches = [
+    # Pre-create a cache within this derivation
+    ./cachefile.patch
+    # Remove the need to test for `tput`, depend on ncurses directly
+    ./tput.patch
+    # Fix the script name in `taoup --help` output
+    ./help.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace taoup \
+     --subst-var-by ncurses ${ncurses} \
+     --subst-var-by pname ${pname}
+    substituteInPlace taoup-fortune \
+      --subst-var-by out $out \
+      --replace "/bin/bash" "${bash}/bin/bash"
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib/taoup}
+
+    cp taoup $out/lib/taoup
+    cat > $out/bin/taoup <<EOF
+    #!${bash}/bin/bash
+    exec ${rubyEnv}/bin/ruby "$out/lib/taoup/taoup" "\$@"
+    EOF
+    chmod +x $out/bin/taoup
+
+    # Populate the cache created by cachedir.patch above
+    $out/bin/taoup > $out/lib/taoup/cache
+
+    cp taoup-fortune $out/bin
+    chmod +x $out/bin/taoup-fortune
+  '';
+
+  meta = {
+    description = "The Tao of Unix Programming (Ruby-powered ANSI colored fortunes)";
+    homepage = "https://github.com/globalcitizen/taoup";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.zakame ];
+  };
+}

--- a/pkgs/tools/misc/taoup/help.patch
+++ b/pkgs/tools/misc/taoup/help.patch
@@ -1,0 +1,21 @@
+--- a/taoup	2021-09-07 16:45:00.000000000 +0800
++++ b/taoup	2021-09-07 16:46:00.000000000 +0800
+@@ -7,12 +7,12 @@
+ 
+ # show help if requested
+ if ARGV[0] == '--help' or ARGV[0] == '-h' then
+- puts "usage: " + $0 + " [arguments]"
+- puts "       " + $0 + "                    Display all fortunes and sections."
+- puts "       " + $0 + " < --help | -h >    This help."
+- puts "       " + $0 + " --whitetrash       Convert ANSI colors for light/white terminals."
+- puts "       " + $0 + " --machine          Remove ANSI colors."
+- puts "       " + $0 + " --fortune          Convert output to fortune format (and lose colors)."
++ puts "usage: " + "@pname@" + " [arguments]"
++ puts "       " + "@pname@" + "                    Display all fortunes and sections."
++ puts "       " + "@pname@" + " < --help | -h >    This help."
++ puts "       " + "@pname@" + " --whitetrash       Convert ANSI colors for light/white terminals."
++ puts "       " + "@pname@" + " --machine          Remove ANSI colors."
++ puts "       " + "@pname@" + " --fortune          Convert output to fortune format (and lose colors)."
+  exit(0)
+ end
+ # ... but optionally make sure ANSI escape sequences are filtered out

--- a/pkgs/tools/misc/taoup/tput.patch
+++ b/pkgs/tools/misc/taoup/tput.patch
@@ -1,0 +1,17 @@
+--- a/taoup	2021-09-05 12:43:48.334615538 +0800
++++ b/taoup	2021-09-05 12:55:07.631617799 +0800
+@@ -26,11 +26,9 @@
+  zero_colors = true
+  fortunify = true
+ else
+- if `which tput` then
+-  colors = `tput colors`
+-  if colors.chop == "-1" then
+-   zero_colors = true
+-  end
++ colors = `@ncurses@/bin/tput colors`
++ if colors.chop == "-1" then
++  zero_colors = true
+  end
+ end
+ if ARGV[0] == '--whitetrash' then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14770,6 +14770,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  taoup = callPackage ../tools/misc/taoup { };
+
   tcptrack = callPackage ../development/tools/misc/tcptrack { };
 
   teensyduino = arduino-core.override { withGui = true; withTeensyduino = true; };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/globalcitizen/taoup is a `fortune`-like tool that tells some words of wisdom from _The Art of Unix Programming_ and other sources.

Some patches are included to simplify the `taoup-fortune` example script (which tries to produce a cache directory at first run - we instead create and populate this at build time,) and `taoup` itself (which tries to test for `tput` - avoid that and just depend on `ncurses` to provide that instead.)

I suspect some improvements can be made still at the `postPatch` and `installPhase` steps - I'd love to hear anyone's guidance on this :pray: Thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
