### PR TITLE
ChowCentaur: init at 1.4.0

### DIFF
--- a/pkgs/applications/audio/ChowCentaur/default.nix
+++ b/pkgs/applications/audio/ChowCentaur/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, cairo, libxkbcommon
+, xcbutilcursor, xcbutilkeysyms, xcbutil, libXrandr, libXinerama, libXcursor
+, alsa-lib, libjack2, lv2, gcc-unwrapped }:
+
+stdenv.mkDerivation rec {
+  pname = "ChowCentaur";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "jatinchowdhury18";
+    repo = "KlonCentaur";
+    rev = "v${version}";
+    sha256 = "0mrzlf4a6f25xd7z9xanpyq7ybb4al01dzpjsgi0jkmlmadyhc4h";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    cairo
+    libxkbcommon
+    xcbutilcursor
+    xcbutilkeysyms
+    xcbutil
+    libXrandr
+    libXinerama
+    libXcursor
+    alsa-lib
+    libjack2
+    lv2
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"
+    "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib"
+    "-DCMAKE_NM=${gcc-unwrapped}/bin/gcc-nm"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2 $out/lib/vst3
+    cd ChowCentaur/ChowCentaur_artefacts/Release
+    cp -r LV2/ChowCentaur.lv2 $out/lib/lv2
+    cp -r VST3/ChowCentaur.vst3 $out/lib/vst3
+  '';
+
+  meta = with lib; {
+    description =
+      "Digital emulation of the Klon Centaur guitar pedal using RNNs, Wave Digital Filters, and more";
+    homepage = "https://github.com/jatinchowdhury18/KlonCentaur";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24777,6 +24777,8 @@ with pkgs;
 
   boops = callPackage ../applications/audio/boops { };
 
+  ChowCentaur  = callPackage ../applications/audio/ChowCentaur { };
+
   ChowKick  = callPackage ../applications/audio/ChowKick { };
 
   CHOWTapeModel = callPackage ../applications/audio/CHOWTapeModel { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
