### PR TITLE
Chowtapemodel: unstable-2020-12-12 -> 2.10.0

### DIFF
--- a/pkgs/applications/audio/CHOWTapeModel/default.nix
+++ b/pkgs/applications/audio/CHOWTapeModel/default.nix
@@ -1,68 +1,76 @@
-{ alsa-lib
-, curl
-, fetchFromGitHub
-, freeglut
-, freetype
-, libGL
-, libXcursor
-, libXext
-, libXinerama
-, libXrandr
-, libjack2
-, pkg-config
-, python3
-, stdenv
-, lib
-}:
+{ alsa-lib, at-spi2-core, cmake, curl, dbus, libepoxy, fetchFromGitHub, freeglut
+, freetype, gcc-unwrapped, gtk3, lib, libGL, libXcursor, libXdmcp, libXext
+, libXinerama, libXrandr, libXtst, libdatrie, libjack2, libpsl, libselinux
+, libsepol, libsysprof-capture, libthai, libxkbcommon, lv2, pcre, pkg-config
+, python3, sqlite, stdenv }:
 
 stdenv.mkDerivation rec {
   pname = "CHOWTapeModel";
-  version = "unstable-2020-12-12";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "jatinchowdhury18";
     repo = "AnalogTapeModel";
-    rev = "a7cf10c3f790d306ce5743bb731e4bc2c1230d70";
-    sha256 = "09nq8x2dwabncbp039dqm1brzcz55zg9kpxd4p5348xlaz5m4661";
+    rev = "v${version}";
+    sha256 = "sha256-iuT7OBRBtMkjcTHayCcne1mNqkcxzKnEYl62n65V7Z4=";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs = [ pkg-config cmake ];
 
   buildInputs = [
     alsa-lib
+    at-spi2-core
     curl
+    dbus
+    libepoxy
     freeglut
     freetype
+    gtk3
     libGL
     libXcursor
+    libXdmcp
     libXext
     libXinerama
     libXrandr
+    libXtst
+    libdatrie
     libjack2
+    libpsl
+    libselinux
+    libsepol
+    libsysprof-capture
+    libthai
+    libxkbcommon
+    lv2
+    pcre
     python3
+    sqlite
+    gcc-unwrapped
   ];
 
-  buildPhase = ''
-    cd Plugin/
-    ./build_linux.sh
-  '';
+  cmakeFlags = [
+    "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"
+    "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib"
+    "-DCMAKE_NM=${gcc-unwrapped}/bin/gcc-nm"
+  ];
+
+  postPatch = "cd Plugin";
 
   installPhase = ''
     mkdir -p $out/lib/lv2 $out/lib/vst3 $out/bin $out/share/doc/CHOWTapeModel/
-    cd Builds/LinuxMakefile/build/
-    cp CHOWTapeModel.a  $out/lib
-    cp -r CHOWTapeModel.lv2 $out/lib/lv2
-    cp -r CHOWTapeModel.vst3 $out/lib/vst3
-    cp CHOWTapeModel  $out/bin
+    cd CHOWTapeModel_artefacts/Release
+    cp libCHOWTapeModel_SharedCode.a  $out/lib
+    cp -r LV2/CHOWTapeModel.lv2 $out/lib/lv2
+    cp -r VST3/CHOWTapeModel.vst3 $out/lib/vst3
+    cp Standalone/CHOWTapeModel  $out/bin
     cp ../../../../Manual/ChowTapeManual.pdf $out/share/doc/CHOWTapeModel/
   '';
 
   meta = with lib; {
     homepage = "https://github.com/jatinchowdhury18/AnalogTapeModel";
-    description = "Physical modelling signal processing for analog tape recording. LV2, VST3 and standalone";
+    description =
+      "Physical modelling signal processing for analog tape recording. LV2, VST3 and standalone";
     license = with licenses; [ gpl3Only ];
     maintainers = with maintainers; [ magnetophon ];
     platforms = platforms.linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
