### PR TITLE
sysklogd: support cross-compilation

### DIFF
--- a/pkgs/os-specific/linux/sysklogd/default.nix
+++ b/pkgs/os-specific/linux/sysklogd/default.nix
@@ -14,6 +14,17 @@ stdenv.mkDerivation {
 
   installFlags = [ "BINDIR=$(out)/sbin" "MANDIR=$(out)/share/man" "INSTALL=install" ];
 
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
+
+  postPatch = ''
+    # Disable stripping during installation, stripping will be done anyway.
+    # Fixes cross-compilation.
+    substituteInPlace Makefile \
+      --replace "-m 500 -s" "-m 500"
+  '';
+
   preConfigure =
     ''
       sed -e 's@-o \''${MAN_USER} -g \''${MAN_GROUP} -m \''${MAN_PERMS} @@' -i Makefile


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for sysklogd, used by e.g. mobile-nixos: https://hydra.nixos.org/build/152116658

Built for aarch64-multiplatform using cross-compilation:

`nix-build -A pkgsCross.aarch64-multiplatform.sysklogd`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
