### PR TITLE
sasquatch: support cross-compilation

### DIFF
--- a/pkgs/tools/filesystems/sasquatch/default.nix
+++ b/pkgs/tools/filesystems/sasquatch/default.nix
@@ -48,7 +48,12 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "INSTALL_DIR=\${out}/bin" ];
 
-  makeFlags = [ "XZ_SUPPORT=1" ]
+  makeFlags = [
+    "XZ_SUPPORT=1"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "CXX=${stdenv.cc.targetPrefix}c++"
+    "AR=${stdenv.cc.targetPrefix}ar"
+  ]
     ++ lib.optional lz4Support "LZ4_SUPPORT=1";
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for sasquatch, used e.g. by mobile-nixos: https://hydra.nixos.org/build/152116607

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
