### PR TITLE
cramfsprogs: support cross-compilation

### DIFF
--- a/pkgs/os-specific/linux/cramfsprogs/default.nix
+++ b/pkgs/os-specific/linux/cramfsprogs/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
   # So patch the "missing include" bug ourselves.
   patches = [ ./include-sysmacros.patch ];
 
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
+
   installPhase = ''
     install --target $out/bin -D cramfsck mkcramfs
   '';


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for cramfsprogs, used by mobile-nixos: https://hydra.nixos.org/build/152116657

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
