### PR TITLE
cabextract: support cross-compilation

### DIFF
--- a/pkgs/tools/archivers/cabextract/default.nix
+++ b/pkgs/tools/archivers/cabextract/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "19qwhl2r8ip95q4vxzxg2kp4p125hjmc9762sns1dwwf7ikm7hmg";
   };
 
+  # Let's assume that fnmatch works for cross-compilation, otherwise it gives an error:
+  # undefined reference to `rpl_fnmatch'.
+  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "ac_cv_func_fnmatch_works=yes"
+  ];
+
   meta = with lib; {
     homepage = "https://www.cabextract.org.uk/";
     description = "Free Software for extracting Microsoft cabinet files";


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for cabextract, used by e.g. autoport in mobile-nixos.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
