### PR TITLE
python3Packages.numpy-stl: use pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/numpy-stl/default.nix
+++ b/pkgs/development/python-modules/numpy-stl/default.nix
@@ -1,4 +1,13 @@
-{ lib, buildPythonPackage, fetchPypi, cython, numpy, nine, pytest, pytest-runner, python-utils, enum34 }:
+{ lib
+, buildPythonPackage
+, cython
+, enum34
+, fetchPypi
+, nine
+, numpy
+, pytestCheckHook
+, python-utils
+}:
 
 buildPythonPackage rec {
   pname = "numpy-stl";
@@ -9,15 +18,24 @@ buildPythonPackage rec {
     sha256 = "3e635b6fb6112a3c5e00e9e20eedab93b9b0c45ff1cc34eb7bdc0b3e922e2d77";
   };
 
-  checkInputs = [ pytest pytest-runner ];
+  propagatedBuildInputs = [
+    cython
+    enum34
+    nine
+    numpy
+    python-utils
+  ];
 
-  checkPhase = "py.test";
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  propagatedBuildInputs = [ cython numpy nine python-utils enum34 ];
+  pythonImportsCheck = [ "stl" ];
 
   meta = with lib; {
     description = "Library to make reading, writing and modifying both binary and ascii STL files easy";
     homepage = "https://github.com/WoLpH/numpy-stl/";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Cleanup and switch to `pytestCheckHook`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
