### PR TITLE
SDl2_mixer: fix MIDI playback by adding timidity paths

### DIFF
--- a/pkgs/development/libraries/SDL2_mixer/default.nix
+++ b/pkgs/development/libraries/SDL2_mixer/default.nix
@@ -13,6 +13,7 @@
 , mpg123
 , opusfile
 , smpeg2
+, timidity
 }:
 
 stdenv.mkDerivation rec {
@@ -42,7 +43,15 @@ stdenv.mkDerivation rec {
     mpg123
     opusfile
     smpeg2
+    # MIDI patterns
+    timidity
   ];
+
+  # fix default path to timidity.cfg so MIDI files could be played
+  postPatch = ''
+    substituteInPlace timidity/options.h \
+      --replace "/usr/share/timidity" "${timidity}/share/timidity"
+  '';
 
   configureFlags = [
     "--disable-music-ogg-shared"


### PR DESCRIPTION
Noticed on fheroes2 package: before the change fheroes2 was not able to
play MIDI samples and complained as:
    PlayMusic:  music parameter was NULL

It happens because default search paths for 'timidity.cfg'
did not include any of nixos's paths in 'timidity/options.h':

    getenv("TIMIDITY_CFG")
    "."
    #define DEFAULT_PATH    "/etc/timidity"
    #define DEFAULT_PATH1   "/usr/share/timidity"
    #define DEFAULT_PATH2   "/usr/local/share/timidity"
    #define DEFAULT_PATH3   "/usr/local/lib/timidity"

As a result even with globally installed timidity MIDI can't be played.
abuse package also has the same problem and works it around by changing
directory to local copy of 'timidity.cfg':

    # The timidity bundled into SDL_mixer looks in . and in several global places
    # like /etc for its configuration file.
    cd @out@/etc
    exec @out@/bin/.abuse-bin "$@"

The change fixes SDL2_mixer by changing "/usr/share/timidity" path
to nix's timidity store path. Tested on fheroes2 with MIDI files.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
