### PR TITLE
[staging-next] icewm: fix empty -I flag

### DIFF
--- a/pkgs/applications/window-managers/icewm/default.nix
+++ b/pkgs/applications/window-managers/icewm/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , asciidoc
 , cmake
 , expat
@@ -47,6 +48,15 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-R06tiWS9z6K5Nbi+vvk7DyozpcFdrHleMeh7Iq/FfHQ=";
   };
+
+  patches = [
+    # https://github.com/ice-wm/icewm/pull/57
+    # Fix trailing -I that leads to "to generate dependencies you must specify either '-M' or '-MM'"
+    (fetchpatch {
+      url = "https://github.com/ice-wm/icewm/pull/57/commits/ebd2c45341cc31755758a423392a0f78a64d2d37.patch";
+      sha256 = "16m9znd3ijcfl7la3l27ac3clx8l9qng3fprkpxqcifd89ny1ml5";
+    })
+  ];
 
   nativeBuildInputs = [
     asciidoc


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://hydra.nixos.org/build/151235004/nixlog/1
https://github.com/ice-wm/icewm/pull/57

@r-burns 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
