### PR TITLE
libjxl: unstable-2021-06-22 -> 0.5

### DIFF
--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -29,6 +29,13 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  # hydra's darwin machines run into https://github.com/libjxl/libjxl/issues/408
+  # unless we disable highway's tests
+  postPatch = lib.optional stdenv.isDarwin ''
+    substituteInPlace third_party/highway/CMakeLists.txt \
+      --replace 'if(BUILD_TESTING)' 'if(false)'
+  '';
+
   nativeBuildInputs = [
     asciidoc # for docs
     cmake

--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libjxl";
-  version = "unstable-2021-06-22";
+  version = "0.5";
 
   src = fetchFromGitHub {
     owner = "libjxl";
     repo = "libjxl";
-    rev = "409efe027d6a4a4446b84abe8d7b2fa40409257d";
-    sha256 = "1akb6yyp2h4h6mfcqd4bgr3ybcik5v5kdc1rxaqnyjs7fp2f6nvv";
+    rev = "v${version}";
+    sha256 = "0grljgmy6cfhm8zni9d1mdn01qzc49k1pl75vhr7qcd3sp4r8lxm";
     # There are various submodules in `third_party/`.
     fetchSubmodules = true;
   };


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-36692

No backport needed because libjxl didn't make it into 21.05.

Already failing on darwin - ~this doesn't fix that unfortunately~. Reverse dependency `photoflow` seems already broken too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
