### PR TITLE
fntsample: init at 5.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -276,6 +276,12 @@
     githubId = 315003;
     name = "Adam Saponara";
   };
+  aegyo = {
+    email = "jessica.scoltock@protonmail.com";
+    github = "aegyo";
+    githubId = 4183969;
+    name = "Jessica Chen";
+  };
   aerialx = {
     email = "aaron+nixos@aaronlindsay.com";
     github = "AerialX";

--- a/pkgs/tools/text/fntsample/default.nix
+++ b/pkgs/tools/text/fntsample/default.nix
@@ -1,0 +1,51 @@
+{ lib, stdenv, fetchurl, fetchFromGitHub, cmake, pkg-config
+, cairo, fontconfig, freetype, glib, pango
+, makeWrapper, perlPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fntsample";
+  version = "5.4";
+
+  src = fetchFromGitHub {
+    owner = "eugmes";
+    repo = pname;
+    rev = "release/${version}";
+    sha256 = "0pcqqdriv6hq64zrqd9vhdd9p2vhimjnajcxdz10qnqgrkmm751v";
+  };
+
+  blocks = fetchurl {
+    url = "https://www.unicode.org/Public/13.0.0/ucd/Blocks.txt";
+    sha256 = "17y1sr17jvjpgvmv15dc9kfazabkrpga3mw8yl99q6ngkxm2pa41";
+  };
+
+  cmakeFlags = [
+    "-DUNICODE_BLOCKS=${blocks.outPath}"
+  ];
+
+  outputs = [ "out" "man" ];
+  nativeBuildInputs = [ cmake pkg-config makeWrapper ];
+  buildInputs = [ cairo fontconfig freetype glib pango perlPackages.perl ];
+
+  postFixup = ''
+    for cmd in pdfoutline pdf-extract-outline; do
+      wrapProgram "$out/bin/$cmd" \
+        --prefix PERL5LIB : "${perlPackages.makePerlPath (
+          with perlPackages; [
+            PDFAPI2
+            libintlperl
+            ListMoreUtils
+            ExporterTiny
+          ]
+        )}"
+    done
+  '';
+
+  meta = with lib; {
+    description = "PDF and PostScript font samples generator";
+    homepage = "https://github.com/eugmes/fntsample";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ aegyo ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1554,6 +1554,8 @@ with pkgs;
 
   flood = nodePackages.flood;
 
+  fntsample = callPackage ../tools/text/fntsample { };
+
   fxlinuxprintutil = callPackage ../tools/misc/fxlinuxprintutil { };
 
   genann = callPackage ../development/libraries/genann { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[fntsample](https://github.com/eugmes/fntsample) is a tool that can be used to make font samples that show coverage of the font
and are similar in appearance to [Unicode Charts](https://www.unicode.org/charts/)

Fixes #128644

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
