### PR TITLE
stdenv: fix __bootPackages when overriding

### DIFF
--- a/pkgs/stdenv/booter.nix
+++ b/pkgs/stdenv/booter.nix
@@ -89,7 +89,7 @@ stageFuns: let
   folder = nextStage: stageFun: prevStage: let
     args = stageFun prevStage;
     args' = args // {
-      stdenv = args.stdenv // {
+      stdenv = args.stdenv.override {
         # For debugging
         __bootPackages = prevStage;
         __hatPackages = nextStage;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -52,6 +52,10 @@ let lib = import ../../../lib; in lib.makeOverridable (
 , # The implementation of `mkDerivation`, parameterized with the final stdenv so we can tie the knot.
   # This is convient to have as a parameter so the stdenv "adapters" work better
   mkDerivationFromStdenv ? import ./make-derivation.nix { inherit lib config; }
+
+  # previous / next stage for debugging, see stdenv/booter.nix
+, __bootPackages ? null
+, __hatPackages ? null
 }:
 
 let
@@ -166,6 +170,8 @@ let
       inherit overrides;
 
       inherit cc hasCC;
+
+      inherit __bootPackages __hatPackages;
     }
 
     # Propagate any extra attributes.  For instance, we use this to


### PR DESCRIPTION
Now that we override stdenv instead of using // since f110a182a66005782c0e58091bcda7243bf2a0ae, the __bootPackages and __hatPackages attrs that were added using // are discarded. This restores them so that they are still exposed in e.g. pkgsStatic.

see https://github.com/NixOS/nixpkgs/pull/134463#issuecomment-901545308

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
