### PR TITLE
fclones: init at 0.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2269,6 +2269,12 @@
     githubId = 1382175;
     name = "Oliver Matthews";
   };
+  cyounkins = {
+    name = "Craig Younkins";
+    email = "cyounkins@gmail.com";
+    github = "cyounkins";
+    githubId = 346185;
+  };
   cypherpunk2140 = {
     email = "stefan.mihaila@pm.me";
     github = "stefan-mihaila";

--- a/pkgs/tools/misc/fclones/default.nix
+++ b/pkgs/tools/misc/fclones/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, udev }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fclones";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "pkolaczk";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ni5amy903cy822yhw070bcrrixrw2m1vr66q1h32bc98pyv4w05";
+  };
+
+  cargoSha256 = "1gcb46k7bwdfsf6hyvmi6dna1nf6myzy63bhjfp0wy7c8g4m2mg8";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ udev ];
+
+  # tests in dedupe.rs fail due to
+  # "creation time is not available for the filesystem"
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Efficient Duplicate File Finder and Remover";
+    homepage = "https://github.com/pkolaczk/fclones";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cyounkins ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24600,6 +24600,8 @@ with pkgs;
 
   fbida = callPackage ../applications/graphics/fbida { };
 
+  fclones = callPackage ../tools/misc/fclones { };
+
   fcp = callPackage ../tools/misc/fcp { };
 
   fdupes = callPackage ../tools/misc/fdupes { };


### PR DESCRIPTION
Adding myself to maintainers and adding fclones tool.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
