### PR TITLE
sdlpop: 1.21 -> 1.22

### DIFF
--- a/pkgs/games/sdlpop/default.nix
+++ b/pkgs/games/sdlpop/default.nix
@@ -8,22 +8,25 @@
 
 stdenv.mkDerivation rec {
   pname = "sdlpop";
-  version = "1.21";
+  version = "1.22";
 
   src = fetchFromGitHub {
     owner = "NagyD";
     repo = "SDLPoP";
     rev = "v${version}";
-    sha256 = "1q4mnyg8v4420f1bp24v8lgi335vijdv61yi3fan14jgfzl38l7w";
+    sha256 = "1yy5r1r0hv0xggk8qd8bwk2zy7abpv89nikq4flqgi53fc5q9xl7";
   };
 
   nativeBuildInputs = [ pkg-config makeWrapper copyDesktopItems ];
+
   buildInputs = [ SDL2 SDL2_image ];
 
   makeFlags = [ "-C" "src" ];
 
   preBuild = ''
-    substituteInPlace src/Makefile --replace "CC = gcc" "CC = ${stdenv.cc.targetPrefix}gcc"
+    substituteInPlace src/Makefile \
+      --replace "CC = gcc" "CC = ${stdenv.cc.targetPrefix}cc" \
+      --replace "CFLAGS += -I/opt/local/include" "CFLAGS += -I${SDL2.dev}/include/SDL2 -I${SDL2_image}/include/SDL2"
   '';
 
   # The prince binary expects two things of the working directory it is called from:
@@ -63,6 +66,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ iblech ];
     platforms = platforms.unix;
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- version update + fix build on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
