### PR TITLE
git-cliff: init at 0.2.6

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-cliff/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cliff/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-cliff";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "orhun";
+    repo = "git-cliff";
+    rev = "v${version}";
+    sha256 = "sha256-oQ23jvKR4HGIMnW56FVE0XlBpO4pnMBbRXVoc6OuiHo=";
+  };
+
+  cargoSha256 = "sha256-49RHGOhTaYrg+JKYZMWcgSL7dxe6H50G6n9tJyGaLMQ=";
+
+  # attempts to run the program on .git in src which is not deterministic
+  doCheck = false;
+
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+
+  meta = with lib; {
+    description = "A highly customizable Changelog Generator that follows Conventional Commit specifications";
+    homepage = "https://github.com/orhun/git-cliff";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5277,6 +5277,10 @@ with pkgs;
 
   git-cinnabar = callPackage ../applications/version-management/git-and-tools/git-cinnabar { };
 
+  git-cliff = callPackage ../applications/version-management/git-and-tools/git-cliff {
+    inherit (pkgs.darwin.apple_sdk.frameworks) Security;
+  };
+
   git-codeowners = callPackage ../applications/version-management/git-and-tools/git-codeowners { };
 
   git-codereview = callPackage ../applications/version-management/git-and-tools/git-codereview { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
