### PR TITLE
pkgs/tracy: fix on Darwin

### DIFF
--- a/pkgs/development/tools/tracy/default.nix
+++ b/pkgs/development/tools/tracy/default.nix
@@ -20,6 +20,9 @@ in stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.isLinux [ gtk3 tbb ];
 
   NIX_CFLAGS_COMPILE = [ ]
+    # Apple's compiler finds a format string security error on
+    # ../../../server/TracyView.cpp:649:34, preventing building.
+    ++ lib.optional stdenv.isDarwin "-Wno-format-security"
     ++ lib.optional stdenv.isLinux "-ltbb"
     ++ lib.optional stdenv.cc.isClang "-faligned-allocation"
     ++ lib.optional disableLTO "-fno-lto";


### PR DESCRIPTION
This was previously making it not build, which I just turned off the warning for, which fixes it:
```
clang++ -c -I/nix/store/w98iga6pdhrg4qa8s70zps5wnp5nsnbp-glfw-3.3.4/include -I/nix/store/j0kyj072aks2x9r30fzwh8hx2kcyjsjq-capstone-4.0.2/include/capstone -I/nix/store/j8kqdc1qg0a2d2r2nc5hqjgsih9awmrl-freetype-2.11.0-dev/include/freetype2 -I../../../imgui -I../../libs/gl3w -O3 -flto -march=native -std=c++17 -D"DISPLAY_SERVER_X11" -DNDEBUG -DIMGUI_IMPL_OPENGL_LOADER_GL3W -DIMGUI_ENABLE_FREETYPE ../../src/main.cpp -o obj/release/o/o/o/../../src/main.o
../../../server/TracyView.cpp:649:34: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
            ImGui::TextDisabled( CompressionDesc[idx] );
                                 ^~~~~~~~~~~~~~~~~~~~
../../../server/TracyView.cpp:649:34: note: treat the string as an argument to avoid this
            ImGui::TextDisabled( CompressionDesc[idx] );
                                 ^
                                 "%s",
```
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
