### PR TITLE
sunxi-tools: 2018-11-13 -> 2021-08-29

### DIFF
--- a/pkgs/development/tools/sunxi-tools/default.nix
+++ b/pkgs/development/tools/sunxi-tools/default.nix
@@ -1,18 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, libusb1, zlib }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, dtc, libusb1, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "sunxi-tools";
-  version = "unstable-2018-11-13";
+  version = "unstable-2021-08-29";
 
   src = fetchFromGitHub {
     owner = "linux-sunxi";
     repo = "sunxi-tools";
-    rev = "6d598a0ed714201380e78130213500be6512942b";
-    sha256 = "1yhl6jfl2cws596ymkyhm8h9qkcvp67v8hlh081lsaqv1i8j9yig";
+    rev = "74273b671a3fc34048383c40c85c684423009fb9";
+    sha256 = "1gwamb64vr45iy2ry7jp1k3zc03q5sydmdflrbwr892f0ijh2wjl";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libusb1 zlib ];
+  buildInputs = [ dtc libusb1 zlib ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
###### Motivation for this change

Update sunxi-tools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested only `sunxi-fel`, but if other tools fail, it's unlikely due to packaging due to how they're made.