### PR TITLE
[staging-next] ocaml fixes due to findlib changes

### DIFF
--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -15,7 +15,11 @@ buildDunePackage rec {
 
   buildInputs = [ cppo ];
 
-  configurePhase = "ocaml configure.ml --share $out/share/camomile";
+  configurePhase = ''
+    runHook preConfigure
+    ocaml configure.ml --share $out/share/camomile
+    runHook postConfigure
+  '';
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/cryptokit/default.nix
+++ b/pkgs/development/ocaml-modules/cryptokit/default.nix
@@ -11,7 +11,11 @@ buildDunePackage {
     sha256 = "0kzqkk451m69nqi5qiwak0rd0rp5vzi613gcngsiig7dyxwka61c";
   };
 
-  dontConfigure = true;
+  # dont do autotools configuration, but do trigger findlib's preConfigure hook
+  configurePhase = ''
+    runHook preConfigure
+    runHook postConfigure
+  '';
 
   buildInputs = [ dune-configurator ncurses ];
   propagatedBuildInputs = [ zarith zlib ];

--- a/pkgs/development/ocaml-modules/erm_xmpp/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/default.nix
@@ -16,9 +16,21 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ocamlbuild camlp4 ];
   propagatedBuildInputs = [ erm_xml mirage-crypto mirage-crypto-rng base64 ];
 
-  configurePhase = "ocaml setup.ml -configure --prefix $out";
-  buildPhase = "ocaml setup.ml -build";
-  installPhase = "ocaml setup.ml -install";
+  configurePhase = ''
+    runHook preConfigure
+    ocaml setup.ml -configure --prefix $out
+    runHook postConfigure
+  '';
+  buildPhase = ''
+    runHook preBuild
+    ocaml setup.ml -build
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    ocaml setup.ml -install
+    runHook postInstall
+  '';
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib cppo ];
 
   createFindlibDestdir = true;
-  dontConfigure = true;
 
   makeFlags = lib.optional minimal "minimal=1";
 

--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -18,9 +18,21 @@ stdenv.mkDerivation {
       ocaml findlib ocamlbuild ocamlmod ocamlify
     ];
 
-  configurePhase = "ocaml setup.ml -configure --prefix $out";
-  buildPhase     = "ocaml setup.ml -build";
-  installPhase   = "ocaml setup.ml -install";
+  configurePhase = ''
+    runHook preConfigure
+    ocaml setup.ml -configure --prefix $out
+    runHook postConfigure
+  '';
+  buildPhase = ''
+    runHook preBuild
+    ocaml setup.ml -build
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    ocaml setup.ml -install
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://oasis.forge.ocamlcore.org/";


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/133008/commits/a3ab43d3a45338f845a0f8a12ed34e84c8b79dae moved a required setup step to a preConfigure hook, which wasn't getting triggered by some packages.

###### Motivation for this change

Fixes e.g. jackline and virt-top on staging-next https://github.com/NixOS/nixpkgs/pull/135477

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
