### PR TITLE
mstflint: 4.14.0-3 -> 4.17.0-1

### DIFF
--- a/pkgs/tools/misc/mstflint/default.nix
+++ b/pkgs/tools/misc/mstflint/default.nix
@@ -1,18 +1,25 @@
-{ lib, stdenv, autoreconfHook, fetchFromGitHub, zlib, libibmad, openssl }:
+{ lib
+, stdenv
+, fetchurl
+, libibmad
+, openssl
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "mstflint";
-  version = "4.14.0-3";
+  version = "4.17.0-1";
 
-  src = fetchFromGitHub {
-    owner = "Mellanox";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0zy9npyzf7dkxlfl9mx6997aa61mk23ixpjb01ckb1wvav5k6z82";
+  src = fetchurl {
+    url = "https://github.com/Mellanox/mstflint/releases/download/v${version}/mstflint-${version}.tar.gz";
+    sha256 = "030vpiv44sxmjf0dng91ziq1cggwj33yp0l4xc6cdhnrv2prjs7y";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ zlib libibmad openssl ];
+  buildInputs = [
+    libibmad
+    openssl
+    zlib
+  ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Switched to the release tarball as the `autogen.sh` script didn't work with any of the available autoreconfHook versions that we currently ship.

https://github.com/Mellanox/mstflint/releases/tag/v4.17.0-1
https://github.com/Mellanox/mstflint/releases/tag/v4.16.0-2
https://github.com/Mellanox/mstflint/releases/tag/v4.16.0-1
https://github.com/Mellanox/mstflint/releases/tag/v4.15.0-1

Some tools require some python packaging, which is still on my TODO.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
