### PR TITLE
tree-sitter: update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-agda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-agda.json
@@ -4,6 +4,7 @@
   "date": "2019-09-20T18:06:06+08:00",
   "path": "/nix/store/wqz9v9znaiwhhqi19hgig9bn0yvl4i9s-tree-sitter-agda",
   "sha256": "1wpfj47l97pxk3i9rzdylqipy849r482fnj3lmx8byhalv7z1vm6",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bash.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bash.json
@@ -4,6 +4,7 @@
   "date": "2021-03-04T14:15:26-08:00",
   "path": "/nix/store/nvlvdv02wdy4dq4w19bvzq6nlkgvpj20-tree-sitter-bash",
   "sha256": "18c030bb65r50i6z37iy7jb9z9i8i36y7b08dbc9bchdifqsijs5",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "3953034ee61e8639100b063092d4280e047ca9e9",
-  "date": "2021-06-21T12:18:46+02:00",
-  "path": "/nix/store/8f2bnr790zwibhyd3jqjm38zfc1md5is-tree-sitter-c-sharp",
-  "sha256": "0k6pb27f463y88bf6ym0zl4d36182y5cr3013j71h3vlg264z96c",
+  "rev": "87c1aba089207f0fcc022ed88138af5a3e4cf454",
+  "date": "2021-09-05T21:16:06+01:00",
+  "path": "/nix/store/wx1asjwcpcmizavl7z756q55z3mvn714-tree-sitter-c-sharp",
+  "sha256": "1c1s2x7bpirsrkr6cqj9v4czpgavyf6b9dg290l9v7vd9fg3zh6v",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "008008e30a81849fca0c79291e2b480855e0e02c",
-  "date": "2021-05-26T09:13:01-07:00",
-  "path": "/nix/store/vkps4991ip8dhgjqwfw7mamnmnizw31m-tree-sitter-c",
-  "sha256": "1mw4vma7kl504qn91f6janiqk9i05849rizqkqhyagb3glfbkrx2",
+  "rev": "d09ab34013de8a30d97a1912fc30811f1172515f",
+  "date": "2021-08-16T09:37:46-07:00",
+  "path": "/nix/store/94lp3b3hgap1baci006329zl2i168scm-tree-sitter-c",
+  "sha256": "0wf85g82p5j1vlw7rphfcpwch4b8sbvp4kk095aqmmcsm7d7dxl4",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
@@ -4,6 +4,7 @@
   "date": "2021-08-13T15:03:50-05:00",
   "path": "/nix/store/4aqsac34f0pzpa889067dqci743axrmx-tree-sitter-comment",
   "sha256": "0fqhgvpd391nxrpyhxcp674h8qph280ax6rm6dz1pj3lqs3grdka",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "53afc568b70e4b71ee799501f34c876ad511f56e",
-  "date": "2021-08-13T10:48:59-05:00",
-  "path": "/nix/store/6gj41lh1fnnmcrz4c1bk3ncw0kpm97nm-tree-sitter-cpp",
-  "sha256": "02avniqmb5hgpkzwmkgxhrxk296dbkra9miyi5pax461ab4j7a9r",
+  "rev": "5bb411db33c86b108c891fb2c1473ddc9fad9701",
+  "date": "2021-08-17T11:20:29-07:00",
+  "path": "/nix/store/a23w5pnww3wryjs1vimp5ggvgq9bg0rl-tree-sitter-cpp",
+  "sha256": "1gxd40ipbzjhlk2amsk09v67cjxk4wal60kxycnb04lp6wxwlm8b",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-css",
-  "rev": "94e10230939e702b4fa3fa2cb5c3bc7173b95d07",
-  "date": "2021-03-04T15:25:23-08:00",
-  "path": "/nix/store/0q3y4zhphdcc54qijbx2pdp8li9idk64-tree-sitter-css",
-  "sha256": "0y90nsfbh13mf33yahbk7zklbv7124rpm0v19qydz6nv1f9hpywd",
+  "rev": "7c390622166517b01445e0bb08f72831731d3088",
+  "date": "2021-08-17T11:20:41-07:00",
+  "path": "/nix/store/wx5dzm92k2zv53r5p2s3jv1sak8xdk57-tree-sitter-css",
+  "sha256": "01r63dqxhgvsc1gkfy0mqsq98dmvc2hdw3c5zdkzdbry8zqpyn8s",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
@@ -4,6 +4,7 @@
   "date": "2021-03-04T10:06:18-08:00",
   "path": "/nix/store/09b9drfnywcy1i8wlw6slnn76ch40kqk-tree-sitter-embedded-template",
   "sha256": "0c9l4i6kwb29zp05h616y3vk2hhcfc8bhdf9m436bk47pfy2zabg",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/travonted/tree-sitter-fennel",
-  "rev": "bc689e2ef264e2cba499cfdcd16194e8f5fe87d2",
-  "date": "2021-03-09T16:47:45-05:00",
-  "path": "/nix/store/3h4j1mrqvn0ybqjalic92bnhk7c15442-tree-sitter-fennel",
-  "sha256": "1jm21bmsdrz9x5skqmx433q9b4mfi88gzc4la5hqps4is28inqms",
+  "rev": "e10b04389094d9b96aa8489121c1f285562d701d",
+  "date": "2021-08-18T16:21:04-04:00",
+  "path": "/nix/store/rmlldcr0yq9c87lp96jrajbf5n4xin6r-tree-sitter-fennel",
+  "sha256": "1bavjjy8wbp1hkj1nps1lsqa9ihwhnj039hfi1fvgxv5j7il74ir",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
@@ -4,6 +4,7 @@
   "date": "2021-08-02T21:46:56+01:00",
   "path": "/nix/store/0n3jfh7gk16bmikix34y5m534ac12xgc-tree-sitter-fish",
   "sha256": "1810z8ah1b09qpxcr4bh63bxsnxx24r6d2h46v2cpqv1lg0g4z14",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fluent.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fluent.json
@@ -4,6 +4,7 @@
   "date": "2018-06-18T13:00:38-07:00",
   "path": "/nix/store/zbj8abdlrqi9swm8qn8rhpqmjwcz145f-tree-sitter-fluent",
   "sha256": "0528v9w0cs73p9048xrddb1wpdhr92sn1sw8yyqfrq5sq0danr9k",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "eb306e6e60f393df346cfc8cbfaf52667a37128a",
-  "date": "2021-05-04T14:03:16-07:00",
-  "path": "/nix/store/xgi4w5by155m1zqhqf2s7hmngy6sxdq3-tree-sitter-go",
-  "sha256": "03x3nkjxdfck9a4z2i50wq065vixqqk4v5w6fnd870q63v0zrc7c",
+  "rev": "42b1e657c3a394c01df51dd3eadc8b214274a73c",
+  "date": "2021-08-16T18:29:17+02:00",
+  "path": "/nix/store/a1crqhfrd8v9g9w0565aca7nc9k2x7a0-tree-sitter-go",
+  "sha256": "1khsl8qz6r4dqw7h43m3jw3iqhh79sgpnsps0jy95f165iy496z3",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "30eea3c1339e573cda5dcffd8f9b06003ec31789",
-  "date": "2021-08-07T14:37:05+02:00",
-  "path": "/nix/store/b99w2q2y5gjj5h1bxipncaf40dyx5sd2-tree-sitter-haskell",
-  "sha256": "0cch7bcr4d9ll92vhcp79bjzs9dw0glvdrdj2q2h2mg5mmkzcya8",
+  "rev": "acafd11d9e45b1c28b49ff798022022b29d8b450",
+  "date": "2021-08-27T16:35:25+02:00",
+  "path": "/nix/store/wmw8ppdkndwg3f8phdhws985ckxs0yvk-tree-sitter-haskell",
+  "sha256": "1zm8m7lpgmh4gr0iw0792bsqi5jpf3w0kx6l3s91clici69nwkiq",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-html",
-  "rev": "af9339f3deb131ab99acfac906713b81dbcc41c9",
-  "date": "2021-07-11T11:04:28-07:00",
-  "path": "/nix/store/jg23pmi6jfy4kykah645gl44a145929c-tree-sitter-html",
-  "sha256": "1qb4rfbra3nc0fwmla8q1hb4r48k8cv3nl60zc24xhrw3q1d9zh1",
+  "rev": "161a92474a7bb2e9e830e48e76426f38299d99d1",
+  "date": "2021-08-17T11:20:56-07:00",
+  "path": "/nix/store/pv8x73j4sbngsqplwfm73jlpwc31mc17-tree-sitter-html",
+  "sha256": "1gwvgwk0py09pp65vnga522l5r16dvgwxsc76fg66y07k2i63cfk",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -4,6 +4,7 @@
   "date": "2021-05-04T14:05:05-07:00",
   "path": "/nix/store/bzljwaraqj6zqpq85cz9xb0vwh7c10yj-tree-sitter-java",
   "sha256": "09v3xg1356ghc2n0yi8iqkp80lbkav0jpfgz8iz2j1sl7ihbvkyw",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "bc2eb3994fd7cc605d27a32f9fcbee80bbb57f6d",
-  "date": "2021-08-13T14:29:43-07:00",
-  "path": "/nix/store/jkq26hbij9si8ri8k5agkdadr3p1nmbi-tree-sitter-javascript",
-  "sha256": "0f6bny38za17mmwqw0q0nmdb4f9i0xs7kbzixxgi44yyd43r5pzp",
+  "rev": "2cc5803225a307308005930b3bedb939b1543722",
+  "date": "2021-08-29T11:32:53-07:00",
+  "path": "/nix/store/kjviknhcrayrzv94i762zsy2kvpxpkx6-tree-sitter-javascript",
+  "sha256": "1xkll7g38j1vajylfaifbn6i5y5f22kmjfy2dxy9bk903assxy05",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsdoc.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsdoc.json
@@ -4,6 +4,7 @@
   "date": "2021-03-04T14:39:14-08:00",
   "path": "/nix/store/dpm11vziss6jbgp3dxvmgkb0dgg1ygc8-tree-sitter-jsdoc",
   "sha256": "0qpsy234p30j6955wpjlaqwbr21bi56p0ln5vhrd84s99ac7s6b6",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-json",
-  "rev": "65bceef69c3b0f24c0b19ce67d79f57c96e90fcb",
-  "date": "2021-03-09T16:25:11-05:00",
-  "path": "/nix/store/bn5smxwwg4zzdc52wp2qb6s6yjdfi8mg-tree-sitter-json",
-  "sha256": "13p4ffmajirl9qh64d6qnng1gjnh5f6jkqbra0nlc1260nsf12hp",
+  "rev": "203e239408d642be83edde8988d6e7b20a19f0e8",
+  "date": "2021-08-18T10:35:07-07:00",
+  "path": "/nix/store/yqbmn17vs2lxqg5wa8b269fcsd5wr4bv-tree-sitter-json",
+  "sha256": "08igb9ylfdsjasyn0p9j4sqpp0i2x1qcdzacbmsag02jmkyi6s7f",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
@@ -4,6 +4,7 @@
   "date": "2021-05-03T17:44:45-07:00",
   "path": "/nix/store/lbz23r698hn7cha09qq0dbfay7dh74gg-tree-sitter-julia",
   "sha256": "0rmd7k3rv567psxrlqv17gvckijs19xs6mxni045rpayxmk441sk",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -4,6 +4,7 @@
   "date": "2021-07-19T17:50:34+02:00",
   "path": "/nix/store/vrpfbjfps3bd9vrx8760l0vx7m7ijhja-tree-sitter-latex",
   "sha256": "0dfpdv5sibvajf2grlc0mqhyggjf6ip9j01jikk58n1yc9va88ib",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -4,6 +4,7 @@
   "date": "2021-08-02T15:13:28+02:00",
   "path": "/nix/store/h1bhl291jac001w2c8fxi9w7dsqxq5q0-tree-sitter-lua",
   "sha256": "05ash0l46s66q9yamzzh6ghk8yv0vas13c7dmz0c9xljbjk5ab1d",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -4,6 +4,7 @@
   "date": "2021-04-18T20:49:21+08:00",
   "path": "/nix/store/4z2k0q6rwqmb7vbqr4vgc26w28szlan3-tree-sitter-markdown",
   "sha256": "1a2899x7i6dgbsrf13qzmh133hgfrlvmjsr3bbpffi1ixw1h7azk",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -4,6 +4,7 @@
   "date": "2021-07-21T20:36:40-05:00",
   "path": "/nix/store/n5pq9gba570874akpwpvs052d7vyalhh-tree-sitter-nix",
   "sha256": "03jhvyrsxq49smk9p2apjj839wmzjmrzy045wcxawz1g7xssp9pr",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ocaml",
-  "rev": "0348562f385bc2bd67ecf181425e1afd6d454192",
-  "date": "2021-05-07T21:05:16+02:00",
-  "path": "/nix/store/s2499rsi28k0nrwx8wl2idsp86zsx2iz-tree-sitter-ocaml",
-  "sha256": "0iqmwcz3c2ai4gyx4xli1rhn6hi6a0f60dn20f8jas9ham9dc2df",
+  "rev": "23d419ba45789c5a47d31448061557716b02750a",
+  "date": "2021-08-26T21:21:27+02:00",
+  "path": "/nix/store/942q4rv9vs77wwvvw46yx0jnqja2cbig-tree-sitter-ocaml",
+  "sha256": "1bh3afd3iix0gf6ldjngf2c65nyfdwvbmsq25gcxm04jwbg9c6k8",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "63cebc37ebed42887f14cdd0baec961d5a1e16c1",
-  "date": "2021-08-10T20:56:40+02:00",
-  "path": "/nix/store/bh4yl563l5fgh7r8f95zzybsavci8hyh-tree-sitter-php",
-  "sha256": "1psiamww22imw05z0h34yks7vh7y4x4bdn62dwic1gpwfbjdrfmr",
+  "rev": "77d98f3ce47ea52ff39137be29bc6376951c2286",
+  "date": "2021-09-03T18:25:31+02:00",
+  "path": "/nix/store/l143h3fxi89kk7dcp71zjdhdfmfmr68s-tree-sitter-php",
+  "sha256": "15cl1mdclhjiw72xzkcmw0lxq2hv1bjf2xf2nkgibi7zp8s1qvyw",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -4,6 +4,7 @@
   "date": "2021-03-27T09:41:53-07:00",
   "path": "/nix/store/4v24ahydid4hr7kj0xi41mgbpglfnnki-tree-sitter-python",
   "sha256": "173lpxi4vqa42dcdr9aj5phg5g6ny9ns04djw9n86pasx2w66dhk",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
@@ -4,6 +4,7 @@
   "date": "2021-06-02T18:46:47+02:00",
   "path": "/nix/store/yhyi9y09shv1fm87gka43vnv9clvyd92-tree-sitter-ql",
   "sha256": "0x5f9989ymqvw3g8acckyk4j7zpmnc667qishbgly9icl9rkmv7w",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-regex",
-  "rev": "3041aa3472d16fd94c6a9e15b741dbfecd9b714e",
-  "date": "2021-03-04T14:37:27-08:00",
-  "path": "/nix/store/7d200fzyx2rkbbgf47g5ismvd4id0fqy-tree-sitter-regex",
-  "sha256": "0jah3apalvp7966sjzdrka2n7f83h64sd56nbq2lzmrxgv98rxmg",
+  "rev": "7b97502cfc3ffa7110f6b68bb39fb259c9a0500c",
+  "date": "2021-08-17T11:21:39-07:00",
+  "path": "/nix/store/3lpj820c141i26p20kin465xlr5jpyjs-tree-sitter-regex",
+  "sha256": "0n9lmwwgij00078v3fr19vfn1g3wh3agm8jqp80v1cnrcsmpn97p",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -4,6 +4,7 @@
   "date": "2021-03-03T16:54:30-08:00",
   "path": "/nix/store/ragrvqj7hm98r74v5b3fljvc47gd3nhj-tree-sitter-ruby",
   "sha256": "0m3h4928rbs300wcb6776h9r88hi32rybbhcaf6rdympl5nzi83v",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "a360da0a29a19c281d08295a35ecd0544d2da211",
-  "date": "2021-03-27T09:50:22-07:00",
-  "path": "/nix/store/h4snh879ccy159fa390qr8l0nyaf5ndr-tree-sitter-rust",
-  "sha256": "0knaza3ww5h5w95hzdaalg5yrfpiv0r394q0imadxp5611132hxz",
+  "rev": "cc7bdd3e6d14677e8aa77da64f6a3f57b6f8b00a",
+  "date": "2021-08-17T11:21:11-07:00",
+  "path": "/nix/store/aw8bi91hz7a26swc5qrfqwn2lrdmiymr-tree-sitter-rust",
+  "sha256": "15qz4rwz1fkpcy78g0aspfgk9pgykvzv5sxmhgm37nfpgyi7vlg1",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "ec38674996753f9631615fa558d4f1fa3bf90633",
-  "date": "2021-08-08T14:43:30-07:00",
-  "path": "/nix/store/2b0z1j06gvpcn1rvq8hv5vdqlh3qlzmv-tree-sitter-scala",
-  "sha256": "1xv544wnyd075g5pc8lxi0ix6wrwiv82sdjhzf3wd1np42vxq3d4",
+  "rev": "449b6baa6b1cd0c2403636459af1571e075dbaa8",
+  "date": "2021-08-31T13:42:29-07:00",
+  "path": "/nix/store/8m3s0ndhmns8435g2mlbcz9sdbqgmjz7-tree-sitter-scala",
+  "sha256": "1lmiljsd5irzc0pabxdcjgfq98xyqm76fracglq68p106mngia07",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -4,6 +4,7 @@
   "date": "2021-03-20T16:45:11+05:30",
   "path": "/nix/store/8krdxqwpi95ljrb5jgalwgygz3aljqr8-tree-sitter-svelte",
   "sha256": "0ckmss5gmvffm6danlsvgh6gwvrlznxsqf6i6ipkn7k5lxg1awg3",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-swift.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-swift.json
@@ -4,6 +4,7 @@
   "date": "2019-10-24T19:04:02-06:00",
   "path": "/nix/store/pk5xk8yp6vanbar75bhfrs104w0k1ph0-tree-sitter-swift",
   "sha256": "14b40lmwrnyvdz2wiv684kfh4fvqfhbj1dgrx81ppmy7hsz7jcq7",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-toml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-toml.json
@@ -4,6 +4,7 @@
   "date": "2021-05-11T12:47:32+08:00",
   "path": "/nix/store/isgpadcxmgkb14w9yg67pb8lx7wlfhnn-tree-sitter-toml",
   "sha256": "0yasw5fp4mq6vzrdwlc3dxlss8a94bsffv4mzrfp0b3iw0s1dlyg",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tsq.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tsq.json
@@ -4,6 +4,7 @@
   "date": "2021-05-18T15:57:40-04:00",
   "path": "/nix/store/j59y4s3bsv6d5nbmhhdgb043hmk8157k-tree-sitter-tsq",
   "sha256": "03bch2wp2jwxk69zjplvm0gbyw06qqdy7il9qkiafvhrbh03ayd9",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,10 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "d598c96714a2dc9e346589c63369aff6719a51e6",
-  "date": "2021-08-02T14:05:14-07:00",
-  "path": "/nix/store/hf714sspmakhzra9bqazhbb0iljva1hi-tree-sitter-typescript",
-  "sha256": "0yra8fhgv7wqkik85icqyckf980v9ch411mqcjcf50n5dc1siaik",
+  "rev": "83816f563c8d9d2f1b9c921206a7944d0c5904ad",
+  "date": "2021-08-17T11:21:26-07:00",
+  "path": "/nix/store/jwxdv5xbs92n43yqvxnwz443jvngxmqp-tree-sitter-typescript",
+  "sha256": "1w989z36pvfv7m4z9s9qq67l81p8rx37z53kqmsxsyc01wnpb4nr",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
@@ -4,6 +4,7 @@
   "date": "2021-03-31T21:27:26-07:00",
   "path": "/nix/store/4j6hrf8bc8zjd7r9xnna9njpw0i4z817-tree-sitter-verilog",
   "sha256": "0ygm6bdxqzpl3qn5l58mnqyj730db0mbasj373bbsx81qmmzkgzz",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
@@ -4,6 +4,7 @@
   "date": "2021-05-11T12:47:24+08:00",
   "path": "/nix/store/7d7m4zs4ydnwbn3xnfm3pvpy7gvkrmg8-tree-sitter-yaml",
   "sha256": "0wyvjh62zdp5bhd2y8k7k7x4wz952l55i1c8d94rhffsbbf9763f",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -4,6 +4,7 @@
   "date": "2021-03-30T12:55:10-03:00",
   "path": "/nix/store/av4xgzr3c1rhr7v4fa9mm68krd2qv1lg-tree-sitter-zig",
   "sha256": "0gjxac43qpqc4332bp3mpdbvh7rqv0q3hvw8834b30ml5q0r0qr0",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
