### PR TITLE
freeimage: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/freeimage/default.nix
+++ b/pkgs/development/libraries/freeimage/default.nix
@@ -18,6 +18,14 @@ stdenv.mkDerivation {
   prePatch = "rm -rf Source/Lib* Source/OpenEXR Source/ZLib";
   patches = [ ./unbundle.diff ];
 
+  postPatch = ''
+    # To support cross compilation, use the correct `pkg-config`.
+    substituteInPlace Makefile.fip \
+      --replace "pkg-config" "$PKG_CONFIG"
+    substituteInPlace Makefile.gnu \
+      --replace "pkg-config" "$PKG_CONFIG"
+  '';
+
   nativeBuildInputs = [
     pkg-config
   ] ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for freeimage. Build for `pkgsCross.aarch64-multiplatform` works.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
