### PR TITLE
python3Packages.envoy-reader: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/development/python-modules/envoy-reader/default.nix
+++ b/pkgs/development/python-modules/envoy-reader/default.nix
@@ -1,30 +1,27 @@
 { lib
 , buildPythonPackage
+, envoy-utils
 , fetchFromGitHub
 , httpx
 , pytest-asyncio
 , pytest-raises
-, pytest-runner
 , pytestCheckHook
 , respx
 }:
 
 buildPythonPackage rec {
   pname = "envoy-reader";
-  version = "0.19.0";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "jesserizzo";
     repo = "envoy_reader";
     rev = version;
-    sha256 = "0jyrgm7dc6k66c94gadc69a6xsv2b48wn3b3rbpwgbssi5s7iiz6";
+    sha256 = "sha256-nPB1Fvb1qwLHeFkXP2jXixD2ZGA09MtS1qXRhYGt0fM=";
   };
 
-  nativeBuildInputs = [
-    pytest-runner
-  ];
-
   propagatedBuildInputs = [
+    envoy-utils
     httpx
   ];
 
@@ -34,6 +31,11 @@ buildPythonPackage rec {
     pytestCheckHook
     respx
   ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest-runner>=5.2" ""
+  '';
 
   pythonImportsCheck = [ "envoy_reader" ];
 

--- a/pkgs/development/python-modules/envoy-utils/default.nix
+++ b/pkgs/development/python-modules/envoy-utils/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, zeroconf
+}:
+
+buildPythonPackage rec {
+  pname = "envoy-utils";
+  version = "0.0.1";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    pname = "envoy_utils";
+    inherit version;
+    sha256 = "13zn0d6k2a4nls9vp8cs0w07bgg4138vz18cadjadhm8p6r3bi0c";
+  };
+
+  propagatedBuildInputs = [
+    zeroconf
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "envoy_utils" ];
+
+  meta = with lib; {
+    description = "Python utilities for the Enphase Envoy";
+    homepage = "https://pypi.org/project/envoy-utils/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2366,6 +2366,8 @@ in {
 
   envoy-reader = callPackage ../development/python-modules/envoy-reader { };
 
+  envoy-utils = callPackage ../development/python-modules/envoy-utils { };
+
   enzyme = callPackage ../development/python-modules/enzyme { };
 
   epc = callPackage ../development/python-modules/epc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.20.0

Change log: https://github.com/jesserizzo/envoy_reader/releases/tag/0.20.0

- Related Home Assistant change: https://github.com/home-assistant/core/pull/55822
- Target Home Assistant release: current (only dependency update, no code changes)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
