### PR TITLE
elasticsearch: update configuration

### DIFF
--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -8,9 +8,10 @@ let
   esConfig = ''
     network.host: ${cfg.listenAddress}
     cluster.name: ${cfg.cluster_name}
+    ${lib.optionalString cfg.single_node "discovery.type: single-node"}
 
     http.port: ${toString cfg.port}
-    transport.tcp.port: ${toString cfg.tcp_port}
+    transport.port: ${toString cfg.tcp_port}
 
     ${cfg.extraConf}
   '';
@@ -75,6 +76,12 @@ in
       description = "Elasticsearch name that identifies your cluster for auto-discovery.";
       default = "elasticsearch";
       type = types.str;
+    };
+
+    single_node = mkOption {
+      description = "Start a single-node cluster";
+      default = true;
+      type = types.bool;
     };
 
     extraConf = mkOption {

--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -8,7 +8,10 @@ let
   esConfig = ''
     network.host: ${cfg.listenAddress}
     cluster.name: ${cfg.cluster_name}
-    ${lib.optionalString cfg.single_node "discovery.type: single-node"}
+    ${lib.optionalString cfg.single_node ''
+      discovery.type: single-node
+      gateway.auto_import_dangling_indices: true
+    ''}
 
     http.port: ${toString cfg.port}
     transport.port: ${toString cfg.tcp_port}


### PR DESCRIPTION
- transport.tcp.port -> transport.port https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.1.html
- default to start a single-node cluster https://stackoverflow.com/questions/59350069/elasticsearch-start-up-error-the-default-discovery-settings-are-unsuitable-for


###### Motivation for this change

small fixes to the service configuration

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
