### PR TITLE
python3Packages.plyer: init at 2.0.0

### DIFF
--- a/pkgs/development/python-modules/plyer/default.nix
+++ b/pkgs/development/python-modules/plyer/default.nix
@@ -1,0 +1,64 @@
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, keyring, mock, pytestCheckHook, stdenv }:
+
+buildPythonPackage rec {
+  pname = "plyer";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "kivy";
+    repo = pname;
+    rev = version;
+    sha256 = "15z1wpq6s69s76r6akzgg340bpc21l2r1j8270gp7i1rpnffcjwm";
+  };
+
+  patches = [
+    # fix naming of the DOCUMENTS dir
+    (fetchpatch {
+      url = "https://github.com/rski/plyer/commit/99dabb2d62248fc3ea5705c2720abf71c9fc378b.patch";
+      sha256 = "1ygahxpb8l6bqwpfba0cm164mwyc2snhpdighzyw540s1l0n31g8";
+    })
+    # fix handling of the ~/.config/user-dirs.dir file
+    (fetchpatch {
+      url = "https://github.com/rski/plyer/commit/f803697a1fe4fb5e9c729ee6ef1997b8d64f3ccd.patch";
+      sha256 = "1ciksqfn63bpn9p3s1min24ipjqp32pgcsffabkxj2b5d1nnbplz";
+    })
+  ];
+
+  postPatch = ''
+    rm -r examples
+    # remove all the wifi stuff. Depends on a python wifi module that has not been updated since 2016
+    find -iname "wifi*" -exec rm {} \;
+    substituteInPlace plyer/__init__.py \
+      --replace "wifi = Proxy('wifi', facades.Wifi)" "" \
+      --replace "'wifi'" ""
+    substituteInPlace plyer/facades/__init__.py \
+      --replace "from plyer.facades.wifi import Wifi" ""
+  '';
+
+  propagatedBuildInputs = [ keyring ];
+
+  checkInputs = [ mock pytestCheckHook ];
+
+  pytestFlagsArray = [ "plyer/tests" ];
+  disabledTests = [
+    # assumes dbus is not installed, it fails and is not very robust.
+    "test_notification_notifysend"
+    # fails during nix-build, but I am not able to explain why.
+    # The test and the API under test do work outside the nix build.
+    "test_uniqueid"
+  ];
+  preCheck = ''
+    HOME=$(mktemp -d)
+    mkdir -p $HOME/.config/ $HOME/Pictures
+  '';
+
+  pythonImportsCheck = [ "plyer" ];
+
+  meta = with lib; {
+    description = "Plyer is a platform-independent api to use features commonly found on various platforms";
+    homepage = "https://github.com/kivy/plyer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rski ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/development/python-modules/plyer/default.nix
+++ b/pkgs/development/python-modules/plyer/default.nix
@@ -15,12 +15,12 @@ buildPythonPackage rec {
     # fix naming of the DOCUMENTS dir
     (fetchpatch {
       url = "https://github.com/rski/plyer/commit/99dabb2d62248fc3ea5705c2720abf71c9fc378b.patch";
-      sha256 = "1ygahxpb8l6bqwpfba0cm164mwyc2snhpdighzyw540s1l0n31g8";
+      sha256 = "sha256-bbnw0TxH4FGTso5dopzquDCjrjZAy+6CJauqi/nfstA=";
     })
     # fix handling of the ~/.config/user-dirs.dir file
     (fetchpatch {
       url = "https://github.com/rski/plyer/commit/f803697a1fe4fb5e9c729ee6ef1997b8d64f3ccd.patch";
-      sha256 = "1ciksqfn63bpn9p3s1min24ipjqp32pgcsffabkxj2b5d1nnbplz";
+      sha256 = "sha256-akuh//P5puz2PwcBRXZQ4KoGk+fxi4jn2H3pTIT5M78=";
     })
   ];
 

--- a/pkgs/development/python-modules/plyer/default.nix
+++ b/pkgs/development/python-modules/plyer/default.nix
@@ -59,6 +59,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/kivy/plyer";
     license = licenses.mit;
     maintainers = with maintainers; [ rski ];
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5548,6 +5548,8 @@ in {
 
   ply = callPackage ../development/python-modules/ply { };
 
+  plyer = callPackage ../development/python-modules/plyer { };
+
   plyfile = callPackage ../development/python-modules/plyfile { };
 
   plyplus = callPackage ../development/python-modules/plyplus { };


### PR DESCRIPTION
This is a dependency of the newer versions of mirage-im.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
