### PR TITLE
uthash: 2.1.0 → 2.3.0

### DIFF
--- a/pkgs/development/libraries/uthash/default.nix
+++ b/pkgs/development/libraries/uthash/default.nix
@@ -1,23 +1,23 @@
-{ lib, stdenv, fetchurl, perl }:
+{ lib, stdenv, fetchFromGitHub, perl }:
 
 stdenv.mkDerivation rec {
   pname = "uthash";
-  version = "2.1.0";
+  version = "2.3.0";
 
-  src = fetchurl {
-    url = "https://github.com/troydhanson/uthash/archive/v${version}.tar.gz";
-    sha256 = "17k6k97n20jpi9zj3lzvqfw8pv670r6rdqrjf8vrbx6hcj7csb0m";
+  src = fetchFromGitHub {
+    owner = "troydhanson";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-F0M5ENT3bMn3dD16Oaq9mBFYOWzVliVWupAIrLc2nkQ=";
   };
-
-  dontBuild = false;
 
   doCheck = true;
   checkInputs = [ perl ];
-  checkTarget = "-C tests/";
+  checkTarget = "all";
+  preCheck = "cd tests";
 
   installPhase = ''
-    mkdir -p "$out/include"
-    cp ./src/* "$out/include/"
+    install -Dm644 $src/include/*.h -t $out/include
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
* update to 2.3.0
* fix tests running

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
