### PR TITLE
freeciv: do not enable gtkClient always on linux

### DIFF
--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, lua5_3, pkg-config, python3
 , zlib, bzip2, curl, xz, gettext, libiconv
 , sdlClient ? true, SDL, SDL_mixer, SDL_image, SDL_ttf, SDL_gfx, freetype, fluidsynth
-, gtkClient ? false, gtk3
+, gtkClient ? false, gtk3, wrapGAppsHook
 , qtClient ? false, qt5
 , server ? true, readline
 , enableSqlite ? true, sqlite
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoreconfHook pkg-config ]
-    ++ lib.optional qtClient [ qt5.wrapQtAppsHook ];
+    ++ lib.optional qtClient [ qt5.wrapQtAppsHook ]
+    ++ lib.optional gtkClient [ wrapGAppsHook ];
 
   buildInputs = [ lua5_3 zlib bzip2 curl xz gettext libiconv ]
     ++ lib.optionals sdlClient [ SDL SDL_mixer SDL_image SDL_ttf SDL_gfx freetype fluidsynth ]
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableSqlite sqlite;
 
   dontWrapQtApps = true;
+  dontWrapGApps = true;
 
   configureFlags = [ "--enable-shared" ]
     ++ lib.optional sdlClient "--enable-client=sdl"
@@ -49,6 +51,8 @@ stdenv.mkDerivation rec {
 
   postFixup = lib.optionalString qtClient ''
     wrapQtApp $out/bin/freeciv-qt
+  '' + lib.optionalString gtkClient ''
+    wrapGApp $out/bin/freeciv-gtk3.22
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, lua5_3, pkg-config, python3
 , zlib, bzip2, curl, xz, gettext, libiconv
 , sdlClient ? true, SDL, SDL_mixer, SDL_image, SDL_ttf, SDL_gfx, freetype, fluidsynth
-, gtkClient ? stdenv.isLinux, gtk3
+, gtkClient ? false, gtk3
 , qtClient ? false, qt5
 , server ? true, readline
 , enableSqlite ? true, sqlite
@@ -46,6 +46,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableSqlite "--enable-fcdb=sqlite3"
     ++ lib.optional (!gtkClient) "--enable-fcmp=cli"
     ++ lib.optional (!server)    "--disable-server";
+
+  postFixup = lib.optionalString qtClient ''
+    wrapQtApp $out/bin/freeciv-qt
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
makes it possible to use the qtClient

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #136749

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
