### PR TITLE
fondo: 1.5.2 -> 1.6.1

### DIFF
--- a/pkgs/applications/graphics/fondo/default.nix
+++ b/pkgs/applications/graphics/fondo/default.nix
@@ -12,23 +12,23 @@
 , gsettings-desktop-schemas
 , gtk3
 , libgee
+, libhandy
+, libsoup
 , json-glib
 , glib-networking
-, libsoup
-, libunity
 , desktop-file-utils
 , wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "fondo";
-  version = "1.5.2";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "calo001";
     repo = pname;
     rev = version;
-    sha256 = "sha256-EATZRmYSGUzWYaPqFT4mLTGGvwUp+Mn93yMF2JsPaYo=";
+    sha256 = "sha256-JiDbkVs+EZRWRohSiuh8xFFgEhbnMYZfnZtz5Z4Wdb0=";
   };
 
   nativeBuildInputs = [
@@ -48,8 +48,8 @@ stdenv.mkDerivation rec {
     gtk3
     json-glib
     libgee
+    libhandy
     libsoup
-    libunity
     pantheon.granite
   ];
 


### PR DESCRIPTION

###### Motivation for this change

https://github.com/calo001/fondo/releases/tag/1.6.1

> - Hide progressbar when download finishes.

https://github.com/calo001/fondo/releases/tag/1.6.0

> - Wallpaper methods have been fixed to work on Odin.
> - The settings panel is redesigned.
> - Now you can select dark, light, or follow system for the UI mode.
> - A lot of custom styles are removed.

Diff: https://github.com/calo001/fondo/compare/1.5.2...1.6.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
