### PR TITLE
protontricks: 1.5.2 → 1.6.0

### DIFF
--- a/pkgs/tools/package-management/protontricks/default.nix
+++ b/pkgs/tools/package-management/protontricks/default.nix
@@ -2,23 +2,24 @@
 , buildPythonApplication
 , fetchFromGitHub
 , setuptools-scm
+, setuptools
 , vdf
 , bash
 , steam-run
 , winetricks
-, zenity
+, yad
 , pytestCheckHook
 }:
 
 buildPythonApplication rec {
   pname = "protontricks";
-  version = "1.5.2";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "Matoking";
     repo = pname;
     rev = version;
-    hash = "sha256-Vmxb8SjPhcSqFzykHRPsLtAoSwomN+se+icwHkucbX8=";
+    hash = "sha256-sbYIqVsuDZ2Htb6SVIe/gBA1UIvUzu4fjTjWQ7k1WFs=";
   };
 
   patches = [
@@ -27,23 +28,31 @@ buildPythonApplication rec {
   ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
   nativeBuildInputs = [ setuptools-scm ];
-  propagatedBuildInputs = [ vdf ];
+
+  propagatedBuildInputs = [
+    setuptools # implicit dependency, used to find data/icon_placeholder.png
+    vdf
+  ];
 
   makeWrapperArgs = [
     "--prefix PATH : ${lib.makeBinPath [
       bash
       steam-run
-      (winetricks.override {
-        # Remove default build of wine to reduce closure size.
-        # Falls back to wine in PATH when --no-runtime is passed.
-        wine = null;
-      })
-      zenity
+      winetricks
+      yad
     ]}"
   ];
 
   checkInputs = [ pytestCheckHook ];
+
+  # From 1.6.0 release notes (https://github.com/Matoking/protontricks/releases/tag/1.6.0):
+  # In most cases the script is unnecessary and should be removed as part of the packaging process.
+  postInstall = ''
+    rm "$out/bin/protontricks-desktop-install"
+  '';
+
   pythonImportsCheck = [ "protontricks" ];
 
   meta = with lib; {
@@ -51,6 +60,6 @@ buildPythonApplication rec {
     homepage = "https://github.com/Matoking/protontricks";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ kira-bruneau ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }

--- a/pkgs/tools/package-management/protontricks/steam-run.patch
+++ b/pkgs/tools/package-management/protontricks/steam-run.patch
@@ -1,31 +1,31 @@
-diff --git a/src/protontricks/cli.py b/src/protontricks/cli.py
-index cc65a03..5c3fc7a 100755
---- a/src/protontricks/cli.py
-+++ b/src/protontricks/cli.py
-@@ -15,8 +15,8 @@ import sys
+diff --git a/src/protontricks/cli/main.py b/src/protontricks/cli/main.py
+index 535ec9b..690c1f9 100755
+--- a/src/protontricks/cli/main.py
++++ b/src/protontricks/cli/main.py
+@@ -14,8 +14,8 @@ import sys
  
- from . import __version__
- from .gui import select_steam_app_with_gui
--from .steam import (find_legacy_steam_runtime_path, find_proton_app,
--                    find_steam_path, get_steam_apps, get_steam_lib_paths)
-+from .steam import (find_proton_app, find_steam_path, get_steam_apps,
-+                    get_steam_lib_paths)
- from .util import run_command, is_flatpak_sandbox
- from .winetricks import get_winetricks_path
- 
-@@ -77,8 +77,7 @@ def main(args=None):
+ from .. import __version__
+ from ..gui import select_steam_app_with_gui
+-from ..steam import (find_legacy_steam_runtime_path, find_proton_app,
+-                     find_steam_path, get_steam_apps, get_steam_lib_paths)
++from ..steam import (find_proton_app, find_steam_path, get_steam_apps,
++                     get_steam_lib_paths)
+ from ..util import is_flatpak_sandbox, run_command
+ from ..winetricks import get_winetricks_path
+ from .util import (CustomArgumentParser, cli_error_handler, enable_logging,
+@@ -60,8 +60,7 @@ def main(args=None):
              "WINE: path to a custom 'wine' executable\n"
              "WINESERVER: path to a custom 'wineserver' executable\n"
              "STEAM_RUNTIME: 1 = enable Steam Runtime, 0 = disable Steam "
 -            "Runtime, valid path = custom Steam Runtime path, "
--            "empty = enable automatically (default)"
-+            "Runtime, empty = enable automatically (default)"
+-            "empty = enable automatically (default)\n"
++            "Runtime, empty = enable automatically (default)\n"
+             "PROTONTRICKS_GUI: GUI provider to use, accepts either 'yad' "
+             "or 'zenity'"
          ),
-         formatter_class=argparse.RawTextHelpFormatter
-     )
-@@ -148,18 +147,9 @@ def main(args=None):
-         )
-         sys.exit(-1)
+@@ -147,17 +146,9 @@ def main(args=None):
+     if not steam_path:
+         exit_("Steam installation directory could not be found.")
  
 -    # 2. Find the pre-installed legacy Steam Runtime if enabled
 -    legacy_steam_runtime_path = None
@@ -38,13 +38,12 @@ index cc65a03..5c3fc7a 100755
 -        )
 -
 -        if not legacy_steam_runtime_path:
--            print("Steam Runtime was enabled but couldn't be found!")
--            sys.exit(-1)
+-            exit_("Steam Runtime was enabled but couldn't be found!")
 +        use_steam_runtime = True
      else:
          use_steam_runtime = False
          logger.info("Steam Runtime disabled.")
-@@ -222,7 +212,6 @@ def main(args=None):
+@@ -218,7 +209,6 @@ def main(args=None):
              proton_app=proton_app,
              steam_app=steam_app,
              use_steam_runtime=use_steam_runtime,
@@ -52,7 +51,7 @@ index cc65a03..5c3fc7a 100755
              command=[winetricks_path, "--gui"],
              use_bwrap=use_bwrap
          )
-@@ -292,7 +281,6 @@ def main(args=None):
+@@ -286,7 +276,6 @@ def main(args=None):
              proton_app=proton_app,
              steam_app=steam_app,
              use_steam_runtime=use_steam_runtime,
@@ -60,7 +59,7 @@ index cc65a03..5c3fc7a 100755
              use_bwrap=use_bwrap,
              command=[winetricks_path] + args.winetricks_command)
      elif args.command:
-@@ -302,7 +290,6 @@ def main(args=None):
+@@ -296,7 +285,6 @@ def main(args=None):
              steam_app=steam_app,
              command=args.command,
              use_steam_runtime=use_steam_runtime,
@@ -69,7 +68,7 @@ index cc65a03..5c3fc7a 100755
              # Pass the command directly into the shell *without*
              # escaping it
 diff --git a/src/protontricks/steam.py b/src/protontricks/steam.py
-index 4ab778b..f3f5f99 100644
+index e898caf..7448d11 100644
 --- a/src/protontricks/steam.py
 +++ b/src/protontricks/steam.py
 @@ -12,8 +12,8 @@ from .util import lower_dict
@@ -77,13 +76,13 @@ index 4ab778b..f3f5f99 100644
  __all__ = (
      "COMMON_STEAM_DIRS", "SteamApp", "find_steam_path",
 -    "find_legacy_steam_runtime_path", "get_appinfo_sections",
--    "get_proton_appid", "find_steam_proton_app", "find_appid_proton_prefix",
-+    "get_appinfo_sections", "get_proton_appid",
-+    "find_steam_proton_app", "find_appid_proton_prefix",
+-    "get_tool_appid", "find_steam_compat_tool_app", "find_appid_proton_prefix",
++    "get_appinfo_sections", "get_tool_appid",
++    "find_steam_compat_tool_app", "find_appid_proton_prefix",
      "find_proton_app", "get_steam_lib_paths", "get_compat_tool_dirs",
-     "get_custom_proton_installations_in_dir", "get_custom_proton_installations",
+     "get_custom_compat_tool_installations_in_dir", "get_custom_compat_tool_installations",
      "find_current_steamid3", "get_appid_from_shortcut",
-@@ -300,37 +300,6 @@ def find_steam_path():
+@@ -311,37 +311,6 @@ def find_steam_path():
      return None, None
  
  
@@ -122,12 +121,12 @@ index 4ab778b..f3f5f99 100644
  APPINFO_STRUCT_SECTION = "<LLLLQ20sL"
  
 diff --git a/src/protontricks/util.py b/src/protontricks/util.py
-index b6617de..85f8b2d 100644
+index 5252d6c..f16dfec 100644
 --- a/src/protontricks/util.py
 +++ b/src/protontricks/util.py
-@@ -4,15 +4,14 @@ import shlex
- import shutil
+@@ -5,15 +5,14 @@ import shutil
  import stat
+ 
  from pathlib import Path
 -from subprocess import check_output, run, PIPE
 +from subprocess import run, PIPE
@@ -146,7 +145,7 @@ index b6617de..85f8b2d 100644
  )
  
  logger = logging.getLogger("protontricks")
-@@ -46,24 +45,6 @@ def lower_dict(d):
+@@ -47,24 +46,6 @@ def lower_dict(d):
      return {k.lower(): _lower_value(v) for k, v in d.items()}
  
  
@@ -171,7 +170,7 @@ index b6617de..85f8b2d 100644
  def get_host_library_paths():
      """
      Get host library paths to use when creating the LD_LIBRARY_PATH environment
-@@ -75,7 +56,7 @@ def get_host_library_paths():
+@@ -76,7 +57,7 @@ def get_host_library_paths():
      # Since that command is unavailable with newer Steam Runtime releases,
      # do it ourselves here.
      result = run(
@@ -180,7 +179,7 @@ index b6617de..85f8b2d 100644
          check=True, stdout=PIPE, stderr=PIPE
      )
      lines = result.stdout.decode("utf-8").split("\n")
-@@ -93,7 +74,7 @@ RUNTIME_ROOT_GLOB_PATTERNS = (
+@@ -94,7 +75,7 @@ RUNTIME_ROOT_GLOB_PATTERNS = (
  )
  
  
@@ -189,7 +188,7 @@ index b6617de..85f8b2d 100644
      """
      Get LD_LIBRARY_PATH value to use when running a command using Steam Runtime
      """
-@@ -116,7 +97,7 @@ def get_runtime_library_paths(proton_app, use_bwrap=True):
+@@ -117,7 +98,7 @@ def get_runtime_library_paths(proton_app, use_bwrap=True):
              )
          )
  
@@ -198,7 +197,7 @@ index b6617de..85f8b2d 100644
          return "".join([
              str(proton_app.proton_dist_path / "lib"), os.pathsep,
              str(proton_app.proton_dist_path / "lib64"), os.pathsep
-@@ -132,14 +113,19 @@ def get_runtime_library_paths(proton_app, use_bwrap=True):
+@@ -133,14 +114,19 @@ def get_runtime_library_paths(proton_app, use_bwrap=True):
      ])
  
  
@@ -225,19 +224,18 @@ index b6617de..85f8b2d 100644
  # Helper script created by Protontricks to run Wine binaries using Steam Runtime
  set -o errexit
  
-@@ -207,7 +193,10 @@ if [[ -n "$PROTONTRICKS_INSIDE_STEAM_RUNTIME" ]]; then
+@@ -208,7 +194,9 @@ if [[ -n "$PROTONTRICKS_INSIDE_STEAM_RUNTIME" ]]; then
    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH":"$PROTON_LD_LIBRARY_PATH"
    "$PROTON_DIST_PATH"/bin/{name} "$@"
  else
 -  exec "$STEAM_RUNTIME_PATH"/run --share-pid --batch \
 +  exec steam-run "$STEAM_RUNTIME_PATH"/pressure-vessel/bin/pressure-vessel-wrap \
-+  --runtime-archive=$(echo "$STEAM_RUNTIME_PATH"/*runtime.tar.gz) \
 +  --variable-dir="${{PRESSURE_VESSEL_VARIABLE_DIR:-$STEAM_RUNTIME_PATH/var}}" \
 +  --share-pid --batch \
    "${{mount_params[@]}}" -- \
    env PROTONTRICKS_INSIDE_STEAM_RUNTIME=1 \
    "$PROTONTRICKS_PROXY_SCRIPT_PATH" "$@"
-@@ -273,7 +262,6 @@ def create_wine_bin_dir(proton_app, use_bwrap=True):
+@@ -274,7 +262,6 @@ def create_wine_bin_dir(proton_app, use_bwrap=True):
  def run_command(
          winetricks_path, proton_app, steam_app, command,
          use_steam_runtime=False,
@@ -245,7 +243,7 @@ index b6617de..85f8b2d 100644
          use_bwrap=True,
          **kwargs):
      """Run an arbitrary command with the correct environment variables
-@@ -350,7 +338,7 @@ def run_command(
+@@ -351,7 +338,7 @@ def run_command(
              os.environ["STEAM_RUNTIME_PATH"] = \
                  str(proton_app.required_tool_app.install_path)
              os.environ["PROTON_LD_LIBRARY_PATH"] = \
@@ -254,7 +252,7 @@ index b6617de..85f8b2d 100644
  
              runtime_name = proton_app.required_tool_app.name
              logger.info(
-@@ -373,11 +361,8 @@ def run_command(
+@@ -372,11 +359,8 @@ def run_command(
                      "Current Steam Runtime not recognized by Protontricks."
                  )
          else:
@@ -267,7 +265,7 @@ index b6617de..85f8b2d 100644
  
          # When Steam Runtime is enabled, create a set of helper scripts
          # that load the underlying Proton Wine executables with Steam Runtime
-@@ -385,8 +370,6 @@ def run_command(
+@@ -384,8 +368,6 @@ def run_command(
          wine_bin_dir = create_wine_bin_dir(
              proton_app=proton_app, use_bwrap=use_bwrap
          )
@@ -276,11 +274,11 @@ index b6617de..85f8b2d 100644
  
          os.environ["PATH"] = "".join([
              str(wine_bin_dir), os.pathsep, os.environ["PATH"]
-diff --git a/tests/test_cli.py b/tests/test_cli.py
-index 580bb5b..3a05ad3 100644
---- a/tests/test_cli.py
-+++ b/tests/test_cli.py
-@@ -117,15 +117,10 @@ class TestCLIRun:
+diff --git a/tests/cli/test_main.py b/tests/cli/test_main.py
+index e6da0fb..46b9545 100644
+--- a/tests/cli/test_main.py
++++ b/tests/cli/test_main.py
+@@ -116,15 +116,10 @@ class TestCLIRun:
          assert str(command.args[0]).endswith(".local/bin/winetricks")
          assert command.args[1] == "winecfg"
          assert command.env["PATH"].startswith(str(wine_bin_dir))
@@ -296,7 +294,7 @@ index 580bb5b..3a05ad3 100644
          assert "STEAM_RUNTIME_PATH" not in command.env
  
          for name in ("wine", "wineserver"):
-@@ -166,16 +161,14 @@ class TestCLIRun:
+@@ -165,16 +160,14 @@ class TestCLIRun:
          assert command.env["PATH"].startswith(str(wine_bin_dir))
  
          # Compared to the traditional Steam Runtime, PROTON_LD_LIBRARY_PATH
@@ -315,7 +313,7 @@ index 580bb5b..3a05ad3 100644
          assert command.env["STEAM_RUNTIME_PATH"] == \
              str(steam_runtime_soldier.install_path)
  
-@@ -239,9 +232,7 @@ class TestCLIRun:
+@@ -238,9 +231,7 @@ class TestCLIRun:
              str(runtime_root / "lib" / "x86_64-linux-gnu")
          ]))
  
@@ -326,9 +324,17 @@ index 580bb5b..3a05ad3 100644
          assert command.env["STEAM_RUNTIME_PATH"] == \
              str(steam_runtime_soldier.install_path)
  
-@@ -324,20 +315,6 @@ class TestCLIRun:
+@@ -335,7 +326,6 @@ class TestCLIRun:
  
-         assert "Zenity is not installed" in result
+         # Also ensure log messages are included in the error message
+         assert b"Found Steam directory at" in message
+-        assert b"Using default Steam Runtime" in message
+ 
+     def test_run_gui_provider_not_found(self, cli, home_dir, steam_app_factory):
+         """
+@@ -349,20 +339,6 @@ class TestCLIRun:
+ 
+         assert "YAD or Zenity is not installed" in result
  
 -    def test_run_steam_runtime_not_found(
 -            self, cli, steam_dir, steam_app_factory):

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29941,9 +29941,13 @@ with pkgs;
   steamcmd = steamPackages.steamcmd;
 
   protontricks = python3Packages.callPackage ../tools/package-management/protontricks {
-    inherit steam-run;
-    inherit winetricks;
-    inherit (gnome) zenity;
+    winetricks = winetricks.override {
+      # Remove default build of wine to reduce closure size.
+      # Falls back to wine in PATH.
+      wine = null;
+    };
+
+    inherit steam-run yad;
   };
 
   protonup = with python3Packages; toPythonApplication protonup;


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/Matoking/protontricks/releases/tag/1.6.0

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Verified with bwrap container (default behaviour)
  - Verified without bwrap container (--no-bwrap)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).