### PR TITLE
cudatext: 1.142.0 → 1.143.0

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.142.0";
+  version = "1.143.0";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "sha256-4kVi921dromMqiAuFjm2EOCDXCq4oT+ijko4/uT4LLs=";
+    sha256 = "sha256-j8J4OA4J43XIJKBMx8hQy7h1BcKfEhWvpgmpNmi/yrw=";
   };
 
   postPatch = ''

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -11,28 +11,28 @@
   },
   "ATFlatControls": {
     "owner": "Alexey-T",
-    "rev": "2021.07.22",
-    "sha256": "sha256-sAF/klzPa8fCKKBtpj0h9B+zoGDvA80uL4u4VTikUaI="
+    "rev": "2021.08.28",
+    "sha256": "sha256-nFRlSeU2ScPQrLXcd4dt8l9Ct7ceJyKMi97gtxz+S8I="
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2021.08.20",
-    "sha256": "sha256-cVl1HJHLsYTFKQ/Ov+rcP6UAwRJPp7rtmLlZC9S+Jek="
+    "rev": "2021.09.03",
+    "sha256": "sha256-2y1E+52MPkimmozo1Qwpg7Qyhjct3cs76nHlOf/Cs0M="
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
-    "rev": "2021.08.20",
-    "sha256": "sha256-PZtP/J4tJN2Egk/Bp/5DtHlV46yRjhcZL9xhDk6xjBk="
+    "rev": "2021.09.03",
+    "sha256": "sha256-pZo+wKnqN2HfDjPeC/WqaE5sdNnpjRN2VKSP8p4Q6Ek="
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2021.08.12",
-    "sha256": "sha256-Ht7jfFGlvb7khLD0OekuBvkU9ROyDiyUSe+lLI/Rm64="
+    "rev": "2021.09.02",
+    "sha256": "sha256-i8laXF9IIhVkGZ2rzv7RlZeMxUza5LAXlTOxDj9CzJo="
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",
-    "rev": "2021.07.29",
-    "sha256": "sha256-mCT3F0GPC+Hl7WOtYznxErMTyr9cH4ghaanYMum+3Fg="
+    "rev": "2021.09.03",
+    "sha256": "sha256-XYFnTfRa0n9XF9l/hL6z5RFZgdpVP9o1If4qln905Yc="
   },
   "Python-for-Lazarus": {
     "owner": "Alexey-T",
@@ -51,7 +51,7 @@
   },
   "bgrabitmap": {
     "owner": "bgrabitmap",
-    "rev": "v11.3.1",
-    "sha256": "1f95rdpfwqy9fipzybi17nbhq46zj45yjps21p2hplhinrr49n2p"
+    "rev": "v11.4",
+    "sha256": "sha256-jZL8lzjua033E76IL0HIk/fihC73ifCb4LqMni7vvb0="
   }
 }


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://cudatext.github.io/history.txt)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
