### PR TITLE
yarn2nix: handle codeload.github.com uris in IFD mode

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/bin/yarn2nix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/bin/yarn2nix.js
@@ -53,7 +53,7 @@ if (json.type !== 'success') {
 
 // Check for missing hashes in the yarn.lock and patch if necessary
 
-const pkgs = R.pipe(
+let pkgs = R.pipe(
   mapObjIndexedReturnArray((value, key) => ({
     ...value,
     nameWithVersion: key,
@@ -61,10 +61,10 @@ const pkgs = R.pipe(
   R.uniqBy(R.prop('resolved')),
 )(json.object)
 
-const fixedPkgsPromises = R.map(fixPkgAddMissingSha1, pkgs)
-
 ;(async () => {
-  const fixedPkgs = await Promise.all(fixedPkgsPromises)
+  if (!options['--no-patch']) {
+    pkgs = await R.map(fixPkgAddMissingSha1, pkgs)
+  }
 
   const origJson = lockfile.parse(data)
 
@@ -81,7 +81,7 @@ const fixedPkgsPromises = R.map(fixPkgAddMissingSha1, pkgs)
 
   if (!options['--no-nix']) {
     // print to stdout
-    console.log(generateNix(fixedPkgs, options['--builtin-fetchgit']))
+    console.log(generateNix(pkgs, options['--builtin-fetchgit']))
   }
 })().catch(error => {
   console.error(error)

--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
@@ -67,7 +67,7 @@ function fetchgit(fileName, url, rev, branch, builtinFetchGit) {
 
 function fetchLockedDep(builtinFetchGit) {
   return function (pkg) {
-    let { nameWithVersion, resolved } = pkg
+    const { nameWithVersion, resolved } = pkg
 
     if (!resolved) {
       console.error(
@@ -76,14 +76,19 @@ function fetchLockedDep(builtinFetchGit) {
       return ''
     }
 
-    const fileName = urlToName(resolved.split('#')[0])
+    const [url, sha1OrRev] = resolved.split('#')
+
+    const fileName = urlToName(url)
 
     if (resolved.startsWith('https://codeload.github.com/')) {
-      let s = resolved.split('/')
-      resolved = `git+https://github.com/${s[3]}/${s[4]}.git#${s[6]}`
-    }
+      const s = resolved.split('/')
+      const githubUrl = `https://github.com/${s[3]}/${s[4]}.git`
+      const githubRev = s[6]
 
-    const [url, sha1OrRev] = resolved.split('#')
+      const [_, branch] = nameWithVersion.split('#')
+
+      return fetchgit(fileName, githubUrl, rev, branch || 'master', builtinFetchGit)
+    }
 
     if (url.startsWith('git+') || url.startsWith("git:")) {
       const rev = sha1OrRev

--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
@@ -67,7 +67,7 @@ function fetchgit(fileName, url, rev, branch, builtinFetchGit) {
 
 function fetchLockedDep(builtinFetchGit) {
   return function (pkg) {
-    const { nameWithVersion, resolved } = pkg
+    let { nameWithVersion, resolved } = pkg
 
     if (!resolved) {
       console.error(
@@ -76,9 +76,14 @@ function fetchLockedDep(builtinFetchGit) {
       return ''
     }
 
-    const [url, sha1OrRev] = resolved.split('#')
+    const fileName = urlToName(resolved.split('#')[0])
 
-    const fileName = urlToName(url)
+    if (resolved.startsWith('https://codeload.github.com/')) {
+      let s = resolved.split('/')
+      resolved = `git+https://github.com/${s[3]}/${s[4]}.git#${s[6]}`
+    }
+
+    const [url, sha1OrRev] = resolved.split('#')
 
     if (url.startsWith('git+') || url.startsWith("git:")) {
       const rev = sha1OrRev


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
