### PR TITLE
llvm_12: fix cross-compilation

### DIFF
--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -54,7 +54,8 @@ in stdenv.mkDerivation (rec {
   buildInputs = [ libxml2 libffi ]
     ++ optional enablePFM libpfm; # exegesis
 
-  propagatedBuildInputs = [ ncurses zlib ];
+  propagatedBuildInputs = optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ ncurses ]
+    ++ [ zlib ];
 
   patches = [
     ./gnu-install-dirs.patch


### PR DESCRIPTION
Cross-compilation is broken because the method of finding ncurses has
changed, causing the build for the 'build system' to fail with a linking
error due to ncurses being for the 'host system' (where you're compiling
for).

This patch disables ncurses, which is not a very neat solution, but will
do until someone takes this upstream and gets it fixed properly.

Closes https://github.com/NixOS/nixpkgs/issues/127946.

Error that's seen before applying this:

/nix/store/hash-binutils-2.35.1/bin/ld: /nix/store/hash-ncurses-6.2-aarch64-unknown-linux-gnu/lib/libtinfo.so: error adding symbols: file in wrong format

###### Motivation for this change

I want llvm_12 to cross-compile, which is a dependency of mesa (which also doesn't cross-compile anymore :(.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] with qemu-aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The ordering with the cross-compiled deps is done deliberately, to prevent reordering resulting in a mass rebuild. Can change if that's preferred, but then I think I'd have to target staging as well.