### PR TITLE
reckon: 0.7.1 -> 0.8.0

### DIFF
--- a/pkgs/tools/text/reckon/Gemfile.lock
+++ b/pkgs/tools/text/reckon/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     chronic (0.10.2)
     highline (2.0.3)
     rchardet (1.8.0)
-    reckon (0.7.1)
+    reckon (0.8.0)
       chronic (>= 0.3.0)
       highline (>= 1.5.2)
       rchardet (>= 1.8.0)
@@ -16,4 +16,4 @@ DEPENDENCIES
   reckon
 
 BUNDLED WITH
-   1.17.2
+   2.2.20

--- a/pkgs/tools/text/reckon/default.nix
+++ b/pkgs/tools/text/reckon/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ nicknovitski ];
     platforms = platforms.unix;
+    changelog = "https://github.com/cantino/reckon/blob/v${version}/CHANGELOG.md";
   };
 }

--- a/pkgs/tools/text/reckon/gemset.nix
+++ b/pkgs/tools/text/reckon/gemset.nix
@@ -35,9 +35,9 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0hsmzjxj1f5ma816gag1b3bdjbynhj2szgar955fcs3gbbzv4sk7";
+      sha256 = "0qnghypb9pj7888096xwyrx7myhzk85x69ympxkxki3kxcgcrdfn";
       type = "gem";
     };
-    version = "0.7.1";
+    version = "0.8.0";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/cantino/reckon/blob/v0.8.0/CHANGELOG.md

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).