### PR TITLE
python3Packages.youless-api: init at 0.12

### DIFF
--- a/pkgs/development/python-modules/youless-api/default.nix
+++ b/pkgs/development/python-modules/youless-api/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromBitbucket
+, pythonOlder
+, certifi
+, chardet
+, idna
+, nose
+, requests
+, six
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "youless-api";
+  version = "0.12";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromBitbucket {
+    owner = "jongsoftdev";
+    repo = "youless-python-bridge";
+    rev = version;
+    sha256 = "18hymahpblq87i7lv479sizj8mgxawjhj31g4j1lyna1mds3887k";
+  };
+
+  propagatedBuildInputs = [
+    certifi
+    chardet
+    idna
+    requests
+    six
+    urllib3
+  ];
+
+  checkInputs = [
+    nose
+  ];
+
+  pythonImportsCheck = [ "youless_api" ];
+
+  meta = with lib; {
+    description = "Python library for YouLess sensors";
+    homepage = "https://pypi.org/project/youless-api/";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -993,7 +993,7 @@
     "yeelight" = ps: with ps; [ yeelight ];
     "yeelightsunflower" = ps: with ps; [ ]; # missing inputs: yeelightsunflower
     "yi" = ps: with ps; [ aioftp ha-ffmpeg ];
-    "youless" = ps: with ps; [ ]; # missing inputs: youless-api
+    "youless" = ps: with ps; [ youless-api ];
     "zabbix" = ps: with ps; [ ]; # missing inputs: py-zabbix
     "zamg" = ps: with ps; [ ];
     "zengge" = ps: with ps; [ ]; # missing inputs: zengge

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -722,6 +722,7 @@ in with py.pkgs; buildPythonApplication rec {
     "yandex_transport"
     "yandextts"
     "yeelight"
+    "youless"
     # disabled, because it tries to join a multicast group and fails to find a usable network interface
     # "zeroconf"
     "zerproc"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9610,6 +9610,8 @@ in {
 
   yoda = toPythonModule (pkgs.yoda.override { inherit python; });
 
+  youless-api = callPackage ../development/python-modules/youless-api { };
+
   youtube-dl = callPackage ../tools/misc/youtube-dl { };
 
   youtube-dl-light = callPackage ../tools/misc/youtube-dl {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for YouLess sensors

https://pypi.org/project/youless-api/

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
