### PR TITLE
python3Packages.pontos: init at 21.7.4

### DIFF
--- a/pkgs/development/python-modules/pontos/default.nix
+++ b/pkgs/development/python-modules/pontos/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry
+, pytestCheckHook
+, pythonOlder
+, colorful
+, tomlkit
+, git
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pontos";
+  version = "21.7.4";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "greenbone";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12z74fp21kv6jf4cwc4hd5xvl5lilhmpprcqimdg85pcddc4zwc2";
+  };
+
+  nativeBuildInputs = [
+    poetry
+  ];
+
+  propagatedBuildInputs = [
+    colorful
+    tomlkit
+    requests
+  ];
+
+  checkInputs = [
+    git
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Signing fails
+    "test_find_no_signing_key"
+    "test_find_signing_key"
+    "test_find_unreleased_information"
+  ];
+
+  pythonImportsCheck = [ "pontos" ];
+
+  meta = with lib; {
+    description = "Collection of Python utilities, tools, classes and functions";
+    homepage = "https://github.com/greenbone/pontos";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5582,6 +5582,8 @@ in {
 
   pomegranate = callPackage ../development/python-modules/pomegranate { };
 
+  pontos = callPackage ../development/python-modules/pontos { };
+
   pony = callPackage ../development/python-modules/pony { };
 
   ponywhoosh = callPackage ../development/python-modules/ponywhoosh { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Collection of Python utilities, tools, classes and functions.

https://github.com/greenbone/pontos

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
