### PR TITLE
vimPlugins.sqlite-lua: fix postPatch substituting nonexistent file

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -480,9 +480,11 @@ self: super: {
   });
 
   sqlite-lua = super.sqlite-lua.overrideAttrs (old: {
-    postPatch = ''
+    postPatch = let
+      libsqlite = "${sqlite.out}/lib/libsqlite3${stdenv.hostPlatform.extensions.sharedLibrary}";
+    in ''
       substituteInPlace lua/sqlite/defs.lua \
-        --replace "vim.g.sqlite_clib_path" "vim.g.sqlite_clib_path or '${sqlite.out}/lib/libsqlite3.so'"
+        --replace "path = vim.g.sqlite_clib_path" "path = vim.g.sqlite_clib_path or ${lib.escapeShellArg libsqlite}"
     '';
   });
 


### PR DESCRIPTION
###### Motivation for this change

The vim sqlite plugin was renamed in d28c708bc75425eccff806ca975c2d309c00dd18 but the postPatch override was not fixed.

This PR also fixes the logic to use the appropriate dynamic library according to the platform (`.dylib` for Darwin otherwise `.so`).

###### Things done

- [x] Tested to be working in my own configuration.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
