### PR TITLE
super-slicer.stable: 2.3.56.8 -> 2.3.56.9

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -13,9 +13,9 @@ let
     inherit version pname;
 
     src = fetchFromGitHub {
-      inherit sha256;
       owner = "supermerill";
       repo = "SuperSlicer";
+      inherit sha256;
       rev = version;
       fetchSubmodules = true;
     };

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -1,23 +1,27 @@
 { lib, fetchFromGitHub, makeDesktopItem, prusa-slicer }:
 let
   appname = "SuperSlicer";
-  version = "2.3.56.8";
   pname = "super-slicer";
   description = "PrusaSlicer fork with more features and faster development cycle";
-  override = super: {
+
+  versions = {
+    stable = { version = "2.3.56.9"; sha256 = "sha256-vv01wGQkrasKKjpGSDeDqZbd1X5/iTfGXYN5Jwz+FKE="; };
+    staging = { version = "2.3.57.0"; sha256 = "sha256-7o0AqgQcKYc6c+Hi3x5pC/pKJZPlEsYOYk9sC21+mvM="; };
+  };
+
+  override = { version, sha256 }: super: {
     inherit version pname;
 
     src = fetchFromGitHub {
+      inherit sha256;
       owner = "supermerill";
       repo = "SuperSlicer";
-      sha256 = "sha256-em0OgrcPaV2VYM8DpvtVJjgdojStMF/ROUEtZ8iLZfo=";
       rev = version;
       fetchSubmodules = true;
     };
 
     # We don't need PS overrides anymore, and gcode-viewer is embedded in the binary.
     postInstall = null;
-    dontStrip = true;
     separateDebugInfo = true;
 
     # See https://github.com/supermerill/SuperSlicer/issues/432
@@ -44,5 +48,10 @@ let
       maintainers = with maintainers; [ cab404 moredread ];
     };
 
+    passthru = allVersions;
+
   };
-in prusa-slicer.overrideAttrs override
+
+  allVersions = builtins.mapAttrs (_name: version: (prusa-slicer.overrideAttrs (override version))) versions;
+in
+allVersions.stable

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27537,6 +27537,8 @@ with pkgs;
 
   super-slicer = callPackage ../applications/misc/prusa-slicer/super-slicer.nix { };
 
+  super-slicer-staging = (callPackage ../applications/misc/prusa-slicer/super-slicer.nix { }).staging;
+
   robustirc-bridge = callPackage ../servers/irc/robustirc-bridge { };
 
   skrooge = libsForQt5.callPackage ../applications/office/skrooge {};


### PR DESCRIPTION
also, super-slicer.staging: init at 2.3.57.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
