### PR TITLE
linux-wifi-hotspot: init at 4.4.0

### DIFF
--- a/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
+++ b/pkgs/os-specific/linux/linux-wifi-hotspot/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, which
+, pkg-config
+, glib
+, gtk3
+, iw
+, makeWrapper
+, qrencode
+, hostapd }:
+
+stdenv.mkDerivation rec {
+  pname = "linux-wifi-hotspot";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "lakinduakash";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-XCgYWOX7QSdANG6DqYk0yZZqnvZGDl3GaF9KtYRmpJ0=";
+  };
+
+  nativeBuildInputs = [
+    which
+    pkg-config
+    makeWrapper
+    qrencode
+    hostapd
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+  ];
+
+  outputs = [ "out" ];
+
+  postPatch = ''
+    substituteInPlace ./src/scripts/Makefile \
+      --replace "etc" "$out/etc"
+    substituteInPlace ./src/scripts/wihotspot \
+      --replace "/usr" "$out"
+    substituteInPlace ./src/scripts/create_ap.service \
+      --replace "/usr/bin/create_ap" "$out/bin/create_cap" \
+      --replace "/etc/create_ap.conf" "$out/etc/create_cap.conf"
+  '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/create_ap \
+      --prefix PATH : ${lib.makeBinPath [ hostapd ]}
+
+    wrapProgram $out/bin/wihotspot-gui \
+      --prefix PATH : ${lib.makeBinPath [ iw ]} \
+      --prefix PATH : "${placeholder "out"}/bin"
+
+    wrapProgram $out/bin/wihotspot \
+      --prefix PATH : ${lib.makeBinPath [ iw ]} \
+      --prefix PATH : "${placeholder "out"}/bin"
+  '';
+
+  meta = with lib; {
+    description = "Feature-rich wifi hotspot creator for Linux which provides both GUI and command-line interface";
+    homepage = "https://github.com/lakinduakash/linux-wifi-hotspot";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ onny ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22699,6 +22699,8 @@ with pkgs;
 
   linuxConsoleTools = callPackage ../os-specific/linux/consoletools { };
 
+  linux-wifi-hotspot = callPackage ../os-specific/linux/linux-wifi-hotspot { };
+
   linthesia = callPackage ../games/linthesia/default.nix { };
 
   libreelec-dvb-firmware = callPackage ../os-specific/linux/firmware/libreelec-dvb-firmware { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes packaging request https://github.com/NixOS/nixpkgs/issues/136480 . Adds command line and GUI tools to easily create wifi hotspots on Linux.


Fixes #136480

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
