### PR TITLE
lib/systems: add minimal s390x-linux cross-compile support

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -107,6 +107,7 @@ rec {
         else if final.isMips then "mips"
         else if final.isPower then "powerpc"
         else if final.isRiscV then "riscv"
+        else if final.isS390 then "s390"
         else final.parsed.cpu.name;
 
       qemuArch =

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -28,7 +28,7 @@ let
     "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux"
     "armv7l-linux" "i686-linux" "m68k-linux" "mipsel-linux"
     "powerpc64-linux" "powerpc64le-linux" "riscv32-linux"
-    "riscv64-linux" "s390-linux" "x86_64-linux"
+    "riscv64-linux" "s390-linux" "s390x-linux" "x86_64-linux"
 
     # MMIXware
     "mmix-mmixware"
@@ -41,7 +41,8 @@ let
     # none
     "aarch64-none" "arm-none" "armv6l-none" "avr-none" "i686-none"
     "msp430-none" "or1k-none" "m68k-none" "powerpc-none"
-    "riscv32-none" "riscv64-none" "s390-none" "vc4-none" "x86_64-none"
+    "riscv32-none" "riscv64-none" "s390-none" "s390x-none" "vc4-none"
+    "x86_64-none"
 
     # OpenBSD
     "i686-openbsd" "x86_64-openbsd"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -152,6 +152,10 @@ rec {
     config = "s390-unknown-linux-gnu";
   };
 
+  s390x = {
+    config = "s390x-unknown-linux-gnu";
+  };
+
   arm-embedded = {
     config = "arm-none-eabi";
     libc = "newlib";

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -106,6 +106,7 @@ rec {
     riscv64  = { bits = 64; significantByte = littleEndian; family = "riscv"; };
 
     s390     = { bits = 32; significantByte = bigEndian; family = "s390"; };
+    s390x    = { bits = 64; significantByte = bigEndian; family = "s390"; };
 
     sparc    = { bits = 32; significantByte = bigEndian;    family = "sparc"; };
     sparc64  = { bits = 64; significantByte = bigEndian;    family = "sparc"; };

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -28,7 +28,7 @@ with lib.systems.doubles; lib.runTests {
   testredox = mseteq redox [ "x86_64-redox" ];
   testgnu = mseteq gnu (linux /* ++ kfreebsd ++ ... */);
   testillumos = mseteq illumos [ "x86_64-solaris" ];
-  testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "mipsel-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux" "powerpc64-linux" "powerpc64le-linux" "m68k-linux" "s390-linux" ];
+  testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "mipsel-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux" "powerpc64-linux" "powerpc64le-linux" "m68k-linux" "s390-linux" "s390x-linux" ];
   testnetbsd = mseteq netbsd [ "aarch64-netbsd" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd" "i686-netbsd" "m68k-netbsd" "mipsel-netbsd" "powerpc-netbsd" "riscv32-netbsd" "riscv64-netbsd" "x86_64-netbsd" ];
   testopenbsd = mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ];
   testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "i686-windows" "x86_64-windows" ];


### PR DESCRIPTION
Tested basic functionality as:

    $ nix-build --arg crossSystem '{ config = "s390x-unknown-linux-gnu"; }' -A re2c
    $ file ./result/bin/re2c
    $ ./result/bin/re2c: ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV),
    dynamically linked, interpreter ...-gnu-2.33-50/lib/ld64.so.1, for GNU/Linux 2.6.32, not stripped
    $ qemu-s390x ./result/bin/re2c --version
    re2c 2.2

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
