### PR TITLE
qmk: 0.0.52 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/qmk-dotty-dict/default.nix
+++ b/pkgs/development/python-modules/qmk-dotty-dict/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonPackage, fetchPypi, lib, pytest, setuptools-scm }:
+
+buildPythonPackage rec {
+  pname = "qmk_dotty_dict";
+  version = "1.3.0.post1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-O2EeOTZgv6poNcaOlHhLroD+B7hJCXi17KsDoNL8fqI=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Dictionary wrapper for quick access to deeply nested keys";
+    homepage = "https://github.com/pawelzny/dotty_dict";
+    license = licenses.mit;
+    maintainers = with maintainers; [ babariviere ];
+  };
+}

--- a/pkgs/tools/misc/qmk/default.nix
+++ b/pkgs/tools/misc/qmk/default.nix
@@ -1,18 +1,18 @@
-{ lib
-, python3
-, fetchpatch
-}:
+{ lib, python3, fetchpatch, writeText }:
 
 let
   inherit (python3.pkgs) buildPythonApplication fetchPypi;
-in
-buildPythonApplication rec {
+  setuppy = writeText "setup.py" ''
+    from setuptools import setup
+    setup()
+  '';
+in buildPythonApplication rec {
   pname = "qmk";
-  version = "0.0.52";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-mNF+bRhaL6JhNbROmjYDHkKKokRIALd5FZbRt9Kg5XQ=";
+    sha256 = "sha256-2mLuxzxFSMw3sLm+OTcgLcOjAdwvJmNhDsynUaYQ+co=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
@@ -27,7 +27,7 @@ buildPythonApplication rec {
     appdirs
     argcomplete
     colorama
-    dotty-dict
+    qmk-dotty-dict
     hid
     hjson
     jsonschema
@@ -35,6 +35,10 @@ buildPythonApplication rec {
     pygments
     pyusb
   ];
+
+  postConfigure = ''
+    cp ${setuppy} setup.py
+  '';
 
   # no tests implemented
   doCheck = false;
@@ -57,6 +61,6 @@ buildPythonApplication rec {
       - ... and many more!
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ bhipple ];
+    maintainers = with maintainers; [ bhipple babariviere ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7563,6 +7563,8 @@ in {
 
   queuelib = callPackage ../development/python-modules/queuelib { };
 
+  qmk-dotty-dict = callPackage ../development/python-modules/qmk-dotty-dict {};
+
   r2pipe = callPackage ../development/python-modules/r2pipe { };
 
   rabbitpy = callPackage ../development/python-modules/rabbitpy { };


### PR DESCRIPTION
###### Motivation for this change

Update qmk to 1.0.0 

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
