### PR TITLE
nixos/doc/md-to-db.sh: handle Docbook inclues in CommonMark

### DIFF
--- a/nixos/doc/manual/from_md/development/writing-documentation.chapter.xml
+++ b/nixos/doc/manual/from_md/development/writing-documentation.chapter.xml
@@ -1,4 +1,4 @@
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-writing-documentation">
+<chapter xmlns="http://docbook.org/ns/docbook"  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="sec-writing-documentation">
   <title>Writing NixOS Documentation</title>
   <para>
     As NixOS grows, so too does the need for a catalogue and explanation

--- a/nixos/doc/manual/md-to-db.sh
+++ b/nixos/doc/manual/md-to-db.sh
@@ -24,15 +24,19 @@ mapfile -t MD_FILES < <(find . -type f -regex '.*\.md$')
 for mf in ${MD_FILES[*]}; do
   if [ "${mf: -11}" == ".section.md" ]; then
     mkdir -p $(dirname "$OUT/$mf")
+    OUTFILE="$OUT/${mf%".section.md"}.section.xml"
     pandoc "$mf" "${pandoc_flags[@]}" \
-      -o "$OUT/${mf%".section.md"}.section.xml"
+      -o "$OUTFILE"
+    grep -q -m 1 "xi:include" "$OUTFILE" && sed -i 's|xmlns:xlink="http://www.w3.org/1999/xlink"| xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"|' "$OUTFILE"
   fi
 
   if [ "${mf: -11}" == ".chapter.md" ]; then
     mkdir -p $(dirname "$OUT/$mf")
+    OUTFILE="$OUT/${mf%".chapter.md"}.chapter.xml"
     pandoc "$mf" "${pandoc_flags[@]}" \
       --top-level-division=chapter \
-      -o "$OUT/${mf%".chapter.md"}.chapter.xml"
+      -o "$OUTFILE"
+    grep -q -m 1 "xi:include" "$OUTFILE" && sed -i 's|xmlns:xlink="http://www.w3.org/1999/xlink"| xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"|' "$OUTFILE"
   fi
 done
 


### PR DESCRIPTION
You can do includes like this in markdown to include docbook files

````
```{=docbook}
<xi:include href="rl-2111.section.xml" />
```
````

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The NixOS manual has multiple levels of Docbook includes, so we need some want to temporarily represent this in CommonMark while we transition.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
