### PR TITLE
jdownloader2: init at 2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9128,6 +9128,12 @@
     githubId = 801525;
     name = "rembo10";
   };
+  remgodow = {
+    email = "remgodow+github@protonmail.com";
+    github = "remgodow";
+    githubId = 10079854;
+    name = "remgodow";
+  };
   renatoGarcia = {
     email = "fgarcia.renato@gmail.com";
     github = "renatoGarcia";

--- a/pkgs/applications/networking/jdownloader2/default.nix
+++ b/pkgs/applications/networking/jdownloader2/default.nix
@@ -1,0 +1,68 @@
+{ stdenv, lib, fetchurl, writeScript, makeDesktopItem, copyDesktopItems, jre, imagemagick, coreutils }:
+
+let
+
+  icon = fetchurl {
+    url = "https://jdownloader.org/_media/vote/trazo.png";
+    sha256 = "3ebab992e7dd04ffcb6c30fee1a7e2b43f3537cb2b22124b30325d25bffdac29";
+  };
+
+  wrapper = writeScript "jdownloader" ''
+    #! ${stdenv.shell}
+    PATH=${lib.makeBinPath [ jre coreutils ]}
+    JDJAR=''${XDG_DATA_HOME:-$HOME/.local/share}/jdownloader/JDownloader.jar
+    dir=`dirname "$0"`
+    if [ ! -f ''${JDJAR} ]; then
+        install -Dm755 $dir/JDownloader.jar ''${JDJAR}
+    fi
+    ${jre}/bin/java -jar ''${JDJAR} "''${@}"
+  '';
+
+in stdenv.mkDerivation rec {
+  pname = "jdownloader2";
+  version = "2.0";
+
+  #there is no https endpoint for this domain
+  src = fetchurl {
+    url = "https://archive.org/download/jdownloader_202109/JDownloader.jar";
+    sha256 = "9951b786e24fc3777a0df0a7b516ba53d0c8e778d6a69ebc29dcff86ee6b5829";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ imagemagick copyDesktopItems ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "JDownloader 2";
+      exec = wrapper;
+      icon = "jdownloader";
+      comment = "Free, open-source download management tool.";
+      desktopName = "JDownloader 2";
+      genericName = "JDownloader 2";
+      categories = "Network;";
+    })
+  ];
+
+  installPhase = ''
+    mkdir -pv $out/bin $out/share/applications
+    cp ${src} $out/bin/JDownloader.jar
+
+    # create icons
+    for size in 16 32 48 64 72 96 128 192 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert -resize "$size"x"$size" \
+        ${icon} \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/jdownloader.png
+    done
+  '';
+
+  # Some easy metadata, in case I forget.
+  meta = with lib; {
+    homepage = "https://jdownloader.org/";
+    description = "Free, open-source download management tool";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ remgodow ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25652,6 +25652,8 @@ with pkgs;
 
   dupd = callPackage ../tools/misc/dupd { };
 
+  jdownloader2 = callPackage ../applications/networking/jdownloader2 { };
+
   jdupes = callPackage ../tools/misc/jdupes { };
 
   jed = callPackage ../applications/editors/jed { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
JDownloader is a popular file downloader. Nix package downloads only bootstraping file and creates a wrapper for it. Inspired by JDownloader flatpak. Unfortunately there is no way to package it "the nix way" due to how the app is designed (mandatory selfupdate + writes configs/logs in its dir, and no way to change that). The upside is that this package should not require any updates. 
Resolves: #41321 and #76568
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
