### PR TITLE
fftw: allow for optional MPI build

### DIFF
--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -9,6 +9,8 @@
 , enableAvx2 ? stdenv.hostPlatform.avx2Support
 , enableAvx512 ? stdenv.hostPlatform.avx512Support
 , enableFma ? stdenv.hostPlatform.fmaSupport
+, enableMpi ? false
+, mpi
 }:
 
 with lib;
@@ -38,10 +40,10 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ gfortran ];
 
-  buildInputs = lib.optionals stdenv.cc.isClang [
+  buildInputs = optionals stdenv.cc.isClang [
     # TODO: This may mismatch the LLVM version sin the stdenv, see #79818.
     llvmPackages.openmp
-  ];
+  ] ++ optional enableMpi mpi;
 
   configureFlags =
     [ "--enable-shared"
@@ -56,6 +58,7 @@ stdenv.mkDerivation {
     ++ optional enableAvx512 "--enable-avx512"
     ++ optional enableFma "--enable-fma"
     ++ [ "--enable-openmp" ]
+    ++ optional enableMpi "--enable-mpi"
     # doc generation causes Fortran wrapper generation which hard-codes gcc
     ++ optional (!withDoc) "--disable-doc";
 


### PR DESCRIPTION
###### Motivation for this change
Add an input flag to allow for build with MPI support. Has been used and tested [here](https://github.com/markuskowa/NixOS-QChem/blob/684a6b4d80b6a5d6e3543578408da29cea7da9d2/nixpkgs-opt.nix#L19).
The default is `false`, thus this change should not cause any rebuilds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
