### PR TITLE
vimPlugins: fix update script

### DIFF
--- a/pkgs/misc/vim-plugins/update-shell.nix
+++ b/pkgs/misc/vim-plugins/update-shell.nix
@@ -7,6 +7,7 @@ mkShell {
   packages = [
     bash
     pyEnv
+    nix
     nix-prefetch-scripts
   ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`update_plugins` from `maintainers/scripts/pluginupdate.py` doesn't work with nix unstable running `pkgs/misc/vim-plugins/update.py` on master with nix unstable gives this error message:
```
error: '(with import <localpkgs> {};
       let
         inherit (vimUtils.override {inherit vim;}) buildVimPluginFrom2Nix;
         generated = callPackage /home/figsoda/.nixpkgs/pkgs/misc/vim-plugins/generated.nix {
           inherit buildVimPluginFrom2Nix;
         };
         hasChecksum = value: lib.isAttrs value && lib.hasAttrByPath ["src" "outputHash"] value;
         getChecksum = name: value:
           if hasChecksum value then {
             submodules = value.src.fetchSubmodules or false;
             sha256 = value.src.outputHash;
             rev = value.src.rev;
           } else null;
         checksums = lib.mapAttrs getChecksum generated;
       in lib.filterAttrs (n: v: v != null) checksums)' is not a valid URL
[...]
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
