### PR TITLE
goverlay: 0.6 → 0.6.3

### DIFF
--- a/pkgs/tools/graphics/goverlay/default.nix
+++ b/pkgs/tools/graphics/goverlay/default.nix
@@ -5,14 +5,15 @@
 , fetchFromGitHub
 , fpc
 , lazarus-qt
-, qt5
-, libX11
+, wrapQtAppsHook
+, libGL
+, libGLU
 , libqt5pas
+, libX11
 , coreutils
 , git
 , gnugrep
 , libnotify
-, mesa-demos
 , polkit
 , procps
 , systemd
@@ -34,13 +35,13 @@ let
   '';
 in stdenv.mkDerivation rec {
   pname = "goverlay";
-  version = "0.6";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "benjamimgois";
     repo = pname;
     rev = version;
-    hash = "sha256-E4SMUL9rpDSSdprX4fPyGCHCowdQavjhGIhV3r4jeiw=";
+    hash = "sha256-nV8pcFBxrOlj4ebfLZF2gQwKt4bt+wtD72sXepu5kRI=";
   };
 
   outputs = [ "out" "man" ];
@@ -61,15 +62,17 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     fpc
     lazarus-qt
-    qt5.wrapQtAppsHook
+    wrapQtAppsHook
   ];
 
   buildInputs = [
-    libX11
+    libGL
+    libGLU
     libqt5pas
+    libX11
   ];
 
-  NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
+  NIX_LDFLAGS = "-lGLU -rpath ${lib.makeLibraryPath buildInputs}";
 
   buildPhase = ''
     runHook preBuild
@@ -85,7 +88,6 @@ in stdenv.mkDerivation rec {
       git
       gnugrep
       libnotify
-      mesa-demos
       polkit
       procps
       systemd

--- a/pkgs/tools/graphics/goverlay/default.nix
+++ b/pkgs/tools/graphics/goverlay/default.nix
@@ -35,13 +35,13 @@ let
   '';
 in stdenv.mkDerivation rec {
   pname = "goverlay";
-  version = "0.6.2";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "benjamimgois";
     repo = pname;
     rev = version;
-    hash = "sha256-nV8pcFBxrOlj4ebfLZF2gQwKt4bt+wtD72sXepu5kRI=";
+    hash = "sha256-ZksQse0xWAtH+U6EjcGWT2BOG5dfSnm6XvZLLE5ynHs=";
   };
 
   outputs = [ "out" "man" ];

--- a/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
+++ b/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
@@ -1,8 +1,8 @@
 diff --git a/overlayunit.pas b/overlayunit.pas
-index de8725f..005f171 100644
+index 1eee68b..3aaf7ae 100644
 --- a/overlayunit.pas
 +++ b/overlayunit.pas
-@@ -5377,7 +5377,7 @@ begin
+@@ -5040,7 +5040,7 @@ begin
     //Determine Mangohud dependency status
  
            //locate MangoHud and store result in tmp folder
@@ -11,7 +11,7 @@ index de8725f..005f171 100644
  
            // Assign Text file dependency_mangohud to variable mangohudVAR
            AssignFile(mangohudVAR, '/tmp/goverlay/dependency_mangohud');
-@@ -5386,7 +5386,7 @@ begin
+@@ -5049,7 +5049,7 @@ begin
            CloseFile(mangohudVAR);
  
            // Read String and store value on mangohuddependencyVALUE based on result
@@ -20,7 +20,7 @@ index de8725f..005f171 100644
            mangohuddependencyVALUE := 1
            else
            mangohuddependencyVALUE := 0;
-@@ -5395,7 +5395,7 @@ begin
+@@ -5058,7 +5058,7 @@ begin
     //Determine vkBasalt dependency staus
  
             //locate vkBasalt and store result in tmp folder
@@ -29,7 +29,7 @@ index de8725f..005f171 100644
  
             // Assign Text file dependency_mangohud to variable mangohudVAR
             AssignFile(vkbasaltVAR, '/tmp/goverlay/dependency_vkbasalt');
-@@ -5404,7 +5404,7 @@ begin
+@@ -5067,7 +5067,7 @@ begin
             CloseFile(vkbasaltVAR);
  
             // Read String and store value on vkbasaltdependencyVALUE based on result

--- a/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
+++ b/pkgs/tools/graphics/goverlay/find-xdg-data-files.patch
@@ -1,8 +1,8 @@
 diff --git a/overlayunit.pas b/overlayunit.pas
-index 1eee68b..3aaf7ae 100644
+index a56cea7..9a4f547 100644
 --- a/overlayunit.pas
 +++ b/overlayunit.pas
-@@ -5040,7 +5040,7 @@ begin
+@@ -4880,7 +4880,7 @@ begin
     //Determine Mangohud dependency status
  
            //locate MangoHud and store result in tmp folder
@@ -11,7 +11,7 @@ index 1eee68b..3aaf7ae 100644
  
            // Assign Text file dependency_mangohud to variable mangohudVAR
            AssignFile(mangohudVAR, '/tmp/goverlay/dependency_mangohud');
-@@ -5049,7 +5049,7 @@ begin
+@@ -4889,7 +4889,7 @@ begin
            CloseFile(mangohudVAR);
  
            // Read String and store value on mangohuddependencyVALUE based on result
@@ -20,7 +20,7 @@ index 1eee68b..3aaf7ae 100644
            mangohuddependencyVALUE := 1
            else
            mangohuddependencyVALUE := 0;
-@@ -5058,7 +5058,7 @@ begin
+@@ -4898,7 +4898,7 @@ begin
     //Determine vkBasalt dependency staus
  
             //locate vkBasalt and store result in tmp folder
@@ -29,7 +29,7 @@ index 1eee68b..3aaf7ae 100644
  
             // Assign Text file dependency_mangohud to variable mangohudVAR
             AssignFile(vkbasaltVAR, '/tmp/goverlay/dependency_vkbasalt');
-@@ -5067,7 +5067,7 @@ begin
+@@ -4907,7 +4907,7 @@ begin
             CloseFile(vkbasaltVAR);
  
             // Read String and store value on vkbasaltdependencyVALUE based on result

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5624,7 +5624,9 @@ with pkgs;
 
   govc = callPackage ../tools/virtualization/govc { };
 
-  goverlay = callPackage ../tools/graphics/goverlay { };
+  goverlay = callPackage ../tools/graphics/goverlay {
+    inherit (qt5) wrapQtAppsHook;
+  };
 
   gpart = callPackage ../tools/filesystems/gpart { };
 


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/benjamimgois/goverlay/releases/tag/0.6.3

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).