### PR TITLE
nlohmann_json: 3.9.1 -> 3.10.2 and make checkPhase work

### DIFF
--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -3,22 +3,14 @@
 
 stdenv.mkDerivation rec {
   pname = "nlohmann_json";
-  version = "3.9.1";
+  version = "3.10.2";
 
   src = fetchFromGitHub {
     owner = "nlohmann";
     repo = "json";
     rev = "v${version}";
-    sha256 = "sha256-THordDPdH2qwk6lFTgeFmkl7iDuA/7YH71PTUe6vJCs=";
+    sha256 = "/OFNfukrIyfJmD0ko174aud9T6ZOesHANJjyfk4q/Vs=";
   };
-
-  patches = [
-    # https://github.com/nlohmann/json/pull/2690
-    (fetchpatch {
-      url = "https://github.com/nlohmann/json/commit/53a9850eebb88c6ff95f6042d08d5c0cc9d18097.patch";
-      sha256 = "k+Og00nXNg5IsFQY5fWD3xVQQXUFFTie44UXole0S1M=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -26,8 +26,9 @@ stdenv.mkDerivation rec {
   postInstall = "rm -rf $out/lib64";
 
   meta = with lib; {
-    description = "Header only C++ library for the JSON file format";
-    homepage = "https://github.com/nlohmann/json";
+    description = "JSON for Modern C++";
+    homepage = "https://json.nlohmann.me";
+    changelog = "https://github.com/nlohmann/json/blob/develop/ChangeLog.md";
     license = licenses.mit;
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -1,7 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
 }:
-
-stdenv.mkDerivation rec {
+let
+  testData = fetchFromGitHub {
+    owner = "nlohmann";
+    repo = "json_test_data";
+    rev = "v3.0.0";
+    sha256 = "O6p2PFB7c2KE9VqWvmTaFywbW1hSzAP5V42EuemX+ls=";
+  };
+in stdenv.mkDerivation rec {
   pname = "nlohmann_json";
   version = "3.10.2";
 
@@ -17,11 +26,14 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBuildTests=${if doCheck then "ON" else "OFF"}"
     "-DJSON_MultipleHeaders=ON"
-  ];
+  ] ++ lib.optional doCheck "-DJSON_TestDataDirectory=${testData}";
 
-  # A test cause the build to timeout https://github.com/nlohmann/json/issues/1816
-  #doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
-  doCheck = false;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+
+  # skip tests that require git or modify “installed files”
+  preCheck = ''
+    checkFlagsArray+=("ARGS=-LE 'not_reproducible|git_required'")
+  '';
 
   postInstall = "rm -rf $out/lib64";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
*   Update to newer version version
*   Enable the `checkPhase`
    *   Fetch nlohmann/json_test_data as a derivation
    *   Run the tests with `ctest -LE git_required`
*   Note that the `checkPhase` seems to take longer time than the `buildPhase`
*   The package lacks the `meta.maintainers` attribute
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
