### PR TITLE
[21.05] salt: 3003 -> 3003.3

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -7,11 +7,11 @@
 }:
 python3.pkgs.buildPythonApplication rec {
   pname = "salt";
-  version = "3003";
+  version = "3003.1";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "xGiXM9/nOM8ofjHLP908uNFgYpUgKxjY5m1I03LVync=";
+    sha256 = "inGE095NFydhjw0/u6eeVDia7/hbcvTOuCALzBZ/br4=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -31,6 +31,8 @@ python3.pkgs.buildPythonApplication rec {
   postPatch = ''
     substituteInPlace "salt/utils/rsax931.py" \
       --subst-var-by "libcrypto" "${openssl.out}/lib/libcrypto.so"
+    substituteInPlace requirements/base.txt \
+      --replace contextvars ""
   '';
 
   # The tests fail due to socket path length limits at the very least;

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -7,11 +7,11 @@
 }:
 python3.pkgs.buildPythonApplication rec {
   pname = "salt";
-  version = "3003.1";
+  version = "3003.2";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "inGE095NFydhjw0/u6eeVDia7/hbcvTOuCALzBZ/br4=";
+    sha256 = "c8hsRLF22M/cAzux5C5P3I3TQkgz+qLqDQk4+hc4Vqk=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -7,11 +7,11 @@
 }:
 python3.pkgs.buildPythonApplication rec {
   pname = "salt";
-  version = "3003.2";
+  version = "3003.3";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "c8hsRLF22M/cAzux5C5P3I3TQkgz+qLqDQk4+hc4Vqk=";
+    sha256 = "pvnIyLXiYA6oYgtKZzcd4XYRvrT42X5LubCzCKN+0eI=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
3003.3 was published, fixing 2 CVEs: https://docs.saltproject.io/en/latest/topics/releases/3003.3.html

Backport of 4ad4ae68c427ef8458be34051b4e545eb752811c from #136619.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
