### PR TITLE
nixos/sane: cleanup & new option

### DIFF
--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -161,6 +161,12 @@ in
       '';
     };
 
+    services.saned.openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Configure the firewall to allow saned traffic to pass.";
+    };
+
     services.saned.extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -186,6 +192,7 @@ in
 
     (mkIf config.services.saned.enable {
       networking.firewall.connectionTrackingModules = [ "sane" ];
+      networking.firewall.allowedTCPPorts = mkIf config.services.saned.openFirewall [ 6566 ];
 
       systemd.services."saned@" = {
         description = "Scanner Service";
@@ -193,7 +200,7 @@ in
         serviceConfig = {
           User = "scanner";
           Group = "scanner";
-          ExecStart = "${pkg}/bin/saned";
+          ExecStart = "${wrappedPkg}/bin/saned";
         };
       };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I needed to scan my school papers and this was a great way to procrastinate!

...also I didn't want to restart i3 for a silly scanner.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (on [cookiemonster](https://github.com/ckiee/nixfiles/blob/31cf9b593b4ce422cf85d42c56b25a20e4a917fd/hosts/cookiemonster/default.nix))
  - [x] aarch64-linux (QEMU emulated build on cookiemonster, runs on [drapion](https://github.com/ckiee/nixfiles/blob/31cf9b593b4ce422cf85d42c56b25a20e4a917fd/hosts/drapion/default.nix))
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` - Unrelated build failure: `pkgs.nixos-install-tools`
- [x] Tested execution of ~~all~~ (just `scanimage`) binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Explanation

This pull request cleans up some of the gunk that has accumulated in this module in the literal [decade](https://github.com/nixos/nixpkgs/commit/e87764e3278) it has existed:

- `environment.sessionVariables` is no longer used so configuration changes are applied instantly for new program launches.
- a helper, `sane-wrap` is added to inject the environment variables for programs that may need to access the SANE, such as `xsane`. (A GUI frontend)
- `services.saned.openFirewall` is added. (pretty self-explanatory)

I've scanned a page or two with this setup and so far nothing has blown up, so I think it's probably fine~

###### TODO

- release notes
- remove `sane-wrap`
