### PR TITLE
home-assistant: pin aioesphomeapi to 7.0.0

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -112,6 +112,19 @@ let
     (self: super: {
       home-assistant-frontend = self.callPackage ./frontend.nix { };
     })
+
+    # Pinned due to incompability with aioesphomeapi 8.0.0
+    (self: super: {
+      aioesphomeapi = super.aioesphomeapi.overrideAttrs (oldAttrs: rec {
+        version = "7.0.0";
+        src = fetchFromGitHub {
+          owner = "esphome";
+          repo = oldAttrs.pname;
+          rev = "v${version}";
+          hash = "sha256-ho/1fpq4yAgmYNERPqs51oqr08ncaN9+GRTUUuGU7ps=";
+        };
+      });
+    })
   ];
 
   mkOverride = attrname: version: sha256:


### PR DESCRIPTION


###### Motivation for this change

Version of Home Assistant in nixpkgs is incompatible with `aioesphomeapi-8.0.0`, so this PR pins the version. 
Mandatory to be able to use e.g. lights, otherwise Home Assistant fails with:

```
ERROR (MainThread) [homeassistant.setup] Unable to prepare setup for platform esphome.light: Platform not found (cannot import name 'LightColorMode' from 'aioesphomeapi' (/nix/store/yw40d736xvv7criyfffz88pcfnvvavx0-python3.9-aioesphomeapi-8.0.0/lib/python3.9/site-packages/aioesphomeapi/__init__.py)).
``` 

Relevant comment in the bump of aioesphomeapi:
https://github.com/NixOS/nixpkgs/pull/135669#issuecomment-912177954

###### Things done

Added it manually via `packageOverrides` on the `services.home-assistant.package` option (so I didn't test the PR in exaclty this form, but an equivalent override).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
