### PR TITLE
python3Packages.python-gvm: init at 21.6.0, python3Packages.gvm-tools: init at 21.6.1

### DIFF
--- a/pkgs/development/python-modules/gvm-tools/default.nix
+++ b/pkgs/development/python-modules/gvm-tools/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, pytestCheckHook
+, python-gvm
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "gvm-tools";
+  version = "21.6.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "greenbone";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1n9alryf52xkwxwagmq8bdn3a8scnmgh3qfdjwj6jybcyk36rv6n";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    python-gvm
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/greenbone/gvm-tools/pull/520
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/greenbone/gvm-tools/commit/db65495181ca339610b1007a33cc13285a470242.patch";
+      sha256 = "069rg742pxjd36vap0xp6367rd69pji4yfxbycc7z0b8gvf80w5z";
+    })
+  ];
+
+  pythonImportsCheck = [ "gvmtools" ];
+
+  meta = with lib; {
+    description = "Collection of APIs that help with remote controlling a Greenbone Security Manager";
+    homepage = "https://github.com/greenbone/gvm-tools";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/python-gvm/default.nix
+++ b/pkgs/development/python-modules/python-gvm/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, paramiko
+, lxml
+, defusedxml
+}:
+
+buildPythonPackage rec {
+  pname = "python-gvm";
+  version = "21.6.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "greenbone";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "070qpj2y7834i50lhkkbv93s77j91js06zs1bpbmplppiraxqmyz";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    paramiko
+    lxml
+    defusedxml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/greenbone/python-gvm/pull/552
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/greenbone/python-gvm/commit/e48afa614ba9cf69d9b22ce1a4642c625acbaa06.patch";
+      sha256 = "0f5wfdymp5dcjk1xb7ynsf0g6idjg2ifwgggp4agic5nkh1k1inl";
+    })
+  ];
+
+  disabledTests = [
+    # No running SSH available
+    "test_connect_error"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "test_feed_xml_error"
+  ];
+
+  pythonImportsCheck = [ "gvm" ];
+
+  meta = with lib; {
+    description = "Collection of APIs that help with remote controlling a Greenbone Security Manager";
+    homepage = "https://github.com/greenbone/python-gvm";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5785,6 +5785,8 @@ with pkgs;
 
   gupnp-tools = callPackage ../tools/networking/gupnp-tools {};
 
+  gvm-tools = with python3.pkgs; toPythonApplication gvm-tools;
+
   gvpe = callPackage ../tools/networking/gvpe {
     openssl = openssl_1_0_2;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7133,6 +7133,8 @@ in {
 
   python-gnupg = callPackage ../development/python-modules/python-gnupg { };
 
+  python-gvm = callPackage ../development/python-modules/python-gvm { };
+
   python-hosts = callPackage ../development/python-modules/python-hosts { };
 
   python-hpilo = callPackage ../development/python-modules/python-hpilo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3241,6 +3241,8 @@ in {
 
   guzzle_sphinx_theme = callPackage ../development/python-modules/guzzle_sphinx_theme { };
 
+  gvm-tools = callPackage ../development/python-modules/gvm-tools {};
+
   gviz-api = callPackage ../development/python-modules/gviz-api {};
 
   gym = callPackage ../development/python-modules/gym { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Collection of APIs that help with remote controlling a Greenbone Security Manager

https://github.com/greenbone/python-gvm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
