### PR TITLE
python3Packages.ospd: init at 21.4.3

### DIFF
--- a/pkgs/development/python-modules/ospd/default.nix
+++ b/pkgs/development/python-modules/ospd/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, defusedxml
+, deprecated
+, fetchFromGitHub
+, lxml
+, paramiko
+, poetry
+, psutil
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "ospd";
+  version = "21.4.3";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7" || stdenv.isDarwin;
+
+  src = fetchFromGitHub {
+    owner = "greenbone";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1i4nfvxgxibqmqb6jwih951960sm2zy00i1wnjfnwb6za1xkpbkp";
+  };
+
+  nativeBuildInputs = [
+    poetry
+  ];
+
+  propagatedBuildInputs = [
+    defusedxml
+    deprecated
+    lxml
+    paramiko
+    psutil
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "ospd" ];
+
+  meta = with lib; {
+    description = "Framework for vulnerability scanners which support OSP";
+    homepage = "https://github.com/greenbone/ospd";
+    license = with licenses; [ agpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5202,6 +5202,8 @@ in {
 
   oslotest = callPackage ../development/python-modules/oslotest { };
 
+  ospd = callPackage ../development/python-modules/ospd { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Framework for vulnerability scanners which support OSP

https://github.com/greenbone/ospd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
