### PR TITLE
python3Packages.scikitimage: 0.18.1 -> 0.18.3

### DIFF
--- a/pkgs/development/python-modules/scikit-image/add-testing-data.patch
+++ b/pkgs/development/python-modules/scikit-image/add-testing-data.patch
@@ -1,0 +1,17 @@
+diff --git a/skimage/data/setup.py b/skimage/data/setup.py
+index 528e9c284ce..ba0e155559c 100644
+--- a/skimage/data/setup.py
++++ b/skimage/data/setup.py
+@@ -11,7 +11,11 @@ def configuration(parent_package='', top_path=None):
+     # further notice.
+     # Testing data and additional datasets should only
+     # be made available via pooch
+-    config.add_data_files(*legacy_datasets)
++    # Nix patch: add ALL images to facilitate testing of a fully-built package
++    from pathlib import Path
++    config.add_data_files(
++        *(path.name for path in Path(__file__).parent.glob("*") if path.suffix != ".py")
++    )
+     # It seems hard to create a consistent hash for README.txt since
+     # the line endings keep getting converted
+     config.add_data_files('README.txt')

--- a/pkgs/development/python-modules/scikit-image/default.nix
+++ b/pkgs/development/python-modules/scikit-image/default.nix
@@ -1,6 +1,7 @@
 { lib
-, fetchPypi
+, fetchFromGitHub
 , buildPythonPackage
+, python
 , cython
 , numpy
 , scipy
@@ -11,18 +12,20 @@
 , pywavelets
 , dask
 , cloudpickle
-, pytest
 , imageio
 , tifffile
+, pytest
 }:
 
 buildPythonPackage rec {
   pname = "scikit-image";
   version = "0.18.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "ecae99f93f4c5e9b1bf34959f4dc596c41f2f6b2fc407d9d9ddf85aebd3137ca";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0a2h3bw5rkk23k4r04qc9maccg00nddssd7lfsps8nhp5agk1vyh";
   };
 
   nativeBuildInputs = [ cython ];
@@ -43,12 +46,55 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest ];
 
-  # No tests in archive
-  doCheck = false;
+  # (1) The package has cythonized modules, whose .so libs will appear only in the wheel, i.e. in nix store;
+  # (2) To stop Python from importing the wrong directory, i.e. the one in the build dir, not the one in nix store, `skimage` dir should be removed or renamed;
+  # (3) Therefore, tests should be run on the installed package in nix store.
+  # (4) It requires setting a custom test root and form appropriate paths to ignored test modules, for which `pytestCheckHook` is insufficient.
+  # Because of that, a custom checkPhase is needed along with the patch to add all the data/image files for testing, not only the "legacy" set.
+  patches = [ ./add-testing-data.patch ];
+
+  checkPhase = ''
+    # Removing of `skimage` in the build dir is required to force Python to use the skimage in the `PYTHONPATH` instead of the build dir.
+    rm -r skimage
+    # Site-packages path for the installed package
+    export INSTALL_PATH=$out/${python.sitePackages}
+
+    # `skimage/filters/rank/tests/test_rank.py`: requires network access (actually some data is loaded via `skimage._shared.testing.fetch` in the global scope, which calls `pytest.skip` when network is unaccessible, leading to a pytest collection error).
+    # `skimage/data/test_data.py::test_skin`: requires network access
+    # `skimage/data/tests/test_data.py::test_skin`: --"--
+    # `skimage/io/tests/test_io.py::test_imread_http_url`: --"--
+    # `skimage/restoration/tests/test_rolling_ball.py::test_ndim`: --"--
+    pytest $INSTALL_PATH \
+      --ignore=$INSTALL_PATH/skimage/filters/rank/tests/test_rank.py \
+      --deselect=skimage/data/test_data.py::test_skin \
+      --deselect=skimage/data/tests/test_data.py::test_skin \
+      --deselect=skimage/io/tests/test_io.py::test_imread_http_url \
+      --deselect=skimage/restoration/tests/test_rolling_ball.py::test_ndim \
+      --pyargs skimage
+  '';
+
+  # Check cythonized modules
+  pythonImportsCheck = [
+    "skimage"
+    "skimage._shared"
+    "skimage.draw"
+    "skimage.feature"
+    "skimage.restoration"
+    "skimage.filters"
+    "skimage.future.graph"
+    "skimage.graph"
+    "skimage.io"
+    "skimage.measure"
+    "skimage.morphology"
+    "skimage.transform"
+    "skimage.util"
+    "skimage.segmentation"
+  ];
 
   meta = {
     description = "Image processing routines for SciPy";
     homepage = "https://scikit-image.org";
     license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ yl3dy ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Version bump + added missing tests. Also added myself as a maintainer, hope it's ok.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
