### PR TITLE
botan2: 2.18.0 -> 2.18.1, add patch for CVE-2021-40529

### DIFF
--- a/pkgs/development/libraries/botan/2.0.nix
+++ b/pkgs/development/libraries/botan/2.0.nix
@@ -1,4 +1,4 @@
-{ callPackage, ... } @ args:
+{ callPackage, fetchpatch, ... } @ args:
 
 callPackage ./generic.nix (args // {
   baseVersion = "2.18";
@@ -7,4 +7,13 @@ callPackage ./generic.nix (args // {
   postPatch = ''
     sed -e 's@lang_flags "@&--std=c++11 @' -i src/build-data/cc/{gcc,clang}.txt
   '';
+  extraPatches = [
+    (fetchpatch {
+      name = "CVE-2021-40529.patch";
+      url = "https://github.com/randombit/botan/commit/9a23e4e3bc3966340531f2ff608fa9d33b5185a2.patch";
+      sha256 = "1ax1n2l9zh0hk35vkkywgkhzpdk76xb9apz2wm3h9kjvjs9acr3y";
+      # our source tarball doesn't include the tests
+      excludes = [ "src/tests/*" ];
+    })
+  ];
 })

--- a/pkgs/development/libraries/botan/2.0.nix
+++ b/pkgs/development/libraries/botan/2.0.nix
@@ -2,8 +2,8 @@
 
 callPackage ./generic.nix (args // {
   baseVersion = "2.18";
-  revision = "0";
-  sha256 = "09z3fy31q1pvnvpy4fswrsl2aq8ksl94lbh5rl7b6nqc3qp8ar6c";
+  revision = "1";
+  sha256 = "0adf53drhk1hlpfih0175c9081bqpclw6p2afn51cmx849ib9izq";
   postPatch = ''
     sed -e 's@lang_flags "@&--std=c++11 @' -i src/build-data/cc/{gcc,clang}.txt
   '';

--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -10,6 +10,7 @@ callPackage ./generic.nix (args // {
     sed -e 's@lang_flags "@&--std=c++11 @' -i src/build-data/cc/{gcc,clang}.txt
   '';
   knownVulnerabilities = [
+    "CVE-2021-40529"
     # https://botan.randombit.net/security.html#id1
     "2020-03-24: Side channel during CBC padding"
   ];

--- a/pkgs/development/libraries/botan/generic.nix
+++ b/pkgs/development/libraries/botan/generic.nix
@@ -3,6 +3,7 @@
 , baseVersion, revision, sha256
 , sourceExtension ? "tar.xz"
 , extraConfigureFlags ? ""
+, extraPatches ? [ ]
 , postPatch ? null
 , knownVulnerabilities ? [ ]
 , CoreServices
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec {
     ];
     inherit sha256;
   };
+  patches = extraPatches;
   inherit postPatch;
 
   buildInputs = [ python3 bzip2 zlib gmp openssl boost ]


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-40529

No release including this fix yet. Bumped at the same time to ensure patch was as applicable as possible.

Also marked `botan` as vulnerable to this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
