### PR TITLE
difftastic: 0.6 -> 0.8

### DIFF
--- a/pkgs/tools/text/difftastic/default.nix
+++ b/pkgs/tools/text/difftastic/default.nix
@@ -2,22 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "difftastic";
-  version = "0.6";
+  version = "0.8";
 
   src = fetchFromGitHub {
     owner = "wilfred";
     repo = pname;
     rev = version;
-    sha256 = "WFvxdRCbTBW1RGn2SvAo2iXn82OO/Z06cZQkIu4eiew=";
+    sha256 = "0103py4v4v7xqv85yiczhd9w9h1aa54svhhdibvbl6x4b35y2mk5";
   };
 
-  cargoSha256 = "2hRUfIxNVs4uSrEESas3wvvVsZHVocP8aiO7K0NZ+mY=";
+  cargoSha256 = "1k0d7yadicfzfc2m1aqs4c4a2k3srb54fpwarc3kwn26v3vfjai1";
 
   meta = with lib; {
     description = "A syntax-aware diff";
     homepage = "https://github.com/Wilfred/difftastic";
+    changelog = "https://github.com/Wilfred/difftastic/raw/${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ ethancedwards8 ];
-    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
