### PR TITLE
htmlq: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/htmlq/default.nix
+++ b/pkgs/development/tools/htmlq/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchpatch
+, fetchFromGitHub
+, rustPlatform
+}:
+let
+  version = "0.2.0";
+  author = "mgdm";
+  pname = "htmlq";
+in
+rustPlatform.buildRustPackage rec {
+  inherit version pname;
+
+  src = fetchFromGitHub {
+    owner = "${author}";
+    repo = "${pname}";
+    rev = "v${version}";
+    hash = "sha256-Q2zjrHKFWowx2yB1cdGxPnNnc8yQJz65HaX0yIqbHks=";
+  };
+
+  cargoSha256 = "sha256-pPtKPVSdEtEPmQPpNRJ4uyguDRAW0YvKgdUw5OAtbjA=";
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Like jq, but for HTML";
+    homepage = "https://github.com/${author}/${pname}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nerdypepper ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5978,6 +5978,8 @@ with pkgs;
 
   html-proofer = callPackage ../tools/misc/html-proofer { };
 
+  htmlq = callPackage ../development/tools/htmlq { };
+
   htpdate = callPackage ../tools/networking/htpdate { };
 
   http-prompt = callPackage ../tools/networking/http-prompt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds `htmlq`, "Like jq, but for HTML", as requested by #137037.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
