### PR TITLE
python3Packages.tensorflow: 2.4.2 -> 2.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9594,6 +9594,12 @@
     githubId = 115821;
     name = "Sam Rose";
   };
+  samuela = {
+    email = "skainsworth@gmail.com";
+    github = "samuela";
+    githubId = 226872;
+    name = "Samuel Ainsworth";
+  };
   samueldr = {
     email = "samuel@dionne-riel.com";
     github = "samueldr";

--- a/pkgs/development/python-modules/clang/common.nix
+++ b/pkgs/development/python-modules/clang/common.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, nose
+, sha256
+, version
+}:
+
+buildPythonPackage rec {
+  inherit version;
+  pname = "clang";
+
+  src = fetchPypi {
+    inherit pname sha256 version;
+  };
+
+  checkInputs = [ nose ];
+
+  meta = with lib; {
+    description = "libclang python bindings";
+    homepage    = "https://clang.llvm.org/";
+    license     = licenses.ncsa;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/clang/common.nix
+++ b/pkgs/development/python-modules/clang/common.nix
@@ -1,7 +1,6 @@
 { buildPythonPackage
 , fetchPypi
 , lib
-, nose
 , sha256
 , version
 }:
@@ -14,12 +13,13 @@ buildPythonPackage rec {
     inherit pname sha256 version;
   };
 
-  checkInputs = [ nose ];
+  # The pypi distribution does not have any tests.
+  doCheck = false;
 
   meta = with lib; {
     description = "Libclang Python bindings";
-    homepage    = "https://clang.llvm.org/";
-    license     = licenses.ncsa;
+    homepage = "https://clang.llvm.org/";
+    license = licenses.ncsa;
     maintainers = with maintainers; [ samuela ];
   };
 }

--- a/pkgs/development/python-modules/clang/common.nix
+++ b/pkgs/development/python-modules/clang/common.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   checkInputs = [ nose ];
 
   meta = with lib; {
-    description = "libclang python bindings";
+    description = "Libclang Python bindings";
     homepage    = "https://clang.llvm.org/";
     license     = licenses.ncsa;
     maintainers = with maintainers; [ samuela ];

--- a/pkgs/development/python-modules/clang/default.nix
+++ b/pkgs/development/python-modules/clang/default.nix
@@ -1,0 +1,12 @@
+self: rec {
+  # Used by tensorflow 2.6.0
+  clang_5 = self.callPackage ./common.nix {
+    version = "5.0";
+    sha256 = "sha256:0fiklmj68x078hzaap46q8jq691f21hzsbyl8idml8m0xnbsxk6f";
+  };
+  clang_11 = self.callPackage ./common.nix {
+    version = "11.0";
+    sha256 = "sha256:1igqqvnm3yrzy08fz9sszn1r9hr0jkhhms4pzcgckr8zbd3ycf7q";
+  };
+  clang = clang_11;
+}

--- a/pkgs/development/python-modules/clang/default.nix
+++ b/pkgs/development/python-modules/clang/default.nix
@@ -2,11 +2,11 @@ self: rec {
   # Used by tensorflow 2.6.0
   clang_5 = self.callPackage ./common.nix {
     version = "5.0";
-    sha256 = "sha256:0fiklmj68x078hzaap46q8jq691f21hzsbyl8idml8m0xnbsxk6f";
+    sha256 = "0fiklmj68x078hzaap46q8jq691f21hzsbyl8idml8m0xnbsxk6f";
   };
   clang_11 = self.callPackage ./common.nix {
     version = "11.0";
-    sha256 = "sha256:1igqqvnm3yrzy08fz9sszn1r9hr0jkhhms4pzcgckr8zbd3ycf7q";
+    sha256 = "1igqqvnm3yrzy08fz9sszn1r9hr0jkhhms4pzcgckr8zbd3ycf7q";
   };
   clang = clang_11;
 }

--- a/pkgs/development/python-modules/gast/common.nix
+++ b/pkgs/development/python-modules/gast/common.nix
@@ -1,0 +1,28 @@
+{ astunparse
+, buildPythonPackage
+, fetchFromGitHub
+, lib
+, sha256
+, version
+}:
+
+buildPythonPackage rec {
+  inherit version;
+  pname = "gast";
+
+  src = fetchFromGitHub {
+    inherit sha256;
+    owner = "serge-sans-paille";
+    repo = "gast";
+    rev = version;
+  };
+
+  checkInputs = [ astunparse ];
+
+  meta = with lib; {
+    description = "GAST provides a compatibility layer between the AST of various Python versions, as produced by ast.parse from the standard ast module.";
+    homepage = "https://github.com/serge-sans-paille/gast/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jyp cpcloud ];
+  };
+}

--- a/pkgs/development/python-modules/gast/common.nix
+++ b/pkgs/development/python-modules/gast/common.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , lib
+, pytestCheckHook
 , sha256
 , version
 }:
@@ -17,7 +18,7 @@ buildPythonPackage rec {
     rev = version;
   };
 
-  checkInputs = [ astunparse ];
+  checkInputs = [ astunparse pytestCheckHook ];
 
   meta = with lib; {
     description = "GAST provides a compatibility layer between the AST of various Python versions, as produced by ast.parse from the standard ast module";

--- a/pkgs/development/python-modules/gast/common.nix
+++ b/pkgs/development/python-modules/gast/common.nix
@@ -20,8 +20,8 @@ buildPythonPackage rec {
   checkInputs = [ astunparse ];
 
   meta = with lib; {
-    description = "GAST provides a compatibility layer between the AST of various Python versions, as produced by ast.parse from the standard ast module.";
-    homepage = "https://github.com/serge-sans-paille/gast/";
+    description = "GAST provides a compatibility layer between the AST of various Python versions, as produced by ast.parse from the standard ast module";
+    homepage = "https://github.com/serge-sans-paille/gast";
     license = licenses.bsd3;
     maintainers = with maintainers; [ jyp cpcloud ];
   };

--- a/pkgs/development/python-modules/gast/default.nix
+++ b/pkgs/development/python-modules/gast/default.nix
@@ -1,26 +1,12 @@
-{ lib
-, fetchFromGitHub
-, buildPythonPackage
-, astunparse
-}:
-
-buildPythonPackage rec {
-  pname = "gast";
-  version = "0.5.1";
-
-  src = fetchFromGitHub {
-    owner = "serge-sans-paille";
-    repo = "gast";
-    rev = version;
-    sha256 = "1gph45frnj47lfr6idiyxrb3gk7vzc9rni9cijmcyz10dyx5kgwa";
+self: rec {
+  # Used by tensorflow 2.6.0
+  gast_0_4 = self.callPackage ./common.nix {
+    version = "0.4.0";
+    sha256 = "sha256:0zhca08ij3rgrpcr3w385dfiwng129s44wsnmcxg7jhbqpyz2s5y";
   };
-
-  checkInputs = [ astunparse ];
-
-  meta = with lib; {
-    description = "GAST provides a compatibility layer between the AST of various Python versions, as produced by ast.parse from the standard ast module.";
-    homepage = "https://github.com/serge-sans-paille/gast/";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ jyp cpcloud ];
+  gast_0_5 = self.callPackage ./common.nix {
+    version = "0.5.2";
+    sha256 = "sha256:05vysdd9hlivq91xyspsjj560xfsjcsjp8491cl0j4p5b1lsmzxa";
   };
+  gast = gast_0_5;
 }

--- a/pkgs/development/python-modules/gast/default.nix
+++ b/pkgs/development/python-modules/gast/default.nix
@@ -2,11 +2,11 @@ self: rec {
   # Used by tensorflow 2.6.0
   gast_0_4 = self.callPackage ./common.nix {
     version = "0.4.0";
-    sha256 = "sha256:0zhca08ij3rgrpcr3w385dfiwng129s44wsnmcxg7jhbqpyz2s5y";
+    sha256 = "0zhca08ij3rgrpcr3w385dfiwng129s44wsnmcxg7jhbqpyz2s5y";
   };
   gast_0_5 = self.callPackage ./common.nix {
     version = "0.5.2";
-    sha256 = "sha256:05vysdd9hlivq91xyspsjj560xfsjcsjp8491cl0j4p5b1lsmzxa";
+    sha256 = "05vysdd9hlivq91xyspsjj560xfsjcsjp8491cl0j4p5b1lsmzxa";
   };
   gast = gast_0_5;
 }

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit format pname version;
-    sha256 = "sha256:1rrpjhk191h9ksnxvkkaj24nx48nxy08b2p47j0gwacqd9jzajjh";
+    sha256 = "1rrpjhk191h9ksnxvkkaj24nx48nxy08b2p47j0gwacqd9jzajjh";
   };
 
   checkInputs = [

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -5,12 +5,13 @@
 }:
 
 buildPythonPackage rec {
-  pname = "Keras";
-  version = "2.4.3";
+  pname = "keras";
+  version = "2.6.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "fedd729b52572fb108a98e3d97e1bac10a81d3917d2103cc20ab2a5f03beb973";
+    inherit format pname version;
+    sha256 = "sha256:1rrpjhk191h9ksnxvkkaj24nx48nxy08b2p47j0gwacqd9jzajjh";
   };
 
   checkInputs = [
@@ -23,9 +24,6 @@ buildPythonPackage rec {
     six pyyaml numpy scipy h5py
     keras-applications keras-preprocessing
   ];
-
-  # Couldn't get tests working
-  doCheck = false;
 
   meta = with lib; {
     description = "Deep Learning library for Theano and TensorFlow";

--- a/pkgs/development/python-modules/tensorflow-estimator/default.nix
+++ b/pkgs/development/python-modules/tensorflow-estimator/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "tensorflow-estimator";
-  version = "2.4.0";
+  version = "2.6.0";
   format = "wheel";
 
   src = fetchPypi {
     pname = "tensorflow_estimator";
     inherit version format;
-    sha256 = "1w0pkcslm6934qqd6m5gxyjdlnb4pbl47k6s99wsh6dyvvr7nysv";
+    sha256 = "sha256:1zasrzznw9nr42p29ss4fmv95wcvj9f55bxbq1x67nzgk24m4y6g";
   };
 
   propagatedBuildInputs = [ mock numpy absl-py ];
@@ -24,4 +24,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ jyp ];
   };
 }
-

--- a/pkgs/development/python-modules/tensorflow-estimator/default.nix
+++ b/pkgs/development/python-modules/tensorflow-estimator/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "tensorflow_estimator";
     inherit version format;
-    sha256 = "sha256:1zasrzznw9nr42p29ss4fmv95wcvj9f55bxbq1x67nzgk24m4y6g";
+    sha256 = "1zasrzznw9nr42p29ss4fmv95wcvj9f55bxbq1x67nzgk24m4y6g";
   };
 
   propagatedBuildInputs = [ mock numpy absl-py ];

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -27,7 +27,7 @@
 # Common deps
 , git, pybind11, which, binutils, glibcLocales, cython, perl
 # Common libraries
-, jemalloc, mpi, gast, grpc, sqlite, boringssl, jsoncpp
+, jemalloc, mpi, gast_0_4, grpc, sqlite, boringssl, jsoncpp
 , curl, snappy, flatbuffers-core, lmdb-core, icu, double-conversion, libpng, libjpeg_turbo, giflib
 # Upsteam by default includes cuda support since tensorflow 1.15. We could do
 # that in nix as well. It would make some things easier and less confusing, but
@@ -99,7 +99,7 @@ let
       astunparse
       dill
       flatbuffers-python
-      gast
+      gast_0_4
       google-pasta
       grpcio
       h5py
@@ -136,7 +136,6 @@ let
       sed -i 's/h5py ~= 3.1.0/h5py >= 3.1.0/' tensorflow/tools/pip_package/setup.py
       sed -i 's/six ~= 1.15.0/six >= 1.15.0/' tensorflow/tools/pip_package/setup.py
       sed -i 's/wheel ~= 0.35/wheel >= 0.35/' tensorflow/tools/pip_package/setup.py
-      sed -i 's/gast == 0.4.0/gast >= 0.4.0/' tensorflow/tools/pip_package/setup.py
     '';
 
     # On update, it can be useful to steal the changes from gentoo
@@ -381,7 +380,7 @@ in buildPythonPackage {
     astunparse
     dill
     flatbuffers-python
-    gast
+    gast_0_4
     google-pasta
     grpcio
     h5py

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -125,7 +125,7 @@ let
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      sha256 = "sha256:0736mx2b9q8fzyl523h1qlqmjqbngx36c9fmddzavw09az49bhh7";
+      sha256 = "0736mx2b9q8fzyl523h1qlqmjqbngx36c9fmddzavw09az49bhh7";
     };
 
     # Relax too strict Python packages versions dependencies.
@@ -304,9 +304,9 @@ let
     fetchAttrs = {
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
       sha256 = if cudaSupport then
-        "sha256:18kid14smhf01ps9kydjrbjpcc82x3h0lxbhw6dlf7bb5qqq6yph"
+        "18kid14smhf01ps9kydjrbjpcc82x3h0lxbhw6dlf7bb5qqq6yph"
       else
-        "sha256:029pn5n1sp3swdxf8ag5lqw02hrjb24gj6w5m8cdpdp0czyv4nxs";
+        "029pn5n1sp3swdxf8ag5lqw02hrjb24gj6w5m8cdpdp0czyv4nxs";
     };
 
     buildAttrs = {

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -120,7 +120,6 @@ let
 
   bazel-build = buildBazelPackage {
     name = "${pname}-${version}";
-    bazel = bazel_3;
 
     src = fetchFromGitHub {
       owner = "tensorflow";

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -3,11 +3,27 @@
 # Python deps
 , buildPythonPackage, pythonOlder, pythonAtLeast, python
 # Python libraries
-, numpy, tensorflow-tensorboard_2, absl-py
-, future, setuptools, wheel, keras-preprocessing, google-pasta
-, opt-einsum, astunparse, h5py
-, termcolor, grpcio, six, wrapt, protobuf, tensorflow-estimator_2
-, dill, flatbuffers-python, tblib, typing-extensions
+, absl-py
+, astunparse
+, dill
+, flatbuffers-python
+, google-pasta
+, grpcio
+, h5py
+, Keras
+, keras-preprocessing
+, numpy
+, opt-einsum
+, protobuf
+, setuptools
+, six
+, tblib
+, tensorflow-estimator_2
+, tensorflow-tensorboard_2
+, termcolor
+, typing-extensions
+, wheel
+, wrapt
 # Common deps
 , git, pybind11, which, binutils, glibcLocales, cython, perl
 # Common libraries
@@ -72,7 +88,7 @@ let
 
   tfFeature = x: if x then "1" else "0";
 
-  version = "2.4.2";
+  version = "2.6.0";
   variant = if cudaSupport then "-gpu" else "";
   pname = "tensorflow${variant}";
 
@@ -110,21 +126,18 @@ let
       owner = "tensorflow";
       repo = "tensorflow";
       rev = "v${version}";
-      sha256 = "07a2y05hixch1bjag5pzw3p1m7bdj3bq4gdvmsfk2xraz49b1pi8";
+      sha256 = "sha256:0736mx2b9q8fzyl523h1qlqmjqbngx36c9fmddzavw09az49bhh7";
     };
 
-    patches = [
-      # included from 2.6.0 onwards
-      (fetchpatch {
-        name = "fix-numpy-1.20-notimplementederror.patch";
-        url = "https://github.com/tensorflow/tensorflow/commit/b258941525f496763d4277045b6513c815720e3a.patch";
-        sha256 = "19f9bzrcfsynk11s2hqvscin5c65zf7r6g3nb10jnimw79vafiry";
-      })
-      # Relax too strict Python packages versions dependencies.
-      ./relax-dependencies.patch
-      # Add missing `io_bazel_rules_docker` dependency.
-      ./workspace.patch
-    ];
+    # Relax too strict Python packages versions dependencies.
+    patchPhase = ''
+      sed -i 's/typing_extensions ~= 3.7.4/typing_extensions >= 3.7.4/' tensorflow/tools/pip_package/setup.py
+      sed -i 's/numpy ~= 1.19.2/numpy >= 1.19.2/' tensorflow/tools/pip_package/setup.py
+      sed -i 's/h5py ~= 3.1.0/h5py >= 3.1.0/' tensorflow/tools/pip_package/setup.py
+      sed -i 's/six ~= 1.15.0/six >= 1.15.0/' tensorflow/tools/pip_package/setup.py
+      sed -i 's/wheel ~= 0.35/wheel >= 0.35/' tensorflow/tools/pip_package/setup.py
+      sed -i 's/gast == 0.4.0/gast >= 0.4.0/' tensorflow/tools/pip_package/setup.py
+    '';
 
     # On update, it can be useful to steal the changes from gentoo
     # https://gitweb.gentoo.org/repo/gentoo.git/tree/sci-libs/tensorflow
@@ -206,7 +219,6 @@ let
       "opt_einsum_archive"
       "org_sqlite"
       "pasta"
-      "pcre"
       "png"
       "pybind11"
       "six_archive"
@@ -294,9 +306,9 @@ let
     fetchAttrs = {
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
       sha256 = if cudaSupport then
-        "10m6qj3kchgxfgb6qh59vc51knm9r9pkng8bf90h00dnggvv8234"
+        "sha256:18kid14smhf01ps9kydjrbjpcc82x3h0lxbhw6dlf7bb5qqq6yph"
       else
-        "04a98yrp09nd0p17k0jbzkgjppxs0yma7m5zkfrwgvr4g0w71v68";
+        "sha256:029pn5n1sp3swdxf8ag5lqw02hrjb24gj6w5m8cdpdp0czyv4nxs";
     };
 
     buildAttrs = {
@@ -373,10 +385,12 @@ in buildPythonPackage {
     google-pasta
     grpcio
     h5py
+    Keras
     keras-preprocessing
     numpy
     opt-einsum
     protobuf
+    python.pkgs.clang_5
     six
     tblib
     tensorflow-estimator_2

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, bazel_3, buildBazelPackage, isPy3k, lib, fetchFromGitHub, symlinkJoin
-, addOpenGLRunpath, fetchpatch, patchelf
+{ stdenv, buildBazelPackage, isPy3k, lib, fetchFromGitHub, symlinkJoin
+, addOpenGLRunpath, patchelf
 # Python deps
-, buildPythonPackage, pythonOlder, pythonAtLeast, python
+, buildPythonPackage, pythonOlder, python
 # Python libraries
 , absl-py
 , astunparse

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -130,11 +130,12 @@ let
 
     # Relax too strict Python packages versions dependencies.
     patchPhase = ''
-      sed -i 's/typing_extensions ~= 3.7.4/typing_extensions >= 3.7.4/' tensorflow/tools/pip_package/setup.py
-      sed -i 's/numpy ~= 1.19.2/numpy >= 1.19.2/' tensorflow/tools/pip_package/setup.py
-      sed -i 's/h5py ~= 3.1.0/h5py >= 3.1.0/' tensorflow/tools/pip_package/setup.py
-      sed -i 's/six ~= 1.15.0/six >= 1.15.0/' tensorflow/tools/pip_package/setup.py
-      sed -i 's/wheel ~= 0.35/wheel >= 0.35/' tensorflow/tools/pip_package/setup.py
+      substituteInPlace tensorflow/tools/pip_package/setup.py \
+        --replace "typing_extensions ~= 3.7.4" "typing_extensions >= 3.7.4" \
+        --replace "numpy ~= 1.19.2" "numpy >= 1.19.2" \
+        --replace "h5py ~= 3.1.0" "h5py >= 3.1.0" \
+        --replace "six ~= 1.15.0" "six >= 1.15.0" \
+        --replace "wheel ~= 0.35" "wheel >= 0.35"
     '';
 
     # On update, it can be useful to steal the changes from gentoo

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -5,6 +5,7 @@
 # Python libraries
 , absl-py
 , astunparse
+, clang_5
 , dill
 , flatbuffers-python
 , google-pasta
@@ -389,7 +390,7 @@ in buildPythonPackage {
     numpy
     opt-einsum
     protobuf
-    python.pkgs.clang_5
+    clang_5
     six
     tblib
     tensorflow-estimator_2

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8722,6 +8722,16 @@ in {
 
   tensorflowWithCuda = self.tensorflow.override {
     cudaSupport = true;
+    # See https://github.com/NixOS/patchelf/pull/256#issuecomment-915617721.
+    # This can be removed once that PR is merged and released.
+    patchelf = pkgs.patchelfUnstable.overrideAttrs(old: {
+      src = pkgs.fetchFromGitHub {
+        owner = "andrewla";
+        repo = "patchelf";
+        rev = "c99745d4040e0b0a9596828e791dbdf1058cd07a";
+        sha256 = "sha256:0b7m7v89c570901pcgv8pdpy42320jndb7gdxsr0ghq810j2ykjn";
+      };
+    });
   };
 
   tensorflowWithoutCuda = self.tensorflow.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2695,9 +2695,13 @@ in {
 
   flask_wtf = callPackage ../development/python-modules/flask-wtf { };
 
-  flatbuffers = callPackage ../development/python-modules/flatbuffers {
+  flatbuffers_1_12 = callPackage ../development/python-modules/flatbuffers {
+    flatbuffers = pkgs.flatbuffers_1_12;
+  };
+  flatbuffers_2 = callPackage ../development/python-modules/flatbuffers {
     inherit (pkgs) flatbuffers;
   };
+  flatbuffers = flatbuffers_2;
 
   flexmock = callPackage ../development/python-modules/flexmock { };
 
@@ -8694,7 +8698,7 @@ in {
     nccl = pkgs.nccl_cudatoolkit_11;
     inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
     flatbuffers-core = pkgs.flatbuffers;
-    flatbuffers-python = self.flatbuffers;
+    flatbuffers-python = self.flatbuffers_1_12;
     lmdb-core = pkgs.lmdb;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2701,7 +2701,7 @@ in {
   flatbuffers_2 = callPackage ../development/python-modules/flatbuffers {
     inherit (pkgs) flatbuffers;
   };
-  flatbuffers = flatbuffers_2;
+  flatbuffers = self.flatbuffers_2;
 
   flexmock = callPackage ../development/python-modules/flexmock { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2836,7 +2836,10 @@ in {
 
   garminconnect-ha = callPackage ../development/python-modules/garminconnect-ha { };
 
-  gast = callPackage ../development/python-modules/gast { };
+  inherit (import ../development/python-modules/gast self)
+    gast_0_4
+    gast_0_5
+    gast;
 
   garages-amsterdam = callPackage ../development/python-modules/garages-amsterdam { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8725,6 +8725,7 @@ in {
     # See https://github.com/NixOS/patchelf/pull/256#issuecomment-915617721.
     # This can be removed once that PR is merged and released.
     patchelf = pkgs.patchelfUnstable.overrideAttrs(old: {
+      version = "unstable+c99745d4";
       src = pkgs.fetchFromGitHub {
         owner = "andrewla";
         repo = "patchelf";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1467,6 +1467,11 @@ in {
 
   ckcc-protocol = callPackage ../development/python-modules/ckcc-protocol { };
 
+  inherit (import ../development/python-modules/clang self)
+    clang_5
+    clang_11
+    clang;
+
   class-registry = callPackage ../development/python-modules/class-registry { };
 
   claripy =  callPackage ../development/python-modules/claripy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade tensorflow to the latest version. 

Upgrading tensorflow required a number of changes to related libraries and dependencies. For some reason tensorflow 2.6.0 introduces a dependency on `clang`, the Python package, so we must package that as well. In addition, keras and tensorflow-estimator must be kept up to date with the same version as tensorflow, hence those commits as well.

~The main blocker right now is that `tensorflowWithCuda` is broken. It fails with the message `patchelf: maximum file size exceeded` in the final install phase.~ This has been fixed. This appears to be related to 
* https://github.com/NixOS/patchelf/pull/256 
* https://github.com/NixOS/patchelf/issues/62#issuecomment-711986300 
* https://github.com/NixOS/nixpkgs/issues/94032
* https://github.com/NixOS/patchelf/issues/222

TODO:
- [x] The default `tensorflow` builds and passes tests (though it takes 24 CPU hours)
- [x] Fix `tensorflowWithCuda`

Optionally,
- [ ] Should we also upgrade the `-bin` derivation?

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
