### PR TITLE
spoof-mac: init at unstable-2018-01-27

### DIFF
--- a/pkgs/tools/networking/spoof-mac/default.nix
+++ b/pkgs/tools/networking/spoof-mac/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub, docopt }:
+
+buildPythonPackage rec {
+  pname = "spoof-mac";
+  version = "unstable-2018-01-27";
+
+  src = fetchFromGitHub {
+    owner = "feross";
+    repo = "SpoofMAC";
+    rev = "2cfc796150ef48009e9b765fe733e37d82c901e0";
+    sha256 = "sha256-Qiu0URjUyx8QDVQQUFGxPax0J80e2m4+bPJeqFoKxX8=";
+  };
+
+  propagatedBuildInputs = [ docopt ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Change your MAC address for debugging purposes";
+    homepage = "https://github.com/feross/SpoofMAC";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9074,6 +9074,8 @@ with pkgs;
 
   spicy = callPackage ../development/tools/spicy { };
 
+  spoof-mac = python3Packages.callPackage ../tools/networking/spoof-mac { };
+
   ssh-askpass-fullscreen = callPackage ../tools/networking/ssh-askpass-fullscreen { };
 
   sshguard = callPackage ../tools/security/sshguard {};


### PR DESCRIPTION
###### Motivation for this change
Scratching my own itch. I have this package installed via Homebrew but didn't bother to package it up until now. Tested on darwin.

```ShellSession
$ sudo ./result/bin/spoof-mac list
Password:
- "Wi-Fi" on device "en0" with MAC address <addr1>
...
$ sudo ./result/bin/spoof-mac randomize en0
$ sudo ./result/bin/spoof-mac list         
- "Wi-Fi" on device "en0" with MAC address <addr1> currently set to 00:50:56:4E:29:FC
...
$ sudo ./result/bin/spoof-mac reset en0    
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
