### PR TITLE
Meillisearch: module cleanup

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -897,6 +897,7 @@
   ./services/search/elasticsearch-curator.nix
   ./services/search/hound.nix
   ./services/search/kibana.nix
+  ./services/search/meilisearch.nix
   ./services/search/solr.nix
   ./services/security/certmgr.nix
   ./services/security/cfssl.nix

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -1,0 +1,83 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.meilisearch;
+
+in {
+
+  meta.maintainers = with maintainers; [ filalex77 ];
+
+  ###### interface
+
+  options.services.meilisearch = {
+    enable = mkEnableOption "MeiliSearch - a RESTful search API";
+
+    listenAddress = mkOption {
+      description = "MeiliSearch listen address.";
+      default = "127.0.0.1";
+      type = types.str;
+    };
+
+    listenPort = mkOption {
+      description = "MeiliSearch port to listen on.";
+      default = 7700;
+      type = types.port;
+    };
+
+    environment = mkOption {
+      description = "Defines the running environment of MeiliSearch.";
+      default = "development";
+      type = types.enum [ "development" "production" ];
+    };
+
+    masterKeyFile = mkOption {
+      description = ''
+        Path to file which contains the master key.
+        By doing so, all routes will be protected and will require a key to be accessed.
+        If no master key is provided, all routes can be accessed without requiring any key.
+      '';
+      default = null;
+      type = with types; nullOr path;
+    };
+
+    noAnalytics = mkOption {
+      description = ''
+        Deactivates analytics.
+        Analytics allow MeiliSearch to know how many users are using MeiliSearch,
+        which versions and which platforms are used.
+        This process is entirely anonymous.
+      '';
+      default = false;
+      type = types.bool;
+    };
+
+  };
+
+  ###### implementation
+  
+  config = mkIf cfg.enable {
+    systemd.services.meilisearch = {
+      description = "MeiliSearch daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      environment = let
+        masterKey = mkIf (cfg.masterKeyFile != null) (builtins.readFile cfg.masterKeyFile);
+      in {
+        MEILI_DB_PATH = "/var/lib/meilisearch";
+        MEILI_HTTP_ADDR = "${cfg.listenAddress}:${toString cfg.listenPort}";
+        MEILI_MASTER_KEY = masterKey;
+        MEILI_NO_ANALYTICS = toString cfg.noAnalytics;
+        MEILI_ENV = cfg.environment;
+      };
+      serviceConfig = {
+        ExecStart = "${pkgs.meilisearch}/bin/meilisearch";
+        DynamicUser = true;
+        StateDirectory = "meilisearch";
+      };
+    };
+
+    environment.systemPackages = [ pkgs.meilisearch ];
+  };
+}

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -5,7 +5,8 @@ with lib;
 let
   cfg = config.services.meilisearch;
 
-in {
+in
+{
 
   meta.maintainers = with maintainers; [ filalex77 ];
 
@@ -56,21 +57,23 @@ in {
   };
 
   ###### implementation
-  
+
   config = mkIf cfg.enable {
     systemd.services.meilisearch = {
       description = "MeiliSearch daemon";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      environment = let
-        masterKey = mkIf (cfg.masterKeyFile != null) (builtins.readFile cfg.masterKeyFile);
-      in {
-        MEILI_DB_PATH = "/var/lib/meilisearch";
-        MEILI_HTTP_ADDR = "${cfg.listenAddress}:${toString cfg.listenPort}";
-        MEILI_MASTER_KEY = masterKey;
-        MEILI_NO_ANALYTICS = toString cfg.noAnalytics;
-        MEILI_ENV = cfg.environment;
-      };
+      environment =
+        let
+          masterKey = mkIf (cfg.masterKeyFile != null) (builtins.readFile cfg.masterKeyFile);
+        in
+        {
+          MEILI_DB_PATH = "/var/lib/meilisearch";
+          MEILI_HTTP_ADDR = "${cfg.listenAddress}:${toString cfg.listenPort}";
+          MEILI_MASTER_KEY = masterKey;
+          MEILI_NO_ANALYTICS = toString cfg.noAnalytics;
+          MEILI_ENV = cfg.environment;
+        };
       serviceConfig = {
         ExecStart = "${pkgs.meilisearch}/bin/meilisearch";
         DynamicUser = true;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -249,6 +249,7 @@ in
   matrix-appservice-irc = handleTest ./matrix-appservice-irc.nix {};
   matrix-synapse = handleTest ./matrix-synapse.nix {};
   mediawiki = handleTest ./mediawiki.nix {};
+  meilisearch = handleTest ./meilisearch.nix {};
   memcached = handleTest ./memcached.nix {};
   metabase = handleTest ./metabase.nix {};
   minecraft = handleTest ./minecraft.nix {};

--- a/nixos/tests/meilisearch.nix
+++ b/nixos/tests/meilisearch.nix
@@ -1,0 +1,60 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+  let
+    listenAddress = "127.0.0.1";
+    listenPort = 7700;
+    apiUrl = "http://${listenAddress}:${toString listenPort}";
+    uid = "movies";
+    indexJSON = pkgs.writeText "index.json" (builtins.toJSON { inherit uid; });
+    moviesJSON = pkgs.runCommand "movies.json" {} ''
+      sed -n '1,5p;$p' ${pkgs.meilisearch.src}/datasets/movies/movies.json > $out
+    '';
+  in {
+    name = "meilisearch";
+    meta.maintainers = with lib.maintainers; [ filalex77 ];
+
+    machine = { ... }: {
+      environment.systemPackages = with pkgs; [ curl jq ];
+      services.meilisearch = {
+        enable = true;
+        inherit listenAddress listenPort;
+      };
+    };
+
+    testScript = ''
+      import json
+
+      start_all()
+
+      machine.wait_for_unit("meilisearch")
+      machine.wait_for_open_port("7700")
+
+      with subtest("check version"):
+          version = json.loads(machine.succeed("curl ${apiUrl}/version"))
+          assert version["pkgVersion"] == "${pkgs.meilisearch.version}"
+
+      with subtest("create index"):
+          machine.succeed(
+              "curl -XPOST ${apiUrl}/indexes --data @${indexJSON}"
+          )
+          indexes = json.loads(machine.succeed("curl ${apiUrl}/indexes"))
+          assert len(indexes) == 1, "index wasn't created"
+
+      with subtest("add documents"):
+          response = json.loads(
+              machine.succeed(
+                  "curl -XPOST ${apiUrl}/indexes/${uid}/documents --data @${moviesJSON}"
+              )
+          )
+          update_id = response["updateId"]
+          machine.wait_until_succeeds(
+              f"curl ${apiUrl}/indexes/${uid}/updates/{update_id} | jq -e '.status == \"processed\"'"
+          )
+
+      with subtest("search"):
+          response = json.loads(
+              machine.succeed("curl ${apiUrl}/indexes/movies/search?q=hero")
+          )
+          print(response)
+          assert len(response["hits"]) >= 1, "no results found"
+    '';
+  })


### PR DESCRIPTION
###### Motivation for this change

meilisearch module cleanup

- switch noAnalytics default to true since the crate is by default compiled without the analytics feature. (it gave me some problems on compilation when packaging, that is why I haven't included it in the package by default)
- add some missing environment variables. coming from https://docs.meilisearch.com/reference/features/configuration.html#options . The notable exception is the snapshot feature. I left it out since I don't have time to test it. Hopefully the next person can improve upon this.
- The one problem where I haven't found a solution is the masterKey secret. Note that by default this is not used. The default running mode is `development` which doesn't require that key. I haven't found a way around the fact that upstream wants to read the secret from an environment variable. I opened an issue asking them to enable reading it from a file, it got moved into a feature request list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
