### PR TITLE
maintainers: remove bricewge

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1520,12 +1520,6 @@
     githubId = 355401;
     name = "Brian Hicks";
   };
-  bricewge = {
-    email = "bricewge@gmail.com";
-    github = "bricewge";
-    githubId = 5525646;
-    name = "Brice Waegeneire";
-  };
   Br1ght0ne = {
     email = "brightone@protonmail.com";
     github = "Br1ght0ne";

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -11,7 +11,7 @@ in
 with lib;
 {
   name = "miniflux";
-  meta.maintainers = with pkgs.lib.maintainers; [ bricewge ];
+  meta.maintainers = with pkgs.lib.maintainers; [ ];
 
   nodes = {
     default =

--- a/pkgs/data/themes/solarc/default.nix
+++ b/pkgs/data/themes/solarc/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     description = "Solarized version of the Arc theme";
     homepage = "https://github.com/schemar/solarc-theme";
     license = licenses.gpl3;
-    maintainers = [ maintainers.bricewge ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/tools/continuous-integration/drone-cli/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-cli/default.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    maintainers = with maintainers; [ bricewge ];
+    maintainers = with maintainers; [ ];
     license = licenses.asl20;
     description = "Command line client for the Drone continuous integration server";
   };

--- a/pkgs/os-specific/linux/ddcci/default.nix
+++ b/pkgs/os-specific/linux/ddcci/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     description = "Kernel module driver for DDC/CI monitors";
     homepage = "https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ bricewge ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     broken = kernel.kernelOlder "5.1";
   };


### PR DESCRIPTION
It has been a long time since I used Nix, as I have now switched to Guix

What is the usual way to remove oneself as a maintainer? Do I need to remove myself from maintainers/maintainer-list.nix? How about the GitHub group?And if one day I have change of heart and want to come back to Nix, how do this work?

I hope to see some of you in parenthesis land.