### PR TITLE
sc-controller: switch to python3 fork

### DIFF
--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -1,19 +1,20 @@
 { lib, buildPythonApplication, fetchFromGitHub, wrapGAppsHook
+, pytestCheckHook
 , gtk3, gobject-introspection, libappindicator-gtk3, librsvg
-, evdev, pygobject3, pylibacl, pytest, bluez
+, evdev, pygobject3, pylibacl, bluez, vdf
 , linuxHeaders
 , libX11, libXext, libXfixes, libusb1, udev
 }:
 
 buildPythonApplication rec {
   pname = "sc-controller";
-  version = "0.4.7";
+  version = "0.4.8.6";
 
   src = fetchFromGitHub {
-    owner  = "kozec";
+    owner  = "Ryochan7";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "1dskjh5qcjf4x21n4nk1zvdfivbgimsrc2lq1id85bibzps29499";
+    sha256 = "1fgizgzm79zl9r2kkwvh1gf9lnxaix15283xxk6bz843inr8b88k";
   };
 
   # see https://github.com/NixOS/nixpkgs/issues/56943
@@ -23,9 +24,9 @@ buildPythonApplication rec {
 
   buildInputs = [ gtk3 gobject-introspection libappindicator-gtk3 librsvg ];
 
-  propagatedBuildInputs = [ evdev pygobject3 pylibacl ];
+  propagatedBuildInputs = [ evdev pygobject3 pylibacl vdf ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytestCheckHook ];
 
   postPatch = ''
     substituteInPlace scc/paths.py --replace sys.prefix "'$out'"
@@ -48,12 +49,8 @@ buildPythonApplication rec {
     )
   '';
 
-  checkPhase = ''
-    PYTHONPATH=. py.test
-  '';
-
   meta = with lib; {
-    homepage    = "https://github.com/kozec/sc-controller";
+    homepage    = "https://github.com/Ryochan7/sc-controller";
     # donations: https://www.patreon.com/kozec
     description = "User-mode driver and GUI for Steam Controller and other controllers";
     license     = licenses.gpl2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32036,7 +32036,7 @@ with pkgs;
 
   satysfi = callPackage ../tools/typesetting/satysfi { };
 
-  sc-controller = pythonPackages.callPackage ../misc/drivers/sc-controller {
+  sc-controller = python3Packages.callPackage ../misc/drivers/sc-controller {
     inherit libusb1; # Shadow python.pkgs.libusb1.
   };
 


### PR DESCRIPTION
###### Motivation for this change

The original sc-controller is being rewritten in C, while the current
version is stuck in maintenance mode and python 2. This fork is based
entirely on the original kozec's sc-controller and introduces python 3
support while staying backward-compatible (including versioning up to
the patch number).

Also, this is the only remaining piece of Python 2 on my computer.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change
- [x] Tested execution of all binary files
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc: @timjrd