### PR TITLE
libopenmpt: 0.5.10 -> 0.5.11

### DIFF
--- a/pkgs/applications/audio/libopenmpt/default.nix
+++ b/pkgs/applications/audio/libopenmpt/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libopenmpt";
-  version = "0.5.10";
+  version = "0.5.11";
 
   outputs = [ "out" "lib" "dev" ];
 
   src = fetchurl {
     url = "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}+release.autotools.tar.gz";
-    sha256 = "sha256-Waj6KNi432nLf6WXK9+TEIHatOHhFWxpoaU7ZcK+n/o=";
+    sha256 = "1c54lldr2imjzhlhq5lvwhj7d5794xm97cby9pznr5wdjjay0sa4";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
https://lib.openmpt.org/libopenmpt/2021/08/22/security-updates-0.5.11-0.4.23-0.3.32/

> · [**Sec**] Possible crash with malformed modules when trying to access non-existent plugin slots FX251-FX255. (r15479, r15518)
> · [**Sec**] Possible read beyond sample start after swapping to a sample with loop points set but not loop enabled. (r15499)
> · [**Sec**] Fixed various possible crashes with malformed MMCMP files. (r15504, 15528)
> · [**Sec**] MED: Possible read past end of sequence name (stack-allocated, so relatively unlikely to result in a crash). (r15477)
> 
> · Fixed excessive memory usage with files claiming to have an extremely high rows per beat count while also using tempo swing. Maximum rows per beat are now limited to 65536.
> · STP: Avoid creating thousands of patterns when loading malformed files even though no more pattern data can be read.
> 
> · mpg123: Update to v1.28.2 (2021-07-12).
> · stb_vorbis: Update v1.22 commit 5a0bb8b1c1b1ca3f4e2485f4114c1c8ea021b781 (2021-07-12).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
