### PR TITLE
mirage-im: 0.6.4 -> 0.7.2

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1025,6 +1025,14 @@ Superuser created successfully.
           changelog</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>mirage-im</literal> was upgraded from 0.6.x to 0.7.x.
+          The 0.7.x release has a different settings format. Mirage
+          notifies at startup when the old configuration file is
+          detected.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -314,6 +314,8 @@ To be able to access the web UI this port needs to be opened in the firewall.
   respectively. As a result `services.datadog-agent` has had breaking changes to the
   configuration file. For details, see the [upstream changelog](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst).
 
+- `mirage-im` was upgraded from 0.6.x to 0.7.x. The 0.7.x release has a different settings format. Mirage notifies at startup when the old configuration file is detected.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 - The linux kernel package infrastructure was moved out of `all-packages.nix`, and restructured. Linux related functions and attributes now live under the `pkgs.linuxKernel` attribute set.

--- a/pkgs/applications/networking/instant-messengers/mirage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mirage/default.nix
@@ -7,19 +7,19 @@
 let
   pypkgs = with python3Packages; [
     aiofiles filetype matrix-nio appdirs cairosvg
-    pymediainfo setuptools html-sanitizer mistune blist
-    pyotherside
+    pymediainfo setuptools html-sanitizer hsluv mistune blist
+    plyer pyotherside redbaron simpleaudio watchgod
   ];
 in
 mkDerivation rec {
   pname = "mirage";
-  version = "0.6.4";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "mirukana";
     repo = pname;
     rev = "v${version}";
-    sha256 = "15x0x2rf4fzsd0zr84fq3j3ddzkgc5il8s54jpxk8wl4ah03g4nv";
+    sha256 = "1mhmly68l4ij3vma3w736i6r1rppj8383ybf002da7670nabi53l";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
The settings file format has changed in 0.7.2. Mirage itself notifies
about that.

The patch added disables desktop notifications, because plyer is not
available in nixpkgs yet. That's fine, 0.6 did not have desktop
notifications anyway. Once
https://github.com/NixOS/nixpkgs/pull/136902 merges, the patch can be
removed.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
