### PR TITLE
gnupg23: init at 2.3.1

### DIFF
--- a/pkgs/tools/security/gnupg/0001-dirmngr-Only-use-SKS-pool-CA-for-SKS-pool_gnupg-2.3.1.patch
+++ b/pkgs/tools/security/gnupg/0001-dirmngr-Only-use-SKS-pool-CA-for-SKS-pool_gnupg-2.3.1.patch
@@ -1,0 +1,39 @@
+From ae37386278ed11724c1e56eeb53aa5d5885ced83 Mon Sep 17 00:00:00 2001
+From: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+Date: Tue, 7 Sep 2021 12:10:44 +0200
+Subject: [PATCH] dirmngr: Only use SKS pool CA for SKS pool
+
+* dirmngr/http.c (http_session_new): when checking whether the
+keyserver is the HKPS pool, check specifically against the pool name,
+as ./configure might have been used to select a different default
+keyserver.  It makes no sense to apply Kristian's certificate
+authority to anything other than the literal host
+hkps.pool.sks-keyservers.net.
+
+Modified to apply to GnuPG release 2.3.1.
+
+Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+Co-authored-by: Leon Schuermann <leon@is.currently.online>
+GnuPG-Bug-Id: 4593
+---
+ dirmngr/http.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dirmngr/http.c b/dirmngr/http.c
+index f7f65303b..4a29e9a8a 100644
+--- a/dirmngr/http.c
++++ b/dirmngr/http.c
+@@ -763,7 +763,7 @@ http_session_new (http_session_t *r_session,
+ 
+     is_hkps_pool = (intended_hostname
+                     && !ascii_strcasecmp (intended_hostname,
+-                                          get_default_keyserver (1)));
++                                          "hkps.pool.sks-keyservers.net"));
+ 
+     /* If we are looking for the hkps pool from sks-keyservers.net,
+      * then forcefully use its dedicated certificate authority.  */
+
+base-commit: cbbdb88627fe57ebf02b8b4bf9002d356e57e2e4
+-- 
+2.31.1
+

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -78,12 +78,12 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://gnupg.org";
-    description = "Modern (2.1) release of the GNU Privacy Guard, a GPL OpenPGP implementation";
+    description = "Modern (2.2) release of the GNU Privacy Guard, a GPL OpenPGP implementation";
     license = licenses.gpl3Plus;
     longDescription = ''
       The GNU Privacy Guard is the GNU project's complete and free
       implementation of the OpenPGP standard as defined by RFC4880.  GnuPG
-      "modern" (2.1) is the latest development with a lot of new features.
+      "modern" (2.2) is the latest development with a lot of new features.
       GnuPG allows to encrypt and sign your data and communication, features a
       versatile key management system as well as access modules for all kind of
       public key directories.  GnuPG, also known as GPG, is a command line tool

--- a/pkgs/tools/security/gnupg/23.nix
+++ b/pkgs/tools/security/gnupg/23.nix
@@ -1,0 +1,102 @@
+{ fetchurl, fetchpatch, lib, stdenv, pkg-config, libgcrypt, libassuan, libksba
+, libgpgerror, libiconv, npth, gettext, texinfo, buildPackages
+
+# Each of the dependencies below are optional.
+# Gnupg can be built without them at the cost of reduced functionality.
+, guiSupport ? true, tpmSupport ? true, enableMinimal ? false
+, adns ? null , bzip2 ? null , gnutls ? null , libusb1 ? null , openldap ? null
+, pcsclite ? null , pinentry ? null , readline ? null , sqlite ? null
+, zlib ? null, tpm2-tss ? null
+}:
+
+with lib;
+
+assert guiSupport -> pinentry != null && enableMinimal == false;
+
+stdenv.mkDerivation rec {
+  pname = "gnupg";
+
+  version = "2.3.1";
+
+  src = fetchurl {
+    url = "mirror://gnupg/gnupg/${pname}-${version}.tar.bz2";
+    sha256 = "1v2ls4n4b17rdwvi0zrjiz78ia60vxb8yk2ikqwlp6lvd8sdp664";
+  };
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ pkg-config texinfo ];
+  buildInputs = [
+    libgcrypt libassuan libksba libiconv npth gettext
+    readline libusb1 gnutls adns openldap zlib bzip2 sqlite
+    tpm2-tss
+  ];
+
+  patches = [
+    ./fix-libusb-include-path.patch
+    ./0001-dirmngr-Only-use-SKS-pool-CA-for-SKS-pool_gnupg-2.3.1.patch
+    ./tests-add-test-cases-for-import-without-uid.patch
+    #./allow-import-of-previously-known-keys-even-without-UI.patch
+    ./accept-subkeys-with-a-good-revocation-but-no-self-sig.patch
+  ];
+  postPatch = ''
+    sed -i 's,hkps://hkps.pool.sks-keyservers.net,hkps://keys.openpgp.org,g' configure doc/dirmngr.texi
+    # Fix broken SOURCE_DATE_EPOCH usage - remove on the next upstream update
+    sed -i 's/$SOURCE_DATE_EPOCH/''${SOURCE_DATE_EPOCH}/' doc/Makefile.am
+    sed -i 's/$SOURCE_DATE_EPOCH/''${SOURCE_DATE_EPOCH}/' doc/Makefile.in
+  '' + lib.optionalString ( stdenv.isLinux && pcsclite != null) ''
+    sed -i 's,"libpcsclite\.so[^"]*","${lib.getLib pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
+  '';
+
+  pinentryBinaryPath = pinentry.binaryPath or "bin/pinentry";
+  configureFlags = [
+    "--with-libgpg-error-prefix=${libgpgerror.dev}"
+    "--with-libgcrypt-prefix=${libgcrypt.dev}"
+    "--with-libassuan-prefix=${libassuan.dev}"
+    "--with-ksba-prefix=${libksba.dev}"
+    "--with-npth-prefix=${npth}"
+  ]
+  ++ optional guiSupport "--with-pinentry-pgm=${pinentry}/${pinentryBinaryPath}"
+  ++ optional tpmSupport "--with-tpm=intel";
+
+  postInstall = if enableMinimal
+  then ''
+    rm -r $out/{libexec,sbin,share}
+    for f in `find $out/bin -type f -not -name gpg`
+    do
+      rm $f
+    done
+  '' else ''
+    mkdir -p $out/lib/systemd/user
+    for f in doc/examples/systemd-user/*.{service,socket} ; do
+      substitute $f $out/lib/systemd/user/$(basename $f) \
+        --replace /usr/bin $out/bin
+    done
+
+    # add gpg2 symlink to make sure git does not break when signing commits
+    ln -s $out/bin/gpg $out/bin/gpg2
+
+    # Make libexec tools available in PATH
+    for tool in $(ls $out/libexec/); do
+      ln -s -t $out/bin $out/libexec/$tool || echo "Failed to create symlink for $tool"
+    done
+  '';
+
+  meta = with lib; {
+    homepage = "https://gnupg.org";
+    description = "Modern (2.3) release of the GNU Privacy Guard, a GPL OpenPGP implementation";
+    license = licenses.gpl3Plus;
+    longDescription = ''
+      The GNU Privacy Guard is the GNU project's complete and free
+      implementation of the OpenPGP standard as defined by RFC4880.  GnuPG
+      "modern" (2.3) is the latest development with a lot of new features.
+      GnuPG allows to encrypt and sign your data and communication, features a
+      versatile key management system as well as access modules for all kind of
+      public key directories.  GnuPG, also known as GPG, is a command line tool
+      with features for easy integration with other applications.  A wealth of
+      frontend applications and libraries are available.  Version 2 of GnuPG
+      also provides support for S/MIME.
+    '';
+    maintainers = with maintainers; [ peti fpletz vrthra ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5512,6 +5512,10 @@ with pkgs;
     guiSupport = stdenv.isDarwin;
     pinentry = if stdenv.isDarwin then pinentry_mac else pinentry-gtk2;
   };
+  gnupg23 = callPackage ../tools/security/gnupg/23.nix {
+    guiSupport = stdenv.isDarwin;
+    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry-gtk2;
+  };
   gnupg = gnupg22;
 
   gnupg-pkcs11-scd = callPackage ../tools/security/gnupg-pkcs11-scd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the current latest version of GnuPG, v2.3.1. Given nixpkgs seems to have individual package definitions for GnuPG minor releases, this change is done in that spirit. Notably, GnuPG gained native TPM2 support in v2.3. This is a potentially very interesting feature given the wide spread of TPM2 chips and the ability to use this chip as a hardware key storage and crypto engine with the standard OpenPGP message format. Furthermore, authentication keys allow the stored keys to be used for SSH access. For instance, these changes have been pushed to GitHub using a TPM-protected authentication subkey for SSH authentication.

Trying to use this version as the system default (i.e. override `gnupg = gnupg23`) will cause a mass rebuild and fails with some packages, for instance notmuch. Thus, as a first step, this simply introduces the new package. Users can opt into using it on NixOS by setting `programs.gnupg.package = pkgs.gnupg23;`. I suspect it might be a good idea to couple the default version switch to a major release of nixpkgs?

`allow-import-of-previously-known-keys-even-without-UI.patch` does not apply any more. I'm not sure whether that's fixed in the source or whether this patch is still needed. Someone with a more in-depth knowledge of GnuPG might be able to help here?

Tagging the maintainers of GnuPG 2.2 which are added as maintainers for this package as well: @peti, @fpletz, @vrthra. I would prefer not to take over maintainership for this version.

This still includes a hack in the post setup phase where some symlinks to libexec tools collide with binaries already in the destination path. I need to debug that further.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [N/A] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
