### PR TITLE
faas-cli: init at 0.13.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11612,6 +11612,16 @@
     githubId = 9002575;
     name = "Weihua Lu";
   };
+  welteki = {
+    email = "welteki@pm.me";
+    github = "welteki";
+    githubId = 16267532;
+    name = "Han Verstraete";
+    keys = [{
+      longkeyid = "rsa4096/0x11F7BAEA856743FF";
+      fingerprint = "2145 955E 3F5E 0C95 3458  41B5 11F7 BAEA 8567 43FF";
+    }];
+  };
   wheelsandmetal = {
     email = "jakob@schmutz.co.uk";
     github = "wheelsandmetal";

--- a/pkgs/development/tools/faas-cli/default.nix
+++ b/pkgs/development/tools/faas-cli/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+let
+  faasPlatform = platform:
+    let cpuName = platform.parsed.cpu.name; in {
+      "aarch64" = "arm64";
+      "armv7l" = "armhf";
+    }.${cpuName} or cpuName;
+in
+buildGoModule rec {
+  pname = "faas-cli";
+  # When updating version change rev.
+  version = "0.13.13";
+  rev = "72816d486cf76c3089b915dfb0b66b85cf096634";
+  platform = faasPlatform stdenv.targetPlatform;
+
+  src = fetchFromGitHub {
+    owner = "openfaas";
+    repo = "faas-cli";
+    rev = version;
+    sha256 = "0mmrakyy2qmkldld7pxf5bx6whdadq2r52b68f9p9z7yqrdimix8";
+  };
+
+  CGO_ENABLED = 0;
+
+  vendorSha256 = null;
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/openfaas/faas-cli/version.GitCommit=${rev}"
+    "-X github.com/openfaas/faas-cli/version.Version=${version}"
+    "-X github.com/openfaas/faas-cli/commands.Platform=${platform}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/openfaas/faas-cli";
+    description = "Official CLI for OpenFaaS ";
+    license = licenses.mit;
+    maintainers = with maintainers; [ welteki ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13836,6 +13836,8 @@ with pkgs;
 
   ezquake = callPackage ../games/ezquake { };
 
+  faas-cli = callPackage ../development/tools/faas-cli { };
+
   findbugs = callPackage ../development/tools/analysis/findbugs { };
 
   findnewest = callPackage ../development/tools/misc/findnewest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[faas-cli](https://github.com/openfaas/faas-cli) is the official CLI for [OpenFaaS](https://github.com/openfaas/faas)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
