### PR TITLE
tremc: fix crash with python 3.9

### DIFF
--- a/pkgs/applications/networking/p2p/tremc/default.nix
+++ b/pkgs/applications/networking/p2p/tremc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, python3Packages
+{ lib, stdenv, fetchFromGitHub, fetchpatch, python3Packages
 , x11Support ? !stdenv.isDarwin
 , xclip ? null
 , pbcopy ? null
@@ -20,6 +20,17 @@ python3Packages.buildPythonApplication rec {
     rev = version;
     sha256 = "1fqspp2ckafplahgba54xmx0sjidx1pdzyjaqjhz0ivh98dkx2n5";
   };
+
+  patches = [
+    # Remove when version >0.9.2 is released
+    (
+      fetchpatch {
+        url = "https://github.com/tremc/tremc/pull/61/commits/bdffff2bd76186a4e3488b83f719fc7f7e3362b6.patch";
+        sha256 = "1zip2skh22v0yyv2hmszxn5jshp9m1jpw0fsyfvmqfxzq7m3czy5";
+        name = "replace-decodestring-with-decodebytes.patch";
+      }
+    )
+  ];
 
   buildInputs = with python3Packages; [
     python

--- a/pkgs/applications/networking/p2p/tremc/default.nix
+++ b/pkgs/applications/networking/p2p/tremc/default.nix
@@ -24,7 +24,7 @@ python3Packages.buildPythonApplication rec {
   patches = [
     # Remove when version >0.9.2 is released
     (fetchpatch {
-      url = "https://github.com/tremc/tremc/pull/61/commits/bdffff2bd76186a4e3488b83f719fc7f7e3362b6.patch";
+      url = "https://github.com/tremc/tremc/commit/bdffff2bd76186a4e3488b83f719fc7f7e3362b6.patch";
       sha256 = "1zip2skh22v0yyv2hmszxn5jshp9m1jpw0fsyfvmqfxzq7m3czy5";
       name = "replace-decodestring-with-decodebytes.patch";
     })

--- a/pkgs/applications/networking/p2p/tremc/default.nix
+++ b/pkgs/applications/networking/p2p/tremc/default.nix
@@ -23,13 +23,11 @@ python3Packages.buildPythonApplication rec {
 
   patches = [
     # Remove when version >0.9.2 is released
-    (
-      fetchpatch {
-        url = "https://github.com/tremc/tremc/pull/61/commits/bdffff2bd76186a4e3488b83f719fc7f7e3362b6.patch";
-        sha256 = "1zip2skh22v0yyv2hmszxn5jshp9m1jpw0fsyfvmqfxzq7m3czy5";
-        name = "replace-decodestring-with-decodebytes.patch";
-      }
-    )
+    (fetchpatch {
+      url = "https://github.com/tremc/tremc/pull/61/commits/bdffff2bd76186a4e3488b83f719fc7f7e3362b6.patch";
+      sha256 = "1zip2skh22v0yyv2hmszxn5jshp9m1jpw0fsyfvmqfxzq7m3czy5";
+      name = "replace-decodestring-with-decodebytes.patch";
+    })
   ];
 
   buildInputs = with python3Packages; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
base64.decodestring is no longer available in python 3.9. The issue in
tremc has long been fixed upstream, but no new release is available yet.
Fix it in nixpkgs collection by pulling a particular patch from the
unreleased version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
