### PR TITLE
nixos/top-level: Check activation script syntax

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -61,6 +61,8 @@ let
       substituteInPlace $out/dry-activate --subst-var out
       chmod u+x $out/activate $out/dry-activate
       unset activationScript dryActivationScript
+      ${pkgs.runtimeShell} -n $out/activate
+      ${pkgs.runtimeShell} -n $out/dry-activate
 
       cp ${config.system.build.bootStage2} $out/init
       substituteInPlace $out/init --subst-var-by systemConfig $out


### PR DESCRIPTION
Probably a good idea. We need to do this because we can't use `pkgs.writeShellScript` since that would lead to an infinite recursion.