### PR TITLE
nixos/cloudflared-dns: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -119,6 +119,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/cloudflare/cloudflared">cloudflared</link>,
+          a program which (among other things) can proxy and encrypt
+          traditional DNS requests using DNS-over-HTTPS. Available as
+          <link xlink:href="options.html#opt-services.cloudflared-dns">services.cloudflared-dns</link>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/maxmind/geoipupdate">geoipupdate</link>,
           a GeoIP database updater from MaxMind. Available as
           <link xlink:href="options.html#opt-services.geoipupdate.enable">services.geoipupdate</link>.

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -38,6 +38,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [dex](https://github.com/dexidp/dex), an OpenID Connect (OIDC) identity and OAuth 2.0 provider. Available at [services.dex](options.html#opt-services.dex.enable).
 
+- [cloudflared](https://github.com/cloudflare/cloudflared), a program which (among other things) can proxy and encrypt traditional DNS requests using DNS-over-HTTPS. Available as [services.cloudflared-dns](options.html#opt-services.cloudflared-dns)
+
 - [geoipupdate](https://github.com/maxmind/geoipupdate), a GeoIP database updater from MaxMind. Available as [services.geoipupdate](options.html#opt-services.geoipupdate.enable).
 
 - [Kea](https://www.isc.org/kea/), ISCs 2nd generation DHCP and DDNS server suite. Available at [services.kea](options.html#opt-services.kea).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -696,6 +696,7 @@
   ./services/networking/blockbook-frontend.nix
   ./services/networking/charybdis.nix
   ./services/networking/cjdns.nix
+  ./services/networking/cloudflared-dns.nix
   ./services/networking/cntlm.nix
   ./services/networking/connman.nix
   ./services/networking/consul.nix

--- a/nixos/modules/services/networking/cloudflared-dns.nix
+++ b/nixos/modules/services/networking/cloudflared-dns.nix
@@ -1,0 +1,122 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.cloudflared-dns;
+  listenAddressParts = splitString ":" cfg.listenAddress;
+  opts = assert (builtins.length listenAddressParts) == 2;
+    [
+      "--metrics ${cfg.metricsAddress}"
+      "--max-upstream-conns ${toString cfg.maxUpstreamConnections}"
+      (concatStringsSep " " (map (ep: "--upstream ${toString ep}") cfg.upstreamEndpoints))
+      (concatStringsSep " " (map (ep: "--bootstrap ${toString ep}") cfg.bootstrapEndpoints))
+      "--address ${builtins.elemAt listenAddressParts 0}"
+      "--port ${builtins.elemAt listenAddressParts 1}"
+    ];
+  cmdline = "${cfg.package}/bin/cloudflared proxy-dns ${concatStringsSep " " opts}";
+in
+
+{
+  meta.maintainers = with lib.maintainers; [ ckie ];
+
+  options.services.cloudflared-dns = {
+    enable = mkEnableOption "Enables the cloudflared DNS-over-HTTPS proxying daemon";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.cloudflared;
+      description = "The cloudflared package to use.";
+    };
+
+    metricsAddress = mkOption {
+      type = types.str;
+      default = "localhost:43759";
+      description = "Listen address for metrics reporting.";
+    };
+
+    listenAddress = mkOption {
+      type = types.str;
+      default = "localhost:53";
+      description = "Listen address for inbound traffic.";
+    };
+
+    maxUpstreamConnections = mkOption {
+      type = types.int;
+      default = 5;
+      description = "Maximum concurrent connections to upstream.";
+    };
+
+    upstreamEndpoints = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "https://1.1.1.1/dns-query"
+        "https://1.0.0.1/dns-query"
+      ];
+      description = "Upstream endpoint URLs";
+    };
+
+    bootstrapEndpoints = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "https://162.159.36.1/dns-query"
+        "https://162.159.46.1/dns-query"
+        "https://[2606:4700:4700::1111]/dns-query"
+        "https://[2606:4700:4700::1001]/dns-query"
+      ];
+      description = "Bootstrap endpoint URLs";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.cloudflared-dns = {
+      description = "cloudflared DNS-over-HTTPS proxying daemon";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "networking.target" ];
+
+      serviceConfig =
+        {
+          ExecStart = cmdline;
+          Restart = "always";
+          DynamicUser = true;
+
+          PrivateTmp = true;
+          ProtectHome = true;
+          ProtectSystem = "full";
+          DevicePolicy = "closed";
+          NoNewPrivileges = true;
+          CapabilityBoundingSet = "";
+          DeviceAllow = [ ];
+          ProtectControlGroups = true;
+          ProtectClock = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          RemoveIPC = true;
+          ProtectProc = "invisible";
+          RestrictAddressFamilies = [ "~AF_UNIX" "~AF_NETLINK" ];
+          RestrictSUIDSGID = true;
+          RestrictRealtime = true;
+          LockPersonality = true;
+          SystemCallArchitectures = "native";
+          ProcSubset = "pid";
+          SystemCallFilter = [
+            "~@reboot"
+            "~@module"
+            "~@mount"
+            "~@swap"
+            "~@resources"
+            "~@cpu-emulation"
+            "~@obsolete"
+            "~@debug"
+            "~@privileged"
+          ];
+        };
+    };
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I was bored and this was something nice to work on.

~~NOTE: I didn't add a `meta.maintainers` as my entry in maintainer-list is currently in flux in another [unmerged PR](https://github.com/NixOS/nixpkgs/pull/131526).~~ Now merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Security
`systemd-analyze security` score: `→ Overall exposure level for cloudflared-dns.service: 2.2 OK 🙂` ([full output](https://i.ckie.dev/42G6XUJ.txt))

###### Example Usage

[`ckiee/nixfiles`:`modules/services/coredns/default.nix`](https://github.com/ckiee/nixfiles/blob/d3427381a45da47561b099197e07bba257cfbf8c/modules/services/coredns/default.nix#L27-L30)