### PR TITLE
ite-backlight: init at v1.1

### DIFF
--- a/pkgs/misc/ite-backlight/default.nix
+++ b/pkgs/misc/ite-backlight/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, pkgs
+, stdenv
+, ninja
+, libusb1
+, meson
+, boost
+, fetchFromGitHub
+, pkg-config
+, microsoft_gsl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ite-backlight";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "hexagonal-sun";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1hany4bn93mac9qyz97r1l858d48zdvvmn3mabzr3441ivqr9j0a";
+  };
+
+  nativeBuildInputs = [
+    ninja
+    pkg-config
+    meson
+    microsoft_gsl
+  ];
+
+  buildInputs = [
+    boost
+    libusb1
+  ];
+
+  meta = with lib; {
+    description = "Commands to control ite-backlight devices";
+    longDescription = ''
+      This project aims to provide a set of simple utilities for controlling ITE 8291
+      keyboard backlight controllers.
+    '';
+    license = with licenses; [ mit ];
+    homepage = "https://github.com/hexagonal-sun/ite-backlight";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ hexagonal-sun ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6212,6 +6212,8 @@ with pkgs;
 
   itm-tools = callPackage ../development/tools/misc/itm-tools { };
 
+  ite-backlight = callPackage ../misc/ite-backlight { };
+
   iwgtk = callPackage ../tools/networking/iwgtk { };
 
   ix = callPackage ../tools/misc/ix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add a package for `ite-backlight` utilities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
