### PR TITLE
gvm-libs: init at 21.4.1

### DIFF
--- a/pkgs/development/libraries/gvm-libs/default.nix
+++ b/pkgs/development/libraries/gvm-libs/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, cmake
+, fetchFromGitHub
+, glib
+, glib-networking
+, gnutls
+, gpgme
+, hiredis
+, libgcrypt
+, libnet
+, libpcap
+, libssh
+, libuuid
+, libxml2
+, pkg-config
+, zlib
+, freeradius
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gvm-libs";
+  version = "21.4.1";
+
+  src = fetchFromGitHub {
+    owner = "greenbone";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ap3m7f1gyv9p96czi8mzryhjijgaqcbdyr8lwvnw8ynzskx8s3y";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    glib-networking
+    gnutls
+    gpgme
+    hiredis
+    libgcrypt
+    freeradius
+    libnet
+    libpcap
+    libssh
+    libuuid
+    libxml2
+    zlib
+  ];
+
+  meta = with lib; {
+    description = "Libraries module for the Greenbone Vulnerability Management Solution";
+    homepage = "https://github.com/greenbone/gvm-libs";
+    license = with licenses; [ gpl2Plus ];
+    maintainers = with maintainers; [ fab ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16086,6 +16086,8 @@ with pkgs;
 
   gvfs = callPackage ../development/libraries/gvfs { };
 
+  gvm-libs = callPackage ../development/libraries/gvm-libs { };
+
   gwenhywfar = callPackage ../development/libraries/aqbanking/gwenhywfar.nix { };
 
   hamlib = hamlib_3;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Libraries module for the Greenbone Vulnerability Management Solution

https://github.com/greenbone/gvm-libs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
