### PR TITLE
python3Packages.notus-scanner: init at unstable-2021-09-05

### DIFF
--- a/pkgs/development/python-modules/notus-scanner/default.nix
+++ b/pkgs/development/python-modules/notus-scanner/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, paho-mqtt
+, poetry-core
+, psutil
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "notus-scanner";
+  version = "unstable-2021-09-05";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "greenbone";
+    repo = pname;
+    rev = "049f9a5e6439e4e5113e3b8f30b25ead12d42a56";
+    sha256 = "1fjxyn8wg2kf6xy3pbh7d7yn20dk529p03xpqyz7s40n9nsxhnza";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    paho-mqtt
+    psutil
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/greenbone/notus-scanner/pull/31
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/greenbone/notus-scanner/commit/b52eea317faca30d411096044f9e5ea20b58da65.patch";
+      sha256 = "0q11aslhva47kkpsnpayra7spa849j894vqv34pjqhcnlyipqw6d";
+    })
+  ];
+
+  pythonImportsCheck = [ "notus.scanner" ];
+
+  meta = with lib; {
+    description = "Helper to create results from local security checks";
+    homepage = "https://github.com/greenbone/notus-scanner";
+    license = with licenses; [ agpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30655,6 +30655,8 @@ with pkgs;
 
   nota = haskellPackages.callPackage ../applications/science/math/nota { };
 
+  notus-scanner = with python3Packages; toPythonApplication notus-scanner;
+
   openblas = callPackage ../development/libraries/science/math/openblas { };
 
   # A version of OpenBLAS using 32-bit integers on all platforms for compatibility with

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4956,6 +4956,8 @@ in {
 
   nototools = callPackage ../data/fonts/noto-fonts/tools.nix { };
 
+  notus-scanner = callPackage ../development/python-modules/notus-scanner { };
+
   nplusone = callPackage ../development/python-modules/nplusone { };
 
   npyscreen = callPackage ../development/python-modules/npyscreen { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Helper to create results from local security checks

https://github.com/greenbone/notus-scanner

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
