### PR TITLE
Assemblers for 8-bit chips

### DIFF
--- a/pkgs/development/compilers/as31/0000-getline-break.patch
+++ b/pkgs/development/compilers/as31/0000-getline-break.patch
@@ -1,0 +1,24 @@
+diff --git old/as31/run.c new/as31/run.c
+index 28c5317..9e5263b 100644
+--- old/as31/run.c
++++ new/as31/run.c
+@@ -113,7 +113,8 @@ int run_as31(const char *infile, int lst, int use_stdout,
+ 	}
+ 
+ 	while (!feof(finPre)) {
+-		getline(&lineBuffer,&sizeBuf,finPre);
++		if (getline(&lineBuffer,&sizeBuf,finPre) == -1)
++			break;
+ 		if ((includePtr=strstr(lineBuffer,INC_CMD))) {
+ 			includePtr=includePtr+strlen(INC_CMD);
+ 			while ((*includePtr==' ')||		//move includePtr to filename
+@@ -138,7 +139,8 @@ int run_as31(const char *infile, int lst, int use_stdout,
+ 				mesg_f("Cannot open include file: %s\n",includePtr);
+ 			} else {
+ 				while (!feof(includeFile)) {
+-					getline(&incLineBuffer,&incSizeBuf,includeFile);
++					if (getline(&incLineBuffer,&incSizeBuf,includeFile) == -1)
++						break;
+ 					fprintf(fin,"%s",incLineBuffer);
+ 					if (strlen(incLineBuffer)) {
+ 						incLineCount++;

--- a/pkgs/development/compilers/as31/default.nix
+++ b/pkgs/development/compilers/as31/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchurl
+, bison
+}:
+
+stdenv.mkDerivation rec {
+  pname = "as31";
+  version = "2.3.1";
+
+  src = fetchurl {
+    url = "http://wiki.erazor-zone.de/_media/wiki:projects:linux:as31:${pname}-${version}.tar.gz";
+    name = "${pname}-${version}.tar.gz";
+    hash = "sha256-zSEyWHFon5nyq717Mpmdv1XZ5Hz0e8ZABqsP8M83c1U=";
+  };
+
+  patches = [
+    # Check return value of getline in run.c
+    ./0000-getline-break.patch
+  ];
+
+  postPatch = ''
+    # parser.c is generated from parser.y; it is better to generate it via bison
+    # instead of using the prebuilt one, especially in x86_64
+    rm -f as31/parser.c
+  '';
+
+  preConfigure = ''
+    chmod +x configure
+  '';
+
+  nativeBuildInputs = [
+    bison
+  ];
+
+  meta = with lib; {
+    homepage = "http://wiki.erazor-zone.de/wiki:projects:linux:as31";
+    description = "An 8031/8051 assembler";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/atasm/0000-file-not-found.diff
+++ b/pkgs/development/compilers/atasm/0000-file-not-found.diff
@@ -1,0 +1,16 @@
+diff -Naur atasm109-old/src/Makefile atasm109-new/src/Makefile
+--- atasm109-old/src/Makefile	2021-09-08 09:53:25.581598063 -0300
++++ atasm109-new/src/Makefile	2021-09-08 09:55:20.366131338 -0300
+@@ -55,9 +55,9 @@
+ 	chown root.root $(DESTDIR)/atasm || true
+ 	chmod 711 $(DESTDIR)/atasm
+ 	mkdir $(DOCDIR) >/dev/null 2>&1 || echo $(DOCDIR) already exists
+-	cp ../atasm.txt $(DOCDIR)
+-	chown root.root $(DOCDIR)/atasm.txt || true
+-	chmod 644 $(DOCDIR)/atasm.txt
++	# cp ../atasm.txt $(DOCDIR)
++	# chown root.root $(DOCDIR)/atasm.txt || true
++	# chmod 644 $(DOCDIR)/atasm.txt
+ 	sed -e 's,%%DOCDIR%%,$(DOCDIR),g' < atasm.1.in > atasm.1
+ 	cp atasm.1 $(MANDIR)
+ 	chown root.root $(MANDIR)/atasm.1 || true

--- a/pkgs/development/compilers/atasm/0001-select-flags.diff
+++ b/pkgs/development/compilers/atasm/0001-select-flags.diff
@@ -1,0 +1,14 @@
+diff -Naur atasm109-old/src/Makefile atasm109-new/src/Makefile
+--- atasm109-old/src/Makefile	2021-09-08 09:53:25.581598063 -0300
++++ atasm109-new/src/Makefile	2021-09-08 09:55:20.366131338 -0300
+@@ -16,8 +16,8 @@
+ UNIX    = -DUNIX
+ 
+ # Compiler flags, if you are using egcs, pgcs, or gcc >2.8.1 use:
+-#CFLAGS  = -g -Wall $(USEZ) $(DOS) $(UNIX) $(ARCH)
+-CFLAGS  = -Wall $(USEZ) $(DOS) $(UNIX) -O3 -fomit-frame-pointer $(ARCH)
++CFLAGS  = -g -Wall $(USEZ) $(DOS) $(UNIX) $(ARCH)
++#CFLAGS  = -Wall $(USEZ) $(DOS) $(UNIX) -O3 -fomit-frame-pointer $(ARCH)
+ 
+ L       =  $(ZLIB)
+ CC      = gcc

--- a/pkgs/development/compilers/atasm/default.nix
+++ b/pkgs/development/compilers/atasm/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "atasm";
+  version = "1.09";
+
+  src = fetchurl {
+    url = "https://atari.miribilist.com/${pname}/${pname}${builtins.replaceStrings ["."] [""] version}.zip";
+    hash = "sha256-26shhw2r30GZIPz6S1rf6dOLKRpgpLwrqCRZX3+8PvA=";
+  };
+
+  patches = [
+    # make install fails because atasm.txt was moved; report to upstream
+    ./0000-file-not-found.diff
+    # select flags for compilation
+    ./0001-select-flags.diff
+  ];
+
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    unzip
+  ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  preBuild = ''
+    makeFlagsArray+=(
+      -C ./src
+      CC=cc
+      USEZ="-DZLIB_CAPABLE -I${zlib}/include"
+      ZLIB="-L${zlib}/lib -lz"
+      UNIX="-DUNIX"
+    )
+  '';
+
+  preInstall = ''
+    install -d $out/share/doc/${pname} $out/man/man1
+    installFlagsArray+=(
+      DESTDIR=$out
+      DOCDIR=$out/share/doc/${pname}
+      MANDIR=$out/man/man1
+    )
+  '';
+
+  postInstall = ''
+    mv docs/* $out/share/doc/${pname}
+  '';
+
+  meta = with lib; {
+    homepage = "https://atari.miribilist.com/atasm/";
+    description = "A commandline 6502 assembler compatible with Mac/65";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10822,6 +10822,8 @@ with pkgs;
 
   asciigraph = callPackage ../tools/text/asciigraph { };
 
+  as31 = callPackage ../development/compilers/as31 { };
+
   asn1c = callPackage ../development/compilers/asn1c { };
 
   aspectj = callPackage ../development/compilers/aspectj { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10828,6 +10828,8 @@ with pkgs;
 
   aspectj = callPackage ../development/compilers/aspectj { };
 
+  atasm = callPackage ../development/compilers/atasm { };
+
   ats = callPackage ../development/compilers/ats { };
   ats2 = callPackage ../development/compilers/ats2 { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
