### PR TITLE
helm: fix #79177 on linux

### DIFF
--- a/pkgs/applications/audio/helm/default.nix
+++ b/pkgs/applications/audio/helm/default.nix
@@ -44,11 +44,6 @@
     sed -i "s|/usr/share/|$out/share/|" src/common/load_save.cpp
   '';
 
-  buildPhase = ''
-    make lv2
-    make standalone
-  '';
-
   installPhase = ''
    make DESTDIR="$out" install
   '';

--- a/pkgs/applications/audio/helm/default.nix
+++ b/pkgs/applications/audio/helm/default.nix
@@ -30,6 +30,7 @@
   ];
 
   CXXFLAGS = "-DHAVE_LROUND";
+  enableParallelBuilding = true;
 
   patches = [
     # gcc9 compatibility https://github.com/mtytel/helm/pull/233

--- a/pkgs/applications/audio/helm/default.nix
+++ b/pkgs/applications/audio/helm/default.nix
@@ -26,11 +26,13 @@
   buildInputs = [
     xorg.libX11 xorg.libXcomposite xorg.libXcursor xorg.libXext
     xorg.libXinerama xorg.libXrender xorg.libXrandr
-    freetype alsa-lib curl libjack2 pkg-config libGLU libGL lv2
+    freetype alsa-lib curl libjack2 libGLU libGL lv2
   ];
+  nativeBuildInputs = [ pkg-config ];
 
   CXXFLAGS = "-DHAVE_LROUND";
   enableParallelBuilding = true;
+  makeFlags = [ "DESTDIR=$(out)" ];
 
   patches = [
     # gcc9 compatibility https://github.com/mtytel/helm/pull/233
@@ -43,10 +45,6 @@
   prePatch = ''
     sed -i 's|usr/||g' Makefile
     sed -i "s|/usr/share/|$out/share/|" src/common/load_save.cpp
-  '';
-
-  installPhase = ''
-   make DESTDIR="$out" install
   '';
 
   meta = with lib; {
@@ -69,7 +67,7 @@
         Simple arpeggiator
         Effects: Formant filter, stutter, delay
     '';
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/audio/helm/default.nix
+++ b/pkgs/applications/audio/helm/default.nix
@@ -41,6 +41,7 @@
 
   prePatch = ''
     sed -i 's|usr/||g' Makefile
+    sed -i "s|/usr/share/|$out/share/|" src/common/load_save.cpp
   '';
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

fix #79177 on linux. can't test on a macos machine for lack of having one. also fix the build process a little (`installPhase` would build the vst portion since `buildPhase` didn't).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @magnetophon 