### PR TITLE
multimc: add Microsoft account support

### DIFF
--- a/pkgs/games/multimc/0001-pick-latest-java-first.patch
+++ b/pkgs/games/multimc/0001-pick-latest-java-first.patch
@@ -4,14 +4,14 @@ Date: Tue, 22 Jun 2021 21:50:11 +0300
 Subject: [PATCH] pick latest java first
 
 ---
- api/logic/java/JavaInstallList.cpp | 4 ++--
- api/logic/java/JavaUtils.cpp       | 2 +-
+ launcher/java/JavaInstallList.cpp | 4 ++--
+ launcher/java/JavaUtils.cpp       | 2 +-
  2 files changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/api/logic/java/JavaInstallList.cpp b/api/logic/java/JavaInstallList.cpp
+diff --git a/launcher/java/JavaInstallList.cpp b/launcher/java/JavaInstallList.cpp
 index 0bded03c..40898e20 100644
---- a/api/logic/java/JavaInstallList.cpp
-+++ b/api/logic/java/JavaInstallList.cpp
+--- a/launcher/java/JavaInstallList.cpp
++++ b/launcher/java/JavaInstallList.cpp
 @@ -120,8 +120,8 @@ void JavaInstallList::updateListData(QList<BaseVersionPtr> versions)
  
  bool sortJavas(BaseVersionPtr left, BaseVersionPtr right)
@@ -23,10 +23,10 @@ index 0bded03c..40898e20 100644
      return (*rleft) > (*rright);
  }
  
-diff --git a/api/logic/java/JavaUtils.cpp b/api/logic/java/JavaUtils.cpp
+diff --git a/launcher/java/JavaUtils.cpp b/launcher/java/JavaUtils.cpp
 index 5f004a10..6d633631 100644
---- a/api/logic/java/JavaUtils.cpp
-+++ b/api/logic/java/JavaUtils.cpp
+--- a/launcher/java/JavaUtils.cpp
++++ b/launcher/java/JavaUtils.cpp
 @@ -350,7 +350,6 @@ QList<QString> JavaUtils::FindJavaPaths()
      qDebug() << "Linux Java detection incomplete - defaulting to \"java\"";
  

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitHub, cmake, jdk8, jdk, zlib, file, makeWrapper, xorg, libpulseaudio, qtbase, libGL }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, jdk8, jdk, zlib, file, makeWrapper, xorg, libpulseaudio, qtbase, libGL, msaClientID ? "" }:
 
 let
   libpath = with xorg; lib.makeLibraryPath [ libX11 libXext libXcursor libXrandr libXxf86vm libpulseaudio libGL ];
@@ -22,6 +22,10 @@ in mkDerivation rec {
     substituteInPlace launcher/java/JavaUtils.cpp \
       --replace 'scanJavaDir("/usr/lib/jvm")' 'javas.append("${jdk}/lib/openjdk/bin/java")' \
       --replace 'scanJavaDir("/usr/lib32/jvm")' 'javas.append("${jdk8}/lib/openjdk/bin/java")'
+
+    # add client ID
+    substituteInPlace notsecrets/Secrets.cpp \
+      --replace 'QString MSAClientID = "";' 'QString MSAClientID = "${msaClientID}";'
   '';
 
   cmakeFlags = [ "-DMultiMC_LAYOUT=lin-system" ];

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -4,12 +4,12 @@ let
   libpath = with xorg; lib.makeLibraryPath [ libX11 libXext libXcursor libXrandr libXxf86vm libpulseaudio libGL ];
 in mkDerivation rec {
   pname = "multimc";
-  version = "unstable-2021-06-21";
+  version = "unstable-2021-09-08";
   src = fetchFromGitHub {
     owner = "MultiMC";
     repo = "MultiMC5";
-    rev = "8179a89103833805d5374399d80a4305be1b8355";
-    sha256 = "lPz6ZM7TjaixfwWMPaXijKZJQKFPrCegBhvbJ8Xg4P8=";
+    rev = "e2355eb276bf355ca4acf526a0f3cc390aa88f8b";
+    sha256 = "3G9QPoAbC+uVfUYR0Kq6hnxl9c2mvCzIEYGjwfarQJ8=";
     fetchSubmodules = true;
   };
   nativeBuildInputs = [ cmake file makeWrapper ];
@@ -19,7 +19,7 @@ in mkDerivation rec {
 
   postPatch = ''
     # hardcode jdk paths
-    substituteInPlace api/logic/java/JavaUtils.cpp \
+    substituteInPlace launcher/java/JavaUtils.cpp \
       --replace 'scanJavaDir("/usr/lib/jvm")' 'javas.append("${jdk}/lib/openjdk/bin/java")' \
       --replace 'scanJavaDir("/usr/lib32/jvm")' 'javas.append("${jdk8}/lib/openjdk/bin/java")'
   '';
@@ -27,8 +27,8 @@ in mkDerivation rec {
   cmakeFlags = [ "-DMultiMC_LAYOUT=lin-system" ];
 
   postInstall = ''
-    install -Dm644 ../application/resources/multimc/scalable/multimc.svg $out/share/pixmaps/multimc.svg
-    install -Dm755 ../application/package/linux/multimc.desktop $out/share/applications/multimc.desktop
+    install -Dm644 ../launcher/resources/multimc/scalable/multimc.svg $out/share/pixmaps/multimc.svg
+    install -Dm755 ../launcher/package/linux/multimc.desktop $out/share/applications/multimc.desktop
 
     # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
     wrapProgram $out/bin/multimc \


### PR DESCRIPTION
###### Motivation for this change
Microsoft/Mojang has been progressively pushing people towards using Microsoft accounts instead of Mojang accounts for logging in. MultiMC's source does not contain the necessary OAuth client ID, so I registered a "MC on NixOS" application:
![permissions request](https://user-images.githubusercontent.com/8355305/132606180-1d48b396-b704-4bde-a07b-c3cce0a0bb9f.png)

The MultiMC source code contains warnings about making the client ID public. From my reading of Microsoft's documentation, I don't believe that this is an issue, but since I registered the application it'd be my problem (and not the NixOS project or MultiMC's).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
