### PR TITLE
bandwidth: 1.9.4 -> 1.10.1, enable on arm

### DIFF
--- a/pkgs/tools/misc/bandwidth/default.nix
+++ b/pkgs/tools/misc/bandwidth/default.nix
@@ -6,21 +6,35 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bandwidth";
-  version = "1.9.4";
+  version = "1.10.1";
 
   src = fetchurl {
     url = "https://zsmith.co/archives/${pname}-${version}.tar.gz";
-    sha256 = "0x798xj3vhiwq2hal0vmf92sq4h7yalp3i6ylqwhnnpv99m2zws4";
+    sha256 = "sha256-trya+/cBNIittQAc5tcykZbImeISqIolO/Y8uOI0jGk=";
   };
 
   postPatch = ''
-    sed -i 's,^CC=gcc .*,,' OOC/Makefile Makefile*
     sed -i 's,ar ,$(AR) ,g' OOC/Makefile
+    # Remove unnecessary -m32 for 32-bit targets
+    sed -i 's,-m32,,g' OOC/Makefile
+    # Fix wrong comment character
+    sed -i 's,# 32,; 32,g' routines-x86-32bit.asm
+    # Fix missing symbol exports for macOS clang
+    echo global _VectorToVector128 >> routines-x86-64bit.asm
+    echo global _VectorToVector256 >> routines-x86-64bit.asm
   '';
 
   nativeBuildInputs = [ nasm ];
 
-  buildFlags = [ arch ];
+  buildFlags = [
+    "AR=${stdenv.cc.targetPrefix}ar"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "ARM_AS=${stdenv.cc.targetPrefix}as"
+    "ARM_CC=$(CC)"
+    "UNAMEPROC=${stdenv.hostPlatform.parsed.cpu.name}"
+    "UNAMEMACHINE=${stdenv.hostPlatform.parsed.cpu.name}"
+    arch
+  ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -31,7 +45,7 @@ stdenv.mkDerivation rec {
     homepage = "https://zsmith.co/bandwidth.html";
     description = "Artificial benchmark for identifying weaknesses in the memory subsystem";
     license = licenses.gpl2Plus;
-    platforms = platforms.x86;
+    platforms = platforms.x86 ++ platforms.arm ++ platforms.aarch64;
     maintainers = with maintainers; [ r-burns ];
   };
 }


### PR DESCRIPTION
add make flags needed for cross-compilation
tested on pkgsCross.{aarch64-multiplatform,armv7l-hf-multiplatform}

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
