### PR TITLE
aws-iot-securetunneling-localproxy: init at 2.0.1

### DIFF
--- a/pkgs/tools/virtualization/aws-iot-securetunneling-localproxy/cmake.patch
+++ b/pkgs/tools/virtualization/aws-iot-securetunneling-localproxy/cmake.patch
@@ -1,0 +1,52 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 007d79f..63389f9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -27,7 +27,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+ 
+ # Configure Compiler flags
+ if (UNIX OR APPLE)
+-    set(CUSTOM_COMPILER_FLAGS "-O2 -D_FORTIFY_SOURCE=2 -fPIE -Wall -Werror")
++    set(CUSTOM_COMPILER_FLAGS "-O2 -D_FORTIFY_SOURCE=2 -fPIE -Wall -Werror -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_LOG_DYN_LINK")
+     set(TEST_COMPILER_FLAGS "${CUSTOM_COMPILER_FLAGS} -D_AWSIOT_TUNNELING_NO_SSL")
+ elseif (WIN32 OR MSVC)
+     set(CUSTOM_COMPILER_FLAGS "/W4 /DYNAMICBASE /NXCOMPAT /analyze")
+@@ -66,15 +66,8 @@ find_package(Catch2 REQUIRED)
+ #########################################
+ # Boost dependencies                    #
+ #########################################
+-set_property(GLOBAL PROPERTY Boost_USE_STATIC_LIBS ON)
+-set_property(GLOBAL PROPERTY Boost_USE_DEBUG_RUNTIME OFF)
+-#set_property(GLOBAL PROPERTY Boost_USE_MULTITHREADED ON)
+-find_package(Boost 1.68.0 REQUIRED COMPONENTS system log log_setup thread program_options date_time filesystem)
++find_package(Boost 1.69.0 REQUIRED COMPONENTS system log log_setup thread program_options date_time filesystem)
+ include_directories(${Boost_INCLUDE_DIRS})
+-foreach(BOOST_LIB ${Boost_LIBRARIES})
+-    string(REPLACE ${CMAKE_SHARED_LIBRARY_SUFFIX} ${CMAKE_STATIC_LIBRARY_SUFFIX} BOOST_STATIC_LIB ${BOOST_LIB})
+-    list(APPEND Boost_STATIC_LIBRARIES ${BOOST_STATIC_LIB})
+-endforeach()
+ 
+ #########################################
+ # Target : Build aws-tunnel-local-proxy #
+@@ -98,7 +91,7 @@ endif()
+ target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} ${CMAKE_THREAD_LIBS_INIT})
+ target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} OpenSSL::SSL)
+ target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} OpenSSL::Crypto)
+-target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} ${Boost_STATIC_LIBRARIES})
++target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} ${Boost_LIBRARIES})
+ target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} ${Protobuf_LITE_STATIC_LIBRARY})
+ 
+ 
+@@ -106,10 +99,11 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
+ target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
+ target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} OpenSSL::SSL)
+ target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} OpenSSL::Crypto)
+-target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${Boost_STATIC_LIBRARIES})
++target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${Boost_LIBRARIES})
+ target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${Protobuf_LITE_STATIC_LIBRARY})
+ 
+ 
+ set_property(TARGET ${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${CUSTOM_COMPILER_FLAGS})
+ set_property(TARGET ${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${TEST_COMPILER_FLAGS})
+ 
++install(TARGETS ${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME})

--- a/pkgs/tools/virtualization/aws-iot-securetunneling-localproxy/default.nix
+++ b/pkgs/tools/virtualization/aws-iot-securetunneling-localproxy/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, cmake, boost, protobuf, openssl, catch2 }:
+
+stdenv.mkDerivation rec {
+  pname = "aws-iot-securetunneling-localproxy";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "aws-samples";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-WGAzf66TaDpzqbdDzP8wyaC89G8FOH0tgR4to+QtYEU=";
+  };
+
+  # The patch addresses several issues:
+  #  1. aws-iot-securetunneling-localproxy sources declare Boost dependency at 1.68.0. We have
+  #     1.69.0 at Nixpkgs currently. I've tested that the application works just fine when compiled
+  #     against 1.69.0, so the patch modifies build scripts to allow for it.
+  #  2. Current version of boost (1.69.0 at the moment of writing) emits warnings that break the
+  #     build. Workaround is to use `BOOST_ALLOW_DEPRECATED_HEADERS` and comes from
+  #     https://github.com/boostorg/random/issues/49
+  #  3. aws-iot-securetunneling-localproxy attemps to link to Boost Log library statically while
+  #     Nixpkgs builds it for dynamic linking. The patch switches linkage mode.
+  patches = [ ./cmake.patch ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost protobuf openssl catch2 ];
+
+  meta = with lib; {
+    description = "C++ implementation of a local proxy for the AWS IoT Secure Tunneling service";
+    homepage = "https://github.com/aws-samples/aws-iot-securetunneling-localproxy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ anton-dessiatov ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1884,6 +1884,8 @@ with pkgs;
 
   aws = callPackage ../tools/virtualization/aws { };
 
+  aws-iot-securetunneling-localproxy = callPackage ../tools/virtualization/aws-iot-securetunneling-localproxy { };
+
   aws_mturk_clt = callPackage ../tools/misc/aws-mturk-clt { };
 
   awstats = callPackage ../tools/system/awstats { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Using AWS IoT infrastructure for [secure tunneling](https://docs.aws.amazon.com/iot/latest/developerguide/local-proxy.html) requires an application to forward connections from local machine to IoT device in the fleet. This PR packages AWS sample application for doing so.

This application is pretty niche, but it was (and still is) useful for me so maybe someone else could benefit from it as well.

Package name is a bit mouthful but I've borrowed that from GitHub source repository name, so I guess it's okay to keep it to reduce ambiguity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
