### PR TITLE
flynt: init at 0.66

### DIFF
--- a/pkgs/development/python-modules/flynt/default.nix
+++ b/pkgs/development/python-modules/flynt/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
-    description = "flynt is a command line tool to automatically convert a project's Python code from old \"%-formatted\" and .format(...) strings into Python 3.6+'s \"f-strings\".";
+    description = "command line tool to automatically convert a project's Python code from old format style strings into Python 3.6+'s f-strings";
     homepage = "https://github.com/ikamensh/flynt";
     license = licenses.mit;
     maintainers = with maintainers; [ cpcloud ];

--- a/pkgs/development/python-modules/flynt/default.nix
+++ b/pkgs/development/python-modules/flynt/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, astor
+, pytestCheckHook
+}:
+buildPythonPackage rec {
+  pname = "flynt";
+  version = "0.66";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "ikamensh";
+    repo = "flynt";
+    rev = "v${version}";
+    hash = "sha256-DV433wqLjF5k4g8J7rj5gZfaw+Y4/TDOoFKo3eKDjZ4=";
+  };
+
+  propagatedBuildInputs = [ astor ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "flynt is a command line tool to automatically convert a project's Python code from old \"%-formatted\" and .format(...) strings into Python 3.6+'s \"f-strings\".";
+    homepage = "https://github.com/ikamensh/flynt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/development/python-modules/flynt/default.nix
+++ b/pkgs/development/python-modules/flynt/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ikamensh";
     repo = "flynt";
-    rev = "v${version}";
+    rev = version;
     hash = "sha256-DV433wqLjF5k4g8J7rj5gZfaw+Y4/TDOoFKo3eKDjZ4=";
   };
 

--- a/pkgs/development/python-modules/flynt/default.nix
+++ b/pkgs/development/python-modules/flynt/default.nix
@@ -5,6 +5,7 @@
 , astor
 , pytestCheckHook
 }:
+
 buildPythonPackage rec {
   pname = "flynt";
   version = "0.66";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2718,6 +2718,8 @@ in {
 
   flux-led = callPackage ../development/python-modules/flux-led { };
 
+  flynt = callPackage ../development/python-modules/flynt { };
+
   fn = callPackage ../development/python-modules/fn { };
 
   fnvhash = callPackage ../development/python-modules/fnvhash { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [`flynt`](https://github.com/ikamensh/flynt) to nixpkgs.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
