### PR TITLE
oha: init at 0.4.6

### DIFF
--- a/pkgs/tools/networking/oha/default.nix
+++ b/pkgs/tools/networking/oha/default.nix
@@ -1,0 +1,30 @@
+{ fetchFromGitHub, lib, pkg-config, rustPlatform, stdenv, openssl, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "oha";
+  version = "0.4.6";
+
+  src = fetchFromGitHub {
+    owner = "hatoo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vx8ki0wi9xil2iksvxzh8mhx4c5ikkhdcnc8mcwqn14cvjkggja";
+  };
+
+  cargoSha256 = "1nx2lvbjflsjma5q9ck6vq499hf75w91i4h8wlzr83wqk37i7rhc";
+
+  nativeBuildInputs = lib.optional stdenv.isLinux pkg-config;
+
+  buildInputs = lib.optional stdenv.isLinux openssl
+    ++ lib.optional stdenv.isDarwin Security;
+
+  # tests don't work inside the sandbox
+  doCheck = false;
+
+  meta = with lib; {
+    description = "HTTP load generator inspired by rakyll/hey with tui animation";
+    homepage = "https://github.com/hatoo/oha";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7708,6 +7708,10 @@ with pkgs;
 
   ocserv = callPackage ../tools/networking/ocserv { };
 
+  oha = callPackage ../tools/networking/oha {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   opencorsairlink = callPackage ../tools/misc/opencorsairlink { };
 
   openfpgaloader = callPackage ../development/embedded/fpga/openfpgaloader { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

oha is a tiny program that sends some load to a web application and show realtime tui inspired by rakyll/hey

`doCheck` is disabled, but simple test with miniserve on x86_64-linux works for me 

https://github.com/hatoo/oha

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
