### PR TITLE
liburing: 2.0 -> 2.1

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -4,21 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "liburing";
-  version = "2.0";
+  version = "2.1";
 
   src = fetchgit {
     url    = "http://git.kernel.dk/${pname}";
     rev    = "liburing-${version}";
-    sha256 = "0has1yd1ns5q5jgcmhrbgwhbwq0wix3p7xv3dyrwdf784p56izkn";
+    sha256 = "sha256-7wSpKqjIdQeOdsQu4xN3kFHV49n6qQ3xVbjUcY1tmas=";
   };
-
-  patches = [
-    # Fix build on 32-bit ARM
-    (fetchpatch {
-      url = "https://github.com/axboe/liburing/commit/808b6c72ab753bda0c300b5683cfd31750d1d49b.patch";
-      sha256 = "1x7a9c5a6rwhfsbjqmhbnwh2aiin6yylckrqdjbzljrprzf11wrd";
-    })
-  ];
 
   separateDebugInfo = true;
   enableParallelBuilding = true;


### PR DESCRIPTION
Signed-off-by: Austin Seipp <aseipp@pobox.com>

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
