### PR TITLE
joshuto: init at 0.9.0

### DIFF
--- a/pkgs/applications/misc/joshuto/default.nix
+++ b/pkgs/applications/misc/joshuto/default.nix
@@ -1,0 +1,31 @@
+{ fetchFromGitHub, lib, rustPlatform, stdenv, SystemConfiguration }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "joshuto";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "kamiyaa";
+    repo = pname;
+    rev = version;
+    sha256 = "08d6h7xwcgycw5bdzwwc6aaikcrw3yc7inkiydgml9q261kql7zl";
+    # upstream includes an outdated Cargo.lock that stops cargo from compiling
+    postFetch = ''
+      mkdir -p $out
+      tar xf $downloadedFile --strip=1 -C $out
+      substituteInPlace $out/Cargo.lock \
+        --replace 0.8.6 ${version}
+    '';
+  };
+
+  cargoSha256 = "1scrqm7fs8y7anfiigimj7y5rjxcc2qvrxiq8ai7k5cwfc4v1ghm";
+
+  buildInputs = lib.optional stdenv.isDarwin SystemConfiguration;
+
+  meta = with lib; {
+    description = "Ranger-like terminal file manager written in Rust";
+    homepage = "https://github.com/kamiyaa/joshuto";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6311,6 +6311,10 @@ with pkgs;
 
   jo = callPackage ../development/tools/jo { };
 
+  joshuto = callPackage ../applications/misc/joshuto {
+    inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
+  };
+
   jrnl = python3Packages.callPackage ../applications/misc/jrnl { };
 
   jsawk = callPackage ../tools/text/jsawk { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

joshuto is a ranger-like terminal file manager written in Rust

https://github.com/kamiyaa/joshuto

Related issue: https://github.com/NixOS/nixpkgs/issues/83554

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
