### PR TITLE
jitsi-meet: add passthru.updateScript for all jitsi server components

### DIFF
--- a/pkgs/misc/jitsi-meet-prosody/default.nix
+++ b/pkgs/misc/jitsi-meet-prosody/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     single-node-smoke-test = nixosTests.jitsi-meet;
   };
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "Prosody configuration for Jitsi Meet";
     longDescription = ''

--- a/pkgs/misc/jitsi-meet-prosody/update.sh
+++ b/pkgs/misc/jitsi-meet-prosody/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl pup common-updater-scripts
+
+set -eu -o pipefail
+
+version="$(curl https://download.jitsi.org/stable/ | \
+    pup 'a[href] text{}' | \
+    awk -F'[_-]' '/jitsi-meet-prosody/ {printf $4"\n"}' | \
+    sort -u | \
+    tail -n 1)"
+
+update-source-version jitsi-meet-prosody "$version"

--- a/pkgs/servers/jibri/default.nix
+++ b/pkgs/servers/jibri/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "JItsi BRoadcasting Infrastructure";
     longDescription = ''

--- a/pkgs/servers/jibri/update.sh
+++ b/pkgs/servers/jibri/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl pup common-updater-scripts
+
+set -eu -o pipefail
+
+version="$(curl https://download.jitsi.org/stable/ | \
+    pup 'a[href] text{}' | \
+    awk -F'[_-]' '/jibri/ {printf $2"-"$3"-"$4"\n"}' | \
+    sort -u | \
+    tail -n 1)"
+
+update-source-version jibri "$version"

--- a/pkgs/servers/jicofo/default.nix
+++ b/pkgs/servers/jicofo/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation {
     single-node-smoke-test = nixosTests.jitsi-meet;
   };
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "A server side focus component used in Jitsi Meet conferences";
     longDescription = ''

--- a/pkgs/servers/jicofo/update.sh
+++ b/pkgs/servers/jicofo/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl pup common-updater-scripts
+
+set -eu -o pipefail
+
+version="$(curl https://download.jitsi.org/stable/ | \
+    pup 'a[href] text{}' | \
+    awk -F'[_-]' '/jicofo/ {printf $2"-"$3"\n"}' | \
+    sort -u | \
+    tail -n 1)"
+
+update-source-version jicofo "$version"

--- a/pkgs/servers/jitsi-videobridge/default.nix
+++ b/pkgs/servers/jitsi-videobridge/default.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation {
     single-host-smoke-test = nixosTests.jitsi-meet;
   };
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "A WebRTC compatible video router";
     longDescription = ''

--- a/pkgs/servers/jitsi-videobridge/update.sh
+++ b/pkgs/servers/jitsi-videobridge/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl pup common-updater-scripts
+
+set -eu -o pipefail
+
+version="$(curl https://download.jitsi.org/stable/ | \
+    pup 'a[href] text{}' | \
+    awk -F'[_-]' '/jitsi-videobridge2/ {printf $3"-"$4"-"$5"\n"}' | \
+    sort -u | \
+    tail -n 1)"
+
+update-source-version jitsi-videobridge "$version"

--- a/pkgs/servers/web-apps/jitsi-meet/default.nix
+++ b/pkgs/servers/web-apps/jitsi-meet/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     single-host-smoke-test = nixosTests.jitsi-meet;
   };
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "Secure, Simple and Scalable Video Conferences";
     longDescription = ''

--- a/pkgs/servers/web-apps/jitsi-meet/update.sh
+++ b/pkgs/servers/web-apps/jitsi-meet/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl pup common-updater-scripts
+
+set -eu -o pipefail
+
+version="$(curl https://download.jitsi.org/stable/ | \
+    pup 'a[href] text{}' | \
+    awk -F'[_-]' '/jitsi-meet-web_/ {printf $4"\n"}' | \
+    sort -u | \
+    tail -n 1)"
+
+update-source-version jitsi-meet "$version"


### PR DESCRIPTION
Add a script to auto-update to the most recent stable version of
jitsi-videobridge.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
