### PR TITLE
jetbrains: 2021.2 -> 2021.2.1

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -242,12 +242,12 @@ in
 
   clion = buildClion rec {
     name = "clion-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.1"; /* updated by script */
     description  = "C/C++ IDE. New. Intelligent. Cross-platform";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/cpp/CLion-${version}.tar.gz";
-      sha256 = "0im14b52b6hgns964m946q68mvyaq8haldm92s9cn5azh8yg1arc"; /* updated by script */
+      sha256 = "0knl0ca15cj0nggyfhd7s0szxr2vp7xvvp3nna3mplssfn59zf9d"; /* updated by script */
     };
     wmClass = "jetbrains-clion";
     update-channel = "CLion RELEASE"; # channel's id as in http://www.jetbrains.com/updates/updates.xml
@@ -255,12 +255,12 @@ in
 
   datagrip = buildDataGrip rec {
     name = "datagrip-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.2"; /* updated by script */
     description = "Your Swiss Army Knife for Databases and SQL";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/datagrip/${name}.tar.gz";
-      sha256 = "17fzrn20mkldf74965c7abw3znyxskssdz1k4lciz6q7kn5cvdbf"; /* updated by script */
+      sha256 = "18dammsvd43x8cx0plzwgankmzfv7j79z0nsdagd540v99c2r2v3"; /* updated by script */
     };
     wmClass = "jetbrains-datagrip";
     update-channel = "DataGrip RELEASE";
@@ -268,12 +268,12 @@ in
 
   goland = buildGoland rec {
     name = "goland-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.2"; /* updated by script */
     description = "Up and Coming Go IDE";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/go/${name}.tar.gz";
-      sha256 = "15pxr9w4gs342g9in7a41x0cpb7z68y28hwsamk9ic7yz2qshps8"; /* updated by script */
+      sha256 = "0ayqvyd24klafm09kls4fdp2acqsvh0zhm4wsrmrshlpmdqd5vjk"; /* updated by script */
     };
     wmClass = "jetbrains-goland";
     update-channel = "GoLand RELEASE";
@@ -281,12 +281,12 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.1"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "1zki6myy3wbr1sgp1gli263y32g75gna2r9m7baa06zvc6c7j9vw"; /* updated by script */
+      sha256 = "1af43c51ryvqc7c9r3kz2266j0nvz50xw1vhfjbd74c3ycj8a1zz"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
     update-channel = "IntelliJ IDEA RELEASE";
@@ -294,12 +294,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.1"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}-no-jbr.tar.gz";
-      sha256 = "0gbx1ngf8i2a0dvysw5g0ikakq4a7gghb4rjk7c99jwzwq9hckjm"; /* updated by script */
+      sha256 = "1257a9d9h3ybdsnm74jmgzp1rfi1629gv9kr0w2nhmxj7ghhbx4w"; /* updated by script */
     };
     wmClass = "jetbrains-idea";
     update-channel = "IntelliJ IDEA RELEASE";
@@ -307,13 +307,13 @@ in
 
   mps = buildMps rec {
     name = "mps-${version}";
-    version = "2021.1.1"; /* updated by script */
+    version = "2021.1.3"; /* updated by script */
     versionMajorMinor = "2021.1"; /* updated by script */
     description = "Create your own domain-specific language";
     license = lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/mps/${versionMajorMinor}/MPS-${version}.tar.gz";
-      sha256 = "1gp9f4b57pr8c20qxcwax4l0d3w13x4lihxpb9z4agdqjafnc9l6"; /* updated by script */
+      sha256 = "0w1nchaa2d3z3mdp43mvifnbibl1ribyc98dm7grnwvrqk72pabf"; /* updated by script */
     };
     wmClass = "jetbrains-mps";
     update-channel = "MPS RELEASE";
@@ -321,12 +321,12 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.1"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "11lm7mja3mc2v329i830j8w1zymlz11sj86qvcg7s4pgc4xwnzd6"; /* updated by script */
+      sha256 = "1iqnq38d71wbl1iqhqr5as1802s53m3220vq4g42mdjgdj296bdk"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
     update-channel = "PhpStorm RELEASE";
@@ -334,12 +334,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.1"; /* updated by script */
     description = "PyCharm Community Edition";
     license = lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "075lb50g853791hj8ahhi88zbp07cvfs3zrdahvvif2nd121r1mx"; /* updated by script */
+      sha256 = "1z59yvk3wrqn0c9581vvv62wxf4fyybha426ipyqml8c405z27y4"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
     update-channel = "PyCharm RELEASE";
@@ -347,12 +347,12 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.1"; /* updated by script */
     description = "PyCharm Professional Edition";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "1l83a8wfqz4xddscpzf7v29rhq9ibx32ximcqrj1cw0i9v7qnv9g"; /* updated by script */
+      sha256 = "0sh9kdr53dhhq171p9lmsvci3qzlds4vzyqx12mzfvfs7svri1w2"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm";
     update-channel = "PyCharm RELEASE";
@@ -360,12 +360,12 @@ in
 
   rider = buildRider rec {
     name = "rider-${version}";
-    version = "2021.1.5"; /* updated by script */
+    version = "2021.2.1"; /* updated by script */
     description = "A cross-platform .NET IDE based on the IntelliJ platform and ReSharper";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/rider/JetBrains.Rider-${version}.tar.gz";
-      sha256 = "17mxqh6p9jby5qrjqaq5km0j8k1bp8061ch2j059ka3n4ycxy7ph"; /* updated by script */
+      sha256 = "1b5ih6q8kyds8px7gldfz1m9ap3kk27yswwxy1735c83094l2nlm"; /* updated by script */
     };
     wmClass = "jetbrains-rider";
     update-channel = "Rider RELEASE";
@@ -373,12 +373,12 @@ in
 
   ruby-mine = buildRubyMine rec {
     name = "ruby-mine-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.1"; /* updated by script */
     description = "The Most Intelligent Ruby and Rails IDE";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/ruby/RubyMine-${version}.tar.gz";
-      sha256 = "169jsd34l83n1pnrhzz548yn7ch1dzxpy8xck7vlymjgrxdqciwi"; /* updated by script */
+      sha256 = "09blnm6han2rmdvjbr1va081zndzvjr1i0m3njaiwcb9rf2axm32"; /* updated by script */
     };
     wmClass = "jetbrains-rubymine";
     update-channel = "RubyMine RELEASE";
@@ -386,12 +386,12 @@ in
 
   webstorm = buildWebStorm rec {
     name = "webstorm-${version}";
-    version = "2021.2"; /* updated by script */
+    version = "2021.2.1"; /* updated by script */
     description = "Professional IDE for Web and JavaScript development";
     license = lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webstorm/WebStorm-${version}.tar.gz";
-      sha256 = "1whikk1izzvhq1d7kaf2kn4j4qpxn7aq70hlbxr1kb7zs4mzy9x3"; /* updated by script */
+      sha256 = "12i9f5sw02gcgviflfs6gwmnxvzhgmm4v4447am0syl4nq8nyv1s"; /* updated by script */
     };
     wmClass = "jetbrains-webstorm";
     update-channel = "WebStorm RELEASE";


### PR DESCRIPTION
###### Motivation for this change
Latest Release

###### Things done
Run update.pl, checked phpstorm while daily driving it about a week now

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
