### PR TITLE
pcl: 1.12.0 propagation fix

### DIFF
--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -12,6 +12,7 @@
 , qtbase
 , libusb1
 , libpcap
+, libtiff
 , libXt
 , libpng
 , Cocoa
@@ -33,19 +34,23 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config cmake wrapQtAppsHook ];
   buildInputs = [
-    qhull
-    flann
-    boost
     eigen
     libusb1
     libpcap
-    libpng
-    vtk
     qtbase
     libXt
   ]
   ++ lib.optionals stdenv.isDarwin [ Cocoa AGL ]
   ++ lib.optionals withCuda [ cudatoolkit ];
+
+  propagatedBuildInputs = [
+    boost
+    flann
+    libpng
+    libtiff
+    qhull
+    vtk
+  ];
 
   cmakeFlags = lib.optionals stdenv.isDarwin [
     "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks"


### PR DESCRIPTION
###### Motivation for this change

When linking directly again PCL, the current setup seems to work fine, however, when linking to a library that links to PCL (for example, a tree of ROS packages in an external flake), you quickly end up in a situation where you have dangling links at runtime because patchelf drops them from the rpath, eg:

```
ldd /nix/store/phrrhk85gcd6xv34j4sh34q75znk17g5-cpr_slam_utils/lib/cpr_slam_utils/cache_map
        libpcl_segmentation.so.1.11 => /nix/store/l1xvb5a27bnqav41h9kpjbk9ngx4v6yi-pcl-1.11.1/lib/libpcl_segmentation.so.1.11 (0x00007f87d08f4000)
        libpcl_surface.so.1.11 => /nix/store/l1xvb5a27bnqav41h9kpjbk9ngx4v6yi-pcl-1.11.1/lib/libpcl_surface.so.1.11 (0x00007f87cfb5d000)
        libqhull_r.so.8.0 => not found
...
        libqhull_r.so.8.0 => /nix/store/rkdhlrlnh1i7r0mi68cnxhpp39x83jiz-qhull-2020.2/lib/libqhull_r.so.8.0 (0x00007fdecebda000)
```

This was also discussed on a Discourse post here: https://discourse.nixos.org/t/linker-chaos-with-regular-gcc-stdenv-and-cmake-packages/14936

###### Things done

The dependencies which we encountered as problematic have been moved to `propagateBuildInputs`. One note is that `libtiff` has been _added_ as a dependency; in reality `libtiff` and `libpng` should really be exported from `vtk`:

https://github.com/NixOS/nixpkgs/blob/26dedb83988154d3f6af3bcbba1a3bb9abe770e9/pkgs/development/libraries/vtk/generic.nix#L27

However, I got scared off trying to make a change there as it seems like there are a lot more flags and it seems like until recently some of those libraries might have been vendored in in that repo also? If people feel that it's valuable, I can make a separate PR to fix `vtk` and then that one can merge before this one and this one can avoid adding the explicit `libtiff` dependency.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

FYI @lopsided98 
