### PR TITLE
menyoki: init at 1.5.3

### DIFF
--- a/pkgs/applications/graphics/menyoki/default.nix
+++ b/pkgs/applications/graphics/menyoki/default.nix
@@ -1,0 +1,44 @@
+{ fetchFromGitHub
+, installShellFiles
+, lib
+, pkg-config
+, rustPlatform
+, stdenv
+, libX11
+, libXrandr
+, withSki ? true
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "menyoki";
+  version = "1.5.3";
+
+  src = fetchFromGitHub {
+    owner = "orhun";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "050c6c60il6cy0a8d3nw4z2cyp043912a7n4n44yjpmx047w7kc7";
+  };
+
+  cargoSha256 = "0wwcda2w8jg3q132cvhdgfmjc0rz93fx6fai93g5w8br98aq9qzx";
+
+  nativeBuildInputs = [ installShellFiles ]
+    ++ lib.optional stdenv.isLinux pkg-config;
+
+  buildInputs = lib.optionals stdenv.isLinux [ libX11 libXrandr ];
+
+  cargoBuildFlags = lib.optional (!withSki) "--no-default-features";
+
+  postInstall = ''
+    installManPage man/*
+    installShellCompletion completions/menyoki.{bash,fish,zsh}
+  '';
+
+  meta = with lib; {
+    description = "Screen{shot,cast} and perform ImageOps on the command line";
+    homepage = "https://menyoki.cli.rs/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ figsoda ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26072,6 +26072,10 @@ with pkgs;
 
   menumaker = callPackage ../applications/misc/menumaker { };
 
+  menyoki = callPackage ../applications/graphics/menyoki {
+    inherit (xorg) libX11 libXrandr;
+  };
+
   mercurial_4 = callPackage ../applications/version-management/mercurial/4.9.nix {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

menyoki is a screencast and screenshot utility that can also perform various image related operations such as making/splitting GIFs and modifying/analyzing/viewing image files

Currently broken on darwin, macos builds are currently [disabled on upstream](https://github.com/orhun/menyoki/blob/master/CHANGELOG.md#153---2021-08-22) since builds seem to hang

https://github.com/orhun/menyoki

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
