### PR TITLE
maintainers/scripts/haskell: Add r-deps information to build-report

### DIFF
--- a/maintainers/scripts/haskell/r-deps.nix
+++ b/maintainers/scripts/haskell/r-deps.nix
@@ -1,0 +1,11 @@
+let
+  pkgs = import ../../.. {};
+  inherit (pkgs) lib;
+  merge = attrs: nextName: attrs // { "${nextName}" = (attrs.${nextName} or 0) + 1; };
+  getDeps = _: pkg: builtins.filter (x: !isNull x) (map (x: x.pname or null) (pkg.propagatedBuildInputs or []));
+  isBroken = _: pkg: pkg.meta.broken or false;
+in
+  {
+    all = builtins.foldl' merge {} (lib.flatten (lib.mapAttrsToList getDeps pkgs.haskellPackages));
+    broken = builtins.foldl' merge {} (lib.flatten (lib.mapAttrsToList getDeps (lib.filterAttrs isBroken pkgs.haskellPackages)));
+  }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

We would like to sort and display the list of broken packages in our build-report (compare https://github.com/cdepillabout/nix-haskell-updates-status) to be sorted by the number of reverse dependencies that a package breaks.

I have written proof-of-concept nix code to calculate the necessary data. Only step missing is to actually use that information in the report script, but that won‘t be hard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
