### PR TITLE
bitmask-vpn: init at 0.21.6

### DIFF
--- a/pkgs/tools/networking/bitmask-vpn/default.nix
+++ b/pkgs/tools/networking/bitmask-vpn/default.nix
@@ -1,0 +1,168 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, mkDerivation
+, buildGoModule
+, wrapQtAppsHook
+, python3Packages
+, pkg-config
+, openvpn
+, cmake
+, qmake
+, which
+, iproute2
+, iptables
+, procps
+, qmltermwidget
+, qtbase
+, qtdeclarative
+, qtinstaller
+, qtquickcontrols
+, qtquickcontrols2
+, qttools
+, CoreFoundation
+, Security
+, provider ? "riseup"
+}:
+let
+  version = "0.21.6";
+
+  src = fetchFromGitLab {
+    domain = "0xacab.org";
+    owner = "leap";
+    repo = "bitmask-vpn";
+    rev = version;
+    sha256 = "sha256-LMz+ZgQVFGujoLA8rlyZ3VnW/NSlPipD5KwCe+cFtnY=";
+  };
+
+  # bitmask-root is only used on GNU/Linux
+  # and may one day be replaced by pkg/helper
+  bitmask-root = mkDerivation {
+    inherit src version;
+    sourceRoot = "source/helpers";
+    pname = "bitmask-root";
+    nativeBuildInputs = [ python3Packages.wrapPython ];
+    postPatch = ''
+      substituteInPlace bitmask-root \
+        --replace 'swhich("ip")' '"${iproute2}/bin/ip"' \
+        --replace 'swhich("iptables")' '"${iptables}/bin/iptables"' \
+        --replace 'swhich("ip6tables")' '"${iptables}/bin/ip6tables"' \
+        --replace 'swhich("sysctl")' '"${procps}/bin/sysctl"' \
+        --replace /usr/sbin/openvpn ${openvpn}/bin/openvpn
+      substituteInPlace se.leap.bitmask.policy \
+        --replace /usr/sbin/bitmask-root $out/bin/bitmask-root
+    '';
+    installPhase = ''
+      runHook preInstall
+
+      install -m 755 -D -t $out/bin bitmask-root
+      install -m 444 -D -t $out/share/polkit-1/actions se.leap.bitmask.policy
+      wrapPythonPrograms
+
+      runHook postInstall
+    '';
+  };
+in
+
+buildGoModule rec {
+  inherit src version;
+  pname = "${provider}-vpn";
+  vendorSha256 = null;
+
+  postPatch = ''
+    substituteInPlace pkg/pickle/helpers.go \
+      --replace /usr/share $out/share
+
+    # Using $PROVIDER is not working,
+    # thus replacing directly into the vendor.conf
+    substituteInPlace providers/vendor.conf \
+      --replace "provider = riseup" "provider = ${provider}"
+
+    patchShebangs gui/build.sh
+    wrapPythonProgramsIn branding/scripts
+  '' + lib.optionalString stdenv.isLinux ''
+    substituteInPlace pkg/helper/linux.go \
+      --replace /usr/sbin/openvpn ${openvpn}/bin/openvpn
+    substituteInPlace pkg/vpn/launcher_linux.go \
+      --replace /usr/sbin/openvpn ${openvpn}/bin/openvpn \
+      --replace /usr/sbin/bitmask-root ${bitmask-root}/bin/bitmask-root \
+      --replace /usr/bin/lxpolkit /run/wrappers/bin/polkit-agent-helper-1 \
+      --replace '"polkit-gnome-authentication-agent-1",' '"polkit-gnome-authentication-agent-1","polkitd",'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3Packages.wrapPython
+    qmake
+    qtquickcontrols
+    qtquickcontrols2
+    qttools
+    which
+    wrapQtAppsHook
+  ] ++ lib.optional (!stdenv.isLinux) qtinstaller;
+
+  buildInputs = [
+    qtbase
+    qmltermwidget
+    qtdeclarative
+  ] ++ lib.optionals stdenv.isDarwin [ CoreFoundation Security ];
+  # FIXME: building on Darwin currently fails
+  # due to missing debug symbols for Qt,
+  # this should be fixable once darwin.apple_sdk >= 10.13
+  # See https://bugreports.qt.io/browse/QTBUG-76777
+
+  # Not using buildGoModule's buildPhase:
+  # gui/build.sh will build Go modules into lib/libgoshim.a
+  buildPhase = ''
+    runHook preBuild
+
+    make gen_providers_json
+    make generate
+    # Remove timestamps in comments
+    sed -i -e '/^\/\//d' pkg/config/version/version.go
+
+    # Not using -j$NIX_BUILD_CORES because the Makefile's rules
+    # are not thread-safe: lib/libgoshim.h is used before being built.
+    make build
+
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    install -m 755 -D -t $out/bin build/qt/release/${provider}-vpn
+
+    VERSION=${version} VENDOR_PATH=providers branding/scripts/generate-debian branding/templates/debian/data.json
+    (cd branding/templates/debian && ${python3Packages.python}/bin/python3 generate.py)
+    install -m 444 -D branding/templates/debian/app.desktop $out/share/applications/${provider}-vpn.desktop
+  '' + lib.optionalString stdenv.isLinux ''
+    install -m 444 -D -t $out/share/polkit-1/actions ${bitmask-root}/share/polkit-1/actions/se.leap.bitmask.policy
+  '';
+
+  # Some tests need access to the Internet:
+  # Post "https://api.black.riseup.net/3/cert": dial tcp: lookup api.black.riseup.net on [::1]:53: read udp [::1]:56553->[::1]:53: read: connection refused
+  doCheck = false;
+
+  passthru = { inherit bitmask-root; };
+
+  meta = {
+    description = "Generic VPN client by LEAP";
+    longDescription = ''
+      Bitmask, by LEAP (LEAP Encryption Access Project),
+      is an application to provide easy and secure encrypted communication
+      with a VPN (Virtual Private Network). It allows you to select from
+      a variety of trusted service provider all from one app.
+      Current providers include Riseup Networks
+      and The Calyx Institute, where the former is default.
+      The <literal>${provider}-vpn</literal> executable should appear
+      in your desktop manager's XDG menu or could be launch in a terminal
+      to get an execution log. A new icon should then appear in your systray
+      to control the VPN and configure some options.
+    '';
+    homepage = "https://bitmask.net";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ julm ];
+    # darwin requires apple_sdk >= 10.13
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3949,6 +3949,11 @@ with pkgs;
 
   bluetooth_battery = python3Packages.callPackage ../applications/misc/bluetooth_battery { };
 
+  calyx-vpn = libsForQt5.callPackage ../tools/networking/bitmask-vpn {
+    provider = "calyx";
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+
   code-browser-qt = libsForQt5.callPackage ../applications/editors/code-browser { withQt = true;
                                                                                 };
   code-browser-gtk = callPackage ../applications/editors/code-browser { withGtk = true;
@@ -8391,6 +8396,11 @@ with pkgs;
 
   rig = callPackage ../tools/misc/rig {
     stdenv = gccStdenv;
+  };
+
+  riseup-vpn = libsForQt5.callPackage ../tools/networking/bitmask-vpn {
+    provider = "riseup";
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
   rocket = libsForQt5.callPackage ../tools/graphics/rocket { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Corresponding issue upstream: https://0xacab.org/leap/bitmask-vpn/-/issues/545

###### Motivation for this change
Being able to use `openvpn` through the graphical apps `riseup-vpn` (see https://riseup.net ) and/or `calyx-vpn` (see https://calyx.net ), both being instances of the https://bitmask.net tool by LEAP (LEAP Encryption Access Project).

Note that those rely upon the `bitmask-root` utility to setup the VPN, which currently only works with the `ip_tables` and `ip6_tables` kernel modules, not with `nf_tables`.

Note also that testing should be done by installing those packages via `environment.systemPackages = [ pkgs.riseup-vpn pkgs.calyx-vpn ];` in order to let NixOS install `bitmask-root`'s `polkit` action into `/run/current-system/sw/share/polkit-1/actions/`.

#### Testing this PR
Because those packages need to register a `polkit` action, they are not readily testable from `nixpkgs-review pr 137242` as one would expect. Instead, on NixOS, you can put this stanza in your `configuration.nix`:

```
environment.systemPackages = [
  (pkgs.libsForQt5.callPackage
    (pkgs.fetchurl {
      url = "https://raw.githubusercontent.com/ju1m/nixpkgs/bitmask/pkgs/tools/networking/bitmask-vpn/default.nix";
      hash = "sha256-mkHwuf1roF8BMORHR8bbe7wfFwPyk0NJgC/Q6KlE5jU";
      # This hash may change in case I update this PR, I'll update it in this intro message;
      # otherwise uncomment the fakeHash line and comment the line above
      # to force the fetching of the url again and get the latest hash of its content.
      #hash = lib.fakeHash;
    }) {
      provider = "riseup" /* or "calyx" */;
      inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation Security;
    })
];
```
Then, after a `nixos-rebuild switch`, run `riseup-vpn` (resp. `calyx-vpn`).

###### Things done
- [X] Package https://0xacab.org/leap/bitmask-vpn
- [X] Test by running `riseup-vpn` from a console and using the systray menu.
- [ ] Darwin support.
```
$ riseup-vpn 
QSystemTrayIcon::setVisible: No Icon set
qrc:/qml/main.qml:41:9: QML QQuickItem: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
qrc:/qml/main.qml:108:9: QML QQuickItem: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
qrc:/qml/main.qml:177:9: QML BridgesItem: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
qml: Platform: linux
qml: DEBUG: Pre-seeded providers:
qml: {
    "default": "riseup",
    "providers": [
        {
            "apiURL": "https://api.black.riseup.net/",
            "applicationName": "RiseupVPN",
            "askForDonations": "true",
            "auth": "anon",
            "authEmptyPass": "false",
            "binaryName": "riseup-vpn",
            "caCertString": "-----BEGIN CERTIFICATE-----\nMIIFjTCCA3WgAwIBAgIBATANBgkqhkiG9w0BAQ0FADBZMRgwFgYDVQQKDA9SaXNl\ndXAgTmV0d29ya3MxGzAZBgNVBAsMEmh0dHBzOi8vcmlzZXVwLm5ldDEgMB4GA1UE\nAwwXUmlzZXVwIE5ldHdvcmtzIFJvb3QgQ0EwHhcNMTQwNDI4MDAwMDAwWhcNMjQw\nNDI4MDAwMDAwWjBZMRgwFgYDVQQKDA9SaXNldXAgTmV0d29ya3MxGzAZBgNVBAsM\nEmh0dHBzOi8vcmlzZXVwLm5ldDEgMB4GA1UEAwwXUmlzZXVwIE5ldHdvcmtzIFJv\nb3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQC76J4ciMJ8Sg0m\nTP7DF2DT9zNe0Csk4myoMFC57rfJeqsAlJCv1XMzBmXrw8wq/9z7XHv6n/0sWU7a\n7cF2hLR33ktjwODlx7vorU39/lXLndo492ZBhXQtG1INMShyv+nlmzO6GT7ESfNE\nLliFitEzwIegpMqxCIHXFuobGSCWF4N0qLHkq/SYUMoOJ96O3hmPSl1kFDRMtWXY\niw1SEKjUvpyDJpVs3NGxeLCaA7bAWhDY5s5Yb2fA1o8ICAqhowurowJpW7n5ZuLK\n5VNTlNy6nZpkjt1QycYvNycffyPOFm/Q/RKDlvnorJIrihPkyniV3YY5cGgP+Qkx\nHUOT0uLA6LHtzfiyaOqkXwc4b0ZcQD5Vbf6Prd20Ppt6ei0zazkUPwxld3hgyw58\nm/4UIjG3PInWTNf293GngK2Bnz8Qx9e/6TueMSAn/3JBLem56E0WtmbLVjvko+LF\nPM5xA+m0BmuSJtrD1MUCXMhqYTtiOvgLBlUm5zkNxALzG+cXB28k6XikXt6MRG7q\nhzIPG38zwkooM55yy5i1YfcIi5NjMH6A+t4IJxxwb67MSb6UFOwg5kFokdONZcwj\nshczHdG9gLKSBIvrKa03Nd3W2dF9hMbRu//STcQxOailDBQCnXXfAATj9pYzdY4k\nha8VCAREGAKTDAex9oXf1yRuktES4QIDAQABo2AwXjAdBgNVHQ4EFgQUC4tdmLVu\nf9hwfK4AGliaet5KkcgwDgYDVR0PAQH/BAQDAgIEMAwGA1UdEwQFMAMBAf8wHwYD\nVR0jBBgwFoAUC4tdmLVuf9hwfK4AGliaet5KkcgwDQYJKoZIhvcNAQENBQADggIB\nAGzL+GRnYu99zFoy0bXJKOGCF5XUXP/3gIXPRDqQf5g7Cu/jYMID9dB3No4Zmf7v\nqHjiSXiS8jx1j/6/Luk6PpFbT7QYm4QLs1f4BlfZOti2KE8r7KRDPIecUsUXW6P/\n3GJAVYH/+7OjA39za9AieM7+H5BELGccGrM5wfl7JeEz8in+V2ZWDzHQO4hMkiTQ\n4ZckuaL201F68YpiItBNnJ9N5nHr1MRiGyApHmLXY/wvlrOpclh95qn+lG6/2jk7\n3AmihLOKYMlPwPakJg4PYczm3icFLgTpjV5sq2md9bRyAg3oPGfAuWHmKj2Ikqch\nTd5CHKGxEEWbGUWEMP0s1A/JHWiCbDigc4Cfxhy56CWG4q0tYtnc2GMw8OAUO6Wf\nXu5pYKNkzKSEtT/MrNJt44tTZWbKV/Pi/N2Fx36my7TgTUj7g3xcE9eF4JV2H/sg\ntsK3pwE0FEqGnT4qMFbixQmc8bGyuakr23wjMvfO7eZUxBuWYR2SkcP26sozF9PF\ntGhbZHQVGZUTVPyvwahMUEhbPGVerOW0IYpxkm0x/eaWdTc4vPpf/rIlgbAjarnJ\nUN9SaWRlWKSdP4haujnzCoJbM7dU9bjvlGZNyXEekgeT0W2qFeGGp+yyUWw8tNsp\n0BuC1b7uW/bBn/xKm319wXVDvBgZgcktMolak39V7DVO\n-----END CERTIFICATE-----",
            "donateURL": "https://riseup.net/vpn/donate",
            "geolocationAPI": "https://api.black.riseup.net:9001/json",
            "helpURL": "https://riseup.net/support",
            "name": "Riseup",
            "providerURL": "riseup.net",
            "timeStamp": "2021-09-10 01:55:47",
            "tosURL": "https://riseup.net/tos"
        }
    ]
}

qml: systray init completed
qml: show systray
2021/09/10 04:30:29 Client expects anon auth
2021/09/10 04:30:29 firewall stop
2021/09/10 04:30:30 Fetching gateways...
2021/09/10 04:30:31 Got sorted gateways: [zarapito.riseup.net hirondelle.riseup.net mouette.riseup.net hoatzin.riseup.net pie.riseup.net fournier.riseup.net hornero.riseup.net mockingjay.riseup.net shag.riseup.net redshank.riseup.net gaei.riseup.net yal.riseup.net starling.riseup.net limpkin.riseup.net crane.riseup.net garza.riseup.net]
2021/09/10 04:30:41 Fetching certificate to /tmp/leap-759395263/openvpn.pem
2021/09/10 04:30:42 DEBUG We have a valid cert: /tmp/leap-759395263/openvpn.pem
2021/09/10 04:30:42 Got sorted gateways: [zarapito.riseup.net fournier.riseup.net pie.riseup.net mouette.riseup.net hoatzin.riseup.net hirondelle.riseup.net mockingjay.riseup.net redshank.riseup.net shag.riseup.net hornero.riseup.net yal.riseup.net gaei.riseup.net starling.riseup.net crane.riseup.net limpkin.riseup.net garza.riseup.net]
2021/09/10 04:30:43 Got sorted gateways: [hoatzin.riseup.net pie.riseup.net zarapito.riseup.net mouette.riseup.net fournier.riseup.net hirondelle.riseup.net hornero.riseup.net redshank.riseup.net shag.riseup.net mockingjay.riseup.net gaei.riseup.net yal.riseup.net starling.riseup.net crane.riseup.net limpkin.riseup.net garza.riseup.net]
2021/09/10 04:30:43 firewall start
2021/09/10 04:30:43 openvpn start:  [--tun-ipv6 --auth SHA1 --cipher AES-128-CBC --keepalive 10 30 --tls-cipher DHE-RSA-AES128-SHA --remote 212.83.143.67 443 tcp4 --remote 212.83.146.228 443 tcp4 --remote 212.129.62.247 443 tcp4 --verb 3 --management-client --management 127.0.0.1 6061 --ca /tmp/leap-759395263/cacert.pem --cert /tmp/leap-759395263/openvpn.pem --key /tmp/leap-759395263/openvpn.pem --persist-tun]
2021/09/10 04:30:43 New connection into the management
2021/09/10 04:30:43 Event: INFO: OpenVPN Management Interface Version 3 -- type 'help' for more info
2021/09/10 04:30:43 Event: AUTH
2021/09/10 04:30:45 Event: GET_CONFIG
2021/09/10 04:30:45 Event: ASSIGN_IP: 10.41.0.9
2021/09/10 04:30:45 Event: CONNECTED: 212.83.143.67
2021/09/10 04:30:45 Connected to gateway: hoatzin.riseup.net
```
- [X] Test by running `calyx-vpn` from a console and using the systray.
There seems to be a mismatch in the certificate with the geolocation service, but mounting the VPN works nonetheless.
```
$ calyx-vpn 
QSystemTrayIcon::setVisible: No Icon set
qrc:/qml/main.qml:41:9: QML QQuickItem: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
qrc:/qml/main.qml:108:9: QML QQuickItem: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
qrc:/qml/main.qml:177:9: QML BridgesItem: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
qml: Platform: linux
qml: DEBUG: Pre-seeded providers:
qml: {
    "default": "calyx",
    "providers": [
        {
            "apiURL": "https://api.calyx.net:4430/",
            "applicationName": "CalyxVPN",
            "askForDonations": "true",
            "auth": "anon",
            "authEmptyPass": "false",
            "binaryName": "calyx-vpn",
            "caCertString": "-----BEGIN CERTIFICATE-----\nMIIFYzCCA0ugAwIBAgIBATANBgkqhkiG9w0BAQ0FADBEMQ4wDAYDVQQKDAVjYWx5\neDEaMBgGA1UECwwRaHR0cHM6Ly9jYWx5eC5uZXQxFjAUBgNVBAMMDWNhbHl4IFJv\nb3QgQ0EwHhcNMTMwNzAyMDAwMDAwWhcNMjMwNzAyMDAwMDAwWjBEMQ4wDAYDVQQK\nDAVjYWx5eDEaMBgGA1UECwwRaHR0cHM6Ly9jYWx5eC5uZXQxFjAUBgNVBAMMDWNh\nbHl4IFJvb3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDupdnx\nBgat537XOqrZOulE/RvjoXB1S07sy9/MMtksXFoQuWJZRCSTp1Jaqg3H/e9o1nct\nLQO91+izfJe07TUyajFl7CfllYgMeyKTYcT85dFwNX4pcIHZr8UpmO0MpGBoR4W1\n8cPa3vxAG0CsyUmrASJVyhRouk4qazRosM5RwBxTdMzCK7L3SwqPQoxlY9YmRJlD\nXYZlK5VMJd0dj9XxhMeFs5n43R0bsDENryrExSbuxoNfnUoQg3wffKk+Z0gW7YgW\nivPsbObqOgXUuBEU0xr9xMNBpU33ffLIsccrHq1EKp8zGfCOcww6v7+zEadUkVLo\n6j/rRhYYgRw9lijZG1rMuV/mTGnUqbjHsdoz5mzkFFWeTSqo44lvhveUyCcwRNmi\n2sjS77l0fCTzfreufffFoOEcRVMRfsnJdu/xPeARoXILEx8nQ421mSn6spOZlDQr\nTt0T0BAWt+VNc+m0IGSW3SwS7r5MUyQ/M5GrbQBGi5W2SzPriKZ79YTOwPVmXKLZ\nvJoEuKRDkEPJLBAhcD5oSQljOm/Wp/hjmRH4HnI1y4XMshWlDsyRDB1Au5yrsfwN\nnoFVSskEcbXlZfNgml4lktLBqz+qwsw+voq6Ak7ROKbc0ii5s8+iNMbAtIK7GcFF\nkuKKIyRmmGlDim/SDhlNdWo7Ah4Akde7zfWufwIDAQABo2AwXjAdBgNVHQ4EFgQU\nAY8+K4ZupAQ+L9ttFJG3vaLBq5gwDgYDVR0PAQH/BAQDAgIEMAwGA1UdEwQFMAMB\nAf8wHwYDVR0jBBgwFoAUAY8+K4ZupAQ+L9ttFJG3vaLBq5gwDQYJKoZIhvcNAQEN\nBQADggIBAOpXi5o3g/2o2rPa53iG7Zgcy8RpePGgZk6xknGYWeLamEqSh+XWQZ2w\n2kQP54bf8HfPj3ugJBWsVtYAs/ltJwzeBfYDrwEJd1N8tw2IRuGlQOWiTAVVLBj4\nZs+dikSuMoA399f/7BlUIEpVLUiV/emTtbkjFnDeKEV9zql6ypR0BtR8Knf8ALvL\nYfMsWLvTe4rXeypzxIaE2pn8ttcXLYAX0ml2MofTi5xcDhMn1vznKIvs82xhncQx\nI1MJMWqPHNHgJUJpA+y1IFh5LPbpag9PKQ0yQ9sM+/dyGumF2jElsMw71flh/Txr\n2dEv8+FNV1pPK26XJZBK24rNWFs30eAFfH9EQCwVla174I4PDoWqsIR7vtQMObDt\nBq34R3TjjJJIt2sCSlYLooWwiK7Q+d/SgYqA+MSDmmwhzm86ToK6cwbCsvuw1AxR\nX6VIs4U8wOotgljzX/CSpKqlxcqZjhnAuelZ1+KiN8RHKPj7AzSLYOv/YwTjLTIq\nEOxquoNR58uDa5pBG22a7xWbSaKosn/mEl8SrUr6klzzc8Vh09IMoxrw74uLdAg2\n1jnrhm7qg91Ttb0aXiqbV+Kg/qQzojdewnnoBFnv4jaQ3y8zDCfMhsBtWlWz4Knb\nZqga1WyRm3Gj1j6IV0oOincYMrw5YA7bgXpwop/Lo/mmliMA14ps\n-----END CERTIFICATE-----",
            "donateURL": "",
            "geolocationAPI": "https://api.black.riseup.net:9001/json",
            "helpURL": "https://calyx.net/support",
            "name": "Calyx",
            "providerURL": "https://calyx.net",
            "timeStamp": "2021-09-10 02:18:57",
            "tosURL": "https://calyx.net/tos"
        }
    ]
}

qml: systray init completed
qml: show systray
2021/09/10 05:23:40 Client expects anon auth
2021/09/10 05:23:40 firewall stop
2021/09/10 05:23:40 Fetching gateways...
2021/09/10 05:23:42 ERROR: could not fetch geolocation: Post "https://api.black.riseup.net:9001/json": x509: certificate signed by unknown authority
2021/09/10 05:23:58 Fetching certificate to /tmp/leap-097269187/openvpn.pem
2021/09/10 05:23:59 DEBUG We have a valid cert: /tmp/leap-097269187/openvpn.pem
2021/09/10 05:24:00 ERROR: could not fetch geolocation: Post "https://api.black.riseup.net:9001/json": x509: certificate signed by unknown authority
2021/09/10 05:24:01 ERROR: could not fetch geolocation: Post "https://api.black.riseup.net:9001/json": x509: certificate signed by unknown authority
2021/09/10 05:24:01 firewall start
2021/09/10 05:24:02 openvpn start:  [--tls-cipher DHE-RSA-AES128-SHA --tun-ipv6 --auth SHA1 --cipher AES-128-CBC --keepalive 10 30 --remote 162.247.73.193 443 tcp4 --verb 3 --management-client --management 127.0.0.1 6061 --ca /tmp/leap-097269187/cacert.pem --cert /tmp/leap-097269187/openvpn.pem --key /tmp/leap-097269187/openvpn.pem --persist-tun]
2021/09/10 05:24:02 New connection into the management
2021/09/10 05:24:02 Event: INFO: OpenVPN Management Interface Version 3 -- type 'help' for more info
2021/09/10 05:24:02 Event: AUTH
2021/09/10 05:24:08 Event: GET_CONFIG
2021/09/10 05:24:08 Event: ASSIGN_IP: 10.41.2.64
2021/09/10 05:24:08 Event: CONNECTED: 162.247.73.193
2021/09/10 05:24:08 Connected to gateway: vpn2.calyx.net
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
