### PR TITLE
k4dirstat: 3.2.2 -> 3.3.0

### DIFF
--- a/pkgs/applications/misc/k4dirstat/default.nix
+++ b/pkgs/applications/misc/k4dirstat/default.nix
@@ -7,21 +7,29 @@
 , kjobwidgets
 , kxmlgui
 , lib
+, testVersion
+, k4dirstat
 }:
 
 mkDerivation rec {
   pname = "k4dirstat";
-  version = "3.2.2";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "jeromerobert";
     repo = pname;
     rev = version;
-    sha256 = "sha256-U5p/gW5GPxRoM9XknP8G7iVhLDoqmvgspeRsmCRdxDg=";
+    hash = "sha256-KLvWSDv4x0tMhAPqp8yNQed2i7R0MPbvadHddSJ1Nx4=";
   };
 
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kiconthemes kio kjobwidgets kxmlgui ];
+
+  passthru.tests.version =
+    testVersion {
+      package = k4dirstat;
+      command = "k4dirstat -platform offscreen --version &>/dev/stdout";
+    };
 
   meta = with lib; {
     homepage = "https://github.com/jeromerobert/k4dirstat";


### PR DESCRIPTION
###### Motivation for this change

Refresh the tree after deleting a file ([#38](https://github.com/jeromerobert/k4dirstat/issues/38)) and preparations for the next major Qt & KDE versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).