### PR TITLE
pythonPackages.glfw: init at 2.2.0

### DIFF
--- a/pkgs/development/python-modules/glfw/default.nix
+++ b/pkgs/development/python-modules/glfw/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub, glfw3 }:
+
+buildPythonPackage rec {
+  pname = "glfw";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "FlorianRhiem";
+    repo = "pyGLFW";
+    rev = "v${version}";
+    sha256 = "1ygcwnh0x07yi87wkxykw566g74vfi8n0w2rzypidhdss14x3pvf";
+  };
+
+  # Patch path to GLFW shared object
+  patches = [ ./search-path.patch ];
+  postPatch = ''
+    substituteInPlace glfw/library.py --replace "@GLFW@" '${glfw3}/lib'
+  '';
+  propagatedBuildInputs = [ glfw3 ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "glfw" ];
+
+  meta = with lib; {
+    description = "Python bindings for GLFW";
+    homepage = "https://github.com/FlorianRhiem/pyGLFW";
+    license = licenses.mit;
+    maintainers = [ maintainers.McSinyx ];
+  };
+}

--- a/pkgs/development/python-modules/glfw/search-path.patch
+++ b/pkgs/development/python-modules/glfw/search-path.patch
@@ -1,0 +1,11 @@
+diff --git a/glfw/library.py b/glfw/library.py
+index 20387e1..9bdd62a 100644
+--- a/glfw/library.py
++++ b/glfw/library.py
+@@ -189,5 +189,4 @@ elif sys.platform == 'win32':
+         except OSError:
+             pass
+ else:
+-    glfw = _load_library(['glfw', 'glfw3'], ['.so', '.dylib'],
+-                          _get_library_search_paths(), _glfw_get_version)
++    glfw = _load_library(['glfw', 'glfw3'], ['.so', '.dylib'], ['@GLFW@'], _glfw_get_version)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2951,6 +2951,8 @@ in {
 
   glcontext = callPackage ../development/python-modules/glcontext { };
 
+  glfw = callPackage ../development/python-modules/glfw { };
+
   glob2 = callPackage ../development/python-modules/glob2 { };
 
   globre = callPackage ../development/python-modules/globre { };


### PR DESCRIPTION
###### Motivation for this change

I use GLFW in a Python game.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
