### PR TITLE
llvmPackages_13, llvmPackages_git: libcxxabi: fix musl build

### DIFF
--- a/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxxabi/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   postUnpack = lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
-  '' + lib.optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -d libcxx -i ${../../libcxx-0001-musl-hacks.patch}
   '' + lib.optionalString stdenv.hostPlatform.isWasm ''
     patch -p1 -d llvm -i ${./wasm.patch}
   '';

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   postUnpack = lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
-  '' + lib.optionalString stdenv.hostPlatform.isMusl ''
-    patch -p1 -d libcxx -i ${../../libcxx-0001-musl-hacks.patch}
   '' + lib.optionalString stdenv.hostPlatform.isWasm ''
     patch -p1 -d llvm -i ${./wasm.patch}
   '';


### PR DESCRIPTION
###### Motivation for this change

Building `pkgsCross.musl64.llvmPackages_13.libcxxabi` results in a patching error:

```
libcxxabi-x86_64-unknown-linux-musl> unpacking sources
libcxxabi-x86_64-unknown-linux-musl> unpacking source archive /nix/store/7ka6s7rmckayjp3kq60lh81llwzcq2rd-source
libcxxabi-x86_64-unknown-linux-musl> source root is source/libcxxabi
libcxxabi-x86_64-unknown-linux-musl> patch: **** Can't change to directory libcxx : No such file or directory
```

Comparing libcxxabi 12 and 13 Nix files, it seems that the line:
```
patch -p1 -d libcxx -i ${../../libcxx-0001-musl-hacks.patch}
```
is not needed anymore: for LLVM 12 the patch is applied in both libcxx and libcxxabi derivations, but for LLVM 13 libcxxabi just refers to already patched include files (via cmake flag `"-DLIBCXXABI_LIBCXX_INCLUDES=${libcxx.dev}/include/c++/v1"`). So simple removal of the line fixes the build.

The same problem applies to llvmPackages_git.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
