### PR TITLE
python3Packages.deprecated: 1.2.12 -> 1.2.13

### DIFF
--- a/pkgs/development/python-modules/deprecated/default.nix
+++ b/pkgs/development/python-modules/deprecated/default.nix
@@ -2,24 +2,32 @@
 , fetchPypi
 , buildPythonPackage
 , wrapt
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
-  pname = "Deprecated";
+  pname = "deprecated";
   version = "1.2.13";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "Deprecated";
+    inherit version;
     sha256 = "sha256-Q6xTNdqQwxwkugKK9TapHUHVP55pAd2wIbzFcs5E440=";
   };
 
-  propagatedBuildInputs = [ wrapt ];
-  checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+    wrapt
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "deprecated" ];
+
   meta = with lib; {
     homepage = "https://github.com/tantale/deprecated";
     description = "Python @deprecated decorator to deprecate old python classes, functions or methods";
-    platforms = platforms.all;
     license = licenses.mit;
     maintainers = with maintainers; [ tilpner ];
   };

--- a/pkgs/development/python-modules/deprecated/default.nix
+++ b/pkgs/development/python-modules/deprecated/default.nix
@@ -1,12 +1,17 @@
-{ lib, fetchPypi, buildPythonPackage, wrapt, pytest }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, wrapt
+, pytest
+}:
 
 buildPythonPackage rec {
   pname = "Deprecated";
-  version = "1.2.12";
+  version = "1.2.13";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6d2de2de7931a968874481ef30208fd4e08da39177d61d3d4ebdf4366e7dbca1";
+    sha256 = "sha256-Q6xTNdqQwxwkugKK9TapHUHVP55pAd2wIbzFcs5E440=";
   };
 
   propagatedBuildInputs = [ wrapt ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.2.13

Change log: https://github.com/tantale/deprecated/releases/tag/v1.2.13

- Switch to `pytestCheckHook`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
