### PR TITLE
python3Packages.aiohttp-swagger: 1.0.5 -> 1.0.15

### DIFF
--- a/pkgs/development/python-modules/aiohttp-swagger/default.nix
+++ b/pkgs/development/python-modules/aiohttp-swagger/default.nix
@@ -2,27 +2,46 @@
 , buildPythonPackage
 , fetchFromGitHub
 , aiohttp
-, flake8
 , jinja2
-, pytestCheckHook
+, markupsafe
 , pytest-aiohttp
+, pytestCheckHook
+, pythonOlder
 , pyyaml
 }:
 
 buildPythonPackage rec {
   pname = "aiohttp-swagger";
-  version = "1.0.5";
+  version = "1.0.15";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "cr0hn";
     repo = pname;
-    rev = "5a59e86f8c5672d2cc97dd35dc730c2f809d95ce"; # corresponds to 1.0.5 on PyPi, no tag on GitHub
-    sha256 = "1vpfk5b3f7s9qzr2q48g776f39xzqppjwm57scfzqqmbldkk5nv7";
+    rev = version;
+    sha256 = "sha256-M43sNpbXWXFRTd549cZhvhO35nBB6OH+ki36BzSk87Q=";
   };
 
-  propagatedBuildInputs = [ aiohttp jinja2 pyyaml ];
+  propagatedBuildInputs = [
+    aiohttp
+    jinja2
+    markupsafe
+    pyyaml
+  ];
 
-  checkInputs = [ flake8 pytestCheckHook pytest-aiohttp ];
+  checkInputs = [
+    pytestCheckHook
+    pytest-aiohttp
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "markupsafe~=1.1.1" "markupsafe>=1.1.1" \
+      --replace "jinja2~=2.11.2" "jinja2>=2.11.2"
+  '';
+
+  pythonImportsCheck = [ "aiohttp_swagger" ];
 
   meta = with lib; {
     description = "Swagger API Documentation builder for aiohttp";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.0.15

Change log: https://github.com/cr0hn/aiohttp-swagger/blob/master/CHANGELOG 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
