### PR TITLE
prisma: #135934 follow-up corrections

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -273,7 +273,7 @@ let
         wrapProgram "$out/bin/prisma" \
           --prefix PRISMA_MIGRATION_ENGINE_BINARY : "${prisma-engines}/bin/migration-engine" \
           --prefix PRISMA_QUERY_ENGINE_BINARY : "${prisma-engines}/bin/query-engine" \
-          --prefix PRISMA_QUERY_ENGINE_LIBRARY : "${lib.getLib prisma-engines}/libquery_engine.so.node"
+          --prefix PRISMA_QUERY_ENGINE_LIBRARY : "${lib.getLib prisma-engines}/libquery_engine.so.node" \
           --prefix PRISMA_INTROSPECTION_ENGINE_BINARY : "${prisma-engines}/bin/introspection-engine" \
           --prefix PRISMA_FMT_BINARY : "${prisma-engines}/bin/prisma-fmt"
       '';

--- a/pkgs/development/tools/database/prisma-engines/default.nix
+++ b/pkgs/development/tools/database/prisma-engines/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     owner = "prisma";
     repo = "prisma-engines";
     rev = version;
-    sha256 = "sha256-i4r+TRC8454awbqe35Kg3M9xN2NnP8Sbd/dITtm9MDg=";
+    sha256 = "sha256-39+pEjve7evxcjcBK1JLTRNNjfUMoCgSgtYcdJ3zIKE=";
   };
 
   cargoPatches = [
@@ -27,8 +27,6 @@ rustPlatform.buildRustPackage rec {
   OPENSSL_NO_VENDOR = 1;
 
   cargoSha256 = "sha256-BldEj8+tzY0dIA/fdrPLsFn3ZdfoGq6GsomCUhQBoLM=";
-
-  outputs = [ "out" "lib" "bin" ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl protobuf ];
@@ -45,7 +43,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   postInstall = ''
-    cp target/release/libquery_engine.so $out/lib/libquery_engine.so.node
+    cp target/x86_64-unknown-linux-gnu/release/libquery_engine.so $out/lib/libquery_engine.so.node
   '';
 
   # Tests are long to compile


### PR DESCRIPTION
###### Motivation for this change

#135934 was incomplete:
* `prisma-engines` actually fails to build
* and so did `nodePackages.prisma`
cc @mohe2015 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
