### PR TITLE
python3Packages.unidecode: 1.2.0 -> 1.3.1

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -35,7 +35,6 @@ let
         (mkOverride "markupsafe" "1.1.1" "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b")
         (mkOverride "sarge" "0.1.5.post0" "1c1ll7pys9vra5cfi8jxlgrgaql6c27l6inpy15aprgqhc4ck36s")
         (mkOverride "tornado" "5.1.1" "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409")
-        (mkOverride "unidecode" "0.04.21" "280a6ab88e1f2eb5af79edff450021a0d3f0448952847cd79677e55e58bad051")
 
         # Requires flask<2, cannot mkOverride because tests need to be disabled
         (
@@ -65,7 +64,20 @@ let
           }
         )
 
-
+        # Requires unidecode>=0.04.14,<0.05. Upstream changed the source naming between releases
+        (
+          self: super: {
+            unidecode = super.unidecode.overridePythonAttrs (oldAttrs: rec {
+              version = "0.04.21";
+              src = fetchFromGitHub {
+                owner = "avian2";
+                repo = "unidecode";
+                rev = "release-${version}";
+                sha256 = "0p5bkibv0xm1265dlfrz3zq3k9bbx07gl8zyq8mvvb8hi7p5lifg";
+              };
+            });
+          }
+        )
 
         # Requires websocket-client <1.0, >=0.57. Cannot do mkOverride b/c differing underscore/hyphen in pypi source name
         (

--- a/pkgs/development/python-modules/unidecode/default.nix
+++ b/pkgs/development/python-modules/unidecode/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "Unidecode";
-  version = "1.2.0";
+  version = "1.3.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8d73a97d387a956922344f6b74243c2c6771594659778744b2dbdaad8f6b727d";
+    sha256 = "sha256-bvrAkL+PKZcK/JDK9Nquh7FycJt4bLG02i0MBiRDHsw=";
   };
 
   LC_ALL="en_US.UTF-8";

--- a/pkgs/development/python-modules/unidecode/default.nix
+++ b/pkgs/development/python-modules/unidecode/default.nix
@@ -1,22 +1,33 @@
-{ lib, buildPythonPackage, fetchPypi, glibcLocales }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
-  pname = "Unidecode";
+  pname = "unidecode";
   version = "1.3.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-bvrAkL+PKZcK/JDK9Nquh7FycJt4bLG02i0MBiRDHsw=";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "avian2";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "07789mrq0gjxrg1b9a3ypzzfww224sbj25wl0h9nik22sjwi8qhh";
   };
 
-  LC_ALL="en_US.UTF-8";
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  buildInputs = [ glibcLocales ];
+  pythonImportsCheck = [ "unidecode" ];
 
   meta = with lib; {
     homepage = "https://pypi.python.org/pypi/Unidecode/";
     description = "ASCII transliterations of Unicode text";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ domenkozar ];
   };
 }

--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -20,7 +20,8 @@ python3.pkgs.buildPythonApplication rec {
     substituteInPlace setup.cfg \
       --replace "requests>=2.11.1,<2.25.0" "requests" \
       --replace "cps = calibreweb:main" "calibre-web = calibreweb:main" \
-      --replace "PyPDF3>=1.0.0,<1.0.4" "PyPDF3>=1.0.0"
+      --replace "PyPDF3>=1.0.0,<1.0.4" "PyPDF3>=1.0.0" \
+      --replace "unidecode>=0.04.19,<1.3.0" "unidecode>=0.04.19"
   '';
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.3.1

Change log: https://github.com/avian2/unidecode/blob/master/ChangeLog

- Enable tests
- Upstream dropped support for Python < 3.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
