### PR TITLE
[staging-next] python3Packages.backports*: use pythonNamespaces

### DIFF
--- a/pkgs/development/python-modules/backports-entry-points-selectable/default.nix
+++ b/pkgs/development/python-modules/backports-entry-points-selectable/default.nix
@@ -21,6 +21,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "backports.entry_points_selectable" ];
 
+  pythonNamespaces = [ "backports" ];
+
   meta = with lib; {
     description = "Compatibility shim providing selectable entry points for older implementations";
     homepage = "https://github.com/jaraco/backports.entry_points_selectable";

--- a/pkgs/development/python-modules/backports_functools_lru_cache/default.nix
+++ b/pkgs/development/python-modules/backports_functools_lru_cache/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
   # Test fail on Python 2
   doCheck = isPy3k;
 
+  pythonNamespaces = [ "backports" ];
+
   meta = {
     description = "Backport of functools.lru_cache";
     homepage = "https://github.com/jaraco/backports.functools_lru_cache";


### PR DESCRIPTION
###### Motivation for this change
The python3 versions of this library should be using native namespaces, fixes ceph failure:

```
building '/nix/store/yn26z3rgiqgrpj56hy40zyncvdhhyiws-python3-3.9.6-env.drv'...
error: collision between `/nix/store/r3qim50y9ikhcykgrfvqbqajni41k3cv-python3.9-backports.functools_lru_cache-1.6.4/lib/python3.9/site-packages/backports/__pycache__/__init__.cpython-39.pyc' and `/nix/store/w90icpb3iijnjnhn5p9m8qrwzd5fgl2i-python3.9-backports-entry-points-selectable-1.1.0/lib/python3.9/site-packages/backports/__pycache__/__init__.cpython-39.pyc'
builder for '/nix/store/yn26z3rgiqgrpj56hy40zyncvdhhyiws-python3-3.9.6-env.drv' failed with exit code 25
cannot build derivation '/nix/store/isda93b9p6j6jbhxfj874h2k6kv151wb-ceph-16.2.5.drv': 1 dependencies couldn't be built
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
