### PR TITLE
skytemple: 1.2.5 -> 1.3.0

### DIFF
--- a/pkgs/applications/misc/skytemple/default.nix
+++ b/pkgs/applications/misc/skytemple/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "skytemple";
-  version = "1.2.5";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "0780517gjc97wb2g67pwdv3fz3sqxm2ica1hdbrhqm4rfbnb28xr";
+    sha256 = "03qmjp257rk4p1zkz89cv26awdgngvakqyg6jc3g6xrhmsvr4r2p";
   };
 
   buildInputs = [

--- a/pkgs/development/python-modules/dungeon-eos/default.nix
+++ b/pkgs/development/python-modules/dungeon-eos/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "dungeon-eos";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = pname;
+    rev = version;
+    sha256 = "0hxygjk9i4qlwsxnxr52cxhqy3i62pc373z1x5sh2pas5ag59bvl";
+  };
+
+  doCheck = false; # there are no tests
+  pythonImportsCheck = [ "dungeon_eos" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/SkyTemple/dungeon-eos";
+    description = "A package that simulates PMD EoS dungeon generation";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ marius851000 xfix ];
+  };
+}

--- a/pkgs/development/python-modules/skytemple-files/default.nix
+++ b/pkgs/development/python-modules/skytemple-files/default.nix
@@ -1,25 +1,18 @@
-{ lib, buildPythonPackage, fetchFromGitHub, appdirs, explorerscript, ndspy, pillow, setuptools, skytemple-rust, tilequant, armips, fetchpatch }:
+{ lib, buildPythonPackage, fetchFromGitHub, appdirs, dungeon-eos, explorerscript
+, ndspy, pillow, setuptools, skytemple-rust, tilequant, armips
+}:
 
 buildPythonPackage rec {
   pname = "skytemple-files";
-  version = "1.2.4";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "1i3045bqg9h7kcx83nlrm1pmikfpi817n0gb8da29m3mqzk7lwws";
+    sha256 = "1gpmgdas7x1zmszs9hlxjb6nk683901cy1kc0gyhz0rzdn5jg3lb";
     fetchSubmodules = true;
   };
-
-  patches = [
-    # fix patching https://github.com/SkyTemple/skytemple-files/pull/128
-    # merged, remove for next update
-    (fetchpatch {
-      url = "http://github.com/SkyTemple/skytemple-files/commit/71dd71e6abb7435405e30225e8a37592b990d692.patch";
-      sha256 = "sha256-CSBaT+LVP9J0C1FlUCduTJroq9z2EAJG6lruvlHlQLI=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace skytemple_files/patch/arm_patcher.py \
@@ -28,7 +21,7 @@ buildPythonPackage rec {
 
   buildInputs = [ armips ];
 
-  propagatedBuildInputs = [ appdirs explorerscript ndspy pillow setuptools skytemple-rust tilequant ];
+  propagatedBuildInputs = [ appdirs dungeon-eos explorerscript ndspy pillow setuptools skytemple-rust tilequant ];
 
   doCheck = false; # requires Pokémon Mystery Dungeon ROM
   pythonImportsCheck = [ "skytemple_files" ];

--- a/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
+++ b/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
@@ -5,13 +5,13 @@
 
 buildPythonPackage rec {
   pname = "skytemple-ssb-debugger";
-  version = "1.2.5";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "0jkx75z8j03jfr9kzd40ip0fy24sfc7f2x430mf48xin272mc87q";
+    sha256 = "12v0071125m8xjcp2hxm9qvs0qw4hdhkx8r3gbl0plm22vl3fk0d";
   };
 
   buildInputs = [ gobject-introspection gtk3 gtksourceview3 ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2247,6 +2247,8 @@ in {
 
   dulwich = callPackage ../development/python-modules/dulwich { };
 
+  dungeon-eos = callPackage ../development/python-modules/dungeon-eos { };
+
   dwdwfsapi = callPackage ../development/python-modules/dwdwfsapi { };
 
   dyn = callPackage ../development/python-modules/dyn { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
