### PR TITLE
[21.05] evolution, evolution-ews, evolution-data-server: backport patch release bumps

### DIFF
--- a/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-ews";
-  version = "3.40.1";
+  version = "3.40.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1kgxdacqqcq8yfkij6vyqlk5r4yqvw7gh7mxqii670hrn1mb2s50";
+    sha256 = "ZAIE5rpPOyZT3VSPYOR143bP8Na7Kv0NQRhQ+p2oxJY=";
   };
 
   nativeBuildInputs = [ cmake gettext intltool pkg-config ];

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -42,11 +42,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.40.1";
+  version = "3.40.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "07n4sbgsh0y9hrn52ymvy45ah65ll55gglgvqqi3h9nhkyy64y9g";
+    sha256 = "/SkjomENe/6212+FMLpAJkBOIf0nOrKKLFtQCJIeDVw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome/core/evolution-data-server/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.40.2";
+  version = "3.40.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "7IKVFjnzKlzs6AqLC5qj9mt9MY4+4sHDUjTy4r3opBg=";
+    sha256 = "Trs5F9a+tUrVlt5dilxG8PtXJJ7Z24HwXHqUpzDB2SE=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome/core/evolution-data-server/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.40.3";
+  version = "3.40.4";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "Trs5F9a+tUrVlt5dilxG8PtXJJ7Z24HwXHqUpzDB2SE=";
+    sha256 = "h8GF8Yw3Jw42EZgfGb2SIayXTIB0Ysjc6QvqCHEsWAA=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

fix a bug that affected me

###### Things done

tested for a few days

- Built on platform(s)
  - |x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of ~all binary files (usually in `./result/bin/`)~ evolution with evolution-ews
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
