### PR TITLE
airshipper: init at 0.6.0

### DIFF
--- a/pkgs/games/airshipper/default.nix
+++ b/pkgs/games/airshipper/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, rustPlatform
+, fetchFromGitLab
+, openssl
+, vulkan-loader
+, wayland
+, wayland-protocols
+, libxkbcommon
+, libX11
+, libXrandr
+, libXi
+, libXcursor
+, pkg-config
+, makeWrapper
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "airshipper";
+  version = "0.6.0";
+
+  src = fetchFromGitLab {
+    owner = "Veloren";
+    repo = "airshipper";
+    rev = "v${version}";
+    sha256 = "sha256-m3H2FE1DoV/uk9PGgf9PCagwmWWSQO/gCi7zpS02/WY=";
+  };
+
+  cargoSha256 = "sha256-ddy4TjT/ia+sLBnpwcXBVUzAS07ar+Jjc04KS5/arlU=";
+
+  buildInputs = [
+    openssl
+    wayland
+    wayland-protocols
+    libxkbcommon
+    libX11
+    libXrandr
+    libXi
+    libXcursor
+  ];
+  nativeBuildInputs = [ pkg-config makeWrapper ];
+
+  postInstall = ''
+    mkdir -p "$out/share/applications" && mkdir -p "$out/share/icons"
+    cp "client/assets/net.veloren.airshipper.desktop" "$out/share/applications"
+    cp "client/assets/logo.ico" "$out/share/icons/net.veloren.airshipper.ico"
+  '';
+
+  postFixup =
+    let
+      libPath = lib.makeLibraryPath [
+        vulkan-loader
+        wayland
+        wayland-protocols
+        libxkbcommon
+        libX11
+        libXrandr
+        libXi
+        libXcursor
+      ];
+    in ''
+      patchelf --set-rpath "${libPath}" "$out/bin/airshipper"
+    '';
+
+  doCheck = false;
+  cargoBuildFlags = [ "--package" "airshipper" ];
+  cargoTestFlags = [ "--package" "airshipper" ];
+
+  meta = with lib; {
+    description = "Provides automatic updates for the voxel RPG Veloren.";
+    homepage = "https://www.veloren.net";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ yusdacra ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29203,6 +29203,8 @@ with pkgs;
 
   adom = callPackage ../games/adom { };
 
+  airshipper = callPackage ../games/airshipper { };
+
   airstrike = callPackage ../games/airstrike { };
 
   alephone = callPackage ../games/alephone { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds https://gitlab.com/veloren/airshipper

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

TODO: which deps are actually needed for buildInputs
