### PR TITLE
loksh: init at 6.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1671,6 +1671,12 @@
     githubId = 7435854;
     name = "Victor Calvert";
   };
+  cameronnemo = {
+    email = "cnemo@tutanota.com";
+    github = "cameronnemo";
+    githubId = 3212452;
+    name = "Cameron Nemo";
+  };
   campadrenalin = {
     email = "campadrenalin@gmail.com";
     github = "campadrenalin";

--- a/pkgs/shells/loksh/default.nix
+++ b/pkgs/shells/loksh/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, meson
+, ninja
+, pkg-config
+, ncurses
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "loksh";
+  version = "6.9";
+
+  src = fetchFromGitHub {
+    owner = "dimkr";
+    repo = pname;
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "0x33plxqhh5202hgqidgccz5hpg8d2q71ylgnm437g60mfi9z0px";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    ncurses
+  ];
+
+  postInstall = ''
+    mv $out/bin/ksh $out/bin/loksh
+    mv $out/share/man/man1/ksh.1 $out/share/man/man1/loksh.1
+    mv $out/share/man/man1/sh.1 $out/share/man/man1/loksh-sh.1
+  '';
+
+  passthru = {
+    shellPath = "/bin/loksh";
+  };
+
+  meta = with lib; {
+    description = "Linux port of OpenBSD's ksh";
+    homepage = "https://github.com/dimkr/loksh";
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ cameronnemo ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10637,6 +10637,8 @@ with pkgs;
 
   oksh = callPackage ../shells/oksh { };
 
+  loksh = callPackage ../shells/loksh { };
+
   pash = callPackage ../shells/pash { };
 
   scponly = callPackage ../shells/scponly { };


### PR DESCRIPTION
- maintainers: add cameronnemo
- loksh: init at 6.9

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

loksh has some nice extra features that oksh does not.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
