### PR TITLE
scrcpy: 1.18 -> 1.19

### DIFF
--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -10,10 +10,10 @@
 }:
 
 let
-  version = "1.18";
+  version = "1.19";
   prebuilt_server = fetchurl {
     url = "https://github.com/Genymobile/scrcpy/releases/download/v${version}/scrcpy-server-v${version}";
-    sha256 = "18si7k9hyqa77yy9w747kl2x2pivyigny49dwzx9sfd9xmmmq734";
+    sha256 = "sha256-h2+TIhguaqxqWNsTNPQiWFXvOhfq68gKq2YB2dHsuGc=";
   };
 in
 stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "Genymobile";
     repo = pname;
     rev = "v${version}";
-    sha256 = "019948v63qhmp742hmar7a98ss673m0wdycpphjhfl1kg4iihiya";
+    sha256 = "sha256-IR4FTbVtHp9rRm0U4d1zkl0u+oR5FeElJ91NIspSKWg=";
   };
 
   # postPatch:

--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -59,6 +59,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Genymobile/scrcpy";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ deltaevo lukeadams ];
+    maintainers = with maintainers; [ deltaevo lukeadams msfjarvis ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updates scrcpy from 1.18 to 1.19 and adds myself as a maintainer of the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
