### PR TITLE
noto-fonts: Fix path to zopflipng, remove broken check

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -141,6 +141,14 @@ in
       # python requirements using python.withPackages
       sed -i '/ifndef VIRTUAL_ENV/,+2d' Makefile
 
+      # Remove check for missing zopfli, it doesn't
+      # work and we guarantee its presence already.
+      sed -i '/ifdef MISSING_ZOPFLI/,+2d' Makefile
+      sed -i '/ifeq (,$(shell which $(ZOPFLIPNG)))/,+4d' Makefile
+
+      sed -i '/ZOPFLIPNG = zopflipng/d' Makefile
+      echo "ZOPFLIPNG = ${zopfli}/bin/zopflipng" >> Makefile
+
       # Make the build verbose so it won't get culled by Hydra thinking that
       # it somehow got stuck doing nothing.
       sed -i 's;\t@;\t;' Makefile


### PR DESCRIPTION

###### Motivation for this change
Building the package (NixOS x86-64) failed as it could not find zopflipng.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
