### PR TITLE
python3.pkgs.osmpythontools: 0.3.0 -> 0.3.2

### DIFF
--- a/pkgs/development/python-modules/osmpythontools/default.nix
+++ b/pkgs/development/python-modules/osmpythontools/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "osmpythontools";
-  version = "0.3.0";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "mocnik-science";
     repo = "osm-python-tools";
     rev = "v${version}";
-    sha256 = "0r72z7f7kmvvbd9zvgci8rwmfj85xj34mb3x5dj3jcv5ij5j72yh";
+    sha256 = "1m5ai9h1zbp79x0vb138fmyh2hg8lqp859s7j33lra9hds6wb40a";
   };
 
   # Upstream setup.py has test dependencies in `install_requires` argument.


### PR DESCRIPTION
###### Motivation for this change

Upstream release 0.3.2 ([PyPI](https://pypi.org/project/OSMPythonTools/0.3.2/), [Git tag](https://github.com/mocnik-science/osm-python-tools/releases/tag/v0.3.2))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (there are no executable files, as this is a library)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
