### PR TITLE
 python39Packages.python-openstackclient: init at 5.6.0 

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -182,7 +182,7 @@ with lib.maintainers; {
     members = [
       angustrau
       superherointj
-      supersandro2000
+      SuperSandro2000
     ];
     scope = "Maintain the ecosystem around OpenStack";
   };

--- a/pkgs/development/python-modules/debtcollector/default.nix
+++ b/pkgs/development/python-modules/debtcollector/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, pbr, six, wrapt, callPackage }:
+
+buildPythonPackage rec {
+  pname = "debtcollector";
+  version = "2.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c7a9fac814ab5904e23905516b18356cc907e7d27c05da58d37103f001967846";
+  };
+
+  nativeBuildInputs = [ pbr ];
+
+  propagatedBuildInputs = [ six wrapt ];
+
+  # check in passthru.tests.pytest to escape infinite recursion with other oslo components
+  doCheck = false;
+
+  passthru.tests = {
+    pytest = callPackage ./tests.nix { };
+  };
+
+  pythonImportsCheck = [ "debtcollector" ];
+
+  meta = with lib; {
+    description = "A collection of Python deprecation patterns and strategies that help you collect your technical debt in a non-destructive manner";
+    homepage = "https://github.com/openstack/debtcollector";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/debtcollector/tests.nix
+++ b/pkgs/development/python-modules/debtcollector/tests.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, debtcollector
+, stestr
+}:
+
+buildPythonPackage rec {
+  pname = "debtcollector-tests";
+  inherit (debtcollector) version;
+
+  src = debtcollector.src;
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  dontBuild = true;
+  dontInstall = true;
+
+  checkInputs = [
+    debtcollector
+    stestr
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+}

--- a/pkgs/development/python-modules/eventlet/default.nix
+++ b/pkgs/development/python-modules/eventlet/default.nix
@@ -1,9 +1,9 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
 , dnspython
-, enum34
 , greenlet
 , monotonic
 , six
@@ -22,10 +22,12 @@ buildPythonPackage rec {
     sha256 = "2f0bb8ed0dc0ab21d683975d5d8ab3c054d588ce61def9faf7a465ee363e839b";
   };
 
-  propagatedBuildInputs = [ dnspython greenlet monotonic six ]
-    ++ lib.optional (pythonOlder "3.4") enum34;
+  propagatedBuildInputs = [ dnspython greenlet pyopenssl six ]
+    ++ lib.optional (pythonOlder "3.5") monotonic;
 
-  checkInputs = [ nose pyopenssl ];
+  checkInputs = [ nose ];
+
+  doCheck = !stdenv.isDarwin;
 
   preCheck = ''
     echo "nameserver 127.0.0.1" > resolv.conf
@@ -47,7 +49,7 @@ buildPythonPackage rec {
   # pythonImportsCheck = [ "eventlet" ];
 
   meta = with lib; {
-    homepage = "https://pypi.python.org/pypi/eventlet/";
+    homepage = "https://github.com/eventlet/eventlet/";
     description = "A concurrent networking library for Python";
     maintainers = with maintainers; [ SuperSandro2000 ];
     license = licenses.mit;

--- a/pkgs/development/python-modules/hacking/default.nix
+++ b/pkgs/development/python-modules/hacking/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pbr
+, flake8
+, stestr
+, eventlet
+, ddt
+, testtools
+, testscenarios
+}:
+
+buildPythonPackage rec {
+  pname = "hacking";
+  version = "4.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fg19rlcky3n1y1ri61xyjp7534yzf8r102z9dw3zqg93f4kj20m";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "flake8<3.9.0,>=3.8.0" "flake8"
+  '';
+
+  nativeBuildInputs = [ pbr ];
+
+  propagatedBuildInputs = [
+    flake8
+  ];
+
+  checkInputs = [
+    ddt
+    stestr
+    testscenarios
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "hacking" ];
+
+  meta = with lib; {
+    description = "OpenStack Hacking Guideline Enforcement";
+    homepage = "https://github.com/openstack/hacking";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/keystoneauth1/default.nix
+++ b/pkgs/development/python-modules/keystoneauth1/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, betamax
+, hacking
+, iso8601
+, lxml
+, oauthlib
+, os-service-types
+, oslo-config
+, oslo-utils
+, pbr
+, pycodestyle
+, pyyaml
+, requests
+, requests-kerberos
+, requests-mock
+, six
+, stestr
+, stevedore
+, testresources
+, testtools
+}:
+
+buildPythonPackage rec {
+  pname = "keystoneauth1";
+  version = "4.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "93605430a6d1424f31659bc5685e9dc1be9a6254e88c99f00cffc0a60c648a64";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  propagatedBuildInputs = [
+    betamax
+    iso8601
+    lxml
+    oauthlib
+    os-service-types
+    pbr
+    requests
+    requests-kerberos
+    six
+    stevedore
+  ];
+
+  checkInputs = [
+    hacking
+    oslo-config
+    oslo-utils
+    pycodestyle
+    pyyaml
+    requests-mock
+    stestr
+    testresources
+    testtools
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "keystoneauth1" ];
+
+  meta = with lib; {
+    description = "Authentication Library for OpenStack Identity";
+    homepage = "https://github.com/openstack/keystoneauth";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/openstacksdk/default.nix
+++ b/pkgs/development/python-modules/openstacksdk/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, appdirs
+, cryptography
+, ddt
+, dogpile_cache
+, hacking
+, jmespath
+, jsonpatch
+, jsonschema
+, keystoneauth1
+, munch
+, netifaces
+, os-service-types
+, oslo-config
+, oslotest
+, pbr
+, prometheus-client
+, requests-mock
+, requestsexceptions
+, stestr
+, testscenarios
+}:
+
+buildPythonPackage rec {
+  pname = "openstacksdk";
+  version = "0.59.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-PfdgzScjmKv6yM6+Yu64LLxJe7JdTdcHV290qM6avw0=";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    cryptography
+    dogpile_cache
+    jmespath
+    jsonpatch
+    keystoneauth1
+    munch
+    netifaces
+    os-service-types
+    pbr
+    requestsexceptions
+  ];
+
+  checkInputs = [
+    ddt
+    hacking
+    jsonschema
+    oslo-config
+    oslotest
+    prometheus-client
+    requests-mock
+    stestr
+    testscenarios
+  ];
+
+  checkPhase = ''
+    stestr run -e <(echo "
+    openstack.tests.unit.cloud.test_image.TestImage.test_create_image_task
+    openstack.tests.unit.image.v2.test_proxy.TestImageProxy.test_wait_for_task_error_396
+    openstack.tests.unit.image.v2.test_proxy.TestImageProxy.test_wait_for_task_wait
+    openstack.tests.unit.test_resource.TestWaitForStatus.test_status_fails
+    openstack.tests.unit.test_resource.TestWaitForStatus.test_status_fails_different_attribute
+    openstack.tests.unit.test_resource.TestWaitForStatus.test_status_match
+    openstack.tests.unit.test_resource.TestWaitForStatus.test_status_match_with_none
+    openstack.tests.unit.test_stats.TestStats.test_list_projects
+    openstack.tests.unit.test_stats.TestStats.test_projects
+    openstack.tests.unit.test_stats.TestStats.test_servers
+    openstack.tests.unit.test_stats.TestStats.test_servers_no_detail
+    ")
+  '';
+
+  pythonImportsCheck = [ "openstack" ];
+
+  meta = with lib; {
+    description = "An SDK for building applications to work with OpenStack";
+    homepage = "https://github.com/openstack/openstacksdk";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/os-service-types/default.nix
+++ b/pkgs/development/python-modules/os-service-types/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pbr
+, six
+, callPackage
+}:
+
+buildPythonPackage rec {
+  pname = "os-service-types";
+  version = "1.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "31800299a82239363995b91f1ebf9106ac7758542a1e4ef6dc737a5932878c6c";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  propagatedBuildInputs = [ pbr six ];
+
+  # check in passthru.tests.pytest to escape infinite recursion with other oslo components
+  doCheck = false;
+
+  passthru.tests = {
+    pytest = callPackage ./tests.nix { };
+  };
+
+  pythonImportsCheck = [ "os_service_types" ];
+
+  meta = with lib; {
+    description = "Python library for consuming OpenStack sevice-types-authority data";
+    homepage = "https://github.com/openstack/os-service-types";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/os-service-types/tests.nix
+++ b/pkgs/development/python-modules/os-service-types/tests.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, buildPythonPackage
+, keystoneauth1
+, os-service-types
+, oslotest
+, requests-mock
+, stestr
+, testscenarios
+}:
+
+buildPythonPackage rec {
+  pname = "os-service-types-tests";
+  inherit (os-service-types) version;
+
+  src = os-service-types.src;
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  dontBuild = true;
+  dontInstall = true;
+
+  checkInputs = [
+    os-service-types
+    keystoneauth1
+    oslotest
+    requests-mock
+    stestr
+    testscenarios
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+}

--- a/pkgs/development/python-modules/osc-lib/default.nix
+++ b/pkgs/development/python-modules/osc-lib/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cliff
+, oslo-i18n
+, oslo-utils
+, openstacksdk
+, pbr
+, requests-mock
+, simplejson
+, stestr
+}:
+
+buildPythonPackage rec {
+  pname = "osc-lib";
+  version = "2.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ianpk32vwdllpbk4zhfifqb5b064cbmia2hm02lcrh2m76z0zi5";
+  };
+
+  nativeBuildInputs = [
+    pbr
+  ];
+
+  propagatedBuildInputs = [
+    cliff
+    openstacksdk
+    oslo-i18n
+    oslo-utils
+    simplejson
+  ];
+
+  checkInputs = [
+    requests-mock
+    stestr
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "osc_lib" ];
+
+  meta = with lib; {
+    description = "OpenStackClient Library";
+    homepage = "https://github.com/openstack/osc-lib";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslo-concurrency/default.nix
+++ b/pkgs/development/python-modules/oslo-concurrency/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, bash
+, coreutils
+, eventlet
+, fasteners
+, fixtures
+, iana-etc
+, libredirect
+, oslo-config
+, oslo-utils
+, oslotest
+, pbr
+, stestr
+}:
+
+buildPythonPackage rec {
+  pname = "oslo-concurrency";
+  version = "4.4.1";
+
+  src = fetchPypi {
+    pname = "oslo.concurrency";
+    inherit version;
+    sha256 = "6449cfbd15dbab20cf9907bbb2f057e0e5267f97161223d2b516cc8226b17ec3";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+
+    substituteInPlace oslo_concurrency/tests/unit/test_processutils.py \
+      --replace "/bin/bash" "${bash}/bin/bash" \
+      --replace "/bin/true" "${coreutils}/bin/true" \
+      --replace "/usr/bin/env" "${coreutils}/bin/env" \
+      --replace "/usr/bin/true" "${coreutils}/bin/true"
+  '';
+
+  propagatedBuildInputs = [
+    fasteners
+    oslo-config
+    oslo-utils
+    pbr
+  ];
+
+  checkInputs = [
+    eventlet
+    fixtures
+    oslotest
+    stestr
+  ];
+
+  checkPhase = ''
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf)
+    export LD_PRELOAD=${libredirect}/lib/libredirect.so
+
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "oslo_concurrency" ];
+
+  meta = with lib; {
+    description = "Oslo Concurrency library";
+    homepage = "https://github.com/openstack/oslo.concurrency";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslo-config/default.nix
+++ b/pkgs/development/python-modules/oslo-config/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, debtcollector
+, netaddr
+, oslo-i18n
+, pbr
+, pyyaml
+, requests
+, rfc3986
+, stevedore
+, callPackage
+}:
+
+buildPythonPackage rec {
+  pname = "oslo-config";
+  version = "8.7.1";
+
+  src = fetchPypi {
+    pname = "oslo.config";
+    inherit version;
+    sha256 = "a0c346d778cdc8870ab945e438bea251b5f45fae05d6d99dfe4953cca2277b60";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  propagatedBuildInputs = [
+    debtcollector
+    netaddr
+    oslo-i18n
+    pbr
+    pyyaml
+    requests
+    rfc3986
+    stevedore
+  ];
+
+  # check in passthru.tests.pytest to escape infinite recursion with other oslo components
+  doCheck = false;
+
+  passthru.tests = {
+    pytest = callPackage ./tests.nix {};
+  };
+
+  pythonImportsCheck = [ "oslo_config" ];
+
+  meta = with lib; {
+    description = "Oslo Configuration API";
+    homepage = "https://github.com/openstack/oslo.config";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslo-config/tests.nix
+++ b/pkgs/development/python-modules/oslo-config/tests.nix
@@ -38,6 +38,5 @@ buildPythonPackage rec {
 
   checkPhase = ''
     stestr run
-
   '';
 }

--- a/pkgs/development/python-modules/oslo-config/tests.nix
+++ b/pkgs/development/python-modules/oslo-config/tests.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, buildPythonPackage
+, oslo-config
+, docutils
+, oslo-log
+, oslotest
+, requests-mock
+, sphinx
+, stestr
+, testscenarios
+}:
+
+buildPythonPackage rec {
+  pname = "oslo-config-tests";
+  inherit (oslo-config) version;
+
+  src = oslo-config.src;
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  dontBuild = true;
+  dontInstall = true;
+
+  checkInputs = [
+    oslo-config
+    docutils
+    oslo-log
+    oslotest
+    requests-mock
+    sphinx
+    stestr
+    testscenarios
+  ];
+
+  checkPhase = ''
+    stestr run
+
+  '';
+}

--- a/pkgs/development/python-modules/oslo-context/default.nix
+++ b/pkgs/development/python-modules/oslo-context/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildPythonPackage, fetchPypi, debtcollector, oslotest, stestr, pbr }:
+
+buildPythonPackage rec {
+  pname = "oslo.context";
+  version = "3.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f578ea38569cf0a677e2167178196b21a54175471358c4320ddfd5c97c52f4d1";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  propagatedBuildInputs = [
+    debtcollector
+    pbr
+  ];
+
+  checkInputs = [
+    oslotest
+    stestr
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "oslo_context" ];
+
+  meta = with lib; {
+    description = "Oslo Context library";
+    homepage = "https://github.com/openstack/oslo.context";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslo-db/default.nix
+++ b/pkgs/development/python-modules/oslo-db/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, alembic
+, oslo-config
+, oslo-context
+, oslo-utils
+, oslotest
+, pbr
+, sqlalchemy
+, sqlalchemy_migrate
+, stestr
+, testresources
+, testscenarios
+}:
+
+buildPythonPackage rec {
+  pname = "oslo-db";
+  version = "11.0.0";
+
+  src = fetchPypi {
+    pname = "oslo.db";
+    inherit version;
+    sha256 = "0cd5679868c0a0d194c916cc855348890820c3183b34a039af1e8698dac7afbf";
+  };
+
+  nativeBuildInputs = [ pbr ];
+
+  propagatedBuildInputs = [
+    alembic
+    oslo-config
+    oslo-context
+    oslo-utils
+    sqlalchemy
+    sqlalchemy_migrate
+    testresources
+    testscenarios
+  ];
+
+  checkInputs = [
+    oslotest
+    stestr
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "oslo_db" ];
+
+  meta = with lib; {
+    description = "Oslo Database library";
+    homepage = "https://github.com/openstack/oslo.db";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslo-i18n/default.nix
+++ b/pkgs/development/python-modules/oslo-i18n/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, oslotest
+, pbr
+, testscenarios
+, stestr
+}:
+
+buildPythonPackage rec {
+  pname = "oslo-i18n";
+  version = "5.1.0";
+
+  src = fetchPypi {
+    pname = "oslo.i18n";
+    inherit version;
+    sha256 = "6bf111a6357d5449640852de4640eae4159b5562bbba4c90febb0034abc095d0";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  nativeBuildInputs = [ pbr ];
+
+  checkInputs = [
+    oslotest
+    stestr
+    testscenarios
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "oslo_i18n" ];
+
+  meta = with lib; {
+    description = "Oslo i18n library";
+    homepage = "https://github.com/openstack/oslo.i18n";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslo-log/default.nix
+++ b/pkgs/development/python-modules/oslo-log/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, oslo-config
+, oslo-context
+, oslo-serialization
+, oslo-utils
+, oslotest
+, pbr
+, pyinotify
+, python-dateutil
+, stestr
+}:
+
+buildPythonPackage rec {
+  pname = "oslo-log";
+  version = "4.6.0";
+
+  src = fetchPypi {
+    pname = "oslo.log";
+    inherit version;
+    sha256 = "dad5d7ff1290f01132b356d36a1bb79f98a3929d5005cce73e849ed31b385ba7";
+  };
+
+  propagatedBuildInputs = [
+    oslo-config
+    oslo-context
+    oslo-serialization
+    oslo-utils
+    pbr
+    python-dateutil
+  ] ++ lib.optionals stdenv.isLinux [
+    pyinotify
+  ];
+
+  checkInputs = [
+    oslotest
+    stestr
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "oslo_log" ];
+
+  meta = with lib; {
+    description = "oslo.log library";
+    homepage = "https://github.com/openstack/oslo.log";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslo-serialization/default.nix
+++ b/pkgs/development/python-modules/oslo-serialization/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, msgpack
+, oslo-utils
+, oslotest
+, pbr
+, pytz
+, stestr
+}:
+
+buildPythonPackage rec {
+  pname = "oslo-serialization";
+  version = "4.2.0";
+
+  src = fetchPypi {
+    pname = "oslo.serialization";
+    inherit version;
+    sha256 = "3007e1b017ad3754cce54def894054cbcd05887e85928556657434b0fc7e4d83";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  nativeBuildInputs = [ pbr ];
+
+  propagatedBuildInputs = [ msgpack oslo-utils pytz ];
+
+  checkInputs = [ oslotest stestr ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "oslo_serialization" ];
+
+  meta = with lib; {
+    description = "Oslo Serialization library";
+    homepage = "https://github.com/openstack/oslo.serialization";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslo-utils/default.nix
+++ b/pkgs/development/python-modules/oslo-utils/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ddt
+, debtcollector
+, eventlet
+, fixtures
+, iso8601
+, netaddr
+, netifaces
+, oslo-i18n
+, oslotest
+, packaging
+, pbr
+, pyparsing
+, pytz
+, stestr
+, testscenarios
+, pyyaml
+, iana-etc
+, libredirect
+}:
+
+buildPythonPackage rec {
+  pname = "oslo-utils";
+  version = "4.10.0";
+
+  src = fetchPypi {
+    pname = "oslo.utils";
+    inherit version;
+    sha256 = "9646e6570ed08a79f21b03acfb60d32a3ac453d76304f8759b1211a59ce372cb";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  nativeBuildInputs = [ pbr ];
+
+  propagatedBuildInputs = [
+    debtcollector
+    iso8601
+    netaddr
+    netifaces
+    oslo-i18n
+    packaging
+    pyparsing
+    pytz
+  ];
+
+  checkInputs = [
+    ddt
+    eventlet
+    fixtures
+    oslotest
+    stestr
+    testscenarios
+    pyyaml
+  ];
+
+  checkPhase = ''
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf)
+    export LD_PRELOAD=${libredirect}/lib/libredirect.so
+
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "oslo_utils" ];
+
+  meta = with lib; {
+    description = "Oslo Utility library";
+    homepage = "https://github.com/openstack/oslo.utils";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslotest/default.nix
+++ b/pkgs/development/python-modules/oslotest/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fixtures
+, pbr
+, subunit
+, callPackage
+}:
+
+buildPythonPackage rec {
+  pname = "oslotest";
+  version = "4.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "360ad2c41ba3ad6f059c7c6e7291450d082c2e5dbb0012e839a829978053dfe6";
+  };
+
+  nativeBuildInputs = [ pbr ];
+
+  propagatedBuildInputs = [
+    fixtures
+    subunit
+  ];
+
+  # check in passthru.tests.pytest to escape infinite recursion with other oslo components
+  doCheck = false;
+
+  passthru.tests = {
+    pytest = callPackage ./tests.nix {};
+  };
+
+  pythonImportsCheck = [ "oslotest" ];
+
+  meta = with lib; {
+    description = "Oslo test framework";
+    homepage = "https://github.com/openstack/oslotest";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/oslotest/tests.nix
+++ b/pkgs/development/python-modules/oslotest/tests.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, oslo-config
+, oslotest
+, stestr
+}:
+
+buildPythonPackage rec {
+  pname = "oslotest-tests";
+  inherit (oslotest) version;
+
+  src = oslotest.src;
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  dontBuild = true;
+  dontInstall = true;
+
+  checkInputs = [
+    oslotest
+    oslo-config
+    stestr
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+}

--- a/pkgs/development/python-modules/python-cinderclient/default.nix
+++ b/pkgs/development/python-modules/python-cinderclient/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ddt
+, keystoneauth1
+, oslo-i18n
+, oslo-serialization
+, oslo-utils
+, pbr
+, requests
+, prettytable
+, requests-mock
+, simplejson
+, stestr
+, stevedore
+}:
+
+buildPythonPackage rec {
+  pname = "python-cinderclient";
+  version = "8.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b57b432b2ac9161c2482a569a023211d2d3d0ada81c4da62c8f6e47f0b2bf82d";
+  };
+
+  propagatedBuildInputs = [
+    simplejson
+    keystoneauth1
+    oslo-i18n
+    oslo-utils
+    pbr
+    prettytable
+    requests
+    stevedore
+  ];
+
+  checkInputs = [
+    ddt
+    oslo-serialization
+    requests-mock
+    stestr
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "cinderclient" ];
+
+  meta = with lib; {
+    description = "OpenStack Block Storage API Client Library";
+    homepage = "https://github.com/openstack/python-cinderclient";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/python-keystoneclient/default.nix
+++ b/pkgs/development/python-modules/python-keystoneclient/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, keystoneauth1
+, openssl
+, oslo-config
+, oslo-serialization
+, pbr
+, requests-mock
+, stestr
+, testresources
+, testscenarios
+}:
+
+buildPythonPackage rec {
+  pname = "python-keystoneclient";
+  version = "4.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12jsiw82x2zcn8sf78xisf85kr28gl3jqj46a0wxx59v91p44j02";
+  };
+
+  propagatedBuildInputs = [
+    keystoneauth1
+    oslo-config
+    oslo-serialization
+    pbr
+  ];
+
+  checkInputs = [
+    openssl
+    requests-mock
+    stestr
+    testresources
+    testscenarios
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "keystoneclient" ];
+
+  meta = with lib; {
+    description = "Client Library for OpenStack Identity";
+    homepage = "https://github.com/openstack/python-keystoneclient";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/python-novaclient/default.nix
+++ b/pkgs/development/python-modules/python-novaclient/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ddt
+, iso8601
+, keystoneauth1
+, openssl
+, oslo-i18n
+, oslo-serialization
+, pbr
+, prettytable
+, requests-mock
+, stestr
+, testscenarios
+}:
+
+buildPythonPackage rec {
+  pname = "python-novaclient";
+  version = "17.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-yRDCCFMQ2mNfs0NYXxBwcS/w+cs8j3nUTKPWMsTyMPU=";
+  };
+
+  propagatedBuildInputs = [
+    iso8601
+    keystoneauth1
+    oslo-i18n
+    oslo-serialization
+    pbr
+    prettytable
+  ];
+
+  checkInputs = [
+    ddt
+    openssl
+    requests-mock
+    stestr
+    testscenarios
+  ];
+
+  checkPhase = ''
+    stestr run -e <(echo "
+    novaclient.tests.unit.test_shell.ShellTest.test_osprofiler
+    novaclient.tests.unit.test_shell.ShellTestKeystoneV3.test_osprofiler
+    ")
+  '';
+
+  pythonImportsCheck = [ "novaclient" ];
+
+  meta = with lib; {
+    description = "Client library for OpenStack Compute API";
+    homepage = "https://github.com/openstack/python-novaclient";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ddt
+, osc-lib
+, pbr
+, python-cinderclient
+, python-keystoneclient
+, python-novaclient
+, requests-mock
+, stestr
+}:
+
+buildPythonPackage rec {
+  pname = "python-openstackclient";
+  version = "5.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0abc6666378c5a7db83ec83515a8524fb6246a919236110169cc5c216ac997ea";
+  };
+
+  propagatedBuildInputs = [
+    osc-lib
+    pbr
+    python-cinderclient
+    python-keystoneclient
+    python-novaclient
+  ];
+
+  checkInputs = [
+    ddt
+    stestr
+    requests-mock
+  ];
+
+  checkPhase = ''
+    stestr run
+  '';
+
+  pythonImportsCheck = [ "openstackclient" ];
+
+  meta = with lib; {
+    description = "OpenStack Command-line Client";
+    homepage = "https://github.com/openstack/python-openstackclient";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/stestr/default.nix
+++ b/pkgs/development/python-modules/stestr/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cliff
+, fixtures
+, future
+, pbr
+, subunit
+, testtools
+, voluptuous
+, callPackage
+}:
+
+buildPythonPackage rec {
+  pname = "stestr";
+  version = "3.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fb492cbdf3d3fdd6812645804efc84a99a68bb60dd7705f15c1a2949c8172bc4";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  propagatedBuildInputs = [
+    cliff
+    fixtures
+    future
+    pbr
+    subunit
+    testtools
+    voluptuous
+  ];
+
+  # check in passthru.tests.pytest to escape infinite recursion with other oslo components
+  doCheck = false;
+
+  passthru.tests = {
+    pytest = callPackage ./tests.nix { };
+  };
+
+  pythonImportsCheck = [ "stestr" ];
+
+  meta = with lib; {
+    description = "A parallel Python test runner built around subunit";
+    homepage = "https://github.com/mtreinish/stestr";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/stestr/tests.nix
+++ b/pkgs/development/python-modules/stestr/tests.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, ddt
+, sqlalchemy
+, stestr
+, subunit2sql
+}:
+
+buildPythonPackage rec {
+  pname = "stestr-tests";
+  inherit (stestr) version;
+
+  src = stestr.src;
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  dontBuild = true;
+  dontInstall = true;
+
+  checkInputs = [
+    stestr
+  ];
+
+  checkPhase = ''
+    export PATH=$out/bin:$PATH
+    export HOME=$TMPDIR
+  '';
+}

--- a/pkgs/development/python-modules/subunit2sql/default.nix
+++ b/pkgs/development/python-modules/subunit2sql/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, mock
+, oslo-concurrency
+, oslo-db
+, pbr
+, python-dateutil
+, stestr
+}:
+
+buildPythonPackage rec {
+  pname = "subunit2sql";
+  version = "1.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-c+Dg6moKiv30M0mmwGQSOEbc94gfH//ZnF7lnBgv8EU=";
+  };
+
+  propagatedBuildInputs = [
+    oslo-db
+    pbr
+    python-dateutil
+  ];
+
+  checkInputs = [
+    mock
+    oslo-concurrency
+    stestr
+  ];
+
+  checkPhase = ''
+    export PATH=$out/bin:$PATH
+    export HOME=$TMPDIR
+
+    stestr run -e <(echo "
+    subunit2sql.tests.db.test_api.TestDatabaseAPI.test_get_failing_test_ids_from_runs_by_key_value
+    subunit2sql.tests.db.test_api.TestDatabaseAPI.test_get_id_from_test_id
+    subunit2sql.tests.db.test_api.TestDatabaseAPI.test_get_test_run_dict_by_run_meta_key_value
+    subunit2sql.tests.migrations.test_migrations.TestWalkMigrations.test_sqlite_opportunistically
+    subunit2sql.tests.test_shell.TestMain.test_main
+    subunit2sql.tests.test_shell.TestMain.test_main_with_targets
+    ")
+  '';
+
+  pythonImportsCheck = [ "subunit2sql" ];
+
+  meta = with lib; {
+    description = "Command to Read a subunit file or stream and put the data in a SQL DB";
+    homepage = "https://opendev.org/opendev/subunit2sql";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18206,6 +18206,8 @@ with pkgs;
 
   openslp = callPackage ../development/libraries/openslp {};
 
+  openstackclient = with python3Packages; toPythonApplication python-openstackclient;
+
   openvdb = callPackage ../development/libraries/openvdb {};
 
   inherit (callPackages ../development/libraries/libressl { })

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -65,6 +65,7 @@ mapAliases ({
   pytestquickcheck = pytest-quickcheck; # added 2021-07-20
   pytestrunner = pytest-runner; # added 2021-01-04
   python-lz4 = lz4; # added 2018-06-01
+  python-subunit = subunit; # added 2021-09-10
   pytest_xdist = pytest-xdist; # added 2021-01-04
   python_simple_hipchat = python-simple-hipchat; # added 2021-07-21
   qasm2image = throw "qasm2image is no longer maintained (since November 2018), and is not compatible with the latest pythonPackages.qiskit versions."; # added 2020-12-09

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7279,6 +7279,8 @@ in {
 
   python-opendata-transport = callPackage ../development/python-modules/python-opendata-transport { };
 
+  python-openstackclient = callPackage ../development/python-modules/python-openstackclient { };
+
   python_openzwave = callPackage ../development/python-modules/python_openzwave { };
 
   python-packer = callPackage ../development/python-modules/python-packer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5156,6 +5156,8 @@ in {
 
   oslo-concurrency = callPackage ../development/python-modules/oslo-concurrency { };
 
+  oslo-config = callPackage ../development/python-modules/oslo-config { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8607,6 +8607,8 @@ in {
     inherit (pkgs) subunit cppunit check;
   };
 
+  subunit2sql = callPackage ../development/python-modules/subunit2sql { };
+
   suds-jurko = callPackage ../development/python-modules/suds-jurko { };
 
   sumo = callPackage ../development/python-modules/sumo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8553,6 +8553,8 @@ in {
 
   stem = callPackage ../development/python-modules/stem { };
 
+  stestr = callPackage ../development/python-modules/stestr { };
+
   stevedore = callPackage ../development/python-modules/stevedore { };
 
   stm32loader = callPackage ../development/python-modules/stm32loader { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3968,6 +3968,8 @@ in {
 
   keystone-engine = callPackage ../development/python-modules/keystone-engine { };
 
+  keystoneauth1 = callPackage ../development/python-modules/keystoneauth1 { };
+
   keyutils = callPackage ../development/python-modules/keyutils {
     inherit (pkgs) keyutils;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5162,6 +5162,8 @@ in {
 
   oslo-db = callPackage ../development/python-modules/oslo-db { };
 
+  oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5166,6 +5166,8 @@ in {
 
   oslo-log = callPackage ../development/python-modules/oslo-log { };
 
+  oslo-serialization = callPackage ../development/python-modules/oslo-serialization { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5160,6 +5160,8 @@ in {
 
   oslo-context = callPackage ../development/python-modules/oslo-context { };
 
+  oslo-db = callPackage ../development/python-modules/oslo-db { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1884,6 +1884,8 @@ in {
 
   debian-inspector = callPackage ../development/python-modules/debian-inspector { };
 
+  debtcollector = callPackage ../development/python-modules/debtcollector { };
+
   debts = callPackage ../development/python-modules/debts { };
 
   debugpy = callPackage ../development/python-modules/debugpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5158,6 +5158,8 @@ in {
 
   oslo-config = callPackage ../development/python-modules/oslo-config { };
 
+  oslo-context = callPackage ../development/python-modules/oslo-context { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5164,6 +5164,8 @@ in {
 
   oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
 
+  oslo-log = callPackage ../development/python-modules/oslo-log { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5510,6 +5510,8 @@ in {
 
   python-juicenet = callPackage ../development/python-modules/python-juicenet { };
 
+  python-keystoneclient = callPackage ../development/python-modules/python-keystoneclient { };
+
   python-lsp-black = callPackage ../development/python-modules/python-lsp-black { };
 
   python-openems = callPackage ../development/python-modules/python-openems { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7127,6 +7127,8 @@ in {
 
   python-box = callPackage ../development/python-modules/python-box { };
 
+  python-cinderclient = callPackage ../development/python-modules/python-cinderclient { };
+
   python-constraint = callPackage ../development/python-modules/python-constraint { };
 
   python-crontab = callPackage ../development/python-modules/python-crontab { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5097,6 +5097,8 @@ in {
 
   opensimplex = callPackage ../development/python-modules/opensimplex { };
 
+  openstacksdk = callPackage ../development/python-modules/openstacksdk { };
+
   opentimestamps = callPackage ../development/python-modules/opentimestamps { };
 
   opentracing = callPackage ../development/python-modules/opentracing { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7240,6 +7240,8 @@ in {
 
   python-nomad = callPackage ../development/python-modules/python-nomad { };
 
+  python-novaclient = callPackage ../development/python-modules/python-novaclient { };
+
   python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };
 
   pythonocc-core = toPythonModule (callPackage ../development/python-modules/pythonocc-core {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5154,6 +5154,8 @@ in {
 
   osmpythontools = callPackage ../development/python-modules/osmpythontools { };
 
+  oslo-concurrency = callPackage ../development/python-modules/oslo-concurrency { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5170,6 +5170,8 @@ in {
 
   oslo-utils = callPackage ../development/python-modules/oslo-utils { };
 
+  oslotest = callPackage ../development/python-modules/oslotest { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5168,6 +5168,8 @@ in {
 
   oslo-serialization = callPackage ../development/python-modules/oslo-serialization { };
 
+  oslo-utils = callPackage ../development/python-modules/oslo-utils { };
+
   osqp = callPackage ../development/python-modules/osqp { };
 
   outcome = callPackage ../development/python-modules/outcome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5136,6 +5136,8 @@ in {
 
   osc = callPackage ../development/python-modules/osc { };
 
+  osc-lib = callPackage ../development/python-modules/osc-lib { };
+
   oscrypto = callPackage ../development/python-modules/oscrypto { };
 
   oset = callPackage ../development/python-modules/oset { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5140,6 +5140,8 @@ in {
 
   orvibo = callPackage ../development/python-modules/orvibo { };
 
+  os-service-types = callPackage ../development/python-modules/os-service-types { };
+
   osc = callPackage ../development/python-modules/osc { };
 
   osc-lib = callPackage ../development/python-modules/osc-lib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3273,6 +3273,8 @@ in {
 
   hachoir = callPackage ../development/python-modules/hachoir { };
 
+  hacking = callPackage ../development/python-modules/hacking { };
+
   hdate = callPackage ../development/python-modules/hdate { };
 
   ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


replaces #134282
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
