### PR TITLE
trustedGrub, trustedGrub-for-HP: apply upstream fix for fresh glibc

### DIFF
--- a/pkgs/tools/misc/grub/trusted.nix
+++ b/pkgs/tools/misc/grub/trusted.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchgit, autogen, flex, bison, python, autoconf, automake
+{ lib, stdenv, fetchurl, fetchgit, fetchpatch, autogen, flex, bison, python, autoconf, automake
 , gettext, ncurses, libusb-compat-0_1, freetype, qemu, lvm2
 , for_HP_laptop ? false
 }:
@@ -81,7 +81,14 @@ stdenv.mkDerivation rec {
            -e "s|/usr/src/unifont.bdf|$PWD/unifont.bdf|g"
     '';
 
-  patches = [ ./fix-bash-completion.patch ];
+  patches = [
+    ./fix-bash-completion.patch
+    (fetchpatch {
+      # glibc-2.26 and above needs '<sys/sysmacros.h>'
+      url = "https://github.com/Rohde-Schwarz/TrustedGRUB2/commit/7a5b301e3adb8e054288518a325135a1883c1c6c.patch";
+      sha256 = "1jfrrmcrd9a8w7n419kszxgbpshx7888wc05smg5q4jvc1ag3xm7";
+    })
+  ];
 
   # save target that grub is compiled for
   grubTarget = if inPCSystems
@@ -89,7 +96,9 @@ stdenv.mkDerivation rec {
                else "";
 
   doCheck = false;
-  enableParallelBuilding = true;
+  # On -j16 races with early header creation:
+  #  config.h:38:10: fatal error: ./config-util.h: No such file or directory
+  enableParallelBuilding = false;
 
   meta = with lib; {
     description = "GRUB 2.0 extended with TCG (TPM) support for integrity measured boot process (trusted boot)";


### PR DESCRIPTION
Fix glibc-2.26+ build failure.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
