### PR TITLE
python38Packages.flask-restx: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/flask-restx/default.nix
+++ b/pkgs/development/python-modules/flask-restx/default.nix
@@ -8,8 +8,6 @@
 , pytz
 , faker
 , six
-, enum34
-, isPy27
 , mock
 , blinker
 , pytest-flask
@@ -20,27 +18,34 @@
 
 buildPythonPackage rec {
   pname = "flask-restx";
-  version = "0.4.0";
+  version = "0.5.1";
 
   # Tests not included in PyPI tarball
   src = fetchFromGitHub {
     owner = "python-restx";
     repo = pname;
     rev = version;
-    sha256 = "sha256-jM0QJ/klbWh3qho6ZQOH2n1qaguK9C98QIuSfqpI8xA=";
+    sha256 = "18vrmknyxw6adn62pz3kr9kvazfgjgl4pgimdf8527fyyiwcqy15";
   };
 
-  postPatch = ''
-    # https://github.com/python-restx/flask-restx/pull/341
-    substituteInPlace requirements/install.pip \
-      --replace "Flask>=0.8, <2.0.0" "Flask>=0.8, !=2.0.0" \
-      --replace "werkzeug <2.0.0" "werkzeug !=2.0.0"
-  '';
+  propagatedBuildInputs = [
+    aniso8601
+    flask
+    jsonschema
+    pytz
+    six
+    werkzeug
+  ];
 
-  propagatedBuildInputs = [ aniso8601 jsonschema flask werkzeug pytz six ]
-    ++ lib.optionals isPy27 [ enum34 ];
-
-  checkInputs = [ pytestCheckHook faker mock pytest-flask pytest-mock pytest-benchmark blinker ];
+  checkInputs = [
+    blinker
+    faker
+    mock
+    pytest-benchmark
+    pytest-flask
+    pytest-mock
+    pytestCheckHook
+  ];
 
   pytestFlagsArray = [
     "--benchmark-disable"


### PR DESCRIPTION
###### Motivation for this change
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32838
https://snyk.io/vuln/SNYK-PYTHON-FLASKRESTX-1583867

Will patch stable as it's trivial.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
