### PR TITLE
[21.05] python38Packages.flask-restx: add patch for CVE-2021-32838

### DIFF
--- a/pkgs/development/python-modules/flask-restx/default.nix
+++ b/pkgs/development/python-modules/flask-restx/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , aniso8601
 , jsonschema
 , flask
@@ -29,6 +30,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "0aj13nd3z71gb8c2kqiaz3f9k7jr0srlvrsx8hpz4nkpki8jiz2s";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2021-32838.patch";
+      url = "https://github.com/python-restx/flask-restx/commit/bab31e085f355dd73858fd3715f7ed71849656da.patch";
+      sha256 = "1n786f0zq3gyrp9s28qw3j8bkqhys38vbaafaizplaf4f76bh7m8";
+    })
+  ];
 
   propagatedBuildInputs = [ aniso8601 jsonschema flask werkzeug pytz six ]
     ++ lib.optionals isPy27 [ enum34 ];


### PR DESCRIPTION
###### Motivation for this change
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32838
https://snyk.io/vuln/SNYK-PYTHON-FLASKRESTX-1583867

See  #137372 for master

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
