### PR TITLE
maddy: include systemd units

### DIFF
--- a/pkgs/servers/maddy/default.nix
+++ b/pkgs/servers/maddy/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, coreutils }:
 
 buildGoModule rec {
   pname = "maddy";
@@ -16,6 +16,18 @@ buildGoModule rec {
   ldflags = [ "-s" "-w" "-X github.com/foxcpp/maddy.Version=${version}" ];
 
   subPackages = [ "cmd/maddy" "cmd/maddyctl" ];
+
+  postInstall = ''
+    mkdir -p $out/lib/systemd/system
+
+    substitute dist/systemd/maddy.service $out/lib/systemd/system/maddy.service \
+      --replace "/usr/bin/maddy" "$out/bin/maddy" \
+      --replace "/bin/kill" "${coreutils}/bin/kill"
+
+    substitute dist/systemd/maddy@.service $out/lib/systemd/system/maddy@.service \
+      --replace "/usr/bin/maddy" "$out/bin/maddy" \
+      --replace "/bin/kill" "${coreutils}/bin/kill"
+  '';
 
   meta = with lib; {
     description = "Composable all-in-one mail server";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
@onny -> https://github.com/NixOS/nixpkgs/issues/133256#issuecomment-917371977

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
