### PR TITLE
torrential: 1.1.0 -> 2.0.0

### DIFF
--- a/pkgs/applications/networking/p2p/torrential/default.nix
+++ b/pkgs/applications/networking/p2p/torrential/default.nix
@@ -1,55 +1,69 @@
 { lib, stdenv
 , fetchFromGitHub
 , nix-update-script
-, cmake
+, desktop-file-utils
+, meson
+, ninja
 , pkg-config
-, vala_0_40
-, pantheon
+, python3
+, vala
+, wrapGAppsHook
 , curl
+, dht
 , glib
 , gtk3
 , libb64
 , libevent
 , libgee
 , libnatpmp
-, libunity
+, libtransmission
+, libutp
 , miniupnpc
 , openssl
-, wrapGAppsHook
+, pantheon
 }:
 
 stdenv.mkDerivation rec {
   pname = "torrential";
-  version = "1.1.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "davidmhewitt";
     repo = "torrential";
     rev = version;
-    fetchSubmodules = true;
-    sha256 = "17aby0c17ybyzyzyc1cg1j6q1a186801fy84avlaxahqp7vdammx";
+    sha256 = "sha256-78eNIz7Lgeq4LTog04TMNuL27Gv0UZ0poBaw8ia1R/g=";
   };
 
   nativeBuildInputs = [
-    cmake
-    vala_0_40 # https://github.com/davidmhewitt/torrential/issues/135
+    desktop-file-utils
+    meson
+    ninja
     pkg-config
+    python3
+    vala
     wrapGAppsHook
   ];
 
   buildInputs = [
     curl
+    dht
     glib
     gtk3
     libb64
     libevent
     libgee
     libnatpmp
-    libunity
+    libtransmission
+    libutp
     miniupnpc
     openssl
     pantheon.granite
   ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
 
   passthru = {
     updateScript = nix-update-script {
@@ -60,8 +74,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Download torrents in style with this speedy, minimalist torrent client for elementary OS";
     homepage = "https://github.com/davidmhewitt/torrential";
-    maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
-    license = licenses.gpl3;
+    license = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

With #134007 merged, we can finally start this. 2.0.0 switched to meson for building.

- https://github.com/davidmhewitt/torrential/releases/tag/2.0.0
- https://github.com/davidmhewitt/torrential/compare/1.1.0...2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
