### PR TITLE
xcbuild: fix build by adding missing include

### DIFF
--- a/pkgs/development/tools/xcbuild/default.nix
+++ b/pkgs/development/tools/xcbuild/default.nix
@@ -30,6 +30,8 @@ in stdenv.mkDerivation {
     sha256 = "1xxwg2849jizxv0g1hy0b1m3i7iivp9bmc4f5pi76swsn423d41m";
   };
 
+  patches = [ ./includes.patch ];
+
   prePatch = ''
     rmdir ThirdParty/*
     cp -r --no-preserve=all ${googletest} ThirdParty/googletest

--- a/pkgs/development/tools/xcbuild/includes.patch
+++ b/pkgs/development/tools/xcbuild/includes.patch
@@ -1,0 +1,10 @@
+--- a/Libraries/plist/Sources/Format/Encoding.cpp
++++ b/Libraries/plist/Sources/Format/Encoding.cpp
+@@ -11,6 +11,7 @@
+ #include <plist/Format/unicode.h>
+ 
+ #include <cassert>
++#include <cstdlib> /* abort() */
+ 
+ #if defined(__linux__)
+ #include <endian.h>


### PR DESCRIPTION
`xcbuild` fials to build on linux due to missing `abort()` declaration.
Fix build with local patch as upstream repository is archived.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Closes: #123106
