### PR TITLE
ccache: 4.4 → 4.4.1

### DIFF
--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , substituteAll
 , binutils
 , asciidoctor
@@ -14,18 +15,25 @@
 
 let ccache = stdenv.mkDerivation rec {
   pname = "ccache";
-  version = "4.4";
+  version = "4.4.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-ZewR1srksfKCxehhAg3i8m+0OvmOSF+24njbtcc1GQY=";
+    hash = "sha256-zsJoaaxYVV78vsxq2nbOh9ZAU1giKp8Kh6qJFL120CQ=";
   };
 
   outputs = [ "out" "man" ];
 
   patches = [
+    # Use the shell builtin pwd for the basedir test
+    # See https://github.com/ccache/ccache/pull/933
+    (fetchpatch {
+      url = "https://github.com/ccache/ccache/commit/58fd1fbe75a1b5dc3f9151947ace15164fdef91c.patch";
+      sha256 = "BoBn4YSDy8pQxJ+fQHSsrUZDBVeLFWXIQ6CunDwMO7o=";
+    })
+
     # When building for Darwin, test/run uses dwarfdump, whereas on
     # Linux it uses objdump. We don't have dwarfdump packaged for
     # Darwin, so this patch updates the test to also use objdump on


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/ccache/ccache/releases/tag/v4.4.1

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@r-burns