### PR TITLE
pythonPackages.debugpy: 1.4.1 → 1.4.3

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.4.2";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-asowRMcNWUsy5av7GOoWALy7Ph3WNk4sU/EsiwVUkf4=";
+    hash = "sha256-ULxVoZuMNDL0Win/+55RnbkCPZ8OI8nhSKshvJOMFQ4=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-W51Y9tZB1Uyp175+hWCpXChwL+MBpDWjudF87F1MRso=";
+    hash = "sha256-asowRMcNWUsy5av7GOoWALy7Ph3WNk4sU/EsiwVUkf4=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
+++ b/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/debug/session.py b/tests/debug/session.py
-index 101492f..4ee7cfb 100644
+index 101492fc..4ee7cfbe 100644
 --- a/tests/debug/session.py
 +++ b/tests/debug/session.py
 @@ -630,6 +630,7 @@ class Session(object):

--- a/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
@@ -1,8 +1,8 @@
 diff --git a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-index 51017f2..46654ab 100644
+index 3c0e1b94..e995a20f 100644
 --- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 +++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-@@ -398,7 +398,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
+@@ -399,7 +399,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
      is_debug = 0
      # Note that the space in the beginning of each line in the multi-line is important!
      cmd = [

--- a/pkgs/development/python-modules/debugpy/hardcode-version.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-version.patch
@@ -1,25 +1,22 @@
 diff --git a/setup.py b/setup.py
-index cfec60d..32ca206 100644
+index ee5bbba9..0b7b9b45 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -24,7 +24,6 @@ elif "--abi" in sys.argv:
- from setuptools import setup  # noqa
+@@ -15,7 +15,6 @@ from distutils.command.build_py import build_py as _build_py
+ 
  
  sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 -import versioneer  # noqa
  
  del sys.path[0]
  
-@@ -86,7 +85,7 @@ if __name__ == "__main__":
-     if not os.getenv("SKIP_CYTHON_BUILD"):
-         cython_build()
+@@ -129,12 +128,12 @@ if __name__ == "__main__":
+     if platforms is not None:
+         extras["platforms"] = platforms
  
 -    cmds = versioneer.get_cmdclass()
 +    cmds = {}
-     cmds["bdist_wheel"] = bdist_wheel
- 
-     extras = {}
-@@ -96,7 +95,7 @@ if __name__ == "__main__":
+     cmds.update(build=build, build_py=build_py)
  
      setup(
          name="debugpy",
@@ -29,7 +26,7 @@ index cfec60d..32ca206 100644
          long_description=long_description,
          long_description_content_type="text/markdown",
 diff --git a/src/debugpy/__init__.py b/src/debugpy/__init__.py
-index baa5a7c..5355327 100644
+index baa5a7c5..53553272 100644
 --- a/src/debugpy/__init__.py
 +++ b/src/debugpy/__init__.py
 @@ -27,7 +27,6 @@ __all__ = [

--- a/pkgs/development/python-modules/debugpy/hardcode-version.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-version.patch
@@ -1,8 +1,8 @@
 diff --git a/setup.py b/setup.py
-index ee5bbba9..0b7b9b45 100644
+index e7487100..10d36520 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -15,7 +15,6 @@ from distutils.command.build_py import build_py as _build_py
+@@ -12,7 +12,6 @@ import sys
  
  
  sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -10,15 +10,16 @@ index ee5bbba9..0b7b9b45 100644
  
  del sys.path[0]
  
-@@ -129,12 +128,12 @@ if __name__ == "__main__":
+@@ -141,13 +140,13 @@ if __name__ == "__main__":
      if platforms is not None:
          extras["platforms"] = platforms
  
 -    cmds = versioneer.get_cmdclass()
 +    cmds = {}
-     cmds.update(build=build, build_py=build_py)
+     override_build(cmds)
+     override_build_py(cmds)
  
-     setup(
+     setuptools.setup(
          name="debugpy",
 -        version=versioneer.get_version(),
 +        version="@version@",


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/microsoft/debugpy/releases/tag/v1.4.3

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files, only a Python library. Tested through `dap-mode` in Emacs.
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).