### PR TITLE
nixos/rabbitmq: clean-up after f091420c1d194ad398142959266f18493da1ff83

### DIFF
--- a/nixos/modules/services/amqp/rabbitmq.nix
+++ b/nixos/modules/services/amqp/rabbitmq.nix
@@ -135,25 +135,14 @@ in
         description = "The list of directories containing external plugins";
       };
 
-      managementPlugin = mkOption {
-        description = "The options to run the management plugin";
-        type = types.submodule {
-          options = {
-            enable = mkOption {
-              default = false;
-              type = types.bool;
-              description = ''
-                Whether to enable the management plugin
-              '';
-            };
-            port = mkOption {
-              default = 15672;
-              type = types.port;
-              description = ''
-                On which port to run the management plugin
-              '';
-            };
-          };
+      managementPlugin = {
+        enable = mkEnableOption "the management plugin";
+        port = mkOption {
+          default = 15672;
+          type = types.port;
+          description = ''
+            On which port to run the management plugin
+          '';
         };
       };
     };


### PR DESCRIPTION
###### Motivation for this change
@happysalada 

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
