### PR TITLE
ccache: 4.4 -> 4.4.1

### DIFF
--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , substituteAll
 , binutils
+, coreutils
 , asciidoctor
 , cmake
 , perl
@@ -14,13 +15,13 @@
 
 let ccache = stdenv.mkDerivation rec {
   pname = "ccache";
-  version = "4.4";
+  version = "4.4.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-ZewR1srksfKCxehhAg3i8m+0OvmOSF+24njbtcc1GQY=";
+    hash = "sha256-zsJoaaxYVV78vsxq2nbOh9ZAU1giKp8Kh6qJFL120CQ=";
   };
 
   outputs = [ "out" "man" ];
@@ -35,6 +36,11 @@ let ccache = stdenv.mkDerivation rec {
       objdump = "${binutils.bintools}/bin/objdump";
     })
   ];
+
+  postPatch = ''
+    substituteInPlace test/suites/basedir.bash \
+       --replace "/bin/pwd" "${coreutils}/bin/pwd"
+  '';
 
   nativeBuildInputs = [ asciidoctor cmake perl ];
   buildInputs = [ zstd ];


### PR DESCRIPTION
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
