### PR TITLE
cni-plugin-flannel: init at 20210910

### DIFF
--- a/pkgs/applications/networking/cluster/cni/plugin-flannel.nix
+++ b/pkgs/applications/networking/cluster/cni/plugin-flannel.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "cni-plugin-flannel";
-  version = "20210910";
+  version = "unstable-2021-09-10";
 
   src = fetchFromGitHub {
     owner = "flannel-io";

--- a/pkgs/applications/networking/cluster/cni/plugin-flannel.nix
+++ b/pkgs/applications/networking/cluster/cni/plugin-flannel.nix
@@ -1,0 +1,29 @@
+{ lib, pkgs, buildGoModule, fetchFromGitHub }:
+
+buildGoModule {
+  pname = "cni-plugin-flannel";
+  version = "20210910";
+
+  src = fetchFromGitHub {
+    owner = "flannel-io";
+    repo = "cni-plugin";
+    rev = "8ce83510da59681da905dccb8364af9472cac341";
+    sha256 = "sha256-x6F8n+IJ1pZdbDwniWWmoGKgQm235ax3mbOcbYqWLCs=";
+  };
+
+  vendorSha256 = "sha256-TLAwE3pTnJYOi1AsOQfsG6t3xLKOah/7DvYjsqyltKs=";
+
+  postInstall = ''
+    mv $out/bin/cni-plugin $out/bin/flannel
+  '';
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "flannel CNI plugin";
+    homepage = "https://github.com/flannel-io/cni-plugin/";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abbe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23890,6 +23890,7 @@ with pkgs;
 
   cni = callPackage ../applications/networking/cluster/cni {};
   cni-plugins = callPackage ../applications/networking/cluster/cni/plugins.nix {};
+  cni-plugin-flannel = callPackage ../applications/networking/cluster/cni/plugin-flannel.nix {};
 
   dnsname-cni = callPackage ../applications/networking/cluster/dnsname-cni {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

While playing with Kubernetes on NixOS, I noticed that `flannel` plugin is missing from `cni-plugins`, courtesy: containernetworking/plugins#633

So, I packaged this latest snapshot, and able to bootstrap my cluster.

To use it with NixOS: `services.kubernetes.kubelet.cni.packages = with pkgs; [ cni-plugins cni-plugin-flannel ];`

I am happy to assign it to same maintainers as `cni-plugins`, or if `cni-plugins` maintainers want to incorporate in some in existing `cni-plugins` derivation way, that'll be even better.

Thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
