### PR TITLE
ghostscript: disable checkPhase, expand installCheckPhase

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -85,7 +85,8 @@ stdenv.mkDerivation rec {
     "--with-cups-datadir=$(out)/share/cups"
   ];
 
-  doCheck = true;
+  # make check does nothing useful
+  doCheck = false;
 
   # don't build/install statically linked bin/gs
   buildFlags = [ "so" ];
@@ -115,6 +116,19 @@ stdenv.mkDerivation rec {
     runHook preInstallCheck
 
     $out/bin/gs --version
+    pushd examples
+    for f in *.{ps,eps,pdf}; do
+      echo "Rendering $f"
+      $out/bin/gs \
+        -dNOPAUSE \
+        -dBATCH \
+        -sDEVICE=bitcmyk \
+        -sOutputFile=/dev/null \
+        -r600 \
+        -dBufferSpace=100000 \
+        $f
+    done
+    popd # examples
 
     runHook postInstallCheck
   '';


### PR DESCRIPTION
###### Motivation for this change
When reviewing #137343, I noticed that the `make check` call we do doesn't really do anything useful. I think it actually rebuilds everything, perhaps with different options.

Ghostscript has a python-based test suite included, but it looks like an unmaintained disaster zone and I couldn't get it to do anything (and is untouched since ~2017)

So the best we can probably do for now is ensure we can render all the provided examples. And that can easily be done from an `installCheckPhase`, allowing us to also ensure proper installation.

A next step might be to add a `passthru.tests` rendering their test corpus https://git.ghostscript.com/?p=tests.git;a=summary

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
