### PR TITLE
[21.05] python3Packages.flask-appbuilder: 3.3.0 -> 3.3.2

### DIFF
--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -5,7 +5,6 @@
 , colorama
 , click
 , email_validator
-, fetchpatch
 , flask
 , flask-babel
 , flask_login
@@ -26,23 +25,18 @@
 
 buildPythonPackage rec {
   pname = "flask-appbuilder";
-  version = "3.3.0";
+  version = "3.3.1";
 
   src = fetchPypi {
     pname = "Flask-AppBuilder";
     inherit version;
-    sha256 = "00dsfv1apl6483wy20aj91f9h5ak2casbx5vcajv2nd3i7c7v8gx";
+    sha256 = "13rlpdf3ipm39zpc62sywn8qjn6gwfbgr43x7lqpxr28br2jcg3j";
   };
 
-  patches = [
-    # https://github.com/dpgaspar/Flask-AppBuilder/pull/1610
-    (fetchpatch {
-      name = "flask_jwt_extended-and-pyjwt-patch";
-      url = "https://github.com/dpgaspar/Flask-AppBuilder/commit/7097a7b133f27c78d2b54d2a46e4a4c24478a066.patch";
-      sha256 = "sha256-ZpY8+2Hoz3z01GVtw2OIbQcsmAwa7iwilFWzgcGhY1w=";
-      includes = [ "flask_appbuilder/security/manager.py" "setup.py" ];
-    })
-  ];
+  # See here: https://github.com/dpgaspar/Flask-AppBuilder/commit/7097a7b133f27c78d2b54d2a46e4a4c24478a066.patch
+  #           https://github.com/dpgaspar/Flask-AppBuilder/pull/1610
+  # The patch from the PR doesn't apply cleanly so I edited it manually.
+  patches = [ ./upgrade-to-flask_jwt_extended-4.patch ];
 
   propagatedBuildInputs = [
     apispec
@@ -70,9 +64,15 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py \
       --replace "apispec[yaml]>=3.3, <4" "apispec[yaml] >=3.3, <5" \
+      --replace "click>=6.7, <8" "click" \
+      --replace "Flask>=0.12, <2" "Flask" \
       --replace "Flask-Login>=0.3, <0.5" "Flask-Login >=0.3, <0.6" \
       --replace "Flask-Babel>=1, <2" "Flask-Babel >=1, <3" \
-      --replace "marshmallow-sqlalchemy>=0.22.0, <0.24.0" "marshmallow-sqlalchemy >=0.22.0, <0.25.0"
+      --replace "Flask-WTF>=0.14.2, <0.15.0" "Flask-WTF" \
+      --replace "marshmallow-sqlalchemy>=0.22.0, <0.24.0" "marshmallow-sqlalchemy" \
+      --replace "Flask-JWT-Extended>=3.18, <4" "Flask-JWT-Extended>=4.1.0" \
+      --replace "PyJWT>=1.7.1, <2.0.0" "PyJWT>=2.0.1" \
+      --replace "SQLAlchemy<1.4.0" "SQLAlchemy"
   '';
 
   # Majority of tests require network access or mongo

--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -25,12 +25,12 @@
 
 buildPythonPackage rec {
   pname = "flask-appbuilder";
-  version = "3.3.1";
+  version = "3.3.2";
 
   src = fetchPypi {
     pname = "Flask-AppBuilder";
     inherit version;
-    sha256 = "13rlpdf3ipm39zpc62sywn8qjn6gwfbgr43x7lqpxr28br2jcg3j";
+    sha256 = "1js1nbal020ilqdrmd471zjab9jj6489fxy4583n55bh5fyiac6i";
   };
 
   # See here: https://github.com/dpgaspar/Flask-AppBuilder/commit/7097a7b133f27c78d2b54d2a46e4a4c24478a066.patch

--- a/pkgs/development/python-modules/flask-appbuilder/upgrade-to-flask_jwt_extended-4.patch
+++ b/pkgs/development/python-modules/flask-appbuilder/upgrade-to-flask_jwt_extended-4.patch
@@ -1,0 +1,45 @@
+diff --git a/flask_appbuilder/security/api.py b/flask_appbuilder/security/api.py
+index 2e2dfd612..df1bd5a25 100644
+--- a/flask_appbuilder/security/api.py
++++ b/flask_appbuilder/security/api.py
+@@ -3,7 +3,7 @@
+     create_access_token,
+     create_refresh_token,
+     get_jwt_identity,
+-    jwt_refresh_token_required,
++    jwt_required,
+ )
+ 
+ from ..api import BaseApi, safe
+@@ -118,7 +118,7 @@ def login(self):
+         return self.response(200, **resp)
+ 
+     @expose("/refresh", methods=["POST"])
+-    @jwt_refresh_token_required
++    @jwt_required(refresh=True)
+     @safe
+     def refresh(self):
+         """
+diff --git a/flask_appbuilder/security/manager.py b/flask_appbuilder/security/manager.py
+index fe7697007..3b22ab255 100644
+--- a/flask_appbuilder/security/manager.py
++++ b/flask_appbuilder/security/manager.py
+@@ -297,7 +297,7 @@ def create_jwt_manager(self, app) -> JWTManager:
+         """
+         jwt_manager = JWTManager()
+         jwt_manager.init_app(app)
+-        jwt_manager.user_loader_callback_loader(self.load_user_jwt)
++        jwt_manager.user_lookup_loader(self.load_user_jwt)
+         return jwt_manager
+ 
+     def create_builtin_roles(self):
+@@ -1944,7 +1944,8 @@ def del_permission_role(self, role, perm_view):
+     def load_user(self, pk):
+         return self.get_user_by_id(int(pk))
+ 
+-    def load_user_jwt(self, pk):
++    def load_user_jwt(self, _jwt_header, jwt_data):
++        pk = jwt_data["sub"]
+         user = self.load_user(pk)
+         # Set flask g.user to JWT user, we can't do it on before request
+         g.user = user


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-32805

See #137370 for master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
