### PR TITLE
spot: 0.1.14 -> 0.2.0

### DIFF
--- a/pkgs/applications/audio/spot/default.nix
+++ b/pkgs/applications/audio/spot/default.nix
@@ -76,6 +76,6 @@ stdenv.mkDerivation rec {
     description = "Native Spotify client for the GNOME desktop";
     homepage = "https://github.com/xou816/spot";
     license = licenses.mit;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ jtojnar tomfitzhenry ];
   };
 }

--- a/pkgs/applications/audio/spot/default.nix
+++ b/pkgs/applications/audio/spot/default.nix
@@ -10,8 +10,9 @@
 , rustPlatform
 , pkg-config
 , glib
+, libadwaita
 , libhandy
-, gtk3
+, gtk4
 , openssl
 , alsa-lib
 , libpulseaudio
@@ -20,19 +21,19 @@
 
 stdenv.mkDerivation rec {
   pname = "spot";
-  version = "0.1.14";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "xou816";
     repo = "spot";
     rev = version;
-    sha256 = "eHhbm1amTx3ngqsP32uDEdrhrBeurMftg5SToTQGX9o=";
+    sha256 = "16pri0in514xzy21bsijyvyyjwa0f6lg4zyizmdcmcdw4glrs11m";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-jY7pWoY9IJi5hHVRS1gQKb+Vmfc+wxHvoAwupOtXXQs=";
+    sha256 = "1fvnidxh4rnkzqg3qjk3zlkp2d41qdamm0bfavk8jrazw8sgih84";
   };
 
   nativeBuildInputs = [
@@ -41,7 +42,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3 # for meson postinstall script
-    gtk3 # for gtk-update-icon-cache
+    gtk4 # for gtk-update-icon-cache
     glib # for glib-compile-schemas
     desktop-file-utils
     rustPlatform.rust.cargo
@@ -52,7 +53,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
-    gtk3
+    gtk4
+    libadwaita
     libhandy
     openssl
     alsa-lib


### PR DESCRIPTION
###### Motivation for this change
https://github.com/xou816/spot/releases/tag/0.1.15
https://github.com/xou816/spot/releases/tag/0.1.16
https://github.com/xou816/spot/releases/tag/0.2.0

I have been using this on my Pinephone for the past few days. The UI adapts to the Pinephone's smaller screen much better now!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
