### PR TITLE
eduke32: implement proper macOS support

### DIFF
--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -18,13 +18,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "eduke32";
-  version = "20210722";
-  rev = "9484";
-  revExtra = "f3fea8c15";
+  version = "20210910";
+  rev = "9603";
+  revExtra = "6c289cce4";
 
   src = fetchurl {
-    url = "http://dukeworld.duke4.net/eduke32/synthesis/${version}-${rev}-${revExtra}/eduke32_src_${version}-${rev}-${revExtra}.tar.xz";
-    sha256 = "0fdl2i465cl5x7129772ksx97lvim98m9009q5cfmf6scagj9pvz";
+    url = "https://dukeworld.com/eduke32/synthesis/${version}-${rev}-${revExtra}/eduke32_src_${version}-${rev}-${revExtra}.tar.xz";
+    sha256 = "sha256-/NQMsmT9z2N3KWBrP8hlGngQKJUgSP+vrNoFqJscRCk=";
   };
 
   buildInputs = [

--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -1,6 +1,8 @@
 { lib, stdenv, fetchurl, makeWrapper, pkg-config, nasm, makeDesktopItem
 , alsa-lib, flac, gtk2, libvorbis, libvpx, libGLU, libGL
-, SDL2, SDL2_mixer }:
+, SDL2, SDL2_mixer
+, AGL, Cocoa, GLUT, OpenGL
+}:
 
 let
   desktopItem = makeDesktopItem {
@@ -25,12 +27,28 @@ in stdenv.mkDerivation rec {
     sha256 = "0fdl2i465cl5x7129772ksx97lvim98m9009q5cfmf6scagj9pvz";
   };
 
-  buildInputs = [ alsa-lib flac gtk2 libvorbis libvpx libGL libGLU SDL2 SDL2_mixer ];
+  buildInputs = [
+    flac
+    libvorbis
+    libvpx
+    SDL2
+    SDL2_mixer
+  ] ++ lib.optionals stdenv.isLinux [
+    alsa-lib
+    gtk2
+    libGL
+    libGLU
+  ] ++ lib.optionals stdenv.isDarwin [
+    AGL
+    Cocoa
+    GLUT
+    OpenGL
+  ];
 
   nativeBuildInputs = [ makeWrapper pkg-config ]
     ++ lib.optional (stdenv.hostPlatform.system == "i686-linux") nasm;
 
-  postPatch = ''
+  postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace source/build/src/glbuild.cpp \
       --replace libGLU.so ${libGLU}/lib/libGLU.so
 
@@ -44,6 +62,9 @@ in stdenv.mkDerivation rec {
 
   makeFlags = [
     "SDLCONFIG=${SDL2}/bin/sdl2-config"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # broken, see: https://github.com/NixOS/nixpkgs/issues/19098
+    "LTO=0"
   ];
 
   enableParallelBuilding = true;
@@ -52,7 +73,7 @@ in stdenv.mkDerivation rec {
     runHook preInstall
 
     install -Dm755 -t $out/bin eduke32 mapster32
-
+  '' + lib.optionalString stdenv.isLinux ''
     makeWrapper $out/bin/eduke32 $out/bin/${wrapper} \
       --set-default EDUKE32_DATA_DIR /var/lib/games/eduke32 \
       --add-flags '-g "$EDUKE32_DATA_DIR/DUKE3D.GRP"'
@@ -60,7 +81,16 @@ in stdenv.mkDerivation rec {
     cp -rv ${desktopItem}/share $out
     substituteInPlace $out/share/applications/eduke32.desktop \
       --subst-var out
+  '' + lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications/EDuke32.app/Contents/MacOS
+    mkdir -p $out/Applications/Mapster32.app/Contents/MacOS
 
+    cp -r platform/Apple/bundles/EDuke32.app/* $out/Applications/EDuke32.app/
+    cp -r platform/Apple/bundles/Mapster32.app/* $out/Applications/Mapster32.app/
+
+    ln -sf $out/bin/eduke32 $out/Applications/EDuke32.app/Contents/MacOS/eduke32
+    ln -sf $out/bin/mapster32 $out/Applications/Mapster32.app/Contents/MacOS/mapster32
+  '' + ''
     runHook postInstall
   '';
 
@@ -68,8 +98,7 @@ in stdenv.mkDerivation rec {
     description = "Enhanched port of Duke Nukem 3D for various platforms";
     homepage = "http://eduke32.com";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ sander ];
-    # Darwin is untested (supported by upstream)
+    maintainers = with maintainers; [ mikroskeem sander ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29473,7 +29473,9 @@ with pkgs;
 
   ecwolf = callPackage ../games/ecwolf { };
 
-  eduke32 = callPackage ../games/eduke32 { };
+  eduke32 = callPackage ../games/eduke32 {
+    inherit (darwin.apple_sdk.frameworks) AGL Cocoa GLUT OpenGL;
+  };
 
   egoboo = callPackage ../games/egoboo { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
