### PR TITLE
stuntman: init at 1.2.16

### DIFF
--- a/pkgs/tools/networking/stuntman/default.nix
+++ b/pkgs/tools/networking/stuntman/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchFromGitHub, openssl, boost }:
+
+stdenv.mkDerivation {
+  pname = "stuntman";
+  version = "1.2.16";
+
+  src = fetchFromGitHub {
+    owner = "jselbie";
+    repo = "stunserver";
+    rev = "cfadf9c3836d5ae63a682913de24ba085df924f3";
+    sha256 = "1gcx4zj44f0viddnn5klkmq0dgd29av5p06iyf9f1va4a3lk0cbg";
+  };
+
+  buildInputs = [
+    boost
+    openssl
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mv stunserver $out/bin/
+    mv stunclient $out/bin/
+
+    runHook postInstall
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    ./stuntestcode
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "STUNTMAN - an open source STUN server and client";
+    homepage = "http://www.stunprotocol.org/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mattchrist ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9315,6 +9315,8 @@ with pkgs;
 
   stunnel = callPackage ../tools/networking/stunnel { };
 
+  stuntman = callPackage ../tools/networking/stuntman { };
+
   stutter = haskell.lib.justStaticExecutables haskellPackages.stutter;
 
   strongswan    = callPackage ../tools/networking/strongswan { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds 'stuntman' STUN server and client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
