### PR TITLE
chatty: 0.3.4 -> 0.4.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatty/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatty/default.nix
@@ -10,11 +10,14 @@
 , wrapGAppsHook
 , evolution-data-server
 , feedbackd
+, glibmm
+, gspell
 , gtk3
 , json-glib
 , libgcrypt
 , libhandy
 , libphonenumber
+, modemmanager
 , olm
 , pidgin
 , protobuf
@@ -24,14 +27,14 @@
 
 stdenv.mkDerivation rec {
   pname = "chatty";
-  version = "0.3.4";
+  version = "0.4.0";
 
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "chatty";
     rev = "v${version}";
-    sha256 = "0910f5bw75ph576gxbsd6ysdwnlk4ysdp0pml2i3mjqpcbkqfs3w";
+    sha256 = "12k1a5xrwd6zk4x0m53hbzggk695z3bpbzy1wcikzy0jvch7h13d";
   };
 
   postPatch = ''
@@ -51,11 +54,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     evolution-data-server
     feedbackd
+    glibmm
+    gspell
     gtk3
     json-glib
     libgcrypt
     libhandy
     libphonenumber
+    modemmanager
     olm
     pidgin
     protobuf


### PR DESCRIPTION
###### Motivation for this change
Release: https://source.puri.sm/Librem5/chatty/-/tags/v0.4.0
Changelog: https://source.puri.sm/Librem5/chatty/-/blob/master/debian/changelog

I have tested this on my Pinephone. I tested that I can send and receive SMS messages (`purple-mm-sms` is no longer needed, which would have previously been used via a plugin).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
