### PR TITLE
megapixels: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/applications/graphics/megapixels/default.nix
+++ b/pkgs/applications/graphics/megapixels/default.nix
@@ -27,13 +27,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "megapixels";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromSourcehut {
     owner = "~martijnbraam";
     repo = "megapixels";
     rev = version;
-    sha256 = "0jnfzwvq58p4ksyifma10i158r2fb7fv72ymibgcxbnx596xpjb2";
+    sha256 = "0dagp1sh5whnnllrydk7ijjid0hmvcbdm8kkzq2g168khdfn80jm";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://git.sr.ht/~martijnbraam/megapixels/refs/1.3.0

Tested on my Pinephone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
