### PR TITLE
azure-cli: 2.26.1 -> 2.28.0

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
@@ -2,10 +2,9 @@
 , buildPythonPackage
 , fetchPypi
 , azure-common
+, azure-mgmt-core
 , azure-mgmt-nspkg
 , msrestazure
-, python
-, isPy3k
 }:
 
 buildPythonPackage rec {
@@ -21,8 +20,9 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     msrestazure
     azure-common
+    azure-mgmt-core
     azure-mgmt-nspkg
-  ];
+ ];
 
   pythonNamespaces = [ "azure.mgmt" ];
 

--- a/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
@@ -2,27 +2,28 @@
 , buildPythonPackage
 , fetchPypi
 , python
-, isPy3k
 , msrest
 , msrestazure
 , azure-common
+, azure-mgmt-core
 , azure-mgmt-nspkg
 }:
 
 buildPythonPackage rec {
   pname = "azure-mgmt-iothubprovisioningservices";
-  version = "0.2.0";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "8c37acfd1c33aba845f2e0302ef7266cad31cba503cc990a48684659acb7b91d";
+    sha256 = "sha256-5YcbA0iLWubfxEHNvaQMs5wABjXuV8UTBTeSs8FYJqk=";
   };
 
   propagatedBuildInputs = [
     msrest
     msrestazure
     azure-common
+    azure-mgmt-core
     azure-mgmt-nspkg
   ];
 

--- a/pkgs/development/python-modules/azure-mgmt-sqlvirtualmachine/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-sqlvirtualmachine/default.nix
@@ -1,5 +1,6 @@
 { lib, buildPythonPackage, fetchPypi, isPy27
 , azure-common
+, azure-mgmt-core
 , msrest
 , msrestazure
 }:
@@ -15,7 +16,12 @@ buildPythonPackage rec {
     extension = "zip";
   };
 
-  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-core
+    msrest
+    msrestazure
+  ];
 
   # no tests included
   doCheck = false;

--- a/pkgs/development/python-modules/azure-synapse-managedprivateendpoints/default.nix
+++ b/pkgs/development/python-modules/azure-synapse-managedprivateendpoints/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchPypi
+, azure-common
+, azure-core
+, msrest
+}:
+
+buildPythonPackage rec {
+  pname = "azure-synapse-managedprivateendpoints";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "900eaeaccffdcd01012b248a7d049008c92807b749edd1c9074ca9248554c17e";
+  };
+
+  propagatedBuildInputs = [
+    azure-common
+    azure-core
+    msrest
+  ];
+
+  pythonNamespaces = [ "azure.synapse" ];
+
+  pythonImportsCheck = [ "azure.synapse.managedprivateendpoints" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure Synapse Managed Private Endpoints Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -28,6 +28,7 @@ py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage {
     substituteInPlace setup.py \
       --replace "javaproperties==0.5.1" "javaproperties" \
       --replace "pytz==2019.1" "pytz" \
+      --replace "scp~=0.13.2" "scp" \
       --replace "jsondiff==1.2.0" "jsondiff~=1.2" \
       --replace "antlr4-python3-runtime~=4.7.2" "antlr4-python3-runtime~=4.7" \
       --replace "mock~=4.0" "mock"

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, python3, fetchFromGitHub, installShellFiles }:
 
 let
-  version = "2.26.1";
+  version = "2.28.0";
   srcName = "azure-cli-${version}-src";
 
   src = fetchFromGitHub {
@@ -9,7 +9,7 @@ let
     owner = "Azure";
     repo = "azure-cli";
     rev = "azure-cli-${version}";
-    sha256 = "sha256-AwchP0o3I2T37dLPNw51wldwYUmcRuWptyzrhOocEaQ=";
+    sha256 = "sha256-fTt6tIcc96f8t3NUaR0RG0JQ+LPgqSHuJSmVx4a6X7M=";
   };
 
   # put packages that needs to be overriden in the py package scope
@@ -125,9 +125,11 @@ py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage {
     azure-storage-blob
     azure-synapse-accesscontrol
     azure-synapse-artifacts
+    azure-synapse-managedprivateendpoints
     azure-synapse-spark
     colorama
     cryptography
+    distro
     Fabric
     jsmin
     knack

--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -91,14 +91,14 @@ let
         '';
 
         doCheck = stdenv.isLinux;
-        # ignore tests that does network call
+        # ignore tests that does network call, or assume powershell
         checkPhase = ''
           rm azure/{,cli/}__init__.py
           python -c 'import azure.common; print(azure.common)'
           PYTHONPATH=$PWD:$PYTHONPATH HOME=$TMPDIR pytest \
             --ignore=azure/cli/core/tests/test_profile.py \
             --ignore=azure/cli/core/tests/test_generic_update.py \
-            -k 'not metadata_url'
+            -k 'not metadata_url and not test_format_styled_text_legacy_powershell'
         '';
 
         pythonImportsCheck = [
@@ -135,14 +135,17 @@ let
       azure-appconfiguration = overrideAzureMgmtPackage super.azure-appconfiguration "1.1.1" "zip"
         "sha256-uDzSy2PZMiXehOJ6u/wFkhL43id2b0xY3Tq7g53/C+Q=";
 
-      azure-batch = overrideAzureMgmtPackage super.azure-batch "10.0.0" "zip"
-        "83d7a2b0be42ca456ac2b56fa3dc6ce704c130e888d37d924072c1d3718f32d0";
+      azure-batch = overrideAzureMgmtPackage super.azure-batch "11.0.0" "zip"
+        "83d7a2b0be42ca456ac2b56fa3dc6ce704c130e888d37d924072c1d3718f32da";
 
       azure-mgmt-apimanagement = overrideAzureMgmtPackage super.azure-mgmt-apimanagement "0.2.0" "zip"
         "0whx3s8ri9939r3pdvjf8iqcslas1xy6cnccidmp10r5ng0023vr";
 
-      azure-mgmt-batch = overrideAzureMgmtPackage super.azure-mgmt-batch "15.0.0" "zip"
-        "9b793bb31a0d4dc8c29186db61db24d83795851a75846aadb187cf95bf853ccb";
+      azure-mgmt-batch = overrideAzureMgmtPackage super.azure-mgmt-batch "16.0.0" "zip"
+        "1b3cecd6f16813879c6ac1a1bb01f9a6f2752cd1f9157eb04d5e41e4a89f3c34";
+
+      azure-mgmt-batchai = overrideAzureMgmtPackage super.azure-mgmt-batchai "7.0.0b1" "zip"
+        "sha256-mT6vvjWbq0RWQidugR229E8JeVEiobPD3XA/nDM3I6Y=";
 
       azure-mgmt-billing = overrideAzureMgmtPackage super.azure-mgmt-billing "6.0.0" "zip"
         "d4f5c5a4188a456fe1eb32b6c45f55ca2069c74be41eb76921840b39f2f5c07f";
@@ -150,20 +153,20 @@ let
       azure-mgmt-botservice = overrideAzureMgmtPackage super.azure-mgmt-botservice "0.3.0" "zip"
         "f8318878a66a0685a01bf27b7d1409c44eb90eb72b0a616c1a2455c72330f2f1";
 
-      azure-mgmt-policyinsights = overrideAzureMgmtPackage super.azure-mgmt-policyinsights "0.5.0" "zip"
-        "1wxh7mgrknnhqyafdd7sbwx8plx0zga2af21vs6yhxy48lw9w8pd";
+      azure-mgmt-policyinsights = overrideAzureMgmtPackage super.azure-mgmt-policyinsights "1.0.0" "zip"
+        "75103fb4541aeae30bb687dee1fedd9ca65530e6b97b2d9ea87f74816905202a";
 
-      azure-mgmt-rdbms = overrideAzureMgmtPackage super.azure-mgmt-rdbms "8.1.0b4" "zip"
-        "sha256-39msNYlZeZdn8cJ4LjZw9oxzy0YrNSPVEIN21wnkMKs=";
+      azure-mgmt-rdbms = overrideAzureMgmtPackage super.azure-mgmt-rdbms "9.1.0b1" "zip"
+        "sha256-O/6dE6lUnowYTWwQLWt3u1dwV4jBof+Jok0PUhFEEs0=";
 
-      azure-mgmt-recoveryservices = overrideAzureMgmtPackage super.azure-mgmt-recoveryservices "1.0.0" "zip"
-        "0v0ycyjnnx09jqf958hj2q6zfpsn80bxxm98jf59y8rj09v99rza";
+      azure-mgmt-recoveryservices = overrideAzureMgmtPackage super.azure-mgmt-recoveryservices "2.0.0" "zip"
+        "sha256-p9MTfVxGD1CsLUQGHWCnC08nedTKhEt3QZtXJeZeCb4=";
 
-      azure-mgmt-recoveryservicesbackup = overrideAzureMgmtPackage super.azure-mgmt-recoveryservicesbackup "0.12.0" "zip"
-        "sha256-mrw1Gs3LMOPFiL5mSSrm+g1/dxihplA6ItYHbwljJbM=";
+      azure-mgmt-recoveryservicesbackup = overrideAzureMgmtPackage super.azure-mgmt-recoveryservicesbackup "0.14.0" "zip"
+        "sha256-sXGUQEO6tba3m1l+0Iir/eptTt+XRXyTr8FxbDzr6I0=";
 
-      azure-mgmt-resource = overrideAzureMgmtPackage super.azure-mgmt-resource "18.0.0" "zip"
-        "551036e592f409ef477d30937ea7cc4dda5126576965d9c816fdb8401bbd774c";
+      azure-mgmt-resource = overrideAzureMgmtPackage super.azure-mgmt-resource "19.0.0" "zip"
+        "bbb60bb9419633c2339569d4e097908638c7944e782b5aef0f5d9535085a9100";
 
       azure-mgmt-appconfiguration = overrideAzureMgmtPackage super.azure-mgmt-appconfiguration "2.0.0" "zip"
         "b58bbe82a7429ba589292024896b58d96fe9fa732c578569cac349928dc2ca5f";
@@ -171,23 +174,23 @@ let
       azure-mgmt-cognitiveservices = overrideAzureMgmtPackage super.azure-mgmt-cognitiveservices "12.0.0" "zip"
         "73054bd19866577e7e327518afc8f47e1639a11aea29a7466354b81804f4a676";
 
-      azure-mgmt-compute = overrideAzureMgmtPackage super.azure-mgmt-compute "21.0.0" "zip"
-        "sha256-kifDdVpwvDd9cONeH8bx+rEJ3YiXT9LHEphnzKoQ+BM=";
+      azure-mgmt-compute = overrideAzureMgmtPackage super.azure-mgmt-compute "22.1.0" "zip"
+        "sha256-Kq1BSEOu4PVEJ/iH91NsxRVdaFJyjUTf7vYzrFITX9w=";
 
       azure-mgmt-consumption = overrideAzureMgmtPackage super.azure-mgmt-consumption "2.0.0" "zip"
         "12ai4qps73ivawh0yzvgb148ksx02r30pqlvfihx497j62gsi1cs";
 
-      azure-mgmt-containerinstance = overrideAzureMgmtPackage super.azure-mgmt-containerinstance "1.4.0" "zip"
-        "1qw6228bia5pimcijr755npli2l33jyfka1s2bzgl1w4h3prsji7";
+      azure-mgmt-containerinstance = overrideAzureMgmtPackage super.azure-mgmt-containerinstance "8.0.0" "zip"
+        "7aeb380af71fc35a71d6752fa25eb5b95fdb2a0027fa32e6f50bce87e2622916";
 
-      azure-mgmt-containerservice = overrideAzureMgmtPackage super.azure-mgmt-containerservice "16.0.0" "zip"
-        "d6aa95951d32fe2cb390b3d8ae4f6459746de51bbaad94b5d1842dd35c4d0c11";
+      azure-mgmt-containerservice = overrideAzureMgmtPackage super.azure-mgmt-containerservice "16.1.0" "zip"
+        "sha256-NlTIrOK4ho0OqcTHjHT1HobiMzDH2KY20TIlN0fm8/Q=";
 
       azure-mgmt-cosmosdb = overrideAzureMgmtPackage super.azure-mgmt-cosmosdb "6.4.0" "zip"
         "fb6b8ab80ab97214b94ae9e462ba1c459b68a3af296ffc26317ebd3ff500e00b";
 
-      azure-mgmt-databoxedge = overrideAzureMgmtPackage super.azure-mgmt-databoxedge "0.2.0" "zip"
-        "sha256-g8BtUpIGOse8Jrws48gQ/o7sgymlgX0XIxl1ThHS3XA=";
+      azure-mgmt-databoxedge = overrideAzureMgmtPackage super.azure-mgmt-databoxedge "1.0.0" "zip"
+        "04090062bc1e8f00c2f45315a3bceb0fb3b3479ec1474d71b88342e13499b087";
 
       azure-mgmt-deploymentmanager = overrideAzureMgmtPackage super.azure-mgmt-deploymentmanager "0.2.0" "zip"
         "0c6pyr36n9snx879vas5r6l25db6nlp2z96xn759mz4kg4i45qs6";
@@ -198,11 +201,14 @@ let
       azure-mgmt-imagebuilder = overrideAzureMgmtPackage super.azure-mgmt-imagebuilder "0.4.0" "zip"
         "0cqpjnkpid6a34ifd4vk4fn1h57pa1bg3r756wv082xl2szr34jc";
 
-      azure-mgmt-iothub = overrideAzureMgmtPackage super.azure-mgmt-iothub "2.0.0" "zip"
-        "653a765f0beb6af0c9ecbd290b4101e1b5e0f6450405faf28ab8234c15d8b38b";
+      azure-mgmt-iothub = overrideAzureMgmtPackage super.azure-mgmt-iothub "2.1.0" "zip"
+        "2724f48cadb1be7ee96fc26c7bfa178f82cea5d325e785e91d9f26965fa8e46f";
 
-      azure-mgmt-iotcentral = overrideAzureMgmtPackage super.azure-mgmt-iotcentral "4.1.0" "zip"
-        "e6d4810f454c0d63a5e816eaa7e54a073a3f70b2256162ff1c234cfe91783ae6";
+      azure-mgmt-iothubprovisioningservices = overrideAzureMgmtPackage super.azure-mgmt-iothubprovisioningservices "0.3.0" "zip"
+        "sha256-0Bt3JfP2jFpv8CGEqb3ajHdYiK9mN43YMUkD0KRuMrk=";
+
+      azure-mgmt-iotcentral = overrideAzureMgmtPackage super.azure-mgmt-iotcentral "9.0.0b1" "zip"
+        "sha256-WEF5HuiaUTnka/2w0cVX/VwRt8/GD0+5fqGkn1BVx4I=";
 
       azure-mgmt-kusto = overrideAzureMgmtPackage super.azure-mgmt-kusto "0.3.0" "zip"
         "1pmcdgimd66h964a3d5m2j2fbydshcwhrk87wblhwhfl3xwbgf4y";
@@ -216,14 +222,14 @@ let
       azure-mgmt-dns = overrideAzureMgmtPackage super.azure-mgmt-dns "8.0.0" "zip"
         "407c2dacb33513ffbe9ca4be5addb5e9d4bae0cb7efa613c3f7d531ef7bf8de8";
 
-      azure-mgmt-loganalytics = overrideAzureMgmtPackage super.azure-mgmt-loganalytics "8.0.0" "zip"
-        "3e7a93186594c328a6f34f0e0d9209a05021228baa85aa4c1c4ffdbf8005a45f";
+      azure-mgmt-loganalytics = overrideAzureMgmtPackage super.azure-mgmt-loganalytics "11.0.0" "zip"
+        "41671fc6e95180fb6147cb40567410c34b85fb69bb0a9b3e09feae1ff370ee9d";
 
       azure-mgmt-network = overrideAzureMgmtPackage super.azure-mgmt-network "19.0.0" "zip"
         "5e39a26ae81fa58c13c02029700f8c7b22c3fd832a294c543e3156a91b9459e8";
 
-      azure-mgmt-maps = overrideAzureMgmtPackage super.azure-mgmt-maps "0.1.0" "zip"
-        "sha256-wSDiELthdo2ineJNKLgvjUKuJOUjlutlabSZcJ4i8AY=";
+      azure-mgmt-maps = overrideAzureMgmtPackage super.azure-mgmt-maps "2.0.0" "zip"
+        "384e17f76a68b700a4f988478945c3a9721711c0400725afdfcb63cf84e85f0e";
 
       azure-mgmt-managedservices = overrideAzureMgmtPackage super.azure-mgmt-managedservices "1.0.0" "zip"
         "sha256-/tg5n8Z3Oq2jfB0ElqRvWUENd8lJTQyllnxTHDN2rRk=";
@@ -234,8 +240,8 @@ let
       azure-mgmt-marketplaceordering = overrideAzureMgmtPackage super.azure-mgmt-marketplaceordering "1.1.0" "zip"
         "68b381f52a4df4435dacad5a97e1c59ac4c981f667dcca8f9d04453417d60ad8";
 
-      azure-mgmt-media = overrideAzureMgmtPackage super.azure-mgmt-media "3.0.0" "zip"
-        "sha256-iUR3VyXFJTYU0ldXbYQe5or6NPVwsFwJJKf3Px2yiiQ=";
+      azure-mgmt-media = overrideAzureMgmtPackage super.azure-mgmt-media "7.0.0" "zip"
+        "sha256-tF6CpZTtkc1ap6XNXQHwOLesPPEiM+e6K+qqNHeQDo4=";
 
       azure-mgmt-msi = overrideAzureMgmtPackage super.azure-mgmt-msi "0.2.0" "zip"
         "0rvik03njz940x2hvqg6iiq8k0d88gyygsr86w8s0sa12sdbq8l6";
@@ -246,11 +252,11 @@ let
       azure-mgmt-web = overrideAzureMgmtPackage super.azure-mgmt-web "2.0.0" "zip"
         "0040e1c9c795f7bebe43647ff30b62cb0db7175175df5cbfa1e554a6a277b81e";
 
-      azure-mgmt-redhatopenshift = overrideAzureMgmtPackage super.azure-mgmt-redhatopenshift "0.1.0" "zip"
-        "1g65lbia1i1jw6qkyjz2ldyl3p90rbr78l8kfryg70sj7z3gnnjn";
+      azure-mgmt-redhatopenshift = overrideAzureMgmtPackage super.azure-mgmt-redhatopenshift "1.0.0" "zip"
+        "94cd41f1ebd82e40620fd3e6d88f666b5c19ac7cf8b4e8edadb9721bd7c80980";
 
-      azure-mgmt-redis = overrideAzureMgmtPackage super.azure-mgmt-redis "7.0.0rc1" "zip"
-        "086wk31wsl8dx14qpd0g1bly8i9a8fix007djlj9cybva2f2bk6k";
+      azure-mgmt-redis = overrideAzureMgmtPackage super.azure-mgmt-redis "13.0.0" "zip"
+        "283f776afe329472c20490b1f2c21c66895058cb06fb941eccda42cc247217f1";
 
       azure-mgmt-reservations = overrideAzureMgmtPackage super.azure-mgmt-reservations "0.6.0" "zip"
         "16ycni3cjl9c0mv419gy5rgbrlg8zp0vnr6aj8z8p2ypdw6sgac3";
@@ -258,23 +264,23 @@ let
       azure-mgmt-search = overrideAzureMgmtPackage super.azure-mgmt-search "8.0.0" "zip"
         "a96d50c88507233a293e757202deead980c67808f432b8e897c4df1ca088da7e";
 
-      azure-mgmt-security = overrideAzureMgmtPackage super.azure-mgmt-security "0.6.0" "zip"
-        "9f37d0151d730801222af111f0830905634795dbfd59ad1b89c35197421e74d3";
+      azure-mgmt-security = overrideAzureMgmtPackage super.azure-mgmt-security "1.0.0" "zip"
+        "ae1cff598dfe80e93406e524c55c3f2cbffced9f9b7a5577e3375008a4c3bcad";
 
       azure-mgmt-signalr = overrideAzureMgmtPackage super.azure-mgmt-signalr "1.0.0b2" "zip"
         "sha256-FTxY8qoihHG4OZuKT3sRRlKfORbIoqDqug9Ko+6S9dw=";
 
-      azure-mgmt-sql = overrideAzureMgmtPackage super.azure-mgmt-sql "0.29.0" "zip"
-        "sha256-a8epWPoGI4SA01DkjToaHmTx8lSPgwMB7dutI/zaoAA=";
+      azure-mgmt-sql = overrideAzureMgmtPackage super.azure-mgmt-sql "3.0.1" "zip"
+        "129042cc011225e27aee6ef2697d585fa5722e5d1aeb0038af6ad2451a285457";
 
-      azure-mgmt-sqlvirtualmachine = overrideAzureMgmtPackage super.azure-mgmt-sqlvirtualmachine "0.5.0" "zip"
-        "1b9am8raa17hxnz7d5pk2ix0309wsnhnchq1mi22icd728sl5adm";
+      azure-mgmt-sqlvirtualmachine = overrideAzureMgmtPackage super.azure-mgmt-sqlvirtualmachine "1.0.0b1" "zip"
+        "sha256-SrFTvU+67U3CpMLPZMawXuRdSIbTsfav2jFZIsZWPmw=";
 
       azure-mgmt-synapse = overrideAzureMgmtPackage super.azure-mgmt-synapse "2.0.0" "zip"
         "bec6bdfaeb55b4fdd159f2055e8875bf50a720bb0fce80a816e92a2359b898c8";
 
-      azure-mgmt-datamigration = overrideAzureMgmtPackage super.azure-mgmt-datamigration "4.1.0" "zip"
-        "c33d1deb0ee173a15c8ec21a1e714ba544fe5f4895d3b1d8b0581f3c1b2e8ce4";
+      azure-mgmt-datamigration = overrideAzureMgmtPackage super.azure-mgmt-datamigration "9.0.0" "zip"
+        "sha256-cDc9vrNad2ikc0G7O1cMVZGXvBujb8j4vxUTnkyLrXA=";
 
       azure-mgmt-relay = overrideAzureMgmtPackage super.azure-mgmt-relay "0.1.0" "zip"
         "1jss6qhvif8l5s0lblqw3qzijjf0h88agciiydaa7f4q577qgyfr";
@@ -282,14 +288,14 @@ let
       azure-mgmt-eventhub = overrideAzureMgmtPackage super.azure-mgmt-eventhub "4.1.0" "zip"
         "186g70slb259ybrr69zr2ibbmqgplnpncwxzg0nxp6rd7pml7d85";
 
-      azure-mgmt-keyvault = overrideAzureMgmtPackage super.azure-mgmt-keyvault "9.0.0" "zip"
-        "2890c489289b8a0bf833852014f2f494eb96873834896910ddfa58cfa97b90da";
+      azure-mgmt-keyvault = overrideAzureMgmtPackage super.azure-mgmt-keyvault "9.1.0" "zip"
+        "sha256-zTXoHEo8+BKt5L3PH3zPS1t4qAHvlnNAASpqyf5h3tI=";
 
       azure-mgmt-cdn = overrideAzureMgmtPackage super.azure-mgmt-cdn "11.0.0" "zip"
         "28e7070001e7208cdb6c2ad253ec78851abdd73be482230d2c0874eed5bc0907";
 
-      azure-mgmt-containerregistry = overrideAzureMgmtPackage super.azure-mgmt-containerregistry "8.0.0" "zip"
-        "480eb5d1bb910da4e87a5d7047e2f3e426083b14911ac64c48badd0218e9e756";
+      azure-mgmt-containerregistry = overrideAzureMgmtPackage super.azure-mgmt-containerregistry "8.1.0" "zip"
+        "62efbb03275d920894d79879ad0ed59605163abd32177dcf24e90c1862ebccbd";
 
       azure-mgmt-monitor = overrideAzureMgmtPackage super.azure-mgmt-monitor "2.0.0" "zip"
         "e7f7943fe8f0efe98b3b1996cdec47c709765257a6e09e7940f7838a0f829e82";
@@ -309,8 +315,8 @@ let
       azure-mgmt-servicebus = overrideAzureMgmtPackage super.azure-mgmt-servicebus "6.0.0" "zip"
         "f6c64ed97d22d0c03c4ca5fc7594bd0f3d4147659c10110160009b93f541298e";
 
-      azure-mgmt-servicefabric = overrideAzureMgmtPackage super.azure-mgmt-servicefabric "0.5.0" "zip"
-        "0x6wxb9zrvcayg3yw0nm99p10vvgc0x3zwk9amzs5m682r2z4wap";
+      azure-mgmt-servicefabric = overrideAzureMgmtPackage super.azure-mgmt-servicefabric "1.0.0" "zip"
+        "de35e117912832c1a9e93109a8d24cab94f55703a9087b2eb1c5b0655b3b1913";
 
       azure-mgmt-hdinsight = overrideAzureMgmtPackage super.azure-mgmt-hdinsight "8.0.0" "zip"
         "2c43f1a62e5b83304392b0ad7cfdaeef2ef2f47cb3fdfa2577b703b6ea126000";
@@ -363,6 +369,16 @@ let
           inherit (oldAttrs) pname;
           inherit version;
           sha256 = "sha256-g14ySiByqPgkJGRH8EnIRJO9Q6H2usS5FOeMCQiUuwQ=";
+          extension = "zip";
+        };
+      });
+
+      azure-synapse-managedprivateendpoints = super.azure-synapse-managedprivateendpoints.overrideAttrs(oldAttrs: rec {
+        version = "0.3.0";
+        src = super.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "sha256-fN1IuZ9fjxgRZv6qh9gg6v6KYpnKlXfnoLqfZCDXoRY=";
           extension = "zip";
         };
       });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -961,6 +961,8 @@ in {
 
   azure-synapse-artifacts = callPackage ../development/python-modules/azure-synapse-artifacts { };
 
+  azure-synapse-managedprivateendpoints = callPackage ../development/python-modules/azure-synapse-managedprivateendpoints { };
+
   azure-synapse-spark = callPackage ../development/python-modules/azure-synapse-spark { };
 
   b2sdk = callPackage ../development/python-modules/b2sdk { };


### PR DESCRIPTION
###### Motivation for this change
Another bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
