### PR TITLE
feedbackd: add device themes

### DIFF
--- a/pkgs/applications/misc/feedbackd/default.nix
+++ b/pkgs/applications/misc/feedbackd/default.nix
@@ -17,6 +17,15 @@
 , dbus
 }:
 
+let
+  themes = fetchFromGitLab {
+    domain = "source.puri.sm";
+    owner = "Librem5";
+    repo = "feedbackd-device-themes";
+    rev = "v0.0.20210909";
+    sha256 = "1d041wnq39sa0sl08xya4yp3n7j6aw560i38chl10vgpmwk9mmhr";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "feedbackd";
   # Not an actual upstream project release,
@@ -63,6 +72,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/lib/udev/rules.d
     sed "s|/usr/libexec/|$out/libexec/|" < $src/debian/feedbackd.udev > $out/lib/udev/rules.d/90-feedbackd.rules
+    cp ${themes}/data/* $out/share/feedbackd/themes/
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Fix https://github.com/NixOS/mobile-nixos/issues/414 by including feedbackd-device-themes.

This PR depends on https://github.com/NixOS/nixpkgs/pull/158566.

This is running on my Pinephone, and I have haptic feedback on squeekboard!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
