### PR TITLE
libsepol: pull upstream fix for -fno-common compiler

### DIFF
--- a/pkgs/os-specific/linux/libsepol/default.nix
+++ b/pkgs/os-specific/linux/libsepol/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, flex }:
+{ lib, stdenv, fetchurl, fetchpatch, flex }:
 
 stdenv.mkDerivation rec {
   pname = "libsepol";
@@ -12,6 +12,20 @@ stdenv.mkDerivation rec {
     url = "${se_url}/${se_release}/libsepol-${version}.tar.gz";
     sha256 = "0ygb6dh5lng91xs6xiqf5v0nxa68qmjc787p0s5h9w89364f2yjv";
   };
+
+  patches = [
+    # upstream build fix against -fno-common compilers like >=gcc-10
+    (fetchpatch {
+      url = "https://github.com/SELinuxProject/selinux/commit/a96e8c59ecac84096d870b42701a504791a8cc8c.patch";
+      sha256 = "0aybv4kzbhx8xq6s82dsh4ib76k59qzh2bgxmk44iq5cjnqn5rd6";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      url = "https://github.com/SELinuxProject/selinux/commit/3d32fc24d6aff360a538c63dad08ca5c957551b0.patch";
+      sha256 = "1mphwdlj4d6mwmsp5xkpf6ci4rxhgbi3fm79d08h4jbzxaf4wny4";
+      stripLen = 1;
+    })
+  ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isStatic ''
     substituteInPlace src/Makefile --replace 'all: $(LIBA) $(LIBSO)' 'all: $(LIBA)'


### PR DESCRIPTION
Fixes build failure against upstream gcc (defaults -fno-common)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
