### PR TITLE
libunwind: pull upstream fix for -fno-common compiler

### DIFF
--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoreconfHook, xz, coreutils }:
+{ stdenv, lib, fetchurl, fetchpatch, autoreconfHook, xz, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "libunwind";
@@ -9,7 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "0dc46flppifrv2z0mrdqi60165ghxm1wk0g47vcbyzjdplqwjnfz";
   };
 
-  patches = [ ./backtrace-only-with-glibc.patch ];
+  patches = [
+    ./backtrace-only-with-glibc.patch
+
+    (fetchpatch {
+      # upstream build fix against -fno-common compilers like >=gcc-10
+      url = "https://github.com/libunwind/libunwind/commit/29e17d8d2ccbca07c423e3089a6d5ae8a1c9cb6e.patch";
+      sha256 = "1angwfq6h0jskg6zx8g6w9min38g5mgmrcbppcy5hqn59cgsxbw0";
+    })
+  ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isMusl ''
     substituteInPlace configure.ac --replace "-lgcc_s" "-lgcc_eh"


### PR DESCRIPTION
Fixes build failure against upstream gcc (defaults -fno-common)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
