### PR TITLE
ocaml-ng.ocamlPackages_4_13.ocaml: 4.13.0-β1 → 4.13.0-rc1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.13.nix
+++ b/pkgs/development/compilers/ocaml/4.13.nix
@@ -1,9 +1,9 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "13";
-  patch_version = "0-beta1";
+  patch_version = "0-rc1";
   src = fetchTarball {
-    url = "https://caml.inria.fr/pub/distrib/ocaml-4.13/ocaml-4.13.0~beta1.tar.xz";
-    sha256 = "0dbz69p1kqabjvzaasy2malfdfn4b93s504x2xs0dl5l3fa3p6c3";
+    url = "https://caml.inria.fr/pub/distrib/ocaml-4.13/ocaml-4.13.0~rc1.tar.xz";
+    sha256 = "0vp19qwdny5z428yjvdn0yxvf3i5l23axjb83y5ccj0rpza1k0im";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://inbox.ocaml.org/caml-list/623764070.13369101.1631279120562.JavaMail.zimbra@inria.fr/T/#u

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
