### PR TITLE
sharutils: pull pending upstream fix for -fno-common compiler

### DIFF
--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, gettext, coreutils }:
+{ lib, stdenv, fetchurl, fetchpatch, gettext, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "sharutils";
@@ -29,6 +29,19 @@ stdenv.mkDerivation rec {
     (fetchurl {
       url = "https://sources.debian.org/data/main/s/sharutils/1:4.15.2-4/debian/patches/02-fix-ftbfs-with-glibc-2.28.patch";
       sha256 = "15kpjqnfs98n6irmkh8pw7masr08xala7gx024agv7zv14722vkc";
+    })
+
+    # pending upstream build fix against -fno-common compilers like >=gcc-10
+    # Taken from https://lists.gnu.org/archive/html/bug-gnu-utils/2020-01/msg00002.html
+    (fetchpatch {
+      name = "sharutils-4.15.2-Fix-building-with-GCC-10.patch";
+      url = "https://lists.gnu.org/archive/html/bug-gnu-utils/2020-01/txtDL8i6V6mUU.txt";
+      sha256 = "0kfch1vm45lg237hr6fdv4b2lh5b1933k0fn8yj91gqm58svskvl";
+    })
+    (fetchpatch {
+      name = "sharutils-4.15.2-Do-not-include-lib-md5.c-into-src-shar.c.patch";
+      url = "https://lists.gnu.org/archive/html/bug-gnu-utils/2020-01/txt5Z_KZup0yN.txt";
+      sha256 = "0an8vfy3qj6sss9w0i4j8ilf7g5mbc7y13l644jy5bcm9przcjbd";
     })
   ];
 


### PR DESCRIPTION
Fixes build failure against upstream gcc (defaults -fno-common)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
