### PR TITLE
libomxil-bellagio: fix build failures against -fno-common compiler

### DIFF
--- a/pkgs/development/libraries/libomxil-bellagio/default.nix
+++ b/pkgs/development/libraries/libomxil-bellagio/default.nix
@@ -12,7 +12,10 @@ stdenv.mkDerivation rec {
   configureFlags =
     lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "ac_cv_func_malloc_0_nonnull=yes" ];
 
-  patches = [ ./fedora-fixes.patch ];
+  patches = [
+    ./fedora-fixes.patch
+    ./fno-common.patch
+  ];
 
   doCheck = false; # fails
 

--- a/pkgs/development/libraries/libomxil-bellagio/fno-common.patch
+++ b/pkgs/development/libraries/libomxil-bellagio/fno-common.patch
@@ -1,0 +1,32 @@
+Fix build faiure on gcc-10 (defaults to -fno-common).
+--- a/src/omx_reference_resource_manager.c
++++ b/src/omx_reference_resource_manager.c
+@@ -30,6 +30,11 @@
+ #include "base/omx_base_component.h"
+ #include "queue.h"
+ 
++int globalIndex;
++NameIndexType *listOfcomponentRegistered;
++ComponentListType **globalComponentList;
++ComponentListType **globalWaitingComponentList;
++
+ /**
+  * This is the static base pointer of the list
+  */
+--- a/src/omx_reference_resource_manager.h
++++ b/src/omx_reference_resource_manager.h
+@@ -49,10 +49,10 @@ struct NameIndexType {
+ };
+ 
+ 
+-int globalIndex;
+-NameIndexType *listOfcomponentRegistered;
+-ComponentListType **globalComponentList;
+-ComponentListType **globalWaitingComponentList;
++extern int globalIndex;
++extern NameIndexType *listOfcomponentRegistered;
++extern ComponentListType **globalComponentList;
++extern ComponentListType **globalWaitingComponentList;
+ 
+ OMX_ERRORTYPE RM_RegisterComponent(char *name, int max_components);
+ OMX_ERRORTYPE addElemToList(ComponentListType **list, OMX_COMPONENTTYPE *openmaxStandComp, int index, OMX_BOOL bIsWaiting);


### PR DESCRIPTION
On vanilla gcc-10 (and gcc-9 -fno-common) build fails as:

```
../libtool --tag=CC   --mode=link gcc ... -o libomxil-bellagio.la ...
ld: .libs/libomxil_bellagio_la-omx_reference_resource_manager.o:(.bss+0x18):
  multiple definition of `globalIndex';
    .libs/libomxil_bellagio_la-st_static_component_loader.o:(.bss+0x358):
      first defined here
```

Upstream gcc-10 changed the default from -fcommon to fno-common:
    https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.