### PR TITLE
nixos/activation-script: Fix dependencies for dry activation

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -18,8 +18,17 @@ let
   });
 
   systemActivationScript = set: onlyDry: let
-    set' = filterAttrs (_: v: onlyDry -> v.supportsDryActivation) (mapAttrs (_: v: if isString v then (noDepEntry v) // { supportsDryActivation = false; } else v) set);
+    set' = mapAttrs (_: v: if isString v then (noDepEntry v) // { supportsDryActivation = false; } else v) set;
     withHeadlines = addAttributeName set';
+    # When building a dry activation script, this replaces all activation scripts
+    # that do not support dry mode with a comment that does nothing. Filtering these
+    # activation scripts out so they don't get generated into the dry activation script
+    # does not work because when an activation script that supports dry mode depends on
+    # an activation script that does not, the dependency cannot be resolved and the eval
+    # fails.
+    withDrySnippets = mapAttrs (a: v: if onlyDry && !v.supportsDryActivation then v // {
+      text = "#### Activation script snippet ${a} does not support dry activation.";
+    } else v) withHeadlines;
   in
     ''
       #!${pkgs.runtimeShell}
@@ -37,7 +46,7 @@ let
       # Ensure a consistent umask.
       umask 0022
 
-      ${textClosureMap id (withHeadlines) (attrNames withHeadlines)}
+      ${textClosureMap id (withDrySnippets) (attrNames withDrySnippets)}
 
     '' + optionalString (!onlyDry) ''
       # Make this configuration the current configuration.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#136605 broke tools like agenix.
The comment in the code should pretty much explain why this fixes it.
For the `simple` test, this results in:
```
$ grep '#### Activation script snippet' dry-activate
#### Activation script snippet specialfs does not support dry activation.
#### Activation script snippet binfmt does not support dry activation.
#### Activation script snippet stdio does not support dry activation.
#### Activation script snippet binsh does not support dry activation.
#### Activation script snippet domain does not support dry activation.
#### Activation script snippet users:
#### Activation script snippet groups does not support dry activation.
#### Activation script snippet etc does not support dry activation.
#### Activation script snippet hostname does not support dry activation.
#### Activation script snippet modprobe does not support dry activation.
#### Activation script snippet nix does not support dry activation.
#### Activation script snippet udevd does not support dry activation.
#### Activation script snippet usrbinenv does not support dry activation.
#### Activation script snippet var does not support dry activation.
#### Activation script snippet wrappers does not support dry activation.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
