### PR TITLE
kitty: Fix compilation on aarch64-darwin

### DIFF
--- a/pkgs/applications/terminal-emulators/kitty/apple-sdk-11.patch
+++ b/pkgs/applications/terminal-emulators/kitty/apple-sdk-11.patch
@@ -1,0 +1,44 @@
+diff --git a/setup.py b/setup.py
+index a9138efe..54172eb9 100755
+--- a/setup.py
++++ b/setup.py
+@@ -14,6 +14,7 @@
+ import sys
+ import sysconfig
+ import platform
++import tempfile
+ import time
+ from contextlib import suppress
+ from functools import partial
+@@ -229,18 +230,19 @@ def get_sanitize_args(cc: str, ccver: Tuple[int, int]) -> List[str]:
+ 
+ def test_compile(cc: str, *cflags: str, src: Optional[str] = None, lang: str = 'c') -> bool:
+     src = src or 'int main(void) { return 0; }'
+-    p = subprocess.Popen(
+-        [cc] + list(cflags) + ['-x', lang, '-o', os.devnull, '-'],
+-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.PIPE,
+-    )
+-    stdin = p.stdin
+-    assert stdin is not None
+-    try:
+-        stdin.write(src.encode('utf-8'))
+-        stdin.close()
+-    except BrokenPipeError:
+-        return False
+-    return p.wait() == 0
++    with tempfile.TemporaryDirectory() as tdir:
++        p = subprocess.Popen(
++            [cc] + list(cflags) + ['-x', lang, '-o', os.path.join(tdir, 'dummy'), '-'],
++            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.PIPE,
++        )
++        stdin = p.stdin
++        assert stdin is not None
++        try:
++            stdin.write(src.encode('utf-8'))
++            stdin.close()
++        except BrokenPipeError:
++            return False
++        return p.wait() == 0
+ 
+ 
+ def first_successful_compile(cc: str, *cflags: str, src: Optional[str] = None, lang: str = 'c') -> str:

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -5,6 +5,7 @@
   lcms2,
   installShellFiles,
   dbus,
+  darwin,
   Cocoa,
   CoreGraphics,
   Foundation,
@@ -45,6 +46,8 @@ buildPythonApplication rec {
     libpng
     python3
     zlib
+  ] ++ lib.optionals (stdenv.isDarwin && (builtins.hasAttr "UserNotifications" darwin.apple_sdk.frameworks)) [
+    darwin.apple_sdk.frameworks.UserNotifications
   ] ++ lib.optionals stdenv.isLinux [
     fontconfig libunistring libcanberra libX11
     libXrandr libXinerama libXcursor libxkbcommon libXi libXext
@@ -66,6 +69,8 @@ buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = lib.optional stdenv.isLinux libGL;
+
+  patches = lib.optionals stdenv.isDarwin [ ./apple-sdk-11.patch ];
 
   outputs = [ "out" "terminfo" ];
 


### PR DESCRIPTION
###### Motivation for this change

See compilation error log in https://hydra.nixos.org/build/151584660/nixlog/1/tail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
