### PR TITLE
zsh-fzf-tab: Support darwin platform

### DIFF
--- a/pkgs/shells/zsh/zsh-fzf-tab/darwin.patch
+++ b/pkgs/shells/zsh/zsh-fzf-tab/darwin.patch
@@ -1,0 +1,11 @@
+diff --git a/modules/Src/aloxaf/fzftab.c b/modules/Src/aloxaf/fzftab.c
+index 60b6330..91975d8 100644
+--- a/modules/Src/aloxaf/fzftab.c
++++ b/modules/Src/aloxaf/fzftab.c
+@@ -1,6 +1,5 @@
+ #include "fzftab.mdh"
+ #include "fzftab.pro"
+-#include <malloc.h>
+ #include <stdarg.h>
+ #include <stdlib.h>
+ #include <sys/stat.h>

--- a/pkgs/shells/zsh/zsh-fzf-tab/default.nix
+++ b/pkgs/shells/zsh/zsh-fzf-tab/default.nix
@@ -42,6 +42,6 @@ in stdenv.mkDerivation rec {
     description = "Replace zsh's default completion selection menu with fzf!";
     license = licenses.mit;
     maintainers = with maintainers; [ vonfry ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/shells/zsh/zsh-fzf-tab/default.nix
+++ b/pkgs/shells/zsh/zsh-fzf-tab/default.nix
@@ -15,6 +15,8 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses ];
 
+  patches = lib.optionals stdenv.isDarwin [ ./darwin.patch ];
+
   postConfigure = ''
     pushd modules
     ./configure --disable-gdbm --without-tcsetpgrp
@@ -40,6 +42,6 @@ in stdenv.mkDerivation rec {
     description = "Replace zsh's default completion selection menu with fzf!";
     license = licenses.mit;
     maintainers = with maintainers; [ vonfry ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

 Support darwin platform

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
