### PR TITLE
android-backup-extractor: init at 20210909062443-4c55371

### DIFF
--- a/pkgs/tools/backup/android-backup-extractor/default.nix
+++ b/pkgs/tools/backup/android-backup-extractor/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "20210909062443-4c55371";
 
   src = fetchurl {
-    url = "https://github.com/nelenkov/${pname}/releases/download/${version}/abe.jar";
+    url = "https://github.com/nelenkov/android-backup-extractor/releases/download/${version}/abe.jar";
     sha256 = "0ms241kb4h9y9apr637sb4kw5mml40c1ac0q4jcxhnwr3dr05w1q";
   };
 

--- a/pkgs/tools/backup/android-backup-extractor/default.nix
+++ b/pkgs/tools/backup/android-backup-extractor/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, lib
+, fetchurl
+, makeWrapper
+, jre
+}:
+
+stdenv.mkDerivation rec {
+  pname = "android-backup-extractor";
+  version = "20210909062443-4c55371";
+
+  src = fetchurl {
+    url = "https://github.com/nelenkov/${pname}/releases/download/${version}/abe.jar";
+    sha256 = "0ms241kb4h9y9apr637sb4kw5mml40c1ac0q4jcxhnwr3dr05w1q";
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ jre ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D $src $out/lib/android-backup-extractor/abe.jar
+    makeWrapper ${jre}/bin/java $out/bin/abe --add-flags "-cp $out/lib/android-backup-extractor/abe.jar org.nick.abe.Main"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Utility to extract and repack Android backups created with adb backup";
+    homepage = "https://github.com/nelenkov/android-backup-extractor";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1105,6 +1105,8 @@ with pkgs;
 
   analog = callPackage ../tools/admin/analog {};
 
+  android-backup-extractor = callPackage ../tools/backup/android-backup-extractor {};
+
   android-tools = lowPrio (callPackage ../tools/misc/android-tools {
     stdenv = if stdenv.targetPlatform.isAarch64 then gcc10Stdenv else stdenv;
   });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- new package: Utility to extract and repack Android backups created with adb backup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
