### PR TITLE
python3Packages.einops: init at 0.3.2

### DIFF
--- a/pkgs/development/python-modules/einops/default.nix
+++ b/pkgs/development/python-modules/einops/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, numpy
+, nose
+, nbformat
+, nbconvert
+, jupyter
+, chainer
+, pytorch
+, mxnet
+, tensorflow
+}:
+
+buildPythonPackage rec {
+  pname = "einops";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "arogozhnikov";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ix094cfh6w4bvx6ymp5dpm35y9nkaibcn1y50g6kwdp4f0473y8";
+  };
+
+  checkInputs = [
+    nose
+    numpy
+    # For notebook tests
+    nbformat
+    nbconvert
+    jupyter
+    # For backend tests
+    chainer
+    pytorch
+    mxnet
+    tensorflow
+  ];
+
+  # No CUDA in sandbox
+  EINOPS_SKIP_CUPY = 1;
+
+  checkPhase = ''
+    export HOME=$TMPDIR
+    nosetests -v -w tests
+  '';
+
+  meta = {
+    description = "Flexible and powerful tensor operations for readable and reliable code";
+    homepage = "https://github.com/arogozhnikov/einops";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yl3dy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2304,6 +2304,8 @@ in {
 
   eggdeps = callPackage ../development/python-modules/eggdeps { };
 
+  einops = callPackage ../development/python-modules/einops { };
+
   elgato = callPackage ../development/python-modules/elgato { };
 
   elasticsearch = callPackage ../development/python-modules/elasticsearch { };


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
