### PR TITLE
ghostscript: add passthru.tests.test-corpus-render

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -1,6 +1,6 @@
 { config, stdenv, lib, fetchurl, pkg-config, zlib, expat, openssl, autoconf
 , libjpeg, libpng, libtiff, freetype, fontconfig, libpaper, jbig2dec
-, libiconv, ijs, lcms2, fetchpatch
+, libiconv, ijs, lcms2, fetchpatch, callPackage
 , cupsSupport ? config.ghostscript.cups or (!stdenv.isDarwin), cups ? null
 , x11Support ? cupsSupport, xlibsWrapper ? null # with CUPS, X11 only adds very little
 }:
@@ -137,6 +137,8 @@ stdenv.mkDerivation rec {
 
     runHook postInstallCheck
   '';
+
+  passthru.tests.test-corpus-render = callPackage ./test-corpus-render.nix {};
 
   meta = {
     homepage = "https://www.ghostscript.com/";

--- a/pkgs/misc/ghostscript/test-corpus-render.nix
+++ b/pkgs/misc/ghostscript/test-corpus-render.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchgit
+, ghostscript
+}:
+
+stdenv.mkDerivation {
+  pname = "ghostscript-test-corpus-render";
+  version = "unstable-2020-02-19";
+
+  src = fetchgit {
+    url = "git://git.ghostscript.com/tests.git";
+    rev = "efdd224340d9a407ed3ec22afa1cb127c8fee73c";
+    sha256 = "1v1iqz897zzrwa8ng22zcf3y61ab5798jdwidgv10w1r9mjrl7ax";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  doCheck = true;
+  checkPhase = ''
+    find . -iregex '.*\.\(ps\|eps\|pdf\)' | while read f; do
+      echo "Rendering $f"
+      ${ghostscript}/bin/gs \
+        -dNOPAUSE \
+        -dBATCH \
+        -sDEVICE=bitcmyk \
+        -sOutputFile=/dev/null \
+        -r600 \
+        -dBufferSpace=100000 \
+        $f
+    done
+  '';
+
+  installPhase = ''
+    touch $out
+  '';
+}


### PR DESCRIPTION
###### Motivation for this change
This simply attempts rendering every ps/eps/pdf file in the ghostscript test corpus.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
