### PR TITLE
gnuplot: Allow compiling with libcaca

### DIFF
--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -2,6 +2,7 @@
 , cairo, gd, libcerf, pango, readline, zlib
 , withTeXLive ? false, texlive
 , withLua ? false, lua
+, withCaca ? false, libcaca
 , libX11 ? null
 , libXt ? null
 , libXpm ? null
@@ -33,6 +34,7 @@ in
     [ cairo gd libcerf pango readline zlib ]
     ++ lib.optional withTeXLive (texlive.combine { inherit (texlive) scheme-small; })
     ++ lib.optional withLua lua
+    ++ lib.optional withCaca libcaca
     ++ lib.optionals withX [ libX11 libXpm libXt libXaw ]
     ++ lib.optionals withQt [ qtbase qtsvg ]
     ++ lib.optional withWxGTK wxGTK;
@@ -46,7 +48,8 @@ in
     (if withX then "--with-x" else "--without-x")
     (if withQt then "--with-qt=qt5" else "--without-qt")
     (if aquaterm then "--with-aquaterm" else "--without-aquaterm")
-  ];
+  ]
+  ++ lib.optional withCaca "--with-caca";
 
   CXXFLAGS = lib.optionalString (stdenv.isDarwin && withQt) "-std=c++11";
 

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -48,8 +48,7 @@ in
     (if withX then "--with-x" else "--without-x")
     (if withQt then "--with-qt=qt5" else "--without-qt")
     (if aquaterm then "--with-aquaterm" else "--without-aquaterm")
-  ]
-  ++ lib.optional withCaca "--with-caca";
+  ] ++ lib.optional withCaca "--with-caca";
 
   CXXFLAGS = lib.optionalString (stdenv.isDarwin && withQt) "-std=c++11";
 


### PR DESCRIPTION
###### Motivation for this change

I want to use the experimental caca terminal. It was added in [Gnuplot 5.0](https://github.com/gnuplot/gnuplot/blob/4c562a91ced26bb987d1cd61ac5172ed0c9ec979/NEWS#L262) and some fixes were made in [Gnuplot 5.4](https://github.com/gnuplot/gnuplot/blob/4c562a91ced26bb987d1cd61ac5172ed0c9ec979/NEWS#L74).

If withCaca is disabled, we don't add `--without-caca` to the configure flags to avoid unnecessary recompilation of 300+ packages for people using the default configuration. This is OK as `--without-caca` is the default - see the relevant part of the [configure.ac](https://github.com/gnuplot/gnuplot/blob/1aee37d67f28f8cecd81a587289679b965fd4620/configure.ac#L665).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
