### PR TITLE
quakespasm: improve xdg desktop file, copy icons

### DIFF
--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -6,12 +6,12 @@
 
 stdenv.mkDerivation rec {
   pname = "quakespasm";
-  majorVersion = "0.93";
-  version = "${majorVersion}.2";
+  majorVersion = "0.94";
+  version = "${majorVersion}.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/quakespasm/quakespasm-${version}.tgz";
-    sha256 = "0qm0j5drybvvq8xadfyppkpk3rxqsxbywzm6iwsjwdf0iia3gss5";
+    url = "mirror://sourceforge/quakespasm/quakespasm-${version}.tar.gz";
+    sha256 = "19grpvsk3ikjypx9j0gpfsx5wanrqxkgf8dwl9h6ab5c8wwmjcjp";
   };
 
   sourceRoot = "${pname}-${version}/Quake";

--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, SDL, fetchurl, gzip, libvorbis, libmad, copyDesktopItems, makeDesktopItem }:
+{ lib, stdenv, SDL, SDL2, fetchurl, gzip, libvorbis, libmad
+, Cocoa, CoreAudio, CoreFoundation, IOKit, OpenGL
+, copyDesktopItems, makeDesktopItem
+, useSDL2 ? stdenv.isDarwin # TODO: CoreAudio fails to initialize with SDL 1.x for some reason.
+}:
 
 stdenv.mkDerivation rec {
   pname = "quakespasm";
@@ -12,16 +16,58 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${pname}-${version}/Quake";
 
-  nativeBuildInputs = [ copyDesktopItems ];
-  buildInputs = [
-    gzip SDL libvorbis libmad
+  patches = lib.optionals stdenv.isDarwin [
+    # Makes Darwin Makefile use system libraries instead of ones from app bundle
+    ./quakespasm-darwin-makefile-improvements.patch
   ];
 
-  buildFlags = [ "DO_USERDIRS=1" ];
+  nativeBuildInputs = [ copyDesktopItems ];
+  buildInputs = [
+    gzip libvorbis libmad (if useSDL2 then SDL2 else SDL)
+  ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa CoreAudio IOKit OpenGL
+  ] ++ lib.optionals (stdenv.isDarwin && useSDL2) [
+    CoreFoundation
+  ];
+
+  buildFlags = [
+    "DO_USERDIRS=1"
+    # Makefile defaults, set here to enforce consistency on Darwin build
+    "USE_CODEC_WAVE=1"
+    "USE_CODEC_MP3=1"
+    "USE_CODEC_VORBIS=1"
+    "USE_CODEC_FLAC=0"
+    "USE_CODEC_OPUS=0"
+    "USE_CODEC_MIKMOD=0"
+    "USE_CODEC_UMX=0"
+    "MP3LIB=mad"
+    "VORBISLIB=vorbis"
+  ] ++ lib.optionals useSDL2 [
+    "SDL_CONFIG=sdl2-config"
+    "USE_SDL2=1"
+  ];
+
+  makefile = if (stdenv.isDarwin) then "Makefile.darwin" else "Makefile";
 
   preInstall = ''
     mkdir -p "$out/bin"
     substituteInPlace Makefile --replace "/usr/local/games" "$out/bin"
+    substituteInPlace Makefile.darwin --replace "/usr/local/games" "$out/bin"
+  '';
+
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    # Let's build app bundle
+    mkdir -p $out/Applications/Quake.app/Contents/MacOS
+    mkdir -p $out/Applications/Quake.app/Contents/Resources
+    cp ../MacOSX/Info.plist $out/Applications/Quake.app/Contents/
+    cp ../MacOSX/QuakeSpasm.icns $out/Applications/Quake.app/Contents/Resources/
+    cp -r ../MacOSX/English.lproj $out/Applications/Quake.app/Contents/Resources/
+    ln -sf $out/bin/quake $out/Applications/Quake.app/Contents/MacOS/quake
+
+    substituteInPlace $out/Applications/Quake.app/Contents/Info.plist \
+      --replace '>''${EXECUTABLE_NAME}' '>quake'
+    substituteInPlace $out/Applications/Quake.app/Contents/Info.plist \
+      --replace '>''${PRODUCT_NAME}' '>QuakeSpasm'
   '';
 
   enableParallelBuilding = true;
@@ -47,7 +93,7 @@ stdenv.mkDerivation rec {
       and smoother mouse input - though no CD support.
     '';
 
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ m3tti ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ mikroskeem m3tti ];
   };
 }

--- a/pkgs/games/quakespasm/quakespasm-darwin-makefile-improvements.patch
+++ b/pkgs/games/quakespasm/quakespasm-darwin-makefile-improvements.patch
@@ -1,0 +1,92 @@
+--- a/Makefile.darwin	2021-09-12 14:42:51.000000000 +0300
++++ b/Makefile.darwin	2021-09-12 15:09:16.000000000 +0300
+@@ -49,6 +49,7 @@
+ LIPO ?= lipo
+ 
+ STRIP ?= strip
++PKG_CONFIG ?= pkg-config
+ 
+ CPUFLAGS=
+ LDFLAGS =
+@@ -84,9 +85,6 @@
+ USE_RPATH=1
+ endif
+ CFLAGS += $(CPUFLAGS)
+-ifeq ($(USE_RPATH),1)
+-LDFLAGS+=-Wl,-rpath,@executable_path/../Frameworks
+-endif
+ 
+ ifneq ($(DEBUG),0)
+ DFLAGS += -DDEBUG
+@@ -115,19 +113,14 @@
+ # not relying on sdl-config command and assuming
+ # /Library/Frameworks/SDL.framework is available
+ SDL_CFLAGS =-D_GNU_SOURCE=1 -D_THREAD_SAFE
+-SDL_CFLAGS+=-DSDL_FRAMEWORK -DNO_SDL_CONFIG
+ ifeq ($(USE_SDL2),1)
+-SDL_FRAMEWORK_NAME = SDL2
++SDL_CONFIG ?= sdl2-config
+ else
+-SDL_FRAMEWORK_NAME = SDL
+-endif
+-# default to our local SDL[2].framework for build
+-SDL_FRAMEWORK_PATH ?=../MacOSX
+-ifneq ($(SDL_FRAMEWORK_PATH),)
+-SDL_LIBS  +=-F$(SDL_FRAMEWORK_PATH)
+-SDL_CFLAGS+=-F$(SDL_FRAMEWORK_PATH)
++SDL_CONFIG ?= sdl2-config
+ endif
+-SDL_LIBS  +=-Wl,-framework,$(SDL_FRAMEWORK_NAME) -Wl,-framework,Cocoa
++SDL_CFLAGS := $(shell $(SDL_CONFIG) --cflags)
++SDL_LIBS   := $(shell $(SDL_CONFIG) --libs)
++SDL_LIBS  += -Wl,-framework,Cocoa
+ 
+ NET_LIBS   :=
+ 
+@@ -164,38 +157,26 @@
+ endif
+ ifeq ($(USE_CODEC_FLAC),1)
+ CFLAGS+= -DUSE_CODEC_FLAC
+-CODEC_INC = -I../MacOSX/codecs/include
+-CODEC_LINK= -L../MacOSX/codecs/lib
+ CODECLIBS+= -lFLAC
+ endif
+ ifeq ($(USE_CODEC_OPUS),1)
+-CFLAGS+= -DUSE_CODEC_OPUS
+-CODEC_INC = -I../MacOSX/codecs/include
+-CODEC_LINK= -L../MacOSX/codecs/lib
+-CODECLIBS+= -lopusfile -lopus -logg
++CFLAGS+= -DUSE_CODEC_OPUS $(shell $(PKG_CONFIG) --cflags opusfile)
++CODECLIBS+= $(shell $(PKG_CONFIG) --libs   opusfile)
+ endif
+ ifeq ($(USE_CODEC_VORBIS),1)
+ CFLAGS+= -DUSE_CODEC_VORBIS $(cpp_vorbisdec)
+-CODEC_INC = -I../MacOSX/codecs/include
+-CODEC_LINK= -L../MacOSX/codecs/lib
+ CODECLIBS+= $(lib_vorbisdec)
+ endif
+ ifeq ($(USE_CODEC_MP3),1)
+ CFLAGS+= -DUSE_CODEC_MP3
+-CODEC_INC = -I../MacOSX/codecs/include
+-CODEC_LINK= -L../MacOSX/codecs/lib
+ CODECLIBS+= $(lib_mp3dec)
+ endif
+ ifeq ($(USE_CODEC_MIKMOD),1)
+ CFLAGS+= -DUSE_CODEC_MIKMOD
+-CODEC_INC = -I../MacOSX/codecs/include
+-CODEC_LINK= -L../MacOSX/codecs/lib
+ CODECLIBS+= -lmikmod
+ endif
+ ifeq ($(USE_CODEC_XMP),1)
+ CFLAGS+= -DUSE_CODEC_XMP
+-CODEC_INC = -I../MacOSX/codecs/include
+-CODEC_LINK= -L../MacOSX/codecs/lib
+ CODECLIBS+= -lxmp
+ endif
+ ifeq ($(USE_CODEC_UMX),1)
+@@ -332,3 +313,5 @@
+ clean:
+ 	rm -f $(shell find . \( -name '*~' -o -name '#*#' -o -name '*.o' -o -name '*.res' -o -name $(DEFAULT_TARGET) \) -print)
+ 
++install:	quakespasm
++	install -D -m 755 quakespasm /usr/local/games/quake

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29898,7 +29898,9 @@ with pkgs;
 
   quake3hires = callPackage ../games/quake3/content/hires.nix { };
 
-  quakespasm = callPackage ../games/quakespasm { };
+  quakespasm = callPackage ../games/quakespasm {
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreAudio CoreFoundation IOKit OpenGL;
+  };
   vkquake = callPackage ../games/quakespasm/vulkan.nix { };
 
   ioquake3 = callPackage ../games/quake3/ioquake { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Does not fit into the scope of #128669, opened separate PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
