### PR TITLE
taskopen: modernize

### DIFF
--- a/pkgs/applications/misc/taskopen/default.nix
+++ b/pkgs/applications/misc/taskopen/default.nix
@@ -1,20 +1,27 @@
-{ fetchurl, lib, stdenv, makeWrapper, which, perl, perlPackages }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, which, perl, perlPackages }:
 
-stdenv.mkDerivation {
-  name = "taskopen-1.1.5";
-  src = fetchurl {
-    url = "https://github.com/ValiValpas/taskopen/archive/v1.1.5.tar.gz";
-    sha256 = "sha256-7fncdt1wCJ4zNLrCf93yRFD8Q4XQ3DCJ1+zJg9Gcl3w=";
+stdenv.mkDerivation rec {
+  pname = "taskopen";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "ValiValpas";
+    repo = "taskopen";
+    rev = "v${version}";
+    sha256 = "sha256-/xf7Ph2KKiZ5lgLKk95nCgw/z9wIBmuWf3QGaNebgHg=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ which perl ] ++ (with perlPackages; [ JSON ]);
-
-  installPhase = ''
+  postPatch = ''
     # We don't need a DESTDIR and an empty string results in an absolute path
     # (due to the trailing slash) which breaks the build.
     sed 's|$(DESTDIR)/||' -i Makefile
+  '';
 
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ which ]
+    ++ (with perlPackages; [ JSON perl ]);
+
+  installPhase = ''
     make PREFIX=$out
     make PREFIX=$out install
   '';
@@ -28,7 +35,7 @@ stdenv.mkDerivation {
     description = "Script for taking notes and open urls with taskwarrior";
     homepage = "https://github.com/ValiValpas/taskopen";
     platforms = platforms.linux;
-    license = lib.licenses.free ;
+    license = licenses.free;
     maintainers = [ maintainers.winpat ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
