### PR TITLE
whitesur-icon-theme: 20210520 -> 20210826

### DIFF
--- a/pkgs/data/icons/whitesur-icon-theme/default.nix
+++ b/pkgs/data/icons/whitesur-icon-theme/default.nix
@@ -1,30 +1,19 @@
-{ lib
-, stdenvNoCC
-, fetchFromGitHub
-, gtk3
-, gnome
-, gnome-icon-theme
-, hicolor-icon-theme
-}:
+{ lib, stdenvNoCC, fetchFromGitHub, gtk3, hicolor-icon-theme }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "Whitesur-icon-theme";
-  version = "2021-05-20";
+  version = "2021-08-26";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    sha256 = "KboUYozTleOBKNun66g2oj7u/36hyQsPtRSk/x/LAWo=";
+    sha256 = "O7nb6X20HvnzldijP/fXqAs/2qE5JUg3DEMb84ZMQp4=";
   };
 
   nativeBuildInputs = [ gtk3 ];
 
-  buildInputs = [
-    gnome-icon-theme
-    gnome.adwaita-icon-theme
-    hicolor-icon-theme
-  ];
+  buildInputs = [ hicolor-icon-theme ];
 
   dontDropIconThemeCache = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgraded whitesur-icon-theme package from older version (2021-05-20) to the current latest released version (2021-08-26).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
