### PR TITLE
update cudatoolkit (11.3/11.4), cuddn and cutensor

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -100,14 +100,14 @@ stdenv.mkDerivation rec {
       mv * $out/
     ''}
     ${lib.optionalString (lib.versionAtLeast version "11") ''
-      mkdir -p $out/bin $out/lib64 $out/include $out/doc
+      mkdir -p $out/bin $out/lib64 $out/include $doc
       for dir in pkg/builds/* pkg/builds/cuda_nvcc/nvvm pkg/builds/cuda_cupti/extras/CUPTI; do
         if [ -d $dir/bin ]; then
           mv $dir/bin/* $out/bin
         fi
         if [ -d $dir/doc ]; then
-          (cd $dir/doc && find . -type d -exec mkdir -p $out/doc/\{} \;)
-          (cd $dir/doc && find . \( -type f -o -type l \) -exec mv \{} $out/doc/\{} \;)
+          (cd $dir/doc && find . -type d -exec mkdir -p $doc/\{} \;)
+          (cd $dir/doc && find . \( -type f -o -type l \) -exec mv \{} $doc/\{} \;)
         fi
         if [ -L $dir/include ] || [ -d $dir/include ]; then
           (cd $dir/include && find . -type d -exec mkdir -p $out/include/\{} \;)

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -72,5 +72,5 @@ rec {
     gcc = gcc10; # can bump to 11 along with stdenv.cc
   };
 
-  cudatoolkit_11 = cudatoolkit_11_2;
+  cudatoolkit_11 = cudatoolkit_11_4;
 }

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -66,9 +66,9 @@ rec {
   };
 
   cudatoolkit_11_4 = common {
-    version = "11.4.1";
-    url = "https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux.run";
-    sha256 = "0180pb1zfajb9l6blr467xkx01yp3snfwm2xix8x52crf6d36v6x";
+    version = "11.4.2";
+    url = "https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run";
+    sha256 = "sha256-u9h8oOkT+DdFSnljZ0c1E83e9VUILk2G7Zo4ZZzIHwo=";
     gcc = gcc10; # can bump to 11 along with stdenv.cc
   };
 

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -72,5 +72,12 @@ rec {
     gcc = gcc10; # can bump to 11 along with stdenv.cc
   };
 
+  cudatoolkit_11_5 = common {
+    version = "11.5.0";
+    url = "https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run";
+    sha256 = "sha256-rgoWk9lJfPPYHmlIlD43lGNpANtxyY1Y7v2sr38aHkw=";
+    gcc = gcc10; # can bump to 11 along with stdenv.cc
+  };
+
   cudatoolkit_11 = cudatoolkit_11_4;
 }

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -56,5 +56,5 @@ in rec {
     cudatoolkit = cudatoolkit_11_4;
   };
 
-  cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_2;
+  cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_4;
 }

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -1,4 +1,6 @@
-{ callPackage, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2 }:
+{ callPackage, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2
+, cudatoolkit_11_3, cudatoolkit_11_4
+}:
 
 let
   generic = args: callPackage (import ./generic.nix (removeAttrs args ["cudatoolkit"])) {
@@ -44,6 +46,14 @@ in rec {
 
   cudnn_cudatoolkit_11_2 = cudnn_cudatoolkit_11_0.override {
     cudatoolkit = cudatoolkit_11_2;
+  };
+
+  cudnn_cudatoolkit_11_3 = cudnn_cudatoolkit_11_0.override {
+    cudatoolkit = cudatoolkit_11_3;
+  };
+
+  cudnn_cudatoolkit_11_4 = cudnn_cudatoolkit_11_0.override {
+    cudatoolkit = cudatoolkit_11_4;
   };
 
   cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_2;

--- a/pkgs/development/libraries/science/math/cutensor/default.nix
+++ b/pkgs/development/libraries/science/math/cutensor/default.nix
@@ -45,5 +45,5 @@ rec {
     cudatoolkit = cudatoolkit_11_4;
   };
 
-  cutensor_cudatoolkit_11 = cutensor_cudatoolkit_11_2;
+  cutensor_cudatoolkit_11 = cutensor_cudatoolkit_11_4;
 }

--- a/pkgs/development/libraries/science/math/cutensor/default.nix
+++ b/pkgs/development/libraries/science/math/cutensor/default.nix
@@ -14,8 +14,12 @@ rec {
   };
 
   cutensor_cudatoolkit_10_2 = cutensor_cudatoolkit_10_1.override {
+    version = "1.3.1.3";
     libPath = "lib/10.2";
     cudatoolkit = cudatoolkit_10_2;
+    # 1.3.1 is compatible with CUDA 11.0, 11.1, and 11.2:
+    # ephemeral doc at https://developer.nvidia.com/cutensor/downloads
+    sha256 = "sha256-mNlVnabB2IC3HnYY0mb06RLqQzDxN9ePGVeBy3hkBC8=";
   };
 
   cutensor_cudatoolkit_10 = cutensor_cudatoolkit_10_2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4154,7 +4154,9 @@ with pkgs;
     cudnn_cudatoolkit_11
     cudnn_cudatoolkit_11_0
     cudnn_cudatoolkit_11_1
-    cudnn_cudatoolkit_11_2;
+    cudnn_cudatoolkit_11_2
+    cudnn_cudatoolkit_11_3
+    cudnn_cudatoolkit_11_4;
 
   cudnn = cudnn_cudatoolkit_10;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4141,7 +4141,8 @@ with pkgs;
     cudatoolkit_11_1
     cudatoolkit_11_2
     cudatoolkit_11_3
-    cudatoolkit_11_4;
+    cudatoolkit_11_4
+    cudatoolkit_11_5;
 
   cudatoolkit = cudatoolkit_10;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
