### PR TITLE
radian: init at 0.5.11 and provide radianWrapper

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4977,6 +4977,12 @@
     githubId = 117874;
     name = "Jeroen de Haas";
   };
+  jdreaver = {
+    email = "johndreaver@gmail.com";
+    github = "jdreaver";
+    githubId = 1253071;
+    name = "David Reaver";
+  };
   jduan = {
     name = "Jingjing Duan";
     email = "duanjingjing@gmail.com";

--- a/pkgs/development/python-modules/lineedit/default.nix
+++ b/pkgs/development/python-modules/lineedit/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pygments
+, six
+, wcwidth
+}:
+
+buildPythonPackage rec {
+  pname = "lineedit";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9HlUeRVONQrZz26L5q06ePEPiSuZZ1ry+BQPLYR/bz8=";
+  };
+
+  # Tests not included in PyPI release
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    pygments
+    six
+    wcwidth
+  ];
+
+  meta = with lib; {
+    description = "A readline library based on prompt_toolkit which supports multiple modes.";
+    homepage = "https://github.com/randy3k/lineedit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jdreaver ];
+  };
+}

--- a/pkgs/development/python-modules/lineedit/default.nix
+++ b/pkgs/development/python-modules/lineedit/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage rec {
     wcwidth
   ];
 
+  pythonImportsCheck = [ "lineedit" ];
+
   meta = with lib; {
     description = "A readline library based on prompt_toolkit which supports multiple modes.";
     homepage = "https://github.com/randy3k/lineedit";

--- a/pkgs/development/python-modules/lineedit/default.nix
+++ b/pkgs/development/python-modules/lineedit/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pygments
 , six
 , wcwidth
@@ -10,12 +10,16 @@ buildPythonPackage rec {
   pname = "lineedit";
   version = "0.1.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "9HlUeRVONQrZz26L5q06ePEPiSuZZ1ry+BQPLYR/bz8=";
+  src = fetchFromGitHub {
+    owner = "randy3k";
+    repo = pname;
+    rev = "4262e9852aa50b09ff3f0569e1840b003ed00584";
+    sha256 = "fq2NpjIQkIq1yzXEUxi6cz80kutVqcH6MqJXHtpTFsk=";
   };
 
-  # Tests not included in PyPI release
+  # Tests fail with "[Errno 1] Operation not permitted". This is
+  # preceded by "Warning: Input is not to a terminal (fd=0)", so
+  # probably related.
   doCheck = false;
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/radian/default.nix
+++ b/pkgs/development/python-modules/radian/default.nix
@@ -1,9 +1,14 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, coverage
 , lineedit
+, pexpect
+, ptyprocess
 , pygments
-, pytest-runner
+, pyte
+, pytestCheckHook
+, R
 , rchitect
 , six
 }:
@@ -12,16 +17,30 @@ buildPythonPackage rec {
   pname = "radian";
   version = "0.5.11";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "hM2IDcBjOFIRC3SdNO9PSM8TqI1ga1GvCFQkqf4Tyto=";
+  src = fetchFromGitHub {
+    owner = "randy3k";
+    repo = pname;
+    rev = "c1579e6b3fa1c302961d08debe17232127616b9b";
+    sha256 = "SAVZgdLv7DZNwfvbu98m3cSZuv/XrRRZXHTT+58z8Ao=";
   };
 
-  buildInputs = [
-    pytest-runner
+  postPatch = ''
+    substituteInPlace setup.py --replace '"pytest-runner"' ""
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    coverage
+    pyte
+    pexpect
+    ptyprocess
   ];
 
-  # Tests not included in PyPI release
+  nativeBuildInputs = [
+    R # needed at setup time to detect R_HOME
+  ];
+
+  # Tests fail in mysterious ways with empty exception values
   doCheck = false;
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/radian/default.nix
+++ b/pkgs/development/python-modules/radian/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, lineedit
+, pygments
+, pytest-runner
+, rchitect
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "radian";
+  version = "0.5.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "hM2IDcBjOFIRC3SdNO9PSM8TqI1ga1GvCFQkqf4Tyto=";
+  };
+
+  buildInputs = [
+    pytest-runner
+  ];
+
+  # Tests not included in PyPI release
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    lineedit
+    pygments
+    rchitect
+    six
+  ];
+
+  meta = with lib; {
+    description = "A 21 century R console.";
+    homepage = "https://github.com/randy3k/radian";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jdreaver ];
+  };
+}

--- a/pkgs/development/python-modules/radian/default.nix
+++ b/pkgs/development/python-modules/radian/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
     six
   ];
 
+  pythonImportsCheck = [ "radian" ];
+
   meta = with lib; {
     description = "A 21 century R console.";
     homepage = "https://github.com/randy3k/radian";

--- a/pkgs/development/python-modules/rchitect/default.nix
+++ b/pkgs/development/python-modules/rchitect/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, backports-shutil-which
+, cffi
+, pytest-runner
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "rchitect";
+  version = "0.3.32";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ghA7Go1E3TcGqgvY6CVP5UKN1S1GLwy5hmxYPrcoasM=";
+  };
+
+  buildInputs = [
+    pytest-runner
+  ];
+
+  # Tests not included in PyPI release
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    cffi
+    six
+  ] ++ lib.optionals isPy27 [
+    backports-shutil-which
+  ];
+
+  meta = with lib; {
+    description = "Interoperate R with Python";
+    homepage = "https://github.com/randy3k/rchitect";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jdreaver ];
+  };
+}

--- a/pkgs/development/python-modules/rchitect/default.nix
+++ b/pkgs/development/python-modules/rchitect/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
     backports-shutil-which
   ];
 
+  pythonImportsCheck = [ "rchitect" ];
+
   meta = with lib; {
     description = "Interoperate R with Python";
     homepage = "https://github.com/randy3k/rchitect";

--- a/pkgs/development/python-modules/rchitect/default.nix
+++ b/pkgs/development/python-modules/rchitect/default.nix
@@ -1,8 +1,8 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , cffi
-, pytest-runner
+, pytestCheckHook
 , six
 }:
 
@@ -10,16 +10,23 @@ buildPythonPackage rec {
   pname = "rchitect";
   version = "0.3.32";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "ghA7Go1E3TcGqgvY6CVP5UKN1S1GLwy5hmxYPrcoasM=";
+  src = fetchFromGitHub {
+    owner = "randy3k";
+    repo = pname;
+    rev = "0f3d5a191cca895a1cb9c41f8391520a08e8b9fc";
+    sha256 = "B+laYoW1XEq+XOoD/gjDngy8o9OSFJPpqdXVpvDIjLA=";
   };
 
-  buildInputs = [
-    pytest-runner
+  postPatch = ''
+    substituteInPlace setup.py --replace '"pytest-runner"' ""
+  '';
+
+  checkInputs = [
+    pytestCheckHook
   ];
 
-  # Tests not included in PyPI release
+  # Problems importing rchitect._cffi, which is a module built with
+  # cffi
   doCheck = false;
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/rchitect/default.nix
+++ b/pkgs/development/python-modules/rchitect/default.nix
@@ -1,8 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
-, backports-shutil-which
 , cffi
 , pytest-runner
 , six
@@ -27,8 +25,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cffi
     six
-  ] ++ lib.optionals isPy27 [
-    backports-shutil-which
   ];
 
   pythonImportsCheck = [ "rchitect" ];

--- a/pkgs/development/r-modules/wrapper-radian.nix
+++ b/pkgs/development/r-modules/wrapper-radian.nix
@@ -4,9 +4,9 @@ runCommand "radian-wrapper" {
   preferLocalBuild = true;
   allowSubstitutes = false;
 
-  nativeBuildInputs = [makeWrapper];
+  nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [R] ++ recommendedPackages ++ packages;
+  buildInputs = [ R ] ++ recommendedPackages ++ packages;
 }
 ''
 makeWrapper ${radian}/bin/radian $out/bin/radian \

--- a/pkgs/development/r-modules/wrapper-radian.nix
+++ b/pkgs/development/r-modules/wrapper-radian.nix
@@ -1,0 +1,15 @@
+{ lib, runCommand, R, recommendedPackages, packages, makeWrapper, radian }:
+
+runCommand "radian-wrapper" {
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+
+  nativeBuildInputs = [makeWrapper];
+
+  buildInputs = [R] ++ recommendedPackages ++ packages;
+}
+''
+makeWrapper ${radian}/bin/radian $out/bin/radian \
+  --set R_LIBS_SITE "$R_LIBS_SITE" \
+  --set R_HOME ${R}/lib/R
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19748,6 +19748,16 @@ with pkgs;
     packages = [];
   };
 
+  radianWrapper = callPackage ../development/r-modules/wrapper-radian.nix {
+    recommendedPackages = with rPackages; [
+      boot class cluster codetools foreign KernSmooth lattice MASS
+      Matrix mgcv nlme nnet rpart spatial survival
+    ];
+    # Override this attribute to register additional libraries.
+    packages = [];
+    radian = python3Packages.radian;
+  };
+
   rstudioWrapper = libsForQt5.callPackage ../development/r-modules/wrapper-rstudio.nix {
     recommendedPackages = with rPackages; [
       boot class cluster codetools foreign KernSmooth lattice MASS

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4251,6 +4251,8 @@ in {
 
   linecache2 = callPackage ../development/python-modules/linecache2 { };
 
+  lineedit = callPackage ../development/python-modules/lineedit { };
+
   line_profiler = callPackage ../development/python-modules/line_profiler { };
 
   linkify-it-py = callPackage ../development/python-modules/linkify-it-py { };
@@ -7633,6 +7635,8 @@ in {
 
   rachiopy = callPackage ../development/python-modules/rachiopy { };
 
+  radian = callPackage ../development/python-modules/radian { };
+
   radicale_infcloud = callPackage ../development/python-modules/radicale_infcloud { };
 
   radio_beam = callPackage ../development/python-modules/radio_beam { };
@@ -7668,6 +7672,8 @@ in {
   rawkit = callPackage ../development/python-modules/rawkit { };
 
   rbtools = callPackage ../development/python-modules/rbtools { };
+
+  rchitect = callPackage ../development/python-modules/rchitect { };
 
   rcssmin = callPackage ../development/python-modules/rcssmin { };
 


### PR DESCRIPTION
Also:
lineedit: init at 0.1.6
rchitect: init at 0.3.32

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds the [`radian` R console](https://pypi.org/project/radian/) along with a couple of its dependencies. It provides `radianWrapper`, similar to `rWrapper` and `rstudioWrapper`, to provide packages to be used with the `radian` shell.

It can be used like so:

```nix
radianWrapper.override {
  packages = with rPackages; [ purrr ]; 
} 
```

Here is an example of it getting built:

```sh
$ nix repl
Welcome to Nix version 2.4pre20210802_47e96bb. Type :? for help.

nix-repl> flake = builtins.getFlake (toString ./.)                                                                    

nix-repl> :b with flake.legacyPackages.x86_64-linux; radianWrapper.override { packages = with rPackages; [ purrr ]; } 
warning: error: plugin-files set after plugins were loaded, you may need to move the flag before the subcommand

this derivation produced the following outputs:
  out -> /nix/store/8hakcfw1zm7v0x5d428mk0nj67qaqprb-radian-wrapper
```

And here is the previous build getting used:

```R
$ /nix/store/8hakcfw1zm7v0x5d428mk0nj67qaqprb-radian-wrapper/bin/radian
R version 4.1.1 (2021-08-10) -- "Kick Things"
Platform: x86_64-pc-linux-gnu (64-bit)

r$> library(purrr)                                                                                                                    
r$> mtcars %>% 
          split(.$cyl) %>% # from base R 
          map(~ lm(mpg ~ wt, data = .)) %>% 
          map(summary) %>% 
          map_dbl("r.squared")          
        4         6         8                                                                                                       
0.5086326 0.4645102 0.4229655                                                                                                                               
```

In particular, the key thing here is making sure `radian` knows about `R_HOME` and `R_LIBS_SITE`, which I verified:

```R
r$> Sys.getenv("R_HOME")
[1] "/nix/store/w57r9xnsfr5snp9pdyqy7xqxq6lgbhay-R-4.1.1/lib/R"

r$> Sys.getenv("R_LIBS_SITE")
[1] "/nix/store/zvbxvifrnqwlwy9zhclbs06x08086nfb-r-boot-1.3-28/library:/nix/store/mqsrh4ykivjh49wmmba8d0gnfawlk0qi-r-class-7.3-19/library:/nix/store/m54bbpls1yj6444vyrfh9if3cacssjcl-r-MASS-7.3-54/library:/nix/store/5gxxm42zjznj2z3ymwqjyf14sblmzdrz-r-cluster-2.1.2/library:/nix/store/mh3iilyaxqq36cxfa0i6qlr761ylc3fh-r-codetools-0.2-18/library:/nix/store/j65lddbycwx009kd595924df27ly4rbp-r-foreign-0.8-81/library:/nix/store/xkdxwjaf0ryfqabxqlpfna3bigw0wb4d-r-KernSmooth-2.23-20/library:/nix/store/icw2qral5naskxl5s152dpbnic945w0c-r-lattice-0.20-44/library:/nix/store/fvk8ripxpbr6sixy6386f1aq27z43kqg-r-Matrix-1.3-3/library:/nix/store/wsnjrc3j9p4qnd79d6wdfrw8sw9nibi1-r-mgcv-1.8-35/library:/nix/store/2jsny9m90a5hi5pz56clkra903wn2cbj-r-nlme-3.1-152/library:/nix/store/a167w7vbc93iyzd4ajkg8inqj78cn61r-r-nnet-7.3-16/library:/nix/store/r0kid1yzdhx9maa3s195bx3rdhfmgrx0-r-rpart-4.1-15/library:/nix/store/nrrkjy221cgpzkqv6zlvx27pdsp49y2j-r-spatial-7.3-14/library:/nix/store/7vnys4dnpyhf3w234l23n4fpdjlv49x3-r-survival-3.2-11/library:/nix/store/5h4x9h0d5h5a6vr6ff7kgrzk16k0g71r-r-purrr-0.3.4/library:/nix/store/gc5bjx2akadw8wap86n561l4pf5vi8dx-r-magrittr-2.0.1/library:/nix/store/89ky56ijslgz3n0gr7a35vlxm14ljzrx-r-rlang-0.4.11/library"

```

I also tested that all 3 of the Python packages built properly with both Python 2 and 3:

```sh
$ nix build .#pythonPackages.lineedit 
$ nix build .#python3Packages.lineedit
$ nix build .#pythonPackages.rchitect
$ nix build .#python3Packages.rchitect
$ nix build .#pythonPackages.radian
$ nix build .#python3Packages.radian
```

This is only my third `nixpkgs` PR, and my first PR touching Python or R. Please feel free to provide any feedback, even if you think it is just a nit! I'm also not sure if this PR is too large; should I make a PR just providing the Python packages, and then make a PR adding the wrapper if there is more discussion needed? Even if I just merged the Python packages, that would simplify my NixOS setup :smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
