### PR TITLE
libexif: 0.6.22 -> 0.6.23

### DIFF
--- a/pkgs/development/libraries/libexif/default.nix
+++ b/pkgs/development/libraries/libexif/default.nix
@@ -1,29 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, gettext }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, gettext }:
 
 stdenv.mkDerivation rec {
   pname = "libexif";
-  version = "0.6.22";
+  version = "0.6.23";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "${pname}-${builtins.replaceStrings ["."] ["_"] version}-release";
-    sha256 = "0mzndakdi816zcs13z7yzp7hj031p2dcyfq2p391r63d9z21jmy1";
+    sha256 = "sha256-Os0yI/IPoe9MuhXgNdDaIg6uohclA2bjeu9t3tbUoNA=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2020-0198.patch";
-      url = "https://github.com/libexif/libexif/commit/ce03ad7ef4e8aeefce79192bf5b6f69fae396f0c.patch";
-      sha256 = "1040278g5dbq3vvlyk8cmzb7flpi9bfsp99268hw69i6ilwbdf2k";
-    })
-    (fetchpatch {
-      name = "CVE-2020-0452.patch";
-      url = "https://github.com/libexif/libexif/commit/9266d14b5ca4e29b970fa03272318e5f99386e06.patch";
-      excludes = [ "NEWS" ];
-      sha256 = "0k4z1gbbkli6wwyy9qm2qvn0h00qda6wqym61nmmbys7yc2zryj6";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook gettext ];
 


### PR DESCRIPTION
From the [release notes](https://github.com/libexif/libexif/releases/tag/v0.6.23):

>   * Security fixes:                                                                                                                                                                                                            
    * CVE-2020-0198: unsigned integer overflow in exif_data_load_data_content                                                                                                                                                  
    * CVE-2020-0452: compiler optimization could remove an a                                                                                                                                                                   
      bufferoverflow check, making a buffer overflow possible with some                                                                                                                                                        
      EXIF tags                                                                                                                                                                                                                
    * some more denial of service (compute time or stack exhaustion) counter-measures                                                                                                                                          
      added that avoid minutes of decoding time with malformed files found                                                                                                                                                     
      by OSS-Fuzz 

The two CVE's were already patched, but for the denial of service mitigations I guess it makes sense to backport it, considering that the overall changes in the release seem to be minor.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
