### PR TITLE
python39Packages.pbr: enable tests, adopt into openstack team

### DIFF
--- a/pkgs/development/python-modules/debtcollector/default.nix
+++ b/pkgs/development/python-modules/debtcollector/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   passthru.tests = {
-    pytest = callPackage ./tests.nix { };
+    tests = callPackage ./tests.nix { };
   };
 
   pythonImportsCheck = [ "debtcollector" ];

--- a/pkgs/development/python-modules/os-service-types/default.nix
+++ b/pkgs/development/python-modules/os-service-types/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   passthru.tests = {
-    pytest = callPackage ./tests.nix { };
+    tests = callPackage ./tests.nix { };
   };
 
   pythonImportsCheck = [ "os_service_types" ];

--- a/pkgs/development/python-modules/oslo-config/default.nix
+++ b/pkgs/development/python-modules/oslo-config/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   passthru.tests = {
-    pytest = callPackage ./tests.nix {};
+    tests = callPackage ./tests.nix {};
   };
 
   pythonImportsCheck = [ "oslo_config" ];

--- a/pkgs/development/python-modules/oslotest/default.nix
+++ b/pkgs/development/python-modules/oslotest/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   passthru.tests = {
-    pytest = callPackage ./tests.nix {};
+    tests = callPackage ./tests.nix {};
   };
 
   pythonImportsCheck = [ "oslotest" ];

--- a/pkgs/development/python-modules/pbr/default.nix
+++ b/pkgs/development/python-modules/pbr/default.nix
@@ -1,4 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi, setuptools }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, callPackage
+}:
 
 buildPythonPackage rec {
   pname = "pbr";
@@ -11,13 +16,19 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ setuptools ];
 
-  # circular dependencies with fixtures
+  # check in passthru.tests.pytest to escape infinite recursion with fixtures
   doCheck = false;
+
+  passthru.tests = {
+    pytest = callPackage ./tests.nix { };
+  };
+
   pythonImportsCheck = [ "pbr" ];
 
   meta = with lib; {
-    homepage = "http://docs.openstack.org/developer/pbr/";
-    license = licenses.asl20;
     description = "Python Build Reasonableness";
+    homepage = "https://github.com/openstack/pbr";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
   };
 }

--- a/pkgs/development/python-modules/pbr/default.nix
+++ b/pkgs/development/python-modules/pbr/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   passthru.tests = {
-    pytest = callPackage ./tests.nix { };
+    tests = callPackage ./tests.nix { };
   };
 
   pythonImportsCheck = [ "pbr" ];

--- a/pkgs/development/python-modules/pbr/tests.nix
+++ b/pkgs/development/python-modules/pbr/tests.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, buildPythonPackage
+, git
+, gnupg
+, pbr
+, mock
+, sphinx
+, stestr
+, testresources
+, testscenarios
+, virtualenv
+}:
+
+buildPythonPackage rec {
+  pname = "pbr";
+  inherit (pbr) version;
+
+  src = pbr.src;
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  dontBuild = true;
+  dontInstall = true;
+
+  checkInputs = [
+    pbr
+    git
+    gnupg
+    mock
+    sphinx
+    stestr
+    testresources
+    testscenarios
+    virtualenv
+  ];
+
+  checkPhase = ''
+    stestr run -e <(echo "
+    pbr.tests.test_core.TestCore.test_console_script_develop
+    pbr.tests.test_core.TestCore.test_console_script_install
+    pbr.tests.test_wsgi.TestWsgiScripts.test_with_argument
+    pbr.tests.test_wsgi.TestWsgiScripts.test_wsgi_script_run
+    ")
+  '';
+}

--- a/pkgs/development/python-modules/stestr/default.nix
+++ b/pkgs/development/python-modules/stestr/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   passthru.tests = {
-    pytest = callPackage ./tests.nix { };
+    tests = callPackage ./tests.nix { };
   };
 
   pythonImportsCheck = [ "stestr" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
