### PR TITLE
go-swag: 1.6.7 -> 1.7.1

### DIFF
--- a/pkgs/development/tools/go-swag/default.nix
+++ b/pkgs/development/tools/go-swag/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "go-swag";
-  version = "1.6.7";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "swaggo";
     repo = "swag";
-    rev = "df209afeed2334a97c83aff34ea7abcad85c31f6";
-    sha256 = "17pmcfkcmgjvs4drs0fyhp2m39gw83s0ck3rdzdkgdhrbhva9ksx";
+    rev = "v${version}";
+    sha256 = "1hcpq85rdip2q75zxqdx2nbn9v1m89vliyc7gbir4f8nw4dzvcwm";
   };
 
-  vendorSha256 = "1i2n2sz2hc89nf2fqfq3swldz0xwrnms4j9q0lrss5gm3bk49q7f";
+  vendorSha256 = "0n6f4z2jvmpg7pr3pyq64a4rh150ixn8dwkzk17j0vcy4bh9fka3";
 
   subPackages = [ "cmd/swag" ];
 

--- a/pkgs/development/tools/go-swag/default.nix
+++ b/pkgs/development/tools/go-swag/default.nix
@@ -1,4 +1,4 @@
-{ buildGoModule, fetchFromGitHub, lib }:
+{ buildGoModule, common-updater-scripts, fetchFromGitHub, genericUpdater, lib }:
 
 buildGoModule rec {
   pname = "go-swag";
@@ -14,6 +14,15 @@ buildGoModule rec {
   vendorSha256 = "0n6f4z2jvmpg7pr3pyq64a4rh150ixn8dwkzk17j0vcy4bh9fka3";
 
   subPackages = [ "cmd/swag" ];
+
+   passthru = {
+     updateScript = genericUpdater {
+       inherit pname version;
+       versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
+       rev-prefix = "v";
+       ignoredVersions = ".(rc|beta).*";
+     };
+   };
 
   meta = with lib; {
     description = "Automatically generate RESTful API documentation with Swagger 2.0 for Go";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The version 1.6.7 is quite outdated.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
