### PR TITLE
{pv,mosh}: fix on aarch64-darwin

### DIFF
--- a/pkgs/tools/misc/pv/default.nix
+++ b/pkgs/tools/misc/pv/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchurl } :
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+}:
 
 stdenv.mkDerivation rec {
   name = "pv-1.6.20";
@@ -7,6 +11,14 @@ stdenv.mkDerivation rec {
     url = "https://www.ivarch.com/programs/sources/${name}.tar.bz2";
     sha256 = "00y6zla8h653sn4axgqz7rr0x79vfwl62a7gn6lzn607zwg9acg8";
   };
+
+  patches = [
+    # Fix build on aarch64-darwin using patch from Homebrew
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/Homebrew/homebrew-core/0780f1df9fdbd8914ff50ac24eb0ec0d3561c1b7/Formula/pv.rb";
+      sha256 = "001xayskfprri4s2gd3bqwajw6nz6nv0ggb0835par7q7bsd0dzr";
+    })
+  ];
 
   meta = {
     homepage = "http://www.ivarch.com/programs/pv";

--- a/pkgs/tools/misc/pv/default.nix
+++ b/pkgs/tools/misc/pv/default.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl } :
 
 stdenv.mkDerivation rec {
-  name = "pv-1.6.6";
+  name = "pv-1.6.20";
 
   src = fetchurl {
     url = "https://www.ivarch.com/programs/sources/${name}.tar.bz2";
-    sha256 = "1wbk14xh9rfypiwyy68ssl8dliyji30ly70qki1y2xx3ywszk3k0";
+    sha256 = "00y6zla8h653sn4axgqz7rr0x79vfwl62a7gn6lzn607zwg9acg8";
   };
 
   meta = {

--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -31,6 +31,14 @@ stdenv.mkDerivation rec {
     ./bash_completion_datadir.patch
   ];
   postPatch = ''
+    # Fix build with Xcode 12.5 toolchain/case-insensitive filesystems
+    # Backport of https://github.com/mobile-shell/mosh/commit/12199114fe4234f791ef4c306163901643b40538;
+    # remove on next upstream release.
+    patch -p0 < ${fetchpatch {
+      url = "https://raw.githubusercontent.com/macports/macports-ports/70ca3f65e622c17582fd938602d800157ed951c3/net/mosh/files/patch-version-subdir.diff";
+      sha256 = "1yyh6d07y9zbdx4fb0r56zkq9nd9knwzj22v4dfi55k4k42qxapd";
+    }}
+
     substituteInPlace scripts/mosh.pl \
         --subst-var-by ssh "${openssh}/bin/ssh"
     substituteInPlace scripts/mosh.pl \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

These fix some trivial incompatibilities with the Apple Silicon toolchain using patches that are already in Homebrew.

I also bumped the (tragically orphaned for >2 years) `pv` package while I was at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
