### PR TITLE
meilisearch: enable flake usage

### DIFF
--- a/pkgs/servers/search/meilisearch/default.nix
+++ b/pkgs/servers/search/meilisearch/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ pkgs
+, lib
 , stdenv
 , buildRustCrate
 , defaultCrateOverrides
@@ -27,7 +28,7 @@ let
     };
   };
   cargo_nix = import ./Cargo.nix {
-    nixpkgs = ../../../..;
+    inherit pkgs;
     buildRustCrateForPkgs = customBuildRustCrateForPkgs;
   };
   meilisearch-http = cargo_nix.workspaceMembers."meilisearch-http".build.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6676,6 +6676,7 @@ with pkgs;
 
   meilisearch = callPackage ../servers/search/meilisearch {
     inherit (darwin.apple_sdk.frameworks) Security;
+    inherit pkgs;
   };
 
   memtester = callPackage ../tools/system/memtester { };


### PR DESCRIPTION
###### Motivation for this change

Coming from https://github.com/kolloch/crate2nix/issues/210#issuecomment-917549305

I'm not 100% sure about removing the `nixpkgs = ...` line. There is a chance it is IFD, let's see what hydra says.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
