### PR TITLE
python39Packages.black: allow setuptools_scm-6.3.0

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -29,6 +29,9 @@ buildPythonPackage rec {
     sha256 = "sha256-VwYI0oqjrxeSuYxKM326xjZ4d7R7EriKtCCVz8GmJ8I=";
   };
 
+  # upstream backport to allow setuptools_scm-6.3
+  patches = [ ./newer-setuptools_scm.patch ];
+
   nativeBuildInputs = [ setuptools-scm ];
 
   # Necessary for the tests to pass on Darwin with sandbox enabled.

--- a/pkgs/development/python-modules/black/newer-setuptools_scm.patch
+++ b/pkgs/development/python-modules/black/newer-setuptools_scm.patch
@@ -1,0 +1,12 @@
+Upstream patch with whitespace change:
+https://github.com/psf/black/commit/41e670064063e3e221b1c3c40db5aaae784b5231.patch
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -23,1 +23,1 @@ extend-exclude = '''
+-requires = ["setuptools>=41.0", "setuptools_scm~=6.0.1", "wheel"]
++requires = ["setuptools>=45.0", "setuptools_scm[toml]>=6.3.1", "wheel"]
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -1,1 +1,1 @@
+-	setuptools_scm~=6.0.1
++	setuptools_scm[toml]>=6.3.1


### PR DESCRIPTION
This change fixes build failure on staging as it uses newer
setuptools_scm-6.3.0:
  ERROR: Could not find a version that satisfies the
    requirement setuptools_scm~=6.0.1 (from versions: none)
  ERROR: No matching distribution found for setuptools_scm~=6.0.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
