### PR TITLE
ristate: init at unstable-2021-09-10

### DIFF
--- a/pkgs/tools/misc/ristate/default.nix
+++ b/pkgs/tools/misc/ristate/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitLab }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ristate";
+  version = "unstable-2021-09-10";
+
+  src = fetchFromGitLab {
+    owner = "snakedye";
+    repo = pname;
+    rev = "34dfd0a0bab5b36df118d8da3956fd938c625b15";
+    sha256 = "sha256-CH9DZ/7Bhbe6qKg1Nbj1rA9SzIsqVlBJg51XxAh0XnY=";
+  };
+
+  cargoSha256 = "sha256-HTfRWvE3m7XZhZDj5bEkrQI3pD6GNiKd2gJtMjRQ8Rw=";
+
+  meta = with lib; {
+    description = "A river-status client written in Rust";
+    homepage = "https://gitlab.com/snakedye/ristate";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kranzes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22206,6 +22206,8 @@ with pkgs;
 
   riscv-pk = callPackage ../misc/riscv-pk { };
 
+  ristate = callPackage ../tools/misc/ristate { };
+
   roccat-tools = callPackage ../os-specific/linux/roccat-tools { };
 
   rtsp-simple-server = callPackage ../servers/rtsp-simple-server { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added the river-status client Ristate.

Closes https://github.com/NixOS/nixpkgs/issues/137600

@wizardwatch Please test this out first.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
