### PR TITLE
buildGoModule: suggest adding `deleteVendor = true;`

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -100,7 +100,7 @@ let
       fi
     '' + ''
       if [ -d vendor ]; then
-        echo "vendor folder exists, please set 'vendorSha256 = null;' in your expression"
+        echo "vendor folder exists, please set 'vendorSha256 = null;' or 'deleteVendor = true;' in your expression"
         exit 10
       fi
 


### PR DESCRIPTION
when the `vendor` folder exists, buildGoModule suggests adding `vendorSha256 = null;`
but with `vendorSha256 = null;` i get

```
error: tar: /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxx-source: Cannot read: Is a directory
```

fixed by adding  `deleteVendor = true;`
EDIT: not fixed. same error from tar

`src` is a `fetchFromGitHub` expression, not sure why buildGoModule expects an archive

observed while building [gitea](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/version-management/gitea/default.nix) with buildGoModule

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
