### PR TITLE
fclones: add Darwin support, bump 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/tools/misc/fclones/default.nix
+++ b/pkgs/tools/misc/fclones/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, udev }:
+{ lib, stdenv
+, fetchFromGitHub
+, libiconv
+, rustPlatform
+, AppKit
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "fclones";
@@ -13,12 +18,13 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-5qX45FJFaiE1vTXjllM9U1w57MX18GgKEFOEBMc64Jk=";
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ udev ];
+  buildInputs = lib.optionals stdenv.isDarwin [
+    AppKit
+    libiconv
+  ];
 
-  # tests in dedupe.rs fail due to
-  # "creation time is not available for the filesystem"
-  doCheck = false;
+  # device::test_physical_device_name test fails on Darwin
+  doCheck = !stdenv.isDarwin;
 
   meta = with lib; {
     description = "Efficient Duplicate File Finder and Remover";

--- a/pkgs/tools/misc/fclones/default.nix
+++ b/pkgs/tools/misc/fclones/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "fclones";
-  version = "0.14.0";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "pkolaczk";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ni5amy903cy822yhw070bcrrixrw2m1vr66q1h32bc98pyv4w05";
+    sha256 = "sha256-8NUneKJpnBjC4OcAABEpI9p+saBqAk+l43FS8/tIYjc=";
   };
 
-  cargoSha256 = "1gcb46k7bwdfsf6hyvmi6dna1nf6myzy63bhjfp0wy7c8g4m2mg8";
+  cargoSha256 = "sha256-5qX45FJFaiE1vTXjllM9U1w57MX18GgKEFOEBMc64Jk=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ udev ];

--- a/pkgs/tools/misc/fclones/default.nix
+++ b/pkgs/tools/misc/fclones/default.nix
@@ -30,6 +30,6 @@ rustPlatform.buildRustPackage rec {
     description = "Efficient Duplicate File Finder and Remover";
     homepage = "https://github.com/pkolaczk/fclones";
     license = licenses.mit;
-    maintainers = with maintainers; [ cyounkins ];
+    maintainers = with maintainers; [ cyounkins msfjarvis ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24738,7 +24738,9 @@ with pkgs;
 
   fbida = callPackage ../applications/graphics/fbida { };
 
-  fclones = callPackage ../tools/misc/fclones { };
+  fclones = callPackage ../tools/misc/fclones {
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+  };
 
   fcp = callPackage ../tools/misc/fcp { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds support to fclones for Darwin builds and updates it to the 0.15.0 release.

While working on this PR I realised the x86_64-linux build did not really need udev to build, so I've removed it to unblock Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [2.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
