### PR TITLE
obitools3: fix build on aarch64 + formatting

### DIFF
--- a/pkgs/applications/science/biology/obitools/obitools3.nix
+++ b/pkgs/applications/science/biology/obitools/obitools3.nix
@@ -1,10 +1,6 @@
-{ lib, fetchurl, python3Packages, cmake, python3 }:
+{ stdenv, lib, fetchurl, python3Packages, cmake, python3 }:
 
-let
-  pythonPackages = python3Packages;
-in
-
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "obitools3";
   version = "3.0.1b11";
 
@@ -13,14 +9,19 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1x7a0nrr9agg1pfgq8i1j8r1p6c0jpyxsv196ylix1dd2iivmas1";
   };
 
+  disabled = python3Packages.pythonOlder "3.5";
+
+  nativeBuildInputs = [ python3Packages.cython cmake ];
+
+  postPatch = lib.optionalString stdenv.isAarch64 ''
+      substituteInPlace setup.py \
+      --replace "'-msse2'," ""
+  '';
+
   preBuild = ''
     substituteInPlace src/CMakeLists.txt --replace \$'{PYTHONLIB}' "$out/lib/${python3.libPrefix}/site-packages";
     export NIX_CFLAGS_COMPILE="-L $out/lib/${python3.libPrefix}/site-packages $NIX_CFLAGS_COMPILE"
   '';
-
-  disabled = !pythonPackages.isPy3k;
-
-  nativeBuildInputs = [ pythonPackages.cython cmake ];
 
   dontConfigure = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix for arch64

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux (build on x86_64 with option --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }')
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
