### PR TITLE
nixos/top-level: fix cross

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -61,8 +61,8 @@ let
       substituteInPlace $out/dry-activate --subst-var out
       chmod u+x $out/activate $out/dry-activate
       unset activationScript dryActivationScript
-      ${pkgs.runtimeShell} -n $out/activate
-      ${pkgs.runtimeShell} -n $out/dry-activate
+      ${pkgs.stdenv.shell} -n $out/activate
+      ${pkgs.stdenv.shell} -n $out/dry-activate
 
       cp ${config.system.build.bootStage2} $out/init
       substituteInPlace $out/init --subst-var-by systemConfig $out


### PR DESCRIPTION
When cross-compiling, we can't run the runtime shell to check syntax if it's e.g. for a different architecture.  We have two options here. We can disable syntax checking when cross compiling, but that risks letting errors through.  Or, we can do what I've done here, and change the syntax check to use stdenv's shell instead of the runtime shell. This requires the stdenv shell and runtime shell to be broadly compatible, but I think that's so ingrained in Nixpkgs anyway that it's fine.  And this way we avoid conditionals that check for cross.
