### PR TITLE
babashka: fix build on darwin

### DIFF
--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
 
     # https://github.com/babashka/babashka/blob/v0.6.0/script/compile#L41-L52
     args=("-jar" "$BABASHKA_JAR"
+          # Required to build babashka on darwin. Do not remove.
+          "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
           "-H:Name=$BABASHKA_BINARY"
           "-H:+ReportExceptionStackTraces"
           # "-H:+PrintAnalysisCallTree"


### PR DESCRIPTION
###### Motivation for this change

Fix build issue after commit https://github.com/NixOS/nixpkgs/commit/8ee160c2d452efc6acff0d4f286970f6f93e35ba on darwin.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
