### PR TITLE
python3Packages.django-debug-toolbar: init at 3.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12050,6 +12050,16 @@
       fingerprint = "9270 66BD 8125 A45B 4AC4 0326 6180 7181 F60E FCB2";
     }];
   };
+  yuu = {
+    email = "yuuyin@protonmail.com";
+    github = "yuuyins";
+    githubId = 86538850;
+    name = "Yuu Yin";
+    keys = [{
+      longkeyid = "rsa4096/0x416F303B43C20AC3";
+      fingerprint = "9F19 3AE8 AA25 647F FC31  46B5 416F 303B 43C2 0AC3";
+    }];
+  };
   yvesf = {
     email = "yvesf+nix@xapek.org";
     github = "yvesf";

--- a/pkgs/development/python-modules/django-debug-toolbar/default.nix
+++ b/pkgs/development/python-modules/django-debug-toolbar/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, fetchFromGitHub
+, pythonOlder
+, buildPythonPackage
+, python
+, django
+, jinja2
+, sqlparse
+, html5lib
+}:
+
+buildPythonPackage rec {
+  pname = "django-debug-toolbar";
+  version = "3.2.2";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "jazzband";
+    repo = pname;
+    rev = version;
+    sha256 = "1dgb3s449nasbnqd5xfikxrfhwwilwlgrw9nv4bfkapvkzpdszjk";
+  };
+
+  propagatedBuildInputs = [
+    django
+    jinja2
+    sqlparse
+  ];
+
+  DB_BACKEND = "sqlite3";
+  DB_NAME = ":memory:";
+  TEST_ARGS = "tests";
+  DJANGO_SETTINGS_MODULE = "tests.settings";
+
+  checkInputs = [
+    html5lib
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m django test ${TEST_ARGS}
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Configurable set of panels that display debug information about the current request/response";
+    homepage = "https://github.com/jazzband/django-debug-toolbar";
+    changelog = "https://django-debug-toolbar.readthedocs.io/en/latest/changes.html";
+    maintainers =  with lib.maintainers; [ yuu ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2040,6 +2040,8 @@ in {
 
   django-csp = callPackage ../development/python-modules/django-csp { };
 
+  django-debug-toolbar = callPackage ../development/python-modules/django-debug-toolbar { };
+
   django-discover-runner = callPackage ../development/python-modules/django-discover-runner { };
 
   django-dynamic-preferences = callPackage ../development/python-modules/django-dynamic-preferences { };


### PR DESCRIPTION
###### Motivation for this change
I was trying to package https://github.com/vitorfs/parsifal, but it requires `django-debug-toolbar` ( https://github.com/vitorfs/parsifal/blob/dev/requirements/local.txt) which isn't on nixpkgs yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Other
On the `checkPhase` I’m getting `django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.`

    ============================= test session starts ==============================
    platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
    rootdir: /build/source
    collected 51 items / 6 errors / 45 selected
    
    ==================================== ERRORS ====================================
    __________________ ERROR collecting tests/test_integration.py __________________
    tests/test_integration.py:21: in <module>
        from .views import regular_view
    tests/views.py:1: in <module>
        from django.contrib.auth.models import User
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/models.py:2: in <module>
        from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/base_user.py:47: in <module>
        class AbstractBaseUser(models.Model):
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/db/models/base.py:103: in __new__
        app_config = apps.get_containing_app_config(module)
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:252: in get_containing_app_config
        self.check_apps_ready()
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:135: in check_apps_ready
        raise AppRegistryNotReady("Apps aren't loaded yet.")
    E   django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
    ____________ ERROR collecting tests/commands/test_debugsqlshell.py _____________
    tests/commands/test_debugsqlshell.py:5: in <module>
        from django.contrib.auth.models import User
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/models.py:2: in <module>
        from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/base_user.py:47: in <module>
        class AbstractBaseUser(models.Model):
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/db/models/base.py:103: in __new__
        app_config = apps.get_containing_app_config(module)
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:252: in get_containing_app_config
        self.check_apps_ready()
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:135: in check_apps_ready
        raise AppRegistryNotReady("Apps aren't loaded yet.")
    E   django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
    ________________ ERROR collecting tests/panels/test_logging.py _________________
    tests/panels/test_logging.py:9: in <module>
        from ..views import regular_view
    tests/views.py:1: in <module>
        from django.contrib.auth.models import User
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/models.py:2: in <module>
        from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/base_user.py:47: in <module>
        class AbstractBaseUser(models.Model):
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/db/models/base.py:103: in __new__
        app_config = apps.get_containing_app_config(module)
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:252: in get_containing_app_config
        self.check_apps_ready()
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:135: in check_apps_ready
        raise AppRegistryNotReady("Apps aren't loaded yet.")
    E   django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
    _______________ ERROR collecting tests/panels/test_profiling.py ________________
    tests/panels/test_profiling.py:1: in <module>
        from django.contrib.auth.models import User
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/models.py:2: in <module>
        from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/base_user.py:47: in <module>
        class AbstractBaseUser(models.Model):
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/db/models/base.py:103: in __new__
        app_config = apps.get_containing_app_config(module)
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:252: in get_containing_app_config
        self.check_apps_ready()
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:135: in check_apps_ready
        raise AppRegistryNotReady("Apps aren't loaded yet.")
    E   django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
    __________________ ERROR collecting tests/panels/test_sql.py ___________________
    tests/panels/test_sql.py:7: in <module>
        from django.contrib.auth.models import User
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/models.py:2: in <module>
        from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/base_user.py:47: in <module>
        class AbstractBaseUser(models.Model):
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/db/models/base.py:103: in __new__
        app_config = apps.get_containing_app_config(module)
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:252: in get_containing_app_config
        self.check_apps_ready()
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:135: in check_apps_ready
        raise AppRegistryNotReady("Apps aren't loaded yet.")
    E   django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
    ________________ ERROR collecting tests/panels/test_template.py ________________
    tests/panels/test_template.py:1: in <module>
        from django.contrib.auth.models import User
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/models.py:2: in <module>
        from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/contrib/auth/base_user.py:47: in <module>
        class AbstractBaseUser(models.Model):
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/db/models/base.py:103: in __new__
        app_config = apps.get_containing_app_config(module)
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:252: in get_containing_app_config
        self.check_apps_ready()
    /nix/store/b6fj23q84lf3w53wpv66kkawmgdrl3g0-python3.9-Django-2.2.24/lib/python3.9/site-packages/django/apps/registry.py:135: in check_apps_ready
        raise AppRegistryNotReady("Apps aren't loaded yet.")
    E   django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
    =========================== short test summary info ============================
    ERROR tests/test_integration.py - django.core.exceptions.AppRegistryNotReady:...
    ERROR tests/commands/test_debugsqlshell.py - django.core.exceptions.AppRegist...
    ERROR tests/panels/test_logging.py - django.core.exceptions.AppRegistryNotRea...
    ERROR tests/panels/test_profiling.py - django.core.exceptions.AppRegistryNotR...
    ERROR tests/panels/test_sql.py - django.core.exceptions.AppRegistryNotReady: ...
    ERROR tests/panels/test_template.py - django.core.exceptions.AppRegistryNotRe...
    !!!!!!!!!!!!!!!!!!! Interrupted: 6 errors during collection !!!!!!!!!!!!!!!!!!!!
    ============================== 6 errors in 1.49s ===============================
    builder for '/nix/store/4r2v0p1lpm4n0zzvmfc25b259k77s13r-python3.9-django-debug-toolbar-3.2.2.drv' failed with exit code 2
    error: build of '/nix/store/4r2v0p1lpm4n0zzvmfc25b259k77s13r-python3.9-django-debug-toolbar-3.2.2.drv' failed

Nobody on NixOS matrix seem to know a fix for this as well, so I just `doCheck = false;`

