### PR TITLE
KDE-frameworks: 5.85 -> 5.86

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.85/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.86/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/karchive.nix
+++ b/pkgs/development/libraries/kde-frameworks/karchive.nix
@@ -1,13 +1,13 @@
 {
   mkDerivation,
   extra-cmake-modules,
-  bzip2, xz, qtbase, zlib,
+  bzip2, xz, qtbase, zlib, zstd
 }:
 
 mkDerivation {
   name = "karchive";
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ bzip2 xz zlib ];
+  buildInputs = [ bzip2 xz zlib zstd ];
   propagatedBuildInputs = [ qtbase ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kcontacts.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcontacts.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation, lib,
-  extra-cmake-modules,
+  extra-cmake-modules, isocodes,
   kcoreaddons, kconfig, kcodecs, ki18n, qtbase,
 }:
 
@@ -9,6 +9,9 @@ mkDerivation {
   meta = {
     license = [ lib.licenses.lgpl21 ];
   };
+  propagatedBuildInputs = [
+    isocodes
+  ];
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kcoreaddons kconfig kcodecs ki18n qtbase ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kded.nix
+++ b/pkgs/development/libraries/kde-frameworks/kded.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, propagate, wrapGAppsHook,
   extra-cmake-modules, kdoctools,
-  gsettings-desktop-schemas, kconfig, kcoreaddons, kcrash, kdbusaddons, kinit,
+  gsettings-desktop-schemas, kconfig, kcoreaddons, kcrash, kdbusaddons,
   kservice, qtbase,
 }:
 
@@ -9,7 +9,7 @@ mkDerivation {
   name = "kded";
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
   buildInputs = [
-    gsettings-desktop-schemas kconfig kcoreaddons kcrash kdbusaddons kinit
+    gsettings-desktop-schemas kconfig kcoreaddons kcrash kdbusaddons
     kservice qtbase
   ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kio/0002-Debug-module-loader.patch
+++ b/pkgs/development/libraries/kde-frameworks/kio/0002-Debug-module-loader.patch
@@ -11,15 +11,15 @@ diff --git a/src/kiod/kiod_main.cpp b/src/kiod/kiod_main.cpp
 index 1976ee1..eb402bf 100644
 --- a/src/kiod/kiod_main.cpp
 +++ b/src/kiod/kiod_main.cpp
-@@ -50,7 +50,7 @@ void KIOD::loadModule(const QString &name)
-         module = factory->create<KDEDModule>();
+@@ -49,7 +49,7 @@ void KIOD::loadModule(const QString &name)
+         module->setModuleName(name); // makes it register to DBus
+         m_modules.insert(name, module);
+     } else {
+-        qCWarning(KIOD_CATEGORY) << "Error loading plugin:" << result.errorText;
++        qCWarning(KIOD_CATEGORY) << "Error loading plugin:" << name << result.errorText;
      }
-     if (!module) {
--        qCWarning(KIOD_CATEGORY) << "Error loading plugin:" << loader.errorString();
-+        qCWarning(KIOD_CATEGORY) << "Error loading plugin" << name << loader.errorString();
-         return;
-     }
-     module->setModuleName(name); // makes it register to DBus
+ }
+ 
 -- 
 2.30.1
 

--- a/pkgs/development/libraries/kde-frameworks/kio/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kio/default.nix
@@ -1,23 +1,27 @@
 {
-  mkDerivation, fetchpatch,
-  util-linux, extra-cmake-modules, kdoctools, qttools,
+  stdenv, lib, mkDerivation, fetchpatch,
+  extra-cmake-modules, kdoctools, qttools,
+  acl, attr, libkrb5, util-linux ? null,
   karchive, kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons,
   kdbusaddons, ki18n, kiconthemes, kitemviews, kjobwidgets, knotifications,
   kservice, ktextwidgets, kwallet, kwidgetsaddons, kwindowsystem, kxmlgui,
-  qtbase, qtscript, qtx11extras, solid, kcrash
+  qtbase, qtscript, qtx11extras, solid, kcrash, kded
 }:
 
 mkDerivation {
   name = "kio";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    util-linux karchive kconfigwidgets kdbusaddons ki18n kiconthemes knotifications
+    karchive kconfigwidgets kdbusaddons ki18n kiconthemes knotifications
     ktextwidgets kwallet kwidgetsaddons kwindowsystem qtscript qtx11extras
-    kcrash
+    kcrash libkrb5
+  ] ++ lib.lists.optionals stdenv.isLinux [
+    acl attr # both are needed for ACL support
+    util-linux # provides libmount
   ];
   propagatedBuildInputs = [
     kbookmarks kcompletion kconfig kcoreaddons kitemviews kjobwidgets kservice
-    kxmlgui qtbase qttools solid
+    kxmlgui qtbase qttools solid kded
   ];
   outputs = [ "out" "dev" ];
   patches = [

--- a/pkgs/development/libraries/kde-frameworks/kio/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kio/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv, lib, mkDerivation, fetchpatch,
   extra-cmake-modules, kdoctools, qttools,
-  acl, attr, libkrb5, util-linux ? null,
+  acl, attr, libkrb5, util-linux,
   karchive, kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons,
   kdbusaddons, ki18n, kiconthemes, kitemviews, kjobwidgets, knotifications,
   kservice, ktextwidgets, kwallet, kwidgetsaddons, kwindowsystem, kxmlgui,

--- a/pkgs/development/libraries/kde-frameworks/knewstuff/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/knewstuff/default.nix
@@ -3,7 +3,7 @@
   extra-cmake-modules,
   attica, karchive, kcompletion, kconfig, kcoreaddons, ki18n, kiconthemes,
   kio, kitemviews, kpackage, kservice, ktextwidgets, kwidgetsaddons, kxmlgui, qtbase,
-  qtdeclarative, kirigami2,
+  qtdeclarative, kirigami2, syndication,
 }:
 
 mkDerivation {
@@ -12,7 +12,7 @@ mkDerivation {
   buildInputs = [
     karchive kcompletion kconfig kcoreaddons ki18n kiconthemes kio kitemviews
     kpackage
-    ktextwidgets kwidgetsaddons qtbase qtdeclarative kirigami2
+    ktextwidgets kwidgetsaddons qtbase qtdeclarative kirigami2 syndication
   ];
   propagatedBuildInputs = [ attica kservice kxmlgui ];
   patches = [

--- a/pkgs/development/libraries/kde-frameworks/kpackage/0002-QDirIterator-follow-symlinks.patch
+++ b/pkgs/development/libraries/kde-frameworks/kpackage/0002-QDirIterator-follow-symlinks.patch
@@ -12,10 +12,10 @@ diff --git a/src/kpackage/packageloader.cpp b/src/kpackage/packageloader.cpp
 index f03d882..d5aee56 100644
 --- a/src/kpackage/packageloader.cpp
 +++ b/src/kpackage/packageloader.cpp
-@@ -210,7 +210,7 @@ QList<KPluginMetaData> PackageLoader::listPackages(const QString &packageFormat,
+@@ -196,7 +196,7 @@ QList<KPluginMetaData> PackageLoader::listPackages(const QString &packageFormat,
      }
 
-     for (auto const &plugindir : qAsConst(paths)) {
+     for (auto const &plugindir : std::as_const(paths)) {
 -        const QDirIterator::IteratorFlags flags = QDirIterator::Subdirectories;
 +        const QDirIterator::IteratorFlags flags = QDirIterator::Subdirectories | QDirIterator::FollowSymlinks;
          const QStringList nameFilters = {QStringLiteral("metadata.json"), QStringLiteral("metadata.desktop")};

--- a/pkgs/development/libraries/kde-frameworks/purpose.nix
+++ b/pkgs/development/libraries/kde-frameworks/purpose.nix
@@ -1,14 +1,14 @@
 {
-  mkDerivation, extra-cmake-modules, qtbase
-, qtdeclarative, kconfig, kcoreaddons, ki18n, kio, kirigami2
-, fetchpatch
+  mkDerivation, extra-cmake-modules, intltool, qtbase
+, accounts-qt, qtdeclarative, kaccounts-integration, kconfig, kcoreaddons, ki18n, kio, kirigami2
+, fetchpatch, signond
 }:
 
 mkDerivation {
   name = "purpose";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ extra-cmake-modules intltool ];
   buildInputs = [
-    qtbase qtdeclarative kconfig kcoreaddons
-    ki18n kio kirigami2
+    qtbase accounts-qt qtdeclarative kaccounts-integration kconfig kcoreaddons
+    ki18n kio kirigami2 signond
   ];
 }

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -4,667 +4,667 @@
 
 {
   attica = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/attica-5.85.0.tar.xz";
-      sha256 = "1rwb2jz2chvxa7hdxn5ms1f93ykpk26kmnngwcixqr7gwlcv8prl";
-      name = "attica-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/attica-5.86.0.tar.xz";
+      sha256 = "0zs61q7wigsqj2wy6hnl7d100f7n0va8cf6b7nk832sq8cvzwbwr";
+      name = "attica-5.86.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/baloo-5.85.0.tar.xz";
-      sha256 = "0kcilv41assarhp54i99scpg08m11fjznw4d1lx5rdy7fyd4bd41";
-      name = "baloo-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/baloo-5.86.0.tar.xz";
+      sha256 = "0z59zzvjzm4s751dklbv15ngrcrp05fzrqxvn32pawxiksfn1kj7";
+      name = "baloo-5.86.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/bluez-qt-5.85.0.tar.xz";
-      sha256 = "18h0swvmimfxr9ygg0fs9gg0bm4a016n55hkvqx6n3y505b2lnx8";
-      name = "bluez-qt-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/bluez-qt-5.86.0.tar.xz";
+      sha256 = "1zk1432mi3di25v3j2g1psxnxr3gqwa1bs5jx0cgn54hnbwdw3nl";
+      name = "bluez-qt-5.86.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/breeze-icons-5.85.0.tar.xz";
-      sha256 = "0g97md30f76x38skqf7xpxxrcpydx4z5adrknq0bcnpqg3baw1s4";
-      name = "breeze-icons-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/breeze-icons-5.86.0.tar.xz";
+      sha256 = "1dpf99szf0m92r1mxgb0sdzsb5x00braq2f0di51zdmkkp8b7xmw";
+      name = "breeze-icons-5.86.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/extra-cmake-modules-5.85.0.tar.xz";
-      sha256 = "0d36dg727d0ilq0ag4mv3vhp065p60nnl61014jm1p0kn71hjhks";
-      name = "extra-cmake-modules-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/extra-cmake-modules-5.86.0.tar.xz";
+      sha256 = "1dbazs15gyyc921vf0lqgjpnqikrqcc39qysw8sgx7krqp6mrk5a";
+      name = "extra-cmake-modules-5.86.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/frameworkintegration-5.85.0.tar.xz";
-      sha256 = "1j3p1hy5fhy1b83mcy2n25a8rzwv8n79c2jwfxhyd2hw1yvrkmzr";
-      name = "frameworkintegration-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/frameworkintegration-5.86.0.tar.xz";
+      sha256 = "0s966pmmykq9dkjhid6wh99v9h3dl5qjdxzyn155higz7p67finl";
+      name = "frameworkintegration-5.86.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kactivities-5.85.0.tar.xz";
-      sha256 = "0c40ripx3k8rccaj699ill4kmdnh1vl9gsxvzvff0y312ya1v2gm";
-      name = "kactivities-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kactivities-5.86.0.tar.xz";
+      sha256 = "1rmp5kxq2dwxg4a7m06ylibqzv7b95slmmllxpm53z7jn1ab7l35";
+      name = "kactivities-5.86.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kactivities-stats-5.85.0.tar.xz";
-      sha256 = "08y5wqalsd3xwczb87n2n5l0rky8lydhyb66xvh2dzl5fmw7k5z1";
-      name = "kactivities-stats-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kactivities-stats-5.86.0.tar.xz";
+      sha256 = "16wlj7yvjnmv875srcvkqgi9ww80pbj7dc9b6z53rbyr5lczlirh";
+      name = "kactivities-stats-5.86.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kapidox-5.85.0.tar.xz";
-      sha256 = "1cmx16gy2s6j2vvs0nn62vczjf6pc8s7dvdz47lrnpmc7p8yzddm";
-      name = "kapidox-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kapidox-5.86.0.tar.xz";
+      sha256 = "123j3vy1rqigwd6kpjvk7gsrfra7ghv4qcplxqxrld27a95p8l0s";
+      name = "kapidox-5.86.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/karchive-5.85.0.tar.xz";
-      sha256 = "0bvbmd3phjyk11ylggmzl0kihmg7w623alplwp3j4mj8jn8nw6cc";
-      name = "karchive-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/karchive-5.86.0.tar.xz";
+      sha256 = "17bfc6sazckw6bhdz902b2lqnq0p13b60rybqclvifkif6hb1gqk";
+      name = "karchive-5.86.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kauth-5.85.0.tar.xz";
-      sha256 = "1ib1i4mpxdkddn0kd6prx0j8vc55ai6nlx71lakr2cdafp296fhs";
-      name = "kauth-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kauth-5.86.0.tar.xz";
+      sha256 = "171f1sz1jn84b9z5c56fa12bcld2a5n5vmhmla0fxcm6ry5nygd6";
+      name = "kauth-5.86.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kbookmarks-5.85.0.tar.xz";
-      sha256 = "0jraagmjch0pda15k9ywpidl474x4wq60zzffi2n3vmy8y9hs4rn";
-      name = "kbookmarks-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kbookmarks-5.86.0.tar.xz";
+      sha256 = "1a0694cjnh9ipx34v009s4dxkz41z0483kfnx2cjj8p81rsil2jh";
+      name = "kbookmarks-5.86.0.tar.xz";
     };
   };
   kcalendarcore = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kcalendarcore-5.85.0.tar.xz";
-      sha256 = "04nrfwd4g5v4lnmlcq0rdmx8xfn9wbzp92izsy7zwwxcmpwivysq";
-      name = "kcalendarcore-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kcalendarcore-5.86.0.tar.xz";
+      sha256 = "1d5j1ka158qy235rvn4q6463arg3fm4qdnwzigap2d0fcmxfsfcn";
+      name = "kcalendarcore-5.86.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kcmutils-5.85.0.tar.xz";
-      sha256 = "14yfkrqv77r6hm390ib8g7gcjcw3dlnlqs9bd3y0mg123wps7s10";
-      name = "kcmutils-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kcmutils-5.86.0.tar.xz";
+      sha256 = "0k6awhrws7v99lndy9kfh9fsrbsbb8hga6yza93m58q10kk9g1x8";
+      name = "kcmutils-5.86.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kcodecs-5.85.0.tar.xz";
-      sha256 = "1zgpi177j0j3jzi3n0kjyddy0d7b9vp7kxv6c2jsqx9ppps0l1k5";
-      name = "kcodecs-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kcodecs-5.86.0.tar.xz";
+      sha256 = "0crbnik03d98vywr31np6flzhhwv66qgrdmc7faklavkk5bwp5i0";
+      name = "kcodecs-5.86.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kcompletion-5.85.0.tar.xz";
-      sha256 = "1vy41mavbm8avr9jfspys4mpzc4i5rkg5gpl9hcbjrkldb9ymfj1";
-      name = "kcompletion-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kcompletion-5.86.0.tar.xz";
+      sha256 = "19l6paczba2l548jd5czcjd88fdr69vlc50izs353q1r89aqkiny";
+      name = "kcompletion-5.86.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kconfig-5.85.0.tar.xz";
-      sha256 = "0qmrv8ixlg7qrb7fyyvk7a0a7avvpflc05rj46zzip6kjhl4imds";
-      name = "kconfig-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kconfig-5.86.0.tar.xz";
+      sha256 = "05q4wqhxspja8a4j0gik62bp2lmyxv0cpbd188q16q97zgbb6xy1";
+      name = "kconfig-5.86.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kconfigwidgets-5.85.0.tar.xz";
-      sha256 = "0hx8f1dcd38wsrifh4j3a5m05xahdqrhsysasbdwxhr5s29d7vvr";
-      name = "kconfigwidgets-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kconfigwidgets-5.86.0.tar.xz";
+      sha256 = "0k846cf2h76815ww514i69cdmhyi56dly5xcsigkd1l7dgm0fk76";
+      name = "kconfigwidgets-5.86.0.tar.xz";
     };
   };
   kcontacts = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kcontacts-5.85.0.tar.xz";
-      sha256 = "07j2h8fd62j7jbcm5fyv27vy120687k1cmp2rw06sf3xl480nk8k";
-      name = "kcontacts-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kcontacts-5.86.0.tar.xz";
+      sha256 = "18xkzl4m7dl1z4vpwmbcqjjhn7jsa3d8v4wjdz0iqwpzsq2vrdc1";
+      name = "kcontacts-5.86.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kcoreaddons-5.85.0.tar.xz";
-      sha256 = "052l8kvv7k3m43r6arckg4fls0y913gklc8jx09y56g1m51mgbwh";
-      name = "kcoreaddons-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kcoreaddons-5.86.0.tar.xz";
+      sha256 = "1ncwf8kqrypmipp43a011rnhlw3qsb98x8nm98rm6v6gl2z3wgy6";
+      name = "kcoreaddons-5.86.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kcrash-5.85.0.tar.xz";
-      sha256 = "14hknkl4md0qzh44f1zqraljzvlbwzc95mci713a9mhk9rb0957f";
-      name = "kcrash-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kcrash-5.86.0.tar.xz";
+      sha256 = "1cyiqca4cwz7r4082mpi3gviicyr28qgk7zswm4a38qhv7vi3rdr";
+      name = "kcrash-5.86.0.tar.xz";
     };
   };
   kdav = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kdav-5.85.0.tar.xz";
-      sha256 = "11wwdv19d0fy7b1bzgqaciv4hg99a8pi6g2ymjn3g0l3ps05a0sl";
-      name = "kdav-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kdav-5.86.0.tar.xz";
+      sha256 = "1wpybm79nw17dqyql312nizvm3rf54ya1drhgvadry1c2lgmdrf3";
+      name = "kdav-5.86.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kdbusaddons-5.85.0.tar.xz";
-      sha256 = "0f8k2kynbspi86gcvpzn209m1bm6vc65flqlnh8prbkd3gg283d6";
-      name = "kdbusaddons-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kdbusaddons-5.86.0.tar.xz";
+      sha256 = "0l50ivsrlkl8npfkpj6qbi3fwwvwwsm0b5ihlp5xpr2pakvas95z";
+      name = "kdbusaddons-5.86.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kdeclarative-5.85.0.tar.xz";
-      sha256 = "1qdbvfx0i09hn9236hnb73fzym529wjsgqmfwzhh5a6dnqdh1rjd";
-      name = "kdeclarative-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kdeclarative-5.86.0.tar.xz";
+      sha256 = "1d7d6limyd9mnnnz7ib3rrywcp5j4s0mfck1invlx3p79pisrj9d";
+      name = "kdeclarative-5.86.0.tar.xz";
     };
   };
   kded = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kded-5.85.0.tar.xz";
-      sha256 = "1yar9zcrrs0c0hakg8sfisnp32284ljj1axhgmx8hkwfj591jdiw";
-      name = "kded-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kded-5.86.0.tar.xz";
+      sha256 = "0sm3310l1rh1kb061flhbh4np954r2yinhsjrhmj7c8j2r656xyw";
+      name = "kded-5.86.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/portingAids/kdelibs4support-5.85.0.tar.xz";
-      sha256 = "1c4zd60s7l1qv719nl28j7gh3lpr1cwqq5vcibb9a6di04k27mm0";
-      name = "kdelibs4support-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/portingAids/kdelibs4support-5.86.0.tar.xz";
+      sha256 = "1ss2viwnksvx24kwpg9x6fk0wfwd0cx84723nb83z5n42lfh07ch";
+      name = "kdelibs4support-5.86.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/portingAids/kdesignerplugin-5.85.0.tar.xz";
-      sha256 = "0pchfvmy7r2mkd412nbzk2pkji2dx5lispwcnk759ffm4wlnxncf";
-      name = "kdesignerplugin-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/portingAids/kdesignerplugin-5.86.0.tar.xz";
+      sha256 = "143fi6rifkcjd37ha1nb1gfh27l15qa69pldf87xwqizb8f5mhxl";
+      name = "kdesignerplugin-5.86.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kdesu-5.85.0.tar.xz";
-      sha256 = "1xqzkyd9flglr3aqabkh54yl7a5a429d24mpqphakc3djmdv5d08";
-      name = "kdesu-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kdesu-5.86.0.tar.xz";
+      sha256 = "08dmig0zlds1ckm2p2a0d0f11bkq06w1yp15a8fyipb8w7mgdxl8";
+      name = "kdesu-5.86.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/portingAids/kdewebkit-5.85.0.tar.xz";
-      sha256 = "14w254wfp35sldadff1y62yl6f1kshlfk4vlhlan626vyidypc43";
-      name = "kdewebkit-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/portingAids/kdewebkit-5.86.0.tar.xz";
+      sha256 = "0vvsvlcq9mjgwklyrm60l25aqb7vx46xjjp6nv883gpy9ppzwvv1";
+      name = "kdewebkit-5.86.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kdnssd-5.85.0.tar.xz";
-      sha256 = "0i1qv6qjsdlb08mwiqs3s6v2hwfr77i65hgc0qj9pbhzvm5v6x8m";
-      name = "kdnssd-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kdnssd-5.86.0.tar.xz";
+      sha256 = "1853jz3xm3hkij5wdxbdfbfwsfg31ynhf2pjrl5b6m29nxh4xr3j";
+      name = "kdnssd-5.86.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kdoctools-5.85.0.tar.xz";
-      sha256 = "01bxzp65ffwr14yrrbw8p15lkwhisv15drwkgcwg48f289f51if1";
-      name = "kdoctools-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kdoctools-5.86.0.tar.xz";
+      sha256 = "13miqjm9lv7jr0chrrynhks1k7f107f7z44f3mdzjx88jgiskllx";
+      name = "kdoctools-5.86.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kemoticons-5.85.0.tar.xz";
-      sha256 = "0zihi00fql8q4jp08n71agmjrpr5177yw24w0vf0lmjhgmxwkrsw";
-      name = "kemoticons-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kemoticons-5.86.0.tar.xz";
+      sha256 = "0lnglx5vaswcfsfj37arzhzinsr46f87s4z48gbs067x97pjj9xd";
+      name = "kemoticons-5.86.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kfilemetadata-5.85.0.tar.xz";
-      sha256 = "07i52zi4jmqhm2sazw2jx7g7s3mp8c7kr32z3ikifsc5wfzy8kix";
-      name = "kfilemetadata-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kfilemetadata-5.86.0.tar.xz";
+      sha256 = "1ksia9ni7427n2xa22gx8b6g7skisaj1fa1pxapcy5q0dw6djwka";
+      name = "kfilemetadata-5.86.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kglobalaccel-5.85.0.tar.xz";
-      sha256 = "0f5ly344a06aaj3rcsa45xzg9xx0s2qsgk5r0h2kphkj8n2gpp70";
-      name = "kglobalaccel-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kglobalaccel-5.86.0.tar.xz";
+      sha256 = "0wn1c6xfh0q152b6bavr3k2jkbbdb7vrsv24ci133ms32617rhcj";
+      name = "kglobalaccel-5.86.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kguiaddons-5.85.0.tar.xz";
-      sha256 = "1d1724k67chiv4sxbaifnwzwcss3kry3ms9frpxifi2nsn0x9nhc";
-      name = "kguiaddons-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kguiaddons-5.86.0.tar.xz";
+      sha256 = "0zrylidwgsrzn23dhba7p9v4qsxa0axp1yjvniwcm0ww7nxk961z";
+      name = "kguiaddons-5.86.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kholidays-5.85.0.tar.xz";
-      sha256 = "0nrxn8sjzp1lg3va7703d5hxmda33d0f91rgq2s99mxi77a82yi2";
-      name = "kholidays-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kholidays-5.86.0.tar.xz";
+      sha256 = "1nqbplazr6nk2369d3jlcd2kkhjk0rjicy26y29q2cy0g7q56gb7";
+      name = "kholidays-5.86.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/portingAids/khtml-5.85.0.tar.xz";
-      sha256 = "0ma9sk51pszxqmvzlrfdsnh2f8fm09wd0kaywsrkvbh2q2f6kg8g";
-      name = "khtml-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/portingAids/khtml-5.86.0.tar.xz";
+      sha256 = "18q6hc4a41jqrmc2npidbp4h79q34wqjx78jv8w5n3s6kizhqvhl";
+      name = "khtml-5.86.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/ki18n-5.85.0.tar.xz";
-      sha256 = "1h1jcdyc3cphkn56qfn5j6jbbb6wp5z0vp8kxzm1wd023sj83dqn";
-      name = "ki18n-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/ki18n-5.86.0.tar.xz";
+      sha256 = "1ldw8775kacs43kkl2yxx7gqqx6hf49pg2dg0fqaayaynx9ymndq";
+      name = "ki18n-5.86.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kiconthemes-5.85.0.tar.xz";
-      sha256 = "0k6ni351b051k8rfncpddf5zplqmg71wf9a5h8k6ix787h1r5dcp";
-      name = "kiconthemes-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kiconthemes-5.86.0.tar.xz";
+      sha256 = "1sa0sn56dc539x3j9rbl7v0iicsqkrwhqsp3wmsiv5h79d2xw4q6";
+      name = "kiconthemes-5.86.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kidletime-5.85.0.tar.xz";
-      sha256 = "1nclrxipjzasqi8g84lvpsr5rwfs9xfqgj377wfphm4qbml09x2z";
-      name = "kidletime-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kidletime-5.86.0.tar.xz";
+      sha256 = "10xk1ch9f3zcz2q5mc9bjzzc6crr3mvm1z6ap3vqd7b3ywv38psv";
+      name = "kidletime-5.86.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kimageformats-5.85.0.tar.xz";
-      sha256 = "1687sh19ph1v1bg4xrdrf0gs2nna0ds8gcqc8x7ydgdc2301m9jh";
-      name = "kimageformats-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kimageformats-5.86.0.tar.xz";
+      sha256 = "11d9p6h21mmwsi55173p8dcvvr2013y16af57y6ac499l9p2vfd5";
+      name = "kimageformats-5.86.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kinit-5.85.0.tar.xz";
-      sha256 = "03m6ik7l54q1w615111rqs0m7az7snh6x418s90xnzm81g0dzpwj";
-      name = "kinit-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kinit-5.86.0.tar.xz";
+      sha256 = "0s6mw8xx1777h7zgw7mwvw1cv3jhlpqrkvhmf5s4pjmp40dkj2i7";
+      name = "kinit-5.86.0.tar.xz";
     };
   };
   kio = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kio-5.85.0.tar.xz";
-      sha256 = "1xhrmpz9xbwipxqvj7l6d1n471isb3jggrvgcx5hqlz659yqmmg4";
-      name = "kio-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kio-5.86.0.tar.xz";
+      sha256 = "01kyrwrrv1y4a4hw4ryfmnncxqcbkc09lz2hxv7w020wavrzm6fn";
+      name = "kio-5.86.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kirigami2-5.85.0.tar.xz";
-      sha256 = "0axdsxzmr735ci19srmgkgpm4x7h23vk37hhakfc6n30ry0j7lik";
-      name = "kirigami2-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kirigami2-5.86.0.tar.xz";
+      sha256 = "1rkxihxj5gh6rqr2h8v21afj1lgaab0v16w5lgzb102xbjl47v6f";
+      name = "kirigami2-5.86.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kitemmodels-5.85.0.tar.xz";
-      sha256 = "0c55lw6r78x41v6fgycr68inviaxlxa6bj8zm8fdia631mhx273s";
-      name = "kitemmodels-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kitemmodels-5.86.0.tar.xz";
+      sha256 = "05pjhvspgbsnalzbpn456xj8gl9wj2mzh0h8p40lcqvc9sl53nag";
+      name = "kitemmodels-5.86.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kitemviews-5.85.0.tar.xz";
-      sha256 = "1fr8ivpvpaxykrgnjjsf8nhnhs60i4xhlkanvhrkkgjabxk0sbl0";
-      name = "kitemviews-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kitemviews-5.86.0.tar.xz";
+      sha256 = "1mzm1wvapwni59x0missyp6mbl9n95kdp4a6c9jzdswydnvn3hpn";
+      name = "kitemviews-5.86.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kjobwidgets-5.85.0.tar.xz";
-      sha256 = "05gpp2bvirbxs5yk0ysi5gh72axwv253yc2sqmzdsjylq4fjy8rl";
-      name = "kjobwidgets-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kjobwidgets-5.86.0.tar.xz";
+      sha256 = "0jm71dy2f4pand2fr0vgbbc1xlpwi1y9mlbjj8q238pax62sh63b";
+      name = "kjobwidgets-5.86.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/portingAids/kjs-5.85.0.tar.xz";
-      sha256 = "0inliv97x63174n3mn5jqyy8d440863g3m5pn69cq1i2mr5zyswb";
-      name = "kjs-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/portingAids/kjs-5.86.0.tar.xz";
+      sha256 = "0gk5za2xyavxm56gxpx1x6jlkgaxhn7mcgdqb60z85372g2kvqg2";
+      name = "kjs-5.86.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/portingAids/kjsembed-5.85.0.tar.xz";
-      sha256 = "1j8prfg7hpk0g7manilds27ivrcgxr3hidjzy0yzn13ckvv3ccj1";
-      name = "kjsembed-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/portingAids/kjsembed-5.86.0.tar.xz";
+      sha256 = "1qash24j0y35j179kbmsp1wg30c97cy1z05vidqg9b7id57c2d5p";
+      name = "kjsembed-5.86.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/portingAids/kmediaplayer-5.85.0.tar.xz";
-      sha256 = "1bmj24d3si937svh8zdi7xs0y4j1ibyj8z8q1y4k2vp8fa9fack6";
-      name = "kmediaplayer-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/portingAids/kmediaplayer-5.86.0.tar.xz";
+      sha256 = "182bg9cbn1m9flp8fqf5v37mjd1kwap16bvg13k9jagr1g9zmar4";
+      name = "kmediaplayer-5.86.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/knewstuff-5.85.0.tar.xz";
-      sha256 = "1j90ysfw1qygaiigizbjik1k7zkl6wkin0r7r9q8r3dibvbqziph";
-      name = "knewstuff-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/knewstuff-5.86.0.tar.xz";
+      sha256 = "1c3mbd1f2hwp4wj1maj7n0d5vmwn77drld3ig0g20l4hvn5biy16";
+      name = "knewstuff-5.86.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/knotifications-5.85.0.tar.xz";
-      sha256 = "0qr695sn2di24cal0x6yj4x1a8qk6jny68r4d4xdcy5i1i4yyni5";
-      name = "knotifications-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/knotifications-5.86.0.tar.xz";
+      sha256 = "0d2hbmj1wlmsc30zb4j9crn22yqhh8nm0lgnfsjjlh3dzq3qf5za";
+      name = "knotifications-5.86.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/knotifyconfig-5.85.0.tar.xz";
-      sha256 = "1aphmi7r4zmzrfk8635a66dnkd6zg2i17nrm0hfqhqhcfn217mfv";
-      name = "knotifyconfig-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/knotifyconfig-5.86.0.tar.xz";
+      sha256 = "1slbsh1i7pld7vjsvsgvjyrb5ppzi9y4vfc9zw06kwnkb6m111fs";
+      name = "knotifyconfig-5.86.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kpackage-5.85.0.tar.xz";
-      sha256 = "14rwq5ckns06h0n8h4q2r7ilfr1myxcan1md1zz4cg4vb87ckimj";
-      name = "kpackage-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kpackage-5.86.0.tar.xz";
+      sha256 = "1kx22l42zvl0dv9alwpvz3lryzl7lw8zqp0xlwxg15vkxl2a6g1b";
+      name = "kpackage-5.86.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kparts-5.85.0.tar.xz";
-      sha256 = "07px14xdh7p2kb9kvsma16xifsc65mhpm6xmnz15i5pdmrz1wxc1";
-      name = "kparts-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kparts-5.86.0.tar.xz";
+      sha256 = "0801far1wzac39cwdlh9nmspx1lvni6ky90ylcw5va69f2ll3ga0";
+      name = "kparts-5.86.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kpeople-5.85.0.tar.xz";
-      sha256 = "03ynnbjj939b3cmczlz9piilkgh45fbyal71pab0qfpxr66m9fk5";
-      name = "kpeople-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kpeople-5.86.0.tar.xz";
+      sha256 = "1ybrs1imlkb2q9nwlkc46fhj736273br0pnyhrfaad3cjrb1rqfh";
+      name = "kpeople-5.86.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kplotting-5.85.0.tar.xz";
-      sha256 = "0jhkc12fiz50iavz9msj6w29lhqrm6chl1521sx55km9cb3wmzda";
-      name = "kplotting-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kplotting-5.86.0.tar.xz";
+      sha256 = "16r0a4rnpzzmn3cyxc33gig7bn5h4p64q7a517s6ai97hm6y5r7w";
+      name = "kplotting-5.86.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kpty-5.85.0.tar.xz";
-      sha256 = "1zmzzlzv1pnx0d7w6v8yiccw1q2g94pfjzh4sm2k1fickgrfrir8";
-      name = "kpty-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kpty-5.86.0.tar.xz";
+      sha256 = "1rgc2n32k39axl2jlmwa8iqr9v4h7n3kwk9971xc1d08cfswqjkm";
+      name = "kpty-5.86.0.tar.xz";
     };
   };
   kquickcharts = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kquickcharts-5.85.0.tar.xz";
-      sha256 = "1hnbr3qkjy48pq8hkvl7lcfd8cywkkr77n8qf296rjmrv23jw4xf";
-      name = "kquickcharts-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kquickcharts-5.86.0.tar.xz";
+      sha256 = "1c0dycnk98p00dgpydnkas9x3yq3lcj5nzckiwk674n1myb78hq7";
+      name = "kquickcharts-5.86.0.tar.xz";
     };
   };
   kross = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/portingAids/kross-5.85.0.tar.xz";
-      sha256 = "07gnh98avv5zzybh4262jqkjy8kg0cplryv356kvsbarl4ksy4kr";
-      name = "kross-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/portingAids/kross-5.86.0.tar.xz";
+      sha256 = "1x7xc35ix83hks25hnwd2l8h1aw4zx8x32if8jbvwfw957i02gdf";
+      name = "kross-5.86.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/krunner-5.85.0.tar.xz";
-      sha256 = "1pz466pjrqd3dj2wdqsqxcpmim0ig8i7gvnw96mxlh262cv15h4d";
-      name = "krunner-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/krunner-5.86.0.tar.xz";
+      sha256 = "17d31szm2pnmc6cp0ijcm3k4a148fhg4m6ccw34rk4pd5pbbfqai";
+      name = "krunner-5.86.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kservice-5.85.0.tar.xz";
-      sha256 = "008b56jibgvpg6qqh7wqbg39fyca62w6nj7c9qxsgj1bd91vglg2";
-      name = "kservice-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kservice-5.86.0.tar.xz";
+      sha256 = "0fnrzfpzdprbk6rn9xdzmaj7pvg6lm72id23cl29zgp0v09a5qa6";
+      name = "kservice-5.86.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/ktexteditor-5.85.0.tar.xz";
-      sha256 = "1j6xkz8w7mb47ypgcf00m7hl1ayli8r5a3l4fk5xzsz1k0g72l6m";
-      name = "ktexteditor-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/ktexteditor-5.86.0.tar.xz";
+      sha256 = "1f7f89sv0wbjlwi1wy96viagxv2yzfn9hsh24yr45qzjvghgx0v2";
+      name = "ktexteditor-5.86.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/ktextwidgets-5.85.0.tar.xz";
-      sha256 = "128jjcay0s2qi0zs32zxwlmh2xq4kzasc0zhy3l9gfv898yaq6zy";
-      name = "ktextwidgets-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/ktextwidgets-5.86.0.tar.xz";
+      sha256 = "1hdwq4kphy7vdy6fg32z8slg8jkz4npd85dsjh6qkrvwpzbbl7yn";
+      name = "ktextwidgets-5.86.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kunitconversion-5.85.0.tar.xz";
-      sha256 = "0rcnmdqnm7h8ffxacza2v7y7zicly0yvz07g4857jxpk7h4z62hy";
-      name = "kunitconversion-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kunitconversion-5.86.0.tar.xz";
+      sha256 = "1svw7ymv2nc89zw4sz0gmsfdji7adwdz8psqy2hkh0qjcwzs157w";
+      name = "kunitconversion-5.86.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kwallet-5.85.0.tar.xz";
-      sha256 = "053ddi83a5d1i61r8y6jimd5pafmilja25w5pl09g3fqkp3id677";
-      name = "kwallet-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kwallet-5.86.0.tar.xz";
+      sha256 = "075djy98bfgxkx5s20h49flxmc20zi8h7bam6f4hgh5vcr0lbwlb";
+      name = "kwallet-5.86.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kwayland-5.85.0.tar.xz";
-      sha256 = "0sfzpqb3v79jrhc49f4v3akc9wrv1976nb7xs9nd6ips237v86v2";
-      name = "kwayland-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kwayland-5.86.0.tar.xz";
+      sha256 = "18rx4lxlria9xzfrmp83qzs5dgqks5gv218sn0lx28is3gg42fw6";
+      name = "kwayland-5.86.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kwidgetsaddons-5.85.0.tar.xz";
-      sha256 = "14042vc9jl48fclsfmsincwqj2s6mfm3lbq4yg5vlj931kznyr31";
-      name = "kwidgetsaddons-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kwidgetsaddons-5.86.0.tar.xz";
+      sha256 = "1ywmyyqbi4lws3bwmak8lmgdfxir7zapq3xvqk2nrbka4i2bggiz";
+      name = "kwidgetsaddons-5.86.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kwindowsystem-5.85.0.tar.xz";
-      sha256 = "07k6d6sgxlfwkjg0r9lgvlkd7j53b986qfv283c313ahy5c3gd3d";
-      name = "kwindowsystem-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kwindowsystem-5.86.0.tar.xz";
+      sha256 = "15b5jd128az4agxkychkxwxm1bkpjyg8f5c11jnp3yd6r4q8gf46";
+      name = "kwindowsystem-5.86.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/kxmlgui-5.85.0.tar.xz";
-      sha256 = "1ciwrm16a5cgmkkm8cv72cyr45q418gsrxc3qrjq3iic9ycf6fi5";
-      name = "kxmlgui-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/kxmlgui-5.86.0.tar.xz";
+      sha256 = "0y8kkqxsppv9h2wvgr76g23kzx0qb669cqbq13whhy0s5rmyxp0h";
+      name = "kxmlgui-5.86.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/portingAids/kxmlrpcclient-5.85.0.tar.xz";
-      sha256 = "117cvdf7iy1139sx0vk906whmkm3ffw0wivqdjdcfwxsdxi6s6d1";
-      name = "kxmlrpcclient-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/portingAids/kxmlrpcclient-5.86.0.tar.xz";
+      sha256 = "13av5ycwfl6580s0hpkxgak4dwm5i5xwvsxr44cxr8mj72syllnq";
+      name = "kxmlrpcclient-5.86.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/modemmanager-qt-5.85.0.tar.xz";
-      sha256 = "1jb27266dc6ry2y3w9bf1sf20xxw2rkb6ac8z9p46r0myhj2zn2j";
-      name = "modemmanager-qt-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/modemmanager-qt-5.86.0.tar.xz";
+      sha256 = "0pdbx3w9rfvj6z8caw7bd4pspxrd852i0f9vvi17hhw0abvc0km3";
+      name = "modemmanager-qt-5.86.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/networkmanager-qt-5.85.0.tar.xz";
-      sha256 = "1lg17ibk9mn4jsxh6dl0yzyhy26xifymvrf5saggl28vkkhvnh6r";
-      name = "networkmanager-qt-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/networkmanager-qt-5.86.0.tar.xz";
+      sha256 = "1h1zfgdnc3331zxlb1g6l9x4n9rpmjjfz5rh4pqw6xplvgrapp2v";
+      name = "networkmanager-qt-5.86.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/oxygen-icons5-5.85.0.tar.xz";
-      sha256 = "0if136n5mkvxhiyvlmwmj3q9y1g1gr9qz4qqdcsn6wy9jippq46g";
-      name = "oxygen-icons5-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/oxygen-icons5-5.86.0.tar.xz";
+      sha256 = "1lgnw6w1mc50fpyasd8yx60vi6cgqj7f3h1jmkcz89nybypd1b52";
+      name = "oxygen-icons5-5.86.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/plasma-framework-5.85.0.tar.xz";
-      sha256 = "1zzqmm7s39bcay3b4f6qzhd5pw3q6p9fas94i88afhqsxjbkm6w7";
-      name = "plasma-framework-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/plasma-framework-5.86.0.tar.xz";
+      sha256 = "17dfxqqw02430zfzncx1gdw4b4ab5mzwb3svq5xsjw0k4vh1airh";
+      name = "plasma-framework-5.86.0.tar.xz";
     };
   };
   prison = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/prison-5.85.0.tar.xz";
-      sha256 = "1c6dq4ql3n6s9xwvs6ix8n3fsv96aqdvd0qwc1n4sap9xlg3752n";
-      name = "prison-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/prison-5.86.0.tar.xz";
+      sha256 = "1p2ix3aw8d3zp1fwywza82dqf73fyqc3pghcp9gfiywbfz2gcli2";
+      name = "prison-5.86.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/purpose-5.85.0.tar.xz";
-      sha256 = "13r47g81qfqdvd0s70r9dwlcdg8c6m5xrnpvypjs6cd51907m0f5";
-      name = "purpose-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/purpose-5.86.0.tar.xz";
+      sha256 = "18xvihyn6897vwk1x2y4xcmafdc2gqmxs58sjm17gm87xzxyc8k7";
+      name = "purpose-5.86.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/qqc2-desktop-style-5.85.0.tar.xz";
-      sha256 = "1hkcy3dzaqfkxnmj9k278q0dijiwhjmzw98xxj9fh8mjygwkj1dp";
-      name = "qqc2-desktop-style-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/qqc2-desktop-style-5.86.0.tar.xz";
+      sha256 = "1yd8j0lhbvqarxrknpvwnmsbggv8g7sg9fsgpzrimf4873pcslnv";
+      name = "qqc2-desktop-style-5.86.0.tar.xz";
     };
   };
   solid = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/solid-5.85.0.tar.xz";
-      sha256 = "0gcddgrz07j9dgf4fg9hc810zr8f3az9b0qvxax9ys9x5kg1dr57";
-      name = "solid-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/solid-5.86.0.tar.xz";
+      sha256 = "0vcb47rh7bvvplfjbhrx8iz0vsrc5rgb9cinbyz0a9qhg062r1m0";
+      name = "solid-5.86.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/sonnet-5.85.0.tar.xz";
-      sha256 = "1cg2f09c0blk7ymlq7j3a1bci78kv1n0xq3ys4kxgf53khwhdqpw";
-      name = "sonnet-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/sonnet-5.86.0.tar.xz";
+      sha256 = "0rx32rdb1f45d2ihbjlhivv7088iqmdl22mj9sqi3phwn6xb3z0j";
+      name = "sonnet-5.86.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/syndication-5.85.0.tar.xz";
-      sha256 = "05hvzxzlvdzc2sxapjvqhdycdvn6bnq0hs45c88pb13ncxxljdxh";
-      name = "syndication-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/syndication-5.86.0.tar.xz";
+      sha256 = "13kbkgbqxqx1ldzi2jsg6xhhwszvmf0ahzjgvjxa3mighzyv2d7f";
+      name = "syndication-5.86.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/syntax-highlighting-5.85.0.tar.xz";
-      sha256 = "1qn9n2sv9n22j7bhq4n93i985v244kkg0vi5c33s9zppb4xgd34a";
-      name = "syntax-highlighting-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/syntax-highlighting-5.86.0.tar.xz";
+      sha256 = "0381j4vvh4g2773zbfd4f54iq6d7mclpqcsrc1bplyy5avmsa073";
+      name = "syntax-highlighting-5.86.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.85.0";
+    version = "5.86.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.85/threadweaver-5.85.0.tar.xz";
-      sha256 = "0md5bnkn5bh2jqzj7m444bmn5c7davyhwlffi0pg22r01m44l6s3";
-      name = "threadweaver-5.85.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.86/threadweaver-5.86.0.tar.xz";
+      sha256 = "1gk45q3li66m8m9h26rm0l1ywzzdsy6shndd2d5hhq19irjbxp44";
+      name = "threadweaver-5.86.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/plasma-wayland-protocols/default.nix
+++ b/pkgs/development/libraries/plasma-wayland-protocols/default.nix
@@ -5,11 +5,11 @@
 
 mkDerivation rec {
   pname = "plasma-wayland-protocols";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-DaojYvLg0V954OAG6NfxkI6I43tcUgi0DJyw1NbcqbU=";
+    sha256 = "sha256-OLBDHZMagzk3cKu4KUIGk2tjuJzu4/DGPw8Ibz0rG6k=";
   };
 
   nativeBuildInputs = [ extra-cmake-modules ];


### PR DESCRIPTION
###### Motivation for this change
Follow up of #136341 , bump KDE-frameworks to most recent version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
