### PR TITLE
nixos/opensnitch: include systemd unit

### DIFF
--- a/pkgs/tools/networking/opensnitch/daemon.nix
+++ b/pkgs/tools/networking/opensnitch/daemon.nix
@@ -5,6 +5,8 @@
 , libnetfilter_queue
 , libnfnetlink
 , lib
+, coreutils
+, iptables
 }:
 
 buildGoModule rec {
@@ -32,6 +34,12 @@ buildGoModule rec {
 
   postBuild = ''
     mv $GOPATH/bin/daemon $GOPATH/bin/opensnitchd
+    mkdir -p $out/lib/systemd/system
+    substitute opensnitchd.service $out/lib/systemd/system/opensnitchd.service \
+      --replace "/usr/local/bin/opensnitchd" "$out/bin/opensnitchd" \
+      --replace "/etc/opensnitchd/rules" "/var/lib/opensnitch/rules" \
+      --replace "/bin/mkdir" "${coreutils}/bin/mkdir"
+    sed -i '/\[Service\]/a Environment=PATH=${iptables}/bin' $out/lib/systemd/system/opensnitchd.service
   '';
 
   vendorSha256 = "sha256-LMwQBFkHg1sWIUITLOX2FZi5QUfOivvrkcl9ELO3Trk=";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR includes systemd unit file which could be reused in a later opensnitch module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
