### PR TITLE
python3Packages.fastavro: init at 1.4.4

### DIFF
--- a/pkgs/development/python-modules/fastavro/default.nix
+++ b/pkgs/development/python-modules/fastavro/default.nix
@@ -1,0 +1,59 @@
+{ buildPythonPackage
+, cython
+, fetchFromGitHub
+, isPy38
+, lib
+, lz4
+, numpy
+, pandas
+, pytestCheckHook
+, python-dateutil
+, python-snappy
+, pythonOlder
+, zstandard
+}:
+
+buildPythonPackage rec {
+  pname = "fastavro";
+  version = "1.4.4";
+
+  disabled = pythonOlder "3.6";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "1sf8nqifwp0cggk59s22ygj3rm1nysa8b91xl8bpv2knqyjy1q32";
+  };
+
+  preBuild = ''
+    export FASTAVRO_USE_CYTHON=1
+  '';
+
+  nativeBuildInputs = [ cython ];
+
+  checkInputs = [
+    lz4
+    numpy
+    pandas
+    pytestCheckHook
+    python-dateutil
+    python-snappy
+    zstandard
+  ];
+
+  # Fails with "AttributeError: module 'fastavro._read_py' has no attribute
+  # 'CYTHON_MODULE'." Doesn't appear to be serious. See https://github.com/fastavro/fastavro/issues/112#issuecomment-387638676.
+  disabledTests = [ "test_cython_python" ];
+
+  # CLI tests are broken on Python 3.8. See https://github.com/fastavro/fastavro/issues/558.
+  disabledTestPaths = lib.optionals isPy38 [ "tests/test_main_cli.py" ];
+
+  pythonImportsCheck = [ "fastavro" ];
+
+  meta = with lib; {
+    description = "Fast read/write of AVRO files";
+    homepage = "https://github.com/fastavro/fastavro";
+    license = licenses.mit;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2500,6 +2500,8 @@ in {
 
   fastapi = callPackage ../development/python-modules/fastapi { };
 
+  fastavro = callPackage ../development/python-modules/fastavro { };
+
   fastcache = callPackage ../development/python-modules/fastcache { };
 
   fastdiff = callPackage ../development/python-modules/fastdiff { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the fastavro package. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
