### PR TITLE
basex: fix Icon= store path to point to nix store.

### DIFF
--- a/pkgs/tools/text/xml/basex/default.nix
+++ b/pkgs/tools/text/xml/basex/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   desktopItem = makeDesktopItem {
     name = "basex";
     exec = "basexgui %f";
-    icon = ./basex.svg; # icon copied from Ubuntu basex package
+    icon = "${./basex.svg}"; # icon copied from Ubuntu basex package
     comment = "Visually query and analyse your XML data";
     desktopName = "BaseX XML Database";
     genericName = "XML database tool";


### PR DESCRIPTION
Noticed the problem on never disappearing diff reported by:

    $ ./maintainers/scripts/rebuild-amount.sh --print HEAD
    Estimating rebuild amount by counting changed Hydra jobs.
          1 x86_64-linux

    basex.x86_64-linux /nix/store/5ng...-basex-9.4.3

Before the change local non-store path was used:

    $ nix-build -A basex; fgrep -R Icon result/
    result/share/applications/basex.desktop:Icon=/home/.../tools/text/xml/basex/basex.svg

After the change the file got into store as expected:

    $ nix-build -A basex; fgrep -R Icon result/
    result/share/applications/basex.desktop:Icon=/nix/store/...-basex.svg

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
