### PR TITLE
coreboot-toolchain: Use nix-update

### DIFF
--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -1,0 +1,102 @@
+{ lib, stdenvNoCC, fetchurl, fetchgit,
+  gnumake, patch, zlib, git, bison,
+  flex, gnat11, curl, perl, binutils,
+  coreutils
+}:
+
+let
+  version_coreboot	= "4.14";
+
+  version_gmp		= "6.2.0";
+  version_mpfr		= "4.1.0";
+  version_mpc		= "1.2.0";
+  version_gcc		= "8.3.0";
+  version_binutils	= "2.35.1";
+  version_acpica	= "20200925";
+  version_nasm		= "2.15.05";
+
+  tar_name_gmp = "gmp-${version_gmp}.tar.xz";
+  tar_gmp = fetchurl {
+    url = "https://ftpmirror.gnu.org/gmp/${tar_name_gmp}";
+    sha256 = "09hmg8k63mbfrx1x3yy6y1yzbbq85kw5avbibhcgrg9z3ganr3i5";
+  };
+
+  tar_name_mpfr = "mpfr-${version_mpfr}.tar.xz";
+  tar_mpfr = fetchurl {
+    url = "https://ftpmirror.gnu.org/mpfr/${tar_name_mpfr}";
+    sha256 = "0zwaanakrqjf84lfr5hfsdr7hncwv9wj0mchlr7cmxigfgqs760c";
+  };
+
+  tar_name_mpc = "mpc-${version_mpc}.tar.gz";
+  tar_mpc = fetchurl {
+    url = "https://ftpmirror.gnu.org/mpc/${tar_name_mpc}";
+    sha256 = "19pxx3gwhwl588v496g3aylhcw91z1dk1d5x3a8ik71sancjs3z9";
+  };
+
+  tar_name_gcc = "gcc-${version_gcc}.tar.xz";
+  tar_gcc = fetchurl {
+    url = "https://ftpmirror.gnu.org/gcc/gcc-${version_gcc}/${tar_name_gcc}";
+    sha256 = "0b3xv411xhlnjmin2979nxcbnidgvzqdf4nbhix99x60dkzavfk4";
+  };
+
+  tar_name_binutils = "binutils-${version_binutils}.tar.xz";
+  tar_binutils = fetchurl {
+    url = "https://ftpmirror.gnu.org/binutils/${tar_name_binutils}";
+    sha256 = "01w6xvfy7sjpw8j08k111bnkl27j760bdsi0wjvq44ghkgdr3v9w";
+  };
+
+  tar_name_acpica = "acpica-unix2-${version_acpica}.tar.gz";
+  tar_acpica = fetchurl {
+    url = "https://acpica.org/sites/acpica/files/${tar_name_acpica}";
+    sha256 = "18n6129fkgj85piid7v4zxxksv3h0amqp4p977vcl9xg3bq0zd2w";
+  };
+
+  tar_name_nasm = "nasm-${version_nasm}.tar.bz2";
+  tar_nasm = fetchurl {
+    url = "https://www.nasm.us/pub/nasm/releasebuilds/${version_nasm}/${tar_name_nasm}";
+    sha256 = "1l1gxs5ncdbgz91lsl4y7w5aapask3w02q9inayb2m5bwlwq6jrw";
+  };
+
+  git_coreboot = fetchgit {
+    url = "https://review.coreboot.org/coreboot";
+    rev = "refs/tags/${version_coreboot}";
+    sha256 = "0mp9hv07ck934b28rsr8h7ldvj3zmh9jgp1lpblvdpipmi9v5hx0";
+    fetchSubmodules = false;
+    leaveDotGit = true;
+  };
+in stdenvNoCC.mkDerivation rec {
+  name = "coreboot-toolchain";
+  version = version_coreboot;
+  src = git_coreboot;
+
+  buildInputs = [ gnat11 perl curl gnumake git bison zlib flex coreutils ];
+
+  enableParallelBuilding = true;
+  dontConfigure = true;
+  dontInstall = true;
+
+  patchPhase = ''
+    mkdir util/crossgcc/tarballs
+    ln -s ${tar_gmp}		util/crossgcc/tarballs/${tar_name_gmp}
+    ln -s ${tar_mpfr}		util/crossgcc/tarballs/${tar_name_mpfr}
+    ln -s ${tar_mpc}		util/crossgcc/tarballs/${tar_name_mpc}
+    ln -s ${tar_gcc}		util/crossgcc/tarballs/${tar_name_gcc}
+    ln -s ${tar_binutils}	util/crossgcc/tarballs/${tar_name_binutils}
+    ln -s ${tar_acpica} 	util/crossgcc/tarballs/${tar_name_acpica}
+    ln -s ${tar_nasm}		util/crossgcc/tarballs/${tar_name_nasm}
+    patchShebangs util/genbuild_h/genbuild_h.sh
+    patchShebangs util/crossgcc/buildgcc
+  '';
+
+  buildPhase = ''
+    make crossgcc-i386 CPUS=$(nproc) DEST=$out
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.coreboot.org";
+    description = "coreboot toolchain";
+    license = with licenses; [ bsd2 bsd3 gpl2 lgpl2Plus gpl3Plus ];
+    maintainers = with maintainers; [ felixsinger ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/coreboot-toolchain/update-shell.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/update-shell.nix
@@ -1,0 +1,5 @@
+with (import <nixpkgs> {});
+
+mkShell {
+  buildInputs = [ nix git cacert getopt nix-update ];
+}

--- a/pkgs/development/tools/misc/coreboot-toolchain/update.sh
+++ b/pkgs/development/tools/misc/coreboot-toolchain/update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i bash update-shell.nix
+
+set -xe
+
+cd "$(dirname "$0")/../.."
+
+nix-update coreboot $@
+
+src="$(nix-build --no-out-link -A coreboot.src)"
+urls=$($src/util/crossgcc/buildgcc -u)
+
+echo '{ fetchurl }: [' > pkgs/coreboot/.files.nix.tmp
+
+for url in $urls
+do
+	name="$(basename $url)"
+	hash="$(nix-prefetch-url "$url")"
+
+	cat << EOF >> pkgs/coreboot/.files.nix.tmp
+  {
+    name = "$name";
+    archive = fetchurl {
+      sha256 = "$hash";
+      url = "$url";
+    };
+  }
+EOF
+
+done
+
+echo ']' >> pkgs/coreboot/.files.nix.tmp
+mv pkgs/coreboot/.files.nix.tmp pkgs/coreboot/files.nix

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11591,6 +11591,8 @@ with pkgs;
 
   pscid = nodePackages.pscid;
 
+  coreboot-toolchain = callPackage ../development/tools/misc/coreboot-toolchain { };
+
   remarkable-toolchain = callPackage ../development/tools/misc/remarkable/remarkable-toolchain { };
 
   remarkable2-toolchain = callPackage ../development/tools/misc/remarkable/remarkable2-toolchain { };


### PR DESCRIPTION
###### Motivation for this change
WIP

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
