### PR TITLE
navidrome: 0.44.1 -> 0.45.1 and added aarch64 support

### DIFF
--- a/pkgs/servers/misc/navidrome/default.nix
+++ b/pkgs/servers/misc/navidrome/default.nix
@@ -1,20 +1,26 @@
-{ lib, stdenv, fetchurl, ffmpeg, ffmpegSupport ? true, makeWrapper, nixosTests }:
+{ lib, stdenv, pkgs, fetchurl, ffmpeg, ffmpegSupport ? true, makeWrapper, nixosTests }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   pname = "navidrome";
-  version = "0.44.1";
+  version = "0.45.1";
 
-  src = fetchurl {
+
+  src = fetchurl (if pkgs.system == "x86_64-linux"
+  then {
     url = "https://github.com/deluan/navidrome/releases/download/v${version}/navidrome_${version}_Linux_x86_64.tar.gz";
-    sha256 = "sha256-2lnj6aNLPeLwxgyRUQFOQJDsOSMu9Banez8RMMQs74Y=";
-  };
+    sha256 = "sha256-TZcXq51sKoeLPmcRpv4VILDmS6dsS7lxlJzTDH0tEWM=";
+  }
+  else {
+    url = "https://github.com/deluan/navidrome/releases/download/v${version}/navidrome_${version}_Linux_arm64.tar.gz";
+    sha256 = "sha256-Va0DSmemj8hsaywoP6WKo/x+QQzSNwHCpU4VWs5lpbI=";
+  });
 
   nativeBuildInputs = [ makeWrapper ];
 
   unpackPhase = ''
-     tar xvf $src navidrome
+    tar xvf $src navidrome
   '';
 
   installPhase = ''
@@ -37,7 +43,7 @@ stdenv.mkDerivation rec {
     description = "Navidrome Music Server and Streamer compatible with Subsonic/Airsonic";
     homepage = "https://www.navidrome.org/";
     license = licenses.gpl3Only;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
     maintainers = with maintainers; [ aciceri ];
   };
 }


### PR DESCRIPTION
I updated the package to the 0.45.1 version and added support for aarch64.
I'm not sure this is the best way to do that.

However I tested the package in both platforms.
