### PR TITLE
arrow-cpp_4: init at 4.0.1

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/4.nix
+++ b/pkgs/development/libraries/arrow-cpp/4.nix
@@ -1,14 +1,14 @@
 { callPackage, fetchurl, fetchFromGitHub, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "5.0.0";
-  srcHash = "sha256-w7QxPspZTCD3Yag2cZchqvB2AAGviWuuw6tkQg/5kQo=";
+  version = "4.0.1";
+  srcHash = "sha256-dcy/ona5JcaxyXipIP8vMMSw0/34tRd3kVtvaaIRiW4=";
 
   arrow-testing = fetchFromGitHub {
     owner = "apache";
     repo = "arrow-testing";
-    rev = "6d98243093c0b36442da94de7010f3eacc2a9909";
-    hash = "sha256-n57Fuz2k6sX1o3vYBmC41eRKGnyt9+YL5r3WTHHRRzw=";
+    rev = "d6c4deb22c4b4e9e3247a2f291046e3c671ad235";
+    hash = "sha256-MfiJYRYdoa1rqNGV0ab5/JhUPYooyQPuF8NUJSO2kDM=";
   };
 
   parquet-testing = fetchFromGitHub {
@@ -19,20 +19,14 @@ callPackage ./generic.nix (args // {
   };
 
   arrow-jemalloc = fetchurl {
-    # From
-    # ./cpp/cmake_modules/ThirdpartyToolchain.cmake
-    # ./cpp/thirdparty/versions.txt
     url =
       "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2";
     hash = "sha256-NDMOXOJ2CZ4uiVDZM121qHVomkxqVnUe87HYxTf4h/Y=";
   };
 
   arrow-mimalloc = fetchurl {
-    # From
-    # ./cpp/cmake_modules/ThirdpartyToolchain.cmake
-    # ./cpp/thirdparty/versions.txt
     url =
-      "https://github.com/microsoft/mimalloc/archive/v1.7.2.tar.gz";
-    hash = "sha256-sZEuNUVlpLaYQQ91g8D4OTSm27Ot5Uq33csVaTIJNr0=";
+      "https://github.com/microsoft/mimalloc/archive/v1.6.4.tar.gz";
+    hash = "sha256-+mFrGudrVY7DjEEcWa+lK1lj1+escFUZVeBgchLYCq0=";
   };
 })

--- a/pkgs/development/libraries/arrow-cpp/4.nix
+++ b/pkgs/development/libraries/arrow-cpp/4.nix
@@ -19,14 +19,12 @@ callPackage ./generic.nix (args // {
   };
 
   arrow-jemalloc = fetchurl {
-    url =
-      "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2";
+    url = "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2";
     hash = "sha256-NDMOXOJ2CZ4uiVDZM121qHVomkxqVnUe87HYxTf4h/Y=";
   };
 
   arrow-mimalloc = fetchurl {
-    url =
-      "https://github.com/microsoft/mimalloc/archive/v1.6.4.tar.gz";
+    url = "https://github.com/microsoft/mimalloc/archive/v1.6.4.tar.gz";
     hash = "sha256-+mFrGudrVY7DjEEcWa+lK1lj1+escFUZVeBgchLYCq0=";
   };
 })

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -31,8 +31,7 @@ callPackage ./generic.nix (args // {
     # From
     # ./cpp/cmake_modules/ThirdpartyToolchain.cmake
     # ./cpp/thirdparty/versions.txt
-    url =
-      "https://github.com/microsoft/mimalloc/archive/v1.7.2.tar.gz";
+    url = "https://github.com/microsoft/mimalloc/archive/v1.7.2.tar.gz";
     hash = "sha256-sZEuNUVlpLaYQQ91g8D4OTSm27Ot5Uq33csVaTIJNr0=";
   };
 })

--- a/pkgs/development/libraries/arrow-cpp/generic.nix
+++ b/pkgs/development/libraries/arrow-cpp/generic.nix
@@ -1,0 +1,157 @@
+{ autoconf
+, boost
+, brotli
+, cmake
+, enableShared ? !stdenv.hostPlatform.isStatic
+, fetchFromGitHub
+, fetchurl
+, fixDarwinDylibNames
+, flatbuffers
+, gflags
+, glog
+, gtest
+, lib
+, lz4
+, perl
+, python3
+, rapidjson
+, re2
+, snappy
+, stdenv
+, thrift
+, utf8proc
+, which
+, xsimd
+, zlib
+, zstd
+, arrow-testing
+, parquet-testing
+, arrow-jemalloc
+, arrow-mimalloc
+, version
+, srcHash
+, ...
+}:
+
+stdenv.mkDerivation rec {
+  inherit version;
+  pname = "arrow-cpp";
+
+  src = fetchurl {
+    url =
+      "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
+    hash = srcHash;
+  };
+  sourceRoot = "apache-arrow-${version}/cpp";
+
+  ARROW_JEMALLOC_URL = arrow-jemalloc;
+  ARROW_MIMALLOC_URL = arrow-mimalloc;
+
+  patches = [
+    # patch to fix python-test
+    ./darwin.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    autoconf # for vendored jemalloc
+    flatbuffers
+  ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  buildInputs = [
+    boost
+    brotli
+    flatbuffers
+    gflags
+    glog
+    gtest
+    lz4
+    rapidjson
+    re2
+    snappy
+    thrift
+    utf8proc
+    zlib
+    zstd
+  ] ++ lib.optionals enableShared [
+    python3.pkgs.python
+    python3.pkgs.numpy
+  ];
+
+  preConfigure = ''
+    patchShebangs build-support/
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
+    "-DARROW_BUILD_SHARED=${if enableShared then "ON" else "OFF"}"
+    "-DARROW_BUILD_STATIC=${if enableShared then "OFF" else "ON"}"
+    "-DARROW_BUILD_TESTS=ON"
+    "-DARROW_VERBOSE_THIRDPARTY_BUILD=ON"
+    "-DARROW_DEPENDENCY_SOURCE=SYSTEM"
+    "-DARROW_DEPENDENCY_USE_SHARED=${if enableShared then "ON" else "OFF"}"
+    "-DARROW_COMPUTE=ON"
+    "-DARROW_CSV=ON"
+    "-DARROW_DATASET=ON"
+    "-DARROW_JSON=ON"
+    "-DARROW_PLASMA=ON"
+    # Disable Python for static mode because openblas is currently broken there.
+    "-DARROW_PYTHON=${if enableShared then "ON" else "OFF"}"
+    "-DARROW_USE_GLOG=ON"
+    "-DARROW_WITH_BROTLI=ON"
+    "-DARROW_WITH_LZ4=ON"
+    "-DARROW_WITH_SNAPPY=ON"
+    "-DARROW_WITH_UTF8PROC=ON"
+    "-DARROW_WITH_ZLIB=ON"
+    "-DARROW_WITH_ZSTD=ON"
+    "-DARROW_MIMALLOC=ON"
+    # Parquet options:
+    "-DARROW_PARQUET=ON"
+    "-DPARQUET_BUILD_EXECUTABLES=ON"
+  ] ++ lib.optionals (!enableShared) [
+    "-DARROW_TEST_LINKAGE=static"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # needed for tests
+    "-DCMAKE_INSTALL_RPATH=@loader_path/../lib" # needed for tools executables
+  ] ++ lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF";
+
+  ARROW_XSIMD_URL = xsimd.src;
+
+  doInstallCheck = true;
+  ARROW_TEST_DATA =
+    if doInstallCheck then "${arrow-testing}/data" else null;
+  PARQUET_TEST_DATA =
+    if doInstallCheck then "${parquet-testing}/data" else null;
+  GTEST_FILTER =
+    if doInstallCheck then
+      let
+        # Upstream Issue: https://issues.apache.org/jira/browse/ARROW-11398
+        filteredTests = lib.optionals stdenv.hostPlatform.isAarch64 [
+          "TestFilterKernelWithNumeric/3.CompareArrayAndFilterRandomNumeric"
+          "TestFilterKernelWithNumeric/7.CompareArrayAndFilterRandomNumeric"
+          "TestCompareKernel.PrimitiveRandomTests"
+        ];
+      in
+      "-${builtins.concatStringsSep ":" filteredTests}" else null;
+  installCheckInputs = [ perl which ];
+  installCheckPhase =
+    let
+      excludedTests = lib.optionals stdenv.isDarwin [
+        # Some plasma tests need to be patched to use a shorter AF_UNIX socket
+        # path on Darwin. See https://github.com/NixOS/nix/pull/1085
+        "plasma-external-store-tests"
+        "plasma-client-tests"
+      ];
+    in
+    ''
+      ctest -L unittest -V \
+        --exclude-regex '^(${builtins.concatStringsSep "|" excludedTests})$'
+    '';
+
+  meta = with lib; {
+    description = "A cross-language development platform for in-memory data";
+    homepage = "https://arrow.apache.org/";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ tobim veprbl ];
+  };
+}

--- a/pkgs/development/libraries/arrow-cpp/generic.nix
+++ b/pkgs/development/libraries/arrow-cpp/generic.nix
@@ -34,12 +34,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  inherit version;
   pname = "arrow-cpp";
+  inherit version;
 
   src = fetchurl {
-    url =
-      "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
+    url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
     hash = srcHash;
   };
   sourceRoot = "apache-arrow-${version}/cpp";
@@ -57,6 +56,7 @@ stdenv.mkDerivation rec {
     autoconf # for vendored jemalloc
     flatbuffers
   ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
   buildInputs = [
     boost
     brotli

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14992,10 +14992,15 @@ with pkgs;
 
   arrayfire = callPackage ../development/libraries/arrayfire {};
 
-  arrow-cpp = callPackage ../development/libraries/arrow-cpp ({
+  arrow-cpp_4 = callPackage ../development/libraries/arrow-cpp/4.nix ({
   } // lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
     stdenv = overrideCC stdenv buildPackages.gcc6; # hidden symbol `__divmoddi4'
   });
+  arrow-cpp_5 = callPackage ../development/libraries/arrow-cpp/default.nix ({
+  } // lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+    stdenv = overrideCC stdenv buildPackages.gcc6; # hidden symbol `__divmoddi4'
+  });
+  arrow-cpp = arrow-cpp_5;
 
   assimp = callPackage ../development/libraries/assimp { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The arrow-cpp package has since been upgraded to 5.0.0, but 4.0.1 is still necessary for some software. In particular, tensorflow-datasets -> apache-beam -> pyarrow<5.0.0 -> arrow-cpp. I'm working towards packaging tensorflow-datasets which will require this transitive dependency.

I've left the `arrow-cpp` attribute unchaged: it still points to `arrow-cpp_5` so this PR won't cause any breakages.

Random question: in all-packages.nix there is a hack to get it building on i686. Is anyone using arrow-cpp on i686 these days? Could we just drop support for that?

See https://github.com/NixOS/nixpkgs/commit/51b1d4b421740ceddf556b9e425b955d1ca3c53a for more information about the previous upgrade from 4.0.1 -> 5.0.0.

A brief overview of changes, since the git diff isn't especially helpful in this case:
* `default.nix` has been renamed to `generic.nix`
* `4.nix` contains version 4.0.1 and calls `generic.nix`
* `default.nix` contains version 5.0.0 and calls `generic.nix`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
