### PR TITLE
dust: fix

### DIFF
--- a/pkgs/development/interpreters/pixie/dust.nix
+++ b/pkgs/development/interpreters/pixie/dust.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, pixie, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub
+, pixie, rlwrap
+}:
 
 stdenv.mkDerivation rec {
   pname = "dust";
@@ -16,8 +18,9 @@ stdenv.mkDerivation rec {
   patches = [ ./make-paths-configurable.patch ];
 
   configurePhase = ''
-    pixiePath="${pixie}/bin/pixie-vm" \
+    pixiePath="${pixie}/bin/pixie" \
     basePath="$out/share/dust" \
+    rlwrapPath="${rlwrap}/bin/rlwrap" \
       substituteAll dust.in dust
     chmod +x dust
   '';

--- a/pkgs/development/interpreters/pixie/make-paths-configurable.patch
+++ b/pkgs/development/interpreters/pixie/make-paths-configurable.patch
@@ -73,11 +73,12 @@ new file mode 100755
 index 0000000..44a7fbd
 --- /dev/null
 +++ b/dust.in
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,40 @@
 +#!/usr/bin/env bash
 +
 +base_path=@basePath@
 +pixie_path=@pixiePath@
++rlwrap_cmd=@rlwrapPath@
 +
 +function set_load_path() {
 +    load_path=""
@@ -98,11 +99,7 @@ index 0000000..44a7fbd
 +
 +case $1 in
 +    ""|"repl")
-+        rlwrap_cmd=""
-+        if [ -n "`which rlwrap`" ]; then
-+            rlwrap_cmd="rlwrap -aignored -n"
-+        fi
-+        $rlwrap_cmd $pixie_path $load_path
++        $rlwrap_cmd -aignored -n $pixie_path $load_path
 +        ;;
 +    "run")
 +        shift


### PR DESCRIPTION
- Use `pixie` (the wrapper) rather than `pixie-vm` (the wrappee)
- Add `rlwrap` command rather than using `which`

Fixes #72129

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
