### PR TITLE
python3Packages.hdfs: init at 2.5.8

### DIFF
--- a/pkgs/development/python-modules/hdfs/default.nix
+++ b/pkgs/development/python-modules/hdfs/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, docopt
+, fastavro
+, fetchFromGitHub
+, lib
+, nose
+, pytestCheckHook
+, requests
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "hdfs";
+  # See https://github.com/mtth/hdfs/issues/176.
+  version = "2.5.8";
+
+  src = fetchFromGitHub {
+    owner = "mtth";
+    repo = pname;
+    rev = version;
+    hash = "sha256-94Q3IUoX1Cb+uRqvsfpVZJ1koJSx5cQ3/XpYJ0gkQNU=";
+  };
+
+  propagatedBuildInputs = [ docopt requests six ];
+
+  checkInputs = [ fastavro nose pytestCheckHook ];
+
+  pythonImportsCheck = [ "hdfs" ];
+
+  meta = with lib; {
+    description = "Python API and command line interface for HDFS";
+    homepage = "https://github.com/mtth/hdfs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3336,6 +3336,8 @@ in {
 
   hdbscan = callPackage ../development/python-modules/hdbscan { };
 
+  hdfs = callPackage ../development/python-modules/hdfs { };
+
   hdlparse = callPackage ../development/python-modules/hdlparse { };
 
   hdmedians = callPackage ../development/python-modules/hdmedians { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the hdfs python package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
