### PR TITLE
tts: 0.2.2 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/coqpit/default.nix
+++ b/pkgs/development/python-modules/coqpit/default.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "coqpit";
-  version = "0.0.13";
+  version = "0.0.14";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "coqui-ai";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-YzCO/i0SMyXRAgiZ8Y97bHHuGFeSF8GqUjvNoHLwXZQ=";
+    sha256 = "041sx7ph8vfx8ivvm6hjj6s83p9lni2agwyrrncqwhcbjy9pbdf1";
   };
 
   checkInputs = [

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -16,13 +16,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "tts";
-  version = "0.2.2";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "coqui-ai";
     repo = "TTS";
     rev = "v${version}";
-    sha256 = "sha256-hhL6/hBs2umR8/VEumr2LzuCAOkroK8vBfDuNVY0ygw=";
+    sha256 = "sha256-LiH056h7eIaikBr6sm5A4T/lF7nVroxaZSYzrES7+zk=";
   };
 
   postPatch = ''
@@ -69,7 +69,7 @@ python3.pkgs.buildPythonApplication rec {
     cp -r TTS/server/templates/ $out/${python3.sitePackages}/TTS/server
     # cython modules are not installed for some reasons
     (
-      cd TTS/tts/layers/glow_tts/monotonic_align
+      cd TTS/tts/utils/monotonic_align
       ${python3.interpreter} setup.py install --prefix=$out
     )
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/coqui-ai/TTS/releases/tag/v0.3.0

Closes #137609 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
