### PR TITLE
opentsdb: fix CVE-2020-35476

### DIFF
--- a/pkgs/tools/misc/opentsdb/default.nix
+++ b/pkgs/tools/misc/opentsdb/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, autoconf, automake, curl, fetchurl, jdk8, makeWrapper, nettools
+{ lib, stdenv, autoconf, automake, curl, fetchurl, fetchpatch, jdk8, makeWrapper, nettools
 , python, git
 }:
 
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
     url = "https://github.com/OpenTSDB/opentsdb/releases/download/v${version}/${pname}-${version}.tar.gz";
     sha256 = "0b0hilqmgz6n1q7irp17h48v8fjpxhjapgw1py8kyav1d51s7mm2";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-35476.patch";
+      url = "https://github.com/OpenTSDB/opentsdb/commit/b89fded4ee326dc064b9d7e471e9f29f7d1dede9.patch";
+      sha256 = "1vb9m0a4fsjqcjagiypvkngzgsw4dil8jrlhn5xbz7rwx8x96wvb";
+    })
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ autoconf automake curl jdk nettools python git ];
@@ -33,8 +41,5 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
     maintainers = [ ];
-    knownVulnerabilities = [
-      "CVE-2020-35476" # https://github.com/OpenTSDB/opentsdb/issues/2051
-    ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This contribution pulls in the patch fixing CVE-2020-35476.
The fix is also included in the 2.4.1 version but the upgrade requires
more work: a tarball with all the third party tools is no more provided.
The build process attempts to get them during the build which fail.

https://github.com/advisories/GHSA-hv53-q76c-7f8c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>opentsdb</li>
  </ul>
</details>
