### PR TITLE
fluxcd: 0.17.0 -> 0.17.1

### DIFF
--- a/pkgs/applications/networking/cluster/fluxcd/default.nix
+++ b/pkgs/applications/networking/cluster/fluxcd/default.nix
@@ -1,11 +1,11 @@
 { lib, buildGoModule, fetchFromGitHub, fetchzip, installShellFiles }:
 
 let
-  version = "0.17.0";
+  version = "0.17.1";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";
-    sha256 = "15ffb8damn935sfnqpshiyaazpldjcq411xrcfngpp7ncl9vbgwm";
+    sha256 = "1v6md4xh4sq1vmb5a8qvb66l101fq75lmv2s4j2z3walssb5mmgj";
     stripRoot = false;
   };
 in
@@ -19,10 +19,10 @@ buildGoModule rec {
     owner = "fluxcd";
     repo = "flux2";
     rev = "v${version}";
-    sha256 = "1pw558d64c6ynqnnadhg8vbi4ql6f5y81l9hpxi0ki5myj2kx6an";
+    sha256 = "1jglv30q6vicdzb2f8amdw9s6wdx8y5jmyr8pzl1psqn8zh0dagb";
   };
 
-  vendorSha256 = "sha256-FUASe7EQ8YVv3R6fPPLtsvMibe00Ox596GoTyKt0S+E=";
+  vendorSha256 = "sha256-uyajP7nLrRXLJcI/sBUEf4PPqz55I/ikCxVe4eAYqGA=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
fluxcd: 0.17.0 -> 0.17.1

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)