### PR TITLE
git: disable flaky test & patch shebangs in test scripts

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -65,6 +65,9 @@ stdenv.mkDerivation {
     # Fix references to gettext introduced by ./git-sh-i18n.patch
     substituteInPlace git-sh-i18n.sh \
         --subst-var-by gettext ${gettext}
+
+    # ensure we are using the correct shell when executing the test scripts
+    patchShebangs t/*.sh
   '';
 
   nativeBuildInputs = [ gettext perlPackages.perl makeWrapper ]

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -321,6 +321,7 @@ stdenv.mkDerivation {
 
     # Flaky tests:
     disable_test t5319-multi-pack-index
+    disable_test t6421-merge-partial-clone
 
     ${lib.optionalString (!perlSupport) ''
       # request-pull is a Bash script that invokes Perl, so it is not available


### PR DESCRIPTION
###### Motivation for this change

This PR disables a flaky test that we encountered recently (https://github.com/NixOS/nixpkgs/commit/64556974b6674338a227d559975c9b4710f6e751#commitcomment-56385360). The test seems to fail unrelated of the actual test inputs and failures purely depend on some property of the derivation that isn't exactly known.

While investigating the flaky test I added patching the shebangs in the test scripts to ensure that we aren't running against the host sandbox provided implementation of /bin/sh. We should always prefer our actual stdenv shell.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
