### PR TITLE
python39Packages.python-swiftclient: adopt into openstack team, fix missing keystone client, remove duplicated propagations, enable tests

### DIFF
--- a/pkgs/development/python-modules/python-swiftclient/default.nix
+++ b/pkgs/development/python-modules/python-swiftclient/default.nix
@@ -1,4 +1,12 @@
-{ lib, buildPythonApplication, fetchPypi, requests, six, pbr, setuptools }:
+{ lib
+, buildPythonApplication
+, fetchPypi
+, mock
+, openstacksdk
+, pbr
+, python-keystoneclient
+, stestr
+}:
 
 buildPythonApplication rec {
   pname = "python-swiftclient";
@@ -9,26 +17,22 @@ buildPythonApplication rec {
     sha256 = "sha256-MTtEShTQ+bYoy/PoxS8sQnFlj56KM9QiKFHC5PD3t6A=";
   };
 
-  nativeBuildInputs = [ pbr ];
+  propagatedBuildInputs = [ pbr python-keystoneclient ];
 
-  propagatedBuildInputs = [ requests six setuptools ];
+  checkInputs = [
+    mock
+    openstacksdk
+    stestr
+  ];
 
-  # For the tests the following requirements are needed:
-  # https://github.com/openstack/python-swiftclient/blob/master/test-requirements.txt
-  #
-  # The ones missing in nixpkgs (currently) are:
-  # - hacking
-  # - keystoneauth
-  # - oslosphinx
-  # - stestr
-  # - reno
-  # - openstackdocstheme
-  doCheck = false;
+  checkPhase = ''
+    stestr run
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/openstack/python-swiftclient";
     description = "Python bindings to the OpenStack Object Storage API";
     license = licenses.asl20;
-    maintainers = with maintainers; [ c0deaddict SuperSandro2000 ];
+    maintainers = teams.openstack.members;
   };
 }


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
