### PR TITLE
mimic: 1.2.0.2 -> 1.3.0.1

### DIFF
--- a/pkgs/applications/audio/mimic/default.nix
+++ b/pkgs/applications/audio/mimic/default.nix
@@ -1,28 +1,36 @@
-{ config, lib, stdenv, autoreconfHook, fetchFromGitHub, pkg-config
-, alsa-lib, libtool, icu
+{ config, lib, stdenv, autoreconfHook, fetchFromGitHub, pkg-config, makeWrapper
+, alsa-lib, alsa-plugins, libtool, icu, pcre2
 , pulseaudioSupport ? config.pulseaudio or false, libpulseaudio }:
 
 stdenv.mkDerivation rec {
   pname = "mimic";
-  version = "1.2.0.2";
+  version = "1.3.0.1";
 
   src = fetchFromGitHub {
     rev = version;
-    repo = "mimic";
+    repo = "mimic1";
     owner = "MycroftAI";
-    sha256 = "1wkpbwk88lsahzkc7pzbznmyy0lc02vsp0vkj8f1ags1gh0lc52j";
+    sha256 = "1agwgby9ql8r3x5rd1rgx3xp9y4cdg4pi3kqlz3vanv9na8nf3id";
   };
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    makeWrapper
   ];
 
   buildInputs = [
     alsa-lib
+    alsa-plugins
     libtool
     icu
+    pcre2
   ] ++ lib.optional pulseaudioSupport libpulseaudio;
+
+  postInstall = ''
+    wrapProgram $out/bin/mimic \
+      --run "export ALSA_PLUGIN_DIR=${alsa-plugins}/lib/alsa-lib"
+  '';
 
   meta = {
     description = "Mycroft's TTS engine, based on CMU's Flite (Festival Lite)";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* version bump
* adopt upstream renaming of repository
* add wrapper for alsaPlugins
* Closes https://github.com/NixOS/nixpkgs/issues/137373

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 137816"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
