### PR TITLE
viddy: init at 0.2.1

### DIFF
--- a/pkgs/tools/misc/viddy/default.nix
+++ b/pkgs/tools/misc/viddy/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "viddy";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "sachaos";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "18ms4kfv332863vd8b7mmrz39y4b8gvhi6lx9x5385jfzd19w5wx";
+  };
+
+  vendorSha256 = "0789wq4d9cynyadvlwahs4586gc3p78gdpv5wf733lpv1h5rjbv3";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "main.version=${version}"
+  ];
+
+  meta = with lib; {
+    description = "A modern watch command";
+    homepage = "https://github.com/sachaos/viddy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ j-hui ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32569,6 +32569,8 @@ with pkgs;
 
   vice = callPackage ../misc/emulators/vice { };
 
+  viddy = callPackage ../tools/misc/viddy { };
+
   ViennaRNA = callPackage ../applications/science/molecular-dynamics/viennarna { };
 
   viewnior = callPackage ../applications/graphics/viewnior { };


### PR DESCRIPTION
###### Motivation for this change

Add [viddy](https://github.com/sachaos/viddy) package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
