### PR TITLE
nix-index: wrap in a separate derivation

### DIFF
--- a/pkgs/tools/package-management/nix-index/default.nix
+++ b/pkgs/tools/package-management/nix-index/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, makeWrapper, openssl, curl
-, nix, Security
+{ lib, stdenv, rustPlatform, fetchFromGitHub, pkg-config, openssl, curl
+, Security
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "161lz96a52s53rhhkxxhcg41bsmh8w6rv6nl8gwqmg3biszy7hah";
 
-  nativeBuildInputs = [ pkg-config makeWrapper ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl curl ]
     ++ lib.optional stdenv.isDarwin Security;
 
@@ -26,14 +26,12 @@ rustPlatform.buildRustPackage rec {
     cp ./command-not-found.sh $out/etc/profile.d/command-not-found.sh
     substituteInPlace $out/etc/profile.d/command-not-found.sh \
       --replace "@out@" "$out"
-    wrapProgram $out/bin/nix-index \
-      --prefix PATH : "${lib.makeBinPath [ nix ]}"
   '';
 
   meta = with lib; {
     description = "A files database for nixpkgs";
     homepage = "https://github.com/bennofs/nix-index";
     license = with licenses; [ bsd3 ];
-    maintainers = [ maintainers.bennofs ];
+    maintainers = with maintainers; [ bennofs ncfavier ];
   };
 }

--- a/pkgs/tools/package-management/nix-index/wrapper.nix
+++ b/pkgs/tools/package-management/nix-index/wrapper.nix
@@ -1,0 +1,19 @@
+{ lib, symlinkJoin, nix-index-unwrapped, makeWrapper, nix }:
+
+if nix == null then nix-index-unwrapped else
+symlinkJoin {
+  inherit (nix-index-unwrapped) name;
+
+  paths = [ nix-index-unwrapped ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/nix-index \
+      --prefix PATH : ${lib.makeBinPath [ nix ]}
+  '';
+
+  meta = nix-index-unwrapped.meta // {
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32052,9 +32052,10 @@ with pkgs;
   nix-info = callPackage ../tools/nix/info { };
   nix-info-tested = nix-info.override { doCheck = true; };
 
-  nix-index = callPackage ../tools/package-management/nix-index {
+  nix-index-unwrapped = callPackage ../tools/package-management/nix-index {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  nix-index = callPackage ../tools/package-management/nix-index/wrapper.nix { };
 
   nix-linter = haskell.lib.justStaticExecutables (haskellPackages.nix-linter);
 


### PR DESCRIPTION
Avoids rebuilding `nix-index` when the only change is the path to `nix` in the wrapper. Also allows setting `nix` to `null` to bypass wrapping.

Also added myself as a maintainer.

cc @Infinisil #51165

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
