### PR TITLE
chromium: 93.0.4577.63 -> 93.0.4577.82

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -1,8 +1,8 @@
 {
   "stable": {
-    "version": "93.0.4577.63",
-    "sha256": "0ls8r77la6p7474j84wchvs4rvnxwfv7c8xvbxjm8h7jqak4zwza",
-    "sha256bin64": "1kv742arnv710mhakm2v59dwfypg7j01k7rd5if8h0s49yzdw3qc",
+    "version": "93.0.4577.82",
+    "sha256": "0lr8zdq06smncdzd6knzww9hxl8ynvxadmrkyyl13fpwb1422rjx",
+    "sha256bin64": "0ydvcakpnl20gx7493hv6aqnyf8f28rkvzgwnm4gws92b92n9ify",
     "deps": {
       "gn": {
         "version": "2021-07-08",
@@ -12,9 +12,9 @@
       }
     },
     "chromedriver": {
-      "version": "93.0.4577.15",
-      "sha256_linux": "11wcimkcgaiz740k9xibi5hq1kd4zgy1vk6bd6cp31wjw4y21x5f",
-      "sha256_darwin": "0cxf3cg5pg9rigq7wmbap6wvmgpdr6v44bndisyaqhlw7s2hhndn"
+      "version": "93.0.4577.63",
+      "sha256_linux": "0w2lyjj0y9g1wnvk1sg2wi9dvhbjhdz1jb20rlrp5ny2gak6a47b",
+      "sha256_darwin": "11420nflyfvf95hxj488336jq6xqjn4lcrwpr67rj2fx6ganji7z"
     }
   },
   "beta": {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2021/09/stable-channel-update-for-desktop.html

This update includes 11 security fixes. Google is aware that exploits
for CVE-2021-30632 and CVE-2021-30633 exist in the wild.

CVEs:
CVE-2021-30625 CVE-2021-30626 CVE-2021-30627 CVE-2021-30628
CVE-2021-30629 CVE-2021-30630 CVE-2021-30631 CVE-2021-30632
CVE-2021-30633

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
