### PR TITLE
python37Packages.pyroma: backport upstream python-3.7 test fix

### DIFF
--- a/pkgs/development/python-modules/pyroma/default.nix
+++ b/pkgs/development/python-modules/pyroma/default.nix
@@ -1,8 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , docutils
 , python
+, pythonOlder
 , pygments
 , setuptools
 , requests
@@ -18,6 +20,17 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "0ln9w984n48nyxwzd1y48l6b18lnv52radcyizaw56lapcgxrzdr";
   };
+
+  patches = lib.optionals (pythonOlder "3.8") [
+    # upstream fix for python-3.7 test failures:
+    #  https://github.com/NixOS/nixpkgs/issues/136901
+    (fetchpatch {
+      name = "fix-py37-tests.patch";
+      url = "https://github.com/regebro/pyroma/commit/d30bc41da7d17a0737eb8ad2267457eff4cac82c.patch";
+      sha256 = "003vvp360cc05kas6bm6pdd6wgw4x3399sprr6pl7f654s730psq";
+      excludes = [ "HISTORY.txt" ];
+    })
+  ];
 
   propagatedBuildInputs = [
     docutils


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/issues/136901

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
