### PR TITLE
plasma-desktop: add missing dependency xf86inputlibinput for mouse settings

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-desktop/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-desktop/default.nix
@@ -42,9 +42,6 @@ mkDerivation {
       sha256 = "sha256-2jqqFjBljbhf7I+fTsIvuFs3Ic662KTKRnbcSm5Jing=";
     })
   ];
-  postPatch = ''
-    sed '1i#include <cmath>' -i kcms/touchpad/backends/x11/synapticstouchpad.cpp
-  '';
   CXXFLAGS = [
     ''-DNIXPKGS_HWCLOCK=\"${lib.getBin util-linux}/sbin/hwclock\"''
   ];

--- a/pkgs/desktops/plasma-5/plasma-desktop/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-desktop/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib,
+  mkDerivation, lib, fetchpatch,
   extra-cmake-modules, kdoctools,
 
   boost, fontconfig, ibus, libXcursor, libXft, libcanberra_kde, libpulseaudio,
@@ -21,7 +21,8 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     boost fontconfig ibus libcanberra_kde libpulseaudio libXcursor libXft xorgserver
-    libxkbfile phonon xf86inputevdev xf86inputsynaptics xinput xkeyboard_config
+    libxkbfile phonon xf86inputlibinput xf86inputevdev xf86inputsynaptics xinput
+    xkeyboard_config
 
     accounts-qt qtdeclarative qtquickcontrols qtquickcontrols2 qtsvg qtx11extras
 
@@ -35,6 +36,11 @@ mkDerivation {
   patches = [
     ./hwclock-path.patch
     ./tzdir.patch
+    # https://invent.kde.org/plasma/plasma-desktop/-/merge_requests/563
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/plasma-desktop/-/commit/8d9bf2032b8a2e5de75edf5713c42866f5b80649.patch";
+      sha256 = "sha256-2jqqFjBljbhf7I+fTsIvuFs3Ic662KTKRnbcSm5Jing=";
+    })
   ];
   postPatch = ''
     sed '1i#include <cmath>' -i kcms/touchpad/backends/x11/synapticstouchpad.cpp


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/132890
Please see the issue for more details
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
