### PR TITLE
emacs.pkgs.ement: init at unstable-2021-09-08

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/ement/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/ement/default.nix
@@ -1,0 +1,32 @@
+{ trivialBuild
+, lib
+, fetchFromGitHub
+, curl
+, plz
+, cl-lib
+, ts
+}:
+
+trivialBuild {
+  pname = "ement";
+  version = "unstable-2021-09-08";
+
+  packageRequires = [
+    plz
+    cl-lib
+    ts
+  ];
+
+  src = fetchFromGitHub {
+    owner = "alphapapa";
+    repo = "ement.el";
+    rev = "468aa9b0526aaa054f059c63797aa3d9ea13611d";
+    sha256 = "sha256-0FCAu253iTSf9qcsmoJxKlzfd5eYc8eJXUxG6+0eg/I=";
+  };
+
+  meta = {
+    description = "plz is an HTTP library for Emacs";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -264,6 +264,8 @@
 
   emacspeak = callPackage ./emacspeak { };
 
+  ement = callPackage ./ement { };
+
   ess-R-object-popup = callPackage ./ess-R-object-popup { };
 
   font-lock-plus = callPackage ./font-lock-plus { };

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -284,6 +284,8 @@
 
   perl-completion = callPackage ./perl-completion { };
 
+  plz = callPackage ./plz { };
+
   pod-mode = callPackage ./pod-mode { };
 
   power-mode = callPackage ./power-mode { };

--- a/pkgs/applications/editors/emacs/elisp-packages/plz/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/plz/default.nix
@@ -1,0 +1,23 @@
+{ trivialBuild, lib, fetchFromGitHub, curl }:
+
+trivialBuild {
+  pname = "plz";
+  version = "unstable-2021-08-22";
+
+  src = fetchFromGitHub {
+    owner = "alphapapa";
+    repo = "plz.el";
+    rev = "7e456638a651bab3a814e3ea81742dd917509cbb";
+    sha256 = "sha256-8kn9ax1AVF6f9iCTqvVeJZihs03pYAhLjUDooG/ubxY=";
+  };
+
+  postPatch = ''
+    substituteInPlace ./plz.el --replace 'plz-curl-program "curl"' 'plz-curl-program "${curl}/bin/curl"'
+  '';
+
+  meta = {
+    description = "plz is an HTTP library for Emacs";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
