### PR TITLE
vscode: save as root fixed

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -7,6 +7,9 @@
 # Populate passthru.tests
 , tests
 
+# needed to fix "Save as Root"
+, nodePackages, bash
+
 # Attributes inherit from specific versions
 , version, src, meta, sourceRoot
 , executableName, longName, shortName, pname, updateScript
@@ -106,6 +109,18 @@ let
         # Add gio to PATH so that moving files to the trash works when not using a desktop environment
         --prefix PATH : ${glib.bin}/bin
       )
+    '';
+
+    # See https://github.com/NixOS/nixpkgs/issues/49643#issuecomment-873853897
+    postPatch = ''
+      # this is a fix for "save as root" functionality
+      packed="resources/app/node_modules.asar"
+      unpacked="resources/app/node_modules"
+      ${nodePackages.asar}/bin/asar extract "$packed" "$unpacked"
+      substituteInPlace $unpacked/sudo-prompt/index.js \
+        --replace "/usr/bin/pkexec" "/run/wrappers/bin/pkexec" \
+        --replace "/bin/bash" "${bash}/bin/bash"
+      rm -rf "$packed"
     '';
 
     inherit meta;


### PR DESCRIPTION
Just a patch for broken "save as root" functionality taken from here: https://github.com/NixOS/nixpkgs/issues/49643