### PR TITLE
terminus_font: 4.48 -> 4.49.1

### DIFF
--- a/pkgs/data/fonts/terminus-font/SOURCE_DATE_EPOCH-for-otb.patch
+++ b/pkgs/data/fonts/terminus-font/SOURCE_DATE_EPOCH-for-otb.patch
@@ -1,0 +1,83 @@
+From 2f935030ddb834426da1180b768e6b1e71d0824a Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Sat, 9 Oct 2021 10:17:05 +0100
+Subject: [PATCH] terminus-font: bin/otb1cli.py: add support for
+ SOURCE_DATE_EPOCH
+
+NixOS (and a few other distributions) strive for bit-reproducible
+builds. terminus-font-4.49.1 fails reproducibility test due to
+timestamp embedding into .otb files. diffoscope says that two
+consecutive builds differ at file creation timestamp:
+
+ $ diffoscope '...-terminus-font-4.49.1' '...-terminus-font-4.49.1.check'
+ - ...-terminus-font-4.49.1/share/fonts/terminus/ter-u12b.otb
+ + ...-terminus-font-4.49.1.check/share/fonts/terminus/ter-u12b.otb
+  showttf {}
+ @@ -1,32 +1,32 @@
+  version=1, numtables=12, searchRange=128 entrySel=3 rangeshift=64
+  File Checksum =b1b0afba (should be 0xb1b0afba), diff=0
+  EBDT checksum=5263c696 actual=5263c696 diff=0 offset=204 len=23056
+  EBLC checksum=350f1222 actual=350f1222 diff=0 offset=23260 len=84
+  OS/2 checksum=8b4939dd actual=8b4939dd diff=0 offset=23344 len=96
+  cmap checksum=da4e56f3 actual=da4e56f3 diff=0 offset=23440 len=1220
+  glyf checksum=00000000 actual=00000000 diff=0 offset=24660 len=0
+ -head checksum=1cb1374e actual=9db28c18 diff=8103bb56 offset=24660 len=54
+ +head checksum=1cb528c7 actual=9dae9a9f diff=811bb258 offset=24660 len=54
+  hhea checksum=055706a2 actual=055706a2 diff=0 offset=24716 len=36
+  hmtx checksum=98000000 actual=98000000 diff=0 offset=24752 len=5424
+  loca checksum=00000000 actual=00000000 diff=0 offset=30176 len=2714
+  maxp checksum=058e0003 actual=058e0003 diff=0 offset=32892 len=32
+  name checksum=208d345e actual=208d345e diff=0 offset=32924 len=448
+  post checksum=ffd80056 actual=ffd80056 diff=0 offset=33372 len=32
+
+  HEAD table (at 24660)
+       Version=1
+       fontRevision=1
+ -     checksumAdj=810154ca
+ +     checksumAdj=80f971d8
+       magicNumber=5f0f3cf5 (0x5f0f3cf5, diff=0)
+       flags=20b baseline_at_0 lsb_at_0 ppem_to_int
+       unitsPerEm=1024
+       create[0]=0
+ -      create[1]=dd831dec
+ -     File created: Wed Oct  6 09:33:32 2021
+ +      create[1]=dd870f65
+ +     File created: Sat Oct  9 09:20:37 2021
+
+The change uses SOURCE_DATE_EPOCH environment variable to override
+on-disk timestamps:
+    https://reproducible-builds.org/docs/source-date-epoch/
+---
+ bin/otb1cli.py | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/bin/otb1cli.py b/bin/otb1cli.py
+index 92ab07b..847b570 100644
+--- a/bin/otb1cli.py
++++ b/bin/otb1cli.py
+@@ -17,6 +17,7 @@
+ #
+ 
+ from datetime import datetime, timezone
++import os
+ 
+ import fnutil
+ import fncli
+@@ -81,8 +82,12 @@ def main_program(nonopt, parsed):
+ 			try:
+ 				stat = ifs.fstat()
+ 				if stat:
+-					parsed.created = datetime.fromtimestamp(stat.st_ctime, timezone.utc)
+-					parsed.modified = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
++					# Allow deterministic builds when SOURCE_DATE_EPOCH is set:
++					#  https://reproducible-builds.org/docs/source-date-epoch/
++					ct = int(os.environ.get('SOURCE_DATE_EPOCH', stat.st_ctime))
++					mt = int(os.environ.get('SOURCE_DATE_EPOCH', stat.st_mtime))
++					parsed.created = datetime.fromtimestamp(ct, timezone.utc)
++					parsed.modified = datetime.fromtimestamp(mt, timezone.utc)
+ 			except Exception as ex:
+ 				fnutil.warning(ifs.location(), str(ex))
+ 
+-- 
+2.33.0
+

--- a/pkgs/data/fonts/terminus-font/default.nix
+++ b/pkgs/data/fonts/terminus-font/default.nix
@@ -1,21 +1,20 @@
 { lib, stdenv, fetchurl, python3
-, libfaketime, fonttosfnt
 , bdftopcf, mkfontscale
 }:
 
 stdenv.mkDerivation rec {
   pname = "terminus-font";
-  version = "4.48"; # set here for use in URL below
+  version = "4.49.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/${pname}/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "1bwlkj39rqbyq57v5yssayav6hzv1n11b9ml2s0dpiyfsn6rqy9l";
+    url = "mirror://sourceforge/project/${pname}/${pname}-${lib.versions.majorMinor version}/${pname}-${version}.tar.gz";
+    sha256 = "0yggffiplk22lgqklfmd2c0rw8gwchynjh5kz4bz8yv2h6vw2qfr";
   };
 
+  patches = [ ./SOURCE_DATE_EPOCH-for-otb.patch ];
+
   nativeBuildInputs =
-    [ python3 bdftopcf libfaketime
-      fonttosfnt mkfontscale
-    ];
+    [ python3 bdftopcf mkfontscale ];
 
   enableParallelBuilding = true;
 
@@ -24,22 +23,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace 'gzip'     'gzip -n'
   '';
 
-  postBuild = ''
-    # convert unicode bdf fonts to otb
-    for i in *.bdf; do
-      name=$(basename $i .bdf)
-      faketime -f "1970-01-01 00:00:01" \
-      fonttosfnt -v -o "$name.otb" "$i"
-    done
-  '';
-
-  postInstall = ''
-    # install otb fonts (for GTK applications)
-    install -m 644 -D *.otb -t "$out/share/fonts/misc";
-    mkfontdir "$out/share/fonts/misc"
-  '';
-
-  installTargets = [ "install" "fontdir" ];
+  installTargets = [ "install" "install-otb" "fontdir" ];
 
   meta = with lib; {
     description = "A clean fixed width font";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23260,7 +23260,7 @@ with pkgs;
   tenderness = callPackage ../data/fonts/tenderness { };
 
   terminus_font = callPackage ../data/fonts/terminus-font
-    { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
+    { inherit (buildPackages.xorg) mkfontscale; };
 
   terminus_font_ttf = callPackage ../data/fonts/terminus-font-ttf { };
 


### PR DESCRIPTION
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
