### PR TITLE
khronos: 1.0.8 -> 3.5.9

### DIFF
--- a/pkgs/applications/office/khronos/default.nix
+++ b/pkgs/applications/office/khronos/default.nix
@@ -9,21 +9,22 @@
 , pantheon
 , python3
 , glib
-, gtk3
+, gtk4
 , json-glib
+, libadwaita
 , libgee
 , wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "khronos";
-  version = "1.0.8";
+  version = "3.5.9";
 
   src = fetchFromGitHub {
     owner = "lainsce";
     repo = pname;
     rev = version;
-    sha256 = "0d5ma1d86lh2apagwrwk0d1v1cm3fifjivhf530nlznb67vi1x80";
+    sha256 = "sha256-3FatmyANB/tNYSN2hu5IVkyCy0YrC3uA2d/3+5u48w8=";
   };
 
   nativeBuildInputs = [
@@ -38,15 +39,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
-    gtk3
+    gtk4
     json-glib
+    libadwaita
     libgee
     pantheon.granite
   ];
 
   postPatch = ''
-    chmod +x meson/post_install.py
-    patchShebangs meson/post_install.py
+    chmod +x build-aux/post_install.py
+    patchShebangs build-aux/post_install.py
   '';
 
   passthru = {

--- a/pkgs/applications/office/khronos/default.nix
+++ b/pkgs/applications/office/khronos/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/lainsce/khronos";
     maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
     platforms = platforms.linux;
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/lainsce/khronos/releases
https://github.com/lainsce/khronos/compare/1.0.8...3.5.9

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
