### PR TITLE
create-amis.sh: configure from env and work with ZFS AMIs

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -104,8 +104,8 @@ in {
        ${pkgs.jq}/bin/jq -n \
          --arg system_label ${lib.escapeShellArg config.system.nixos.label} \
          --arg system ${lib.escapeShellArg pkgs.stdenv.hostPlatform.system} \
-         --arg root_logical_bytes "$(${pkgs.qemu}/bin/qemu-img info --output json "$bootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
-         --arg boot_logical_bytes "$(${pkgs.qemu}/bin/qemu-img info --output json "$rootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
+         --arg root_logical_bytes "$(${pkgs.qemu}/bin/qemu-img info --output json "$rootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
+         --arg boot_logical_bytes "$(${pkgs.qemu}/bin/qemu-img info --output json "$bootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
          --arg root "$rootDisk" \
          --arg boot "$bootDisk" \
         '{}

--- a/nixos/maintainers/scripts/ec2/create-amis.sh
+++ b/nixos/maintainers/scripts/ec2/create-amis.sh
@@ -15,18 +15,22 @@
 # set -x
 set -euo pipefail
 
-# configuration
-state_dir=$HOME/amis/ec2-images
-home_region=eu-west-1
-bucket=nixos-amis
-service_role_name=vmimport
+var () { true; }
 
-regions=(eu-west-1 eu-west-2 eu-west-3 eu-central-1 eu-north-1
+# configuration
+var ${state_dir:=$HOME/amis/ec2-images}
+var ${home_region:=eu-west-1}
+var ${bucket:=nixos-amis}
+var ${service_role_name:=vmimport}
+
+var ${regions:=eu-west-1 eu-west-2 eu-west-3 eu-central-1 eu-north-1
          us-east-1 us-east-2 us-west-1 us-west-2
          ca-central-1
          ap-southeast-1 ap-southeast-2 ap-northeast-1 ap-northeast-2
          ap-south-1 ap-east-1
-         sa-east-1)
+         sa-east-1}
+
+regions=($regions)
 
 log() {
     echo "$@" >&2

--- a/nixos/maintainers/scripts/ec2/create-amis.sh
+++ b/nixos/maintainers/scripts/ec2/create-amis.sh
@@ -123,11 +123,11 @@ wait_for_import() {
     local state snapshot_id
     log "Waiting for import task $task_id to be completed"
     while true; do
-        read -r state progress snapshot_id < <(
+        read -r state message snapshot_id < <(
             aws ec2 describe-import-snapshot-tasks --region "$region" --import-task-ids "$task_id" | \
-                jq -r '.ImportSnapshotTasks[].SnapshotTaskDetail | "\(.Status) \(.Progress) \(.SnapshotId)"'
+                jq -r '.ImportSnapshotTasks[].SnapshotTaskDetail | "\(.Status) \(.StatusMessage) \(.SnapshotId)"'
         )
-        log " ... state=$state progress=$progress snapshot_id=$snapshot_id"
+        log " ... state=$state message=$message snapshot_id=$snapshot_id"
         case "$state" in
             active)
                 sleep 10

--- a/nixos/maintainers/scripts/ec2/create-amis.sh
+++ b/nixos/maintainers/scripts/ec2/create-amis.sh
@@ -252,7 +252,7 @@ upload_image() {
         write_state "$state_key" ami_id "$ami_id"
     fi
 
-    make_image_public "$region" "$ami_id"
+    [[ -v PRIVATE ]] || make_image_public "$region" "$ami_id"
 
     echo "$ami_id"
 }
@@ -280,7 +280,7 @@ copy_to_region() {
         write_state "$state_key" ami_id "$ami_id"
     fi
 
-    make_image_public "$region" "$ami_id"
+    [[ -v PRIVATE ]] || make_image_public "$region" "$ami_id"
 
     echo "$ami_id"
 }

--- a/nixos/maintainers/scripts/ec2/create-amis.sh
+++ b/nixos/maintainers/scripts/ec2/create-amis.sh
@@ -69,7 +69,7 @@ image_label="$(read_image_info .label)${zfs_disks:+-ZFS}"
 image_system=$(read_image_info .system)
 image_files=( $(read_image_info "${zfs_disks:+.disks.root}.file") )
 
-image_logical_bytes=$(read_image_info "${zfs_disks:+.disks.root}.logical_bytes")
+image_logical_bytes=$(read_image_info "${zfs_disks:+.disks.boot}.logical_bytes")
 
 if [[ -n "$zfs_disks" ]]; then
   image_files+=( $(read_image_info .disks.boot.file) )
@@ -242,10 +242,7 @@ upload_image() {
         if [[ -n "$zfs_disks" ]]; then
             local root_snapshot_id=$(read_state "$region.$image_label.root.$image_system" snapshot_id)
 
-            # currently there is a bug in the ZFS AMI derivation, mismatching logical_bytes
-            # root.logical_bytes should be boot.logical_bytes and vice versa
-            # work around until fixed
-            local root_image_logical_bytes=$(read_image_info ".disks.boot.logical_bytes")
+            local root_image_logical_bytes=$(read_image_info ".disks.root.logical_bytes")
             local root_image_logical_gigabytes=$(((root_image_logical_bytes-1)/1024/1024/1024+1)) # Round to the next GB
 
             block_device_mappings+=(


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The existing script has several hardcoded values that can now be overriden from the environment to make it a bit more flexible. In addition, some logic has been added to make the multi-image output of the ZFS AMI added in #106574 work properly.

It is also now possible to upload AMIs as private by setting the `PRIVATE` variable in the env.

I am assuming we use this script somewhere in the CI chain so I tried to make the changes in such a way that it wouldn't break it's original API.

The ZFS AMIs uploaded with this script have been tested and are working.

###### Things done
Built custom ZFS AMIs based on a work configuration and uploaded them successfully to a private s3 bucket using this script. Those AMIs were also successfully accessed with the bootstrap AWS key as well as keys specified in the NixOS config.

Also have now used said AMIs in a production environment as a base for [bitte](https://github.com/input-output-hk/bitte) client nodes.

### Testing Images:
To assist with review, here are a few public AMIs built with the latest force push at time of writing:
```nix
  {
    eu-central-1 = "ami-07cf06fc2cf0de485";
    us-east-2 = "ami-08c2048194fde1422";
    eu-west-1 = "ami-0ac83c4afcc9e6ecc";
    us-east-1 = "ami-0baa6fb5107677998";
  }
```
These are built from this expression:
https://github.com/input-output-hk/bitte/blob/ami/pkgs/ami.nix