### PR TITLE
gitui: do not compile openssl

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitui/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitui/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, libiconv, perl, python3, Security, AppKit, openssl, xclip }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub, libiconv, perl, python3, Security, AppKit, openssl, xclip, pkg-config }:
 rustPlatform.buildRustPackage rec {
   pname = "gitui";
   version = "0.17.1";
@@ -12,10 +12,13 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-9uRvxax0SrvRkD89mbZPxsfRItde11joA/ZgnXK9XBE=";
 
-  nativeBuildInputs = [ python3 perl ];
+  nativeBuildInputs = [ python3 perl pkg-config ];
   buildInputs = [ openssl ]
     ++ lib.optional stdenv.isLinux xclip
     ++ lib.optionals stdenv.isDarwin [ libiconv Security AppKit ];
+
+  # Needed to get openssl-sys to use pkg-config.
+  OPENSSL_NO_VENDOR = 1;
 
   meta = with lib; {
     description = "Blazing fast terminal-ui for git written in rust";


### PR DESCRIPTION
###### Motivation for this change

```
error: failed to run custom build command for `openssl-sys v0.9.66`

Caused by:
  process didn't exit successfully: `/private/tmp/nix-build-gitui-0.17.1.drv-0/source/target/release/build
  --- stdout
  cargo:rustc-cfg=const_fn
  cargo:rerun-if-env-changed=X86_64_APPLE_DARWIN_OPENSSL_NO_VENDOR
  X86_64_APPLE_DARWIN_OPENSSL_NO_VENDOR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_VENDOR
  OPENSSL_NO_VENDOR unset
```

today updating on the latest gitui, the compilation failed on openssl.
Even if the compilation didn't fail, gitui should not compile openssl but use the provided one by nix. (it will also quicken the build)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
