### PR TITLE
opencv3: 3.4.8 -> 3.4.15

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchFromGitHub, fetchpatch
+, fetchFromGitHub
 , cmake, pkg-config, unzip, zlib, pcre, hdf5
 , glog, boost, gflags, protobuf
 , config
@@ -39,20 +39,20 @@ assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 assert enablePython -> pythonPackages != null;
 
 let
-  version = "3.4.8";
+  version = "3.4.15";
 
   src = fetchFromGitHub {
     owner  = "opencv";
     repo   = "opencv";
     rev    = version;
-    sha256 = "1dnz3gfj70lm1gbrk8pz28apinlqi2x6nvd6xcy5hs08505nqnjp";
+    hash   = "sha256-dLwQM2VhVlBV4xazS2rItTscKYeeNlNT0G8G1A1mOmc=";
   };
 
   contribSrc = fetchFromGitHub {
     owner  = "opencv";
     repo   = "opencv_contrib";
     rev    = version;
-    sha256 = "0psaa1yx36n34l09zd1y8jxgf8q4jzxd3vn06fqmzwzy85hcqn8i";
+    hash   = "sha256-FJDRMmSOT5jA+n2Ke0gEH7n5rgGvB1UzYpYZ1vmucjg=";
   };
 
   # Contrib must be built in order to enable Tesseract support:
@@ -150,6 +150,11 @@ stdenv.mkDerivation {
   postUnpack = lib.optionalString buildContrib ''
     cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/opencv_contrib"
   '';
+
+  # Ensures that we use the system OpenEXR rather than the vendored copy of the source included with OpenCV.
+  patches = [
+    ./cmake-don-t-use-OpenCVFindOpenEXR.patch
+  ];
 
   # This prevents cmake from using libraries in impure paths (which
   # causes build failure on non NixOS)

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -214,11 +214,13 @@ stdenv.mkDerivation {
     cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/source/opencv_contrib"
   '';
 
-  # This prevents cmake from using libraries in impure paths (which
-  # causes build failure on non NixOS)
+  # Ensures that we use the system OpenEXR rather than the vendored copy of the source included with OpenCV.
   patches = [
     ./cmake-don-t-use-OpenCVFindOpenEXR.patch
   ] ++ lib.optional enableCuda ./cuda_opt_flow.patch;
+
+  # This prevents cmake from using libraries in impure paths (which
+  # causes build failure on non NixOS)
   postPatch = ''
     sed -i '/Add these standard paths to the search paths for FIND_LIBRARY/,/^\s*$/{d}' CMakeLists.txt
   '';


### PR DESCRIPTION
###### Motivation for this change

Version 3.4.8 is from Nov 2019, almost two years ago. The proposed version was released July 19, 2021.

Bumping only the version forward results in a linker failure when `enableUnfree = true`:

```
opencv> [ 71%] Linking CXX executable ../../bin/opencv_annotation
opencv> [ 71%] Building CXX object modules/calib3d/CMakeFiles/opencv_calib3d.dir/src/sqpnp.cpp.o
opencv> /nix/store/v8imx1nvyz0hgvx9cbcmh6gp4ngw3ffj-binutils-2.35.1/bin/ld: ../../lib/libopencv_imgcodecs.so.3.4.15: undefined reference to `Imf_opencv::Chromaticities::Chromaticities(Imath_2_5::Vec2<float> const&, Imath_2_5::Vec2<float> const&, Imath_2_5::Vec2<float> const&, Imath_2_5::Vec2<float> const&)'
opencv> /nix/store/v8imx1nvyz0hgvx9cbcmh6gp4ngw3ffj-binutils-2.35.1/bin/ld: ../../lib/libopencv_imgcodecs.so.3.4.15: undefined reference to `Imf_opencv::Header::Header(int, int, float, Imath_2_5::Vec2<float> const&, float, Imf_opencv::LineOrder, Imf_opencv::Compression)'
opencv> collect2: error: ld returned 1 exit status
opencv> make[2]: *** [apps/annotation/CMakeFiles/opencv_annotation.dir/build.make:108: bin/opencv_annotation] Error 1
opencv> make[1]: *** [CMakeFiles/Makefile2:5104: apps/annotation/CMakeFiles/opencv_annotation.dir/all] Error 2
opencv> make[1]: *** Waiting for unfinished jobs....
opencv> [ 71%] Building CXX object modules/dnn/CMakeFiles/opencv_dnn.dir/layers/layers_common.avx2.cpp.o
opencv> [ 71%] Building CXX object modules/bioinspired/CMakeFiles/opencv_bioinspired.dir/src/imagelogpolprojection.cpp.o
opencv> [ 71%] Linking CXX executable ../../bin/opencv_visualisation
opencv> /nix/store/v8imx1nvyz0hgvx9cbcmh6gp4ngw3ffj-binutils-2.35.1/bin/ld: ../../lib/libopencv_imgcodecs.so.3.4.15: undefined reference to `Imf_opencv::Chromaticities::Chromaticities(Imath_2_5::Vec2<float> const&, Imath_2_5::Vec2<float> const&, Imath_2_5::Vec2<float> const&, Imath_2_5::Vec2<float> const&)'
opencv> /nix/store/v8imx1nvyz0hgvx9cbcmh6gp4ngw3ffj-binutils-2.35.1/bin/ld: ../../lib/libopencv_imgcodecs.so.3.4.15: undefined reference to `Imf_opencv::Header::Header(int, int, float, Imath_2_5::Vec2<float> const&, float, Imf_opencv::LineOrder, Imf_opencv::Compression)'
opencv> collect2: error: ld returned 1 exit status
opencv> make[2]: *** [apps/visualisation/CMakeFiles/opencv_visualisation.dir/build.make:108: bin/opencv_visualisation] Error 1
opencv> make[1]: *** [CMakeFiles/Makefile2:5135: apps/visualisation/CMakeFiles/opencv_visualisation.dir/all] Error 2
```

The root cause of this is that OpenCV ships a bundled copy of the OpenEXR sources, and uses them by default. This can be confirmed in 3.4.8 by setting `enableUnfree` in _that_ build, and then checking with `nix path-info -r` that there is no runtime dependency on `openexr`.

Fortunately, there was already a patch in the folder which corrects this issue for OpenCV 4, though the comment in the Nix file is a bit confusing about its purpose. I've applied the same patch to both builds and included the same comment for both explaining. I've validated that in an `enableUnfree` build, a) the build succeeds, and b) the expected dependency exists in the result:

```
$ nix why-depends ~/nixpkgs#opencv3 ~/nixpkgs#openexr.out
/nix/store/fk7733hdkk3dy1020kmdd6cka8bf6iw9-opencv-3.4.15
└───lib/libopencv_imgcodecs.so.3.4.15: …c7-libwebp-1.1.0/lib:/nix/store/97dg1cknpnm9vggyncrq9i93br89wbrs-openexr-2.5.7/lib:/nix/store/9b…
    → /nix/store/97dg1cknpnm9vggyncrq9i93br89wbrs-openexr-2.5.7
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Built on NixOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
