### PR TITLE
tree-sitter: add rydesun/tree-sitter-dot and update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -6,6 +6,7 @@
   tree-sitter-comment = (builtins.fromJSON (builtins.readFile ./tree-sitter-comment.json));
   tree-sitter-cpp = (builtins.fromJSON (builtins.readFile ./tree-sitter-cpp.json));
   tree-sitter-css = (builtins.fromJSON (builtins.readFile ./tree-sitter-css.json));
+  tree-sitter-dot = (builtins.fromJSON (builtins.readFile ./tree-sitter-dot.json));
   tree-sitter-embedded-template = (builtins.fromJSON (builtins.readFile ./tree-sitter-embedded-template.json));
   tree-sitter-fennel = (builtins.fromJSON (builtins.readFile ./tree-sitter-fennel.json));
   tree-sitter-fish = (builtins.fromJSON (builtins.readFile ./tree-sitter-fish.json));

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "87c1aba089207f0fcc022ed88138af5a3e4cf454",
-  "date": "2021-09-05T21:16:06+01:00",
-  "path": "/nix/store/wx1asjwcpcmizavl7z756q55z3mvn714-tree-sitter-c-sharp",
-  "sha256": "1c1s2x7bpirsrkr6cqj9v4czpgavyf6b9dg290l9v7vd9fg3zh6v",
+  "rev": "c9e1952d311cf87762a42a79cb801c7bef1af815",
+  "date": "2021-09-09T23:38:47+01:00",
+  "path": "/nix/store/cl05d3zpbbkhms5fmd6wc4jhasjhg12l-tree-sitter-c-sharp",
+  "sha256": "0kn7p203ij8vz1cdxmxvn85mf3hpmz08l5psza96xxif2lcz8li8",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "5bb411db33c86b108c891fb2c1473ddc9fad9701",
-  "date": "2021-08-17T11:20:29-07:00",
-  "path": "/nix/store/a23w5pnww3wryjs1vimp5ggvgq9bg0rl-tree-sitter-cpp",
-  "sha256": "1gxd40ipbzjhlk2amsk09v67cjxk4wal60kxycnb04lp6wxwlm8b",
+  "rev": "f53c3c013a1c223f7ca4614895bef4fe05928101",
+  "date": "2021-09-14T15:11:36-05:00",
+  "path": "/nix/store/lc1jjys6lgp19d52n6qgymfqx9pwg0xa-tree-sitter-cpp",
+  "sha256": "05al4yrb39cfa96cf4armv47ja5qccmc3mvbmzfwc7hh1rq621n7",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/rydesun/tree-sitter-dot",
+  "rev": "e6f55c43b87b81cc982e38d414f0147fefa2515c",
+  "date": "2021-09-01T14:36:57+08:00",
+  "path": "/nix/store/n5a6bzh8rf35865wvcr3cis9r0fn2047-tree-sitter-dot",
+  "sha256": "1s3fpd0lnbm3gk9nbskdkdjlmdm7kz0l0g2zipv1m7qkc05nnkfy",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "acafd11d9e45b1c28b49ff798022022b29d8b450",
-  "date": "2021-08-27T16:35:25+02:00",
-  "path": "/nix/store/wmw8ppdkndwg3f8phdhws985ckxs0yvk-tree-sitter-haskell",
-  "sha256": "1zm8m7lpgmh4gr0iw0792bsqi5jpf3w0kx6l3s91clici69nwkiq",
+  "rev": "bf7d643b494b7c7eed909ed7fbd8447231152cb0",
+  "date": "2021-09-09T20:07:38+02:00",
+  "path": "/nix/store/nkx9qf63nwl1ql6gl3q1fm4ykqax1isx-tree-sitter-haskell",
+  "sha256": "1wlp6kncjadhfz8y2wn90gkbqf35iidrn0y1ga360l5wyzx1mpid",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "2cc5803225a307308005930b3bedb939b1543722",
-  "date": "2021-08-29T11:32:53-07:00",
-  "path": "/nix/store/kjviknhcrayrzv94i762zsy2kvpxpkx6-tree-sitter-javascript",
-  "sha256": "1xkll7g38j1vajylfaifbn6i5y5f22kmjfy2dxy9bk903assxy05",
+  "rev": "435db852fbeff8fe298e25ad967c634d9698eec0",
+  "date": "2021-09-13T13:32:20-07:00",
+  "path": "/nix/store/idvb37g3nqpidw0jviiw4b71sqpihhs0-tree-sitter-javascript",
+  "sha256": "0plc5jxxh1bm1dig6gsk1ma7gp29ad3p0169jd9xlagc4vysfgc3",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "77d98f3ce47ea52ff39137be29bc6376951c2286",
-  "date": "2021-09-03T18:25:31+02:00",
-  "path": "/nix/store/l143h3fxi89kk7dcp71zjdhdfmfmr68s-tree-sitter-php",
-  "sha256": "15cl1mdclhjiw72xzkcmw0lxq2hv1bjf2xf2nkgibi7zp8s1qvyw",
+  "rev": "d1bdb1e535d39d4f93f7373f406e1837c8a7bb25",
+  "date": "2021-09-10T08:16:50+02:00",
+  "path": "/nix/store/4zzs4f1hz5il35pqyf355aps6k4a83i8-tree-sitter-php",
+  "sha256": "0ymkwlh1japlwsajxd06254qadzq9bvm5db02cg4n3zv0pkvyrzz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "83816f563c8d9d2f1b9c921206a7944d0c5904ad",
-  "date": "2021-08-17T11:21:26-07:00",
-  "path": "/nix/store/jwxdv5xbs92n43yqvxnwz443jvngxmqp-tree-sitter-typescript",
-  "sha256": "1w989z36pvfv7m4z9s9qq67l81p8rx37z53kqmsxsyc01wnpb4nr",
+  "rev": "98ef311701c51f72c83e5285366e00adb7a446c8",
+  "date": "2021-09-14T18:18:35-07:00",
+  "path": "/nix/store/fcl3abkk7blcq8hfk7l70j32nhx4ka24-tree-sitter-typescript",
+  "sha256": "1jpfmpisyz020h3vj7i4km8ha9axl6kqn75ikd26bvyxqir38cnr",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -114,6 +114,10 @@ let
       orga = "ram02z";
       repo = "tree-sitter-fish";
     };
+    "tree-sitter-dot" = {
+      orga = "rydesun";
+      repo = "tree-sitter-dot";
+    };
   };
 
   allGrammars =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
