### PR TITLE
libsForQt5.mauikit: 1.2.2 -> 2.0.1

### DIFF
--- a/pkgs/applications/misc/index-fm/default.nix
+++ b/pkgs/applications/misc/index-fm/default.nix
@@ -17,14 +17,14 @@
 
 mkDerivation rec {
   pname = "index";
-  version = "1.2.2";
+  version = "2.0.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "maui";
     repo = "index-fm";
     rev = "v${version}";
-    sha256 = "sha256-N9/Jt18QRqDMWtEfxWn22e5Ud3YMwJ9B7OQRwTvwX8g=";
+    sha256 = "sha256-aY8JBCIh6VyCDOGQIMWhO6asGMo6I6ZTgzpDnnDy9eo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/mauikit-filebrowsing/default.nix
+++ b/pkgs/development/libraries/mauikit-filebrowsing/default.nix
@@ -10,14 +10,14 @@
 
 mkDerivation rec {
   pname = "mauikit-filebrowsing";
-  version = "1.2.2";
+  version = "2.0.1";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "maui";
     repo = "mauikit-filebrowsing";
     rev = "v${version}";
-    sha256 = "1m56lil7w884wn8qycl7y55abvw2vanfy8c4g786200p6acsh3kl";
+    sha256 = "sha256-hiR0RbZTduH0noyzpewsNJAtSdCtiSmTP8SLMBgK3uA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/mauikit/default.nix
+++ b/pkgs/development/libraries/mauikit/default.nix
@@ -6,20 +6,21 @@
 , kconfig
 , kcoreaddons
 , ki18n
+, knotifications
 , qtbase
 , qtquickcontrols2
 }:
 
 mkDerivation rec {
   pname = "mauikit";
-  version = "1.2.2";
+  version = "2.0.1";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "maui";
     repo = "mauikit";
     rev = "v${version}";
-    sha256 = "1jz0a65bbznjg7aaq19rdyp956wn6xc1x4xigfkhj6mwsvnb49av";
+    sha256 = "sha256-qz/MePMvyGR8lzR2xB2f9QENx04UHu0Xef7v0xcKovo=";
   };
 
   nativeBuildInputs = [
@@ -31,6 +32,7 @@ mkDerivation rec {
     kconfig
     kcoreaddons
     ki18n
+    knotifications
     qtquickcontrols2
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
