### PR TITLE
mapserver: init at 7.6.4

### DIFF
--- a/pkgs/servers/mapcache/default.nix
+++ b/pkgs/servers/mapcache/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, apacheHttpd, apr, aprutil, curl, db, fcgi, gdal, geos
+, libgeotiff, libjpeg, libpng, libtiff, pcre, pixman, proj, sqlite, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mapcache";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "MapServer";
+    repo = pname;
+    rev = "rel-${lib.replaceStrings [ "." ] [ "-" ] version}";
+    sha256 = "sha256-HrvcJAf0a6tu8AKKuW5TaCtqPMgzH21fGMBxIfUzdgY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    apacheHttpd
+    apr
+    aprutil
+    curl
+    db
+    fcgi
+    gdal
+    geos
+    libgeotiff
+    libjpeg
+    libpng
+    libtiff
+    pcre
+    pixman
+    proj
+    sqlite
+    zlib
+  ];
+
+  cmakeFlags = [
+    "-DWITH_BERKELEY_DB=ON"
+    "-DWITH_MEMCACHE=ON"
+    "-DWITH_TIFF=ON"
+    "-DWITH_GEOTIFF=ON"
+    "-DWITH_PCRE=ON"
+    "-DAPACHE_MODULE_DIR=${placeholder "out"}/modules"
+  ];
+
+  meta = with lib; {
+    description = "A server that implements tile caching to speed up access to WMS layers";
+    homepage = "https://mapserver.org/mapcache/";
+    changelog = "https://www.mapserver.org/development/changelog/mapcache/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/mapserver/default.nix
+++ b/pkgs/servers/mapserver/default.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, cairo, curl, fcgi, freetype, fribidi, gdal, geos, giflib, harfbuzz
+, libjpeg, libpng, librsvg, libxml2, postgresql, proj, protobufc, zlib
+, withPython ? true, swig, python
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mapserver";
+  version = "7.6.4";
+
+  src = fetchFromGitHub {
+    owner = "MapServer";
+    repo = "MapServer";
+    rev = "rel-${lib.replaceStrings [ "." ] [ "-" ] version}";
+    sha256 = "sha256-NMo/7CtWYIP1oPKki09oDWLCbj2vPk3xCU4rkHq8YKY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ] ++ lib.optional withPython swig;
+
+  buildInputs = [
+    cairo
+    curl
+    fcgi
+    freetype
+    fribidi
+    gdal
+    geos
+    giflib
+    harfbuzz
+    libjpeg
+    libpng
+    librsvg
+    libxml2
+    postgresql
+    proj
+    protobufc
+    zlib
+  ] ++ lib.optional withPython python;
+
+  cmakeFlags = [
+    "-DWITH_KML=ON"
+    "-DWITH_SOS=ON"
+    "-DWITH_RSVG=ON"
+    "-DWITH_CURL=ON"
+    "-DWITH_CLIENT_WMS=ON"
+    "-DWITH_CLIENT_WFS=ON"
+  ] ++ lib.optional withPython "-DWITH_PYTHON=ON";
+
+  meta = with lib; {
+    description = "Platform for publishing spatial data and interactive mapping applications to the web";
+    homepage = "https://mapserver.org/";
+    changelog = "https://mapserver.org/development/changelog/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6630,6 +6630,8 @@ with pkgs;
 
   makebootfat = callPackage ../tools/misc/makebootfat { };
 
+  mapserver = callPackage ../servers/mapserver { };
+
   martin = callPackage ../servers/martin {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6630,6 +6630,8 @@ with pkgs;
 
   makebootfat = callPackage ../tools/misc/makebootfat { };
 
+  mapcache = callPackage ../servers/mapcache { };
+
   mapserver = callPackage ../servers/mapserver { };
 
   martin = callPackage ../servers/martin {


### PR DESCRIPTION
###### Motivation for this change
* [MapServer](https://www.mapserver.org) is an Open Source platform for publishing spatial data and interactive mapping applications to the web.
* [MapCache](https://www.mapserver.org/mapcache/) is a server that implements tile caching to speed up access to WMS layers.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
