### PR TITLE
orjson: init at 3.6.3

### DIFF
--- a/pkgs/development/python-modules/orjson/default.nix
+++ b/pkgs/development/python-modules/orjson/default.nix
@@ -33,7 +33,10 @@ buildPythonPackage rec {
 
   format = "pyproject";
 
-  nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
 

--- a/pkgs/development/python-modules/orjson/default.nix
+++ b/pkgs/development/python-modules/orjson/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, pythonOlder
+, rustPlatform
+, fetchFromGitHub
+, buildPythonPackage
+, libiconv
+, numpy
+, psutil
+, pytestCheckHook
+, python-dateutil
+, pytz
+, xxhash
+}:
+
+buildPythonPackage rec {
+  pname = "orjson";
+  version = "3.6.3";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ijl";
+    repo = pname;
+    rev = version;
+    sha256 = "10clf13bp3fqd9b7n1isrfwz7sngcl1j6birqc1xyg9wzfw1kslj";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    sha256 = "163rf8k7qb1whjf78i8v5dlyif1sgvd9xkj8li81j45abgzkq86w";
+  };
+
+  format = "pyproject";
+
+  nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+
+  checkInputs = [
+    numpy
+    psutil
+    pytestCheckHook
+    python-dateutil
+    pytz
+    xxhash
+  ];
+
+  pythonImportsCheck = [ pname ];
+
+  meta = with lib; {
+    description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy";
+    homepage = "https://github.com/ijl/orjson";
+    license = with licenses; [ asl20 mit ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ misuzu ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5155,6 +5155,8 @@ in {
 
   orderedset = callPackage ../development/python-modules/orderedset { };
 
+  orjson = callPackage ../development/python-modules/orjson { };
+
   orm = callPackage ../development/python-modules/orm { };
 
   ortools = (toPythonModule (pkgs.or-tools.override { inherit (self) python; })).python;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`orjson` now compiles using stable rust

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
