### PR TITLE
libogg: 1.3.4 -> 1.3.5

### DIFF
--- a/pkgs/development/libraries/libogg/default.nix
+++ b/pkgs/development/libraries/libogg/default.nix
@@ -1,22 +1,15 @@
-{ lib, stdenv, fetchurl, fetchpatch }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libogg-1.3.4";
+  pname = "libogg";
+  version = "1.3.5";
 
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/ogg/${name}.tar.xz";
-    sha256 = "1zlk33vxvxr0l9lhkbhkdwvylw96d2n0fnd3d8dl031hph9bqqy1";
+    url = "http://downloads.xiph.org/releases/ogg/${pname}-${version}.tar.xz";
+    sha256 = "01b7050bghdvbxvw0gzv588fn4a27zh42ljpwzm4vrf8dziipnf4";
   };
 
   outputs = [ "out" "dev" "doc" ];
-
-  patches = lib.optionals stdenv.isDarwin [
-    # Fix unsigned typedefs on darwin. Remove with the next release https://github.com/xiph/ogg/pull/64
-    (fetchpatch {
-      url = "https://github.com/xiph/ogg/commit/c8fca6b4a02d695b1ceea39b330d4406001c03ed.patch";
-      sha256 = "1s72g37y87x0a74zjji9vx2hyk86kr4f2l3m4y2fipvlf9348b3f";
-    })
-  ];
 
   meta = with lib; {
     description = "Media container library to manipulate Ogg files";


### PR DESCRIPTION
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
