### PR TITLE
nixos/lock-kernel-modules: use `udevadm settle`

### DIFF
--- a/nixos/modules/security/lock-kernel-modules.nix
+++ b/nixos/modules/security/lock-kernel-modules.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, pkgs, lib, ... }:
 
 with lib;
 
@@ -13,7 +13,7 @@ with lib;
       default = false;
       description = ''
         Disable kernel module loading once the system is fully initialised.
-        Module loading is disabled until the next reboot.  Problems caused
+        Module loading is disabled until the next reboot. Problems caused
         by delayed module loading can be fixed by adding the module(s) in
         question to <option>boot.kernelModules</option>.
       '';
@@ -29,20 +29,30 @@ with lib;
             else [ x.fsType ]
         else []) config.system.build.fileSystems;
 
-    systemd.services.disable-kernel-module-loading = rec {
+    systemd.services.disable-kernel-module-loading = {
       description = "Disable kernel module loading";
 
+      wants = [ "systemd-udevd.service" ];
       wantedBy = [ config.systemd.defaultUnit ];
 
-      after = [ "systemd-udev-settle.service" "firewall.service" "systemd-modules-load.service" ] ++ wantedBy;
+      before = [ config.systemd.defaultUnit ];
+      after =
+        [ "firewall.service"
+          "systemd-modules-load.service"
+        ];
 
       unitConfig.ConditionPathIsReadWrite = "/proc/sys/kernel";
 
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        ExecStart = "/bin/sh -c 'echo -n 1 >/proc/sys/kernel/modules_disabled'";
-      };
+      serviceConfig =
+        { Type = "oneshot";
+          RemainAfterExit = true;
+          TimeoutSec = 180;
+        };
+
+      script = ''
+        ${pkgs.udev}/bin/udevadm settle
+        echo -n 1 >/proc/sys/kernel/modules_disabled
+      '';
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fix for #73095

Instead of relying on systemd-udev-settle, which is deprecated,
directly call `udevamd settle` to wait for hardware to settle.

###### Things done

- [x] Tested via `hardened`
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
