### PR TITLE
lib: introduce `forEachAttr` = flip mapAttrs

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -161,6 +161,16 @@ rec {
         ) a (attrNames n)
     ) {} list_of_attrs;
 
+  /*  Apply the function to each element in the attribute set. Same as
+      `mapAttrs`, but arguments flipped.
+
+     Example:
+       forEachAttr { x = "foo"; y = "bar"; } (name: value:
+         name + "-" + value
+       )
+       => { x = "x-foo"; y = "y-bar"; }
+  */
+  forEachAttr = set: f: mapAttrs f set;
 
   /* Recursively collect sets that verify a given predicate named `pred'
      from the set `attrs'.  The recursion is stopped when the predicate is


### PR DESCRIPTION

###### Motivation for this change
This PR introduces `forEachAttr` that is the flipped version of `mapAttrs`, similar to `forEach` vs `map`. The same reason `forEach` was introduced also apply here: Oftentimes an anonymous function is used while the looped value usually comes from a variable. For these cases, I believe `forEach` and `forEachAttr` makes the expression more readable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
