### PR TITLE
migen: init at unstable-2021-09-14

### DIFF
--- a/pkgs/development/python-modules/migen/default.nix
+++ b/pkgs/development/python-modules/migen/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, colorama
+}:
+
+buildPythonPackage rec {
+  pname = "migen";
+  version = "unstable-2021-09-14";
+  disabled = pythonOlder "3.3";
+
+  src = fetchFromGitHub {
+    owner = "m-labs";
+    repo = "migen";
+    rev = "a5bc262560238f93ceaad423820eb06843326274";
+    sha256 = "32UjaIam/B7Gx6XbPcR067LcXfokJH2mATG9mU38a6o=";
+  };
+
+  propagatedBuildInputs = [
+    colorama
+  ];
+
+  pythonImportsCheck = [ "migen" ];
+
+  meta = with lib; {
+    description = " A Python toolbox for building complex digital hardware";
+    homepage = "https://m-labs.hk/migen";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ l-as ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4524,6 +4524,8 @@ in {
 
   mido = callPackage ../development/python-modules/mido { };
 
+  migen = callPackage ../development/python-modules/migen { };
+
   milc = callPackage ../development/python-modules/milc { };
 
   milksnake = callPackage ../development/python-modules/milksnake { };


### PR DESCRIPTION
###### Motivation for this change

It's FPGA tooling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
