### PR TITLE
 nixos/unifi + nixos/gpsd: fix after #133166 

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -529,7 +529,7 @@ in
       #ntp = 179; # unused
       zabbix = 180;
       #redis = 181; # unused, removed 2018-01-03
-      #unifi = 183; # unused
+      unifi = 183; # unused
       #uptimed = 184; # unused
       #zope2 = 185; # unused
       #ripple-data-api = 186; #unused

--- a/nixos/modules/services/misc/gpsd.nix
+++ b/nixos/modules/services/misc/gpsd.nix
@@ -90,6 +90,7 @@ in
       { inherit uid;
         description = "gpsd daemon user";
         home = "/var/empty";
+        group = "gpsd";
       };
 
     users.groups.gpsd = { inherit gid; };

--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -116,8 +116,12 @@ in
 
     users.users.unifi = {
       uid = config.ids.uids.unifi;
+      group = "unifi";
       description = "UniFi controller daemon user";
       home = "${stateDir}";
+    };
+    users.groups.unifi = {
+      gid = config.ids.gids.unifi;
     };
 
     networking.firewall = mkIf cfg.openPorts {


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
