### PR TITLE
xorg.xf86*: fix include dir

### DIFF
--- a/pkgs/desktops/lxqt/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-config/default.nix
@@ -51,10 +51,6 @@ mkDerivation rec {
     xorg.xf86inputlibinput.dev
   ];
 
-  postPatch = ''
-    sed -i "/\''${XORG_LIBINPUT_INCLUDE_DIRS}/a ${xorg.xf86inputlibinput.dev}/include/xorg" lxqt-config-input/CMakeLists.txt
-  '';
-
   passthru.updateScript = lxqtUpdateScript { inherit pname version src; };
 
   meta = with lib; {

--- a/pkgs/desktops/plasma-5/plasma-desktop/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-desktop/default.nix
@@ -40,13 +40,7 @@ mkDerivation {
     sed '1i#include <cmath>' -i kcms/touchpad/backends/x11/synapticstouchpad.cpp
   '';
   CXXFLAGS = [
-    "-I${lib.getDev xorgserver}/include/xorg"
-    "-I${lib.getDev xf86inputsynaptics}/include/xorg"
     ''-DNIXPKGS_HWCLOCK=\"${lib.getBin util-linux}/sbin/hwclock\"''
-  ];
-  cmakeFlags = [
-    "-DEvdev_INCLUDE_DIRS=${lib.getDev xf86inputevdev}/include/xorg"
-    "-DXORGLIBINPUT_INCLUDE_DIRS=${lib.getDev xf86inputlibinput}/include/xorg"
   ];
   postInstall = ''
     # Display ~/Desktop contents on the desktop by default.

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -367,35 +367,35 @@ self: super:
   xf86inputevdev = super.xf86inputevdev.overrideAttrs (attrs: {
     outputs = [ "out" "dev" ]; # to get rid of xorgserver.dev; man is tiny
     preBuild = "sed -e '/motion_history_proc/d; /history_size/d;' -i src/*.c";
-    installFlags = [
-      "sdkdir=${placeholder "out"}/include/xorg"
+    configureFlags = [
+      "--with-sdkdir=${placeholder "dev"}/include/xorg"
     ];
   });
 
   xf86inputmouse = super.xf86inputmouse.overrideAttrs (attrs: {
-    installFlags = [
-      "sdkdir=${placeholder "out"}/include/xorg"
+    configureFlags = [
+      "--with-sdkdir=${placeholder "out"}/include/xorg"
     ];
   });
 
   xf86inputjoystick = super.xf86inputjoystick.overrideAttrs (attrs: {
-    installFlags = [
-      "sdkdir=${placeholder "out"}/include/xorg"
+    configureFlags = [
+      "--with-sdkdir=${placeholder "out"}/include/xorg"
     ];
   });
 
   xf86inputlibinput = super.xf86inputlibinput.overrideAttrs (attrs: {
     outputs = [ "out" "dev" ];
-    installFlags = [
-      "sdkdir=${placeholder "dev"}/include/xorg"
+    configureFlags = [
+      "--with-sdkdir=${placeholder "dev"}/include/xorg"
     ];
   });
 
   xf86inputsynaptics = super.xf86inputsynaptics.overrideAttrs (attrs: {
     outputs = [ "out" "dev" ]; # *.pc pulls xorgserver.dev
-    installFlags = [
-      "sdkdir=${placeholder "out"}/include/xorg"
-      "configdir=${placeholder "out"}/share/X11/xorg.conf.d"
+    configureFlags = [
+      "--with-sdkdir=${placeholder "dev"}/include/xorg"
+      "--with-xorg-conf-dir=${placeholder "out"}/share/X11/xorg.conf.d"
     ];
   });
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`installFlags` do not work since .pc files are generated during configure phase. We need to override them with configure flags.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
12 packages updated:
lxqt-config pa-applet-unstable plasma-desktop plasma-desktop plasma-desktop plasma-desktop xf86-input-evdev xf86-input-joystick xf86-input-libinput xf86-input-mouse xf86-input-synaptics xfce4-settings

2 packages marked as broken and skipped:
libsForQt512.plasma-desktop libsForQt514.plasma-desktop

9 packages built:
plasma-desktop lxqt.lxqt-config pa_applet xfce.xfce4-settings xorg.xf86inputevdev xorg.xf86inputjoystick xorg.xf86inputlibinput xorg.xf86inputmouse xorg.xf86inputsynaptics
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
