### PR TITLE
Allow overriding fetchFromGitLab protocol.

### DIFF
--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -1,7 +1,7 @@
 { fetchgit, fetchzip, lib }:
 
 # gitlab example
-{ owner, repo, rev, domain ? "gitlab.com", name ? "source", group ? null
+{ owner, repo, rev, protocol ? "https", domain ? "gitlab.com", name ? "source", group ? null
 , fetchSubmodules ? false, leaveDotGit ? false, deepClone ? false
 , ... # For hash agility
 } @ args:
@@ -17,10 +17,10 @@ let
 
   fetcherArgs = (if useFetchGit then {
     inherit rev deepClone fetchSubmodules leaveDotGit;
-    url = "https://${domain}/${slug}.git";
+    url = "${protocol}://${domain}/${slug}.git";
   } else {
-    url = "https://${domain}/api/v4/projects/${escapedSlug}/repository/archive.tar.gz?sha=${escapedRev}";
+    url = "${protocol}://${domain}/api/v4/projects/${escapedSlug}/repository/archive.tar.gz?sha=${escapedRev}";
   }) // passthruAttrs // { inherit name; };
 in
 
-fetcher fetcherArgs // { meta.homepage = "https://${domain}/${slug}/"; inherit rev; }
+fetcher fetcherArgs // { meta.homepage = "${protocol}://${domain}/${slug}/"; inherit rev; }


### PR DESCRIPTION
###### Motivation for this change

This simple change will be a no-op for all existing usages of `fetchFromGitLab`, but allows the caller to override the protocol from the default `https` back to `http` if required.

Needed for testing scenarios and usage against small non-public GitLab instances where HTTPS termination has not been set up.


###### Things done

I picked the first GitLab-using package that came up in the search, mutated the hash, and rebuilt the src, demonstrating no issues introduced by this change:

```
$ nix build ~/nixpkgs#pleroma.src
error: hash mismatch in fixed-output derivation '/nix/store/0rbf0i40fibs8hjffl3bjj0a8p2jnw53-source.drv':
         specified: sha256-1za/qVk2K3q8AtkfXab0MBAHaQnY5enVtfdu64FFPhg=
            got:    sha256-1zp/qVk2K3q8AtkfXab0MBAHaQnY5enVtfdu64FFPhg=
```
