### PR TITLE
swtpm: ensure tests run

### DIFF
--- a/pkgs/tools/security/swtpm/default.nix
+++ b/pkgs/tools/security/swtpm/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchFromGitHub, fetchpatch
+, fetchFromGitHub
 , autoreconfHook
 , pkg-config
 , libtasn1, openssl, fuse, glib, libseccomp, json-glib
@@ -8,6 +8,9 @@
 , unixtools, expect, socat
 , gnutls
 , perl
+
+# Tests
+, python3, which
 }:
 
 stdenv.mkDerivation rec {
@@ -21,17 +24,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-7YzdwGAGECj7PhaCOf/dLSILPXqtbylCkN79vuFBw5Y=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/stefanberger/swtpm/pull/527.patch";
-      sha256 = "sha256-cpKHP15a27ifmmswSgHoNzGPO6TY/ZuJIfM5xLOlqlU=";
-    })
-  ];
+  postPatch = ''
+    patchShebangs tests/*
+  '';
 
   nativeBuildInputs = [
     pkg-config unixtools.netstat expect socat
     perl # for pod2man
     autoreconfHook
+  ];
+  checkInputs = [
+    python3 which
   ];
   buildInputs = [
     libtpms
@@ -57,6 +60,7 @@ stdenv.mkDerivation rec {
         '# define CERTTOOL_NAME "${gnutls}/bin/certtool"'
   '';
 
+  doCheck = true;
   enableParallelBuilding = true;
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
###### Motivation for this change

Previously tests were not running.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
