### PR TITLE
cvise: use /bin.bash from nix store

### DIFF
--- a/pkgs/development/tools/misc/cvise/default.nix
+++ b/pkgs/development/tools/misc/cvise/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonApplication, fetchFromGitHub, cmake, flex
+{ lib, buildPythonApplication, fetchFromGitHub, bash, cmake, flex
 , libclang, llvm, unifdef
 , pebble, psutil, pytestCheckHook, pytest-flake8
 }:
@@ -20,9 +20,15 @@ buildPythonApplication rec {
   ];
 
   nativeBuildInputs = [ cmake flex llvm.dev ];
-  buildInputs = [ libclang llvm llvm.dev unifdef ];
+  buildInputs = [ bash libclang llvm llvm.dev unifdef ];
   propagatedBuildInputs = [ pebble psutil ];
   checkInputs = [ pytestCheckHook pytest-flake8 unifdef ];
+
+  # 'cvise --command=...' generates a script with hardcoded shebang.
+  postPatch = ''
+    substituteInPlace cvise.py \
+      --replace "#!/bin/bash" "#!${bash}/bin/bash"
+  '';
 
   preCheck = ''
     patchShebangs cvise.py


### PR DESCRIPTION
Noticed failures as an incorrect handling of `--command` param:

    $ cvise --command="gcc -c bug.c |& fgrep 'during RTL pass: expand'" bug.c
    C-Vise cannot run because the interestingness test does not return
    zero.

This happens because temporary shell script has "#!/bin/bash" shebang.

The change replaces it to path from nix store.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
