### PR TITLE
varnish6/7: updates

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1002,8 +1002,8 @@ Superuser created successfully.
       <listitem>
         <para>
           The <literal>varnish</literal> package was upgraded from 6.3.x
-          to 6.5.x. <literal>varnish60</literal> for the last LTS
-          release is also still available.
+          to 7.x. <literal>varnish60</literal> for the last LTS release
+          is also still available.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -310,7 +310,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   configures the address and port the web UI is listening, it defaults to `:9001`.
   To be able to access the web UI this port needs to be opened in the firewall.
 
-- The `varnish` package was upgraded from 6.3.x to 6.5.x. `varnish60` for the last LTS release is also still available.
+- The `varnish` package was upgraded from 6.3.x to 7.x. `varnish60` for the last LTS release is also still available.
 
 - The `kubernetes` package was upgraded to 1.22. The `kubernetes.apiserver.kubeletHttps` option was removed and HTTPS is always used.
 

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -50,10 +50,6 @@ in
     version = "6.0.8";
     sha256 = "1zk83hfxgjq1d0n4zx86q3f05y9f2zc6a1miz1zcvfa052q4bljx";
   };
-  varnish65 = common {
-    version = "6.5.2";
-    sha256 = "041gc22h8cwsb8jw7zdv6yk5h8xg2q0g655m5zhi5jxq35f2sljx";
-  };
   varnish70 = common {
     version = "7.0.0";
     sha256 = "11z0pa618lh925ih67wmp1gqk7i46l486j4spjy71g1n3w5mqylc";

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pcre, pcre2, libxslt, groff, ncurses, pkg-config, readline, libedit, coreutils
+{ lib, stdenv, fetchurl, fetchpatch, pcre, pcre2, libxslt, groff, ncurses, pkg-config, readline, libedit, coreutils
 , python3, makeWrapper }:
 
 let
@@ -50,8 +50,15 @@ in
     version = "6.0.8";
     sha256 = "1zk83hfxgjq1d0n4zx86q3f05y9f2zc6a1miz1zcvfa052q4bljx";
   };
-  varnish70 = common {
+  varnish70 = (common {
     version = "7.0.0";
     sha256 = "11z0pa618lh925ih67wmp1gqk7i46l486j4spjy71g1n3w5mqylc";
-  };
+  }).overrideAttrs (oA: {
+    patches = [
+      (fetchpatch {
+        url = "https://github.com/varnishcache/varnish-cache/commit/20e007a5b17c1f68f70ab42080de384f9e192900.patch";
+        sha256 = "0vvihbjknb0skdv2ksn2lz89pwmn4f2rjmb6q65cvgnnjfj46s82";
+      })
+    ];
+  });
 }

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pcre, libxslt, groff, ncurses, pkg-config, readline, libedit, coreutils
+{ lib, stdenv, fetchurl, pcre, pcre2, libxslt, groff, ncurses, pkg-config, readline, libedit, coreutils
 , python3, makeWrapper }:
 
 let
@@ -16,8 +16,10 @@ let
 
       nativeBuildInputs = with python3.pkgs; [ pkg-config docutils sphinx ];
       buildInputs = [
-        pcre libxslt groff ncurses readline libedit makeWrapper python3
-      ];
+        libxslt groff ncurses readline libedit makeWrapper python3
+      ]
+      ++ lib.optional (lib.versionOlder version "7") pcre
+      ++ lib.optional (lib.versionAtLeast version "7") pcre2;
 
       buildFlags = [ "localstatedir=/var/spool" ];
 
@@ -51,5 +53,9 @@ in
   varnish65 = common {
     version = "6.5.2";
     sha256 = "041gc22h8cwsb8jw7zdv6yk5h8xg2q0g655m5zhi5jxq35f2sljx";
+  };
+  varnish70 = common {
+    version = "7.0.0";
+    sha256 = "11z0pa618lh925ih67wmp1gqk7i46l486j4spjy71g1n3w5mqylc";
   };
 }

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -47,8 +47,8 @@ let
 in
 {
   varnish60 = common {
-    version = "6.0.7";
-    sha256 = "0njs6xpc30nc4chjdm4d4g63bigbxhi4dc46f4az3qcz51r8zl2a";
+    version = "6.0.8";
+    sha256 = "1zk83hfxgjq1d0n4zx86q3f05y9f2zc6a1miz1zcvfa052q4bljx";
   };
   varnish65 = common {
     version = "6.5.2";

--- a/pkgs/servers/varnish/packages.nix
+++ b/pkgs/servers/varnish/packages.nix
@@ -1,4 +1,4 @@
-{ callPackage, varnish60, varnish65, varnish70, fetchFromGitHub }: {
+{ callPackage, varnish60, varnish70, fetchFromGitHub }: {
   varnish60Packages = rec {
     varnish = varnish60;
     digest  = callPackage ./digest.nix {
@@ -10,19 +10,6 @@
       inherit varnish;
       version = "0.4";
       sha256 = "1n94slrm6vn3hpymfkla03gw9603jajclg84bjhwb8kxsk3rxpmk";
-    };
-  };
-  varnish65Packages = rec {
-    varnish = varnish65;
-    digest  = callPackage ./digest.nix {
-      inherit varnish;
-      version = "6.6";
-      sha256 = "0n33g8ml4bsyvcvl5lk7yng1ikvmcv8dd6bc1mv2lj4729pp97nn";
-    };
-    dynamic = callPackage ./dynamic.nix  {
-      inherit varnish;
-      version = "2.3.1";
-      sha256 = "060vkba7jwcvx5704hh6ds0g0kfzpkdrg8548frvkrkz2s5j9y88";
     };
   };
   varnish70Packages = rec {

--- a/pkgs/servers/varnish/packages.nix
+++ b/pkgs/servers/varnish/packages.nix
@@ -1,4 +1,4 @@
-{ callPackage, varnish60, varnish65, fetchFromGitHub }: {
+{ callPackage, varnish60, varnish65, varnish70, fetchFromGitHub }: {
   varnish60Packages = rec {
     varnish = varnish60;
     digest  = callPackage ./digest.nix {
@@ -23,6 +23,19 @@
       inherit varnish;
       version = "2.3.1";
       sha256 = "060vkba7jwcvx5704hh6ds0g0kfzpkdrg8548frvkrkz2s5j9y88";
+    };
+  };
+  varnish70Packages = rec {
+    varnish = varnish70;
+    digest  = callPackage ./digest.nix {
+      inherit varnish;
+      version = "6.6";
+      sha256 = "0n33g8ml4bsyvcvl5lk7yng1ikvmcv8dd6bc1mv2lj4729pp97nn";
+    };
+    dynamic = callPackage ./dynamic.nix  {
+      inherit varnish;
+      version = "2.4.0";
+      sha256 = "1g53zblyxi1jivwppmpdqhi5xnzapsfib453sxyqbc5dfs7fijxr";
     };
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -969,6 +969,7 @@ mapAliases ({
   vamp = { vampSDK = vamp-plugin-sdk; }; # added 2020-03-26
   varnish62 = throw "varnish62 was removed from nixpkgs, because it is unmaintained upstream. Please switch to a different release."; # 2021-07-26
   varnish63 = throw "varnish63 was removed from nixpkgs, because it is unmaintained upstream. Please switch to a different release."; # 2021-07-26
+  varnish65 = throw "varnish65 was removed from nixpkgs, because it is unmaintained upstream. Please switch to a different release."; # 2021-09-15
   venus = throw "venus has been removed from nixpkgs, as it's unmaintained"; # added 2021-02-05
   vdirsyncerStable  = vdirsyncer; # added 2020-11-08, see https://github.com/NixOS/nixpkgs/issues/103026#issuecomment-723428168
   vimbWrapper = vimb; # added 2015-01

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10406,9 +10406,9 @@ with pkgs;
   valum = callPackage ../development/web/valum { };
 
   inherit (callPackages ../servers/varnish { })
-    varnish60 varnish65;
+    varnish60 varnish65 varnish70;
   inherit (callPackages ../servers/varnish/packages.nix { })
-    varnish60Packages varnish65Packages;
+    varnish60Packages varnish65Packages varnish70Packages;
 
   varnishPackages = varnish65Packages;
   varnish = varnishPackages.varnish;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10406,11 +10406,11 @@ with pkgs;
   valum = callPackage ../development/web/valum { };
 
   inherit (callPackages ../servers/varnish { })
-    varnish60 varnish65 varnish70;
+    varnish60 varnish70;
   inherit (callPackages ../servers/varnish/packages.nix { })
-    varnish60Packages varnish65Packages varnish70Packages;
+    varnish60Packages varnish70Packages;
 
-  varnishPackages = varnish65Packages;
+  varnishPackages = varnish70Packages;
   varnish = varnishPackages.varnish;
 
   hitch = callPackage ../servers/hitch { };


### PR DESCRIPTION
###### Motivation for this change
Upstream releases

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
