### PR TITLE
quantum-espresso,postgresql11Packages.pg_ed25519: switch to fetchFromGitlab

### DIFF
--- a/pkgs/applications/science/chemistry/quantum-espresso/default.nix
+++ b/pkgs/applications/science/chemistry/quantum-espresso/default.nix
@@ -1,5 +1,10 @@
-{ lib, stdenv, fetchurl
-, gfortran, fftw, blas, lapack
+{ lib
+, stdenv
+, fetchFromGitLab
+, gfortran
+, fftw
+, blas
+, lapack
 , useMpi ? false
 , mpi
 }:
@@ -8,9 +13,11 @@ stdenv.mkDerivation rec {
   version = "6.6";
   pname = "quantum-espresso";
 
-  src = fetchurl {
-    url = "https://gitlab.com/QEF/q-e/-/archive/qe-${version}/q-e-qe-${version}.tar.gz";
-    sha256 = "0b3718bwdqfyssyz25jknijar79qh5cf1bbizv9faliz135mcilj";
+  src = fetchFromGitLab {
+    owner = "QEF";
+    repo = "q-e";
+    rev = "qe-${version}";
+    sha256 = "1mkfmw0fq1dabplzdn6v1abhw0ds55gzlvbx3a9brv493whk21yp";
   };
 
   passthru = {
@@ -24,18 +31,18 @@ stdenv.mkDerivation rec {
   buildInputs = [ fftw blas lapack gfortran ]
     ++ (lib.optionals useMpi [ mpi ]);
 
-configureFlags = if useMpi then [ "LD=${mpi}/bin/mpif90" ] else [ "LD=${gfortran}/bin/gfortran" ];
+  configureFlags = if useMpi then [ "LD=${mpi}/bin/mpif90" ] else [ "LD=${gfortran}/bin/gfortran" ];
 
   makeFlags = [ "all" ];
 
   meta = with lib; {
     description = "Electronic-structure calculations and materials modeling at the nanoscale";
     longDescription = ''
-        Quantum ESPRESSO is an integrated suite of Open-Source computer codes for
-        electronic-structure calculations and materials modeling at the
-        nanoscale. It is based on density-functional theory, plane waves, and
-        pseudopotentials.
-      '';
+      Quantum ESPRESSO is an integrated suite of Open-Source computer codes for
+      electronic-structure calculations and materials modeling at the
+      nanoscale. It is based on density-functional theory, plane waves, and
+      pseudopotentials.
+    '';
     homepage = "https://www.quantum-espresso.org/";
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
@@ -1,12 +1,13 @@
-{ lib, stdenv, fetchurl, postgresql }:
+{ lib, stdenv, fetchFromGitLab, postgresql }:
 
 stdenv.mkDerivation rec {
   pname = "pg_ed25519";
   version = "0.2";
-
-  src = fetchurl {
-    url = "https://gitlab.com/dwagin/${pname}/-/archive/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "0q46pvk1vq5w3al6i3inzlw6w7za3n7p1gd4wfbbxzvzh7qnynda";
+  src = fetchFromGitLab {
+    owner = "dwagin";
+    repo = "pg_ed25519";
+    rev = version;
+    sha256 = "16w3qx3wj81bzfhydl2pjhn8b1jak6h7ja9wq1kc626g0siggqi0";
   };
 
   buildInputs = [ postgresql ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
