### PR TITLE
bash-preexec: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4287,6 +4287,12 @@
     githubId = 731722;
     name = "Ryan Scheel";
   };
+  hawkw = {
+    email = "eliza@elizas.website";
+    github = "hawkw";
+    githubId = 2796466;
+    name = "Eliza Weisman";
+  };
   hax404 = {
     email = "hax404foogit@hax404.de";
     github = "hax404";

--- a/pkgs/development/libraries/bash/bash-preexec/default.nix
+++ b/pkgs/development/libraries/bash/bash-preexec/default.nix
@@ -1,0 +1,41 @@
+{ stdenvNoCC, lib, fetchFromGitHub, bats }:
+
+let version = "0.4.1";
+in stdenvNoCC.mkDerivation {
+  pname = "bash-preexec";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "rcaloras";
+    repo = "bash-preexec";
+    rev = version;
+    sha256 = "062iigps285628p710i7vh7kmgra5gahq9qiwj7rxir167lg0ggw";
+  };
+
+  checkInputs = [ bats ];
+
+  dontConfigure = true;
+  doCheck = true;
+  dontBuild = true;
+
+  patchPhase = ''
+    # Needed since the tests expect that HISTCONTROL is set.
+    sed -i '/setup()/a HISTCONTROL=""' test/bash-preexec.bats
+  '';
+
+  checkPhase = ''
+    bats test
+  '';
+
+  installPhase = ''
+    install -Dm755 $src/bash-preexec.sh $out/share/bash/bash-preexec.sh
+  '';
+
+  meta = with lib; {
+    description = "preexec and precmd functions for Bash just like Zsh";
+    license = licenses.mit;
+    homepage = "https://github.com/rcaloras/bash-preexec";
+    maintainers = [ maintainers.hawkw maintainers.rycee ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19581,6 +19581,10 @@ with pkgs;
   };
   agda = agdaPackages.agda;
 
+  ### DEVELOPMENT / LIBRARIES / BASH
+
+  bash-preexec = callPackage ../development/libraries/bash/bash-preexec { };
+
   ### DEVELOPMENT / LIBRARIES / JAVA
 
   commonsBcel = callPackage ../development/libraries/java/commons/bcel { };


### PR DESCRIPTION
###### Motivation for this change

Packages the bash-preexec Bash library. Based on @hawkw's package in https://github.com/nix-community/home-manager/pull/2260.

@hawkw: If you would like to be maintainer of this package let me know. I'm already a bit swamped but I'm OK with being marked as maintainer since I imagine this package won't need a lot of work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
