### PR TITLE
octopus: add CPU optimization flags

### DIFF
--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -1,6 +1,10 @@
 { lib, stdenv, fetchFromGitLab, gfortran, perl, procps
 , libyaml, libxc, fftw, blas, lapack, gsl, netcdf, arpack, autoreconfHook
 , python3
+, enableFma ? stdenv.hostPlatform.fmaSupport
+, enableFma4 ? stdenv.hostPlatform.fma4Support
+, enableAvx ? stdenv.hostPlatform.avx2Support
+, enableAvx512 ? stdenv.hostPlatform.avx512Support
 }:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
@@ -35,14 +39,18 @@ stdenv.mkDerivation rec {
     (python3.withPackages (ps: [ ps.pyyaml ]))
   ];
 
-  configureFlags = [
+  configureFlags = with lib; [
     "--with-yaml-prefix=${libyaml}"
     "--with-blas=-lblas"
     "--with-lapack=-llapack"
     "--with-fftw-prefix=${fftw.dev}"
     "--with-gsl-prefix=${gsl}"
     "--with-libxc-prefix=${libxc}"
-  ];
+    "--enable-openmp"
+  ] ++ optional enableFma "--enable-fma3"
+    ++ optional enableFma4 "--enable-fma4"
+    ++ optional enableAvx "--enable-avx"
+    ++ optional enableAvx512 "--enable-avx512";
 
   doCheck = false;
   checkTarget = "check-short";


### PR DESCRIPTION
###### Motivation for this change
Add some optional to `enable*` flags to make use of AVX-type CPU optimizations offered by the configure scripts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
