### PR TITLE
pyscf: backport of h5py fixes

### DIFF
--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -13,6 +13,10 @@ buildPythonPackage rec {
     sha256  = "0xbwkjxxysfpqz72qn6n4a0zr2h6sprbcal8j7kzymh7swjy117w";
   };
 
+  # Backport from the 2.0.0 alpha releases of PySCF.
+  # H5Py > 3.3 deprecates the file modes, that PySCF sets.
+  patches = [ ./h5py.patch ];
+
   buildInputs = [
     libcint
     libxc

--- a/pkgs/development/python-modules/pyscf/h5py.patch
+++ b/pkgs/development/python-modules/pyscf/h5py.patch
@@ -1,0 +1,13 @@
+diff --git a/pyscf/lib/misc.py b/pyscf/lib/misc.py
+index ed43689ff..a8a0d0e20 100644
+--- a/pyscf/lib/misc.py
++++ b/pyscf/lib/misc.py
+@@ -42,8 +42,6 @@ if h5py.version.version[:4] == '2.2.':
+     sys.stderr.write('h5py-%s is found in your environment. '
+                      'h5py-%s has bug in threading mode.\n'
+                      'Async-IO is disabled.\n' % ((h5py.version.version,)*2))
+-if h5py.version.version[:2] == '3.':
+-    h5py.get_config().default_file_mode = 'a'
+ 
+ c_double_p = ctypes.POINTER(ctypes.c_double)
+ c_int_p = ctypes.POINTER(ctypes.c_int)


### PR DESCRIPTION
###### Motivation for this change
Backport of h5py fixes, which make the latest stable PySCF and h5py releases compatible.

Closes #138127 


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
