### PR TITLE
chonburi-font: init at unstable-2021-09-15

### DIFF
--- a/pkgs/data/fonts/chonburi/default.nix
+++ b/pkgs/data/fonts/chonburi/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "chonburi";
+  version = "unstable-2021-09-15";
+
+  src = fetchFromGitHub {
+    owner = "cadsondemak";
+    repo = pname;
+    rev = "daf26bf77d82fba50eaa3aa3fad905cb9f6b5e28";
+    sha256 = "sha256-oC7ZCfNOyvGtqT9+Ap/CfCHzdWNzeCuac2dJ9fctgB8=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/doc/chonburi $out/share/fonts/{opentype,truetype}
+
+    cp $src/OFL.txt $src/BRIEF.md $out/share/doc/chonburi
+    cp $src/fonts/*.otf $out/share/fonts/opentype
+    cp $src/fonts/*.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://cadsondemak.github.io/chonburi/";
+    description = "A Didonic Thai and Latin display typeface";
+    longDescription = ''
+      The objective of this project is to create a Thai and Latin Display
+      typeface. Chonburi is a display typeface with high contrast in a Didone
+      style. This single-weight typeface provides advance typographical support
+      with features such as discretionary ligature. This font can be extended
+      the family to other weights including both narrow and extended version. It
+      is also ready to be matched with other non-Latin script.
+    '';
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.toastal ];
+  };
+}

--- a/pkgs/data/fonts/kanit/default.nix
+++ b/pkgs/data/fonts/kanit/default.nix
@@ -12,12 +12,16 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/share/doc/${pname}/css/ $out/share/fonts/{opentype,truetype}
+    runHook preInstall
 
-    cp $src/OFL.txt $src/documentation/{BRIEF.md,features.html} $out/share/doc/${pname}
-    cp $src/documentation/css/fonts.css $out/share/doc/${pname}/css
+    mkdir -p $out/share/doc/kanit/css/ $out/share/fonts/{opentype,truetype}
+
+    cp $src/OFL.txt $src/documentation/{BRIEF.md,features.html} $out/share/doc/kanit
+    cp $src/documentation/css/fonts.css $out/share/doc/kanit/css
     cp $src/fonts/otf/*.otf $out/share/fonts/opentype
     cp $src/fonts/ttf/*.ttf $out/share/fonts/truetype
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22313,6 +22313,8 @@ with pkgs;
 
   cherry = callPackage ../data/fonts/cherry { inherit (xorg) fonttosfnt mkfontdir; };
 
+  chonburi-font = callPackage ../data/fonts/chonburi { };
+
   cldr-emoji-annotation = callPackage ../data/misc/cldr-emoji-annotation { };
 
   clearlooks-phenix = callPackage ../data/themes/clearlooks-phenix { };


### PR DESCRIPTION
OFL font: https://github.com/cadsondemak/chonburi

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Another free font, like `kanit-font`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
