### PR TITLE
nixpkgs/manual: add mvapich to overlays/mpi section

### DIFF
--- a/doc/using/overlays.chapter.md
+++ b/doc/using/overlays.chapter.md
@@ -138,6 +138,8 @@ All programs that are built with [MPI](https://en.wikipedia.org/wiki/Message_Pas
 
 -   [MPICH](https://www.mpich.org/), attribute name `mpich`
 
+-   [MVAPICH](https://mvapich.cse.ohio-state.edu/), attribute name `mvapich`
+
 To provide MPI enabled applications that use `MPICH`, instead of the default `Open MPI`, simply use the following overlay:
 
 ```nix


### PR DESCRIPTION
###### Motivation for this change
Since https://github.com/NixOS/nixpkgs/pull/125267, we also MVAPICH available. This PR simply puts it in the list of alterantives in the manual.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
