### PR TITLE
grafana-agent: backport version bumps

### DIFF
--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.18.0";
+  version = "0.18.1";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "agent";
-    sha256 = "sha256-FUAaM4jYjyYeu5TX5I8icuzjGv80ZzZPWSsNwE5w84U=";
+    sha256 = "sha256-sKD9ulA6iaaI5yMja0ohDlXDNH4jZzyJWlXdvJo3Q2g=";
   };
 
-  vendorSha256 = "sha256-xQNsRL0hFuJ/gm1K/1IpzAGIqpyN2CF1EeX/cEfcBBM=";
+  vendorSha256 = "sha256-MZGOZB/mS3pmZuI35E/QkaNLLhbuW2DfZiih9OCXMj0=";
 
   patches = [
     # https://github.com/grafana/agent/issues/731

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.17.0";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "agent";
-    sha256 = "sha256-rHJGVQWbvgcvwPzt8e2uWs1n4bbaAZz6lQjyvmqmLZw=";
+    sha256 = "sha256-FUAaM4jYjyYeu5TX5I8icuzjGv80ZzZPWSsNwE5w84U=";
   };
 
-  vendorSha256 = "sha256-jA8M8ZdJWmrGRQb0W1duVV+XwxqJVQ/ek0Yhw6JZvX8=";
+  vendorSha256 = "sha256-xQNsRL0hFuJ/gm1K/1IpzAGIqpyN2CF1EeX/cEfcBBM=";
 
   patches = [
     # https://github.com/grafana/agent/issues/731

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.18.1";
+  version = "0.18.2";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "agent";
-    sha256 = "sha256-sKD9ulA6iaaI5yMja0ohDlXDNH4jZzyJWlXdvJo3Q2g=";
+    sha256 = "sha256-yTCFMnOSRgMqL9KD26cYeJcQ1rrUBOf8I+i7IPExP9I=";
   };
 
   vendorSha256 = "sha256-MZGOZB/mS3pmZuI35E/QkaNLLhbuW2DfZiih9OCXMj0=";

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.18.2";
+  version = "0.18.4";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "agent";
-    sha256 = "sha256-yTCFMnOSRgMqL9KD26cYeJcQ1rrUBOf8I+i7IPExP9I=";
+    sha256 = "sha256-NlktNBVljMgcivB0N/X3aAEJyZK2GyDD7o86qx/5YmQ=";
   };
 
   vendorSha256 = "sha256-MZGOZB/mS3pmZuI35E/QkaNLLhbuW2DfZiih9OCXMj0=";

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.13.1";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "agent";
-    sha256 = "sha256-ySdBHlUSGIyhMwInoFT90mm+HfAkO/60wBPACQgxDAM=";
+    sha256 = "sha256-mRDd9G/VMbDwp/GYPoUE0v9j+BmUd08wOMJjgcg2qdo=";
   };
 
-  vendorSha256 = null;
+  vendorSha256 = "sha256-sQFWdBOjfYb1e7ZzHGgtgnuEQCU4xnkJTyzC/9DRcYs=";
 
   # uses go-systemd, which uses libsystemd headers
   # https://github.com/coreos/go-systemd/issues/351

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,16 +2,21 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.15.0";
+  version = "0.16.1";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "agent";
-    sha256 = "sha256-mRDd9G/VMbDwp/GYPoUE0v9j+BmUd08wOMJjgcg2qdo=";
+    sha256 = "0kqbn6fqlrxjqdkkhbr7qmm2m05a7dlskfdb7y4gr5ggi65m6ik5";
   };
 
-  vendorSha256 = "sha256-sQFWdBOjfYb1e7ZzHGgtgnuEQCU4xnkJTyzC/9DRcYs=";
+  vendorSha256 = "0xi69a1zkcmi5q8m7lfwp3xb4cbkwc2dzqm24lfqsq13xj5jq6ph";
+
+  patches = [
+    # https://github.com/grafana/agent/issues/731
+    ./skip_test_requiring_network.patch
+  ];
 
   # uses go-systemd, which uses libsystemd headers
   # https://github.com/coreos/go-systemd/issues/351

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "grafana-agent";
-  version = "0.16.1";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "agent";
-    sha256 = "0kqbn6fqlrxjqdkkhbr7qmm2m05a7dlskfdb7y4gr5ggi65m6ik5";
+    sha256 = "sha256-rHJGVQWbvgcvwPzt8e2uWs1n4bbaAZz6lQjyvmqmLZw=";
   };
 
-  vendorSha256 = "0xi69a1zkcmi5q8m7lfwp3xb4cbkwc2dzqm24lfqsq13xj5jq6ph";
+  vendorSha256 = "sha256-jA8M8ZdJWmrGRQb0W1duVV+XwxqJVQ/ek0Yhw6JZvX8=";
 
   patches = [
     # https://github.com/grafana/agent/issues/731

--- a/pkgs/servers/monitoring/grafana-agent/skip_test_requiring_network.patch
+++ b/pkgs/servers/monitoring/grafana-agent/skip_test_requiring_network.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/operator/selector_eventhandler_test.go b/pkg/operator/selector_eventhandler_test.go
+index 7b6ec602..e79bae0e 100644
+--- a/pkg/operator/selector_eventhandler_test.go
++++ b/pkg/operator/selector_eventhandler_test.go
+@@ -39,6 +39,10 @@ var (
+ // TestEnqueueRequestForSelector creates an example Kubenretes cluster and runs
+ // EnqueueRequestForSelector to validate it works.
+ func TestEnqueueRequestForSelector(t *testing.T) {
++	// Requires network access, which is not available during
++	// the nixpkgs sandboxed build
++	t.Skip()
++
+ 	l := log.NewNopLogger()
+ 
+ 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)


### PR DESCRIPTION
###### Motivation for this change

Backport the recent version bumps to 21.05.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
