### PR TITLE
vscode: bundled ripgrep fixed

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -121,6 +121,9 @@ let
         --replace "/usr/bin/pkexec" "/run/wrappers/bin/pkexec" \
         --replace "/bin/bash" "${bash}/bin/bash"
       rm -rf "$packed"
+
+      # this fixes bundled ripgrep
+      chmod +x resources/app/node_modules/vscode-ripgrep/bin/rg
     '';
 
     inherit meta;


### PR DESCRIPTION
This is a followup for https://github.com/NixOS/nixpkgs/pull/137912

This P/R just sets +x attribute on bundled ripgrep