### PR TITLE
amber: init at 0.1.1

### DIFF
--- a/pkgs/tools/security/amber/default.nix
+++ b/pkgs/tools/security/amber/default.nix
@@ -1,0 +1,24 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  # Renaming it to amber-secret because another package named amber exists
+  pname = "amber-secret";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "fpco";
+    repo = "amber";
+    rev = "v${version}";
+    sha256 = "1l5c7vdi885z56nqqbm4sw9hvqk3rfzm0mgcwk5cbwjlrz7yjq4m";
+  };
+
+  cargoSha256 = "0dmhlyrw6yd7p80v7anz5nrd28bcrhq27vzy605dinddvncjn13q";
+
+  meta = with lib; {
+    description = "Manage secret values in-repo via public key cryptography";
+    homepage = "https://github.com/fpco/amber";
+    license = licenses.mit;
+    maintainers = with maintainers; [ psibi ];
+    mainProgram = "amber";
+  };
+}

--- a/pkgs/tools/security/amber/default.nix
+++ b/pkgs/tools/security/amber/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub, Security }:
 
 rustPlatform.buildRustPackage rec {
   # Renaming it to amber-secret because another package named amber exists
@@ -13,6 +13,8 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "0dmhlyrw6yd7p80v7anz5nrd28bcrhq27vzy605dinddvncjn13q";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 
   meta = with lib; {
     description = "Manage secret values in-repo via public key cryptography";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1096,6 +1096,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  amber-secret = callPackage ../tools/security/amber { };
+
   inherit (callPackages ../development/tools/ammonite {})
     ammonite_2_12
     ammonite_2_13;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1096,7 +1096,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  amber-secret = callPackage ../tools/security/amber { };
+  amber-secret = callPackage ../tools/security/amber {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   inherit (callPackages ../development/tools/ammonite {})
     ammonite_2_12


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This tools allows for easily managing secrets in a repo. Tested it locally on a NixOS machine:

```
❯ amber
amber 0.1.1
Utility to store encrypted secrets in version trackable plain text files

USAGE:
    amber [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help        Prints help information
        --unmasked    Disable masking of secret values during exec
    -v, --verbose     Turn on verbose output
    -V, --version     Prints version information

OPTIONS:
        --amber-yaml <amber-yaml>    amber.yaml file location [env: AMBER_YAML=] [default:
                                     amber.yaml]

SUBCOMMANDS:
    encrypt     Add or update a secret
    exec        Run a command with all of the secrets set as environment variables
    generate    Generate a new strong secret value, and add it to the repository
    help        Prints this message or the help of the given subcommand(s)
    init        Initialize a new directory
    print       Print all of the secrets
    remove      Remove a secret
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
