### PR TITLE
stdenv: remove isMachO helper function

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -199,29 +199,6 @@ isELF() {
     if [ "$magic" = $'\177ELF' ]; then return 0; else return 1; fi
 }
 
-# Return success if the specified file is a Mach-O object.
-isMachO() {
-    local fn="$1"
-    local fd
-    local magic
-    exec {fd}< "$fn"
-    read -r -n 4 -u "$fd" magic
-    exec {fd}<&-
-    # https://opensource.apple.com/source/lldb/lldb-310.2.36/examples/python/mach_o.py.auto.html
-    if [[ "$magic" = $'\xfe\xed\xfa\xcf' || "$magic" = $'\xcf\xfa\xed\xfe' ]]; then
-        # MH_MAGIC_64 || MH_CIGAM_64
-        return 0;
-    elif [[ "$magic" = $'\xfe\xed\xfa\xce' || "$magic" = $'\xce\xfa\xed\xfe' ]]; then
-        # MH_MAGIC || MH_CIGAM
-        return 0;
-    elif [[ "$magic" = $'\xca\xfe\xba\xbe' || "$magic" = $'\xbe\xba\xfe\xca' ]]; then
-        # FAT_MAGIC || FAT_CIGAM
-        return 0;
-    else
-        return 1;
-    fi
-}
-
 # Return success if the specified file is a script (i.e. starts with
 # "#!").
 isScript() {


### PR DESCRIPTION
###### Motivation for this change

Currently, `nix print-dev-env` fails to execute if this function is present, because of its use of hex literals.
Until this issue (https://github.com/NixOS/nix/issues/5262) is solved, we should revert this to prevent breakage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
