### PR TITLE
python3Packages.mypy-protobuf: Add missing inputs

### DIFF
--- a/pkgs/development/python-modules/mypy-protobuf/default.nix
+++ b/pkgs/development/python-modules/mypy-protobuf/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonApplication, protobuf, pythonOlder }:
+{ lib, fetchPypi, buildPythonApplication, protobuf, types-protobuf, grpcio-tools, pythonOlder }:
 
 buildPythonApplication rec {
   pname = "mypy-protobuf";
@@ -11,7 +11,7 @@ buildPythonApplication rec {
     sha256 = "278172935d7121c2f8c7c0a05518dd565a2b76d9e9c4a0a3fcd08a21fa685d43";
   };
 
-  propagatedBuildInputs = [ protobuf ];
+  propagatedBuildInputs = [ protobuf types-protobuf grpcio-tools ];
 
   meta = with lib; {
     description = "Generate mypy stub files from protobuf specs";

--- a/pkgs/development/python-modules/types-futures/default.nix
+++ b/pkgs/development/python-modules/types-futures/default.nix
@@ -1,0 +1,18 @@
+{ buildPythonPackage, fetchPypi, lib }:
+
+buildPythonPackage rec {
+  pname = "types-futures";
+  version = "3.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p00wb93af01b6fw9wxk9qm4kbhqwb48nszmm16slsrc1nx4px25";
+  };
+
+  meta = with lib; {
+    description = "Typing stubs for futures";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ andersk ];
+  };
+}

--- a/pkgs/development/python-modules/types-protobuf/default.nix
+++ b/pkgs/development/python-modules/types-protobuf/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, fetchPypi, lib, types-futures }:
+
+buildPythonPackage rec {
+  pname = "types-protobuf";
+  version = "3.17.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r42kzspqna2b2jiz9bjzagrd4gbh0sd6jp4v7i9nv09y0ifrkrn";
+  };
+
+  propagatedBuildInputs = [ types-futures ];
+
+  meta = with lib; {
+    description = "Typing stubs for protobuf";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ andersk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9124,6 +9124,8 @@ in {
 
   types-decorator = callPackage ../development/python-modules/types-decorator { };
 
+  types-futures = callPackage ../development/python-modules/types-futures { };
+
   types-pytz = callPackage ../development/python-modules/types-pytz { };
 
   types-requests = callPackage ../development/python-modules/types-requests { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9126,6 +9126,8 @@ in {
 
   types-futures = callPackage ../development/python-modules/types-futures { };
 
+  types-protobuf = callPackage ../development/python-modules/types-protobuf { };
+
   types-pytz = callPackage ../development/python-modules/types-pytz { };
 
   types-requests = callPackage ../development/python-modules/types-requests { };


### PR DESCRIPTION
###### Motivation for this change

Commit 96e5573a3e5175d63aa0deeb756f6bcc50373697 bumped mypy-protobuf without adding its newly required build inputs, and the resulting derivation fails to build. Fix it.

(Cc @mweinelt.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
