### PR TITLE
mbedtls: fix gcc-11 build by disabling a warning

### DIFF
--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -33,10 +33,12 @@ stdenv.mkDerivation rec {
     perl scripts/config.pl set MBEDTLS_THREADING_PTHREAD    # POSIX thread wrapper layer for the threading layer.
   '';
 
-  cmakeFlags = [ "-DUSE_SHARED_MBEDTLS_LIBRARY=on" ];
-  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [
-    "-Wno-error=format"
-    "-Wno-error=format-truncation"
+  cmakeFlags = [
+    "-DUSE_SHARED_MBEDTLS_LIBRARY=on"
+
+    # Blanket -Werror produces false positives on fresh
+    # toolchains and on non-default CFLAGS (like -Wformat).
+    "-DMBEDTLS_FATAL_WARNINGS=off"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
The build fails on gcc-11. Example reproducer:

    $ nix-build -E 'with import ./. {}; mbedtls.override { stdenv = gcc11Stdenv; }'
    ...
    /build/source/library/ssl_tls.c:3334:5: error:
      'mbedtls_sha512_finish_ret' accessing 64 bytes in a region
        of size 48 [-Werror=stringop-overflow=]
     3334 |     finish( &sha512, padbuf );
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~

Instead of backporting an API change let's disable warning for now.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
