### PR TITLE
Yarn fetcher

### DIFF
--- a/pkgs/build-support/fetchyarn/default.nix
+++ b/pkgs/build-support/fetchyarn/default.nix
@@ -1,0 +1,89 @@
+{ lib, stdenvNoCC, cacert, git, nodePackages, jq, moreutils }:
+
+{ packageJson
+, yarnLock ? null
+, packageLockJson ? null
+, nodeModulesSha256
+, name ? "node_modules"
+, version 
+, yarnFlags ? [ "--frozen-lockfile" "--production=false" "--verbose" "--check-files" ]
+, patches ? []
+, ...
+} @ args:
+
+assert (packageLockJson != null) -> (yarnLock == null); 
+assert (yarnLock != null) -> (packageLockJson == null); 
+  
+stdenvNoCC.mkDerivation ({
+  name = "${name}-${version}.tar.gz";
+  nativeBuildInputs = [ cacert git nodePackages.yarn ];
+  
+  dontUnpack = true;
+
+  configurePhase = ''
+    runHook preConfigure
+
+    # Yarn writes cache directories etc to $HOME.
+    export HOME=$(mktemp -d yarn-home.XXX)
+
+    cp ${packageJson} ./package.json
+    
+    ${lib.optionalString (packageLockJson != null) ''
+      cp ${packageLockJson} ./package-lock.json
+    ''}
+
+    ${lib.optionalString (yarnLock != null) ''
+      cp ${yarnLock} ./yarn.lock
+    ''}
+    
+    packageJsonVersion=$(${jq}/bin/jq '.version' package.json)
+    
+    if [[ $packageJsonVersion == null ]]; then
+        echo "Warning: missing version in package.json"
+        echo "yarn will not work properly without a version attribute, patching..."
+        ${jq}/bin/jq '.version = "${version}"' package.json | ${moreutils}/bin/sponge package.json
+    fi
+
+    yarn config set yarn-offline-mirror $name
+    yarn config set disable-self-update-check true
+    
+    runHook postConfigure
+  '';
+  
+  buildPhase = ''
+    runHook preBuild
+
+    ${lib.optionalString (packageLockJson != null) ''
+      yarn import
+      # just to remove the warning from yarn if you have both a yarn.lock and package-lock.json files
+      rm package-lock.json
+    ''}
+    
+    yarn install ${lib.concatStringsSep " " yarnFlags}
+
+    cp -r node_modules $name
+    
+    ${lib.optionalString (packageLockJson != null) ''
+      # Add the yarn.lock to allow hash invalidation
+      cp yarn.lock $name/yarn.lock
+    ''}
+    
+    runHook postBuild
+  '';
+
+  SOURCE_DATE_EPOCH=1;
+  # Build a reproducible tar, per instructions at https://reproducible-builds.org/docs/archives/  
+  installPhase = ''
+    tar --owner=0 --group=0 --numeric-owner --format=gnu \
+        --sort=name --mtime="@$SOURCE_DATE_EPOCH" \
+        -czf $out $name
+  '';
+
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = nodeModulesSha256;  
+  
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+} // (builtins.removeAttrs args [
+  "name" "nodeModulesSha256" "importPackageLockJson" "yarnFlags"
+]))

--- a/pkgs/build-support/fetchyarn/default.nix
+++ b/pkgs/build-support/fetchyarn/default.nix
@@ -6,7 +6,7 @@
 , nodeModulesSha256
 , name ? "node_modules"
 , version
-, yarnFlags ? [ "--frozen-lockfile" "--production=false" "--verbose" "--check-files" ]
+, yarnFlags ? [ "--frozen-lockfile" "--production=false" "--verbose" "--check-files" "--ignore-scripts"]
 , patches ? [ ]
 , ...
 } @ args:

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -8,7 +8,7 @@ let
     inherit (stdenv.hostPlatform) system;
   };
   self = super // {
-    fetchYarn = pkgs.callPackage ../../build-support/fetchyarn { };    
+    fetchYarn = pkgs.callPackage ../../build-support/fetchyarn { };
 
     "@angular/cli" = super."@angular/cli".override {
       prePatch = ''

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -8,6 +8,8 @@ let
     inherit (stdenv.hostPlatform) system;
   };
   self = super // {
+    fetchYarn = pkgs.callPackage ../../build-support/fetchyarn { };    
+
     "@angular/cli" = super."@angular/cli".override {
       prePatch = ''
         export NG_CLI_ANALYTICS=false

--- a/pkgs/servers/web-apps/plausible/default.nix
+++ b/pkgs/servers/web-apps/plausible/default.nix
@@ -51,7 +51,7 @@ let
       substituteInPlace package.json --replace "../deps/phoenix" "./phoenix"
       substituteInPlace package-lock.json  --replace "../deps/phoenix" "./phoenix"
     '';
-    
+
     nodeModulesSha256 = "sha256-1QcV8TiVBQjl9yB5m3SRnap1JChhKnWTw7GY2s4Jw6s=";
   };
 in
@@ -80,7 +80,7 @@ beamPackages.mixRelease {
 
   postBuild = ''
     unpackFile ${yarnDeps}
-    cp -r "${yarnDeps.name}" assets/node_modules 
+    cp -r "${yarnDeps.name}" assets/node_modules
     npm run deploy --prefix ./assets
 
     # for external task you need a workaround for the no deps check flag

--- a/pkgs/servers/web-apps/plausible/default.nix
+++ b/pkgs/servers/web-apps/plausible/default.nix
@@ -52,7 +52,7 @@ let
       substituteInPlace package-lock.json  --replace "../deps/phoenix" "./phoenix"
     '';
 
-    nodeModulesSha256 = "sha256-1QcV8TiVBQjl9yB5m3SRnap1JChhKnWTw7GY2s4Jw6s=";
+    nodeModulesSha256 = "sha256-QPnbucLqiL/N8ktudTb9ejX5he+ML4bACQoKoWi7T9A=";
   };
 in
 beamPackages.mixRelease {


### PR DESCRIPTION
###### Motivation for this change

This is work in progress for a proposal around a yarn fetcher.
This is an alternative to https://github.com/NixOS/nixpkgs/pull/128749 to generate discussions about the good and bad parts of each approach

Please note that the `plausible` modification is not a proposition to modify the plausible package, but just to illustrate planned usage.

This includes
- handles package-lock.json and yarn.lock (using the [`import`](https://classic.yarnpkg.com/en/docs/cli/import) feature from yarn)

There are still some things I am not sure about
- I didn't include the `--ignore-scripts` flag, as I'm still weighing pros and cons about it, happy to get more informations regarding it.
- I haven't tested with other packages, I would be happy to get more feedback.
- this only includes a yarn fetcher, no yarn builder. Meaning that it's a way to get node_modules, however usage is not as straightforward as the `buildRustCrate` or the `buildGoModule`. Ideally this can be merged and tested as is for a while, if it actually works, then a follow up PR can happen to make a yarnBuilder which would make usage easier.
- This is just providing a tarball (potential smaller downloads). I find usage from a tarball a bit awkward so far. Also I'm having trouble figuring out when would a dependency tarball actually be downloaded. I'm considering at the moment going back to just files and directories in $out (I would like a single way to proceed, so potentially no way to make tarball at all).
- I'm not sure yet how the dependency override would work, haven't given that any consideration.

This is mostly for a short term solution so that more JS things can be merged, I'm not too attached to this, so feel free to critize!
(the other alternatve for things with lockfiles, npmlock2nix currently doesn't have a precise date as to when it will be available).
 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
