### PR TITLE
python3Packages.pook: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/pook/default.nix
+++ b/pkgs/development/python-modules/pook/default.nix
@@ -2,7 +2,6 @@
 , aiohttp
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , furl
 , jsonschema
 , nose
@@ -14,24 +13,15 @@
 
 buildPythonPackage rec {
   pname = "pook";
-  version = "1.0.1";
+  version = "1.0.2";
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "h2non";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0z48vswj07kr2sdvq5qzrwqyijpmj2rlnh2z2b32id1mckr6nnz8";
+    sha256 = "sha256-4OGcnuajGdBRlXCYwbTK/zLNQRrir60qCYajHRRCpkU=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Will be fixed with the new release, https://github.com/h2non/pook/issues/69
-      name = "use-match-keyword-in-pytest.patch";
-      url = "https://github.com/h2non/pook/commit/2071da27701c82ce02b015e01e2aa6fd203e7bb5.patch";
-      sha256 = "0i3qcpbdqqsnbygi46dyqamgkh9v8rhpbm4lkl75riw48j4n080k";
-    })
-  ];
 
   propagatedBuildInputs = [
     aiohttp


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.0.2

Change log: https://github.com/h2non/pook/releases/tag/v1.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
