### PR TITLE
python3Packages.service-identity: 18.1.0 -> 21.1.0

### DIFF
--- a/pkgs/development/python-modules/service_identity/default.nix
+++ b/pkgs/development/python-modules/service_identity/default.nix
@@ -1,37 +1,46 @@
 { lib
+, attrs
 , buildPythonPackage
-, fetchFromGitHub
-, pythonOlder
 , cryptography
-, ipaddress
+, fetchFromGitHub
+, idna
 , pyasn1
 , pyasn1-modules
-, idna
-, attrs
-, pytest
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  pname = "service_identity";
-  version = "18.1.0";
+  pname = "service-identity";
+  version = "21.1.0";
+
+  disabled = pythonOlder "3.4";
 
   src = fetchFromGitHub {
     owner = "pyca";
     repo = pname;
     rev = version;
-    sha256 = "1aw475ksmd4vpl8cwfdcsw2v063nbhnnxpy633sb75iqp9aazhlx";
+    sha256 = "sha256-pWc2rU3ULqEukMhd1ySY58lTm3s8f/ayQ7CY4nG24AQ=";
   };
 
   propagatedBuildInputs = [
-    pyasn1 pyasn1-modules idna attrs cryptography
-  ] ++ lib.optionals (pythonOlder "3.3") [ ipaddress ];
+    attrs
+    cryptography
+    idna
+    pyasn1
+    pyasn1-modules
+  ];
 
-  checkInputs = [ pytest ];
-  checkPhase = "py.test";
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "service_identity" ];
 
   meta = with lib; {
     description = "Service identity verification for pyOpenSSL";
-    license = licenses.mit;
     homepage = "https://service-identity.readthedocs.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 21.1.0

Change log: https://service-identity.readthedocs.io/en/stable/changelog.html#id1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
