### PR TITLE
md4c: fix generated pkg-config .pc files

### DIFF
--- a/pkgs/development/libraries/md4c/default.nix
+++ b/pkgs/development/libraries/md4c/default.nix
@@ -16,6 +16,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-+LObAD5JB8Vb4Rt4hTo1Z4ispxzfFkkXA2sw6TKB7Yo=";
   };
 
+  patches = [
+    # We set CMAKE_INSTALL_LIBDIR to the absolute path in $out, so
+    # prefix and exec_prefix cannot be $out, too
+    # Use CMake's _FULL_ variables instead of `prefix` concatenation.
+    ./fix-pkgconfig.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/development/libraries/md4c/fix-pkgconfig.patch
+++ b/pkgs/development/libraries/md4c/fix-pkgconfig.patch
@@ -1,0 +1,44 @@
+From 0ab8f5a6ee305cf4edcebfdc7b9eb5f98302de75 Mon Sep 17 00:00:00 2001
+From: Leif Middelschulte <Leif.Middelschulte@klsmartin.com>
+Date: Fri, 17 Sep 2021 16:16:17 +0200
+Subject: [PATCH] pc.in: use _FULL_ variable variants
+
+Nix' cmake packaging handler replaces the CMAKE_INSTALL_INCLUDEDIR
+with the absolute path. Which break package
+portability (i.e. `prefix`-usage).
+---
+ src/md4c-html.pc.in | 6 ++----
+ src/md4c.pc.in      | 6 ++----
+ 2 files changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/src/md4c-html.pc.in b/src/md4c-html.pc.in
+index 504bb52..fec7df4 100644
+--- a/src/md4c-html.pc.in
++++ b/src/md4c-html.pc.in
+@@ -1,7 +1,5 @@
+-prefix=@CMAKE_INSTALL_PREFIX@
+-exec_prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+ Name: @PROJECT_NAME@ HTML renderer
+ Description: Markdown to HTML converter library.
+diff --git a/src/md4c.pc.in b/src/md4c.pc.in
+index cd8842d..b5d81f8 100644
+--- a/src/md4c.pc.in
++++ b/src/md4c.pc.in
+@@ -1,7 +1,5 @@
+-prefix=@CMAKE_INSTALL_PREFIX@
+-exec_prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+ Name: @PROJECT_NAME@
+ Description: Markdown parser library with a SAX-like callback-based interface.
+-- 
+2.31.0
+


### PR DESCRIPTION
Nix uses absolute paths for certain CMake variables, where relative ones
are expected. Fix this by useing CMake's _FULL_ variables instead.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
