### PR TITLE
yubikey-touch-detector: init at 1.9.1

### DIFF
--- a/pkgs/tools/security/yubikey-touch-detector/default.nix
+++ b/pkgs/tools/security/yubikey-touch-detector/default.nix
@@ -1,0 +1,26 @@
+{ lib, libnotify, buildGoModule, fetchFromGitHub, pkg-config }:
+
+buildGoModule rec {
+  pname = "yubikey-touch-detector";
+  version = "1.9.1";
+
+  src = fetchFromGitHub {
+    owner = "maximbaz";
+    repo = "yubikey-touch-detector";
+    rev = version;
+    sha256 = "sha256-I9dRCQhbXd8K1zp291z9XVwHI9DcxgvrzYaHICZH5v0=";
+  };
+  vendorSha256 = "sha256-UeDLGwYrXwLOtQt/8fEmficc/1j0x+zr/JLa6lLF5cs=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libnotify ];
+
+  meta = with lib; {
+    description = "A tool to detect when your YubiKey is waiting for a touch (to send notification or display a visual indicator on the screen).";
+    homepage = "https://github.com/maximbaz/yubikey-touch-detector";
+    maintainers = with maintainers; [ sumnerevans ];
+    license = licenses.isc;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19522,6 +19522,8 @@ with pkgs;
 
   yubikey-agent = callPackage ../tools/security/yubikey-agent { };
 
+  yubikey-touch-detector = callPackage ../tools/security/yubikey-touch-detector { };
+
   zchunk = callPackage ../development/libraries/zchunk { };
 
   zeitgeist = callPackage ../development/libraries/zeitgeist { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/maximbaz/yubikey-touch-detector/releases/tag/1.9.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
