### PR TITLE
orjail: init at 1.1

### DIFF
--- a/pkgs/tools/security/orjail/default.nix
+++ b/pkgs/tools/security/orjail/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, tor
+, firejail
+, iptables
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "orjail";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06bwqb3l7syy4c1d8xynxwakmdxvm3qfm8r834nidsknvpdckd9z";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    patchShebangs make-helper.bsh
+    mkdir bin
+    mv usr/sbin/orjail bin/orjail
+    rm -r usr
+  '';
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+  ];
+
+  postInstall = ''
+    # Specify binary paths: tor, firejail, iptables
+    # mktemp fails with /tmp path prefix, will work without it anyway
+    # https://github.com/orjail/orjail/issues/78
+    # firejail will fail reading /etc/hosts, therefore remove --hostname arg
+    # https://github.com/netblue30/firejail/issues/2758
+    substituteInPlace $out/bin/orjail \
+      --replace ''$'TORBIN=\n' ''$'TORBIN=${tor}/bin/tor\n' \
+      --replace ''$'FIREJAILBIN=\n' ''$'FIREJAILBIN=${firejail}/bin/firejail\n' \
+      --replace 'iptables -' '${iptables}/bin/iptables -' \
+      --replace 'mktemp /tmp/' 'mktemp ' \
+      --replace '--hostname=host ' ""
+  '';
+
+  meta = with lib; {
+    description = "Force programs to exclusively use tor network";
+    homepage = "https://github.com/orjail/orjail";
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ onny ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3591,6 +3591,8 @@ with pkgs;
 
   oneshot = callPackage ../tools/networking/oneshot { };
 
+  orjail = callPackage ../tools/security/orjail { };
+
   online-judge-tools = with python3.pkgs; toPythonApplication online-judge-tools;
 
   xkbd = callPackage ../applications/misc/xkbd { };


### PR DESCRIPTION
###### Motivation for this change
Adds package [orjail](https://github.com/orjail/orjail), a program to run applications inside a "sandbox" tunneling all traffic through the Tor network.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
