### PR TITLE
ocrmypdf: 12.3.0 -> 12.5.0

### DIFF
--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -30,13 +30,13 @@ let
 in
 buildPythonApplication rec {
   pname = "ocrmypdf";
-  version = "12.3.0";
+  version = "12.5.0";
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
     repo = "OCRmyPDF";
     rev = "v${version}";
-    sha256 = "122yv3p0v4fbx30zgppcznwnm7svg97gv0sa103xb6zcld68ggn2";
+    sha256 = "sha256-g80WedX+TGHE9EJ/RSgOc53PM17V3WZslUNaHoqKTo0=";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -47,9 +47,9 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     cffi
-    chardet
     coloredlogs
     img2pdf
+    importlib-resources
     pdfminer
     pluggy
     pikepdf
@@ -84,6 +84,6 @@ buildPythonApplication rec {
     license = with licenses; [ mpl20 mit ];
     platforms = platforms.linux;
     maintainers = [ maintainers.kiwi ];
-    changelog  = "https://github.com/jbarlow83/OCRmyPDF/blob/v${version}/docs/release_notes.rst";
+    changelog = "https://github.com/jbarlow83/OCRmyPDF/blob/v${version}/docs/release_notes.rst";
   };
 }


### PR DESCRIPTION
This PR updates ocrmypdf to be compatible with pluggy 1.0 (#135477).

###### Motivation for this change

Fixes #138292

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
