### PR TITLE
palemoon: 29.4.0.2 -> 29.4.1

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchFromGitHub
+, fetchzip
 , writeScript
 , alsa-lib
 , autoconf213
@@ -52,15 +52,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "29.4.0.2";
+  version = "29.4.1";
 
-  src = fetchFromGitHub {
-    githubBase = "repo.palemoon.org";
-    owner = "MoonchildProductions";
-    repo = "Pale-Moon";
-    rev = "${version}_Release";
-    sha256 = "086f517xkk4smx57klyyvx4m3g6r5f1667w990zhpapbh997hfri";
-    fetchSubmodules = true;
+  src = fetchzip {
+    url = "http://archive.palemoon.org/source/palemoon-${version}-source.tar.xz";
+    stripRoot = false;
+    sha256 = "0kb9yn1q8rrmnlsyvxvv2gdgyyf12g6rxlyh82lmc0gysvd4qd2c";
   };
 
   passthru.updateScript = writeScript "update-${pname}" ''


### PR DESCRIPTION
###### Motivation for this change
> This is a security update.
> 
> Changes/fixes:
> 
> - Fixed potential crashes. DiD
> - Fixed a potential indirect exploit of Microsoft Internet Explorer. (CVE-2021-38492)
> - Unified XUL Platform Mozilla Security Patch Summary: 1 fixed, 2 DiD, 8 not applicable.

Upstream have [discontinued](https://forum.palemoon.org/viewtopic.php?f=5&t=27369) their public git repositories for Pale-Moon & UXP, instead they now upload release snapshots to build from.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
