### PR TITLE
squeekboard: fix build with rust 1.54

### DIFF
--- a/pkgs/applications/accessibility/squeekboard/default.nix
+++ b/pkgs/applications/accessibility/squeekboard/default.nix
@@ -14,6 +14,7 @@
 , rustPlatform
 , feedbackd
 , wrapGAppsHook
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -36,6 +37,15 @@ stdenv.mkDerivation rec {
     name = "${pname}-${version}";
     sha256 = "0148ynzmapxfrlccikf20ikmi0ssbkn9fl5wi6nh6azflv50pzzn";
   };
+
+  patches = [
+    # remove when updating from 1.14.0
+    (fetchpatch {
+      name = "fix-rust-1.54-build.patch";
+      url = "https://gitlab.gnome.org/World/Phosh/squeekboard/-/commit/9cd56185c59ace535a6af26384ef6beca4423816.patch";
+      sha256 = "sha256-8rWcfhQmGiwlc2lpkRvJ95XQp1Xg7St+0K85x8nQ0mk=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
###### Motivation for this change

Squeekboard build was broken, presumably due to the upgrade of rust from 1.53 to 1.54 (?). This fixes the build.

<s>(I'm still building it, but I don't expect any issues. WIll update here when build is done.)</s> Build succeeded :)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
