### PR TITLE
vivisect: enable building for Python 3

### DIFF
--- a/pkgs/development/python-modules/vivisect/default.nix
+++ b/pkgs/development/python-modules/vivisect/default.nix
@@ -11,7 +11,6 @@
 buildPythonPackage rec {
   pname = "vivisect";
   version = "1.0.4";
-  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;
@@ -24,6 +23,10 @@ buildPythonPackage rec {
     cxxfilt
     msgpack
     pycparser
+  ];
+
+  patches = [
+    ./vivisect-cxxfilt-version.patch
   ];
 
   preBuild = ''

--- a/pkgs/development/python-modules/vivisect/vivisect-cxxfilt-version.patch
+++ b/pkgs/development/python-modules/vivisect/vivisect-cxxfilt-version.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 549d00b..c81d0bc 100644
+--- a/setup.py
++++ b/setup.py
+@@ -31,7 +31,7 @@ setup(
+     install_requires=[
+         'pyasn1>=0.4.5,<0.5.0',
+         'pyasn1-modules>=0.2.4,<0.3.0',
+-        'cxxfilt>=0.2.1,<0.3.0',
++        'cxxfilt>=0.2.1,<=0.3.0',
+         'msgpack>=1.0.0,<1.1.0',
+         'pycparser>=2.20',
+     ],


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Vivisect didn't work on Python 3, see #138272

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
