### PR TITLE
nogroup fixes after #133166

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -139,7 +139,7 @@ in
       #users = 100; # unused
       # cgminer = 101; #dynamically allocated as of 2021-09-17
       munin = 102;
-      logcheck = 103;
+      #logcheck = 103; #dynamically allocated as of 2021-09-17
       #nix-ssh = 104; #dynamically allocated as of 2021-09-03
       dictd = 105;
       couchdb = 106;

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -244,7 +244,7 @@ in
       #kibana = 211;# dynamically allocated as of 2021-09-03
       xtreemfs = 212;
       calibre-server = 213;
-      heapster = 214;
+      #heapster = 214; #dynamically allocated as of 2021-09-17
       bepasty = 215;
       # pumpio = 216; # unused, removed 2018-02-24
       nm-openvpn = 217;

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -258,7 +258,7 @@ in
       rspamd = 225;
       # rmilter = 226; # unused, removed 2019-08-22
       cfdyndns = 227;
-      gammu-smsd = 228;
+      # gammu-smsd = 228; #dynamically allocated as of 2021-09-17
       pdnsd = 229;
       octoprint = 230;
       avahi-autoipd = 231;

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -215,7 +215,7 @@ in
       ntp = 179;
       zabbix = 180;
       #redis = 181; removed 2018-01-03
-      unifi = 183;
+      #unifi = 183; dynamically allocated as of 2021-09-17
       uptimed = 184;
       zope2 = 185;
       ripple-data-api = 186;

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -212,7 +212,7 @@ in
       sddm = 175;
       tss = 176;
       #memcached = 177; removed 2018-01-03
-      ntp = 179;
+      #ntp = 179; # dynamically allocated as of 2021-09-17
       zabbix = 180;
       #redis = 181; removed 2018-01-03
       #unifi = 183; dynamically allocated as of 2021-09-17

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -137,7 +137,7 @@ in
       #mongodb = 98; #dynamically allocated as of 2021-09-03
       #openldap = 99; # dynamically allocated as of PR#94610
       #users = 100; # unused
-      cgminer = 101;
+      # cgminer = 101; #dynamically allocated as of 2021-09-17
       munin = 102;
       logcheck = 103;
       #nix-ssh = 104; #dynamically allocated as of 2021-09-03

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -262,7 +262,7 @@ in
       pdnsd = 229;
       octoprint = 230;
       avahi-autoipd = 231;
-      nntp-proxy = 232;
+      # nntp-proxy = 232; #dynamically allocated as of 2021-09-17
       mjpg-streamer = 233;
       #radicale = 234;# dynamically allocated as of 2021-09-03
       hydra-queue-runner = 235;

--- a/nixos/modules/services/logging/logcheck.nix
+++ b/nixos/modules/services/logging/logcheck.nix
@@ -215,11 +215,15 @@ in
 
     users.users = optionalAttrs (cfg.user == "logcheck") {
       logcheck = {
-        uid = config.ids.uids.logcheck;
+        group = "logcheck";
+        isSystemUser = true;
         shell = "/bin/sh";
         description = "Logcheck user account";
         extraGroups = cfg.extraGroups;
       };
+    };
+    users.groups = optionalAttrs (cfg.user == "logcheck") {
+      logcheck = {};
     };
 
     system.activationScripts.logcheck = ''

--- a/nixos/modules/services/misc/cgminer.nix
+++ b/nixos/modules/services/misc/cgminer.nix
@@ -110,9 +110,13 @@ in
 
     users.users = optionalAttrs (cfg.user == "cgminer") {
       cgminer = {
-        uid = config.ids.uids.cgminer;
+        isSystemUser = true;
+        group = "cgminer";
         description = "Cgminer user";
       };
+    };
+    users.groups = optionalAttrs (cfg.user == "cgminer") {
+      cgminer = {};
     };
 
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/services/misc/cgminer.nix
+++ b/nixos/modules/services/misc/cgminer.nix
@@ -86,7 +86,7 @@ in
 
       config = mkOption {
         default = {};
-        type = (types.either types.bool types.int);
+        type = types.attrsOf (types.either types.bool types.int);
         description = "Additional config";
         example = {
           auto-fan = true;

--- a/nixos/modules/services/misc/gammu-smsd.nix
+++ b/nixos/modules/services/misc/gammu-smsd.nix
@@ -202,8 +202,8 @@ in {
   config = mkIf cfg.enable {
     users.users.${cfg.user} = {
       description = "gammu-smsd user";
-      uid = config.ids.uids.gammu-smsd;
-      extraGroups = [ "${cfg.device.group}" ];
+      isSystemUser = true;
+      group = cfg.device.group;
     };
 
     environment.systemPackages = with cfg.backend; [ gammuPackage ]

--- a/nixos/modules/services/misc/gpsd.nix
+++ b/nixos/modules/services/misc/gpsd.nix
@@ -88,6 +88,7 @@ in
 
     users.users.gpsd =
       { inherit uid;
+        group = "gpsd";
         description = "gpsd daemon user";
         home = "/var/empty";
       };

--- a/nixos/modules/services/monitoring/heapster.nix
+++ b/nixos/modules/services/monitoring/heapster.nix
@@ -50,8 +50,10 @@ in {
     };
 
     users.users.heapster = {
-      uid = config.ids.uids.heapster;
+      isSystemUser = true;
+      group = "heapster";
       description = "Heapster user";
     };
+    users.groups.heapster = {};
   };
 }

--- a/nixos/modules/services/networking/nntp-proxy.nix
+++ b/nixos/modules/services/networking/nntp-proxy.nix
@@ -6,8 +6,6 @@ let
 
   inherit (pkgs) nntp-proxy;
 
-  proxyUser = "nntp-proxy";
-
   cfg = config.services.nntp-proxy;
 
   configBool = b: if b then "TRUE" else "FALSE";
@@ -210,16 +208,18 @@ in
 
   config = mkIf cfg.enable {
 
-    users.users.${proxyUser} =
-      { uid = config.ids.uids.nntp-proxy;
-        description = "NNTP-Proxy daemon user";
-      };
+    users.users.nntp-proxy = {
+      isSystemUser = true;
+      group = "nntp-proxy";
+      description = "NNTP-Proxy daemon user";
+    };
+    users.groups.nntp-proxy = {};
 
     systemd.services.nntp-proxy = {
       description = "NNTP proxy";
       after = [ "network.target" "nss-lookup.target" ];
       wantedBy = [ "multi-user.target" ];
-      serviceConfig = { User="${proxyUser}"; };
+      serviceConfig = { User="nntp-proxy"; };
       serviceConfig.ExecStart = "${nntp-proxy}/bin/nntp-proxy ${confFile}";
       preStart = ''
         if [ ! \( -f ${cfg.sslCert} -a -f ${cfg.sslKey} \) ]; then

--- a/nixos/modules/services/networking/ntp/ntpd.nix
+++ b/nixos/modules/services/networking/ntp/ntpd.nix
@@ -10,8 +10,6 @@ let
 
   stateDir = "/var/lib/ntp";
 
-  ntpUser = "ntp";
-
   configFile = pkgs.writeText "ntp.conf" ''
     driftfile ${stateDir}/ntp.drift
 
@@ -27,7 +25,7 @@ let
     ${cfg.extraConfig}
   '';
 
-  ntpFlags = "-c ${configFile} -u ${ntpUser}:nogroup ${toString cfg.extraFlags}";
+  ntpFlags = "-c ${configFile} -u ntp:ntp ${toString cfg.extraFlags}";
 
 in
 
@@ -119,11 +117,13 @@ in
 
     systemd.services.systemd-timedated.environment = { SYSTEMD_TIMEDATED_NTP_SERVICES = "ntpd.service"; };
 
-    users.users.${ntpUser} =
-      { uid = config.ids.uids.ntp;
+    users.users.ntp =
+      { isSystemUser = true;
+        group = "ntp";
         description = "NTP daemon user";
         home = stateDir;
       };
+    users.groups.ntp = {};
 
     systemd.services.ntpd =
       { description = "NTP Daemon";
@@ -135,7 +135,7 @@ in
         preStart =
           ''
             mkdir -m 0755 -p ${stateDir}
-            chown ${ntpUser} ${stateDir}
+            chown ntp ${stateDir}
           '';
 
         serviceConfig = {

--- a/nixos/modules/services/networking/ntp/openntpd.nix
+++ b/nixos/modules/services/networking/ntp/openntpd.nix
@@ -61,10 +61,12 @@ in
     environment.etc."ntpd.conf".text = configFile;
 
     users.users.ntp = {
-      uid = config.ids.uids.ntp;
+      isSystemUser = true;
+      group = "ntp";
       description = "OpenNTP daemon user";
       home = "/var/empty";
     };
+    users.groups.ntp = {};
 
     systemd.services.openntpd = {
       description = "OpenNTP Server";

--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -115,10 +115,12 @@ in
   config = mkIf cfg.enable {
 
     users.users.unifi = {
-      uid = config.ids.uids.unifi;
+      isSystemUser = true;
+      group = "unifi";
       description = "UniFi controller daemon user";
       home = "${stateDir}";
     };
+    users.groups.unifi = {};
 
     networking.firewall = mkIf cfg.openPorts {
       # https://help.ubnt.com/hc/en-us/articles/218506997


### PR DESCRIPTION
###### Motivation for this change

cc #133166 #138027

cc @ajs124 @zhaofengli @dschrempf 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
