### PR TITLE
buildRustCrate: Fix some things for cross builds

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -17,7 +17,6 @@
         (mkRustcFeatureArgs crateFeatures)
       ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
         "--target" (rust.toRustTargetSpec stdenv.hostPlatform)
-        "-C" "linker=${stdenv.hostPlatform.config}-ld"
       ] ++ extraRustcOpts
       # since rustc 1.42 the "proc_macro" crate is part of the default crate prelude
       # https://github.com/rust-lang/cargo/commit/4d64eb99a4#diff-7f98585dbf9d30aa100c8318e2c77e79R1021-R1022

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -15,8 +15,10 @@
         "--remap-path-prefix=$NIX_BUILD_TOP=/"
         (mkRustcDepArgs dependencies crateRenames)
         (mkRustcFeatureArgs crateFeatures)
+      ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+        "--target" (rust.toRustTargetSpec stdenv.hostPlatform)
+        "-C" "linker=${stdenv.hostPlatform.config}-ld"
       ] ++ extraRustcOpts
-      ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--target ${rust.toRustTargetSpec stdenv.hostPlatform} -C linker=${stdenv.hostPlatform.config}-gcc"
       # since rustc 1.42 the "proc_macro" crate is part of the default crate prelude
       # https://github.com/rust-lang/cargo/commit/4d64eb99a4#diff-7f98585dbf9d30aa100c8318e2c77e79R1021-R1022
       ++ lib.optional (lib.elem "proc-macro" crateType) "--extern proc_macro"

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -13,7 +13,7 @@
 , crateRenames
 , crateVersion
 , extraLinkFlags
-, extraRustcOpts
+, extraRustcOptsForBuildRs
 , libName
 , libPath
 , release
@@ -24,7 +24,7 @@ let version_ = lib.splitString "-" crateVersion;
     version = lib.splitVersion (lib.head version_);
     rustcOpts = lib.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")
-        (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOpts);
+        (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOptsForBuildRs);
     buildDeps = mkRustcDepArgs buildDependencies crateRenames;
     authors = lib.concatStringsSep ":" crateAuthors;
     optLevel = if release then 3 else 0;

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -172,6 +172,11 @@ crate_: lib.makeOverridable
       # Example: [ "-Z debuginfo=2" ]
       # Default: []
     , extraRustcOpts
+      # A list of extra options to pass to rustc when building a build.rs.
+      #
+      # Example: [ "-Z debuginfo=2" ]
+      # Default: []
+    , extraRustcOptsForBuildRs
       # Whether to enable building tests.
       # Use true to enable.
       # Default: false
@@ -228,6 +233,7 @@ crate_: lib.makeOverridable
       nativeBuildInputs_ = nativeBuildInputs;
       buildInputs_ = buildInputs;
       extraRustcOpts_ = extraRustcOpts;
+      extraRustcOptsForBuildRs_ = extraRustcOptsForBuildRs;
       buildTests_ = buildTests;
 
       # crate2nix has a hack for the old bash based build script that did split
@@ -308,12 +314,16 @@ crate_: lib.makeOverridable
         lib.optionals (crate ? extraRustcOpts) crate.extraRustcOpts
           ++ extraRustcOpts_
           ++ (lib.optional (edition != null) "--edition ${edition}");
+      extraRustcOptsForBuildRs =
+        lib.optionals (crate ? extraRustcOptsForBuildRs) crate.extraRustcOptsForBuildRs
+        ++ extraRustcOptsForBuildRs_
+        ++ (lib.optional (edition != null) "--edition ${edition}");
 
 
       configurePhase = configureCrate {
         inherit crateName buildDependencies completeDeps completeBuildDeps crateDescription
           crateFeatures crateRenames libName build workspace_member release libPath crateVersion
-          extraLinkFlags extraRustcOpts
+          extraLinkFlags extraRustcOptsForBuildRs
           crateAuthors crateHomepage verbose colors;
       };
       buildPhase = buildCrate {
@@ -337,6 +347,7 @@ crate_: lib.makeOverridable
   release = crate_.release or true;
   verbose = crate_.verbose or true;
   extraRustcOpts = [ ];
+  extraRustcOptsForBuildRs = [ ];
   features = [ ];
   nativeBuildInputs = [ ];
   buildInputs = [ ];


### PR DESCRIPTION
###### Motivation for this change

See each commit message for details.

CC @kolloch 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
