### PR TITLE
emacs.pkgs.ement: unstable-2021-09-08 -> unstable-2021-09-16

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/ement/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/ement/default.nix
@@ -9,7 +9,14 @@
 
 trivialBuild {
   pname = "ement";
-  version = "unstable-2021-09-08";
+  version = "unstable-2021-09-16";
+
+  src = fetchFromGitHub {
+    owner = "alphapapa";
+    repo = "ement.el";
+    rev = "c07e914f077199c95b0e7941a421675c95d4687e";
+    sha256 = "sha256-kYVb2NrHYC87mY/hFUMAjb4TLJ9A2L2RrHoiAXvRaGg=";
+  };
 
   packageRequires = [
     plz
@@ -17,12 +24,9 @@ trivialBuild {
     ts
   ];
 
-  src = fetchFromGitHub {
-    owner = "alphapapa";
-    repo = "ement.el";
-    rev = "468aa9b0526aaa054f059c63797aa3d9ea13611d";
-    sha256 = "sha256-0FCAu253iTSf9qcsmoJxKlzfd5eYc8eJXUxG6+0eg/I=";
-  };
+  patches = [
+    ./handle-nil-images.patch
+  ];
 
   meta = {
     description = "Ement.el is a Matrix client for Emacs";

--- a/pkgs/applications/editors/emacs/elisp-packages/ement/handle-nil-images.patch
+++ b/pkgs/applications/editors/emacs/elisp-packages/ement/handle-nil-images.patch
@@ -1,0 +1,28 @@
+diff --git a/ement.el b/ement.el
+index c9596a7..1b33045 100644
+--- a/ement.el
++++ b/ement.el
+@@ -682,14 +682,15 @@ can cause undesirable underlining."
+   "Return a copy of IMAGE set to MAX-WIDTH and MAX-HEIGHT.
+ IMAGE should be one as created by, e.g. `create-image'."
+   ;; It would be nice if the image library had some simple functions to do this sort of thing.
+-  (let ((new-image (cl-copy-list image)))
+-    (when (fboundp 'imagemagick-types)
+-      ;; Only do this when ImageMagick is supported.
+-      ;; FIXME: When requiring Emacs 27+, remove this (I guess?).
+-      (setf (image-property new-image :type) 'imagemagick))
+-    (setf (image-property new-image :max-width) max-width
+-          (image-property new-image :max-height) max-height)
+-    new-image))
++  (when image
++    (let ((new-image (cl-copy-list image)))
++      (when (fboundp 'imagemagick-types)
++        ;; Only do this when ImageMagick is supported.
++        ;; FIXME: When requiring Emacs 27+, remove this (I guess?).
++        (setf (image-property new-image :type) 'imagemagick))
++      (setf (image-property new-image :max-width) max-width
++            (image-property new-image :max-height) max-height)
++      new-image)))
+ 
+ ;;;;; Reading/writing sessions
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
