### PR TITLE
vscode-extensions.formulahendry.terminal: init at 0.0.10

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -646,39 +646,53 @@ let
         };
       };
 
-      formulahendry.auto-close-tag = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "auto-close-tag";
-          publisher = "formulahendry";
-          version = "0.5.6";
-          sha256 = "058jgmllqb0j6gg5anghdp35nkykii28igfcwqgh4bp10pyvspg0";
+      formulahendry = {
+        auto-close-tag = buildVscodeMarketplaceExtension {
+          mktplcRef = {
+            name = "auto-close-tag";
+            publisher = "formulahendry";
+            version = "0.5.6";
+            sha256 = "058jgmllqb0j6gg5anghdp35nkykii28igfcwqgh4bp10pyvspg0";
+          };
+          meta = {
+            license = lib.licenses.mit;
+          };
         };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
 
-      formulahendry.auto-rename-tag = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "auto-rename-tag";
-          publisher = "formulahendry";
-          version = "0.1.6";
-          sha256 = "0cqg9mxkyf41brjq2c764w42lzyn6ffphw6ciw7xnqk1h1x8wwbs";
+        auto-rename-tag = buildVscodeMarketplaceExtension {
+          mktplcRef = {
+            name = "auto-rename-tag";
+            publisher = "formulahendry";
+            version = "0.1.6";
+            sha256 = "0cqg9mxkyf41brjq2c764w42lzyn6ffphw6ciw7xnqk1h1x8wwbs";
+          };
+          meta = {
+            license = lib.licenses.mit;
+          };
         };
-        meta = {
-          license = lib.licenses.mit;
-        };
-      };
 
-      formulahendry.code-runner = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "code-runner";
-          publisher = "formulahendry";
-          version = "0.11.2";
-          sha256 = "0qwcxr6m1xwhqmdl4pccjgpikpq1hgi2hgrva5abn8ixa2510hcy";
+        code-runner = buildVscodeMarketplaceExtension {
+          mktplcRef = {
+            name = "code-runner";
+            publisher = "formulahendry";
+            version = "0.11.2";
+            sha256 = "0qwcxr6m1xwhqmdl4pccjgpikpq1hgi2hgrva5abn8ixa2510hcy";
+          };
+          meta = {
+            license = lib.licenses.mit;
+          };
         };
-        meta = {
-          license = lib.licenses.mit;
+
+        terminal = buildVscodeMarketplaceExtension {
+          mktplcRef = {
+            publisher = "formulahendry";
+            name = "terminal";
+            version = "0.0.10";
+            sha256 = "sha256-9hGkD/mWGhwH0ACA3nUD75/XCIi6A8DiDVagfHwPRz4=";
+          };
+          meta = {
+            license = lib.licenses.mit;
+          };
         };
       };
 


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
