### PR TITLE
libopenmpt: default to supporting pulseaudio

### DIFF
--- a/pkgs/applications/audio/libopenmpt/default.nix
+++ b/pkgs/applications/audio/libopenmpt/default.nix
@@ -1,5 +1,5 @@
 { config, lib, stdenv, fetchurl, zlib, pkg-config, mpg123, libogg, libvorbis, portaudio, libsndfile, flac
-, usePulseAudio ? config.pulseaudio or false, libpulseaudio }:
+, usePulseAudio ? config.pulseaudio or stdenv.isLinux, libpulseaudio }:
 
 stdenv.mkDerivation rec {
   pname = "libopenmpt";


### PR DESCRIPTION
###### Motivation for this change

see: https://github.com/NixOS/nixpkgs/issues/138332

When #136735 was merged, it included this as a new input for libopenmpt:

`usePulseAudio ? config.pulseaudio or false`

Any user that had `config.pulseaudio = true` set, will start having to build libopenmpt and its dependents (including webkit-gtk) from source.

We should instead default to building this with pulse support to be more in line with other desktop-oriented packages in nixpkgs that tend to build with support for Pulse when building for linux.

For example, this is how `libao` is packaged+built.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
