### PR TITLE
hostapd: workaround networkd timing issue to bring up wlan bridge correctly

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -212,6 +212,11 @@ in
 
         serviceConfig =
           { ExecStart = "${pkgs.hostapd}/bin/hostapd ${configFile}";
+            # ensure hostapd isn't marked started until wlan's operational state is "carrier" or higher
+            ExecStartPost = mkIf config.networking.useNetworkd [
+              "${pkgs.systemd}/lib/systemd/systemd-networkd-wait-online -i ${cfg.interface} -o carrier"
+              "networkctl reconfigure ${cfg.interface}" # bring up the bridge
+            ];
             Restart = "always";
           };
       };


### PR DESCRIPTION
###### Motivation for this change

systemd-networkd is unable to bring up a bridge network on a hostapd-configured wlan interface, because it doesn't wait for the device to reach carrier state before [trying to join the interface to the bridge](https://github.com/systemd/systemd/issues/936).

###### Things done

This change does two things, only if `networking.useNetworkd`:

 - It ensures the hostapd unit isn't marked as started until it gets the wlan interface to carrier state
 - It tells networkd to reconfigure the wlan. If the wlan is configured to join a bridge, it will allow this to happen.

###### A third desirable thing it doesn't do:

 - [add](https://github.com/edrex/nixos-config/blob/master/hosts/whitecanyon/router.nix#L61) `ActivationPolicy=manual` in the systemd.network file, which would prevent networkd from trying to activate early. I couldn't see a way to do this without adding an option. This would allow the bridge to come up without the wlan interface if wlan fails to come up at all.

cc @rnhmjoj 

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
