### PR TITLE
pomerium: 0.14.7 -> 0.15.7

### DIFF
--- a/pkgs/development/tools/build-managers/gn/default.nix
+++ b/pkgs/development/tools/build-managers/gn/default.nix
@@ -1,64 +1,10 @@
-{ stdenv, lib, fetchgit, darwin, writeText
-, ninja, python3
-}:
+{ callPackage, ... } @ args:
 
-let
+callPackage ./generic.nix args {
   # Note: Please use the recommended version for Chromium, e.g.:
   # https://git.archlinux.org/svntogit/packages.git/tree/trunk/chromium-gn-version.sh?h=packages/gn
   rev = "fd3d768bcfd44a8d9639fe278581bd9851d0ce3a";
   revNum = "1718"; # git describe HEAD --match initial-commit | cut -d- -f3
   version = "2020-03-09";
   sha256 = "1asc14y8by7qcn10vbk467hvx93s30pif8r0brissl0sihsaqazr";
-
-  revShort = builtins.substring 0 7 rev;
-  lastCommitPosition = writeText "last_commit_position.h" ''
-    #ifndef OUT_LAST_COMMIT_POSITION_H_
-    #define OUT_LAST_COMMIT_POSITION_H_
-
-    #define LAST_COMMIT_POSITION_NUM ${revNum}
-    #define LAST_COMMIT_POSITION "${revNum} (${revShort})"
-
-    #endif  // OUT_LAST_COMMIT_POSITION_H_
-  '';
-
-in stdenv.mkDerivation {
-  pname = "gn-unstable";
-  inherit version;
-
-  src = fetchgit {
-    # Note: The TAR-Archives (+archive/${rev}.tar.gz) are not deterministic!
-    url = "https://gn.googlesource.com/gn";
-    inherit rev sha256;
-  };
-
-  nativeBuildInputs = [ ninja python3 ];
-  buildInputs = lib.optionals stdenv.isDarwin (with darwin; with apple_sdk.frameworks; [
-    libobjc
-    cctools
-
-    # frameworks
-    ApplicationServices
-    Foundation
-    AppKit
-  ]);
-
-  buildPhase = ''
-    python build/gen.py --no-last-commit-position
-    ln -s ${lastCommitPosition} out/last_commit_position.h
-    ninja -j $NIX_BUILD_CORES -C out gn
-  '';
-
-  installPhase = ''
-    install -vD out/gn "$out/bin/gn"
-  '';
-
-  setupHook = ./setup-hook.sh;
-
-  meta = with lib; {
-    description = "A meta-build system that generates build files for Ninja";
-    homepage = "https://gn.googlesource.com/gn";
-    license = licenses.bsd3;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ stesie matthewbauer primeos ];
-  };
 }

--- a/pkgs/development/tools/build-managers/gn/generic.nix
+++ b/pkgs/development/tools/build-managers/gn/generic.nix
@@ -1,0 +1,60 @@
+{ stdenv, lib, fetchgit, darwin, writeText
+, ninja, python3
+, ...
+}:
+
+{ rev, revNum, version, sha256 }:
+
+let
+  revShort = builtins.substring 0 7 rev;
+  lastCommitPosition = writeText "last_commit_position.h" ''
+    #ifndef OUT_LAST_COMMIT_POSITION_H_
+    #define OUT_LAST_COMMIT_POSITION_H_
+
+    #define LAST_COMMIT_POSITION_NUM ${revNum}
+    #define LAST_COMMIT_POSITION "${revNum} (${revShort})"
+
+    #endif  // OUT_LAST_COMMIT_POSITION_H_
+  '';
+
+in stdenv.mkDerivation {
+  pname = "gn-unstable";
+  inherit version;
+
+  src = fetchgit {
+    # Note: The TAR-Archives (+archive/${rev}.tar.gz) are not deterministic!
+    url = "https://gn.googlesource.com/gn";
+    inherit rev sha256;
+  };
+
+  nativeBuildInputs = [ ninja python3 ];
+  buildInputs = lib.optionals stdenv.isDarwin (with darwin; with apple_sdk.frameworks; [
+    libobjc
+    cctools
+
+    # frameworks
+    ApplicationServices
+    Foundation
+    AppKit
+  ]);
+
+  buildPhase = ''
+    python build/gen.py --no-last-commit-position
+    ln -s ${lastCommitPosition} out/last_commit_position.h
+    ninja -j $NIX_BUILD_CORES -C out gn
+  '';
+
+  installPhase = ''
+    install -vD out/gn "$out/bin/gn"
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  meta = with lib; {
+    description = "A meta-build system that generates build files for Ninja";
+    homepage = "https://gn.googlesource.com/gn";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ stesie matthewbauer primeos ];
+  };
+}

--- a/pkgs/development/tools/build-managers/gn/rev1924.nix
+++ b/pkgs/development/tools/build-managers/gn/rev1924.nix
@@ -1,0 +1,8 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic.nix args {
+  rev = "24e2f7df92641de0351a96096fb2c490b2436bb8";
+  revNum = "1924"; # git describe HEAD --match initial-commit | cut -d- -f3
+  version = "2021-08-08";
+  sha256 = "1lwkyhfhw0zd7daqz466n7x5cddf0danr799h4jg3s0yvd4galjl";
+}

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -17,8 +17,8 @@ let
     # However, the version string is more useful for end-users.
     # These are contained in a attrset of their own to make it obvious that
     # people should update both.
-    version = "1.17.3";
-    commit = "46bf743b97d0d3f01ff437b2f10cc0bd9cdfe6e4";
+    version = "1.19.1";
+    commit = "a2a1e3eed4214a38608ec223859fcfa8fb679b14";
   };
 in
 buildBazelPackage rec {
@@ -28,7 +28,7 @@ buildBazelPackage rec {
     owner = "envoyproxy";
     repo = "envoy";
     rev = srcVer.commit;
-    hash = "sha256:09zzr4h3zjsb2rkxrvlazpx0jy33yn9j65ilxiqbvv0ckaralqfc";
+    hash = "sha256:1v1hv4blrppnhllsxd9d3k2wl6nhd59r4ydljy389na3bb41jwf9";
 
     extraPostFetch = ''
       chmod -R +w $out
@@ -58,7 +58,7 @@ buildBazelPackage rec {
   ];
 
   fetchAttrs = {
-    sha256 = "sha256:1cy2b73x8jzczq9z9c1kl7zrg5iasvsakb50zxn4mswpmajkbj5h";
+    sha256 = "sha256:0vnl0gq6nhvyzz39jg1bvvna0xyhxalg71bp1jbxib7ql026004r";
     dontUseCmakeConfigure = true;
     dontUseGnConfigure = true;
     preInstall = ''
@@ -74,12 +74,6 @@ buildBazelPackage rec {
         $bazelOut/external/com_github_luajit_luajit/build.py \
         $bazelOut/external/local_config_sh/BUILD
       rm -r $bazelOut/external/go_sdk
-
-      # Replace some wheels which are only used for tests with empty files;
-      # they're nondeterministically built and packed.
-      >$bazelOut/external/config_validation_pip3/PyYAML-5.3.1-cp38-cp38-linux_x86_64.whl
-      >$bazelOut/external/protodoc_pip3/PyYAML-5.3.1-cp38-cp38-linux_x86_64.whl
-      >$bazelOut/external/thrift_pip3/thrift-0.13.0-cp38-cp38-linux_x86_64.whl
 
       # Remove Unix timestamps from go cache.
       rm -rf $bazelOut/external/bazel_gazelle_go_repository_cache/{gocache,pkg/mod/cache,pkg/sumdb}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14956,6 +14956,7 @@ with pkgs;
   nimbo = with python3Packages; callPackage ../applications/misc/nimbo { };
 
   gn = callPackage ../development/tools/build-managers/gn { };
+  gn1924 = callPackage ../development/tools/build-managers/gn/rev1924.nix { };
 
   nixbang = callPackage ../development/tools/misc/nixbang {
     pythonPackages = python3Packages;
@@ -20738,6 +20739,7 @@ with pkgs;
   envoy = callPackage ../servers/http/envoy {
     go = go_1_15;
     jdk = openjdk11;
+    gn = gn1924;
   };
 
   etcd = callPackage ../servers/etcd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update Pomerium to latest version. Includes bumps to Envoy to match what upstream has done, and a bump to Gn because otherwise Envoy doesn't build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ x Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
