### PR TITLE
smartdns: Fix systemd service

### DIFF
--- a/pkgs/tools/networking/smartdns/default.nix
+++ b/pkgs/tools/networking/smartdns/default.nix
@@ -13,6 +13,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ];
 
+  # Force the systemd service file to be regenerated from it's template.  This
+  # file is erroneously added in version 35 and it has already been deleted from
+  # upstream's git repository.  So this "postPatch" phase can be deleted in next
+  # release.
+  postPatch = ''
+    rm -f systemd/smartdns.service
+  '';
+
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "SYSTEMDSYSTEMUNITDIR=${placeholder "out"}/lib/systemd/system"


### PR DESCRIPTION

###### Motivation for this change

Fix smartdns' systemd service

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
