### PR TITLE
plasma5Packages: add missing homepages and descriptions

### DIFF
--- a/pkgs/applications/kde/akregator.nix
+++ b/pkgs/applications/kde/akregator.nix
@@ -12,6 +12,8 @@
 mkDerivation {
   pname = "akregator";
   meta = {
+    homepage = "https://apps.kde.org/akregator/";
+    description = "KDE feed reader";
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };

--- a/pkgs/applications/kde/ark/default.nix
+++ b/pkgs/applications/kde/ark/default.nix
@@ -30,6 +30,7 @@ mkDerivation {
   qtWrapperArgs = [ "--prefix" "PATH" ":" (lib.makeBinPath extraTools) ];
 
   meta = with lib; {
+    homepage = "https://apps.kde.org/ark/";
     description = "Graphical file compression/decompression utility";
     license = with licenses; [ gpl2 lgpl3 ] ++ optional unfreeEnableUnrar unfree;
     maintainers = [ maintainers.ttuegel ];

--- a/pkgs/applications/kde/dolphin.nix
+++ b/pkgs/applications/kde/dolphin.nix
@@ -11,6 +11,8 @@
 mkDerivation {
   pname = "dolphin";
   meta = {
+    homepage = "https://apps.kde.org/dolphin/";
+    description = "KDE file manager";
     license = with lib.licenses; [ gpl2 fdl12 ];
     maintainers = [ lib.maintainers.ttuegel ];
     broken = lib.versionOlder qtbase.version "5.14";

--- a/pkgs/applications/kde/dragon.nix
+++ b/pkgs/applications/kde/dragon.nix
@@ -10,6 +10,7 @@
 mkDerivation {
   pname = "dragon";
   meta = {
+    homepage = "https://apps.kde.org/dragonplayer/";
     license = with lib.licenses; [ gpl2 fdl12 ];
     description = "A simple media player for KDE";
     maintainers = [ lib.maintainers.jonathanreeve ];

--- a/pkgs/applications/kde/elisa.nix
+++ b/pkgs/applications/kde/elisa.nix
@@ -40,6 +40,7 @@ mkDerivation rec {
   ];
 
   meta = with lib; {
+    homepage = "https://apps.kde.org/elisa/";
     description = "A simple media player for KDE";
     license = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/applications/kde/filelight.nix
+++ b/pkgs/applications/kde/filelight.nix
@@ -7,6 +7,8 @@
 mkDerivation {
   pname = "filelight";
   meta = {
+    description = "Disk usage statistics";
+    homepage = "https://apps.kde.org/filelight/";
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ fridh vcunat ];
     broken = lib.versionOlder qtbase.version "5.13";

--- a/pkgs/applications/kde/gwenview.nix
+++ b/pkgs/applications/kde/gwenview.nix
@@ -9,6 +9,8 @@
 mkDerivation {
   pname = "gwenview";
   meta = {
+    homepage = "https://apps.kde.org/gwenview/";
+    description = "KDE image viewer";
     license = with lib.licenses; [ gpl2 fdl12 ];
     maintainers = [ lib.maintainers.ttuegel ];
   };

--- a/pkgs/applications/kde/k3b.nix
+++ b/pkgs/applications/kde/k3b.nix
@@ -10,6 +10,8 @@
 mkDerivation {
   pname = "k3b";
   meta = with lib; {
+    homepage = "https://apps.kde.org/k3b/";
+    description = "Disk burning application";
     license = with licenses; [ gpl2Plus ];
     maintainers = with maintainers; [ sander phreedom ];
     platforms = platforms.linux;

--- a/pkgs/applications/kde/kaddressbook.nix
+++ b/pkgs/applications/kde/kaddressbook.nix
@@ -10,6 +10,8 @@
 mkDerivation {
   pname = "kaddressbook";
   meta = {
+    homepage = "https://apps.kde.org/kaddressbook/";
+    description = "KDE contact manager";
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };

--- a/pkgs/applications/kde/kalarm.nix
+++ b/pkgs/applications/kde/kalarm.nix
@@ -19,6 +19,8 @@
 mkDerivation {
   pname = "kalarm";
   meta = {
+    homepage = "https://apps.kde.org/kalarm/";
+    description = "Personal alarm scheduler";
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.rittelle ];
   };

--- a/pkgs/applications/kde/kamoso.nix
+++ b/pkgs/applications/kde/kamoso.nix
@@ -37,5 +37,9 @@ mkDerivation {
     "--prefix GST_PLUGIN_PATH : ${lib.makeSearchPath "lib/gstreamer-1.0" gst}"
   ];
 
-  meta.license = with lib.licenses; [ lgpl21Only gpl3Only ];
+  meta = {
+    homepage = "https://apps.kde.org/kamoso/";
+    description = "A simple and friendly program to use your camera";
+    license = with lib.licenses; [ lgpl21Only gpl3Only ];
+  };
 }

--- a/pkgs/applications/kde/kate.nix
+++ b/pkgs/applications/kde/kate.nix
@@ -10,6 +10,8 @@
 mkDerivation {
   pname = "kate";
   meta = {
+    homepage = "https://apps.kde.org/kate/";
+    description = "Advanced text editor";
     license = with lib.licenses; [ gpl3 lgpl3 lgpl2 ];
     maintainers = [ lib.maintainers.ttuegel ];
   };

--- a/pkgs/applications/kde/kbreakout.nix
+++ b/pkgs/applications/kde/kbreakout.nix
@@ -11,7 +11,11 @@
 
 mkDerivation {
   pname = "kbreakout";
-  meta.license = with lib.licenses; [ lgpl21 gpl3 ];
+  meta = {
+    homepage = "KBreakOut";
+    description = "Breakout-like game";
+    license = with lib.licenses; [ lgpl21 gpl3 ];
+  };
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [
     cmake extra-cmake-modules

--- a/pkgs/applications/kde/kcachegrind.nix
+++ b/pkgs/applications/kde/kcachegrind.nix
@@ -8,6 +8,8 @@
 mkDerivation {
   pname = "kcachegrind";
   meta = {
+    homepage = "https://apps.kde.org/kcachegrind/";
+    description = "Profiler frontend";
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ orivej ];
   };

--- a/pkgs/applications/kde/kcalc.nix
+++ b/pkgs/applications/kde/kcalc.nix
@@ -8,6 +8,8 @@
 mkDerivation {
   pname = "kcalc";
   meta = {
+    homepage = "https://apps.kde.org/kcalc/";
+    description = "Scientific calculator";
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.fridh ];
   };

--- a/pkgs/applications/kde/kcharselect.nix
+++ b/pkgs/applications/kde/kcharselect.nix
@@ -7,6 +7,7 @@
 mkDerivation {
   pname = "kcharselect";
   meta = {
+    homepage = "https://apps.kde.org/kcharselect/";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.schmittlauch ];
     description = "A tool to select special characters from all installed fonts and copy them into the clipboard";

--- a/pkgs/applications/kde/kcolorchooser.nix
+++ b/pkgs/applications/kde/kcolorchooser.nix
@@ -7,6 +7,8 @@
 mkDerivation {
   pname = "kcolorchooser";
   meta = {
+    homepage = "https://apps.kde.org/kcolorchooser/";
+    description = "Color chooser";
     license = with lib.licenses; [ mit ];
     maintainers = [ lib.maintainers.ttuegel ];
   };

--- a/pkgs/applications/kde/kdebugsettings.nix
+++ b/pkgs/applications/kde/kdebugsettings.nix
@@ -9,6 +9,8 @@
 mkDerivation {
   pname = "kdebugsettings";
   meta = {
+    homepage = "https://apps.kde.org/kdebugsettings/";
+    description = "KDE debug settings";
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.rittelle ];
     broken = lib.versionOlder qtbase.version "5.13";

--- a/pkgs/applications/kde/kdenlive/default.nix
+++ b/pkgs/applications/kde/kdenlive/default.nix
@@ -101,6 +101,8 @@ mkDerivation {
   '';
 
   meta = {
+    homepage = "https://apps.kde.org/kdenlive/";
+    description = "Video editor";
     license = with lib.licenses; [ gpl2Plus ];
     maintainers = with lib.maintainers; [ turion ];
   };

--- a/pkgs/applications/kde/kdialog.nix
+++ b/pkgs/applications/kde/kdialog.nix
@@ -8,6 +8,8 @@ mkDerivation {
   pname = "kdialog";
 
   meta = {
+    homepage = "https://apps.kde.org/kdialog/";
+    description = "Display dialog boxes from shell scripts";
     license = with lib.licenses; [ gpl2 fdl12 ];
     maintainers = with lib.maintainers; [ peterhoeg ];
   };

--- a/pkgs/applications/kde/kfind.nix
+++ b/pkgs/applications/kde/kfind.nix
@@ -7,6 +7,8 @@
 mkDerivation {
   pname = "kfind";
   meta = {
+    homepage = "https://apps.kde.org/kfind/";
+    description = "Find files/folders";
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.iblech ];
   };

--- a/pkgs/applications/kde/kgeography.nix
+++ b/pkgs/applications/kde/kgeography.nix
@@ -7,6 +7,8 @@
 mkDerivation {
   pname = "kgeography";
   meta = {
+    homepage = "https://apps.kde.org/kgeography/";
+    description = "Geography trainer";
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.globin ];
   };

--- a/pkgs/applications/kde/kget.nix
+++ b/pkgs/applications/kde/kget.nix
@@ -16,6 +16,8 @@ mkDerivation {
   ];
 
   meta = with lib; {
+    homepage = "https://apps.kde.org/kget/";
+    description = "Download manager";
     license = with licenses; [ gpl2 ];
     maintainers = with maintainers; [ peterhoeg ];
   };

--- a/pkgs/applications/kde/kgpg.nix
+++ b/pkgs/applications/kde/kgpg.nix
@@ -18,6 +18,8 @@ mkDerivation {
     wrapProgram "$out/bin/kgpg" --prefix PATH : "${lib.makeBinPath [ gnupg ]}"
   '';
   meta = {
+    homepage = "https://apps.kde.org/kgpg/";
+    description = "Encryption tool";
     license = [ lib.licenses.gpl2 ];
     maintainers = [ lib.maintainers.ttuegel ];
   };

--- a/pkgs/applications/kde/khelpcenter.nix
+++ b/pkgs/applications/kde/khelpcenter.nix
@@ -1,8 +1,7 @@
-{
-  mkDerivation,
-  extra-cmake-modules, kdoctools,
-  grantlee, kcmutils, kconfig, kcoreaddons, kdbusaddons, ki18n,
-  kinit, khtml, kservice, xapian
+{ lib, mkDerivation
+, extra-cmake-modules, kdoctools
+, grantlee, kcmutils, kconfig, kcoreaddons, kdbusaddons, ki18n
+, kinit, khtml, kservice, xapian
 }:
 
 mkDerivation {
@@ -12,4 +11,9 @@ mkDerivation {
     grantlee kcmutils kconfig kcoreaddons kdbusaddons khtml
     ki18n kinit kservice xapian
   ];
+  meta = with lib; {
+    homepage = "https://apps.kde.org/help/";
+    description = "Help center";
+    license = licenses.gpl2Plus;
+  };
 }

--- a/pkgs/applications/kde/kig.nix
+++ b/pkgs/applications/kde/kig.nix
@@ -8,6 +8,8 @@
 mkDerivation {
   pname = "kig";
   meta = {
+    homepage = "https://apps.kde.org/kig/";
+    description = "Interactive geometry";
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ raskin ];
   };
@@ -16,4 +18,3 @@ mkDerivation {
     boost karchive kcrash kiconthemes kparts ktexteditor qtsvg qtxmlpatterns
   ];
 }
-

--- a/pkgs/applications/kde/kleopatra.nix
+++ b/pkgs/applications/kde/kleopatra.nix
@@ -8,6 +8,8 @@
 mkDerivation {
   pname = "kleopatra";
   meta = {
+    homepage = "https://apps.kde.org/kleopatra/";
+    description = "Certificate manager and unified crypto GUI";
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };

--- a/pkgs/applications/kde/kmahjongg.nix
+++ b/pkgs/applications/kde/kmahjongg.nix
@@ -13,6 +13,8 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ kdeclarative libkmahjongg knewstuff libkdegames ];
   meta = {
+    description = "Mahjongg solitaire";
+    homepage = "https://apps.kde.org/kmahjongg/";
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ ];
   };

--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -53,6 +53,8 @@
 mkDerivation {
   pname = "kmail";
   meta = {
+    homepage = "https://apps.kde.org/kmail2/";
+    description = "Mail client";
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };

--- a/pkgs/applications/kde/kmix.nix
+++ b/pkgs/applications/kde/kmix.nix
@@ -8,6 +8,8 @@
 mkDerivation {
   pname = "kmix";
   meta = {
+    homepage = "https://apps.kde.org/kmix/";
+    description = "Sound mixer";
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = [ lib.maintainers.rongcuid ];
   };

--- a/pkgs/applications/kde/kmplot.nix
+++ b/pkgs/applications/kde/kmplot.nix
@@ -5,6 +5,8 @@
 mkDerivation {
   pname = "kmplot";
   meta = {
+    homepage = "https://apps.kde.org/kmplot/";
+    description = "Mathematical function plotter";
     license = with lib.licenses; [ gpl2Plus fdl12 ];
     maintainers = [ lib.maintainers.orivej ];
   };

--- a/pkgs/applications/kde/knotes.nix
+++ b/pkgs/applications/kde/knotes.nix
@@ -1,14 +1,13 @@
-{
-  mkDerivation,
-  extra-cmake-modules, kdoctools,
-  kcompletion, kconfig, kconfigwidgets, kcoreaddons, kcrash,
-  kdbusaddons, kdnssd, kglobalaccel, kiconthemes, kitemmodels,
-  kitemviews, kcmutils, knewstuff, knotifications, knotifyconfig,
-  kparts, ktextwidgets, kwidgetsaddons, kwindowsystem,
-  grantlee, grantleetheme, qtx11extras,
-  akonadi, akonadi-notes, akonadi-search, kcalutils,
-  kontactinterface, libkdepim, kmime, pimcommon, kpimtextedit,
-  kcalendarcore
+{ lib, mkDerivation
+, extra-cmake-modules, kdoctools
+, kcompletion, kconfig, kconfigwidgets, kcoreaddons, kcrash
+, kdbusaddons, kdnssd, kglobalaccel, kiconthemes, kitemmodels
+, kitemviews, kcmutils, knewstuff, knotifications, knotifyconfig
+, kparts, ktextwidgets, kwidgetsaddons, kwindowsystem
+, grantlee, grantleetheme, qtx11extras
+, akonadi, akonadi-notes, akonadi-search, kcalutils
+, kontactinterface, libkdepim, kmime, pimcommon, kpimtextedit
+, kcalendarcore
 }:
 
 mkDerivation {
@@ -25,4 +24,9 @@ mkDerivation {
     akonadi-search
     kcalendarcore
   ];
+  meta = with lib; {
+    homepage = "https://apps.kde.org/knotes/";
+    description = "Popup notes";
+    license = licenses.gpl2Plus;
+  };
 }

--- a/pkgs/applications/kde/kolf.nix
+++ b/pkgs/applications/kde/kolf.nix
@@ -10,6 +10,8 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ libkdegames kio ktextwidgets ];
   meta = {
+    homepage = "https://apps.kde.org/kolf/";
+    description = "Miniature golf";
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ peterhoeg ];
   };

--- a/pkgs/applications/kde/kolourpaint.nix
+++ b/pkgs/applications/kde/kolourpaint.nix
@@ -17,6 +17,8 @@ mkDerivation {
     kguiaddons kio ktextwidgets kwidgetsaddons kxmlgui libkexiv2
   ];
   meta = {
+    homepage = "https://apps.kde.org/kolourpaint/";
+    description = "Paint program";
     maintainers = [ lib.maintainers.fridh ];
     license = with lib.licenses; [ gpl2 ];
   };

--- a/pkgs/applications/kde/kompare.nix
+++ b/pkgs/applications/kde/kompare.nix
@@ -7,7 +7,11 @@
 
 mkDerivation {
   pname = "kompare";
-  meta = { license = with lib.licenses; [ gpl2 ]; };
+  meta = {
+    homepage = "https://apps.kde.org/kompare/";
+    description = "Diff/patch frontend";
+    license = with lib.licenses; [ gpl2 ];
+  };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     kiconthemes kparts ktexteditor kwidgetsaddons libkomparediff2

--- a/pkgs/applications/kde/konqueror.nix
+++ b/pkgs/applications/kde/konqueror.nix
@@ -22,6 +22,8 @@ mkDerivation {
   '';
 
   meta = {
+    homepage = "https://apps.kde.org/konqueror/";
+    description = "Web browser, file manager and viewer";
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ ];
     broken = lib.versionOlder qtbase.version "5.13";

--- a/pkgs/applications/kde/konquest.nix
+++ b/pkgs/applications/kde/konquest.nix
@@ -22,6 +22,8 @@ mkDerivation {
     qtquickcontrols
   ];
   meta = {
+    homepage = "https://apps.kde.org/konquest/";
+    description = "Galactic strategy game";
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ lheckemann ];
   };

--- a/pkgs/applications/kde/konsole.nix
+++ b/pkgs/applications/kde/konsole.nix
@@ -10,6 +10,8 @@
 mkDerivation {
   pname = "konsole";
   meta = {
+    homepage = "https://apps.kde.org/konsole/";
+    description = "KDE terminal emulator";
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = with lib.maintainers; [ ttuegel turion ];
   };

--- a/pkgs/applications/kde/kontact.nix
+++ b/pkgs/applications/kde/kontact.nix
@@ -10,6 +10,8 @@
 mkDerivation {
   pname = "kontact";
   meta = {
+    homepage = "https://apps.kde.org/kontact/";
+    description = "Personal information manager";
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };

--- a/pkgs/applications/kde/korganizer.nix
+++ b/pkgs/applications/kde/korganizer.nix
@@ -13,6 +13,8 @@
 mkDerivation {
   pname = "korganizer";
   meta = {
+    homepage = "https://apps.kde.org/korganizer/";
+    description = "Personal organizer";
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };

--- a/pkgs/applications/kde/krdc.nix
+++ b/pkgs/applications/kde/krdc.nix
@@ -18,6 +18,7 @@ mkDerivation {
   '';
   meta = with lib; {
     homepage = "http://www.kde.org";
+    description = "Remote desktop client";
     license = with licenses; [ gpl2 lgpl21 fdl12 bsd3 ];
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;

--- a/pkgs/applications/kde/krfb.nix
+++ b/pkgs/applications/kde/krfb.nix
@@ -10,6 +10,8 @@
 mkDerivation {
   pname = "krfb";
   meta = {
+    homepage = "https://apps.kde.org/krfb/";
+    description = "Desktop sharing (VNC)";
     license = with lib.licenses; [ gpl2 fdl12 ];
     maintainers = with lib.maintainers; [ jerith666 ];
   };

--- a/pkgs/applications/kde/kruler.nix
+++ b/pkgs/applications/kde/kruler.nix
@@ -7,6 +7,8 @@
 mkDerivation {
   pname = "kruler";
   meta = {
+    homepage = "https://apps.kde.org/kruler/";
+    description = "Screen ruler";
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.vandenoever ];
   };

--- a/pkgs/applications/kde/kspaceduel.nix
+++ b/pkgs/applications/kde/kspaceduel.nix
@@ -11,7 +11,11 @@
 
 mkDerivation {
   pname = "kspaceduel";
-  meta.license = with lib.licenses; [ lgpl21 gpl3 ];
+  meta = {
+    homepage = "https://apps.kde.org/kspaceduel/";
+    description = "Space arcade game";
+    license = with lib.licenses; [ lgpl21 gpl3 ];
+  };
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [
     cmake extra-cmake-modules

--- a/pkgs/applications/kde/ksudoku.nix
+++ b/pkgs/applications/kde/ksudoku.nix
@@ -12,6 +12,8 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ libGLU kdeclarative libkdegames ];
   meta = {
+    homepage = "https://apps.kde.org/ksudoku/";
+    description = "Suduko game";
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ ];
   };

--- a/pkgs/applications/kde/ksystemlog.nix
+++ b/pkgs/applications/kde/ksystemlog.nix
@@ -11,6 +11,8 @@ mkDerivation {
   propagatedBuildInputs = [ karchive kconfig kio ];
 
   meta = with lib; {
+    homepage = "https://apps.kde.org/ksystemlog/";
+    description = "System log viewer";
     license = with licenses; [ gpl2 ];
     maintainers = with maintainers; [ peterhoeg ];
   };

--- a/pkgs/applications/kde/ktouch.nix
+++ b/pkgs/applications/kde/ktouch.nix
@@ -7,22 +7,22 @@
 , xorg
 }:
 
+mkDerivation {
+  pname = "ktouch";
+  meta = {
+    homepage = "https://apps.kde.org/ktouch/";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.schmittlauch ];
+    description = "A touch typing tutor from the KDE software collection";
+  };
+  nativeBuildInputs = [ extra-cmake-modules kdoctools qtdeclarative ];
+  buildInputs = [
+    kconfig kconfigwidgets kcoreaddons kdeclarative ki18n
+    kitemviews kcmutils kio knewstuff ktexteditor kwidgetsaddons
+    kwindowsystem kxmlgui qtscript qtdeclarative kqtquickcharts
+    qtx11extras qtgraphicaleffects qtxmlpatterns qtquickcontrols2
+    xorg.libxkbfile xorg.libxcb
+  ];
 
-  mkDerivation {
-    pname = "ktouch";
-    meta = {
-      license = lib.licenses.gpl2;
-      maintainers = [ lib.maintainers.schmittlauch ];
-      description = "A touch typing tutor from the KDE software collection";
-    };
-    nativeBuildInputs = [ extra-cmake-modules kdoctools qtdeclarative ];
-    buildInputs = [
-      kconfig kconfigwidgets kcoreaddons kdeclarative ki18n
-      kitemviews kcmutils kio knewstuff ktexteditor kwidgetsaddons
-      kwindowsystem kxmlgui qtscript qtdeclarative kqtquickcharts
-      qtx11extras qtgraphicaleffects qtxmlpatterns qtquickcontrols2
-      xorg.libxkbfile xorg.libxcb
-    ];
-
-    enableParallelBuilding = true;
+  enableParallelBuilding = true;
 }

--- a/pkgs/applications/kde/kwalletmanager.nix
+++ b/pkgs/applications/kde/kwalletmanager.nix
@@ -14,6 +14,9 @@
 mkDerivation {
   pname = "kwalletmanager";
   meta = {
+    homepage = "https://apps.kde.org/kwalletmanager5/";
+
+    description = "KDE wallet management tool";
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ fridh ];
   };

--- a/pkgs/applications/kde/marble.nix
+++ b/pkgs/applications/kde/marble.nix
@@ -7,7 +7,11 @@
 
 mkDerivation {
   pname = "marble";
-  meta.license = with lib.licenses; [ lgpl21 gpl3 ];
+  meta = {
+    homepage = "https://apps.kde.org/marble/";
+    description = "Virtual globe";
+    license = with lib.licenses; [ lgpl21 gpl3 ];
+  };
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [ extra-cmake-modules kdoctools perl ];
   propagatedBuildInputs = [

--- a/pkgs/applications/kde/minuet.nix
+++ b/pkgs/applications/kde/minuet.nix
@@ -8,6 +8,8 @@
 mkDerivation {
   pname = "minuet";
   meta = with lib; {
+    homepage = "https://apps.kde.org/minuet/";
+    description = "Music Education Software";
     license = with licenses; [ lgpl21 gpl3 ];
     maintainers = with maintainers; [ peterhoeg HaoZeke ];
     broken = lib.versionOlder qtbase.version "5.14";

--- a/pkgs/applications/kde/okular.nix
+++ b/pkgs/applications/kde/okular.nix
@@ -29,6 +29,7 @@ mkDerivation {
 
   meta = with lib; {
     homepage = "http://www.kde.org";
+    description = "KDE document viewer";
     license = with licenses; [ gpl2 lgpl21 fdl12 bsd3 ];
     maintainers = with maintainers; [ ttuegel turion ];
     platforms = lib.platforms.linux;

--- a/pkgs/applications/kde/picmi.nix
+++ b/pkgs/applications/kde/picmi.nix
@@ -6,6 +6,7 @@
 mkDerivation {
   pname = "picmi";
   meta = with lib; {
+    homepage = "https://apps.kde.org/picmi/";
     description = "Nonogram game";
     longDescription = ''The goal is to reveal the hidden pattern in the board by coloring or
       leaving blank the cells in a grid according to numbers given at the side of the grid.

--- a/pkgs/applications/kde/pim-data-exporter.nix
+++ b/pkgs/applications/kde/pim-data-exporter.nix
@@ -10,6 +10,8 @@
 mkDerivation {
   pname = "pim-data-exporter";
   meta = {
+    homepage = "https://apps.kde.org/pimdataexporter/";
+    description = "Saves and restores all data from PIM apps";
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };

--- a/pkgs/applications/kde/spectacle.nix
+++ b/pkgs/applications/kde/spectacle.nix
@@ -20,6 +20,8 @@ mkDerivation {
   '';
   propagatedUserEnvPkgs = [ kipi-plugins libkipi ];
   meta = with lib; {
+    homepage = "https://apps.kde.org/spectacle/";
+    description = "Screenshot capture utility";
     maintainers = with maintainers; [ ttuegel ];
     broken = versionOlder qtbase.version "5.15";
   };


### PR DESCRIPTION
Adapted from <https://apps.kde.org/>.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
