### PR TITLE
catatonit: 0.1.5 -> 0.1.6

### DIFF
--- a/pkgs/applications/virtualization/catatonit/default.nix
+++ b/pkgs/applications/virtualization/catatonit/default.nix
@@ -1,23 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, glibc, nixosTests }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, glibc, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "catatonit";
-  version = "0.1.5";
+  version = "0.1.6";
 
   src = fetchFromGitHub {
     owner = "openSUSE";
     repo = pname;
     rev = "v${version}";
-    sha256 = "ciJ1MI7jr5P2PgxIykQ+BiwNUO8lQHGt0+U8CNbc5bI=";
+    sha256 = "sha256-hokG6o7toZxU984EvIlne33Aa2EZVZ3qu1jTZMm5nt4=";
   };
-
-  patches = [
-    # Fix compilation with musl
-    (fetchpatch {
-      url = "https://github.com/openSUSE/catatonit/commit/75014b1c3099245b7d0f44f24d7f6dc4888a45fd.patch";
-      sha256 = "sha256-9VMNUT1U90ocjvE7EXYfLxuodDwTXXHYg89qqa5Jq0g=";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = lib.optionals (!stdenv.hostPlatform.isMusl) [ glibc glibc.static ];


### PR DESCRIPTION
https://github.com/openSUSE/catatonit/releases/tag/v0.1.6

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
