### PR TITLE
memorymapping: constrain to darwin (fails on linux)

### DIFF
--- a/pkgs/development/libraries/memorymapping/default.nix
+++ b/pkgs/development/libraries/memorymapping/default.nix
@@ -37,7 +37,9 @@ stdenv.mkDerivation {
     description = "fmemopen for Mac OS and iOS";
     license = licenses.asl20;
     maintainers = with maintainers; [ veprbl ];
-    platforms = platforms.unix;
+    # Uses BSD-style funopen() to implement glibc-style fmemopen().
+    # Add more BSDs if you need to.
+    platforms = platforms.darwin;
     broken = stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/issues/138378