### PR TITLE
spot: Build an optimised binary, to drop CPU usage: 70% -> 10%

### DIFF
--- a/pkgs/applications/audio/spot/default.nix
+++ b/pkgs/applications/audio/spot/default.nix
@@ -59,6 +59,9 @@ stdenv.mkDerivation rec {
     libpulseaudio
   ];
 
+  # Per https://github.com/xou816/spot/blob/2a591febcfa4b9690ea166097392d2a327cd0c60/README.md#L111 .
+  mesonBuildType = "release";
+
   postPatch = ''
     chmod +x build-aux/cargo.sh
     patchShebangs build-aux/cargo.sh build-aux/meson/postinstall.py

--- a/pkgs/applications/audio/spot/default.nix
+++ b/pkgs/applications/audio/spot/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     libpulseaudio
   ];
 
-  # Per https://github.com/xou816/spot/blob/2a591febcfa4b9690ea166097392d2a327cd0c60/README.md#L111 .
+  # https://github.com/xou816/spot/issues/313
   mesonBuildType = "release";
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Spot had 70% CPU usage while playing music on my Pinephone.

https://github.com/xou816/spot/blob/2a591febcfa4b9690ea166097392d2a327cd0c60/README.md?plain=1#L111 suggests the fix in this PR.

This PR dropped CPU usage to 10%.

https://github.com/xou816/spot/issues/131 reports that this dropped ~30-40% to 5-10% on an i7-7700.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
