### PR TITLE
gd: 2.3.0 -> 2.3.3

### DIFF
--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -14,27 +14,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gd";
-  version = "2.3.0";
+  version = "2.3.3";
 
   src = fetchurl {
     url = "https://github.com/libgd/libgd/releases/download/${pname}-${version}/libgd-${version}.tar.xz";
-    sha256 = "0n5czhxzinvjvmhkf5l9fwjdx5ip69k5k7pj6zwb6zs1k9dibngc";
+    sha256 = "0qas3q9xz3wgw06dm2fj0i189rain6n60z1vyq50d5h7wbn25s1z";
   };
 
   hardeningDisable = [ "format" ];
-  patches = [
-    # Fixes an issue where some other packages would fail to build
-    # their documentation with an error like:
-    # "Error: Problem doing text layout"
-    #
-    # Can be removed if Wayland can still be built successfully with
-    # documentation.
-    (fetchpatch {
-      url = "https://github.com/libgd/libgd/commit/3dd0e308cbd2c24fde2fc9e9b707181252a2de95.patch";
-      excludes = [ "tests/gdimagestringft/.gitignore" ];
-      sha256 = "12iqlanl9czig9d7c3rvizrigw2iacimnmimfcny392dv9iazhl1";
-    })
-  ];
 
   # -pthread gets passed to clang, causing warnings
   configureFlags = lib.optional stdenv.isDarwin "--enable-werror=no";


### PR DESCRIPTION
###### Motivation for this change
This *partially* resolves https://nvd.nist.gov/vuln/detail/CVE-2021-40812. Fixes it for BMP and WebP, leaves GIF unresolved. That will apparently take a significantly larger fix, possibly API-breaking.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
