### PR TITLE
lib: Add attrsets.mainProgram

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -497,7 +497,8 @@ rec {
   getMan = getOutput "man";
 
   /* Get a package's main executable's path */
-  mainProgram = pkg: "${getBin pkg}/bin/${pkg.meta.mainProgram}";
+  mainProgram = pkg:
+    "${getBin pkg}/bin/${pkg.meta.mainProgram or (lib.getName pkg)}";
 
   /* Pick the outputs of packages to place in buildInputs */
   chooseDevOutputs = drvs: builtins.map getDev drvs;

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -496,6 +496,9 @@ rec {
   getDev = getOutput "dev";
   getMan = getOutput "man";
 
+  /* Get a package's main executable's path */
+  mainProgram = pkg: "${getBin pkg}/bin/${pkg.meta.mainProgram}";
+
   /* Pick the outputs of packages to place in buildInputs */
   chooseDevOutputs = drvs: builtins.map getDev drvs;
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -496,7 +496,7 @@ rec {
   getDev = getOutput "dev";
   getMan = getOutput "man";
 
-  /* Get a package's main executable's path */
+  /* Get the path to a package's main executable */
   mainProgram = pkg:
     "${getBin pkg}/bin/${pkg.meta.mainProgram or (lib.getName pkg)}";
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -78,7 +78,7 @@ let
       genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
-      getLib getDev getMan chooseDevOutputs zipWithNames zip
+      getLib getDev getMan mainProgram chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProductOfSets;
     inherit (self.lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nodejs, stdenv, applyPatches, fetchFromGitHub, fetchpatch, fetchurl }:
+{ lib, pkgs, nodejs, stdenv, applyPatches, fetchFromGitHub, fetchpatch, fetchurl }:
 
 let
   since = (version: pkgs.lib.versionAtLeast nodejs.version version);
@@ -33,7 +33,7 @@ let
       '';
       postInstall = ''
         wrapProgram $out/bin/aws-azure-login \
-            --set PUPPETEER_EXECUTABLE_PATH ${pkgs.chromium}/bin/chromium
+            --set PUPPETEER_EXECUTABLE_PATH ${lib.mainProgram pkgs.chromium}
       '';
     };
 
@@ -68,7 +68,7 @@ let
       '';
       postInstall = ''
         wrapProgram $out/bin/fast \
-          --set PUPPETEER_EXECUTABLE_PATH ${pkgs.chromium.outPath}/bin/chromium
+          --set PUPPETEER_EXECUTABLE_PATH ${lib.mainProgram pkgs.chromium}
       '';
     });
 
@@ -240,7 +240,7 @@ let
       '';
       postInstall = ''
         wrapProgram $out/bin/mmdc \
-        --set PUPPETEER_EXECUTABLE_PATH ${pkgs.chromium.outPath}/bin/chromium
+        --set PUPPETEER_EXECUTABLE_PATH ${lib.mainProgram pkgs.chromium}
       '';
     });
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Writing `"${pkgs.something}/bin/something"` is a common idiom, both in `nixpkgs` itself and Nix users' configuration.
That idiom is brittle, as it will break if the binary is renamed ~~or the package is made multi-output~~.

Using instead `lib.mainProgram pkgs.something` avoids both of those issues, and avoids implementing ad-hoc solutions
everywhere, while often being shorter.

As an example, `node-packages` is simplified and made more uniform; prior to the change, `PUPEETER_EXECUTABLE_PATH`
was defined in several different — but equivalent — ways using `.outPath` or not; using `lib.mainProgram` is 
equivalent to both of those and less brittle.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))~~
- ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - ~~(Module updates) Added a release notes entry if the change is significant~~
  - ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
