### PR TITLE
pantheon-tweaks: init at 1.0.1

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -273,6 +273,13 @@
           <link linkend="opt-services.touchegg.enable">services.touchegg</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/pantheon-tweaks/pantheon-tweaks">pantheon-tweaks</link>,
+          an unofficial system settings panel for Pantheon. Available as
+          <link linkend="opt-programs.pantheon-tweaks.enable">programs.pantheon-tweaks</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -86,6 +86,8 @@ subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable
 
 - [touchegg](https://github.com/JoseExposito/touchegg), a multi-touch gesture recognizer. Available as [services.touchegg](#opt-services.touchegg.enable).
 
+- [pantheon-tweaks](https://github.com/pantheon-tweaks/pantheon-tweaks), an unofficial system settings panel for Pantheon. Available as [programs.pantheon-tweaks](#opt-programs.pantheon-tweaks.enable).
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -171,6 +171,7 @@
   ./programs/npm.nix
   ./programs/noisetorch.nix
   ./programs/oblogout.nix
+  ./programs/pantheon-tweaks.nix
   ./programs/partition-manager.nix
   ./programs/plotinus.nix
   ./programs/proxychains.nix

--- a/nixos/modules/programs/pantheon-tweaks.nix
+++ b/nixos/modules/programs/pantheon-tweaks.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta = {
+    maintainers = teams.pantheon.members;
+  };
+
+  ###### interface
+  options = {
+    programs.pantheon-tweaks.enable = mkEnableOption "Pantheon Tweaks, an unofficial system settings panel for Pantheon";
+  };
+
+  ###### implementation
+  config = mkIf config.programs.pantheon-tweaks.enable {
+    services.xserver.desktopManager.pantheon.extraSwitchboardPlugs = [ pkgs.pantheon-tweaks ];
+  };
+}

--- a/pkgs/applications/system/pantheon-tweaks/default.nix
+++ b/pkgs/applications/system/pantheon-tweaks/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, nix-update-script
+, meson
+, ninja
+, pkg-config
+, python3
+, vala
+, gtk3
+, libgee
+, pantheon
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pantheon-tweaks";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "pantheon-tweaks";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-tAfDxX/RD7pO5PN/LaZ92Cj/iZtBI/EHb0+pORfYnPM=";
+  };
+
+  patches = [
+    ./fix-paths.patch
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+    vala
+  ];
+
+  buildInputs = [
+    gtk3
+    libgee
+    pantheon.granite
+    pantheon.switchboard
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with lib; {
+    description = "Unofficial system settings panel for Pantheon";
+    longDescription = ''
+      Unofficial system settings panel for Pantheon
+      that lets you easily and safely customise your desktop's appearance.
+      Use programs.pantheon-tweaks.enable to add this to your switchboard.
+    '';
+    homepage = "https://github.com/pantheon-tweaks/pantheon-tweaks";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.pantheon.members;
+  };
+}

--- a/pkgs/applications/system/pantheon-tweaks/fix-paths.patch
+++ b/pkgs/applications/system/pantheon-tweaks/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Settings/ThemeSettings.vala b/src/Settings/ThemeSettings.vala
+index 589121b..8e9c81e 100644
+--- a/src/Settings/ThemeSettings.vala
++++ b/src/Settings/ThemeSettings.vala
+@@ -29,7 +29,7 @@ public class PantheonTweaks.ThemeSettings {
+         var themes = new Gee.ArrayList<string> ();
+ 
+         string[] dirs = {
+-            "/usr/share/" + path + "/",
++            "/run/current-system/sw/share/" + path + "/",
+             Environment.get_home_dir () + "/." + path + "/",
+             Environment.get_home_dir () + "/.local/share/" + path + "/"};
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8021,6 +8021,8 @@ with pkgs;
 
   pamtester = callPackage ../tools/security/pamtester { };
 
+  pantheon-tweaks = callPackage ../applications/system/pantheon-tweaks { };
+
   paperless-ng = callPackage ../applications/office/paperless-ng { };
 
   paperwork = callPackage ../applications/office/paperwork/paperwork-gtk.nix { };


### PR DESCRIPTION
###### Motivation for this change

A switchboard plugin.

Closes #115222 (some related discussions also happened here, I did not put the package or the option in the pantheon namespace due to reasons mentioned inside). I am not sure [if we really need an option for this](https://github.com/NixOS/nixpkgs/issues/115222#issuecomment-905957324) though.

###### Things done

- [x] Tested the option under Pantheon 6.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
