### PR TITLE
treewide: switch from pantheon.maintainers to lib.teams.pantheon

### DIFF
--- a/nixos/modules/services/desktops/gsignond.nix
+++ b/nixos/modules/services/desktops/gsignond.nix
@@ -9,7 +9,7 @@ let
 in
 {
 
-  meta.maintainers = pkgs.pantheon.maintainers;
+  meta.maintainers = teams.pantheon.members;
 
   ###### interface
 

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -18,7 +18,7 @@ in
 
   meta = {
     doc = ./pantheon.xml;
-    maintainers = pkgs.pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 
   options = {

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -3,8 +3,8 @@ import ./make-test-python.nix ({ pkgs, ...} :
 {
   name = "pantheon";
 
-  meta = with pkgs.lib.maintainers; {
-    maintainers = pkgs.pantheon.maintainers;
+  meta = with lib; {
+    maintainers = teams.pantheon.members;
   };
 
   machine = { ... }:

--- a/pkgs/applications/graphics/akira/default.nix
+++ b/pkgs/applications/graphics/akira/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     description = "Native Linux Design application built in Vala and GTK";
     homepage = "https://github.com/akiraux/Akira";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ Br1ght0ne neonfuz ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ Br1ght0ne neonfuz ] ++ teams.pantheon.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/ideogram/default.nix
+++ b/pkgs/applications/graphics/ideogram/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     description = "Insert emoji anywhere, even in non-native apps - designed for elementary OS";
     homepage = "https://github.com/cassidyjames/ideogram";
     license = licenses.gpl2Plus;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
     platforms = platforms.linux;
   };
 

--- a/pkgs/applications/misc/appeditor/default.nix
+++ b/pkgs/applications/misc/appeditor/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Edit the Pantheon desktop application menu";
     homepage = "https://github.com/donadigo/appeditor";
-    maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
   };

--- a/pkgs/applications/misc/cipher/default.nix
+++ b/pkgs/applications/misc/cipher/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A simple application for encoding and decoding text, designed for elementary OS";
     homepage = "https://github.com/arshubham/cipher";
-    maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
   };

--- a/pkgs/applications/misc/formatter/default.nix
+++ b/pkgs/applications/misc/formatter/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A simple formatter designed for elementary OS";
     homepage = "https://github.com/Djaler/Formatter";
-    maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.lgpl2Plus;
   };

--- a/pkgs/applications/misc/plank/default.nix
+++ b/pkgs/applications/misc/plank/default.nix
@@ -23,7 +23,6 @@
 , libgee
 , wrapGAppsHook
 , autoreconfHook
-, pantheon
 }:
 
 stdenv.mkDerivation rec {
@@ -84,6 +83,6 @@ stdenv.mkDerivation rec {
     homepage = "https://launchpad.net/plank";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ davidak ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ davidak ] ++ teams.pantheon.members;
   };
 }

--- a/pkgs/applications/misc/sequeler/default.nix
+++ b/pkgs/applications/misc/sequeler/default.nix
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/Alecaddd/sequeler";
     license = licenses.gpl3;
-    maintainers = [ maintainers.etu ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ etu ] ++ teams.pantheon.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/browsers/ephemeral/default.nix
+++ b/pkgs/applications/networking/browsers/ephemeral/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "The always-incognito web browser";
     homepage = "https://github.com/cassidyjames/ephemeral";
-    maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3;
   };

--- a/pkgs/applications/networking/ping/default.nix
+++ b/pkgs/applications/networking/ping/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A helpful tool that lets you debug what part of your API is causing you issues";
     homepage = "https://github.com/jeremyvaartjes/ping";
-    maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3;
   };

--- a/pkgs/applications/office/agenda/default.nix
+++ b/pkgs/applications/office/agenda/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A simple, fast, no-nonsense to-do (task) list designed for elementary OS";
     homepage = "https://github.com/dahenson/agenda";
-    maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3;
   };

--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
     description = "Task manager with Todoist support designed for GNU/Linux 🚀️";
     homepage = "https://planner-todo.web.app";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ dtzWill ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ dtzWill ] ++ teams.pantheon.members;
   };
 }
 

--- a/pkgs/applications/office/khronos/default.nix
+++ b/pkgs/applications/office/khronos/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Track each task's time in a simple inobtrusive way";
     homepage = "https://github.com/lainsce/khronos";
-    maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
   };

--- a/pkgs/applications/office/spice-up/default.nix
+++ b/pkgs/applications/office/spice-up/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Create simple and beautiful presentations";
     homepage = "https://github.com/Philip-Scott/Spice-up";
-    maintainers = with maintainers; [ samdroid-apps xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ samdroid-apps xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     # The COPYING file has GPLv3; some files have GPLv2+ and some have GPLv3+
     license = licenses.gpl3Plus;

--- a/pkgs/applications/science/math/nasc/default.nix
+++ b/pkgs/applications/science/math/nasc/default.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
       the equations it’s used in.
     '';
     homepage = "https://github.com/parnold-x/nasc";
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
   };

--- a/pkgs/applications/system/monitor/default.nix
+++ b/pkgs/applications/system/monitor/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
       section in the NixOS manual.
     '';
     homepage = "https://github.com/stsdc/monitor";
-    maintainers = with maintainers; [ xiorcale ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ xiorcale ] ++ teams.pantheon.members;
     platforms = platforms.linux;
     license = licenses.gpl3;
   };

--- a/pkgs/desktops/gnome/core/gnome-settings-daemon/3.38/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-settings-daemon/3.38/default.nix
@@ -129,7 +129,7 @@ stdenv.mkDerivation rec {
     description = "GNOME Settings Daemon";
     homepage = "https://gitlab.gnome.org/GNOME/gnome-settings-daemon/";
     license = licenses.gpl2Plus;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome/core/mutter/3.38/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/3.38/default.nix
@@ -157,7 +157,7 @@ let self = stdenv.mkDerivation rec {
     description = "A window manager for GNOME";
     homepage = "https://gitlab.gnome.org/GNOME/mutter";
     license = licenses.gpl2Plus;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
     platforms = platforms.linux;
   };
 };

--- a/pkgs/desktops/pantheon/apps/appcenter/default.nix
+++ b/pkgs/desktops/pantheon/apps/appcenter/default.nix
@@ -97,6 +97,6 @@ stdenv.mkDerivation rec {
     description = "An open, pay-what-you-want app store for indie developers, designed for elementary OS";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-calculator/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-calculator/default.nix
@@ -68,6 +68,6 @@ stdenv.mkDerivation rec {
     description = "Calculator app designed for elementary OS";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
@@ -83,6 +83,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/calendar";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-camera/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-camera/default.nix
@@ -80,6 +80,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/camera";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-code/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-code/default.nix
@@ -107,6 +107,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/code";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-dock/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-dock/default.nix
@@ -75,6 +75,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/dock";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ davidak ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ davidak ] ++ teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
@@ -79,6 +79,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/feedback";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-files/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-files/default.nix
@@ -99,6 +99,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/files";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
@@ -84,6 +84,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/mail";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers ++ [ maintainers.ethancedwards8 ];
+    maintainers = with maintainers; [ ethancedwards8 ] ++ teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-music/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-music/default.nix
@@ -107,6 +107,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/music";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -113,6 +113,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/photos";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-screenshot/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-screenshot/default.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/screenshot";
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-tasks/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-tasks/default.nix
@@ -79,6 +79,6 @@ stdenv.mkDerivation rec {
     description = "Synced tasks and reminders on elementary OS";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
@@ -90,6 +90,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/terminal";
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/elementary-videos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-videos/default.nix
@@ -82,6 +82,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/videos";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/sideload/default.nix
+++ b/pkgs/desktops/pantheon/apps/sideload/default.nix
@@ -71,6 +71,6 @@ stdenv.mkDerivation rec {
     description = "Flatpak installer, designed for elementary OS";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
@@ -66,6 +66,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-a11y";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-about";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-applications";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-bluetooth";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
@@ -66,6 +66,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-datetime";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-display";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -74,6 +74,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-keyboard";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -73,6 +73,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-mouse-touchpad";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-network";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-notifications";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-onlineaccounts";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
@@ -78,6 +78,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-pantheon-shell";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-power";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-printers";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-security-privacy";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-sharing";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-sound";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/wacom/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/wacom/default.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard-plug-wacom";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/apps/switchboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/default.nix
@@ -74,6 +74,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/switchboard";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/stylesheet";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/icons";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/artwork/elementary-redacted-script/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-redacted-script/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     description = "Font for concealing text";
     homepage = "https://github.com/png2378/redacted-elementary";
     license = licenses.ofl;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/pantheon/artwork/elementary-sound-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-sound-theme/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/sound-theme";
     license = licenses.unlicense;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/artwork/elementary-wallpapers/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-wallpapers/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wallpapers";
     license = licenses.publicDomain;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }
 

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
@@ -85,6 +85,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/default-settings";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -134,6 +134,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/greeter";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
@@ -76,6 +76,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/onboarding";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/elementary-print-shim/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-print-shim/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/print";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
@@ -155,6 +155,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/session-settings";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/shortcut-overlay";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/gala/default.nix
+++ b/pkgs/desktops/pantheon/desktop/gala/default.nix
@@ -94,6 +94,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/gala";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/a11y/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/a11y/default.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-a11y";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
@@ -95,6 +95,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/applications-menu";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-bluetooth";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
@@ -83,6 +83,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-datetime";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-keyboard";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
@@ -68,6 +68,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-network";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-nightlight";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-notifications";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
@@ -72,6 +72,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-power";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-session";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
@@ -73,6 +73,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel-indicator-sound";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
@@ -84,6 +84,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/wingpanel";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/granite/default.nix
+++ b/pkgs/desktops/pantheon/granite/default.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/granite";
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/services/contractor/default.nix
+++ b/pkgs/desktops/pantheon/services/contractor/default.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/contractor";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/services/elementary-capnet-assist/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-capnet-assist/default.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/capnet-assist";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/services/elementary-notifications/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-notifications/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     description = "GTK notification server for Pantheon";
     homepage = "https://github.com/elementary/notifications";
     license = licenses.gpl3Plus;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     description = "Settings daemon for Pantheon";
     homepage = "https://github.com/elementary/settings-daemon";
     license = licenses.gpl3Plus;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/pantheon/services/pantheon-agent-geoclue2/default.nix
+++ b/pkgs/desktops/pantheon/services/pantheon-agent-geoclue2/default.nix
@@ -56,6 +56,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/pantheon-agent-geoclue2";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/pantheon/services/pantheon-agent-polkit/default.nix
+++ b/pkgs/desktops/pantheon/services/pantheon-agent-polkit/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/elementary/pantheon-agent-polkit";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/development/libraries/bamf/default.nix
+++ b/pkgs/development/libraries/bamf/default.nix
@@ -94,6 +94,6 @@ stdenv.mkDerivation rec {
     homepage = "https://launchpad.net/bamf";
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ davidak ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ davidak ] ++ teams.pantheon.members;
   };
 }

--- a/pkgs/development/tools/vala-lint/default.nix
+++ b/pkgs/development/tools/vala-lint/default.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/misc/screensavers/light-locker/default.nix
+++ b/pkgs/misc/screensavers/light-locker/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
       ConsoleKit/UPower or logind/systemd.
     '';
     license = licenses.gpl2;
-    maintainers = with maintainers; [ obadz ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ obadz ] ++ teams.pantheon.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/inputmethods/touchegg/default.nix
+++ b/pkgs/tools/inputmethods/touchegg/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     description = "Linux multi-touch gesture recognizer";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
   };
 }

--- a/pkgs/tools/misc/hashit/default.nix
+++ b/pkgs/tools/misc/hashit/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     description = "A simple app for checking usual checksums - Designed for elementary OS";
     homepage = "https://github.com/artemanufrij/hashit";
     license = licenses.gpl2Plus;
-    maintainers = pantheon.maintainers;
+    maintainers = teams.pantheon.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/text/snippetpixie/default.nix
+++ b/pkgs/tools/text/snippetpixie/default.nix
@@ -86,9 +86,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.snippetpixie.com";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [
-      ianmjones
-    ] ++ pantheon.maintainers;
+    maintainers = with maintainers; [ ianmjones ] ++ teams.pantheon.members;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

There are both:

https://github.com/NixOS/nixpkgs/blob/a92dd171bae2db6eeff74a3d31fa99e47e793359/pkgs/applications/misc/appeditor/default.nix#L59

and

https://github.com/NixOS/nixpkgs/blob/a92dd171bae2db6eeff74a3d31fa99e47e793359/pkgs/development/compilers/vala/default.nix#L103

in Nixpkgs currently, I try to do the same thing as:
- https://github.com/NixOS/nixpkgs/pull/83975

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
