### PR TITLE
phoronix-test-suite: run missing hooks: preInstall, postInstall

### DIFF
--- a/pkgs/tools/misc/phoronix-test-suite/default.nix
+++ b/pkgs/tools/misc/phoronix-test-suite/default.nix
@@ -13,10 +13,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which gnused makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
+
     ./install-sh $out
     wrapProgram $out/bin/phoronix-test-suite \
     --set PHP_BIN ${php}/bin/php \
     --prefix PATH : ${lib.makeBinPath [ gnumake gcc ]}
+
+    runHook postInstall
   '';
 
   passthru.tests = {


### PR DESCRIPTION
###### Motivation for this change
I tried to customize the build by appending to `postInstall` in an overlay, but it had no effect. This fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
