### PR TITLE
libsixel: 1.8.6 -> 1.10.1 (fix build + security)

### DIFF
--- a/pkgs/development/libraries/libsixel/default.nix
+++ b/pkgs/development/libraries/libsixel/default.nix
@@ -1,30 +1,56 @@
-{lib, stdenv, fetchFromGitHub}:
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, libbsd
+, gdk-pixbuf
+, gd
+, libjpeg
+, pkg-config
+, fetchpatch
+}:
 stdenv.mkDerivation rec {
-  version = "1.8.6";
   pname = "libsixel";
+  version = "1.10.1";
 
   src = fetchFromGitHub {
+    owner = "libsixel";
     repo = "libsixel";
     rev = "v${version}";
-    owner = "saitoha";
-    sha256 = "1saxdj6sldv01g6w6yk8vr7px4bl31xca3a82j6v1j3fw5rbfphy";
+    sha256 = "sha256-ACypJTFjXSzBjo4hQzUiJOqnaRaZnYX+/NublN9sbBo=";
   };
 
-  configureFlags = [
-    "--enable-tests"
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/libsixel/libsixel/commit/4d3e53ee007f3b71f638875f9fabbba658b2ca8a.patch";
+      sha256 = "sha256-iDfsTyUczjtzV3pt1ZErbhVO2rMm2ZYKWSBl+ru+5HA=";
+    })
+  ];
+
+  buildInputs = [
+    libbsd gdk-pixbuf gd
+  ];
+
+  nativeBuildInputs = [
+    meson ninja pkg-config
   ];
 
   doCheck = true;
 
+  mesonFlags = [
+    "-Dtests=enabled"
+    # build system seems to be broken here, it still seems to handle jpeg
+    # through some other ways.
+    "-Djpeg=disabled"
+    "-Dpng=disabled"
+  ];
+
   meta = with lib; {
     description = "The SIXEL library for console graphics, and converter programs";
-    homepage = "http://saitoha.github.com/libsixel";
+    homepage = "https://github.com/libsixel/libsixel";
     maintainers = with maintainers; [ vrthra ];
     license = licenses.mit;
-    platforms = with platforms; unix;
-    knownVulnerabilities = [
-      "CVE-2020-11721" # https://github.com/saitoha/libsixel/issues/134
-      "CVE-2020-19668" # https://github.com/saitoha/libsixel/issues/136
-    ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
- Switched to maintained fork of libsixel
- Linked CVEs were fixed in 1.10.1

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
