### PR TITLE
sigtool: 4a3719b4 -> 2a13539d

### DIFF
--- a/pkgs/os-specific/darwin/sigtool/default.nix
+++ b/pkgs/os-specific/darwin/sigtool/default.nix
@@ -6,19 +6,12 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "thefloweringash";
     repo = "sigtool";
-    rev = "4a3719b42dc91c3f513df94048851cc98e7c7fcf";
-    sha256 = "04ra1cx7k1sdbkj5yrvl0s3l333vpir8rnm8k1dh2zy1w0a6hpqa";
+    rev = "2a13539dc4893f39412a3fb810afc78b183df3df";
+    sha256 = "sha256-iCsdklN3crFx6CKsMIUP/fA3twLh4ArQh7OsVug5UjE=";
   };
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
   buildInputs = [ openssl ];
 
   installFlags = [ "PREFIX=$(out)" ];
-
-  # Upstream (me) asserts the driver script is optional.
-  postInstall = ''
-    substitute $NIX_BUILD_TOP/$sourceRoot/codesign.sh $out/bin/codesign \
-      --replace sigtool "$out/bin/sigtool"
-    chmod a+x $out/bin/codesign
-  '';
 }

--- a/pkgs/os-specific/darwin/sigtool/default.nix
+++ b/pkgs/os-specific/darwin/sigtool/default.nix
@@ -1,13 +1,14 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, openssl }:
 
-stdenv.mkDerivation {
-  name = "sigtool";
+stdenv.mkDerivation rec {
+  pname = "sigtool";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "thefloweringash";
     repo = "sigtool";
-    rev = "2a13539dc4893f39412a3fb810afc78b183df3df";
-    sha256 = "sha256-iCsdklN3crFx6CKsMIUP/fA3twLh4ArQh7OsVug5UjE=";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-GSVkF1BkZEkIF+q0SsoCuE0q48DRclE3E+qKc6JEc/0=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/os-specific/darwin/sigtool/default.nix
+++ b/pkgs/os-specific/darwin/sigtool/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "thefloweringash";
     repo = "sigtool";
-    rev = "refs/tags/v${version}";
+    rev = "v${version}";
     sha256 = "sha256-GSVkF1BkZEkIF+q0SsoCuE0q48DRclE3E+qKc6JEc/0=";
   };
 

--- a/pkgs/os-specific/darwin/sigtool/default.nix
+++ b/pkgs/os-specific/darwin/sigtool/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, makeWrapper, openssl }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, openssl }:
 
 stdenv.mkDerivation {
   name = "sigtool";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "sha256-iCsdklN3crFx6CKsMIUP/fA3twLh4ArQh7OsVug5UjE=";
   };
 
-  nativeBuildInputs = [ pkg-config makeWrapper ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 
   installFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -268,6 +268,12 @@ rec {
               ${bootstrapTools}/bin/codesign > $out/bin/codesign
             chmod a+x $out/bin/codesign
           '';
+          # on next bootstrap tools update, use the following:
+          # installPhase = ''
+          #   mkdir -p $out/bin
+          #   ln -s ${bootstrapTools}/bin/sigtool  $out/bin
+          #   ln -s ${bootstrapTools}/bin/codesign $out/bin
+          # '';
         };
 
         print-reexports = stdenv.mkDerivation {

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -206,7 +206,7 @@ in rec {
       done
 
       for i in $out/bin/*; do
-        if test -x "$i" -a ! -L "$i" -a "$(basename $i)" != codesign; then
+        if test -x "$i" -a ! -L "$i"; then
           echo "Adding @executable_path to rpath in $i"
           ${stdenv.cc.targetPrefix}install_name_tool -add_rpath '@executable_path/../lib' $i
         fi


### PR DESCRIPTION
###### Motivation for this change

This draft PR proposes updates to `darwin.sigtool` based on recent upstream development. It is being prepared in anticipation of a forthcoming upstream release (see thefloweringash/sigtool#2) and to facilitate broader testing of the new version against the rest of nixpkgs.

Key changes in this new version of `sigtool`: 

1. Replace the old sigtool `codesign.sh` wrapper script with a new `codesign` driver program implemented directly in C++, hopefully with good drop-in compatibility for various common uses of Apple's original `codesign` binary. 
2. Add limited support for Apple's "entitlements" system, which is used by, e.g., `qemu`, to access certain `*-darwin` features like `Hypervisor.framework`.
3. Various other contributed improvements.

CC: @thefloweringash 

Also potentially relevant to: #130132, #135877.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Other notes

Since `sigtool` is used by `darwin.stdenv`, I anticipate that this or successor PRs will likely require a Darwin mass-rebuild.