### PR TITLE
osl: fix build by overriding llvm-as path

### DIFF
--- a/pkgs/development/compilers/osl/default.nix
+++ b/pkgs/development/compilers/osl/default.nix
@@ -17,7 +17,15 @@ in clangStdenv.mkDerivation rec {
     sha256 = "1dwf10f2fpxc55pymwkapql20nc462mq61hv21c527994c2qp1ll";
   };
 
-  cmakeFlags = [ "-DUSE_BOOST_WAVE=ON" "-DENABLERTTI=ON" ];
+  cmakeFlags = [
+    "-DUSE_BOOST_WAVE=ON"
+    "-DENABLERTTI=ON"
+
+    # Build system implies llvm-config and llvm-as are in the same directory.
+    # Override defaults.
+    "-DLLVM_DIRECTORY=${llvm}"
+    "-DLLVM_CONFIG=${llvm.dev}/bin/llvm-config"
+  ];
 
   preConfigure = "patchShebangs src/liboslexec/serialize-bc.bash ";
 


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/issues/138373

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
