### PR TITLE
cargo-spellcheck: init at 0.8.13

### DIFF
--- a/pkgs/development/tools/rust/cargo-spellcheck/default.nix
+++ b/pkgs/development/tools/rust/cargo-spellcheck/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, libclang
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-spellcheck";
+  version = "0.8.13";
+
+  src = fetchFromGitHub {
+    owner = "drahnr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0k88ma00gj8wjdvd7ysbbvqnf5sk1w8d3wqbi6qfxnqrc1k3hlv2";
+  };
+
+  cargoSha256 = "0mmk0igm2s8sxi65zvikxhz52xhkyd3ljqy61mij7zlx95rf639x";
+
+  LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  checkFlags = [
+    "--skip checker::hunspell::tests::hunspell_binding_is_sane"
+  ];
+
+  meta = with lib; {
+    description = "Checks rust documentation for spelling and grammar mistakes";
+    homepage = "https://github.com/drahnr/cargo-spellcheck";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ newam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12426,6 +12426,7 @@ with pkgs;
   };
   cargo-readme = callPackage ../development/tools/rust/cargo-readme {};
   cargo-sort = callPackage ../development/tools/rust/cargo-sort { };
+  cargo-spellcheck = callPackage ../development/tools/rust/cargo-spellcheck { };
   cargo-sweep = callPackage ../development/tools/rust/cargo-sweep { };
   cargo-sync-readme = callPackage ../development/tools/rust/cargo-sync-readme {};
   cargo-udeps = callPackage ../development/tools/rust/cargo-udeps {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [cargo-spellcheck](https://github.com/drahnr/cargo-spellcheck), a tool to check rust documentation for spelling and grammar mistakes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
