### PR TITLE
[staging-next] linuxPackages.bcc: fix build 

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , makeWrapper, cmake, llvmPackages, kernel
 , flex, bison, elfutils, python, luajit, netperf, iperf, libelf
 , systemtap, bash, libbpf
@@ -29,6 +29,12 @@ python.pkgs.buildPythonApplication rec {
     # This is needed until we fix
     # https://github.com/NixOS/nixpkgs/issues/40427
     ./fix-deadlock-detector-import.patch
+    # Add definition for BTF_KIND_FLOAT, added in Linux 5.14
+    # Can be removed once linuxHeaders (used here via glibc) are bumped to 5.14+.
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/bpfcc/-/raw/71136ef5b66a2ecefd635a7aca2e0e835ff09095/debian/patches/0004-compat-defs.patch";
+      sha256 = "05s1zxihwkvbl2r2mqc5dj7fpcipqyvwr11v8b9hqbwjkm3qpz40";
+    })
   ];
 
   propagatedBuildInputs = [ python.pkgs.netaddr ];


### PR DESCRIPTION
Use Debian downstream patch to fix compilation against linuxHeaders < 5.14.

Our linux headers exposed by glibc are still at 5.12. We should be able
to remove this patch once our linuxHeaders are bumped to 5.14+.

###### Motivation for this change

Fixes linuxPackages*.bcc
For https://github.com/NixOS/nixpkgs/pull/138268

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
