### PR TITLE
ligolo-ng: init at 0.1

### DIFF
--- a/pkgs/tools/networking/ligolo-ng/default.nix
+++ b/pkgs/tools/networking/ligolo-ng/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "ligolo-ng";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "tnpitsecurity";
+    repo = "ligolo-ng";
+    rev = "v${version}";
+    sha256 = "sha256-Ipfp+Ke4iSJmvUtfNUt/XSPTSDSdeMs+Ss8acZHUYrE=";
+  };
+
+  postConfigure = ''
+    export CGO_ENABLED=0
+  '';
+
+  ldflags = [ "-s" "-w" "-extldflags '-static'" ];
+
+  vendorSha256 = "sha256-axRCThmFavR+GTRWSgdAr2mbrp07hsFea0rKLQNIhgU=";
+
+  doCheck = false; # tests require network access
+
+  meta = with lib; {
+    homepage = "https://github.com/tnpitsecurity/ligolo-ng";
+    description = "A tunneling/pivoting tool that uses a TUN interface";
+    platforms = platforms.linux;
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17857,6 +17857,8 @@ with pkgs;
 
   lightstep-tracer-cpp = callPackage ../development/libraries/lightstep-tracer-cpp { };
 
+  ligolo-ng = callPackage ../tools/networking/ligolo-ng { };
+
   linenoise = callPackage ../development/libraries/linenoise { };
 
   linenoise-ng = callPackage ../development/libraries/linenoise-ng { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Added package useful for pentesting. #81418

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
