### PR TITLE
Revert "nixos/lock-kernel-modules: use `udevadm settle`"

### DIFF
--- a/nixos/modules/security/lock-kernel-modules.nix
+++ b/nixos/modules/security/lock-kernel-modules.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, lib, ... }:
 
 with lib;
 
@@ -13,7 +13,7 @@ with lib;
       default = false;
       description = ''
         Disable kernel module loading once the system is fully initialised.
-        Module loading is disabled until the next reboot. Problems caused
+        Module loading is disabled until the next reboot.  Problems caused
         by delayed module loading can be fixed by adding the module(s) in
         question to <option>boot.kernelModules</option>.
       '';
@@ -29,30 +29,20 @@ with lib;
             else [ x.fsType ]
         else []) config.system.build.fileSystems;
 
-    systemd.services.disable-kernel-module-loading = {
+    systemd.services.disable-kernel-module-loading = rec {
       description = "Disable kernel module loading";
 
-      wants = [ "systemd-udevd.service" ];
       wantedBy = [ config.systemd.defaultUnit ];
 
-      before = [ config.systemd.defaultUnit ];
-      after =
-        [ "firewall.service"
-          "systemd-modules-load.service"
-        ];
+      after = [ "systemd-udev-settle.service" "firewall.service" "systemd-modules-load.service" ] ++ wantedBy;
 
       unitConfig.ConditionPathIsReadWrite = "/proc/sys/kernel";
 
-      serviceConfig =
-        { Type = "oneshot";
-          RemainAfterExit = true;
-          TimeoutSec = 180;
-        };
-
-      script = ''
-        ${pkgs.udev}/bin/udevadm settle
-        echo -n 1 >/proc/sys/kernel/modules_disabled
-      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "/bin/sh -c 'echo -n 1 >/proc/sys/kernel/modules_disabled'";
+      };
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This reverts commit dc34788a25664926a04393d5f20a266c4a884385,
which is reportedly breaking networking on hardened profiles.

cc: @izorkin
