### PR TITLE
python3Packages.wandb: init at 0.12.7

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -1,0 +1,138 @@
+{ bokeh
+, buildPythonPackage
+, click
+, configparser
+, docker_pycreds
+, fetchFromGitHub
+, flask
+, git
+, GitPython
+, jsonref
+, jsonschema
+, lib
+, matplotlib
+, pandas
+, pathtools
+, promise
+, protobuf
+, psutil
+, pydantic
+, pytest-mock
+, pytest-xdist
+, pytestCheckHook
+, python
+, python-dateutil
+, pyyaml
+, requests
+, scikit-learn
+, sentry-sdk
+, setuptools
+, shortuuid
+, stdenv
+, tqdm
+, yaspin
+}:
+
+buildPythonPackage rec {
+  pname = "wandb";
+  version = "0.12.7";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "client";
+    rev = "v${version}";
+    sha256 = "sha256-YG0BSIENnmF9n+oNIBcbpTh7obYx+Lpuak8pJzvjuJ8=";
+  };
+
+  # The wandb requirements.txt does not distinguish python2/3 dependencies. We
+  # need to drop the subprocess32 dependency when building for python3.
+  patchPhase = ''
+    substituteInPlace requirements.txt --replace "subprocess32>=3.5.3" ""
+  '';
+
+  # git is not a setup.py dependency of wandb, but wandb does expect git to be
+  # in PATH. See https://gist.github.com/samuela/57aeee710e41ab2bf361b7ed8fbbeabf
+  # for the error message, and an example usage here: https://github.com/wandb/client/blob/master/wandb/sdk/internal/meta.py#L139-L141.
+  # setuptools is necessary since pkg_resources is required at runtime.
+  propagatedBuildInputs = [
+    click
+    configparser
+    docker_pycreds
+    git
+    GitPython
+    pathtools
+    promise
+    protobuf
+    psutil
+    python-dateutil
+    pyyaml
+    requests
+    sentry-sdk
+    setuptools
+    shortuuid
+    yaspin
+  ];
+
+  disabledTestPaths = [
+    # Tests that require docker access, not possible in the nix build environment.
+    "tests/launch/test_launch.py"
+    "tests/launch/test_launch_cli.py"
+
+    # Tests that try to get chatty over sockets or spin up servers, not possible in the nix build environment.
+    "tests/test_cli.py"
+    "tests/test_data_types.py"
+    "tests/test_file_stream.py"
+    "tests/test_file_upload.py"
+    "tests/test_footer.py"
+    "tests/test_internal_api.py"
+    "tests/test_label_full.py"
+    "tests/test_login.py"
+    "tests/test_meta.py"
+    "tests/test_metric_full.py"
+    "tests/test_metric_internal.py"
+    "tests/test_mode_disabled.py"
+    "tests/test_mp_full.py"
+    "tests/test_notebooks.py"
+    "tests/test_public_api.py"
+    "tests/test_redir.py"
+    "tests/test_runtime.py"
+    "tests/test_sender.py"
+    "tests/test_start_method.py"
+    "tests/test_tb_watcher.py"
+    "tests/test_telemetry_full.py"
+    "tests/wandb_agent_test.py"
+    "tests/wandb_artifacts_test.py"
+    "tests/wandb_history_test.py"
+    "tests/wandb_integration_test.py"
+    "tests/wandb_run_test.py"
+    "tests/wandb_settings_test.py"
+    "tests/wandb_sweep_test.py"
+
+    # Fails and borks the pytest runner as well.
+    "tests/wandb_test.py"
+  ];
+
+  checkInputs = [
+    bokeh
+    flask
+    jsonref
+    jsonschema
+    matplotlib
+    pandas
+    pydantic
+    pytest-mock
+    pytest-xdist
+    pytestCheckHook
+    scikit-learn
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "wandb" ];
+
+  meta = with lib; {
+    description = "A CLI and library for interacting with the Weights and Biases API";
+    homepage = "https://github.com/wandb/client";
+    license = licenses.mit;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/yaspin/default.nix
+++ b/pkgs/development/python-modules/yaspin/default.nix
@@ -1,0 +1,32 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, poetry-core
+, termcolor
+}:
+
+buildPythonPackage rec {
+  pname = "yaspin";
+  version = "2.1.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "pavdmyt";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vhh4mp706kz5fba8nvr9jm51jsd32xj97m3law6ixw3lj91sh1a";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [ termcolor ];
+
+  pythonImportsCheck = [ "yaspin" ];
+
+  meta = with lib; {
+    description = "Yet Another Terminal Spinner";
+    homepage = "https://github.com/pavdmyt/yaspin";
+    license = licenses.mit;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9923,6 +9923,8 @@ in {
 
   Wand = callPackage ../development/python-modules/Wand { };
 
+  wandb = callPackage ../development/python-modules/wandb { };
+
   warlock = callPackage ../development/python-modules/warlock { };
 
   warrant = callPackage ../development/python-modules/warrant { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10229,6 +10229,8 @@ in {
 
   yarl = callPackage ../development/python-modules/yarl { };
 
+  yaspin = callPackage ../development/python-modules/yaspin { };
+
   yaswfp = callPackage ../development/python-modules/yaswfp { };
 
   yattag = callPackage ../development/python-modules/yattag { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the Weights & Biases client API to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
