### PR TITLE
lisgd: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/tools/inputmethods/lisgd/default.nix
+++ b/pkgs/tools/inputmethods/lisgd/default.nix
@@ -4,19 +4,20 @@
 , writeText
 , libinput
 , libX11
+, wayland
 , conf ? null
 , patches ? [ ]
 }:
 
 stdenv.mkDerivation rec {
   pname = "lisgd";
-  version = "0.3.1";
+  version = "0.3.2";
 
   src = fetchFromSourcehut {
     owner = "~mil";
     repo = "lisgd";
     rev = version;
-    sha256 = "sha256-A8SsF5k4GwfVCj8JtodNWoLdPzaA9YsoP5EHHakUguc=";
+    sha256 = "sha256-yE2CUv1XDvo8fW0bLS1O2oxgDUu4drCO3jFpxPgAYKU=";
   };
 
   inherit patches;
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libinput
     libX11
+    wayland
   ];
 
   makeFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
