### PR TITLE
haskell: update maintainer script for merging and opening PR to also upload package versions to Hackage

### DIFF
--- a/maintainers/scripts/haskell/merge-and-open-pr.sh
+++ b/maintainers/scripts/haskell/merge-and-open-pr.sh
@@ -75,6 +75,9 @@ fi
 echo "Merging https://github.com/NixOS/nixpkgs/pull/${curr_haskell_updates_pr_num}..."
 gh pr merge --repo NixOS/nixpkgs --merge "$curr_haskell_updates_pr_num"
 
+# Update the list of Haskell package versions in NixOS on Hackage.
+./maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
+
 # Update stackage, Hackage hashes, and regenerate Haskell package set
 echo "Updating Stackage..."
 ./maintainers/scripts/haskell/update-stackage.sh --do-commit

--- a/maintainers/scripts/haskell/merge-and-open-pr.sh
+++ b/maintainers/scripts/haskell/merge-and-open-pr.sh
@@ -76,6 +76,7 @@ echo "Merging https://github.com/NixOS/nixpkgs/pull/${curr_haskell_updates_pr_nu
 gh pr merge --repo NixOS/nixpkgs --merge "$curr_haskell_updates_pr_num"
 
 # Update the list of Haskell package versions in NixOS on Hackage.
+echo "Updating list of Haskell package versions in NixOS on Hackage..."
 ./maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
 
 # Update stackage, Hackage hashes, and regenerate Haskell package set
@@ -87,7 +88,7 @@ echo "Regenerating Hackage packages..."
 ./maintainers/scripts/haskell/regenerate-hackage-packages.sh --do-commit
 
 # Push these new commits to the haskell-updates branch
-echo "Pushing commits just created to the haskell-updates branch"
+echo "Pushing commits just created to the remote haskell-updates branch..."
 git push
 
 # Open new PR
@@ -117,5 +118,5 @@ This is the follow-up to #${curr_haskell_updates_pr_num}. Come to [#haskell:nixo
 EOF
 )
 
-echo "Opening a PR for the next haskell-updates merge cycle"
+echo "Opening a PR for the next haskell-updates merge cycle..."
 gh pr create --repo NixOS/nixpkgs --base master --head haskell-updates --title "haskellPackages: update stackage and hackage" --body "$new_pr_body"

--- a/maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
+++ b/maintainers/scripts/haskell/upload-nixos-package-list-to-hackage.sh
@@ -19,3 +19,4 @@ package_list="$(nix-build -A haskell.package-list)/nixos-hackage-packages.csv"
 username=$(grep "^username:" ~/.cabal/config | sed "s/^username: //")
 password_command=$(grep "^password-command:" ~/.cabal/config | sed "s/^password-command: //")
 curl -u "$username:$($password_command | head -n1)" --digest -H "Content-type: text/csv" -T "$package_list" http://hackage.haskell.org/distro/NixOS/packages.csv
+echo

--- a/pkgs/development/haskell-modules/HACKING.md
+++ b/pkgs/development/haskell-modules/HACKING.md
@@ -206,8 +206,16 @@ opening the next one.  When you want to merge the currently open
     script uses the `gh` command to merge the current PR and open a new one.
     You should only need to do this once.
 
+    This command can be used to authenticate:
+
     ```console
     $ gh auth login
+    ```
+
+    This command can be used to confirm that you have already authenticated:
+
+    ```console
+    $ gh auth status
     ```
 
 1.  Make sure you have setup your `~/.cabal/config` file for authentication
@@ -216,6 +224,14 @@ opening the next one.  When you want to merge the currently open
 
 1.  Make sure you have correctly marked packages broken.  One of the previous
     sections explains how to do this.
+
+    In short:
+
+    ```console
+    $ ./maintainers/scripts/haskell/hydra-report.hs get-report
+    $ ./maintainers/scripts/haskell/hydra-report.hs mark-broken-list
+    $ ./maintainers/scripts/haskell/mark-broken.sh --do-commit
+    ```
 
 1.  Merge `master` into `haskell-updates` and make sure to push to the
     `haskell-updates` branch.  (This can be skipped if `master` has recently
@@ -241,6 +257,8 @@ opening the next one.  When you want to merge the currently open
         `origin/haskell-updates`.
 
     1.  Merges the currently open `haskell-updates` PR.
+
+    1.  Updates the version of Haskell packages in NixOS on Hackage.
 
     1.  Updates Stackage and Hackage snapshots.  Regenerates the Haskell package set.
 

--- a/pkgs/development/haskell-modules/HACKING.md
+++ b/pkgs/development/haskell-modules/HACKING.md
@@ -210,6 +210,10 @@ opening the next one.  When you want to merge the currently open
     $ gh auth login
     ```
 
+1.  Make sure you have setup your `~/.cabal/config` file for authentication
+    for uploading the NixOS package versions to Hackage.  See the following
+    section for details on how to do this.
+
 1.  Make sure you have correctly marked packages broken.  One of the previous
     sections explains how to do this.
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update `maintainers/scripts/haskell/merge-and-open-pr.sh` to also upload Haskell package versions in NixOS to Hackage.  Also update a few other log messages and info in the docs.

I've used the code here to merge https://github.com/NixOS/nixpkgs/pull/138316 and open https://github.com/NixOS/nixpkgs/pull/138596, so I'm thinking this should be working well now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
