### PR TITLE
kio-fuse: init at 5.0.1

### DIFF
--- a/pkgs/tools/filesystems/kio-fuse/default.nix
+++ b/pkgs/tools/filesystems/kio-fuse/default.nix
@@ -5,7 +5,6 @@
 , extra-cmake-modules
 , kio
 , fuse3
-, ...
 }:
 
 mkDerivation rec {

--- a/pkgs/tools/filesystems/kio-fuse/default.nix
+++ b/pkgs/tools/filesystems/kio-fuse/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, mkDerivation
+, fetchgit
+, cmake
+, extra-cmake-modules
+, kio
+, fuse3
+, ...
+}:
+
+mkDerivation rec {
+  pname = "kio-fuse";
+  version = "5.0.1";
+
+  src = fetchgit {
+    url = "https://invent.kde.org/system/kio-fuse.git";
+    sha256 = "sha256-LSFbFCaEPkQTk1Rg9xpueBOQpkbr/tgYxLD31F6i/qE=";
+    rev = "v${version}";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+
+  buildInputs = [ kio fuse3 ];
+
+  meta = with lib; {
+    description = "FUSE Interface for KIO";
+    homepage = "https://invent.kde.org/system/kio-fuse";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ _1000teslas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6457,6 +6457,8 @@ with pkgs;
 
   kibi = callPackage ../applications/editors/kibi { };
 
+  kio-fuse = libsForQt5.callPackage ../tools/filesystems/kio-fuse { };
+
   kismet = callPackage ../applications/networking/sniffers/kismet { };
 
   kiterunner = callPackage ../tools/security/kiterunner { };


### PR DESCRIPTION
###### Motivation for this change
I use KIOFuse to mount Samba shares.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
