### PR TITLE
python3Packages.cirq-core: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/cirq-aqt/default.nix
+++ b/pkgs/development/python-modules/cirq-aqt/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, cirq-core
+, pythonOlder
+, fetchFromGitHub
+, requests
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "cirq-aqt";
+  inherit (cirq-core) version src meta;
+
+  sourceRoot = "source/${pname}";
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "requests~=2.18" "requests"
+  '';
+
+  propagatedBuildInputs = [
+    cirq-core
+    requests
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # cirq's importlib hook doesn't work here
+  #pythonImportsCheck = [ "cirq_aqt" ];
+}

--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -1,5 +1,5 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
@@ -26,9 +26,10 @@
 , freezegun
 , pytest-asyncio
 }:
+
 buildPythonPackage rec {
   pname = "cirq-core";
-  version = "0.11.0";
+  version = "0.12.0";
 
   disabled = pythonOlder "3.6";
 
@@ -36,7 +37,7 @@ buildPythonPackage rec {
     owner = "quantumlib";
     repo = "cirq";
     rev = "v${version}";
-    hash = "sha256-JaKTGnkYhzIFb35SGaho8DRupoT0JFYKA5+rJEq4oXw=";
+    sha256 = "sha256-NPaADiRoPL0KoLugtk0vsnTGuRDK85e4j9kHv9aO/Po=";
   };
 
   sourceRoot = "source/${pname}";
@@ -45,8 +46,7 @@ buildPythonPackage rec {
     substituteInPlace requirements.txt \
       --replace "matplotlib~=3.0" "matplotlib" \
       --replace "networkx~=2.4" "networkx" \
-      --replace "numpy~=1.16" "numpy" \
-      --replace "requests~=2.18" "requests"
+      --replace "numpy~=1.16" "numpy"
   '';
 
   propagatedBuildInputs = [
@@ -89,10 +89,10 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
+    description = "Framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits";
     homepage = "https://github.com/quantumlib/cirq";
     changelog = "https://github.com/quantumlib/Cirq/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ drewrisinger ];
+    maintainers = with maintainers; [ drewrisinger fab ];
   };
 }

--- a/pkgs/development/python-modules/cirq-google/default.nix
+++ b/pkgs/development/python-modules/cirq-google/default.nix
@@ -27,5 +27,8 @@ buildPythonPackage rec {
     protobuf
   ];
 
-  checkInputs = [ pytestCheckHook freezegun ];
+  checkInputs = [
+    freezegun
+    pytestCheckHook
+  ];
 }

--- a/pkgs/development/python-modules/cirq-ionq/default.nix
+++ b/pkgs/development/python-modules/cirq-ionq/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, cirq-core
+, pythonOlder
+, fetchFromGitHub
+, requests
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "cirq-ionq";
+  inherit (cirq-core) version src meta;
+
+  sourceRoot = "source/${pname}";
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "requests~=2.18" "requests"
+  '';
+
+  propagatedBuildInputs = [
+    cirq-core
+    requests
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # cirq's importlib hook doesn't work here
+  #pythonImportsCheck = [ "cirq_ionq" ];
+}

--- a/pkgs/development/python-modules/cirq-pasqal/default.nix
+++ b/pkgs/development/python-modules/cirq-pasqal/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, cirq-core
+, pythonOlder
+, fetchFromGitHub
+, requests
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "cirq-pasqal";
+  inherit (cirq-core) version src meta;
+
+  sourceRoot = "source/${pname}";
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "requests~=2.18" "requests"
+  '';
+
+  propagatedBuildInputs = [
+    cirq-core
+    requests
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # cirq's importlib hook doesn't work here
+  #pythonImportsCheck = [ "cirq_pasqal" ];
+}

--- a/pkgs/development/python-modules/cirq-rigetti/default.nix
+++ b/pkgs/development/python-modules/cirq-rigetti/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, buildPythonPackage
+, cirq-core
+, pythonOlder
+, fetchFromGitHub
+, requests
+, pytestCheckHook
+, attrs
+, certifi
+, h11
+, httpcore
+, idna
+, httpx
+, iso8601
+, pydantic
+, pyjwt
+, pyquil
+, python-dateutil
+, qcs-api-client
+, retrying
+, rfc3339
+, rfc3986
+, six
+, sniffio
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "cirq-rigetti";
+  inherit (cirq-core) version src meta;
+
+  sourceRoot = "source/${pname}";
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "attrs~=20.3.0" "attrs" \
+      --replace "h11~=0.9.0" "h11" \
+      --replace "httpcore~=0.11.1" "httpcore" \
+      --replace "httpx~=0.15.5" "httpx" \
+      --replace "idna~=2.10" "idna" \
+      --replace "requests~=2.18" "requests" \
+      --replace "pyjwt~=1.7.1" "pyjwt"
+  '';
+
+  propagatedBuildInputs = [
+    cirq-core
+    attrs
+    certifi
+    h11
+    httpcore
+    httpx
+    idna
+    iso8601
+    pydantic
+    pyjwt
+    pyquil
+    python-dateutil
+    qcs-api-client
+    retrying
+    rfc3339
+    rfc3986
+    six
+    sniffio
+    toml
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # cirq's importlib hook doesn't work here
+  #pythonImportsCheck = [ "cirq_rigetti" ];
+}

--- a/pkgs/development/python-modules/cirq-web/default.nix
+++ b/pkgs/development/python-modules/cirq-web/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, cirq-core
+, pythonOlder
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "cirq-web";
+  inherit (cirq-core) version src meta;
+
+  sourceRoot = "source/${pname}";
+
+  propagatedBuildInputs = [
+    cirq-core
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  # cirq's importlib hook doesn't work here
+  #pythonImportsCheck = [ "cirq_web" ];
+}

--- a/pkgs/development/python-modules/pyquil/default.nix
+++ b/pkgs/development/python-modules/pyquil/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, importlib-metadata
+, ipython
+, lark-parser
+, networkx
+, numpy
+, poetry-core
+, pytest-asyncio
+, pytest-freezegun
+, pytest-httpx
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, qcs-api-client
+, retry
+, rpcq
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "pyquil";
+  version = "3.0.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "rigetti";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0070pslz6vvyavm5pm27q2bng2mfmkb41v5czzckz7m8db3b1r2x";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    lark-parser
+    networkx
+    numpy
+    qcs-api-client
+    retry
+    rpcq
+    scipy
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-freezegun
+    pytest-httpx
+    pytest-mock
+    pytestCheckHook
+    ipython
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'lark = "^0.11.1"' 'lark-parser = ">=0.11.1"'
+  '';
+
+  disabledTestPaths = [
+    # Tests require network access
+    "test/e2e/"
+    "test/unit/test_api.py"
+    "test/unit/test_operator_estimation.py"
+    "test/unit/test_wavefunction_simulator.py"
+    "test/unit/test_compatibility_v2_operator_estimation.py"
+    "test/unit/test_compatibility_v2_quantum_computer.py"
+    "test/unit/test_compatibility_v2_qvm.py"
+    "test/unit/test_quantum_computer.py"
+    "test/unit/test_qvm.py"
+    "test/unit/test_reference_wavefunction.py"
+  ];
+
+  disabledTests = [
+    "test_compile_with_quilt_calibrations"
+    "test_sets_timeout_on_requests"
+  ];
+
+  pythonImportsCheck = [ "pyquil" ];
+
+  meta = with lib; {
+    description = "Python library for creating Quantum Instruction Language (Quil) programs";
+    homepage = "https://github.com/rigetti/pyquil";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/qcs-api-client/default.nix
+++ b/pkgs/development/python-modules/qcs-api-client/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, attrs
+, buildPythonPackage
+, fetchPypi
+, httpx
+, iso8601
+, pydantic
+, pyjwt
+, pytest-asyncio
+, pytestCheckHook
+, python-dateutil
+, pythonOlder
+, respx
+, retrying
+, rfc3339
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "qcs-api-client";
+  version = "0.8.0";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1c0g3aa2pk4zd40banap2j797080qivd42q7imla2yvv6cvq24b8";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    httpx
+    iso8601
+    pydantic
+    pyjwt
+    python-dateutil
+    retrying
+    rfc3339
+    toml
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+    respx
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "attrs>=20.1.0,<21.0.0" "attrs" \
+      --replace "httpx>=0.15.0,<0.16.0" "httpx" \
+      --replace "pyjwt>=1.7.1,<2.0.0" "pyjwt"
+  '';
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "qcs_api_client" ];
+
+  meta = with lib; {
+    description = "Python library for accessing the Rigetti QCS API";
+    homepage = "https://pypi.org/project/qcs-api-client/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/rfc3339/default.nix
+++ b/pkgs/development/python-modules/rfc3339/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "rfc3339";
+  version = "6.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1l6l1bh91i2r4dwcm86hlkx8cbh1xwgsk8hb4jvr5y5fxxg3ng6m";
+  };
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "rfc3339" ];
+
+  meta = with lib; {
+    description = "Format dates according to the RFC 3339";
+    homepage = "https://hg.sr.ht/~henryprecheur/rfc3339";
+    license = licenses.isc;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/rpcq/default.nix
+++ b/pkgs/development/python-modules/rpcq/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, msgpack
+, numpy
+, pytest-asyncio
+, pytestCheckHook
+, python-rapidjson
+, pythonOlder
+, pyzmq
+, ruamel-yaml
+}:
+
+buildPythonPackage rec {
+  pname = "rpcq";
+  version = "3.9.2";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "rigetti";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1vvf6y7459f8aamhkcxx36ajiai143s2vwg751x0dl0lx7hp3yn5";
+  };
+
+  propagatedBuildInputs = [
+    msgpack
+    python-rapidjson
+    pyzmq
+    ruamel-yaml
+  ];
+
+  checkInputs = [
+    numpy
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "msgpack>=0.6,<1.0" "msgpack"
+  '';
+
+  pythonImportsCheck = [ "rpcq" ];
+
+  meta = with lib; {
+    description = "The RPC framework and message specification for rigetti Quantum Cloud services";
+    homepage = "https://github.com/rigetti/rpcq";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1465,6 +1465,8 @@ in {
 
   cirq-google = callPackage ../development/python-modules/cirq-google { };
 
+  cirq-pasqal = callPackage ../development/python-modules/cirq-pasqal { };
+
   ciscomobilityexpress = callPackage ../development/python-modules/ciscomobilityexpress { };
 
   ciso8601 = callPackage ../development/python-modules/ciso8601 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1467,6 +1467,8 @@ in {
 
   cirq-pasqal = callPackage ../development/python-modules/cirq-pasqal { };
 
+  cirq-web = callPackage ../development/python-modules/cirq-web { };
+
   ciscomobilityexpress = callPackage ../development/python-modules/ciscomobilityexpress { };
 
   ciso8601 = callPackage ../development/python-modules/ciso8601 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6655,8 +6655,6 @@ in {
 
   pyquery = callPackage ../development/python-modules/pyquery { };
 
-  pyquil = callPackage ../development/python-modules/pyquil { };
-
   pyrabbit2 = callPackage ../development/python-modules/pyrabbit2 { };
 
   pyrad = callPackage ../development/python-modules/pyrad { };
@@ -7604,6 +7602,8 @@ in {
   qcelemental = callPackage ../development/python-modules/qcelemental { };
 
   qcengine = callPackage ../development/python-modules/qcengine { };
+
+  qcs-api-client = callPackage ../development/python-modules/qcs-api-client { };
 
   qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1465,8 +1465,6 @@ in {
 
   cirq-google = callPackage ../development/python-modules/cirq-google { };
 
-  cirq-rigetti = callPackage ../development/python-modules/cirq-rigetti { };
-
   cirq-pasqal = callPackage ../development/python-modules/cirq-pasqal { };
 
   cirq-web = callPackage ../development/python-modules/cirq-web { };
@@ -6654,6 +6652,8 @@ in {
   };
 
   pyquery = callPackage ../development/python-modules/pyquery { };
+
+  pyquil = callPackage ../development/python-modules/pyquil { };
 
   pyrabbit2 = callPackage ../development/python-modules/pyrabbit2 { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1465,6 +1465,8 @@ in {
 
   cirq-google = callPackage ../development/python-modules/cirq-google { };
 
+  cirq-rigetti = callPackage ../development/python-modules/cirq-rigetti { };
+
   cirq-pasqal = callPackage ../development/python-modules/cirq-pasqal { };
 
   cirq-web = callPackage ../development/python-modules/cirq-web { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1465,6 +1465,8 @@ in {
 
   cirq-google = callPackage ../development/python-modules/cirq-google { };
 
+  cirq-rigetti = callPackage ../development/python-modules/cirq-rigetti { };
+
   cirq-pasqal = callPackage ../development/python-modules/cirq-pasqal { };
 
   cirq-web = callPackage ../development/python-modules/cirq-web { };
@@ -7917,6 +7919,8 @@ in {
   ropper = callPackage ../development/python-modules/ropper { };
 
   routes = callPackage ../development/python-modules/routes { };
+
+  rpcq = callPackage ../development/python-modules/rpcq { };
 
   rpdb = callPackage ../development/python-modules/rpdb { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1461,6 +1461,8 @@ in {
 
   cirq = callPackage ../development/python-modules/cirq { };
 
+  cirq-aqt = callPackage ../development/python-modules/cirq-aqt { };
+
   cirq-core = callPackage ../development/python-modules/cirq-core { };
 
   cirq-ionq = callPackage ../development/python-modules/cirq-ionq { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6655,6 +6655,8 @@ in {
 
   pyquery = callPackage ../development/python-modules/pyquery { };
 
+  pyquil = callPackage ../development/python-modules/pyquil { };
+
   pyrabbit2 = callPackage ../development/python-modules/pyrabbit2 { };
 
   pyrad = callPackage ../development/python-modules/pyrad { };
@@ -7833,6 +7835,8 @@ in {
   retrying = callPackage ../development/python-modules/retrying { };
 
   retworkx = callPackage ../development/python-modules/retworkx { };
+
+  rfc3339 = callPackage ../development/python-modules/rfc3339 { };
 
   rfc3339-validator = callPackage ../development/python-modules/rfc3339-validator { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1463,6 +1463,8 @@ in {
 
   cirq-core = callPackage ../development/python-modules/cirq-core { };
 
+  cirq-ionq = callPackage ../development/python-modules/cirq-ionq { };
+
   cirq-google = callPackage ../development/python-modules/cirq-google { };
 
   cirq-rigetti = callPackage ../development/python-modules/cirq-rigetti { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.12.0

Change log: https://github.com/quantumlib/Cirq/releases/tag/v0.12.0

Upstream restructured some parts and this requires additional packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
