### PR TITLE
xorg.xorgproto: 2021.4 -> 2021.5

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3087,11 +3087,11 @@ lib.makeScope newScope (self: with self; {
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xorgproto = callPackage ({ stdenv, pkg-config, fetchurl, libXt, python3 }: stdenv.mkDerivation {
     pname = "xorgproto";
-    version = "2021.4";
+    version = "2021.5";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/proto/xorgproto-2021.4.tar.bz2";
-      sha256 = "1gwz8lhvczjinndrq2jb0swfvhk7p65rprkwiqwlp132041mfl8g";
+      url = "mirror://xorg/individual/proto/xorgproto-2021.5.tar.bz2";
+      sha256 = "05d0kib351qmnlfimaznaw0220fr0ym7fx2gn9h2jqxxilxncbxa";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config python3 ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -211,7 +211,7 @@ mirror://xorg/individual/lib/libXxf86misc-1.0.4.tar.bz2
 mirror://xorg/individual/lib/libXxf86vm-1.1.4.tar.bz2
 mirror://xorg/individual/lib/xtrans-1.4.0.tar.bz2
 mirror://xorg/individual/proto/xcb-proto-1.14.1.tar.xz
-mirror://xorg/individual/proto/xorgproto-2021.4.tar.bz2
+mirror://xorg/individual/proto/xorgproto-2021.5.tar.bz2
 mirror://xorg/individual/util/gccmakedep-1.0.3.tar.bz2
 mirror://xorg/individual/util/imake-1.0.8.tar.bz2
 mirror://xorg/individual/util/lndir-1.0.3.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-September/003108.html

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).