### PR TITLE
sysz: init at 1.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4441,6 +4441,12 @@
       fingerprint = "D618 7A03 A40A 3D56 62F5  4B46 03EF BF83 9A5F DC15";
     }];
   };
+  hleboulanger = {
+    email = "hleboulanger@protonmail.com";
+    name = "Harold Leboulanger";
+    github = "thbkrhsw";
+    githubId = 33122;
+  };
   hlolli = {
     email = "hlolli@gmail.com";
     github = "hlolli";

--- a/pkgs/tools/misc/sysz/default.nix
+++ b/pkgs/tools/misc/sysz/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenvNoCC, fetchFromGitHub, makeWrapper, fzf, gawk }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "sysz";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "joehillen";
+    repo = pname;
+    rev = version;
+    sha256 = "HNwsYE1Cv90IDi3A5PmRv3uHANR3ya+VOGBQ3+zkBLM=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 sysz $out/libexec/sysz
+    makeWrapper $out/libexec/sysz $out/bin/sysz \
+      --prefix PATH : ${lib.makeBinPath [ fzf gawk ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/joehillen/sysz";
+    description = "A fzf terminal UI for systemctl";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ hleboulanger ];
+    platforms = platforms.unix;
+    changelog = "https://github.com/joehillen/sysz/blob/${version}/CHANGELOG.md";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32034,6 +32034,8 @@ with pkgs;
 
   sumneko-lua-language-server = callPackage ../development/tools/sumneko-lua-language-server { };
 
+  sysz = callPackage  ../tools/misc/sysz { };
+
   go-swag = callPackage ../development/tools/go-swag { };
 
   go-swagger = callPackage ../development/tools/go-swagger { };


### PR DESCRIPTION
###### Motivation for this change

Add a new package

Closes #138472

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
