### PR TITLE
firejail: Remove symlink check patch

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
     # By default fbuilder hardcodes the firejail binary to the install path.
     # On NixOS the firejail binary is a setuid wrapper available in $PATH.
     ./fbuilder-call-firejail-on-path.patch
+    # Disable symlink check on /etc/hosts, see
+    # https://github.com/netblue30/firejail/issues/2758#issuecomment-805174951
+    ./remove-link-check.patch
   ];
 
   prePatch = ''

--- a/pkgs/os-specific/linux/firejail/remove-link-check.patch
+++ b/pkgs/os-specific/linux/firejail/remove-link-check.patch
@@ -1,0 +1,48 @@
+From ccc726f8ec877d8cda720daa2498e43629b6dd48 Mon Sep 17 00:00:00 2001
+From: Jonas Heinrich <onny@project-insanity.org>
+Date: Sun, 19 Sep 2021 11:48:06 +0200
+Subject: [PATCH 1/2] remove hosts file link check
+
+---
+ src/firejail/fs_hostname.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/src/firejail/fs_hostname.c b/src/firejail/fs_hostname.c
+index 42255070c4..97ce70f9c1 100644
+--- a/src/firejail/fs_hostname.c
++++ b/src/firejail/fs_hostname.c
+@@ -132,10 +132,6 @@ char *fs_check_hosts_file(const char *fname) {
+ 	invalid_filename(fname);
+ 	char *rv = expand_home(fname, cfg.homedir);
+ 
+-	// no a link
+-	if (is_link(rv))
+-		goto errexit;
+-
+ 	// the user has read access to the file
+ 	if (access(rv, R_OK))
+ 		goto errexit;
+
+From c2c51e7ca56075e7388b4f50922b148615d1b125 Mon Sep 17 00:00:00 2001
+From: Jonas Heinrich <onny@project-insanity.org>
+Date: Sun, 19 Sep 2021 11:49:08 +0200
+Subject: [PATCH 2/2] remove hosts file link check
+
+---
+ src/firejail/fs_hostname.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/firejail/fs_hostname.c b/src/firejail/fs_hostname.c
+index 97ce70f9c1..b228707131 100644
+--- a/src/firejail/fs_hostname.c
++++ b/src/firejail/fs_hostname.c
+@@ -154,9 +154,6 @@ void fs_mount_hosts_file(void) {
+ 	struct stat s;
+ 	if (stat("/etc/hosts", &s) == -1)
+ 		goto errexit;
+-	// not a link
+-	if (is_link("/etc/hosts"))
+-		goto errexit;
+ 	// owned by root
+ 	if (s.st_uid != 0)
+ 		goto errexit;


### PR DESCRIPTION
This patch fixes an issue using Firejail on NixOS mentioned here https://github.com/netblue30/firejail/issues/2758#issuecomment-805174951
Even one specifies a custom hosts file with command line argument `--hosts-file`, firejail is still checking if `/etc/hosts` is a symlink and fails. This patch removes the check which is not needed on NixOS.