### PR TITLE
nixos/lock-kernel-modules: reorder before/after

### DIFF
--- a/nixos/modules/security/lock-kernel-modules.nix
+++ b/nixos/modules/security/lock-kernel-modules.nix
@@ -35,10 +35,10 @@ with lib;
       wants = [ "systemd-udevd.service" ];
       wantedBy = [ config.systemd.defaultUnit ];
 
-      before = [ config.systemd.defaultUnit ];
       after =
         [ "firewall.service"
           "systemd-modules-load.service"
+           config.systemd.defaultUnit
         ];
 
       unitConfig.ConditionPathIsReadWrite = "/proc/sys/kernel";

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -57,6 +57,7 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... } : {
       # Test kernel module hardening
       with subtest("No more kernel modules can be loaded"):
           # note: this better a be module we normally wouldn't load ...
+          machine.wait_for_unit("disable-kernel-module-loading.service")
           machine.fail("modprobe dccp")
 
 


### PR DESCRIPTION
###### Motivation for this change

Alternative to https://github.com/NixOS/nixpkgs/pull/138473

Moving the service before multi-user.target (so the `hardened` test
continue to work the way it did before) can result in locking the kernel
too early. It's better to lock it a bit later and changing the test to
wait specifically for the disable-kernel-module-loading.service.

###### Things done

- [x] Tested via `nixosTests.hardened`
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @Izorkin
