### PR TITLE
pkgs/misc: switch to fetchFromGitHub

### DIFF
--- a/pkgs/misc/drivers/xboxdrv/default.nix
+++ b/pkgs/misc/drivers/xboxdrv/default.nix
@@ -1,15 +1,27 @@
-{ lib, stdenv, fetchurl, sconsPackages, libX11, pkg-config
-, libusb1, boost, glib, dbus-glib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, sconsPackages
+, libX11
+, pkg-config
+, libusb1
+, boost
+, glib
+, dbus-glib
+}:
 
 let
   version = "0.8.8";
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   pname = "xboxdrv";
   inherit version;
 
-  src = fetchurl {
-    url = "https://github.com/xboxdrv/xboxdrv/archive/v${version}.tar.gz";
-    sha256 = "0jx2wqmc7602dxyj19n3h8x0cpy929h7c0h39vcc5rf0q74fh3id";
+  src = fetchFromGitHub {
+    owner = "xboxdrv";
+    repo = "xboxdrv";
+    rev = "v${version}";
+    hash = "sha256-R0Bt4xfzQA1EmZbf7lcWLwSSUayf5Y711QhlAVhiLrY=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/misc/screensavers/pipes/default.nix
+++ b/pkgs/misc/screensavers/pipes/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, fetchurl, makeWrapper, coreutils, ncurses }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, coreutils, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "pipes";
   version = "1.3.0";
 
-  src = fetchurl {
-    url = "https://github.com/pipeseroni/pipes.sh/archive/v${version}.tar.gz";
-    sha256 = "09m4alb3clp3rhnqga5v6070p7n1gmnwp2ssqhq87nf2ipfpcaak";
+  src = fetchFromGitHub {
+    owner = "pipeseroni";
+    repo = "pipes.sh";
+    rev = "v${version}";
+    hash = "sha256-856OWlnNiGB20571TJg7Ayzcz4r6NqdW5DMDiim09mc=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
use fetchFromGitHub

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
