### PR TITLE
libdnf: switch back to default stdenv.

### DIFF
--- a/pkgs/tools/package-management/libdnf/default.nix
+++ b/pkgs/tools/package-management/libdnf/default.nix
@@ -1,7 +1,7 @@
-{ gcc9Stdenv, lib, stdenv, fetchFromGitHub, cmake, gettext, pkg-config, gpgme, libsolv, openssl, check
+{ lib, stdenv, fetchFromGitHub, cmake, gettext, pkg-config, gpgme, libsolv, openssl, check
 , json_c, libmodulemd, libsmartcols, sqlite, librepo, libyaml, rpm, zchunk }:
 
-gcc9Stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "libdnf";
   version = "0.63.1";
 


### PR DESCRIPTION
###### Motivation for this change

The only reason this was on GCC was because of some implicit constructor conversion issues that gcc handled without complaining and clang did not.

This commit fixed those:
https://github.com/rpm-software-management/libdnf/commit/fefe0b69e8368a8e9ceeed107add174c64f00f5e

Now that it works on clang, might as well revert back to the default.

Note: I can't currently test this on darwin because libbfd in master seem broken even without my modifications. I just end up with this: https://www.internalfb.com/phabricator/paste/view/P459437194

I did however apply the fefe0b69e8368a8e9ceeed107add174c64f00f5e commit as a patch to 21.05 and was able to also compile it with stdenv.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
