### PR TITLE
libbfd: add libintl dependency for darwin.

### DIFF
--- a/pkgs/development/libraries/libbfd/default.nix
+++ b/pkgs/development/libraries/libbfd/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv
 , fetchpatch, gnu-config, autoreconfHook, bison, binutils-unwrapped
-, libiberty, zlib
+, libiberty, libintl, zlib
 }:
 
 stdenv.mkDerivation {
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
 
   strictDeps = true;
   nativeBuildInputs = [ autoreconfHook bison ];
-  buildInputs = [ libiberty zlib.dev ];
+  buildInputs = [ libiberty zlib ] ++ lib.optionals stdenv.isDarwin [ libintl ];
 
   configurePlatforms = [ "build" "host" ];
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
This was introduced as part of strictDeps in https://github.com/NixOS/nixpkgs/pull/133008 but seems to break compilation on darwin with this error:
```
/nix/store/j4bf4z7zrd461r4bjiwsrnzc5am0jv9a-bash-4.4-p23/bin/bash ./libtool  --tag=CC   --mode=link clang -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow  -g -O2  -release `cat libtool-soversion` -liberty   -o libbfd.la -rpath /nix/store/sbmig002wpjdzafrjhnil8bx97pdq28h-libbfd-2.35.1/lib archive.lo archures.lo bfd.lo bfdio.lo bfdwin.lo cache.lo coff-bfd.lo compress.lo corefile.lo elf-properties.lo format.lo hash.lo init.lo libbfd.lo linker.lo merge.lo opncls.lo reloc.lo section.lo simple.lo stab-syms.lo stabs.lo syms.lo targets.lo binary.lo ihex.lo srec.lo tekhex.lo verilog.lo `cat ofiles` -liberty -lintl -ldl -lz 
libtool: link: clang -dynamiclib -Wl,-undefined -Wl,dynamic_lookup -o .libs/libbfd-2.35.1.dylib  .libs/archive.o .libs/archures.o .libs/bfd.o .libs/bfdio.o .libs/bfdwin.o .libs/cache.o .libs/coff-bfd.o .libs/compress.o .libs/corefile.o .libs/elf-properties.o .libs/format.o .libs/hash.o .libs/init.o .libs/libbfd.o .libs/linker.o .libs/merge.o .libs/opncls.o .libs/reloc.o .libs/section.o .libs/simple.o .libs/stab-syms.o .libs/stabs.o .libs/syms.o .libs/targets.o .libs/binary.o .libs/ihex.o .libs/srec.o .libs/tekhex.o .libs/verilog.o .libs/mach-o-x86-64.o .libs/mach-o-i386.o .libs/mach-o.o .libs/dwarf2.o .libs/pef.o .libs/xsym.o .libs/plugin.o .libs/elf32-aarch64.o .libs/elf64-aarch64.o .libs/elfxx-aarch64.o .libs/aix5ppc-core.o .libs/aout64.o .libs/coff-alpha.o .libs/coff-x86_64.o .libs/coff64-rs6000.o .libs/elf32-ia64.o .libs/elf32-mips.o .libs/elf32-score.o .libs/elf32-score7.o .libs/elf64-alpha.o .libs/elf64-gen.o .libs/elf64-hppa.o .libs/elf64-ia64.o .libs/elf64-ia64-vms.o .libs/elfxx-ia64.o .libs/elfn32-mips.o .libs/elf64-mips.o .libs/elfxx-mips.o .libs/elf64-mmix.o .libs/elf64-nfp.o .libs/elf64-ppc.o .libs/elf32-riscv.o .libs/elf64-riscv.o .libs/elfxx-riscv.o .libs/elf64-s390.o .libs/elf64-sparc.o .libs/elf64-tilegx.o .libs/elf64-x86-64.o .libs/elfxx-x86.o .libs/elf64-bpf.o .libs/elf64.o .libs/mach-o-aarch64.o .libs/mmo.o .libs/pe-x86_64.o .libs/pei-ia64.o .libs/pei-x86_64.o .libs/pepigen.o .libs/pex64igen.o .libs/vms-alpha.o .libs/aout-cris.o .libs/aout-ns32k.o .libs/aout32.o .libs/cf-i386lynx.o .libs/coff-go32.o .libs/coff-i386.o .libs/coff-mips.o .libs/coff-rs6000.o .libs/coff-sh.o .libs/coff-stgo32.o .libs/coff-tic30.o .libs/coff-tic4x.o .libs/coff-tic54x.o .libs/coff-z80.o .libs/coff-z8k.o .libs/coffgen.o .libs/cofflink.o .libs/dwarf1.o .libs/ecoff.o .libs/ecofflink.o .libs/elf-attrs.o .libs/elf-eh-frame.o .libs/elf-ifunc.o .libs/elf-m10200.o .libs/elf-m10300.o .libs/elf-nacl.o .libs/elf-strtab.o .libs/elf-vxworks.o .libs/elf.o .libs/elf32-am33lin.o .libs/elf32-arc.o .libs/elf32-arm.o .libs/elf32-avr.o .libs/elf32-bfin.o .libs/elf32-cr16.o .libs/elf32-cris.o .libs/elf32-crx.o .libs/elf32-csky.o .libs/elf32-d10v.o .libs/elf32-d30v.o .libs/elf32-dlx.o .libs/elf32-epiphany.o .libs/elf32-fr30.o .libs/elf32-frv.o .libs/elf32-ft32.o .libs/elf32-gen.o .libs/elf32-h8300.o .libs/elf32-hppa.o .libs/elf32-i386.o .libs/elf32-ip2k.o .libs/elf32-iq2000.o .libs/elf32-lm32.o .libs/elf32-m32c.o .libs/elf32-m32r.o .libs/elf32-m68hc11.o .libs/elf32-m68hc12.o .libs/elf32-m68hc1x.o .libs/elf32-m68k.o .libs/elf32-s12z.o .libs/elf32-mcore.o .libs/elf32-mep.o .libs/elf32-metag.o .libs/elf32-microblaze.o .libs/elf32-moxie.o .libs/elf32-msp430.o .libs/elf32-mt.o .libs/elf32-nds32.o .libs/elf32-nios2.o .libs/elf32-or1k.o .libs/elf32-pj.o .libs/elf32-ppc.o .libs/elf32-pru.o .libs/elf32-rl78.o .libs/elf32-rx.o .libs/elf32-s390.o .libs/elf32-sh.o .libs/elf32-sparc.o .libs/elf32-spu.o .libs/elf32-tic6x.o .libs/elf32-tilegx.o .libs/elf32-tilepro.o .libs/elf32-v850.o .libs/elf32-vax.o .libs/elf32-visium.o .libs/elf32-wasm32.o .libs/elf32-xc16x.o .libs/elf32-xgate.o .libs/elf32-xstormy16.o .libs/elf32-xtensa.o .libs/elf32-z80.o .libs/elf32.o .libs/elflink.o .libs/elfxx-sparc.o .libs/elfxx-tilegx.o .libs/i386aout.o .libs/i386bsd.o .libs/i386lynx.o .libs/i386msdos.o .libs/mach-o-arm.o .libs/ns32knetbsd.o .libs/pc532-mach.o .libs/pdp11.o .libs/pe-arm-wince.o .libs/pe-arm.o .libs/pe-i386.o .libs/pe-mcore.o .libs/pe-ppc.o .libs/pe-sh.o .libs/pei-arm-wince.o .libs/pei-arm.o .libs/pei-i386.o .libs/pei-mcore.o .libs/pei-ppc.o .libs/pei-sh.o .libs/peigen.o .libs/ppcboot.o .libs/reloc16.o .libs/som.o .libs/vax1knetbsd.o .libs/vaxnetbsd.o .libs/vms-lib.o .libs/vms-misc.o .libs/wasm-module.o .libs/xcofflink.o .libs/xtensa-isa.o .libs/xtensa-modules.o .libs/cpu-i386.o .libs/cpu-powerpc.o .libs/cpu-rs6000.o .libs/cpu-aarch64.o .libs/cpu-alpha.o .libs/cpu-arc.o .libs/cpu-arm.o .libs/cpu-avr.o .libs/cpu-bfin.o .libs/cpu-bpf.o .libs/cpu-cr16.o .libs/cpu-cris.o .libs/cpu-crx.o .libs/cpu-csky.o .libs/cpu-d10v.o .libs/cpu-d30v.o .libs/cpu-dlx.o .libs/cpu-epiphany.o .libs/cpu-fr30.o .libs/cpu-frv.o .libs/cpu-ft32.o .libs/cpu-h8300.o .libs/cpu-hppa.o .libs/cpu-iamcu.o .libs/cpu-l1om.o .libs/cpu-k1om.o .libs/cpu-ia64.o .libs/cpu-ip2k.o .libs/cpu-iq2000.o .libs/cpu-lm32.o .libs/cpu-m10200.o .libs/cpu-m10300.o .libs/cpu-m32c.o .libs/cpu-m32r.o .libs/cpu-m68hc11.o .libs/cpu-m68hc12.o .libs/cpu-m9s12x.o .libs/cpu-s12z.o .libs/cpu-m9s12xg.o .libs/cpu-m68k.o .libs/cpu-mcore.o .libs/cpu-mep.o .libs/cpu-metag.o .libs/cpu-microblaze.o .libs/cpu-mips.o .libs/cpu-mmix.o .libs/cpu-moxie.o .libs/cpu-msp430.o .libs/cpu-mt.o .libs/cpu-nds32.o .libs/cpu-nfp.o .libs/cpu-nios2.o .libs/cpu-ns32k.o .libs/cpu-or1k.o .libs/cpu-pdp11.o .libs/cpu-pj.o .libs/cpu-pru.o .libs/cpu-riscv.o .libs/cpu-rl78.o .libs/cpu-rx.o .libs/cpu-s390.o .libs/cpu-score.o .libs/cpu-sh.o .libs/cpu-sparc.o .libs/cpu-spu.o .libs/cpu-tic30.o .libs/cpu-tic4x.o .libs/cpu-tic54x.o .libs/cpu-tic6x.o .libs/cpu-tilegx.o .libs/cpu-tilepro.o .libs/cpu-v850.o .libs/cpu-v850_rh850.o .libs/cpu-vax.o .libs/cpu-visium.o .libs/cpu-wasm32.o .libs/cpu-xc16x.o .libs/cpu-xgate.o .libs/cpu-xstormy16.o .libs/cpu-xtensa.o .libs/cpu-z80.o .libs/cpu-z8k.o .libs/archive64.o   -liberty -lintl -ldl -lz  -g -O2   -install_name  /nix/store/sbmig002wpjdzafrjhnil8bx97pdq28h-libbfd-2.35.1/lib/libbfd-2.35.1.dylib  -Wl,-single_module
ld: library not found for -lintl
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [Makefile:1437: libbfd.la] Error 1
make[2]: Leaving directory '/private/tmp/nix-build-libbfd-2.35.1.drv-0/binutils-2.35.1/bfd'
make[1]: *** [Makefile:1807: all-recursive] Error 1
make[1]: Leaving directory '/private/tmp/nix-build-libbfd-2.35.1.drv-0/binutils-2.35.1/bfd'
make: *** [Makefile:1330: all] Error 2
builder for '/nix/store/fvqxn7n351mwsjh1isfarfc58jqz4g16-libbfd-2.35.1.drv' failed with exit code 2
error: build of '/nix/store/fvqxn7n351mwsjh1isfarfc58jqz4g16-libbfd-2.35.1.drv' failed
```
Disabling it makes it compile again, adding libintl/gettext for darwin does as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
