### PR TITLE
lirc: Set a writable lockdir

### DIFF
--- a/nixos/modules/services/hardware/lirc.nix
+++ b/nixos/modules/services/hardware/lirc.nix
@@ -65,7 +65,7 @@ in {
       unitConfig.Documentation = [ "man:lircd(8)" ];
 
       serviceConfig = {
-        RuntimeDirectory = "lirc";
+        RuntimeDirectory = ["lirc" "lirc/lock"];
 
         # Service runtime directory and socket share same folder.
         # Following hacks are necessary to get everything right:

--- a/pkgs/development/libraries/lirc/default.nix
+++ b/pkgs/development/libraries/lirc/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
     "--with-systemdsystemunitdir=$(out)/lib/systemd/system"
     "--enable-uinput" # explicit activation because build env has no uinput
     "--enable-devinput" # explicit activation because build env has no /dev/input
+    "--with-lockdir=/run/lirc/lock" # /run/lock is not writable for 'lirc' user
   ];
 
   installFlags = [


### PR DESCRIPTION
###### Motivation for this change
lircd could not send IR commands because `/run/lock` is not writable by `lirc`-user.

###### Things done
I configured the service to create a writable runtime directory in `/run/lirc/lock` and configured the package to use that as the lock directory.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
