### PR TITLE
cataclysmDDA: update mods: mirror github user

### DIFF
--- a/pkgs/games/cataclysm-dda/pkgs/tilesets/UndeadPeople/default.nix
+++ b/pkgs/games/cataclysm-dda/pkgs/tilesets/UndeadPeople/default.nix
@@ -5,7 +5,7 @@ buildTileSet {
   version = "2020-07-08";
 
   src = fetchFromGitHub {
-    owner = "SomeDeadGuy";
+    owner = "jmz-b";
     repo = "UndeadPeopleTileset";
     rev = "f7f13b850fafe2261deee051f45d9c611a661534";
     sha256 = "0r06srjr7rq51jk9yfyxz80nfgb98mkn86cbcjfxpibgbqvcp0zm";
@@ -15,7 +15,7 @@ buildTileSet {
 
   meta = with lib; {
     description = "Cataclysm DDA tileset based on MSX++ tileset";
-    homepage = "https://github.com/SomeDeadGuy/UndeadPeopleTileset";
+    homepage = "https://github.com/jmz-b/UndeadPeopleTileset";
     license = licenses.unfree;
     maintainers = with maintainers; [ mnacamura ];
     platforms = platforms.all;


### PR DESCRIPTION
SomeDeadGuy/UndeadPeopleTileset disappeared from GitHub, replaced with jmz-b/UndeadPeopleTileset who mirrored it

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
