### PR TITLE
Add --with-versioned-syms to ncurses' configure.

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
     "--enable-symlinks"
     "--with-manpage-format=normal"
     "--disable-stripping"
+    "--with-versioned-syms"
   ] ++ lib.optional unicodeSupport "--enable-widec"
     ++ lib.optional (!withCxx) "--without-cxx"
     ++ lib.optional (abiVersion == "5") "--with-abi-version=5"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The ghc binary distribution requires versioned symbols in `libtinfo/libncurses`. Without this change, the loader gives warning `no version information available`
```
[nix-shell:~/df/nix/nixpkgs]$ ghc --version
/nix/store/n2k3l4dnn439ifv53am52vvdvkw2g16g-ghc-9.2.0.20210821-binary/lib/ghc-9.2.0.20210821/bin/ghc: /nix/store/m8ranjrd8ilm4acgkdzr3vmvc47vsa2x-ncurses-6.2/lib/libtinfo.so.6: no version information available (required by /nix/store/n2k3l4dnn439ifv53am52vvdvkw2g16g-ghc-9.2.0.20210821-binary/lib/ghc-9.2.0.20210821/bin/../haskeline-0.8.2/libHShaskeline-0.8.2-ghc9.2.0.20210821.so)
/nix/store/n2k3l4dnn439ifv53am52vvdvkw2g16g-ghc-9.2.0.20210821-binary/lib/ghc-9.2.0.20210821/bin/ghc: /nix/store/m8ranjrd8ilm4acgkdzr3vmvc47vsa2x-ncurses-6.2/lib/libtinfo.so.6: no version information available (required by /nix/store/n2k3l4dnn439ifv53am52vvdvkw2g16g-ghc-9.2.0.20210821-binary/lib/ghc-9.2.0.20210821/bin/../ghc-9.2.0.20210821/libHSghc-9.2.0.20210821-ghc9.2.0.20210821.so)
/nix/store/n2k3l4dnn439ifv53am52vvdvkw2g16g-ghc-9.2.0.20210821-binary/lib/ghc-9.2.0.20210821/bin/ghc: /nix/store/m8ranjrd8ilm4acgkdzr3vmvc47vsa2x-ncurses-6.2/lib/libtinfo.so.6: no version information available (required by /nix/store/n2k3l4dnn439ifv53am52vvdvkw2g16g-ghc-9.2.0.20210821-binary/lib/ghc-9.2.0.20210821/bin/../terminfo-0.4.1.4/libHSterminfo-0.4.1.4-ghc9.2.0.20210821.so)
The Glorious Glasgow Haskell Compilation System, version 9.2.0.20210821
```
with this change
```
[nix-shell:~/df/nix/nixpkgs]$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 9.2.0.20210821
```
This PR https://github.com/NixOS/nixpkgs/pull/126991 also was adding this option, but looks like it was abandoned.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
