### PR TITLE
cargo-deadlinks: init at 0.8.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-deadlinks/default.nix
+++ b/pkgs/development/tools/rust/cargo-deadlinks/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-deadlinks";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "deadlinks";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "1zd5zgq3346xijllr0qdvvmsilpawisrqgdmsqir8v3bk55ybj4g";
+  };
+
+  cargoSha256 = "1ar3iwpy9mng4j09z4g3ynxra2qwc8454dnc0wjal4h16fk8gxwv";
+
+  checkFlags = [
+    # uses internet
+    "--skip non_existent_http_link --skip working_http_check"
+    # expects top-level directory to be named "cargo-deadlinks"
+    "--skip simple_project::it_checks_okay_project_correctly"
+  ];
+
+  buildInputs = lib.optional stdenv.isDarwin Security;
+
+  meta = with lib; {
+    description = "Cargo subcommand to check rust documentation for broken links";
+    homepage = "https://github.com/deadlinks/cargo-deadlinks";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ newam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12358,6 +12358,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
   cargo-criterion = callPackage ../development/tools/rust/cargo-criterion { };
+  cargo-deadlinks = callPackage ../development/tools/rust/cargo-deadlinks {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-deb = callPackage ../tools/package-management/cargo-deb {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [cargo-deadlinks](https://github.com/deadlinks/cargo-deadlinks), a cargo sub-command to check rust documentation for broken links.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
