### PR TITLE
[staging-next] kwin: fix build against libglvnd 1.3.4+

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -40,6 +40,18 @@ mkDerivation {
     ./0002-xwayland.patch
     ./0003-plugins-qpa-allow-using-nixos-wrapper.patch
     ./0001-NixOS-Unwrap-executable-name-for-.desktop-search.patch
+    # Fix build against libglvnd 1.3.4+
+    # Remove with release 5.22.90
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/kwin/-/commit/839710201c389b7f4ed248cb3818e755a37ce977.patch";
+      sha256 = "09rldhy0sbmqdfpyjzwm20cwnmrmj0w2751vyi5xlr414g0rzyc1";
+    })
+    # Fixup previous patch for i686
+    # Remove with release 5.22.90
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/kwin/-/commit/38e24ecd6416a975db0989c21b70d6a4cc242f35.patch";
+      sha256 = "0zsjmzswcnvfd2jm1c8i9aijpbap1141mjv6y4j282bplyqlp966";
+    })
   ];
   CXXFLAGS = [
     ''-DNIXPKGS_XWAYLAND=\"${lib.getBin xwayland}/bin/Xwayland\"''


### PR DESCRIPTION
https://hydra.nixos.org/build/153586964
https://bugs.kde.org/show_bug.cgi?id=440372
https://invent.kde.org/plasma/kwin/-/merge_requests/1404
https://invent.kde.org/plasma/kwin/-/merge_requests/1420

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

For https://github.com/NixOS/nixpkgs/pull/138268

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
