### PR TITLE
[staging-next] python3Packages.libarcus: fix build against protobuf 3.18+

### DIFF
--- a/pkgs/development/python-modules/libarcus/default.nix
+++ b/pkgs/development/python-modules/libarcus/default.nix
@@ -1,4 +1,5 @@
 { lib, buildPythonPackage, python, fetchFromGitHub
+, fetchpatch
 , cmake, sip_4, protobuf, pythonOlder }:
 
 buildPythonPackage rec {
@@ -13,7 +14,16 @@ buildPythonPackage rec {
     sha256 = "1ahka8s8fjwymyr7pca7i7h51ikfr35zy4nkzfcjn946x7p0dprf";
   };
 
-  disabled = pythonOlder "3.4.0";
+  patches = [
+    # Fix build against protobuf 3.18+
+    # https://github.com/Ultimaker/libArcus/issues/121
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/coryan/vcpkg/f69b85aa403b04e7d442c90db3418d484e44024f/ports/arcus/0001-fix-protobuf-deprecated.patch";
+      sha256 = "0bqj7pxzpwsamknd6gadj419x6mwx8wnlfzg4zqn6cax3cmasjb2";
+    })
+  ];
+
+  disabled = pythonOlder "3.4";
 
   propagatedBuildInputs = [ sip_4 ];
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Still needs upstream resolution (https://github.com/Ultimaker/libArcus/issues/121), but we can grab a ~~Void Linux~~ Vcpkg patch in the meantime

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

For https://github.com/NixOS/nixpkgs/pull/138268

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
