### PR TITLE
rpm: 4.16.1.3 -> 4.17.0

### DIFF
--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchpatch
+{ stdenv, lib
 , pkg-config, autoreconfHook
 , fetchurl, cpio, zlib, bzip2, file, elfutils, libbfd, libgcrypt, libarchive, nspr, nss, popt, db, xz, python, lua, llvmPackages
 , sqlite, zstd
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "rpm";
-  version = "4.16.1.3";
+  version = "4.17.0";
 
   src = fetchurl {
     url = "http://ftp.rpm.org/releases/rpm-${lib.versions.majorMinor version}.x/rpm-${version}.tar.bz2";
-    sha256 = "07g2g0adgjm29wqy94iqhpp5dk0hacfw1yf7kzycrrxnfbwwfgai";
+    sha256 = "2e0d220b24749b17810ed181ac1ed005a56bbb6bc8ac429c21f314068dc65e6a";
   };
 
   outputs = [ "out" "dev" "man" ];
@@ -34,22 +34,6 @@ stdenv.mkDerivation rec {
     "--enable-zstd"
     "--localstatedir=/var"
     "--sharedstatedir=/com"
-  ];
-
-  patches = [
-    # Small fixes for ndb on darwin
-    # https://github.com/rpm-software-management/rpm/pull/1465
-    (fetchpatch {
-      name = "darwin-support.patch";
-      url = "https://github.com/rpm-software-management/rpm/commit/2d20e371d5e38f4171235e5c64068cad30bda557.patch";
-      sha256 = "0p3j5q5a4hl357maf7018k3826jhcpqg6wfrnccrkv30g0ayk171";
-    })
-    # Fix build on aarch64-darwin
-    # https://github.com/rpm-software-management/rpm/pull/1775
-    (fetchpatch {
-      url = "https://github.com/emilazy/rpm/commit/45120e756930b4787ea2e06fb8a9e623ea13f2f3.patch";
-      sha256 = "0zzblwx9apxyjsri4cxd09y9b2hs57r2fck98939j1qgcwy732ar";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8760,6 +8760,7 @@ with pkgs;
 
   rpm = callPackage ../tools/package-management/rpm {
     python = python3;
+    lua = lua5_4;
   };
 
   rpm-ostree = callPackage ../tools/misc/rpm-ostree {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://rpm.org/wiki/Releases/4.17.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>lattice-diamond</li>
    <li>python38Packages.mkl-service</li>
    <li>python39Packages.mkl-service</li>
  </ul>
</details>
<details>
  <summary>55 packages built:</summary>
  <ul>
    <li>aliza</li>
    <li>bluejeans-gui</li>
    <li>clair</li>
    <li>clmagma</li>
    <li>createrepo_c</li>
    <li>dell-530cdn</li>
    <li>diffoscope</li>
    <li>diffoscopeMinimal</li>
    <li>doodle</li>
    <li>drawio</li>
    <li>dsseries</li>
    <li>dtrx</li>
    <li>ec2-utils</li>
    <li>epkowa</li>
    <li>epm</li>
    <li>epson-201106w</li>
    <li>epson-workforce-635-nx625-series</li>
    <li>epson_201207w</li>
    <li>flatpak-builder</li>
    <li>gnunet</li>
    <li>gnunet-gtk</li>
    <li>gutenprintBin</li>
    <li>hpmyroom</li>
    <li>hqplayer-desktop</li>
    <li>hqplayerd</li>
    <li>hydra-unstable</li>
    <li>intel-ocl</li>
    <li>libdnf</li>
    <li>libextractor</li>
    <li>libmodulemd</li>
    <li>libsolv</li>
    <li>megacli</li>
    <li>microdnf</li>
    <li>micromamba</li>
    <li>mkl</li>
    <li>nice-dcv-client</li>
    <li>nix-template-rpm</li>
    <li>perl532Packages.RPM2</li>
    <li>perl534Packages.RPM2</li>
    <li>postscript-lexmark</li>
    <li>python38Packages.libmodulemd</li>
    <li>python38Packages.osc</li>
    <li>python38Packages.rpm</li>
    <li>python39Packages.libmodulemd</li>
    <li>python39Packages.osc</li>
    <li>rpm (python39Packages.rpm)</li>
    <li>realvnc-vnc-viewer</li>
    <li>rpm-ostree</li>
    <li>rpmextract</li>
    <li>scaleft</li>
    <li>snowsql</li>
    <li>taler-exchange</li>
    <li>taler-merchant</li>
    <li>vk-messenger</li>
    <li>yandex-disk</li>
  </ul>
</details>