### PR TITLE
weechatScripts.zncplayback: init at 0.2.1

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -28,4 +28,6 @@
   buffer_autoset = callPackage ./buffer_autoset { };
 
   highmon = callPackage ./highmon { };
+
+  zncplayback = callPackage ./zncplayback { };
 }

--- a/pkgs/applications/networking/irc/weechat/scripts/zncplayback/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/zncplayback/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  pname = "weechat-zncplayback";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://github.com/weechat/scripts/raw/bcc9643136addd2cd68ac957dd64e336e4f88aa1/python/zncplayback.py";
+    sha256 = "1k32p6naxg40g664ip48zvm61xza7l9az3v3rawmjw97i0mwz7y3";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp $src $out/share/zncplayback.py
+  '';
+
+  passthru = {
+    scripts = [ "zncplayback.py" ];
+  };
+
+  meta = with lib; {
+    description = "Add support for the ZNC Playback module";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ qyliss ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
