### PR TITLE
mesa (+stdenv / meson): fix cross-compilation support w/ llvm

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -93,6 +93,10 @@ self = stdenv.mkDerivation {
     ++ lib.optional stdenv.isLinux "driversdev"
     ++ lib.optional enableOpenCL "opencl";
 
+  preConfigure = ''
+    PATH=${llvmPackages.libllvm.dev}/bin:$PATH
+  '';
+
   # TODO: Figure out how to enable opencl without having a runtime dependency on clang
   mesonFlags = [
     "--sysconfdir=/etc"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -305,6 +305,9 @@ else let
           cpu_family = '${cpuFamily stdenv.targetPlatform}'
           cpu = '${stdenv.targetPlatform.parsed.cpu.name}'
           endian = ${if stdenv.targetPlatform.isLittleEndian then "'little'" else "'big'"}
+
+          [binaries]
+          llvm-config = 'llvm-config-native'
         '';
       in [ "--cross-file=${crossFile}" ] ++ mesonFlags;
     } // lib.optionalAttrs (attrs.enableParallelBuilding or false) {


### PR DESCRIPTION
###### Motivation for this change

Mesa didn't cross-compile anymore since 21.0.3 (the update to 21.1.x broke it), since the way it's packaged requires llvm since that update. This properly adds llvm-config-native to the meson cross config file and adds the llvm dependency to mesa.

I'm not 100% sure if this should be llvmPackages.llvm or if it can also be e.g. llvmPackages.libllvm, but this seems to work fine.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
