### PR TITLE
nixos/jackline: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -287,6 +287,13 @@
           <link linkend="opt-programs.pantheon-tweaks.enable">programs.pantheon-tweaks</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/hannesm/jackline">jackline</link>,
+          a minimalistic secure XMPP client in OCaml. Available as
+          <link linkend="opt-services.jackline.enable">services.jackline</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -90,6 +90,8 @@ subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable
 
 - [pantheon-tweaks](https://github.com/pantheon-tweaks/pantheon-tweaks), an unofficial system settings panel for Pantheon. Available as [programs.pantheon-tweaks](#opt-programs.pantheon-tweaks.enable).
 
+- [jackline](https://github.com/hannesm/jackline), a minimalistic secure XMPP client in OCaml. Available as [services.jackline](#opt-services.jackline.enable).
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 - The `security.wrappers` option now requires to always specify an owner, group and whether the setuid/setgid bit should be set.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -528,6 +528,7 @@
   ./services/misc/ihaskell.nix
   ./services/misc/irkerd.nix
   ./services/misc/jackett.nix
+  ./services/misc/jackline.nix
   ./services/misc/jellyfin.nix
   ./services/misc/klipper.nix
   ./services/misc/logkeys.nix

--- a/nixos/modules/services/misc/jackline.nix
+++ b/nixos/modules/services/misc/jackline.nix
@@ -1,0 +1,82 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.jackline;
+in {
+  options.services.jackline = {
+    enable = mkOption {
+      description = ''
+        Whether to enable jackline, a minimalistic secure XMPP client in OCaml.
+
+        By doing so, jackline will be run in a screen session. One can attach
+        this session via <literal>sudo -u jackline screen -x jackline-screen</literal>.
+      '';
+      type = types.bool;
+      default = false;
+      example = true;
+    };
+
+    root = mkOption {
+      description = "Jackline state directory.";
+      type = types.str;
+      default = "/var/lib/jackline";
+    };
+
+    sessionName = mkOption {
+      description = "Name of the `screen' session for jackline.";
+      default = "jackline-screen";
+      type = types.str;
+    };
+
+    package = mkOption {
+      type = types.package;
+      description = "Package that should be used for jackline.";
+      default = pkgs.jackline;
+      defaultText = "pkgs.jackline";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      groups.jackline = {};
+
+      users.jackline = {
+        createHome = true;
+        group = "jackline";
+        home = cfg.root;
+        isSystemUser = true;
+      };
+    };
+
+    security.wrappers.screen = {
+      setuid = true;
+      owner = "root";
+      group = "root";
+      source = "${pkgs.screen}/bin/screen";
+    };
+
+    systemd.services.jackline = {
+      description = "jackline, a minimalistic secure XMPP client in OCaml";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "exec";
+        ExecStart = "${config.security.wrapperDir}/screen -Dm -S ${cfg.sessionName} ${cfg.package}/bin/jackline";
+
+        User = "jackline";
+        Group = "jackline";
+
+        RemainAfterExit = "yes";
+
+        ProtectSystem = "strict";
+        ReadWritePaths = "${cfg.root} /tmp/screens/";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ oxzi ];
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The new services.jackline module allows using the already packaged
jackline XMPP client in an interactive screen session. The module's
design is heavily inspired by the weechat module, which also provides a
screen session, just for weechat.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
