### PR TITLE
python3Packages.python3-eventlib: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1853,6 +1853,12 @@
     githubId = 1762540;
     name = "Changlin Li";
   };
+  chanley = {
+    email = "charlieshanley@gmail.com";
+    github = "charlieshanley";
+    githubId = 8228888;
+    name = "Charlie Hanley";
+  };
   CharlesHD = {
     email = "charleshdespointes@gmail.com";
     github = "CharlesHD";

--- a/pkgs/development/python-modules/python3-eventlib/default.nix
+++ b/pkgs/development/python-modules/python3-eventlib/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchFromGitHub, buildPythonPackage, isPy3k, zope_interface, twisted, greenlet }:
+
+buildPythonPackage rec {
+  pname = "python3-eventlib";
+  version = "0.3.0";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "AGProjects";
+    repo = "python3-eventlib";
+    rev = version;
+    sha256 = "sha256-LFW3rCGa7A8tk6SjgYgjkLQ+72GE2WN8wG+XkXYTAoQ=";
+  };
+
+  propagatedBuildInputs = [ zope_interface twisted greenlet ];
+
+  dontUseSetuptoolsCheck = true;
+
+  pythonImportsCheck = [ "eventlib" ];
+
+  meta = with lib; {
+    description = "A networking library written in Python";
+    homepage = "https://github.com/AGProjects/python3-eventlib";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ chanley ];
+    longDescription = ''
+      Eventlib is a networking library written in Python. It achieves high
+      scalability by using non-blocking I/O while at the same time retaining
+      high programmer usability by using coroutines to make the non-blocking io
+      operations appear blocking at the source code level.
+    '';
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7150,6 +7150,8 @@ in {
 
   pytest-xvfb = callPackage ../development/python-modules/pytest-xvfb { };
 
+  python3-eventlib = callPackage ../development/python-modules/python3-eventlib { };
+
   python3-openid = callPackage ../development/python-modules/python3-openid { };
 
   python-awair = callPackage ../development/python-modules/python-awair { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Split from #136924. This adds a dependency of blink-qt and sipclients3, which I intend to add.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
