### PR TITLE
Nesthub: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7699,6 +7699,12 @@
     email = "natedevv@gmail.com";
     name = "Nathan Moore";
   };
+  nateinaction = {
+    email = "email@n8.gay";
+    github = "nateinaction";
+    githubId = 105005;
+    name = "Nate Gay";
+  };
   nathanruiz = {
     email = "nathanruiz@protonmail.com";
     github = "nathanruiz";

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -287,6 +287,13 @@
           <link linkend="opt-programs.pantheon-tweaks.enable">programs.pantheon-tweaks</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/yangl1996/nesthub">nesthub</link>,
+          HomeKit bridge for Nest thermostats. Available as
+          <link xlink:href="options.html#opt-services.nesthub.enable">services.nesthub</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -90,6 +90,8 @@ subsonic-compatible api. Available as [navidrome](#opt-services.navidrome.enable
 
 - [pantheon-tweaks](https://github.com/pantheon-tweaks/pantheon-tweaks), an unofficial system settings panel for Pantheon. Available as [programs.pantheon-tweaks](#opt-programs.pantheon-tweaks.enable).
 
+- [nesthub](https://github.com/yangl1996/nesthub), HomeKit bridge for Nest thermostats. Available as [services.nesthub](options.html#opt-services.nesthub.enable).
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 - The `security.wrappers` option now requires to always specify an owner, group and whether the setuid/setgid bit should be set.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -547,6 +547,7 @@
   ./services/misc/mwlib.nix
   ./services/misc/mx-puppet-discord.nix
   ./services/misc/n8n.nix
+  ./services/misc/nesthub.nix
   ./services/misc/nitter.nix
   ./services/misc/nix-daemon.nix
   ./services/misc/nix-gc.nix

--- a/nixos/modules/services/misc/nesthub.nix
+++ b/nixos/modules/services/misc/nesthub.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.nesthub;
+in {
+  options = {
+    services.nesthub = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the Nesthub service.";
+      };
+      configPath = mkOption {
+        type = types.str;
+        default = "/var/lib/nesthub/config.json";
+        description = "Path to the config file.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.nesthub = {
+      description = "Nesthub Homekit bridge for Nest thermostats";
+      serviceConfig = {
+        ExecStart = "${pkgs.nesthub}/bin/nesthub -config ${config.services.nesthub.configPath}";
+      };
+      after = [ "network.online" ];
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}
+

--- a/pkgs/servers/misc/nesthub/default.nix
+++ b/pkgs/servers/misc/nesthub/default.nix
@@ -1,0 +1,23 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "nesthub";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "yangl1996";
+    repo = "nesthub";
+    rev = "v${version}";
+    sha256 = "013zk8r0zadwh40wdmagzgvsvbpj6yya31gg3fx2iw28slh40vrh";
+  };
+
+  vendorSha256 = "1hm97iyj7cwh7vckj3sv0q93wp1bxjj24bjkrzpphgas7v559dj9";
+
+  meta = with lib; {
+    description = "HomeKit bridge for Nest thermostats";
+    homepage = "https://github.com/yangl1996/nesthub";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nateinaction ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3187,6 +3187,8 @@ with pkgs;
 
   n2n = callPackage ../tools/networking/n2n { };
 
+  nesthub = callPackage ../servers/misc/nesthub { };
+
   nextdns = callPackage ../applications/networking/nextdns { };
 
   ngadmin = callPackage ../applications/networking/ngadmin { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Create a NixOS package and service to bridge Nest thermostats and Apple HomeKit.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
