### PR TITLE
bottles: 2021.7.14-treviso -> 2021.9.14-treviso

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    hash = "sha256:0wdb6pc9gl6fnmd500smsq303snncaim284wgz7isjwhmwmfyw8m";
+    sha256 = "0wdb6pc9gl6fnmd500smsq303snncaim284wgz7isjwhmwmfyw8m";
   };
 
   postPatch = ''

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -8,13 +8,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2021.7.14-treviso";
+  version = "2021.9.14-treviso";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    sha256 = "0xhfk1ll8vacgrr0kkhynq4bryjhfjs29j824bark5mj9b6lkbix";
+    hash = "sha256:0wdb6pc9gl6fnmd500smsq303snncaim284wgz7isjwhmwmfyw8m";
   };
 
   postPatch = ''
@@ -52,6 +52,7 @@ python3Packages.buildPythonApplication rec {
     dbus-python
     gst-python
     liblarch
+    patool
   ] ++ [ steam-run-native ];
 
   format = "other";
@@ -61,7 +62,7 @@ python3Packages.buildPythonApplication rec {
   preConfigure = ''
     substituteInPlace build-aux/meson/postinstall.py \
       --replace "'update-desktop-database'" "'${desktop-file-utils}/bin/update-desktop-database'"
-    substituteInPlace src/runner.py \
+    substituteInPlace src/backend/runner.py \
       --replace " {runner}" " ${steam-run-native}/bin/steam-run {runner}" \
       --replace " {dxvk_setup}" " ${steam-run-native}/bin/steam-run {dxvk_setup}"
   '';

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -2,7 +2,7 @@
 , meson, ninja, pkg-config, wrapGAppsHook
 , desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy
 , python3Packages, gettext
-, appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3
+, appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3, pciutils, xdg-utils
 , steam-run-native
 }:
 
@@ -53,7 +53,11 @@ python3Packages.buildPythonApplication rec {
     gst-python
     liblarch
     patool
-  ] ++ [ steam-run-native ];
+  ] ++ [
+    steam-run-native
+    pciutils
+    xdg-utils
+  ];
 
   format = "other";
   strictDeps = false; # broken with gobject-introspection setup hook, see https://github.com/NixOS/nixpkgs/issues/56943


### PR DESCRIPTION
Added new dependency `patool` as it's now needed during runtime.

###### Motivation for this change
Update to latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 30, done.
remote: Counting objects: 100% (24/24), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 30 (delta 15), reused 14 (delta 13), pack-reused 6
Unpacking objects: 100% (30/30), 224.55 KiB | 782.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   9f761047cc4..b7255cd8b96  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-df00de53009d941f5417aa298761f558da758a5b-dirty/nixpkgs b7255cd8b96994ebfc20810f3cad4b6e871af7f4
Preparing worktree (detached HEAD b7255cd8b96)
Updating files: 100% (27893/27893), done.
HEAD is now at b7255cd8b96 Merge pull request #138542 from figsoda/cargo-tally
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-df00de53009d941f5417aa298761f558da758a5b-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
