### PR TITLE
nixos/tpm2: define group, fix after #133166

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -210,7 +210,7 @@ in
       #fleet = 173; # unused
       #input = 174; # unused
       sddm = 175;
-      tss = 176;
+      #tss = 176; # dynamically allocated as of 2021-09-17
       #memcached = 177; removed 2018-01-03
       #ntp = 179; # dynamically allocated as of 2021-09-17
       zabbix = 180;

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -524,7 +524,7 @@ in
       #fleet = 173; # unused
       input = 174;
       sddm = 175;
-      tss = 176;
+      #tss = 176; #dynamically allocateda as of 2021-09-20
       #memcached = 177; # unused, removed 2018-01-03
       #ntp = 179; # unused
       zabbix = 180;

--- a/nixos/modules/security/tpm2.nix
+++ b/nixos/modules/security/tpm2.nix
@@ -146,6 +146,7 @@ in {
       # Create the tss user and group only if the default value is used
       users.users.${cfg.tssUser} = lib.mkIf (cfg.tssUser == "tss") {
         isSystemUser = true;
+        group = "tss";
       };
       users.groups.${cfg.tssGroup} = lib.mkIf (cfg.tssGroup == "tss") {};
 
@@ -172,7 +173,7 @@ in {
           BusName = "com.intel.tss2.Tabrmd";
           ExecStart = "${cfg.abrmd.package}/bin/tpm2-abrmd";
           User = "tss";
-          Group = "nogroup";
+          Group = "tss";
         };
       };
 

--- a/nixos/modules/services/hardware/tcsd.nix
+++ b/nixos/modules/services/hardware/tcsd.nix
@@ -149,12 +149,10 @@ in
     users.users = optionalAttrs (cfg.user == "tss") {
       tss = {
         group = "tss";
-        uid = config.ids.uids.tss;
+        isSystemUser = true;
       };
     };
 
-    users.groups = optionalAttrs (cfg.group == "tss") {
-      tss.gid = config.ids.gids.tss;
-    };
+    users.groups = optionalAttrs (cfg.group == "tss") { tss = {}; };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/133166 broke tpm2 module. Also addresses https://github.com/NixOS/nixpkgs/issues/55370.

I don't use `tcsd` nor have TPM 1.2, so would appreciate someone testing.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).