### PR TITLE
python3Packages.poetry: 1.1.8 -> 1.1.11

### DIFF
--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -1,4 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub, pythonOlder, isPy27
+, git
 , importlib-metadata
 , intreehooks
 , pathlib2
@@ -12,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "poetry-core";
-  version = "1.0.4";
+  version = "1.0.7";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = pname;
     rev = version;
-    sha256 = "0jgd4d7m5y8ly8n0l9lcq7cjab2y3hifk90f343ksmjzssfd5lg3";
+    sha256 = "0v86x8f8pcbviv2cdn7jjbgj3c994qasx0bqk1kr0mj8m6pjwy9z";
   };
 
   postPatch = lib.optionalString (pythonOlder "3.8") ''
@@ -41,6 +42,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    git
     pep517
     pytest-mock
     pytestCheckHook

--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "poetry";
-  version = "1.1.8";
+  version = "1.1.11";
   format = "pyproject";
   disabled = isPy27;
 
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "python-poetry";
     repo = pname;
     rev = version;
-    sha256 = "0qcgjb78nj69sppd8146519q9422xxg1bi34gyxy51sjkvd5lxhz";
+    sha256 = "17yi15jp32v5vc9aarxkncz3jd0s4bqw8p26yyf4swdvafig0qab";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Upgrade package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).