### PR TITLE
nixos/smokeping: drop dangling fping6 suid swapper

### DIFF
--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -284,12 +284,6 @@ in
           group = "root";
           source = "${pkgs.fping}/bin/fping";
         };
-      fping6 =
-        { setuid = true;
-          owner = "root";
-          group = "root";
-          source = "${pkgs.fping}/bin/fping6";
-        };
     };
     environment.systemPackages = [ pkgs.fping ];
     users.users.${cfg.user} = {


### PR DESCRIPTION
After recent change `services.smokeping.enable = true;` system
started failing the build as:

```
nixpkgs-master $ nix build --no-link -f nixos system --keep-going
...
Checking that Nix store paths of all wrapped programs exist... FAIL
The path /nix/store/kr2sr80g9ny74im6m6dyh9v44hnzm261-fping-5.0/bin/fping6 does not exist!
Please, check the value of `security.wrappers."fping6".source`.
```

`fping` does not provide `fping6` binary for a while. Let's just remove it.

Closes: https://github.com/NixOS/nixpkgs/issues/138581

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
