### PR TITLE
python3Packages.deezer-python: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/development/python-modules/deezer-python/default.nix
+++ b/pkgs/development/python-modules/deezer-python/default.nix
@@ -1,26 +1,27 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, poetry-core
+, pytest-mock
+, pytest-vcr
+, pytestCheckHook
 , pythonOlder
 , requests
 , tornado
-, poetry-core
-, pytestCheckHook
-, pytest-cov
-, pytest-vcr
 }:
 
 buildPythonPackage rec {
   pname = "deezer-python";
-  version = "2.3.0";
-  disabled = pythonOlder "3.6";
+  version = "2.3.1";
   format = "pyproject";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "browniebroke";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-pRYC0kJHJ5SKgDdGS1KkQEbv+DkF9oPw/A1GnB0AwfQ=";
+    sha256 = "sha256-0gkPwIz+nZJjxfucy71D0A5CFkhQaW32UH5t1DkuvEs=";
   };
 
   nativeBuildInputs = [
@@ -29,14 +30,21 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-    pytest-cov
     pytest-vcr
+    pytest-mock
   ];
 
   propagatedBuildInputs = [
     requests
     tornado
   ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace " --cov=deezer" ""
+  '';
+
+  pythonImportsCheck = [ "deezer" ];
 
   meta = with lib; {
     description = "A friendly Python wrapper around the Deezer API";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.3.1

Change log: https://github.com/browniebroke/deezer-python/releases/tag/v2.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
