### PR TITLE
sslh: 1.21c → 1.22c

### DIFF
--- a/pkgs/servers/sslh/default.nix
+++ b/pkgs/servers/sslh/default.nix
@@ -1,17 +1,19 @@
-{ lib, stdenv, fetchurl, libcap, libconfig, perl, tcp_wrappers, pcre, nixosTests }:
+{ lib, stdenv, fetchFromGitHub, libcap, libconfig, perl, tcp_wrappers, pcre2, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "sslh";
-  version = "1.21c";
+  version = "1.22c";
 
-  src = fetchurl {
-    url = "https://www.rutschle.net/tech/sslh/sslh-v${version}.tar.gz";
-    sha256 = "01p7w74ppszxgz6n41lqd6xqvc7bjk2dsc769dd1yb7q4qvpiziv";
+  src = fetchFromGitHub {
+    owner = "yrutschle";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-A+nUWiOPoz/T5afZUzt5In01e049TgHisTF8P5Vj180=";
   };
 
   postPatch = "patchShebangs *.sh";
 
-  buildInputs = [ libcap libconfig perl tcp_wrappers pcre ];
+  buildInputs = [ libcap libconfig perl tcp_wrappers pcre2 ];
 
   makeFlags = [ "USELIBCAP=1" "USELIBWRAP=1" ];
 


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/yrutschle/sslh/blob/master/ChangeLog)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
