### PR TITLE
git-fast-export: 200213 -> 210917

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/fast-export/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/fast-export/default.nix
@@ -1,18 +1,18 @@
-{lib, stdenv, fetchFromGitHub, git, mercurial, makeWrapper}:
+{ lib, stdenv, fetchFromGitHub, git, mercurial, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "fast-export";
-  version = "200213";
+  version = "210917";
 
   src = fetchFromGitHub {
     owner = "frej";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0hzyh66rlawxip4n2pvz7pbs0cq82clqv1d6c7hf60v1drjxw287";
+    sha256 = "sha256-o3nuo7Uj9hl8AWyOq15iRB75qtCzdaxyzPVsvHLK6HU=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [mercurial.python mercurial];
+  buildInputs = [ mercurial.python mercurial ];
 
   installPhase = ''
     binPath=$out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5404,7 +5404,7 @@ with pkgs;
 
   git-fame = callPackage ../applications/version-management/git-and-tools/git-fame {};
 
-  git-fast-export = callPackage ../applications/version-management/git-and-tools/fast-export { mercurial = mercurial_4; };
+  git-fast-export = callPackage ../applications/version-management/git-and-tools/fast-export { };
 
   git-filter-repo = callPackage ../applications/version-management/git-and-tools/git-filter-repo {
     pythonPackages = python3Packages;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to support Python 3 & Mercurial 5.

I'm not sure whether it's worth renaming this package entirely; it'd be
more accurate to call it `hg-fast-export` (see also `cvs-fast-export` and
`svn-all-fast-export`) especially since the exported binaries have the
`hg-` prefix.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
