### PR TITLE
python3Packages.GitPython: 3.1.23 -> 3.1.24

### DIFF
--- a/pkgs/development/python-modules/GitPython/default.nix
+++ b/pkgs/development/python-modules/GitPython/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "gitpython";
-  version = "3.1.23";
+  version = "3.1.24";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "gitpython-developers";
     repo = "GitPython";
     rev = version;
-    sha256 = "sha256-1+jMg5pOrYJBgv/q9FFnR5Ujc8pwEPZHfLssNnt8nmA=";
+    sha256 = "sha256-KfR14EqXsDgIZUerk/hHDB0Z7IuqncbTNd/yNwrV9I0=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.1.24

Change log: https://github.com/gitpython-developers/GitPython/blob/main/doc/source/changes.rst#3124

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
