### PR TITLE
influxdb2: 2.0.6 -> 2.0.8

### DIFF
--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -1,10 +1,10 @@
 { buildGoModule
 , buildGoPackage
 , fetchFromGitHub
+, fetchurl
 , go-bindata
 , lib
 , llvmPackages
-, mkYarnPackage
 , pkg-config
 , rustPlatform
 , stdenv
@@ -15,36 +15,21 @@
 # dependencies nix expression.
 
 let
-  version = "2.0.6";
-  shorthash = "4db98b4c9a"; # git rev-parse HEAD with 2.0.6 checked out
-  libflux_version = "0.115.0";
+  version = "2.0.8";
+  shorthash = "e91d41810f"; # git rev-parse HEAD with 2.0.8 checked out
+  libflux_version = "0.124.0";
 
   src = fetchFromGitHub {
     owner = "influxdata";
     repo = "influxdb";
     rev = "v${version}";
-    sha256 = "1x74p87csx4m4cgijk57xs75nikv3bnh7skgnzk30ab1ar13iirw";
+    sha256 = "0hbinnja13xr9ziyynjsnsbrxmyrvag7xdgfwq2ya28g07lw5wgq";
   };
 
-  ui = mkYarnPackage {
-    src = src;
-    packageJSON = ./influx-ui-package.json;
-    yarnLock = "${src}/ui/yarn.lock";
-    yarnNix = ./influx-ui-yarndeps.nix;
-    configurePhase = ''
-      cp -r $node_modules ui/node_modules
-      rsync -r $node_modules/../deps/influxdb-ui/node_modules/ ui/node_modules
-    '';
-    INFLUXDB_SHA = shorthash;
-    buildPhase = ''
-      pushd ui
-      yarn build:ci
-      popd
-    '';
-    installPhase = ''
-      mv ui/build $out
-    '';
-    distPhase = "true";
+  ui = fetchurl {
+    url = "https://github.com/influxdata/ui/releases/download/OSS-v${version}/build.tar.gz";
+    # https://github.com/influxdata/ui/releases/download/OSS-v${version}/sha256.txt
+    sha256 = "94965ae999a1098c26128141fbb849be3da9a723d509118eb6e0db4384ee01fc";
   };
 
   flux = rustPlatform.buildRustPackage {
@@ -54,10 +39,10 @@ let
       owner = "influxdata";
       repo = "flux";
       rev = "v${libflux_version}";
-      sha256 = "0zplwsk9xidv8l9sqbxqivy6q20ryd31fhrzspn1mjn4i45kkwz1";
+      sha256 = "1g1qilfzxqbbjbfvgkf7k7spcnhzvlmrqacpqdl05418ywkp3v29";
     };
     sourceRoot = "source/libflux";
-    cargoSha256 = "06gh466q7qkid0vs5scic0qqlz3h81yb00nwn8nwq8ppr5z2ijyq";
+    cargoSha256 = "0farcjwnwwgfvcgbs5r6vsdrsiwq2mp82sjxkqb1pzqfls4ixcxj";
     nativeBuildInputs = [ llvmPackages.libclang ];
     buildInputs = lib.optional stdenv.isDarwin libiconv;
     LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
@@ -85,7 +70,7 @@ in buildGoModule {
 
   nativeBuildInputs = [ go-bindata pkg-config ];
 
-  vendorSha256 = "03pabm0h9q0v5dfdq9by2l2n32bz9imwalz0aw897vsrfhci0ldf";
+  vendorSha256 = "1kar88vlm6px7smlnajpyf8qx6d481xk979qafpfb1xy8931781m";
   subPackages = [ "cmd/influxd" "cmd/influx" ];
 
   PKG_CONFIG_PATH = "${flux}/pkgconfig";
@@ -95,7 +80,8 @@ in buildGoModule {
   # the relevant go:generate directives, and run them by hand without
   # breaking hermeticity.
   preBuild = ''
-    ln -s ${ui} ui/build
+    tar -xzf ${ui} -C static/data
+
     grep -RI -e 'go:generate.*go-bindata' | cut -f1 -d: | while read -r filename; do
       sed -i -e 's/go:generate.*go-bindata/go:generate go-bindata/' $filename
       pushd $(dirname $filename)


### PR DESCRIPTION
###### Motivation for this change

New upstream release and Hydra fails to build since a few weeks. See e.g. https://hydra.nixos.org/build/150607627:

```
   Compiling tera v1.8.0
error: field is never read: `message`
  --> flux-core/src/parser/mod.rs:35:5
   |
35 |     pub message: String,
   |     ^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> flux-core/src/lib.rs:1:38
   |
1  | #![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
   |                                      ^^^^^^^^
   = note: `#[deny(dead_code)]` implied by `#[deny(warnings)]`

error: field is never read: `message`
  --> flux-core/src/parser/mod.rs:35:5
   |
35 |     pub message: String,
   |     ^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> flux-core/src/lib.rs:1:38
   |
1  | #![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
   |                                      ^^^^^^^^
   = note: `#[deny(dead_code)]` implied by `#[deny(warnings)]`

error: aborting due to previous error

error: could not compile `flux-core`
```


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
