### PR TITLE
tdesktop  3.0.1 -> 3.1.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -45,6 +45,7 @@
 , libsysprof-capture
 , libpsl
 , brotli
+, microsoft_gsl
 }:
 
 # Main reference:
@@ -59,7 +60,7 @@ let
 in
 mkDerivation rec {
   pname = "telegram-desktop";
-  version = "3.0.1";
+  version = "3.1.0";
   # Note: Update via pkgs/applications/networking/instant-messengers/telegram/tdesktop/update.py
 
   # Telegram-Desktop with submodules
@@ -68,7 +69,7 @@ mkDerivation rec {
     repo = "tdesktop";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "196w82a92jahz7caqv2cyhhq53xm3figa7kiq59kid5wbqg33c9x";
+    sha256 = "0507qdkz8gn0gyyhxsy4mc4rs2r94s1ipqfxrc6ghgj43jkrklx3";
   };
 
   postPatch = ''
@@ -136,6 +137,7 @@ mkDerivation rec {
     libsysprof-capture
     libpsl
     brotli
+    microsoft_gsl
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/tg_owt.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation {
   pname = "tg_owt";
-  version = "unstable-2021-06-27";
+  version = "unstable-2021-09-15";
 
   src = fetchFromGitHub {
     owner = "desktop-app";
     repo = "tg_owt";
-    rev = "91d836dc84a16584c6ac52b36c04c0de504d9c34";
-    sha256 = "1ir4svv5mijpzr0rmx65088iikck83vhcdqrpf9dnk6yp4j9v4v2";
+    rev = "575fb17d2853c43329e45f6693370f5e41668055";
+    sha256 = "17lhy5g4apdakspv75zm070k7003crf1i80m8wy8f631s86v30md";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
