### PR TITLE
tlsh: 4.5.0 -> 4.9.3

### DIFF
--- a/pkgs/development/python-modules/tlsh/default.nix
+++ b/pkgs/development/python-modules/tlsh/default.nix
@@ -4,15 +4,15 @@
 , cmake
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "tlsh";
-  version = "4.5.0";
+  version = "4.9.3";
 
   src = fetchFromGitHub {
     owner = "trendmicro";
     repo = "tlsh";
-    rev = "f2bb7a97cfb0f9418a750ba92c182d1091e6c159";
-    sha256 = "1kxfhdwqjd4pjdlr1gjh2am8mxpaqmfq7rrxkjfi0mbisl1krkwb";
+    rev = version;
+    sha256 = "sha256-12bhxJTJJWzoiWt4YwhcdwHDvJNoBenWl3l26SFuIGU=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/tlsh/default.nix
+++ b/pkgs/development/python-modules/tlsh/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Trend Micro Locality Sensitive Hash";
-    homepage = "http://tlsh.org/";
+    homepage = "https://tlsh.org/";
     license = licenses.asl20;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

Latest tagged version.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
