### PR TITLE
unbound: enable more features

### DIFF
--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -5,9 +5,13 @@
 , nettle
 , expat
 , libevent
+, libsodium
+, protobufc
+, hiredis
 , dns-root-data
 , pkg-config
 , makeWrapper
+, symlinkJoin
   #
   # By default unbound will not be built with systemd support. Unbound is a very
   # commmon dependency. The transitive dependency closure of systemd also
@@ -21,6 +25,11 @@
 , systemd ? null
   # optionally support DNS-over-HTTPS as a server
 , withDoH ? false
+, withECS ? false
+, withDNSCrypt ? false
+, withDNSTAP ? false
+, withTFO ? false
+, withRedis ? false
 , libnghttp2
 }:
 
@@ -57,7 +66,23 @@ stdenv.mkDerivation rec {
     "--enable-systemd"
   ] ++ lib.optionals withDoH [
     "--with-libnghttp2=${libnghttp2.dev}"
+  ] ++ lib.optionals withECS [
+    "--enable-subnet"
+  ] ++ lib.optionals withDNSCrypt [
+    "--enable-dnscrypt"
+    "--with-libsodium=${symlinkJoin { name = "libsodium-full"; paths = [ libsodium.dev libsodium.out ]; }}"
+  ] ++ lib.optionals withDNSTAP [
+    "--enable-dnstap"
+    "--with-protobuf-c=${protobufc}"
+  ] ++ lib.optionals withTFO [
+    "--enable-tfo-client"
+    "--enable-tfo-server"
+  ] ++ lib.optionals withRedis [
+    "--enable-cachedb"
+    "--with-libhiredis=${hiredis}"
   ];
+
+  PROTOC_C = if withDNSTAP then "${protobufc}/bin/protoc-c" else null;
 
   # Remove references to compile-time dependencies that are included in the configure flags
   postConfigure = let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10449,6 +10449,11 @@ with pkgs;
   unbound-full = unbound.override {
     withSystemd = true;
     withDoH = true;
+    withECS = true;
+    withDNSCrypt = true;
+    withDNSTAP = true;
+    withTFO = true;
+    withRedis = true;
   };
 
   unicorn = callPackage ../development/libraries/unicorn { };


### PR DESCRIPTION
###### Motivation for this change
Currently unbound in nixpkgs has a lot of not-enabled features. Some of them are quite useful.

###### Things done
This pull request adds options for these features:

- EDNS Client Subnet
- DNSCrypt
- DNSTAP
- TCP Fast Open
- Cache DB module
- Redis backend for the Cache DB module

(also is there a more elegant way of achieving the same goal as [these lines](https://github.com/poscat0x04/nixpkgs/blob/unbound-ecs/pkgs/tools/networking/unbound/default.nix#L123-L125)?)

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).