### PR TITLE
heisenbridge: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/servers/heisenbridge/default.nix
+++ b/pkgs/servers/heisenbridge/default.nix
@@ -1,14 +1,14 @@
-{ lib, fetchFromGitHub, python3Packages }:
+{ lib, fetchurl, python3Packages }:
 
 python3Packages.buildPythonPackage rec {
   pname = "heisenbridge";
-  version = "1.1.0";
+  version = "1.1.1";
 
-  src = fetchFromGitHub {
-    owner = "hifi";
-    repo = "heisenbridge";
-    rev = "v${version}";
-    sha256 = "sha256-7B4orrANb4hTXJ4cFYxhmrOgEIoU3TPmsR239JhIrTw=";
+  # Use the release tarball because it has the version set correctly using the
+  # version.txt file.
+  src = fetchurl {
+    url = "https://github.com/hifi/heisenbridge/releases/download/v${version}/heisenbridge-v${version}.tar.gz";
+    sha256 = "sha256-thI3NYYnLHmlfs5mmH2SQcREBLWtnilYlxriKWnamPM=";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/hifi/heisenbridge/releases/tag/v1.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
