### PR TITLE
vdexExtractor: init at 0.6.0

### DIFF
--- a/pkgs/development/tools/vdexExtractor/default.nix
+++ b/pkgs/development/tools/vdexExtractor/default.nix
@@ -1,0 +1,52 @@
+{ lib, fetchFromGitHub, stdenv, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "vdexExtractor";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "anestisb";
+    repo = "vdexExtractor";
+    rev = version;
+    sha256 = "sha256-dSzNK1dvllmY9HcA7u0tbhDM8tY/I6GqzgAJ56mB5vE=";
+  };
+
+  # No tests
+  doCheck = false;
+
+  postPatch = ''
+    patchShebangs make.sh
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./make.sh
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D bin/vdexExtractor $out/bin/vdexExtractor
+
+    runHook postInstall
+  '';
+
+  buildInputs = [
+    zlib
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=stringop-truncation"
+  ];
+
+  meta = with lib; {
+    description = "Tool to decompile & extract Android Dex bytecode from Vdex files";
+    homepage = "https://github.com/anestisb/vdexExtractor";
+    license = with licenses; [ asl20 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ambroisie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12114,6 +12114,8 @@ with pkgs;
 
   vcstool = callPackage ../development/tools/vcstool { };
 
+  vdexExtractor = callPackage ../development/tools/vdexExtractor { };
+
   verco = callPackage ../applications/version-management/verco { };
 
   verible = callPackage ../development/tools/verible { };


### PR DESCRIPTION
###### Motivation for this change

Closes  #130943.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
