### PR TITLE
eccodes: 2.12.5 -> 2.23.0

### DIFF
--- a/pkgs/development/libraries/eccodes/default.nix
+++ b/pkgs/development/libraries/eccodes/default.nix
@@ -1,23 +1,23 @@
 { fetchurl, lib, stdenv
-, cmake, netcdf, openjpeg, libpng, gfortran
+, cmake, netcdf, openjpeg, libpng, gfortran, perl
 , enablePython ? false, pythonPackages
 , enablePosixThreads ? false
 , enableOpenMPThreads ? false}:
 with lib;
 stdenv.mkDerivation rec {
   pname = "eccodes";
-  version = "2.12.5";
+  version = "2.23.0";
 
   src = fetchurl {
     url = "https://confluence.ecmwf.int/download/attachments/45757960/eccodes-${version}-Source.tar.gz";
-    sha256 = "0576fccng4nvmq5gma1nb1v00if5cwl81w4nv5zkb80q5wicn50c";
+    sha256 = "sha256-y9yFMlN+loLxqT3bA0QEFrZpBqTMJd7Dy9c5QNGUvww=";
   };
 
   postPatch = ''
     substituteInPlace cmake/FindOpenJPEG.cmake --replace openjpeg-2.1 ${openjpeg.incDir}
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake perl ];
 
   buildInputs = [ netcdf
                   openjpeg

--- a/pkgs/development/libraries/eccodes/default.nix
+++ b/pkgs/development/libraries/eccodes/default.nix
@@ -13,7 +13,6 @@
 , enableOpenMPThreads ? false
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "eccodes";
   version = "2.23.0";
@@ -36,7 +35,7 @@ stdenv.mkDerivation rec {
     gfortran
   ];
 
-  propagatedBuildInputs = optionals enablePython [
+  propagatedBuildInputs = lib.optionals enablePython [
     pythonPackages.python
     pythonPackages.numpy
   ];
@@ -57,7 +56,7 @@ stdenv.mkDerivation rec {
     ctest -R "eccodes_t_(definitions|calendar|unit_tests|md5|uerra|grib_2nd_order_numValues|julian)" -VV
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://confluence.ecmwf.int/display/ECC/";
     license = licenses.asl20;
     maintainers = with maintainers; [ knedlsepp ];

--- a/pkgs/development/libraries/eccodes/default.nix
+++ b/pkgs/development/libraries/eccodes/default.nix
@@ -1,8 +1,18 @@
-{ fetchurl, lib, stdenv
-, cmake, netcdf, openjpeg, libpng, gfortran, perl
-, enablePython ? false, pythonPackages
+{ fetchurl
+, lib
+, stdenv
+, cmake
+, netcdf
+, openjpeg
+, libpng
+, gfortran
+, perl
+, enablePython ? false
+, pythonPackages
 , enablePosixThreads ? false
-, enableOpenMPThreads ? false}:
+, enableOpenMPThreads ? false
+}:
+
 with lib;
 stdenv.mkDerivation rec {
   pname = "eccodes";
@@ -19,21 +29,24 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake perl ];
 
-  buildInputs = [ netcdf
-                  openjpeg
-                  libpng
-                  gfortran
-                ];
-  propagatedBuildInputs = optionals enablePython [
-                  pythonPackages.python
-                  pythonPackages.numpy
-                ];
+  buildInputs = [
+    netcdf
+    openjpeg
+    libpng
+    gfortran
+  ];
 
-  cmakeFlags = [ "-DENABLE_PYTHON=${if enablePython then "ON" else "OFF"}"
-                 "-DENABLE_PNG=ON"
-                 "-DENABLE_ECCODES_THREADS=${if enablePosixThreads then "ON" else "OFF"}"
-                 "-DENABLE_ECCODES_OMP_THREADS=${if enableOpenMPThreads then "ON" else "OFF"}"
-               ];
+  propagatedBuildInputs = optionals enablePython [
+    pythonPackages.python
+    pythonPackages.numpy
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_PYTHON=${if enablePython then "ON" else "OFF"}"
+    "-DENABLE_PNG=ON"
+    "-DENABLE_ECCODES_THREADS=${if enablePosixThreads then "ON" else "OFF"}"
+    "-DENABLE_ECCODES_OMP_THREADS=${if enableOpenMPThreads then "ON" else "OFF"}"
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to eccodes 2.23.0. Perl is now required as a dependency since some version in between.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
