### PR TITLE
python3Packages.python3-gnutls: init at 3.1.9

### DIFF
--- a/pkgs/development/python-modules/python3-gnutls/default.nix
+++ b/pkgs/development/python-modules/python3-gnutls/default.nix
@@ -1,0 +1,52 @@
+{ lib, fetchFromGitHub, substituteAll, buildPythonPackage, isPy3k, gnutls
+, twisted, pyopenssl, service-identity }:
+
+buildPythonPackage rec {
+  pname = "python3-gnutls";
+  version = "3.1.9";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "AGProjects";
+    repo = "python3-gnutls";
+    rev = "324b78f7cd3d9fe58c89c7f0b2bf94199bd6a6e5"; # version not tagged
+    sha256 = "sha256-18T8bAHlNERHobsspUFvSC6ulN55nrFFb5aqNwU8T00=";
+  };
+
+  propagatedBuildInputs = [ twisted pyopenssl service-identity ];
+
+  patches = [
+    (substituteAll {
+      src = ./libgnutls-path.patch;
+      gnutlslib = "${lib.getLib gnutls}/lib";
+    })
+   ];
+
+  pythonImportsCheck = [ "gnutls" ];
+
+  meta = with lib; {
+    description = "Python wrapper for the GnuTLS library";
+    homepage = "https://github.com/AGProjects/python3-gnutls";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ chanley ];
+    longDescription = ''
+      This package provides a high level object oriented wrapper around libgnutls,
+      as well as low level bindings to the GnuTLS types and functions via ctypes.
+      The high level wrapper hides the details of accessing the GnuTLS library via
+      ctypes behind a set of classes that encapsulate GnuTLS sessions, certificates
+      and credentials and expose them to python applications using a simple API.
+
+      The package also includes a Twisted interface that has seamless intergration
+      with Twisted, providing connectTLS and listenTLS methods on the Twisted
+      reactor once imported (the methods are automatically attached to the reactor
+      by simply importing the GnuTLS Twisted interface module).
+
+      The high level wrapper is written using the GnuTLS library bindings that are
+      made available via ctypes. This makes the wrapper very powerful and flexible
+      as it has direct access to all the GnuTLS internals and is also very easy to
+      extend without any need to write C code or recompile anything.
+
+    '';
+  };
+}

--- a/pkgs/development/python-modules/python3-gnutls/libgnutls-path.patch
+++ b/pkgs/development/python-modules/python3-gnutls/libgnutls-path.patch
@@ -1,0 +1,42 @@
+diff --git a/gnutls/library/__init__.py b/gnutls/library/__init__.py
+index c1d898a..b87bd2e 100644
+--- a/gnutls/library/__init__.py
++++ b/gnutls/library/__init__.py
+@@ -18,35 +18,19 @@ def _library_locations(abi_version):
+     system = _get_system_name()
+     if system == "darwin":
+         library_names = ["libgnutls.%d.dylib" % abi_version]
+-        dynamic_loader_env_vars = ["DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH"]
+-        additional_paths = ["/usr/local/lib", "/opt/local/lib", "/sw/lib"]
+     elif system == "windows":
+         library_names = ["libgnutls-%d.dll" % abi_version]
+-        dynamic_loader_env_vars = ["PATH"]
+-        additional_paths = ["."]
+     elif system == "cygwin":
+         library_names = ["cyggnutls-%d.dll" % abi_version]
+-        dynamic_loader_env_vars = ["LD_LIBRARY_PATH"]
+-        additional_paths = ["/usr/bin"]
+     else:
+         # Debian uses libgnutls-deb0.so.28, go figure
+         library_names = [
+             "libgnutls.so.%d" % abi_version,
+             "libgnutls-deb0.so.%d" % abi_version,
+         ]
+-        dynamic_loader_env_vars = ["LD_LIBRARY_PATH"]
+-        additional_paths = ["/usr/local/lib"]
+     for library_name in library_names:
+-        for path in (
+-            path
+-            for env_var in dynamic_loader_env_vars
+-            for path in os.environ.get(env_var, "").split(":")
+-            if os.path.isdir(path)
+-        ):
+-            yield os.path.join(path, library_name)
+-        yield library_name
+-        for path in additional_paths:
+-            yield os.path.join(path, library_name)
++        path = "@gnutlslib@"
++        yield os.path.join(path, library_name)
+ 
+ 
+ def _load_library(abi_versions):

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7152,6 +7152,8 @@ in {
 
   python3-eventlib = callPackage ../development/python-modules/python3-eventlib { };
 
+  python3-gnutls = callPackage ../development/python-modules/python3-gnutls { };
+
   python3-openid = callPackage ../development/python-modules/python3-openid { };
 
   python-awair = callPackage ../development/python-modules/python-awair { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Split from #136924. This adds a dependency of blink-qt and sipclients3, which I intend to add.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
