### PR TITLE
vapoursynth: R54 -> R55

### DIFF
--- a/pkgs/development/libraries/vapoursynth/0001-Call-weak-function-to-allow-adding-preloaded-plugins.patch
+++ b/pkgs/development/libraries/vapoursynth/0001-Call-weak-function-to-allow-adding-preloaded-plugins.patch
@@ -1,4 +1,4 @@
-From 9b05a6f331506afa5aca8865677af83403d2a32d Mon Sep 17 00:00:00 2001
+From 439e2effe1cc372925daf6d5c28569663ffb93ed Mon Sep 17 00:00:00 2001
 From: Tadeo Kondrak <me@tadeo.ca>
 Date: Mon, 25 Jan 2021 11:17:44 -0700
 Subject: [PATCH] Call weak function to allow adding preloaded plugins after
@@ -10,10 +10,10 @@ Subject: [PATCH] Call weak function to allow adding preloaded plugins after
  2 files changed, 24 insertions(+)
 
 diff --git a/src/core/vscore.cpp b/src/core/vscore.cpp
-index 2d29844d..35c509ed 100644
+index f8e69062..4ce4c623 100644
 --- a/src/core/vscore.cpp
 +++ b/src/core/vscore.cpp
-@@ -1229,6 +1229,20 @@ void VSCore::destroyFilterInstance(VSNode *node) {
+@@ -1791,6 +1791,20 @@ void VSCore::destroyFilterInstance(VSNode *node) {
      freeDepth--;
  }
  
@@ -31,10 +31,10 @@ index 2d29844d..35c509ed 100644
 +}
 +}
 +
- VSCore::VSCore(int threads) :
-     coreFreed(false),
+ VSCore::VSCore(int flags) :
      numFilterInstances(1),
-@@ -1351,6 +1365,11 @@ VSCore::VSCore(int threads) :
+     numFunctionInstances(0),
+@@ -1918,6 +1932,11 @@ VSCore::VSCore(int flags) :
      } // If neither exists, an empty string will do.
  #endif
  
@@ -44,14 +44,14 @@ index 2d29844d..35c509ed 100644
 +    }
 +
      VSMap *settings = readSettings(configFile);
-     const char *error = vs_internal_vsapi.getError(settings);
+     const char *error = vs_internal_vsapi.mapGetError(settings);
      if (error) {
 diff --git a/src/core/vscore.h b/src/core/vscore.h
-index 74df8a84..3efac811 100644
+index 2ce0f56b..2982b133 100644
 --- a/src/core/vscore.h
 +++ b/src/core/vscore.h
-@@ -582,6 +582,9 @@ public:
-     VSFunction() : functionData(nullptr), func(nullptr) {}
+@@ -985,6 +985,9 @@ public:
+     std::string getV3ArgString() const;
  };
  
 +extern "C" {
@@ -59,10 +59,10 @@ index 74df8a84..3efac811 100644
 +}
  
  struct VSPlugin {
- private:
-@@ -683,6 +686,8 @@ public:
+     friend struct VSPluginFunction;
+@@ -1140,6 +1143,8 @@ public:
  
-     explicit VSCore(int threads);
+     explicit VSCore(int flags);
      void freeCore();
 +
 +    friend void VSLoadPluginsNixCallback(void *data, const char *path);
@@ -70,5 +70,5 @@ index 74df8a84..3efac811 100644
  
  #endif // VSCORE_H
 -- 
-2.30.0
+2.32.0
 

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -10,13 +10,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "vapoursynth";
-  version = "R54";
+  version = "R55";
 
   src = fetchFromGitHub {
     owner  = "vapoursynth";
     repo   = "vapoursynth";
     rev    = version;
-    sha256 = "01jym2rq28j0g792yagk9dvm411gwmk6qgj9rgrg7ckpxmw27w2s";
+    sha256 = "sha256-91lPknNX3NM3NraIcPAR478paPoYvgjgCOIcdgaR5nE=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
