### PR TITLE
linuxPackages.rr-zen_workaround: init at 2020-09-22

### DIFF
--- a/pkgs/development/tools/analysis/rr/zen_workaround.nix
+++ b/pkgs/development/tools/analysis/rr/zen_workaround.nix
@@ -1,0 +1,44 @@
+{ stdenv, lib, fetchzip, kernel }:
+
+/* The python script shouldn't be needed for users of this kernel module.
+  https://github.com/rr-debugger/rr/blob/master/scripts/zen_workaround.py
+  The module itself is called "zen_workaround" (a bit generic unfortunatelly).
+*/
+stdenv.mkDerivation rec {
+  pname = "rr-zen_workaround";
+  version = "2020-09-22";
+
+  src = fetchzip {
+    url = "https://gist.github.com/glandium/01d54cefdb70561b5f6675e08f2990f2/archive/2f430f0c136a69b0886281d0c76708997d8878af.zip";
+    sha256 = "1mbmbyymgl75wparv3rgnyxnc44rd6n935jziz9anl9apy031ryi";
+  };
+
+  hardeningDisable = [ "pic" ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "-C${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+  postConfigure = ''
+    makeFlags="$makeFlags M=$(pwd)"
+  '';
+  buildFlags = "modules";
+
+  installPhase = let
+    modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel"; #TODO: longer path?
+  in ''
+    runHook preInstall
+    mkdir -p "${modDestDir}"
+    cp *.ko "${modDestDir}/"
+    find ${modDestDir} -name '*.ko' -exec xz -f '{}' \;
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Kernel module supporting the rr debugger on (some) AMD Zen-based CPUs";
+    homepage = "https://github.com/rr-debugger/rr/wiki/Zen#kernel-module";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vcunat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -390,6 +390,8 @@ in {
 
     isgx = callPackage ../os-specific/linux/isgx { };
 
+    rr-zen_workaround = callPackage ../development/tools/analysis/rr/zen_workaround.nix { };
+
     sysdig = callPackage ../os-specific/linux/sysdig {};
 
     systemtap = callPackage ../development/tools/profiling/systemtap { };


### PR DESCRIPTION
###### Motivation for this change

Without this `rr` apparently can't be used well on my CPU (first-gen Ryzen), and that was a real shame.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] N/A Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
