### PR TITLE
ocamlPackages.qcheck: 0.17 → 0.18

### DIFF
--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, qtest, num }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, qtest, num
+, doCheck ? lib.versionAtLeast ocaml.version "4.08" && !stdenv.isAarch64
+}:
 
 let version = "3.3.0"; in
 
@@ -14,7 +16,7 @@ stdenv.mkDerivation {
   checkInputs = [ qtest ];
   propagatedBuildInputs = [ num ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.04" && !stdenv.isAarch64;
+  inherit doCheck;
   checkTarget = "test";
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/containers/data.nix
+++ b/pkgs/development/ocaml-modules/containers/data.nix
@@ -6,10 +6,9 @@
 buildDunePackage {
   pname = "containers-data";
 
-  inherit (containers) src version useDune2;
+  inherit (containers) src version doCheck useDune2;
 
   buildInputs = [ dune-configurator ];
-  doCheck = true;
   checkInputs = [ gen iter qcheck ];
 
   propagatedBuildInputs = [ containers ];

--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -22,7 +22,7 @@ buildDunePackage rec {
 
   checkInputs = [ gen iter ounit qcheck uutf ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     homepage = "https://github.com/c-cube/ocaml-containers";

--- a/pkgs/development/ocaml-modules/gen/default.nix
+++ b/pkgs/development/ocaml-modules/gen/default.nix
@@ -1,9 +1,8 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, ounit }:
 
-let version = "0.5"; in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-gen-${version}";
+stdenv.mkDerivation rec {
+  version = "0.5";
+  pname = "ocaml${ocaml.version}-gen";
 
   src = fetchFromGitHub {
     owner = "c-cube";
@@ -13,14 +12,12 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ qtest ounit ];
+  buildInputs = lib.optionals doCheck [ qtest ounit ];
   strictDeps = true;
 
-  configureFlags = [
-    "--enable-tests"
-  ];
+  configureFlags = lib.optional doCheck "--enable-tests";
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkTarget = "test";
 
   createFindlibDestdir = true;
@@ -29,6 +26,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/c-cube/gen";
     description = "Simple, efficient iterators for OCaml";
     license = lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
+    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/iter/default.nix
+++ b/pkgs/development/ocaml-modules/iter/default.nix
@@ -18,7 +18,7 @@ buildDunePackage rec {
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ result ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.07";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ mdx.bin qtest ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/lru/default.nix
+++ b/pkgs/development/ocaml-modules/lru/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ psq ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ qcheck-alcotest ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/psq/default.nix
+++ b/pkgs/development/ocaml-modules/psq/default.nix
@@ -14,7 +14,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ seq ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.07";
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ qcheck-alcotest ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/qcheck/core.nix
+++ b/pkgs/development/ocaml-modules/qcheck/core.nix
@@ -2,17 +2,17 @@
 
 buildDunePackage rec {
   pname = "qcheck-core";
-  version = "0.17";
+  version = "0.18";
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "qcheck";
-    rev = version;
-    sha256 = "0qfyqhfg98spmfci9z6f527a16gwjnx2lrbbgw67p37ys5acrfar";
+    rev = "v${version}";
+    sha256 = "1s652hrj2sxqj30dfl300zjvvqk3r62a1bnzqw1hqyf6pi88qn8x";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/reason-native/qcheck-rely.nix
+++ b/pkgs/development/ocaml-modules/reason-native/qcheck-rely.nix
@@ -16,5 +16,6 @@
   meta = {
     description = "A library containing custom Rely matchers allowing for easily using QCheck with Rely. QCheck is a 'QuickCheck inspired property-based testing for OCaml, and combinators to generate random values to run tests on'";
     downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/qcheck-rely";
+    broken = true;
   };
 }

--- a/pkgs/development/ocaml-modules/stdint/default.nix
+++ b/pkgs/development/ocaml-modules/stdint/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, fetchpatch, buildDunePackage, qcheck }:
+{ lib, fetchurl, fetchpatch, buildDunePackage, ocaml, qcheck }:
 
 buildDunePackage rec {
   pname = "stdint";
@@ -35,7 +35,7 @@ buildDunePackage rec {
                 'let pos_int = QCheck.int_range 0 maxi'
   '';
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [ qcheck ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/stringext/default.nix
+++ b/pkgs/development/ocaml-modules/stringext/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchurl, ocaml, buildDunePackage, ounit, qtest
 # Optionally enable tests; test script use OCaml-4.01+ features
-, doCheck ? lib.versionAtLeast ocaml.version "4.04"
+, doCheck ? lib.versionAtLeast ocaml.version "4.08"
 }:
 
 let version = "1.6.0"; in

--- a/pkgs/development/ocaml-modules/syslog-message/default.nix
+++ b/pkgs/development/ocaml-modules/syslog-message/default.nix
@@ -1,4 +1,5 @@
 { lib, buildDunePackage, fetchurl
+, ocaml
 , astring, ptime, rresult, qcheck
 }:
 
@@ -21,7 +22,7 @@ buildDunePackage rec {
     rresult
   ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
   checkInputs = [
     qcheck
   ];


### PR DESCRIPTION
###### Motivation for this change

Improvements: https://github.com/c-cube/qcheck/releases/tag/v0.18

Since this library is used for testing other packages and the updated version is only compatible with OCaml ≥ 4.08, this PR disables the testing of a few packages when built with OCaml < 4.08.

This breaks `reason-native.qcheck-rely`, ping @superherointj

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
