### PR TITLE
fits-cloudctl: 0.9.11 -> 0.10.0

### DIFF
--- a/pkgs/tools/admin/fits-cloudctl/default.nix
+++ b/pkgs/tools/admin/fits-cloudctl/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "fits-cloudctl";
-  version = "0.9.11";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "fi-ts";
     repo = "cloudctl";
     rev = "v${version}";
-    sha256 = "1i9h96b0b69ib72b2ayp8mhgvkm21jbh8mf7wb1fp2gdzbxcgrhg";
+    sha256 = "09v5fgqf4c2d6k2z638g29mcsmdisg3zfq1g7330wsd7yaxv9m23";
   };
 
-  vendorSha256 = "1fs1jqxz36i25vyb0mznkjglz8wwq9a8884052cjpacvsgd3glkf";
+  vendorSha256 = "1rdqih04mlp33m69y9zxm4llx8cafwqhjhfxw873s8b35j0xz2m5";
 
   meta = with lib; {
     description = "Command-line client for FI-TS Finance Cloud Native services";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`fits-cloudctl`: upgrade `0.9.11 -> 0.10.0`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
