### PR TITLE
cargo-cross: set meta.mainProgram

### DIFF
--- a/pkgs/development/tools/rust/cargo-cross/default.nix
+++ b/pkgs/development/tools/rust/cargo-cross/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
     owner = "rust-embedded";
     repo = "cross";
     rev = "v${version}";
-    sha256 = "sha256:1py5w4kf612x4qxi190ilsrx0zzwdzk9i47ppvqblska1s47qa2w";
+    sha256 = "1py5w4kf612x4qxi190ilsrx0zzwdzk9i47ppvqblska1s47qa2w";
   };
 
   cargoSha256 = "sha256-zk6cbN4iSHnyoeWupufVf2yQK6aq3S99uk9lqpjCw4c=";
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
   cargoPatches = [
     (fetchpatch {
       url = "https://github.com/rust-embedded/cross/commit/e86ad2e5a55218395df7eaaf91900e22b809083c.patch";
-      sha256 = "sha256:1zrcj5fm3irmlrfkgb65kp2pjkry0rg5nn9pwsk9p0i6dpapjc7k";
+      sha256 = "1zrcj5fm3irmlrfkgb65kp2pjkry0rg5nn9pwsk9p0i6dpapjc7k";
     })
   ];
 
@@ -36,5 +36,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/rust-embedded/cross";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ otavio ];
+    mainProgram = "cross";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

so that `nix run nixpkgs#cargo-cross` works

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
