### PR TITLE
electrs: 0.8.11 -> 0.8.12

### DIFF
--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -6,20 +6,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "electrs";
-  version = "0.8.11";
+  version = "0.8.12";
 
   src = fetchFromGitHub {
     owner = "romanz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "024sdyvrx7s4inldamq4c8lv0iijjyd18j1mm9x6xf2clmvicaa6";
+    sha256 = "0kd5zki9f1pnwscnvd921dw0lc45nfkwk23l33nzdjn005lmsw7v";
   };
+
+  cargoSha256 = "1l8dwjwj21crxampzj5c0k98xnisgy3d9c3dkgf5vaybrcp04k85";
 
   # needed for librocksdb-sys
   nativeBuildInputs = [ llvmPackages.clang ];
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-
-  cargoSha256 = "0yl50ryxidbs9wkabz919mgbmsgsqjp1bjw792l1lkgncq8z9r5b";
 
   meta = with lib; {
     description = "An efficient re-implementation of Electrum Server in Rust";

--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -2,6 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , llvmPackages
+, rocksdb
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -20,6 +21,11 @@ rustPlatform.buildRustPackage rec {
   # needed for librocksdb-sys
   nativeBuildInputs = [ llvmPackages.clang ];
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  # link rocksdb dynamically
+  ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
+  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+  cargoBuildFlags = "--no-default-features";
 
   meta = with lib; {
     description = "An efficient re-implementation of Electrum Server in Rust";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- version update (0.8.11 -> 0.8.12)
- link rocksdb dynamically

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
