### PR TITLE
fakeroot: Use a fixed git commit as a reference in patch URLs

### DIFF
--- a/pkgs/tools/system/fakeroot/default.nix
+++ b/pkgs/tools/system/fakeroot/default.nix
@@ -14,15 +14,15 @@ stdenv.mkDerivation rec {
 
     # glibc 2.33 patches from ArchLinux
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/packages/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-1.patch";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/15b01cf37ff64c487f7440df4e09b090cd93b58f/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-1.patch";
       sha256 = "sha256-F6BcxYInSLu7Fxg6OmMZDhTWoLqsc//yYPlTZqQQl68=";
     })
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/packages/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-2.patch";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/15b01cf37ff64c487f7440df4e09b090cd93b58f/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-2.patch";
       sha256 = "sha256-ifpJxhk6MyQpFolC1hIAAUjcHmOHVU1D25tRwpu2S/k=";
     })
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/packages/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-3.patch";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/15b01cf37ff64c487f7440df4e09b090cd93b58f/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-3.patch";
       sha256 = "sha256-o2Xm4C64Ny9TL8fjsZltjO1CdJ4VGwqZ+LnufVL5Sq8=";
     })
   ]


### PR DESCRIPTION
###### Motivation for this change

Arch Linux has bumped the fakeroot version and these patch URLs now 404.
This is a short-term fix. I will bump the package version very soon, but in the mean time these URLs needs to be updated.

Note that none of the file hashes have changed.

For future reference: It's important to ensure a fixed reference point in the URLs when fetching patches from Github.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @ma27