### PR TITLE
rust-petname: init at 1.1.1

### DIFF
--- a/pkgs/tools/text/rust-petname/default.nix
+++ b/pkgs/tools/text/rust-petname/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchCrate }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rust-petname";
+  version = "1.1.1";
+
+  src = fetchCrate {
+    inherit version;
+    crateName = "petname";
+    sha256 = "sha256-X1p9W+N0Nhh7CSh776ofzHmG0ayi5COLJjBncxmL8CM=";
+  };
+
+  cargoSha256 = "sha256-jxN2EKLjf9yKkhZ4wsH72sNdk6UYAcCUrg4+qx75bWs=";
+
+  meta = with lib; {
+    description = "Generate human readable random names";
+    homepage = "https://github.com/allenap/rust-petname";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ figsoda ];
+    mainProgram = "petname";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8808,6 +8808,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  rust-petname = callPackage ../tools/text/rust-petname { };
+
   rustscan = callPackage ../tools/security/rustscan {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

rust-petname is a cli to generate human readable random names

https://github.com/allenap/rust-petname

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
