### PR TITLE
libpsm2: disable blanket -Werror (gcc-11 fix)

### DIFF
--- a/pkgs/os-specific/linux/libpsm2/default.nix
+++ b/pkgs/os-specific/linux/libpsm2/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/intel/opa-psm2";
     description = "The PSM2 library supports a number of fabric media and stacks";
     license = with licenses; [ gpl2 bsd3 ];
-   platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
     maintainers = [ maintainers.bzizou ];
   };
 }

--- a/pkgs/os-specific/linux/libpsm2/default.nix
+++ b/pkgs/os-specific/linux/libpsm2/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ numactl pkg-config ];
 
+  makeFlags = [
+    # Disable blanket -Werror to avoid build failures
+    # on fresh toolchains like gcc-11.
+    "WERROR="
+  ];
+
   installFlags = [
     "DESTDIR=$(out)"
     "UDEVDIR=/etc/udev"


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).