### PR TITLE
modules/nix-daemon: Replace daemon(IO)NiceLevel options

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1131,6 +1131,21 @@ Superuser created successfully.
       </listitem>
       <listitem>
         <para>
+          <literal>nix.daemonNiceLevel</literal> and
+          <literal>nix.daemonIONiceLevel</literal> have been removed in
+          favour of the new options
+          <link xlink:href="options.html#opt-nix.daemonCPUSchedPolicy"><literal>nix.daemonCPUSchedPolicy</literal></link>,
+          <link xlink:href="options.html#opt-nix.daemonIOSchedClass"><literal>nix.daemonIOSchedClass</literal></link>
+          and
+          <link xlink:href="options.html#opt-nix.daemonIOSchedPriority"><literal>nix.daemonIOSchedPriority</literal></link>.
+          Please refer to the options documentation and the
+          <literal>sched(7)</literal> and
+          <literal>ioprio_set(2)</literal> man pages for guidance on how
+          to use them.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>coursier</literal> package’s binary was renamed
           from <literal>coursier</literal> to <literal>cs</literal>.
           Completions which haven’t worked for a while should now work

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -349,6 +349,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `boot.kernelParams` now only accepts one command line parameter per string. This change is aimed to reduce common mistakes like "param = 12", which would be parsed as 3 parameters.
 
+- `nix.daemonNiceLevel` and `nix.daemonIONiceLevel` have been removed in favour of the new options [`nix.daemonCPUSchedPolicy`](options.html#opt-nix.daemonCPUSchedPolicy), [`nix.daemonIOSchedClass`](options.html#opt-nix.daemonIOSchedClass) and [`nix.daemonIOSchedPriority`](options.html#opt-nix.daemonIOSchedPriority). Please refer to the options documentation and the `sched(7)` and `ioprio_set(2)` man pages for guidance on how to use them.
+
 - The `coursier` package's binary was renamed from `coursier` to `cs`. Completions which haven't worked for a while should now work with the renamed binary. To keep using `coursier`, you can create a shell alias.
 
 - The `services.mosquitto` module has been rewritten to support multiple listeners and per-listener configuration.

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -184,34 +184,51 @@ in
         '';
       };
 
-      daemonNiceLevel = mkOption {
-        type = types.int;
-        default = 0;
+      daemonCPUSchedPolicy = mkOption {
+        type = types.enum ["other" "batch" "idle"];
+        default = "other";
+        example = "batch";
         description = ''
-          Nix daemon process priority. This priority propagates to build processes.
-          0 is the default Unix process priority, 19 is the lowest. Note that nix
-          bypasses nix-daemon when running as root and this option does not have
-          any effect in such a case.
+          Nix daemon process CPU scheduling policy. This policy propagates to
+          build processes. other is the default scheduling policy for regular
+          tasks. The batch policy is similar to other, but optimised for
+          non-interactive tasks. idle is for extremely low-priority tasks
+          that should only be run when no other task requires CPU time.
 
-          Please note that if used on a recent Linux kernel with group scheduling,
-          setting the nice level will only have an effect relative to other threads
-          in the same task group. Therefore this option is only useful if
-          autogrouping has been disabled (see the kernel.sched_autogroup_enabled
-          sysctl) and no systemd unit uses any of the per-service CPU accounting
-          features of systemd. Otherwise the Nix daemon process may be placed in a
-          separate task group and the nice level setting will have no effect.
-          Refer to the man pages sched(7) and systemd.resource-control(5) for
-          details.
-        '';
+          Please note that while using the idle policy may greatly improve
+          responsiveness of a system performing expensive builds, it may also
+          slow down and potentially starve crucial configuration updates
+          during load.
+      '';
       };
 
-      daemonIONiceLevel = mkOption {
+      daemonIOSchedClass = mkOption {
+        type = types.enum ["best-effort" "idle"];
+        default = "best-effort";
+        example = "idle";
+        description = ''
+          Nix daemon process I/O scheduling class. This class propagates to
+          build processes. best-effort is the default class for regular tasks.
+          The idle class is for extremely low-priority tasks that should only
+          perform I/O when no other task does.
+
+          Please note that while using the idle scheduling class can improve
+          responsiveness of a system performing expensive builds, it might also
+          slow down or starve crucial configuration updates during load.
+      '';
+      };
+
+      daemonIOSchedPriority = mkOption {
         type = types.int;
         default = 0;
+        example = 1;
         description = ''
-          Nix daemon process I/O priority. This priority propagates to build processes.
-          0 is the default Unix process I/O priority, 7 is the lowest.
-        '';
+          Nix daemon process I/O scheduling priority. This priority propagates
+          to build processes. The supported priorities depend on the
+          scheduling policy: With idle, priorities are not used in scheduling
+          decisions. best-effort supports values in the range 0 (high) to 7
+          (low).
+      '';
       };
 
       buildMachines = mkOption {
@@ -587,8 +604,9 @@ in
         unitConfig.RequiresMountsFor = "/nix/store";
 
         serviceConfig =
-          { Nice = cfg.daemonNiceLevel;
-            IOSchedulingPriority = cfg.daemonIONiceLevel;
+          { CPUSchedulingPolicy = cfg.daemonCPUSchedPolicy;
+            IOSchedulingClass = cfg.daemonIOSchedClass;
+            IOSchedulingPriority = cfg.daemonIOSchedPriority;
             LimitNOFILE = 4096;
           };
 


### PR DESCRIPTION
The `nix.daemonNiceLevel` options allows for setting the nice level of the
Nix daemon process. On a modern Linux kernel with group scheduling the
nice level only affects threads relative to other threads in the same
task group (see `sched(7)`). Therefore this option has not the effect one
might expect.

The options `daemonCPUSchedPolicy`, `daemonCPUSchedPriority`,
`daemonIOSchedClass` are introduced and the `daemonIONiceLevel` option
renamed to `daemonIOSchedPrority` for consistency. These options allow for
more effective control over CPU and I/O scheduling.

Instead of setting `daemonNiceLevel` to a high value to increase the
responsiveness of an interactive system during builds -- which would not
have the desired effect, as described above -- one could set both
`daemonCPUSchedPolicy` and `daemonIOSchedClass` to idle.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Heavy build jobs can affect other tasks on a system and reduce responsiveness during interactive use.

The `daemonNiceLevel` option is not particularly useful to mitigate this problem on recent Linux kernels, because with group scheduling the nice level of a thread only affects scheduling relative to other threads in the same task group.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
