### PR TITLE
cve-bin-tool: unstable-2021-04-15 -> 2.2.1

### DIFF
--- a/pkgs/tools/security/cve-bin-tool/default.nix
+++ b/pkgs/tools/security/cve-bin-tool/default.nix
@@ -1,5 +1,5 @@
 { lib
-, buildPythonPackage
+, buildPythonApplication
 , fetchFromGitHub
 , jsonschema
 , plotly
@@ -18,6 +18,7 @@
 , rich
 , aiohttp
 , toml
+, distro
   # aiohttp[speedups]
 , aiodns
 , brotlipy
@@ -25,15 +26,15 @@
 , pillow
 , pytestCheckHook
 }:
-buildPythonPackage {
+buildPythonApplication rec {
   pname = "cve-bin-tool";
-  version = "unstable-2021-04-15";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "cve-bin-tool";
-    rev = "10cb6fd0baffe35babfde024bc8c70aa58629237";
-    sha256 = "STf0tJBpadBqsbC+MghBai8zahDkrXfLoFRJ+84wvvY=";
+    rev = "v${version}";
+    sha256 = "087w7fsc4vd4sjz8ww6q71b108yhz94ydr76d99rhlmcqsq7fihs";
   };
 
   # Wants to open a sqlite database, access the internet, etc
@@ -57,7 +58,7 @@ buildPythonPackage {
     rich
     aiohttp
     toml
-
+    distro
     # aiohttp[speedups]
     aiodns
     brotlipy

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4168,6 +4168,8 @@ with pkgs;
 
   cwebbin = callPackage ../development/tools/misc/cwebbin { };
 
+  cve-bin-tool = python3Packages.callPackage ../tools/security/cve-bin-tool { };
+
   cvs-fast-export = callPackage ../applications/version-management/cvs-fast-export { };
 
   dadadodo = callPackage ../tools/text/dadadodo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1770,8 +1770,6 @@ in {
 
   curve25519-donna = callPackage ../development/python-modules/curve25519-donna { };
 
-  cve-bin-tool = callPackage ../development/python-modules/cve-bin-tool { };
-
   cvxopt = callPackage ../development/python-modules/cvxopt { };
 
   cvxpy = callPackage ../development/python-modules/cvxpy { };


### PR DESCRIPTION
* move cve-bin-tool from development/python-modules to tools/security

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
