### PR TITLE
sic-image-cli: init at 0.19.0

### DIFF
--- a/pkgs/tools/graphics/sic-image-cli/default.nix
+++ b/pkgs/tools/graphics/sic-image-cli/default.nix
@@ -1,0 +1,35 @@
+{ lib, rustPlatform, fetchFromGitHub, installShellFiles, nasm }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sic-image-cli";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "foresterre";
+    repo = "sic";
+    rev = "v${version}";
+    sha256 = "11km8ngndmzp6sxyfnbll80nigi790s353v7j31jvqcgyn9gjdq9";
+  };
+
+  cargoSha256 = "sha256-mHfQ36Xo37VRRq0y0xvUYy0MAlrfnOfMy1t3IZFdrE8=";
+
+  nativeBuildInputs = [ installShellFiles nasm ];
+
+  postBuild = ''
+    cargo run --example gen_completions
+  '';
+
+  postInstall = ''
+    installShellCompletion sic.{bash,fish}
+    installShellCompletion --zsh _sic
+  '';
+
+  meta = with lib; {
+    description = "Accessible image processing and conversion from the terminal";
+    homepage = "https://github.com/foresterre/sic-image-cli";
+    changelog = "https://github.com/foresterre/sic/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ figsoda ];
+    mainProgram = "sic";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27154,6 +27154,8 @@ with pkgs;
 
   shutter = callPackage ../applications/graphics/shutter { };
 
+  sic-image-cli = callPackage ../tools/graphics/sic-image-cli { };
+
   simple-scan = gnome.simple-scan;
 
   siproxd = callPackage ../applications/networking/siproxd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

sic (sic image cli) is a tool for accessible image processing and conversion from the terminal

https://github.com/foresterre/sic

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
