### PR TITLE
docker-compose-wait: init at 2.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11004,6 +11004,12 @@
     githubId = 9870613;
     name = "Hubert Mühlhans";
   };
+  tristanpemble = {
+    email = "tpemble@gmail.com";
+    github = "tristanpemble";
+    githubId = 2466322;
+    name = "Tristan Pemble";
+  };
   troydm = {
     email = "d.geurkov@gmail.com";
     github = "troydm";

--- a/pkgs/tools/misc/docker-compose-wait/default.nix
+++ b/pkgs/tools/misc/docker-compose-wait/default.nix
@@ -1,0 +1,26 @@
+{ pkgs
+, lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "docker-compose-wait";
+  version = "2.9.0";
+
+  src = fetchFromGitHub {
+    owner = "ufoscout";
+    repo = pname;
+    rev = version;
+    sha256 = "141m8ll9fm3863fgp8pcy8sgv5ills9kskzb3ymdi1ppwdq2hzhm";
+  };
+
+  cargoSha256 = "000kb8ahkzbr2w60rsx3qchdjhkiy9g44c9b9qjq3krqi242fqp6";
+
+  meta = with lib; {
+    description = "A small command-line utility to wait for other docker images to be started while using docker-compose.";
+    homepage = "https://github.com/ufoscout/docker-compose-wait";
+    license = licenses.asl20;
+    maintainers = [ maintainers.tristanpemble ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -366,6 +366,8 @@ with pkgs;
 
   docker-compose = python3Packages.callPackage ../applications/virtualization/docker-compose {};
 
+  docker-compose-wait = callPackage ../tools/misc/docker-compose-wait {};
+
   docker-ls = callPackage ../tools/misc/docker-ls { };
 
   docker-slim = callPackage ../applications/virtualization/docker-slim { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
