### PR TITLE
libfabric: meta.platforms = lib.platforms.all and 1.13.0 -> 1.13.1

### DIFF
--- a/pkgs/development/libraries/libfabric/default.nix
+++ b/pkgs/development/libraries/libfabric/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, libpsm2 }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, libpsm2
+, enablePsm2 ? (stdenv.isx86_64 && stdenv.isLinux) }:
 
 stdenv.mkDerivation rec {
   pname = "libfabric";
@@ -13,17 +14,17 @@ stdenv.mkDerivation rec {
     sha256 = "0USQMBXZrbz4GtXLNsSti9ohUOqqo0OCtVz+0Uk9ndI=";
   };
 
-  nativeBuildInputs = [ pkg-config autoreconfHook ] ;
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
 
-  buildInputs = [ libpsm2 ] ;
+  buildInputs = lib.optional enablePsm2 libpsm2;
 
-  configureFlags = [ "--enable-psm2=${libpsm2}" ] ;
+  configureFlags = [ (if enablePsm2 then "--enable-psm2=${libpsm2}" else "--disable-psm2") ];
 
   meta = with lib; {
     homepage = "https://ofiwg.github.io/libfabric/";
     description = "Open Fabric Interfaces";
     license = with licenses; [ gpl2 bsd2 ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.all;
     maintainers = [ maintainers.bzizou ];
   };
 }

--- a/pkgs/os-specific/linux/libfabric/default.nix
+++ b/pkgs/os-specific/linux/libfabric/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libfabric";
-  version = "1.13.0";
+  version = "1.13.1";
 
   enableParallelBuilding = true;
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "ofiwg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-felGKpdihOi4TCp95T1ti7fErQVphP0vYGRKEwlQt4Q=";
+    sha256 = "0USQMBXZrbz4GtXLNsSti9ohUOqqo0OCtVz+0Uk9ndI=";
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ] ;
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-psm2=${libpsm2}" ] ;
 
   meta = with lib; {
-    homepage = "http://libfabric.org/";
+    homepage = "https://ofiwg.github.io/libfabric/";
     description = "Open Fabric Interfaces";
     license = with licenses; [ gpl2 bsd2 ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17037,7 +17037,7 @@ with pkgs;
 
   libf2c = callPackage ../development/libraries/libf2c {};
 
-  libfabric = callPackage ../os-specific/linux/libfabric {};
+  libfabric = callPackage ../development/libraries/libfabric {};
 
   libfive = libsForQt5.callPackage ../development/libraries/libfive { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
