### PR TITLE
freenet: build01475 -> build01480

### DIFF
--- a/pkgs/applications/networking/p2p/freenet/default.nix
+++ b/pkgs/applications/networking/p2p/freenet/default.nix
@@ -15,7 +15,7 @@ let
     url = "https://downloads.freenetproject.org/alpha/opennet/seednodes.fref";
     sha256 = "08awwr8n80b4cdzzb3y8hf2fzkr1f2ly4nlq779d6pvi5jymqdvv";
   };
-  version = "build01475";
+  version = "build01480";
 
   freenet-jars = stdenv.mkDerivation {
     pname = "freenet-jars";
@@ -25,7 +25,7 @@ let
       owner = "freenet";
       repo = "fred";
       rev = version;
-      sha256 = "0k02fna9x219j7dhginbnf27i36bibb0rmm4qdwr5xm28hy1nd08";
+      sha256 = "0wddkfyhsgs7bcq9svicz6l0a35yv82yqzmji3c345hg4hbch3kb";
     };
 
     patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

last update before the gradle buildsystem change

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).