### PR TITLE
libchipcard: 5.0.4 -> 5.1.6

### DIFF
--- a/pkgs/development/libraries/aqbanking/libchipcard.nix
+++ b/pkgs/development/libraries/aqbanking/libchipcard.nix
@@ -17,8 +17,6 @@ in stdenv.mkDerivation rec {
 
   makeFlags = [ "crypttokenplugindir=$(out)/lib/gwenhywfar/plugins/ct" ];
 
-  configureFlags = [ "--with-gwen-dir=${gwenhywfar}" ];
-
   meta = with lib; {
     description = "Library for access to chipcards";
     homepage = "https://www.aquamaniac.de/rdm/projects/libchipcard";

--- a/pkgs/development/libraries/aqbanking/sources.nix
+++ b/pkgs/development/libraries/aqbanking/sources.nix
@@ -2,9 +2,9 @@
   gwenhywfar.version = "5.6.0";
   gwenhywfar.sha256 = "1isbj4a7vdgagp3kkvx2pjcjy8lba6kzjr11fmr06aci1694dbsp";
   gwenhywfar.releaseId = "364";
-  libchipcard.version = "5.0.4";
-  libchipcard.sha256 = "0fj2h39ll4kiv28ch8qgzdbdbnzs8gl812qnm660bw89rynpjnnj";
-  libchipcard.releaseId = "158";
+  libchipcard.version = "5.1.6";
+  libchipcard.sha256 = "087xihxnxk9c8imycj9zsfpxpd0ys6j2s0cr9w3n4xbz84kza1vc";
+  libchipcard.releaseId = "382";
   aqbanking.version = "6.3.0";
   aqbanking.sha256 = "1k2mhdnk0jc0inq1hmp74m3y7azxrjm8r07x5k1pp4ic0yi5vs50";
   aqbanking.releaseId = "372";


### PR DESCRIPTION
###### Motivation for this change



###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).