### PR TITLE
tytools: init at 0.9.3

### DIFF
--- a/pkgs/development/embedded/tytools/default.nix
+++ b/pkgs/development/embedded/tytools/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "Collection of tools to manage Teensy boards";
     homepage = "https://koromix.dev/tytools";
     license = licenses.unlicense;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ ahuzik ];
   };
 }

--- a/pkgs/development/embedded/tytools/default.nix
+++ b/pkgs/development/embedded/tytools/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, wrapQtAppsHook , qtbase}:
+
+stdenv.mkDerivation rec {
+  pname = "tytools";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "Koromix";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ax6j17f5nm0q4sp8sg1412hd48qp7whdy7dd699kwjcm763bl5j";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
+  buildInputs = [
+    qtbase
+  ];
+
+  meta = with lib; {
+    description = "Collection of tools to manage Teensy boards";
+    homepage = "https://koromix.dev/tytools";
+    license = licenses.unlicense;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ ahuzik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14742,6 +14742,8 @@ with pkgs;
 
   teensy-loader-cli = callPackage ../development/embedded/teensy-loader-cli { };
 
+  tytools = libsForQt5.callPackage ../development/embedded/tytools { };
+
   terracognita = callPackage ../development/tools/misc/terracognita { };
 
   terraform-lsp = callPackage ../development/tools/misc/terraform-lsp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add tytools for flashing Teensy boards.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
