### PR TITLE
 sabnzbd: 3.4.0 -> 3.4.2, add missing dependencies, add a simple test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -389,6 +389,7 @@ in
   rss2email = handleTest ./rss2email.nix {};
   rsyslogd = handleTest ./rsyslogd.nix {};
   rxe = handleTest ./rxe.nix {};
+  sabnzbd = handleTest ./sabnzbd.nix {};
   samba = handleTest ./samba.nix {};
   samba-wsdd = handleTest ./samba-wsdd.nix {};
   sanoid = handleTest ./sanoid.nix {};

--- a/nixos/tests/sabnzbd.nix
+++ b/nixos/tests/sabnzbd.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "sabnzbd";
+  meta = with pkgs.lib; {
+    maintainers = with maintainers; [ jojosch ];
+  };
+
+  machine = { pkgs, ... }: {
+    services.sabnzbd = {
+      enable = true;
+    };
+
+    # unrar is unfree
+    nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "unrar" ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("sabnzbd.service")
+    machine.wait_until_succeeds(
+        "curl --fail -L http://localhost:8080/"
+    )
+  '';
+})

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -17,6 +17,8 @@ let
     configobj
     feedparser
     sabyenc3
+    puremagic
+    guessit
   ]);
   path = lib.makeBinPath [ par2cmdline unrar unzip p7zip ];
 in stdenv.mkDerivation rec {

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -23,14 +23,14 @@ let
   ]);
   path = lib.makeBinPath [ par2cmdline unrar unzip p7zip ];
 in stdenv.mkDerivation rec {
-  version = "3.4.1";
+  version = "3.4.2";
   pname = "sabnzbd";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-X+NkaNjIeIPut+o5iE8glMM9rMgV/8RJN5xReiFeIW4=";
+    sha256 = "sha256-Pl2i/k5tilPvMWLRtzZ2imOJQdZYKDAz8bt847ZAXF8=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -53,6 +53,6 @@ in stdenv.mkDerivation rec {
     homepage = "https://sabnzbd.org";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with lib.maintainers; [ fridh ];
+    maintainers = with lib.maintainers; [ fridh jojosch ];
   };
 }

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -6,6 +6,7 @@
 , unrar
 , p7zip
 , makeWrapper
+, nixosTests
 }:
 
 let
@@ -47,6 +48,10 @@ in stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    smoke-test = nixosTests.sabnzbd;
+  };
 
   meta = with lib; {
     description = "Usenet NZB downloader, par2 repairer and auto extracting server";

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -23,14 +23,14 @@ let
   ]);
   path = lib.makeBinPath [ par2cmdline unrar unzip p7zip ];
 in stdenv.mkDerivation rec {
-  version = "3.4.0";
+  version = "3.4.1";
   pname = "sabnzbd";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-zax+PuvCmYOlEhRmiCp7UOd9VI0i8dbgTPyTtqLuGUM=";
+    sha256 = "sha256-X+NkaNjIeIPut+o5iE8glMM9rMgV/8RJN5xReiFeIW4=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [two missing, new dependencies](https://github.com/sabnzbd/sabnzbd/blame/e7527c45cde697ae1a4b3439fab625d1d3ce1f0c/requirements.txt#L11-L12) for sabnzbd with version 3.4.0. Also added a simple test which catches this error and add myself as an additional maintainer.

Also updated to latest version https://github.com/sabnzbd/sabnzbd/releases/tag/3.4.1 and https://github.com/sabnzbd/sabnzbd/releases/tag/3.4.2

```
./result/bin/sabnzbd --help
Traceback (most recent call last):
  File "/nix/store/cgc7rppaz8nkp8sw7bzfsbnpxi5ifxx2-sabnzbd-3.4.0/SABnzbd.py", line 56, in <module>
    import sabnzbd
  File "/nix/store/cgc7rppaz8nkp8sw7bzfsbnpxi5ifxx2-sabnzbd-3.4.0/sabnzbd/__init__.py", line 91, in <module>
    import sabnzbd.rss as rss
  File "/nix/store/cgc7rppaz8nkp8sw7bzfsbnpxi5ifxx2-sabnzbd-3.4.0/sabnzbd/rss.py", line 35, in <module>
    import sabnzbd.emailer as emailer
  File "/nix/store/cgc7rppaz8nkp8sw7bzfsbnpxi5ifxx2-sabnzbd-3.4.0/sabnzbd/emailer.py", line 36, in <module>
    from sabnzbd.notifier import check_cat
  File "/nix/store/cgc7rppaz8nkp8sw7bzfsbnpxi5ifxx2-sabnzbd-3.4.0/sabnzbd/notifier.py", line 36, in <module>
    from sabnzbd.newsunpack import create_env
  File "/nix/store/cgc7rppaz8nkp8sw7bzfsbnpxi5ifxx2-sabnzbd-3.4.0/sabnzbd/newsunpack.py", line 60, in <module>
    from sabnzbd.nzbstuff import NzbObject, NzbFile
  File "/nix/store/cgc7rppaz8nkp8sw7bzfsbnpxi5ifxx2-sabnzbd-3.4.0/sabnzbd/nzbstuff.py", line 89, in <module>
    from sabnzbd.deobfuscate_filenames import is_probably_obfuscated
  File "/nix/store/cgc7rppaz8nkp8sw7bzfsbnpxi5ifxx2-sabnzbd-3.4.0/sabnzbd/deobfuscate_filenames.py", line 38, in <module>
    import sabnzbd.utils.file_extension as file_extension
  File "/nix/store/cgc7rppaz8nkp8sw7bzfsbnpxi5ifxx2-sabnzbd-3.4.0/sabnzbd/utils/file_extension.py", line 8, in <module>
    import puremagic
ModuleNotFoundError: No module named 'puremagic'

./result/bin/sabnzbd --help
Traceback (most recent call last):
  File "/nix/store/awxj5kr0cgg72fxqdcapaa18yvfj8nzy-sabnzbd-3.4.0/SABnzbd.py", line 56, in <module>
    import sabnzbd
  File "/nix/store/awxj5kr0cgg72fxqdcapaa18yvfj8nzy-sabnzbd-3.4.0/sabnzbd/__init__.py", line 91, in <module>
    import sabnzbd.rss as rss
  File "/nix/store/awxj5kr0cgg72fxqdcapaa18yvfj8nzy-sabnzbd-3.4.0/sabnzbd/rss.py", line 35, in <module>
    import sabnzbd.emailer as emailer
  File "/nix/store/awxj5kr0cgg72fxqdcapaa18yvfj8nzy-sabnzbd-3.4.0/sabnzbd/emailer.py", line 36, in <module>
    from sabnzbd.notifier import check_cat
  File "/nix/store/awxj5kr0cgg72fxqdcapaa18yvfj8nzy-sabnzbd-3.4.0/sabnzbd/notifier.py", line 36, in <module>
    from sabnzbd.newsunpack import create_env
  File "/nix/store/awxj5kr0cgg72fxqdcapaa18yvfj8nzy-sabnzbd-3.4.0/sabnzbd/newsunpack.py", line 61, in <module>
    from sabnzbd.sorting import SeriesSorter
  File "/nix/store/awxj5kr0cgg72fxqdcapaa18yvfj8nzy-sabnzbd-3.4.0/sabnzbd/sorting.py", line 25, in <module>
    import guessit
ModuleNotFoundError: No module named 'guessit'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
