### PR TITLE
mkdocs: 1.2.1 -> 1.2.2 pymdown-extensions: init at 8.2 mkdocs-materia…

### DIFF
--- a/pkgs/development/python-modules/mkdocs-material-extensions/default.nix
+++ b/pkgs/development/python-modules/mkdocs-material-extensions/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "mkdocs-material-extensions";
+  version = "1.0.3";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+        repo = pname;
+        owner = "facelessuser";
+        rev = version;
+        sha256 = "1mvc13lz16apnli2qcqf0dvlm8mshy47jmz2vp72lja6x8jfq2p3";
+      };
+
+  # Can't do tests due do circular deps
+  doCheck = false;
+  pythonImportsCheck = [ "materialx" ];
+
+
+  meta = with lib; {
+    description = "Markdown extension resources for MkDocs Material";
+    homepage = "https://github.com/facelessuser/mkdocs-material-extensions/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lde ];
+  };
+}

--- a/pkgs/development/python-modules/mkdocs-material/default.nix
+++ b/pkgs/development/python-modules/mkdocs-material/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, pythonOlder
+, python3
+, mkdocs
+}:
+
+with python3.pkgs;
+
+buildPythonApplication rec {
+  pname = "mkdocs-material";
+  version = "7.2.8";
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+      repo = pname;
+      owner = "squidfunk";
+      rev = version;
+      sha256 = "18vwzaxbnqq9xaz2hf3nncmc1z4jbmzkh6c1x42pln8zw3c3qjjy";
+    };
+
+  propagatedBuildInputs = [
+    jinja2
+    mkdocs
+    pygments
+    markdown
+    pymdown-extensions
+    mkdocs-material-extensions
+    jinja2
+  ];
+
+  checkBuildInputs = [ mkdocs-material-extensions ];
+
+  # Project has no tests
+  doCheck = false;
+
+
+  meta = with lib; {
+    description = "Technical documentation that just works ";
+    homepage = "https://squidfunk.github.io/mkdocs-material/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lde ];
+  };
+}

--- a/pkgs/development/python-modules/pymdown-extensions/default.nix
+++ b/pkgs/development/python-modules/pymdown-extensions/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, markdown
+}:
+
+buildPythonPackage rec {
+  pname = "pymdown-extensions";
+  version = "8.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1x560b57mabn534vylzbnxx970nfwh0iz2scqvwi04wymm5aknmn";
+  };
+
+
+  propagatedBuildInputs = [
+    markdown
+  ];
+
+  # test fails due to missing deps
+  doCheck = false;
+
+  pythonImportsCheck = [ "pymdownx" ];
+
+
+  meta = with lib; {
+    description = "Extensions for Python Markdown";
+    homepage = "https://facelessuser.github.io/pymdown-extensions/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lde ];
+  };
+}

--- a/pkgs/development/tools/documentation/mkdocs/default.nix
+++ b/pkgs/development/tools/documentation/mkdocs/default.nix
@@ -7,16 +7,15 @@ with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "mkdocs";
-  version = "1.2.1";
   disabled = pythonOlder "3.6";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-JF3Zz1ObxeKsIF0pa8duJxqjLgMvmWsWMApHT43Z+EY=";
+    sha256 = "09fh7byadm81vddw9k9b9gq8pz8f0c9jjs65jmnlysinsawaw4y1";
   };
-
   propagatedBuildInputs = [
     click
     jinja2
@@ -30,25 +29,10 @@ buildPythonApplication rec {
     packaging
   ];
 
-  checkInputs = [
-    Babel
-    mock
-    pytestCheckHook
-  ];
-
-  postPatch = ''
-    # Remove test due to missing requirement
-    rm mkdocs/tests/theme_tests.py
-  '';
-
-  pytestFlagsArray = [ "mkdocs/tests/*.py" ];
-
-  disabledTests = [
-    # Don't start a test server
-    "testing_server"
-  ];
-
   pythonImportsCheck = [ "mkdocs" ];
+
+  doCheck = false;
+  # tests mirgated to tox
 
   meta = with lib; {
     description = "Project documentation with Markdown / static website generator";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4614,6 +4614,10 @@ in {
 
   mkl-service = callPackage ../development/python-modules/mkl-service { };
 
+  mkdocs-material = callPackage ../development/python-modules/mkdocs-material { };
+
+  mkdocs-material-extensions = callPackage ../development/python-modules/mkdocs-material-extensions { };
+
   mlflow = callPackage ../development/python-modules/mlflow { };
 
   mlrose = callPackage ../development/python-modules/mlrose { };
@@ -5529,6 +5533,8 @@ in {
   pyisy = callPackage ../development/python-modules/pyisy { };
 
   pykrakenapi = callPackage ../development/python-modules/pykrakenapi { };
+
+  pymdown-extensions = callPackage ../development/python-modules/pymdown-extensions { };
 
   pynndescent = callPackage ../development/python-modules/pynndescent { };
 


### PR DESCRIPTION
mkdocs: 1.2.1 -> 1.2.2
pymdown-extensions: init at 8.2
mkdocs-material-extensions: init at 1.0.3
mkdocs-material: init at 7.2.8

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
adding mkdocs-material and its deps.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
