### PR TITLE
rust-analyzer: 2021-09-06 -> 2021-09-20

### DIFF
--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -6,20 +6,23 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-analyzer-unwrapped";
-  version = "2021-09-06";
-  cargoSha256 = "sha256-CTCDSoViyVMHxUKQz8fE+r3rkXf7yRgzZ90fZmMtcNM=";
+  version = "2021-09-20";
+  cargoSha256 = "sha256-OPolZ0oXGRcKvWxXkRMjyEXzvf1p41hGfHBpbDbLJck=";
 
   src = fetchFromGitHub {
     owner = "rust-analyzer";
     repo = "rust-analyzer";
     rev = version;
-    sha256 = "sha256-TacpTVvHAIs4kZ5vibj8luy/kryYwxY+OXFNPnqiXP0=";
+    sha256 = "sha256-k2UGz+h9++8wtV+XdGZbWysjkIDe+UNudKL46eisZzw=";
   };
 
   patches = [
     # Code format and git history check require more dependencies but don't really matter for packaging.
     # So just ignore them.
     ./ignore-git-and-rustfmt-tests.patch
+
+    # Patch for our rust 1.54.0 in nixpkgs. Remove it when we have rust >= 1.55.0
+    ./no-1-55-control-flow.patch
   ];
 
   buildAndTestSubdir = "crates/rust-analyzer";

--- a/pkgs/development/tools/rust/rust-analyzer/no-1-55-control-flow.patch
+++ b/pkgs/development/tools/rust/rust-analyzer/no-1-55-control-flow.patch
@@ -1,0 +1,212 @@
+diff --git a/crates/hir/src/lib.rs b/crates/hir/src/lib.rs
+index 3b0c29e87..2841a39e2 100644
+--- a/crates/hir/src/lib.rs
++++ b/crates/hir/src/lib.rs
+@@ -31,7 +31,7 @@ pub mod db;
+ 
+ mod display;
+ 
+-use std::{iter, ops::ControlFlow, sync::Arc};
++use std::{iter, sync::Arc};
+ 
+ use arrayvec::ArrayVec;
+ use base_db::{CrateDisplayName, CrateId, Edition, FileId};
+@@ -70,7 +70,7 @@ use itertools::Itertools;
+ use nameres::diagnostics::DefDiagnosticKind;
+ use once_cell::unsync::Lazy;
+ use rustc_hash::FxHashSet;
+-use stdx::{format_to, impl_from};
++use stdx::{format_to, impl_from, ControlFlow};
+ use syntax::{
+     ast::{self, AttrsOwner, NameOwner},
+     AstNode, AstPtr, SmolStr, SyntaxKind, SyntaxNodePtr,
+diff --git a/crates/hir_ty/src/method_resolution.rs b/crates/hir_ty/src/method_resolution.rs
+index c88a8b653..039b5589e 100644
+--- a/crates/hir_ty/src/method_resolution.rs
++++ b/crates/hir_ty/src/method_resolution.rs
+@@ -2,7 +2,7 @@
+ //! For details about how this works in rustc, see the method lookup page in the
+ //! [rustc guide](https://rust-lang.github.io/rustc-guide/method-lookup.html)
+ //! and the corresponding code mostly in librustc_typeck/check/method/probe.rs.
+-use std::{iter, ops::ControlFlow, sync::Arc};
++use std::{iter, sync::Arc};
+ 
+ use arrayvec::ArrayVec;
+ use base_db::{CrateId, Edition};
+@@ -13,6 +13,7 @@ use hir_def::{
+ };
+ use hir_expand::name::Name;
+ use rustc_hash::{FxHashMap, FxHashSet};
++use stdx::{try_control_flow, ControlFlow};
+ 
+ use crate::{
+     autoderef,
+@@ -483,7 +484,7 @@ pub fn iterate_method_candidates_dyn(
+ 
+             let deref_chain = autoderef_method_receiver(db, krate, ty);
+             for i in 0..deref_chain.len() {
+-                iterate_method_candidates_with_autoref(
++                try_control_flow!(iterate_method_candidates_with_autoref(
+                     &deref_chain[i..],
+                     db,
+                     env.clone(),
+@@ -492,7 +493,7 @@ pub fn iterate_method_candidates_dyn(
+                     visible_from_module,
+                     name,
+                     callback,
+-                )?;
++                ));
+             }
+             ControlFlow::Continue(())
+         }
+@@ -522,7 +523,7 @@ fn iterate_method_candidates_with_autoref(
+     name: Option<&Name>,
+     mut callback: &mut dyn FnMut(&Canonical<Ty>, AssocItemId) -> ControlFlow<()>,
+ ) -> ControlFlow<()> {
+-    iterate_method_candidates_by_receiver(
++    try_control_flow!(iterate_method_candidates_by_receiver(
+         &deref_chain[0],
+         &deref_chain[1..],
+         db,
+@@ -532,7 +533,7 @@ fn iterate_method_candidates_with_autoref(
+         visible_from_module,
+         name,
+         &mut callback,
+-    )?;
++    ));
+ 
+     let refed = Canonical {
+         binders: deref_chain[0].binders.clone(),
+@@ -540,7 +541,7 @@ fn iterate_method_candidates_with_autoref(
+             .intern(&Interner),
+     };
+ 
+-    iterate_method_candidates_by_receiver(
++    try_control_flow!(iterate_method_candidates_by_receiver(
+         &refed,
+         deref_chain,
+         db,
+@@ -550,7 +551,7 @@ fn iterate_method_candidates_with_autoref(
+         visible_from_module,
+         name,
+         &mut callback,
+-    )?;
++    ));
+ 
+     let ref_muted = Canonical {
+         binders: deref_chain[0].binders.clone(),
+@@ -586,7 +587,7 @@ fn iterate_method_candidates_by_receiver(
+     // be found in any of the derefs of receiver_ty, so we have to go through
+     // that.
+     for self_ty in std::iter::once(receiver_ty).chain(rest_of_deref_chain) {
+-        iterate_inherent_methods(
++        try_control_flow!(iterate_inherent_methods(
+             self_ty,
+             db,
+             env.clone(),
+@@ -595,11 +596,11 @@ fn iterate_method_candidates_by_receiver(
+             krate,
+             visible_from_module,
+             &mut callback,
+-        )?
++        ))
+     }
+ 
+     for self_ty in std::iter::once(receiver_ty).chain(rest_of_deref_chain) {
+-        iterate_trait_method_candidates(
++        try_control_flow!(iterate_trait_method_candidates(
+             self_ty,
+             db,
+             env.clone(),
+@@ -608,7 +609,7 @@ fn iterate_method_candidates_by_receiver(
+             name,
+             Some(receiver_ty),
+             &mut callback,
+-        )?
++        ))
+     }
+ 
+     ControlFlow::Continue(())
+@@ -624,7 +625,7 @@ fn iterate_method_candidates_for_self_ty(
+     name: Option<&Name>,
+     mut callback: &mut dyn FnMut(&Canonical<Ty>, AssocItemId) -> ControlFlow<()>,
+ ) -> ControlFlow<()> {
+-    iterate_inherent_methods(
++    try_control_flow!(iterate_inherent_methods(
+         self_ty,
+         db,
+         env.clone(),
+@@ -633,7 +634,7 @@ fn iterate_method_candidates_for_self_ty(
+         krate,
+         visible_from_module,
+         &mut callback,
+-    )?;
++    ));
+     iterate_trait_method_candidates(self_ty, db, env, krate, traits_in_scope, name, None, callback)
+ }
+ 
+@@ -697,7 +698,7 @@ fn iterate_trait_method_candidates(
+             }
+             known_implemented = true;
+             // FIXME: we shouldn't be ignoring the binders here
+-            callback(self_ty, *item)?
++            try_control_flow!(callback(self_ty, *item))
+         }
+     }
+     ControlFlow::Continue(())
+@@ -774,7 +775,7 @@ fn iterate_inherent_methods(
+                     continue;
+                 }
+                 let receiver_ty = receiver_ty.unwrap_or(self_ty);
+-                callback(receiver_ty, item)?;
++                try_control_flow!(callback(receiver_ty, item));
+             }
+         }
+     }
+diff --git a/crates/ide/src/hover.rs b/crates/ide/src/hover.rs
+index 506d3ba3c..590963c17 100644
+--- a/crates/ide/src/hover.rs
++++ b/crates/ide/src/hover.rs
+@@ -1,4 +1,4 @@
+-use std::{collections::HashSet, ops::ControlFlow};
++use std::collections::HashSet;
+ 
+ use either::Either;
+ use hir::{AsAssocItem, HasAttrs, HasSource, HirDisplay, Semantics, TypeInfo};
+@@ -12,7 +12,7 @@ use ide_db::{
+     RootDatabase,
+ };
+ use itertools::Itertools;
+-use stdx::format_to;
++use stdx::{format_to, ControlFlow};
+ use syntax::{
+     algo, ast, display::fn_as_proc_macro_label, match_ast, AstNode, Direction, SyntaxKind::*,
+     SyntaxNode, SyntaxToken, TextRange, TextSize, T,
+diff --git a/crates/stdx/src/lib.rs b/crates/stdx/src/lib.rs
+index e7d4753de..fddf95147 100644
+--- a/crates/stdx/src/lib.rs
++++ b/crates/stdx/src/lib.rs
+@@ -7,6 +7,22 @@ pub mod panic_context;
+ 
+ pub use always_assert::{always, never};
+ 
++/// std::ops::ControlFlow from rust std 1.55.0
++pub enum ControlFlow<B, C = ()> {
++    Continue(C),
++    Break(B),
++}
++
++#[macro_export]
++macro_rules! try_control_flow {
++    ($e:expr) => {
++        match $e {
++            $crate::ControlFlow::Continue(c) => c,
++            $crate::ControlFlow::Break(b) => return $crate::ControlFlow::Break(b),
++        }
++    };
++}
++
+ #[inline(always)]
+ pub fn is_ci() -> bool {
+     option_env!("CI").is_some()
+

--- a/pkgs/misc/vscode-extensions/rust-analyzer/build-deps/package.json
+++ b/pkgs/misc/vscode-extensions/rust-analyzer/build-deps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-analyzer",
-  "version": "0.2.735",
+  "version": "0.2.751",
   "dependencies": {
     "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump with patch for our rustc 1.54.0.
Tested via vscode extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
3 packages built:
rust-analyzer rust-analyzer-unwrapped vscode-extensions.matklad.rust-analyzer
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
