### PR TITLE
k3s: add updateScript

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -45,10 +45,16 @@ with lib;
 let
   k3sVersion = "1.21.4+k3s1";     # k3s git tag
   k3sCommit = "3e250fdbab72d88f7e6aae57446023a0567ffc97"; # k3s git commit at the above version
+  k3sRepoSha256 = "1w7drvk0bmlmqrxh1y6dxjy7dk6bdrl72pkd25lc1ir6wbzb05h9";
 
   traefikChartVersion = "9.18.2"; # taken from ./scripts/download at TRAEFIK_VERSION
+  traefikChartSha256 = "sha256-9d7p0ngyMN27u4OPgz7yI14Zj9y36t9o/HMX5wyDpUI=";
+
   k3sRootVersion = "0.9.1";       # taken from ./scripts/download at ROOT_VERSION
+  k3sRootSha256 = "sha256-qI84KYJKY/T6pqWZW9lOTq5NzZiu//v1zrMzUCiRTGQ=";
+
   k3sCNIVersion = "0.8.6-k3s1";   # taken from ./scripts/version.sh at VERSION_CNIPLUGINS
+  k3sCNISha256 = "sha256-uAy17eRRAXPCcnh481KxFMvFQecnnBs24jn5YnVNfY4=";
 
   baseMeta = {
     description = "A lightweight Kubernetes distribution";
@@ -61,7 +67,7 @@ let
   # bundled into the k3s binary
   traefikChart = fetchurl {
     url = "https://helm.traefik.io/traefik/traefik-${traefikChartVersion}.tgz";
-    sha256 = "sha256-9d7p0ngyMN27u4OPgz7yI14Zj9y36t9o/HMX5wyDpUI=";
+    sha256 = traefikChartSha256;
   };
   # so, k3s is a complicated thing to package
   # This derivation attempts to avoid including any random binaries from the
@@ -75,7 +81,7 @@ let
   k3sRoot = fetchzip {
     # Note: marked as apache 2.0 license
     url = "https://github.com/k3s-io/k3s-root/releases/download/v${k3sRootVersion}/k3s-root-amd64.tar";
-    sha256 = "sha256-qI84KYJKY/T6pqWZW9lOTq5NzZiu//v1zrMzUCiRTGQ=";
+    sha256 = k3sRootSha256;
     stripRoot = false;
   };
   k3sPlugins = buildGoPackage rec {
@@ -89,7 +95,7 @@ let
       owner = "rancher";
       repo = "plugins";
       rev = "v${version}";
-      sha256 = "sha256-uAy17eRRAXPCcnh481KxFMvFQecnnBs24jn5YnVNfY4=";
+      sha256 = k3sCNISha256;
     };
 
     meta = baseMeta // {
@@ -101,7 +107,7 @@ let
   k3sRepo = fetchgit {
     url = "https://github.com/k3s-io/k3s";
     rev = "v${k3sVersion}";
-    sha256 = "1w7drvk0bmlmqrxh1y6dxjy7dk6bdrl72pkd25lc1ir6wbzb05h9";
+    sha256 = k3sRepoSha256;
   };
   # Stage 1 of the k3s build:
   # Let's talk about how k3s is structured.
@@ -279,6 +285,8 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     $out/bin/k3s --version | grep v${k3sVersion} > /dev/null
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = baseMeta;
 }

--- a/pkgs/applications/networking/cluster/k3s/update.sh
+++ b/pkgs/applications/networking/cluster/k3s/update.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq
+
+set -eu -o pipefail
+
+WORKDIR=$(mktemp -d)
+trap "rm -rf ${WORKDIR}" EXIT
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+LATEST_TAG_RAWFILE=${WORKDIR}/latest_tag.json
+curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
+    https://api.github.com/repos/k3s-io/k3s/releases/latest > ${LATEST_TAG_RAWFILE}
+
+LATEST_TAG_NAME=$(jq -r '.tag_name' ${LATEST_TAG_RAWFILE})
+
+K3S_VERSION=$(echo ${LATEST_TAG_NAME} | sed 's/^v//')
+
+LATEST_TAG_TARBALL_URL=$(jq -r '.tarball_url' ${LATEST_TAG_RAWFILE})
+
+K3S_COMMIT=$(curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
+    https://api.github.com/repos/k3s-io/k3s/tags \
+    | jq -r "map(select(.name == \"${LATEST_TAG_NAME}\")) | .[0] | .commit.sha")
+
+K3S_REPO_SHA256=$(nix-prefetch-url --quiet --unpack ${LATEST_TAG_TARBALL_URL})
+
+FILE_SCRIPTS_DOWNLOAD=${WORKDIR}/scripts-download
+curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts/download > $FILE_SCRIPTS_DOWNLOAD
+
+FILE_SCRIPTS_VERSION=${WORKDIR}/scripts-version.sh
+curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts/version.sh > $FILE_SCRIPTS_VERSION
+
+TRAEFIK_CHART_VERSION=$(grep TRAEFIK_VERSION= $FILE_SCRIPTS_DOWNLOAD \
+    | cut -d'=' -f2 | cut -d' ' -f1)
+TRAEFIK_CHART_SHA256=$(nix-prefetch-url --quiet "https://helm.traefik.io/traefik/traefik-${TRAEFIK_CHART_VERSION}.tgz")
+
+K3S_ROOT_VERSION=$(grep ROOT_VERSION= $FILE_SCRIPTS_DOWNLOAD \
+    | cut -d'=' -f2 | cut -d' ' -f1 | sed 's/^v//')
+K3S_ROOT_SHA256=$(nix-prefetch-url --quiet --unpack \
+    "https://github.com/k3s-io/k3s-root/releases/download/v${K3S_ROOT_VERSION}/k3s-root-amd64.tar")
+
+CNIPLUGINS_VERSION=$(grep VERSION_CNIPLUGINS= $FILE_SCRIPTS_VERSION \
+    | cut -d'=' -f2 | cut -d' ' -f1 | sed -e 's/"//g' -e 's/^v//')
+CNIPLUGINS_SHA256=$(nix-prefetch-url --quiet --unpack \
+    "https://github.com/rancher/plugins/archive/refs/tags/v${CNIPLUGINS_VERSION}.tar.gz")
+
+setKV () {
+  sed -i "s/$1 = \".*\"/$1 = \"$2\"/" ./default.nix
+}
+
+setKV k3sVersion ${K3S_VERSION}
+setKV k3sCommit ${K3S_COMMIT}
+setKV k3sRepoSha256 ${K3S_REPO_SHA256}
+
+setKV traefikChartVersion ${TRAEFIK_CHART_VERSION}
+setKV traefikChartSha256 ${TRAEFIK_CHART_SHA256}
+
+setKV k3sRootVersion ${K3S_ROOT_VERSION}
+setKV k3sRootSha256 ${K3S_ROOT_SHA256}
+
+setKV k3sCNIVersion ${CNIPLUGINS_VERSION}
+setKV k3sCNISha256 ${CNIPLUGINS_SHA256}


### PR DESCRIPTION
Currently k3s is outdated (current version is `v1.21.5+k3s`).
Let's see in action this `updateScript`.