### PR TITLE
[DRAFT] onlyoffice-documentserver-bin: init at 7.0.1

### DIFF
--- a/pkgs/servers/onlyoffice-documentserver/default.nix
+++ b/pkgs/servers/onlyoffice-documentserver/default.nix
@@ -9,10 +9,10 @@
 
 stdenv.mkDerivation rec {
   pname = "onlyoffice-documentserver";
-  version = "6.4.2";
+  version = "7.0.0";
   src = fetchurl {
     url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${version}/onlyoffice-documentserver_amd64.deb";
-    sha256 = "00c91s57qiw6kd15qi14y0jb2wbjlpdcwvfmrvck5faic21bfh2i";
+    sha256 = "sha256-JhUKaPYPreyWSR2lUlIfnfm8X7wvEYMof9Yd9Xm/NZc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/onlyoffice-documentserver/default.nix
+++ b/pkgs/servers/onlyoffice-documentserver/default.nix
@@ -9,10 +9,10 @@
 
 stdenv.mkDerivation rec {
   pname = "onlyoffice-documentserver";
-  version = "6.4.1";
+  version = "6.4.2";
   src = fetchurl {
     url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${version}/onlyoffice-documentserver_amd64.deb";
-    sha256 = "0q9ara3l7l0k4hx0kk36kkvzka5kw7fqk3r45zdfsx6ac8gnvm70";
+    sha256 = "00c91s57qiw6kd15qi14y0jb2wbjlpdcwvfmrvck5faic21bfh2i";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/onlyoffice-documentserver/default.nix
+++ b/pkgs/servers/onlyoffice-documentserver/default.nix
@@ -9,10 +9,10 @@
 
 stdenv.mkDerivation rec {
   pname = "onlyoffice-documentserver";
-  version = "7.0.0";
+  version = "7.0.1";
   src = fetchurl {
     url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${version}/onlyoffice-documentserver_amd64.deb";
-    sha256 = "sha256-JhUKaPYPreyWSR2lUlIfnfm8X7wvEYMof9Yd9Xm/NZc=";
+    sha256 = "sha256-5+Ii9CU3/xWUt8YclqpMavcXoKP6WBN/bh1UAnbBgCU=";
   };
 
   nativeBuildInputs = [
@@ -29,12 +29,12 @@ stdenv.mkDerivation rec {
     dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
   '';
 
-  # docservice is a node program packaged using zeit/pkg.
+  # docservice is a node program packaged using vercel/pkg.
   # thus, it contains hardcoded offsets.
   # patchelf shifts these locations when it expands headers.
 
   # this could probably be generalised into allowing any program packaged
-  # with zeit/pkg to be run on nixos.
+  # with vercel/pkg to be run on nixos.
 
   preFixup = let
     libPath = lib.makeLibraryPath [stdenv.cc.cc];

--- a/pkgs/servers/onlyoffice-documentserver/default.nix
+++ b/pkgs/servers/onlyoffice-documentserver/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     # ^-- grep points here
     #
     # var_* are as described above
-    # shift_by seems to be safe so long as all patchelf adjustments occur 
+    # shift_by seems to be safe so long as all patchelf adjustments occur
     # before any locations pointed to by hardcoded offsets
     var_skip=20
     var_select=22

--- a/pkgs/servers/onlyoffice-documentserver/default.nix
+++ b/pkgs/servers/onlyoffice-documentserver/default.nix
@@ -1,0 +1,111 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, glib
+, nodejs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "onlyoffice-documentserver";
+  version = "6.4.0";
+  src = fetchurl {
+    url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${version}/onlyoffice-documentserver_amd64.deb";
+    sha256 = "0yq7z73wvlfw01pxk637nxq73j145q00mxs6niddr4jv0hr24sad";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    glib
+    nodejs
+  ];
+
+  unpackPhase = ''
+    dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
+  '';
+
+  # docservice is a node program packaged using zeit/pkg.
+  # thus, it contains hardcoded offsets.
+  # patchelf shifts these locations when it expands headers.
+
+  # this could probably be generalised into allowing any program packaged
+  # with zeit/pkg to be run on nixos.
+
+  preFixup = let
+    libPath = lib.makeLibraryPath [stdenv.cc.cc];
+  in ''
+    orig_size=$(stat --printf=%s $out/bin/docservice)
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/docservice
+    patchelf --set-rpath ${libPath} $out/bin/docservice
+    chmod +x $out/bin/docservice
+    new_size=$(stat --printf=%s $out/bin/docservice)
+    ###### zeit-pkg fixing starts here.
+    # we're replacing plaintext js code that looks like
+    # PAYLOAD_POSITION = '1234                  ' | 0
+    # [...]
+    # PRELUDE_POSITION = '1234                  ' | 0
+    # ^-----20-chars-----^^------22-chars------^
+    # ^-- grep points here
+    #
+    # var_* are as described above
+    # shift_by seems to be safe so long as all patchelf adjustments occur 
+    # before any locations pointed to by hardcoded offsets
+    var_skip=20
+    var_select=22
+    shift_by=$(expr $new_size - $orig_size)
+    function fix_offset {
+      # $1 = name of variable to adjust
+      location=$(grep -obUam1 "$1" $out/bin/docservice | cut -d: -f1)
+      location=$(expr $location + $var_skip)
+      value=$(dd if=$out/bin/docservice iflag=count_bytes,skip_bytes skip=$location \
+                 bs=1 count=$var_select status=none)
+      value=$(expr $shift_by + $value)
+      echo -n $value | dd of=$out/bin/docservice bs=1 seek=$location conv=notrunc
+    }
+    fix_offset PAYLOAD_POSITION
+    fix_offset PRELUDE_POSITION
+  '';
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib $out/etc
+
+    find -L var/www/onlyoffice/documentserver/server -mindepth 1 -type f -executable \
+      -exec cp -d {} "$out/bin" \;
+
+    find -L var/www/onlyoffice/documentserver/server -mindepth 1 -type f -name "*.so*" \
+      -exec cp -d {} "$out/lib" \;
+
+    substitute etc/onlyoffice/documentserver/production-linux.json $out/etc/production-linux.json \
+      --replace "/var/www/onlyoffice/documentserver/dictionaries" "$out/dictionaries" \
+      --replace "/var/lib/onlyoffice/documentserver/App_Data" "/var/lib/onlyoffice/documentserver/App_Data" \
+      --replace "/var/www/onlyoffice/documentserver/core-fonts" "$out/core-fonts" \
+      --replace "/var/lib/onlyoffice/documentserver/App_Data/docbuilder/AllFonts.js" "/var/lib/onlyoffice/App_Data/docbuilder/AllFonts.js" \
+      --replace "/var/www/onlyoffice/documentserver/server/FileConverter/bin/docbuilder" "$out/bin/docbuilder" \
+      --replace "/var/www/onlyoffice/documentserver/server/FileConverter/bin/x2t" "$out/bin/x2t" \
+      --replace "/var/www/onlyoffice/documentserver/sdkjs-plugins" "$out/sdkjs-plugins" \
+      --replace "/etc/onlyoffice/documentserver/log4js/production.json" "$out/etc/log4js-production.json"
+    cp etc/onlyoffice/documentserver/log4js/production.json $out/etc/log4js-production.json
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Online office suite comprising viewers and editors for texts, spreadsheets and presentations, enabling collaborative editing in real time";
+    homepage = "https://www.onlyoffice.com/";
+    downloadPage = "https://github.com/ONLYOFFICE/DocumentServer/releases";
+    changelog = "https://raw.githubusercontent.com/ONLYOFFICE/DocumentServer/master/CHANGELOG.md";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/servers/onlyoffice-documentserver/default.nix
+++ b/pkgs/servers/onlyoffice-documentserver/default.nix
@@ -9,10 +9,10 @@
 
 stdenv.mkDerivation rec {
   pname = "onlyoffice-documentserver";
-  version = "6.4.0";
+  version = "6.4.1";
   src = fetchurl {
     url = "https://github.com/ONLYOFFICE/DocumentServer/releases/download/v${version}/onlyoffice-documentserver_amd64.deb";
-    sha256 = "0yq7z73wvlfw01pxk637nxq73j145q00mxs6niddr4jv0hr24sad";
+    sha256 = "0q9ara3l7l0k4hx0kk36kkvzka5kw7fqk3r45zdfsx6ac8gnvm70";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8584,6 +8584,8 @@ with pkgs;
 
   onlykey = callPackage ../tools/security/onlykey { node_webkit = nwjs; };
 
+  onlyoffice-documentserver = callPackage ../servers/onlyoffice-documentserver { };
+
   openapi-generator-cli = callPackage ../tools/networking/openapi-generator-cli { jre = pkgs.jre_headless; };
   openapi-generator-cli-unstable = callPackage ../tools/networking/openapi-generator-cli/unstable.nix { jre = pkgs.jre_headless; };
 


### PR DESCRIPTION
###### Motivation for this change
Adding onlyoffice-documentserver, fixes https://github.com/NixOS/nixpkgs/issues/132815 . Package contains server binaries to run Onlyoffice-Documentserver and all of its components.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
