### PR TITLE
  discourse: use ghostscript-fonts for letter avatars

### DIFF
--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -4,6 +4,7 @@
 , ruby, replace, gzip, gnutar, git, cacert, util-linux, gawk
 , imagemagick, optipng, pngquant, libjpeg, jpegoptim, gifsicle, libpsl
 , redis, postgresql, which, brotli, procps, rsync, nodePackages, v8
+, ghostscript
 
 , plugins ? []
 }@args:
@@ -296,6 +297,9 @@ let
       ln -sf /run/discourse/public $out/share/discourse/public
       ln -sf ${assets} $out/share/discourse/public.dist/assets
       ${lib.concatMapStringsSep "\n" (p: "ln -sf ${p} $out/share/discourse/plugins/${p.pluginName or ""}") plugins}
+
+      substituteInPlace $out/share/discourse/lib/letter_avatar.rb --replace Helvetica \
+        ${ghostscript}/share/ghostscript/fonts/n019003l.pfb
 
       runHook postInstall
     '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The letter avatar code expects imagmagick to be able to use
Helvetica. The ghostscript fonts package includes a helvetica
substitute that discourse uses in its Docker container.

references:
- https://meta.discourse.org/t/new-letter-avatars-are-sometimes-blank/27225/6
- https://github.com/discourse/discourse_docker/commit/8ee0f7f4c8e0090f4c12ee53a70072aac875b838

This is only needed if the setting for external avatars is turned off.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
