### PR TITLE
EmptyEpsilon: use updated CMake target for GLM

### DIFF
--- a/pkgs/games/empty-epsilon/0001-bundle-system-glm-in-seriousproton.patch
+++ b/pkgs/games/empty-epsilon/0001-bundle-system-glm-in-seriousproton.patch
@@ -26,7 +26,7 @@ index cbd68ca..730df82 100644
  target_link_libraries(seriousproton_deps
      INTERFACE 
 -        box2d lua glew ${SFML_LIBRARIES}
-+        box2d lua glew ${SFML_LIBRARIES} glm
++        box2d lua glew ${SFML_LIBRARIES} glm::glm
          "$<$<BOOL:${WIN32}>:wsock32>"
          # LTO flag must be on the linker's list as well.
          "$<$<AND:$<BOOL:${CMAKE_COMPILER_IS_GNUCC}>,$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Release>>>:-flto>"


### PR DESCRIPTION
###### Motivation for this change

The GLM derivation was updated by #134913, and the CMake target name changed from `glm` to the namespaced `glm::glm`.

This fixes the broken build as reported in https://github.com/NixOS/nixpkgs/pull/134913#issuecomment-923705220.


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
