### PR TITLE
jitsi-meet: add default hostname equal to networking.fqdn

### DIFF
--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -46,8 +46,11 @@ in
     hostName = mkOption {
       type = str;
       example = "meet.example.org";
+      default = config.networking.fqdn;
       description = ''
         Hostname of the Jitsi Meet instance.
+        It defaults to the fully qualified domain name of the host (networking.fqdn)
+        and may cause issues if it is not equal to (or a subdomain of) the FQDN.
       '';
     };
 


### PR DESCRIPTION
Jitsi-meet fails if the `services.jitsi.hostName` is not equal to or a subdomain of the FQDN of the underlying server.  This change adds the FQDN as a default for the hostname, which may help avoid some confusion.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Confusion at jitsi-meet failing when `networking.fqdn` did not equal `services.jitsi.hostName`. This seemed to be due to how the `services.jitsi.hostName` is used in the prosody config. I figured that this seemed like a sensible default that could help avoid some confusion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
