### PR TITLE
panamax: init at 1.0.3

### DIFF
--- a/pkgs/development/tools/rust/panamax/default.nix
+++ b/pkgs/development/tools/rust/panamax/default.nix
@@ -1,0 +1,24 @@
+{ lib, rustPlatform, fetchCrate, pkg-config, openssl, stdenv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "panamax";
+  version = "1.0.3";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-w4waFdzd/Ps0whOp39QLBE/YF2eyc4t2Ili7FskUt1M=";
+  };
+
+  cargoSha256 = "sha256-52snmkTFHI26xJo9qJkmqh1M5lLzhDxw8WT6uFd57aw=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin Security;
+
+  meta = with lib; {
+    description = "Mirror rustup and crates.io repositories for offline Rust and cargo usage";
+    homepage = "https://github.com/panamax-rs/panamax";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12501,6 +12501,9 @@ with pkgs;
   maturin = callPackage ../development/tools/rust/maturin {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  panamax = callPackage ../development/tools/rust/panamax {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   inherit (rustPackages) rls;
   rustfmt = rustPackages.rustfmt;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Panamax is a tool to mirror the Rust and crates.io repositories, for offline usage of rustup and cargo

https://github.com/panamax-rs/panamax

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
