### PR TITLE
Revert "[Backport staging-21.05] gd: 2.3.0 -> 2.3.3"

### DIFF
--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -14,14 +14,27 @@
 
 stdenv.mkDerivation rec {
   pname = "gd";
-  version = "2.3.3";
+  version = "2.3.0";
 
   src = fetchurl {
     url = "https://github.com/libgd/libgd/releases/download/${pname}-${version}/libgd-${version}.tar.xz";
-    sha256 = "0qas3q9xz3wgw06dm2fj0i189rain6n60z1vyq50d5h7wbn25s1z";
+    sha256 = "0n5czhxzinvjvmhkf5l9fwjdx5ip69k5k7pj6zwb6zs1k9dibngc";
   };
 
   hardeningDisable = [ "format" ];
+  patches = [
+    # Fixes an issue where some other packages would fail to build
+    # their documentation with an error like:
+    # "Error: Problem doing text layout"
+    #
+    # Can be removed if Wayland can still be built successfully with
+    # documentation.
+    (fetchpatch {
+      url = "https://github.com/libgd/libgd/commit/3dd0e308cbd2c24fde2fc9e9b707181252a2de95.patch";
+      excludes = [ "tests/gdimagestringft/.gitignore" ];
+      sha256 = "12iqlanl9czig9d7c3rvizrigw2iacimnmimfcny392dv9iazhl1";
+    })
+  ];
 
   # -pthread gets passed to clang, causing warnings
   configureFlags = lib.optional stdenv.isDarwin "--enable-werror=no";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#138557

Looks like this breaks some php versions: https://github.com/NixOS/nixpkgs/pull/138417#issuecomment-924456709

I think the answer will be to bump to 2.3.2 instead and patch from there, but for now I'd like to revert this before it hits release and breaks things for people.