### PR TITLE
cups-filters: 1.25.12 -> 1.28.10

### DIFF
--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, pkg-config, cups, poppler, poppler_utils, fontconfig
 , libjpeg, libpng, perl, ijs, qpdf, dbus, avahi
 , makeWrapper, coreutils, gnused, bc, gawk, gnugrep, which, ghostscript
-, mupdf
+, mupdf, dejavu_fonts, liblouis
 }:
 
 let
@@ -9,11 +9,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "cups-filters";
-  version = "1.25.12";
+  version = "1.28.10";
 
   src = fetchurl {
     url = "https://openprinting.org/download/cups-filters/${pname}-${version}.tar.xz";
-    sha256 = "1kv25011iyzvd33n5zmmn1z2p6pzk26hmmw6qvjjnx8p3sp7raqn";
+    sha256 = "sha256-z4yQRpTETPaJtXJORtI9qa5RJdVDdLNAxkIHfMKcqDc=";
   };
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
@@ -21,6 +21,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     cups poppler poppler_utils fontconfig libjpeg libpng perl
     ijs qpdf dbus avahi ghostscript mupdf
+    liblouis # braille embosser support
   ];
 
   configureFlags = [
@@ -33,7 +34,7 @@ in stdenv.mkDerivation rec {
     "--enable-imagefilters"
     "--with-rcdir=no"
     "--with-shell=${stdenv.shell}"
-    "--with-test-font-path=/path-does-not-exist"
+    "--with-test-font-path=${dejavu_fonts}/share/fonts/truetype/DejaVuSans.ttf"
   ];
 
   makeFlags = [ "CUPS_SERVERBIN=$(out)/lib/cups" "CUPS_DATADIR=$(out)/share/cups" "CUPS_SERVERROOT=$(out)/etc/cups" ];
@@ -60,7 +61,7 @@ in stdenv.mkDerivation rec {
     '';
 
   enableParallelBuilding = true;
-  doCheck = false; # fails 4 out of 6 tests
+  doCheck = true;
 
   meta = {
     homepage = "http://www.linuxfoundation.org/collaborate/workgroups/openprinting/cups-filters";


### PR DESCRIPTION
enable tests
enable braille embosser support

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
