### PR TITLE
quilt: wrap all required inputs

### DIFF
--- a/pkgs/development/tools/quilt/default.nix
+++ b/pkgs/development/tools/quilt/default.nix
@@ -1,4 +1,19 @@
-{ lib, stdenv, fetchurl, makeWrapper, bash, perl, diffstat, diffutils, patch, findutils }:
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, bash
+, coreutils
+, diffstat
+, diffutils
+, findutils
+, gawk
+, gnugrep
+, gnused
+, patch
+, perl
+, unixtools
+}:
 
 stdenv.mkDerivation rec {
 
@@ -11,11 +26,24 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ perl bash diffutils patch findutils diffstat ];
+
+  buildInputs = [
+    bash
+    coreutils
+    diffstat
+    diffutils
+    findutils
+    gawk
+    gnugrep
+    gnused
+    patch
+    perl
+    unixtools.column
+    unixtools.getopt
+  ];
 
   postInstall = ''
-    wrapProgram $out/bin/quilt --prefix PATH : \
-      ${perl}/bin:${bash}/bin:${diffstat}/bin:${diffutils}/bin:${findutils}/bin:${patch}/bin
+    wrapProgram $out/bin/quilt --prefix PATH : ${lib.makeBinPath buildInputs}
   '';
 
   meta = {

--- a/pkgs/development/tools/quilt/default.nix
+++ b/pkgs/development/tools/quilt/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/quilt --prefix PATH : ${lib.makeBinPath buildInputs}
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://savannah.nongnu.org/projects/quilt";
     description = "Easily manage large numbers of patches";
 
@@ -57,8 +57,9 @@ stdenv.mkDerivation rec {
       and more.
     '';
 
-    license = lib.licenses.gpl2Plus;
-    platforms = lib.platforms.all;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ smancill ];
+    platforms = platforms.all;
   };
 
 }


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Some quilt commands fail on darwin with this error:

    stat: illegal option -- c
    usage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]

This is because at build time quilt is configured to use the `coreutils` version of `stat`, but the `quilt` wrapper does not wrap this `coreutils` dependency and then at runtime the version from macOS is used (as found in $PATH).

###### Things done

Wrap `coreutils` input to fix the problem.

Also add and wrap the missing inputs for the other programs used by the quilt commands: `gawk`, `gnugrep`, `gnused`, `unixtools.column` and `unixtools.getopt`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
