### PR TITLE
sleuthkit: add build for JNI libraries

### DIFF
--- a/pkgs/tools/system/sleuthkit/default.nix
+++ b/pkgs/tools/system/sleuthkit/default.nix
@@ -1,15 +1,54 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, libewf, afflib, openssl, zlib }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, libewf, afflib, openssl, zlib, openjdk, perl, ant }:
 
 stdenv.mkDerivation rec {
   version = "4.11.0";
   pname = "sleuthkit";
 
-  src = fetchFromGitHub {
+  sleuthsrc = fetchFromGitHub {
     owner = "sleuthkit";
     repo = "sleuthkit";
     rev = "${pname}-${version}";
-    sha256 = "sha256-cY55zK6N3tyCLBJtZn4LhK9kLkikJjg640Pm/NA0ALY=";
+    sha256 = "1dh06k8grrj3wcx3h9m490p69bw41dz6cv8j5j1drpldmv67k3ki";
   };
+
+  # Fetch libraries using a fixed output derivation
+  rdeps = stdenv.mkDerivation rec {
+
+    version = "1.0";
+    pname = "sleuthkit-deps";
+    nativeBuildInputs = [ openjdk ant ];
+
+    src = sleuthsrc;
+
+    # unpack, build, install
+    dontConfigure = true;
+
+    buildPhase = ''
+      export IVY_HOME=$NIX_BUILD_TOP/.ant
+      pushd bindings/java
+      ant retrieve-deps
+      popd
+      pushd case-uco/java
+      ant get-ivy-dependencies
+      popd
+    '';
+
+    installPhase = ''
+      export IVY_HOME=$NIX_BUILD_TOP/.ant
+      mkdir -m 755 -p $out/bindings/java
+      cp -r bindings/java/lib $out/bindings/java
+      mkdir -m 755 -p $out/case-uco/java
+      cp -r case-uco/java/lib $out/case-uco/java
+      cp -r $IVY_HOME/lib $out
+      chmod -R 755 $out/lib
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = "0fq7v6zlgybg4v6k9wqjlk4gaqgjrpihbnr182vaqriihflav2s8";
+    outputHashAlgo = "sha256";
+  };
+
+  src = sleuthsrc;
 
   postPatch = ''
     substituteInPlace tsk/img/ewf.cpp --replace libewf_handle_read_random libewf_handle_read_buffer_at_offset
@@ -17,17 +56,34 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook openjdk perl ant rdeps ];
   buildInputs = [ libewf afflib openssl zlib ];
 
-  # Hack to fix the RPATH.
-  preFixup = "rm -rf */.libs";
+  # Hack to fix the RPATH
+  preFixup = ''
+    rm -rf */.libs
+  '';
 
-  meta = {
+  postUnpack = ''
+    export IVY_HOME="$NIX_BUILD_TOP/.ant"
+    export JAVA_HOME="${openjdk}"
+    export ant_args="-Doffline=true -Ddefault-jar-location=$IVY_HOME/lib"
+
+    # pre-positioning these jar files allows -Doffline=true to work
+    mkdir -p source/{bindings,case-uco}/java $IVY_HOME
+    cp -r ${rdeps}/bindings/java/lib source/bindings/java
+    chmod -R 755 source/bindings/java
+    cp -r ${rdeps}/case-uco/java/lib source/case-uco/java
+    chmod -R 755 source/case-uco/java
+    cp -r ${rdeps}/lib $IVY_HOME
+    chmod -R 755 $IVY_HOME
+  '';
+
+  meta = with lib; {
     description = "A forensic/data recovery tool";
     homepage = "https://www.sleuthkit.org/";
-    maintainers = [ lib.maintainers.raskin ];
-    platforms = lib.platforms.linux;
-    license = lib.licenses.ipl10;
+    maintainers = with maintainers; [ raskin gfrascadorio ];
+    platforms = platforms.linux;
+    license = licenses.ipl10;
   };
 }


### PR DESCRIPTION
Enhance sleuthkit package so it builds the optional JNI libraries that
allow clients like autopsy to use sleuthkit.

###### Motivation for this change
We need sleuthkit to build JNI libraries so that packages can be written for programs like autopsy and #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) [ I checked for execution, but no usage testing ]
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
