### PR TITLE
Fix several NixOS errors in Hydra evaluation

### DIFF
--- a/nixos/modules/config/krb5/default.nix
+++ b/nixos/modules/config/krb5/default.nix
@@ -84,7 +84,7 @@ in {
         type = types.package;
         default = pkgs.krb5Full;
         defaultText = "pkgs.krb5Full";
-        example = literalExample "pkgs.heimdalFull";
+        example = literalExample "pkgs.heimdal";
         description = ''
           The Kerberos implementation that will be present in
           <literal>environment.systemPackages</literal> after enabling this

--- a/nixos/modules/programs/atop.nix
+++ b/nixos/modules/programs/atop.nix
@@ -141,8 +141,15 @@ in
             // mkService cfg.atopgpu.enable "atopgpu" [ atop ];
           timers = mkTimer cfg.atopRotateTimer.enable "atop-rotate" [ atop ];
         };
-      security.wrappers =
-        lib.mkIf cfg.setuidWrapper.enable { atop = { source = "${atop}/bin/atop"; }; };
+
+      security.wrappers = lib.mkIf cfg.setuidWrapper.enable {
+        atop =
+          { setuid = true;
+            owner = "root";
+            group = "root";
+            source = "${atop}/bin/atop";
+          };
+      };
     }
   );
 }

--- a/nixos/modules/programs/plotinus.nix
+++ b/nixos/modules/programs/plotinus.nix
@@ -30,7 +30,7 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-    environment.variables.XDG_DATA_DIRS = [ "${pkgs.plotinus}/share/gsettings-schemas/${pkgs.plotinus.name}" ];
+    environment.sessionVariables.XDG_DATA_DIRS = [ "${pkgs.plotinus}/share/gsettings-schemas/${pkgs.plotinus.name}" ];
     environment.variables.GTK3_MODULES = [ "${pkgs.plotinus}/lib/libplotinus.so" ];
   };
 }

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -5,28 +5,33 @@ with lib;
 let
   cfg = config.services.kubernetes;
 
-  defaultContainerdConfigFile = pkgs.writeText "containerd.toml" ''
-    version = 2
-    root = "/var/lib/containerd"
-    state = "/run/containerd"
-    oom_score = 0
+  defaultContainerdSettings = {
+    version = 2;
+    root = "/var/lib/containerd";
+    state = "/run/containerd";
+    oom_score = 0;
 
-    [grpc]
-      address = "/run/containerd/containerd.sock"
+    grpc = {
+      address = "/run/containerd/containerd.sock";
+    };
 
-    [plugins."io.containerd.grpc.v1.cri"]
-      sandbox_image = "pause:latest"
+    plugins."io.containerd.grpc.v1.cri" = {
+      sandbox_image = "pause:latest";
 
-    [plugins."io.containerd.grpc.v1.cri".cni]
-      bin_dir = "/opt/cni/bin"
-      max_conf_num = 0
+      cni = {
+        bin_dir = "/opt/cni/bin";
+        max_conf_num = 0;
+      };
 
-    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-      runtime_type = "io.containerd.runc.v2"
+      containerd.runtimes.runc = {
+        runtime_type = "io.containerd.runc.v2";
+      };
 
-    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."io.containerd.runc.v2".options]
-      SystemdCgroup = true
-  '';
+      containerd.runtimes."io.containerd.runc.v2".options = {
+        SystemdCgroup = true;
+      };
+    };
+  };
 
   mkKubeConfig = name: conf: pkgs.writeText "${name}-kubeconfig" (builtins.toJSON {
     apiVersion = "v1";
@@ -248,7 +253,7 @@ in {
     (mkIf cfg.kubelet.enable {
       virtualisation.containerd = {
         enable = mkDefault true;
-        configFile = mkDefault defaultContainerdConfigFile;
+        settings = mkDefault defaultContainerdSettings;
       };
     })
 

--- a/nixos/modules/services/networking/dnscrypt-wrapper.nix
+++ b/nixos/modules/services/networking/dnscrypt-wrapper.nix
@@ -217,6 +217,7 @@ in {
       home = "${dataDir}";
       createHome = true;
       isSystemUser = true;
+      group = "dnscrypt-wrapper";
     };
     users.groups.dnscrypt-wrapper = { };
 

--- a/nixos/modules/services/networking/flannel.nix
+++ b/nixos/modules/services/networking/flannel.nix
@@ -164,7 +164,7 @@ in {
       path = [ pkgs.iptables ];
       preStart = optionalString (cfg.storageBackend == "etcd") ''
         echo "setting network configuration"
-        until ${pkgs.etcdctl}/bin/etcdctl set /coreos.com/network/config '${builtins.toJSON networkConfig}'
+        until ${pkgs.etcd}/bin/etcdctl set /coreos.com/network/config '${builtins.toJSON networkConfig}'
         do
           echo "setting network configuration, retry"
           sleep 1

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -8,7 +8,7 @@ let
 in
 {
 
-  meta.maintainers = with maintainers; [ filalex77 ];
+  meta.maintainers = with maintainers; [ Br1ght0ne ];
 
   ###### interface
 

--- a/nixos/modules/services/system/kerberos/heimdal.nix
+++ b/nixos/modules/services/system/kerberos/heimdal.nix
@@ -27,7 +27,7 @@ in
 {
   # No documentation about correct triggers, so guessing at them.
 
-  config = mkIf (cfg.enable && kerberos == pkgs.heimdalFull) {
+  config = mkIf (cfg.enable && kerberos == pkgs.heimdal) {
     systemd.services.kadmind = {
       description = "Kerberos Administration Daemon";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -223,7 +223,6 @@ in
   krb5 = discoverTests (import ./krb5 {});
   ksm = handleTest ./ksm.nix {};
   kubernetes = handleTestOn ["x86_64-linux"] ./kubernetes {};
-  latestKernel.hardened = handleTest ./hardened.nix { latestKernel = true; };
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };
   leaps = handleTest ./leaps.nix {};
   libreddit = handleTest ./libreddit.nix {};

--- a/nixos/tests/atop.nix
+++ b/nixos/tests/atop.nix
@@ -105,8 +105,6 @@ let assertions = rec {
 };
 in
 {
-  name = "atop";
-
   justThePackage = makeTest {
     name = "atop-justThePackage";
     machine = {

--- a/nixos/tests/cntr.nix
+++ b/nixos/tests/cntr.nix
@@ -9,7 +9,7 @@ let
     makeTest {
       name = "cntr-${backend}";
 
-      meta = { maintainers = with lib.maintainers; [ srk mic92 ]; };
+      meta = { maintainers = with lib.maintainers; [ sorki mic92 ]; };
 
       nodes = {
         ${backend} = { pkgs, ... }: {

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -24,6 +24,11 @@ let
           ln -s vda1 /dev/xvda1
         '';
 
+        # In a NixOS test the serial console is occupied by the "backdoor"
+        # (see testing/test-instrumentation.nix) and is incompatible with
+        # the configuration in virtualisation/amazon-image.nix.
+        systemd.services."serial-getty@ttyS0".enable = mkForce false;
+
         # Needed by nixos-rebuild due to the lack of network
         # access. Determined by trial and error.
         system.extraDependencies = with pkgs; ( [

--- a/nixos/tests/enlightenment.nix
+++ b/nixos/tests/enlightenment.nix
@@ -11,8 +11,8 @@ import ./make-test-python.nix ({ pkgs, ...} :
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
     services.xserver.desktopManager.enlightenment.enable = true;
-    services.xserver.displayManager.lightdm = {
-      enable = true;
+    services.xserver.displayManager = {
+      lightdm.enable = true;
       autoLogin = {
         enable = true;
         user = "alice";

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... } : {
+import ./make-test-python.nix ({ pkgs, ... } : {
   name = "hardened";
   meta = with pkgs.lib.maintainers; {
     maintainers = [ joachifm ];
@@ -10,8 +10,6 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... } : {
     { users.users.alice = { isNormalUser = true; extraGroups = [ "proc" ]; };
       users.users.sybil = { isNormalUser = true; group = "wheel"; };
       imports = [ ../modules/profiles/hardened.nix ];
-      boot.kernelPackages =
-        lib.mkIf latestKernel pkgs.linuxPackages_latest_hardened;
       environment.memoryAllocator.provider = "graphene-hardened";
       nix.useSandbox = false;
       virtualisation.emptyDiskImages = [ 4096 ];

--- a/nixos/tests/kerberos/heimdal.nix
+++ b/nixos/tests/kerberos/heimdal.nix
@@ -9,7 +9,7 @@ import ../make-test-python.nix ({pkgs, ...}: {
     };
     krb5 = {
       enable = true;
-      kerberos = pkgs.heimdalFull;
+      kerberos = pkgs.heimdal;
       libdefaults = {
         default_realm = "FOO.BAR";
       };

--- a/nixos/tests/meilisearch.nix
+++ b/nixos/tests/meilisearch.nix
@@ -10,7 +10,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
     '';
   in {
     name = "meilisearch";
-    meta.maintainers = with lib.maintainers; [ filalex77 ];
+    meta.maintainers = with lib.maintainers; [ Br1ght0ne ];
 
     machine = { ... }: {
       environment.systemPackages = with pkgs; [ curl jq ];

--- a/nixos/tests/minio.nix
+++ b/nixos/tests/minio.nix
@@ -28,7 +28,10 @@ in {
     machine = { pkgs, ... }: {
       services.minio = {
         enable = true;
-        inherit accessKey secretKey;
+        rootCredentialsFile = pkgs.writeText "minio-credentials" ''
+          MINIO_ROOT_USER=${accessKey}
+          MINIO_ROOT_PASSWORD=${secretKey}
+        '';
       };
       environment.systemPackages = [ pkgs.minio-client ];
 

--- a/nixos/tests/mpv.nix
+++ b/nixos/tests/mpv.nix
@@ -14,7 +14,7 @@ in
     {
       environment.systemPackages = [
         pkgs.curl
-        (pkgs.mpv-with-scripts.override {
+        (pkgs.wrapMpv pkgs.mpv-unwrapped {
           scripts = [ pkgs.mpvScripts.simple-mpv-webui ];
         })
       ];

--- a/nixos/tests/mysql/mariadb-galera-mariabackup.nix
+++ b/nixos/tests/mysql/mariadb-galera-mariabackup.nix
@@ -4,6 +4,16 @@ let
   mysqlenv-common      = pkgs.buildEnv { name = "mysql-path-env-common";      pathsToLink = [ "/bin" ]; paths = with pkgs; [ bash gawk gnutar inetutils which ]; };
   mysqlenv-mariabackup = pkgs.buildEnv { name = "mysql-path-env-mariabackup"; pathsToLink = [ "/bin" ]; paths = with pkgs; [ gzip iproute2 netcat procps pv socat ]; };
 
+  # Common user configuration
+  users = { ... }:
+  {
+    users.users.testuser = {
+      isSystemUser = true;
+      group = "testusers";
+    };
+    users.groups.testusers = { };
+  };
+
 in {
   name = "mariadb-galera-mariabackup";
   meta = with pkgs.lib.maintainers; {
@@ -17,6 +27,7 @@ in {
     galera_01 =
       { pkgs, ... }:
       {
+      imports = [ users ];
       networking = {
         interfaces.eth1 = {
           ipv4.addresses = [
@@ -31,7 +42,6 @@ in {
         firewall.allowedTCPPorts = [ 3306 4444 4567 4568 ];
         firewall.allowedUDPPorts = [ 4567 ];
       };
-      users.users.testuser = { isSystemUser = true; };
       systemd.services.mysql = with pkgs; {
         path = [ mysqlenv-common mysqlenv-mariabackup ];
       };
@@ -75,6 +85,7 @@ in {
     galera_02 =
       { pkgs, ... }:
       {
+      imports = [ users ];
       networking = {
         interfaces.eth1 = {
           ipv4.addresses = [
@@ -89,7 +100,6 @@ in {
         firewall.allowedTCPPorts = [ 3306 4444 4567 4568 ];
         firewall.allowedUDPPorts = [ 4567 ];
       };
-      users.users.testuser = { isSystemUser = true; };
       systemd.services.mysql = with pkgs; {
         path = [ mysqlenv-common mysqlenv-mariabackup ];
       };
@@ -122,6 +132,7 @@ in {
     galera_03 =
       { pkgs, ... }:
       {
+      imports = [ users ];
       networking = {
         interfaces.eth1 = {
           ipv4.addresses = [
@@ -136,7 +147,6 @@ in {
         firewall.allowedTCPPorts = [ 3306 4444 4567 4568 ];
         firewall.allowedUDPPorts = [ 4567 ];
       };
-      users.users.testuser = { isSystemUser = true; };
       systemd.services.mysql = with pkgs; {
         path = [ mysqlenv-common mysqlenv-mariabackup ];
       };

--- a/nixos/tests/mysql/mariadb-galera-rsync.nix
+++ b/nixos/tests/mysql/mariadb-galera-rsync.nix
@@ -4,6 +4,16 @@ let
   mysqlenv-common      = pkgs.buildEnv { name = "mysql-path-env-common";      pathsToLink = [ "/bin" ]; paths = with pkgs; [ bash gawk gnutar inetutils which ]; };
   mysqlenv-rsync       = pkgs.buildEnv { name = "mysql-path-env-rsync";       pathsToLink = [ "/bin" ]; paths = with pkgs; [ lsof procps rsync stunnel ]; };
 
+  # Common user configuration
+  users = { ... }:
+  {
+    users.users.testuser = {
+      isSystemUser = true;
+      group = "testusers";
+    };
+    users.groups.testusers = { };
+  };
+
 in {
   name = "mariadb-galera-rsync";
   meta = with pkgs.lib.maintainers; {
@@ -17,6 +27,7 @@ in {
     galera_04 =
       { pkgs, ... }:
       {
+      imports = [ users ];
       networking = {
         interfaces.eth1 = {
           ipv4.addresses = [
@@ -31,7 +42,6 @@ in {
         firewall.allowedTCPPorts = [ 3306 4444 4567 4568 ];
         firewall.allowedUDPPorts = [ 4567 ];
       };
-      users.users.testuser = { isSystemUser = true; };
       systemd.services.mysql = with pkgs; {
         path = [ mysqlenv-common mysqlenv-rsync ];
       };
@@ -70,6 +80,7 @@ in {
     galera_05 =
       { pkgs, ... }:
       {
+      imports = [ users ];
       networking = {
         interfaces.eth1 = {
           ipv4.addresses = [
@@ -84,7 +95,6 @@ in {
         firewall.allowedTCPPorts = [ 3306 4444 4567 4568 ];
         firewall.allowedUDPPorts = [ 4567 ];
       };
-      users.users.testuser = { isSystemUser = true; };
       systemd.services.mysql = with pkgs; {
         path = [ mysqlenv-common mysqlenv-rsync ];
       };
@@ -116,6 +126,7 @@ in {
     galera_06 =
       { pkgs, ... }:
       {
+      imports = [ users ];
       networking = {
         interfaces.eth1 = {
           ipv4.addresses = [
@@ -130,7 +141,6 @@ in {
         firewall.allowedTCPPorts = [ 3306 4444 4567 4568 ];
         firewall.allowedUDPPorts = [ 4567 ];
       };
-      users.users.testuser = { isSystemUser = true; };
       systemd.services.mysql = with pkgs; {
         path = [ mysqlenv-common mysqlenv-rsync ];
       };

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -1,4 +1,26 @@
-import ./../make-test-python.nix ({ pkgs, ...} : {
+import ./../make-test-python.nix ({ pkgs, ...}:
+
+
+let
+  # Setup common users
+  users = { ... }:
+  {
+    users.groups.testusers = { };
+
+    users.users.testuser = {
+      isSystemUser = true;
+      group = "testusers";
+    };
+
+    users.users.testuser2 = {
+      isSystemUser = true;
+      group = "testusers";
+    };
+  };
+
+in
+
+{
   name = "mysql";
   meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco shlevy ];
@@ -9,8 +31,8 @@ import ./../make-test-python.nix ({ pkgs, ...} : {
       { pkgs, ... }:
 
       {
-        users.users.testuser = { isSystemUser = true; };
-        users.users.testuser2 = { isSystemUser = true; };
+        imports = [ users ];
+
         services.mysql.enable = true;
         services.mysql.initialDatabases = [
           { name = "testdb3"; schema = ./testdb.sql; }
@@ -40,12 +62,12 @@ import ./../make-test-python.nix ({ pkgs, ...} : {
       { pkgs, ... }:
 
       {
+        imports = [ users ];
+
         # prevent oom:
         # Kernel panic - not syncing: Out of memory: compulsory panic_on_oom is enabled
         virtualisation.memorySize = 1024;
 
-        users.users.testuser = { isSystemUser = true; };
-        users.users.testuser2 = { isSystemUser = true; };
         services.mysql.enable = true;
         services.mysql.initialDatabases = [
           { name = "testdb3"; schema = ./testdb.sql; }
@@ -75,8 +97,8 @@ import ./../make-test-python.nix ({ pkgs, ...} : {
       { pkgs, ... }:
 
       {
-        users.users.testuser = { isSystemUser = true; };
-        users.users.testuser2 = { isSystemUser = true; };
+        imports = [ users ];
+
         services.mysql.enable = true;
         services.mysql.initialScript = pkgs.writeText "mariadb-init.sql" ''
           ALTER USER root@localhost IDENTIFIED WITH unix_socket;

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ pkgs, ...} :
+import ./make-test-python.nix ({ pkgs, lib, ...} :
 
 {
   name = "pantheon";

--- a/nixos/tests/postfixadmin.nix
+++ b/nixos/tests/postfixadmin.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "postfixadmin";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ globin ];
   };
 

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -554,7 +554,11 @@ let
             WorkingDirectory = "/var/spool/mail";
           };
         };
-        users.users.mailexporter.isSystemUser = true;
+        users.users.mailexporter = {
+          isSystemUser = true;
+          group = "mailexporter";
+        };
+        users.groups.mailexporter = {};
       };
       exporterTest = ''
         wait_for_unit("postfix.service")

--- a/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
+++ b/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
@@ -42,6 +42,8 @@ import ./make-test-python.nix ({pkgs, ...}: {
       # DO NOT COPY THIS TO PRODUCTION AS IS. Think about it at least twice.
       # Everyone on the "isp" machine will be able to add routes to the kernel.
       security.wrappers.add-dhcpd-lease = {
+        owner = "root";
+        group = "root";
         source = pkgs.writeShellScript "add-dhcpd-lease" ''
           exec ${pkgs.iproute2}/bin/ip -6 route replace "$1" via "$2"
         '';

--- a/nixos/tests/tigervnc.nix
+++ b/nixos/tests/tigervnc.nix
@@ -6,7 +6,7 @@
 with import ../lib/testing-python.nix { inherit system pkgs; };
 makeTest {
   name = "tigervnc";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lheckemann ];
   };
 

--- a/nixos/tests/wasabibackend.nix
+++ b/nixos/tests/wasabibackend.nix
@@ -14,7 +14,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
           port = 18332;
         };
       };
-      services.bitcoind = {
+      services.bitcoind."testnet" = {
         enable = true;
         testnet = true;
         rpc.users = {


### PR DESCRIPTION
###### Motivation for this change

A cleaner hydra-eval-jobs output.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

You can get a list of mostly relevant errors with

```shell
curl -s https://hydra.nixos.org/jobset/nixos/trunk-combined | \
  tail -n +221 | \
  head -n -212 | \
  sed \
    -e '/insecure, refusing to evaluate./,+32d' \
    -e '/as broken, refusing to evaluate./,+13d' \
    -e '/unfree license.\+refusing to evaluate./,+19d' \
    -e '/is not supported on /,+13d' \
    -e '/Failed to evaluate.\+unfree\|broken\|insecure/d' \
    -e '/warning: error: SQLite database/d' \
    -e '/android-sdk-license/,+143d' \
    -e '/not supported for interpreter/d' \
    >  clean-log
```
