### PR TITLE
upx: disable blanket -Werror (fix gcc-11 build)

### DIFF
--- a/pkgs/tools/compression/upx/default.nix
+++ b/pkgs/tools/compression/upx/default.nix
@@ -8,15 +8,19 @@ stdenv.mkDerivation rec {
     sha256 = "051pk5jk8fcfg5mpgzj43z5p4cn7jy5jbyshyn78dwjqr7slsxs7";
   };
 
-  CXXFLAGS = "-Wno-unused-command-line-argument";
-
   buildInputs = [ ucl zlib perl ];
 
   preConfigure = ''
     export UPX_UCLDIR=${ucl}
   '';
 
-  makeFlags = [ "-C" "src" "CHECK_WHITESPACE=true" ];
+  makeFlags = [
+    "-C" "src"
+    "CHECK_WHITESPACE=true"
+
+    # Disable blanket -Werror. Triggers failues on minor gcc-11 warnings.
+    "CXXFLAGS_WERROR="
+  ];
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
On gcc-11 build fails as:

```
$ nix-build -E 'with import ./.{}; upx.override { stdenv = gcc11Stdenv; }'
...
  ./../src/lzma-sdk/C/7zip/Compress/LZMA/../../../Common/MyCom.h:159:32:
    error: this 'if' clause does not guard... [-Werror=misleading-indentation]
  159 | STDMETHOD_(ULONG, Release)() { if (--__m_RefCount != 0)  \
      |                                ^~
```
