### PR TITLE
python3Packages.parts: 1.0.3 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/bitlist/default.nix
+++ b/pkgs/development/python-modules/bitlist/default.nix
@@ -24,6 +24,11 @@ buildPythonPackage rec {
     nose
   ];
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "parts~=1.0.3" "parts>=1.0.3"
+  '';
+
   pythonImportsCheck = [ "bitlist" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/parts/default.nix
+++ b/pkgs/development/python-modules/parts/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "parts";
-  version = "1.0.3";
+  version = "1.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a4137612bc050f606b4d6f9e6a554ebfb50633c8dd9699481f82271f84d9425f";
+    sha256 = "sha256-Xtcu/0ZO+6L7RiVfq/Jog4f7LOtZo4QUD1qi7UdPO7g=";
   };
 
   # Project has no tests


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
