### PR TITLE
python3Packages.pyspnego: 0.1.6 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/pyspnego/default.nix
+++ b/pkgs/development/python-modules/pyspnego/default.nix
@@ -2,6 +2,9 @@
 , buildPythonPackage
 , cryptography
 , fetchFromGitHub
+, gssapi
+, krb5
+, ruamel-yaml
 , pytest-mock
 , pytestCheckHook
 , pythonOlder
@@ -10,24 +13,33 @@
 
 buildPythonPackage rec {
   pname = "pyspnego";
-  version = "0.1.6";
-  disabled = pythonOlder "3.6";
+  version = "0.2.0";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "jborean93";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0pfh2x0539f0k2qi2pbjm64b2fqp64c63xxpinvg1yfaw915kgpb";
+    sha256 = "sha256-puv9aq53NbjSuN561XFou404N9pIxvvMjZMgnNx3SjM=";
   };
 
   propagatedBuildInputs = [
     cryptography
+    gssapi
+    krb5
+    ruamel-yaml
   ];
 
   checkInputs = [
     glibcLocales
     pytest-mock
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # struct.error: unpack requires a buffer of 1 bytes
+    "test_credssp_invalid_client_authentication"
   ];
 
   LC_ALL = "en_US.UTF-8";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.2.0

Change log: https://github.com/jborean93/pyspnego/releases/tag/v0.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
