### PR TITLE
python3Packages.wsgiprox: init at 1.5.2

### DIFF
--- a/pkgs/development/python-modules/wsgiprox/default.nix
+++ b/pkgs/development/python-modules/wsgiprox/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, six
+, certauth
+}:
+
+buildPythonPackage rec {
+  pname = "wsgiprox";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "webrecorder";
+    repo = "wsgiprox";
+    # https://github.com/webrecorder/wsgiprox/issues/8
+    rev = "004870a87959e68ff28ff4362e4f0df28ec22030";
+    sha256 = "sha256-EquddaNrVceyJHuQMCajKHGZX2Q7ebR0Zhvi2pl2WEw=";
+  };
+
+  propagatedBuildInputs = [
+    six
+    certauth
+  ];
+
+  pythonImportsCheck = [ "wsgiprox" ];
+
+  # See https://github.com/webrecorder/wsgiprox/issues/6
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python WSGI Middleware for adding HTTP/S proxy support to any WSGI Application";
+    homepage = "https://github.com/webrecorder/wsgiprox";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9579,6 +9579,8 @@ in {
 
   wsgi-intercept = callPackage ../development/python-modules/wsgi-intercept { };
 
+  wsgiprox = callPackage ../development/python-modules/wsgiprox { };
+
   wsgiproxy2 = callPackage ../development/python-modules/wsgiproxy2 { };
 
   wsgitools = callPackage ../development/python-modules/wsgitools { };


### PR DESCRIPTION
###### Motivation for this change
This is a dependency of warcio, which I plan to add in the future.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).