### PR TITLE
cambalache: init at 0.8.0

### DIFF
--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -202,6 +202,9 @@ stdenv.mkDerivation rec {
     for f in $dev/bin/gtk4-encode-symbolic-svg; do
       wrapProgram $f --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
     done
+  '' + lib.optionalString broadwaySupport ''
+    # Broadway daemon
+    moveToOutput bin/gtk4-broadwayd "$out"
   '';
 
   # Wrap demos

--- a/pkgs/development/tools/cambalache/default.nix
+++ b/pkgs/development/tools/cambalache/default.nix
@@ -1,0 +1,96 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, python3
+, meson
+, ninja
+, pkg-config
+, gobject-introspection
+, desktop-file-utils
+, shared-mime-info
+, wrapGAppsHook
+, glib
+, gtk3
+, gtk4
+, webkitgtk
+, nix-update-script
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "cambalache";
+  version = "0.8.2";
+
+  format = "other";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "jpu";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-1+IoBoaNHwvN8W+KRyV5cTFkFG+pTHJBehQ2VosCEfs=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection # for setup hook
+    desktop-file-utils # for update-desktop-database
+    shared-mime-info # for update-mime-database
+    wrapGAppsHook
+  ];
+
+  pythonPath = with python3.pkgs; [
+    pygobject3
+    lxml
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    gtk4
+    webkitgtk
+  ];
+
+  # Not compatible with gobject-introspection setup hooks.
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  # Prevent double wrapping.
+  dontWrapGApps = true;
+
+  postPatch = ''
+    patchShebangs postinstall.py
+  '';
+
+  preFixup = ''
+    # Let python wrapper use GNOME flags.
+    makeWrapperArgs+=(
+      # For broadway daemons
+      --prefix PATH : "${lib.makeBinPath [ gtk3 gtk4 ]}"
+      "''${gappsWrapperArgs[@]}"
+    )
+  '';
+
+  postFixup = ''
+    # Wrap a helper script in an unusual location.
+    wrapPythonProgramsIn "$out/${python3.sitePackages}/cambalache/priv/merengue" "$out $pythonPath"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://gitlab.gnome.org/jpu/cambalache";
+    description = "RAD tool for GTK 4 and 3 with data model first philosophy";
+    maintainers = teams.gnome.members;
+    license = with licenses; [
+      lgpl21Only # Cambalache
+      gpl2Only # tools
+    ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2759,6 +2759,8 @@ with pkgs;
 
   ydotool = callPackage ../tools/wayland/ydotool { };
 
+  cambalache = callPackage ../development/tools/cambalache { };
+
   clipster = callPackage ../tools/misc/clipster { };
 
   clockify = callPackage ../applications/office/clockify {


### PR DESCRIPTION
###### Motivation for this change
UI designer for GTK 3 & 4 (sort of like Glade):

https://gitlab.gnome.org/jpu/cambalache

- [x] GTK 3 works but GTK 4 currently does not and no errors are logged, needs debugging. https://gitlab.gnome.org/jpu/cambalache/-/issues/28
- [x] MIME declarations (`$out/share/mime/`) are required for filters in „Open project“ dialogue, can we add them to XDG_DATA_DIRS or something – turns out it is a bug https://gitlab.gnome.org/jpu/cambalache/-/merge_requests/7
- [x] Opening projects is broken on main branch https://gitlab.gnome.org/jpu/cambalache/-/issues/29
- [x] GTK 4’s Broadway daemon should be moved out of `dev` output to reduce runtime closure.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
