### PR TITLE
Backport 137264 to release 21.05

### DIFF
--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -1,5 +1,5 @@
 { python3Packages, fetchurl, lib,
-  yubikey-personalization, libu2f-host, libusb1 }:
+  yubikey-personalization, libu2f-host, libusb1, procps }:
 
 python3Packages.buildPythonPackage rec {
   pname = "yubikey-manager";
@@ -9,6 +9,11 @@ python3Packages.buildPythonPackage rec {
     url = "https://developers.yubico.com/${pname}/Releases/${pname}-${version}.tar.gz";
     hash = "sha256-OxbKo5vwOBabU6/2hO4RMWiifo4IVIxz+DlcwP9xO/E=";
   };
+
+  postPatch = ''
+    substituteInPlace "ykman/pcsc/__init__.py" \
+      --replace '/usr/bin/pkill' '${procps}/bin/pkill'
+  '';
 
   propagatedBuildInputs =
     with python3Packages; [


### PR DESCRIPTION
###### Motivation for this change

There was a conflict and the [automatic cherry-picking failed](https://github.com/NixOS/nixpkgs/pull/137264#issuecomment-916868117).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
