### PR TITLE
python3Packages.syslog-rfc5424-formatter: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
+++ b/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "syslog-rfc5424-formatter";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "easypost";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "17ym5ls5r6dd9pg9frdz8myfq5fxyqlwdq1gygc9vnrxbgw2c9kb";
+  };
+
+  # Tests are not picked up, review later again
+  doCheck = false;
+
+  pythonImportsCheck = [ "syslog_rfc5424_formatter" ];
+
+  meta = with lib; {
+    description = "Python logging formatter for emitting RFC5424 Syslog messages";
+    homepage = "https://github.com/easypost/syslog-rfc5424-formatter";
+    license = with licenses; [ isc ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8704,6 +8704,8 @@ in {
 
   synologydsm-api = callPackage ../development/python-modules/synologydsm-api { };
 
+  syslog-rfc5424-formatter = callPackage ../development/python-modules/syslog-rfc5424-formatter { };
+
   systembridge = callPackage ../development/python-modules/systembridge { };
 
   systemd = callPackage ../development/python-modules/systemd {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python logging formatter for emitting RFC5424 Syslog messages

https://github.com/easypost/syslog-rfc5424-formatter

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
