### PR TITLE
glibcLocales: Fix build for duplicates in locales list

### DIFF
--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -34,9 +34,9 @@ callPackage ./common.nix { inherit stdenv; } {
       + lib.optionalString (!allLocales) ''
       # Check that all locales to be built are supported
       echo -n '${lib.concatMapStrings (s: s + " \\\n") locales}' \
-        | sort > locales-to-build.txt
+        | sort -u > locales-to-build.txt
       cat ../glibc-2*/localedata/SUPPORTED | grep ' \\' \
-        | sort > locales-supported.txt
+        | sort -u > locales-supported.txt
       comm -13 locales-supported.txt locales-to-build.txt \
         > locales-unsupported.txt
       if [[ $(wc -c locales-unsupported.txt) != "0 locales-unsupported.txt" ]]; then


### PR DESCRIPTION
###### Motivation for this change

Without this patch, setting the same locale twice, e.g. like this in
NixOS:

```nix
{
  i18n.supportedLocales = [
    (config.i18n.defaultLocale + "/UTF-8")
    (config.i18n.defaultLocale + "/UTF-8")
  ];
}
```

Would make the glibcLocales build fail with

```
Error: unsupported locales detected:
en_US.UTF-8/UTF-8 \
You should choose from the list above the error.
```

Ping @Mic92 @Ericson2314 @vcunat 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
