### PR TITLE
nss modules: better non-nixos support

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1057,6 +1057,36 @@ Superuser created successfully.
       </listitem>
       <listitem>
         <para>
+          NSS modules are now globally provided (by a
+          <literal>/run/nss-modules</literal> symlink), similar to how
+          we handle OpenGL drivers.
+        </para>
+        <para>
+          This removes the need for nscd as a proxy for all NSS
+          requests, and avoids DNS requests leaking across network
+          namespaces.
+        </para>
+        <para>
+          While doing this upgrade, existing applications need to be
+          restarted, so they know how to pick up NSS modules from
+          <literal>/run/nss-modules/lib</literal>.
+        </para>
+        <para>
+          If you want to defer application restart to a later time,
+          explicitly enable <literal>nscd</literal> via
+          <literal>services.nscd.enable</literal> until the application
+          restarts.
+        </para>
+        <para>
+          We can mix NSS modules from any version of glibc according to
+          https://sourceware.org/legacy-ml/libc-help/2016-12/msg00008.html,
+          so future glibc upgrades shouldn’t break old userland loading
+          more recent NSS modules (and most likely, NSS modules are
+          already loaded)
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The
           <link xlink:href="options.html#opt-networking.wireless.iwd.enable">networking.wireless.iwd</link>
           module has a new

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1058,7 +1058,7 @@ Superuser created successfully.
       <listitem>
         <para>
           NSS modules are now globally provided (by a
-          <literal>/run/nss-modules</literal> symlink), similar to how
+          <literal>/nix/var/nix/profiles/system/sw/lib/</literal> symlink), similar to how
           we handle OpenGL drivers.
         </para>
         <para>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -307,6 +307,23 @@ To be able to access the web UI this port needs to be opened in the firewall.
     `myhostname`, but before `dns` should use the default priority
   - NSS modules which should come after `dns` should use mkAfter.
 
+- NSS modules are now globally provided (by a `/run/nss-modules` symlink),
+  similar to how we handle OpenGL drivers.
+
+  This removes the need for nscd as a proxy for all NSS requests, and avoids
+  DNS requests leaking across network namespaces.
+
+  While doing this upgrade, existing applications need to be restarted, so
+  they know how to pick up NSS modules from `/run/nss-modules/lib`.
+
+  If you want to defer application restart to a later time, explicitly enable
+  `nscd` via `services.nscd.enable` until the application restarts.
+
+  We can mix NSS modules from any version of glibc according to
+  https://sourceware.org/legacy-ml/libc-help/2016-12/msg00008.html,
+  so future glibc upgrades shouldn't break old userland loading more recent NSS
+  modules (and most likely, NSS modules are already loaded)
+
 - The [networking.wireless.iwd](options.html#opt-networking.wireless.iwd.enable) module has a new [networking.wireless.iwd.settings](options.html#opt-networking.wireless.iwd.settings) option.
 
 - The [services.syncoid.enable](options.html#opt-services.syncoid.enable) module now properly drops ZFS permissions after usage. Before it delegated permissions to whole pools instead of datasets and didn't clean up after execution. You can manually look this up for your pools by running `zfs allow your-pool-name` and use `zfs unallow syncoid your-pool-name` to clean this up.

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -14,14 +14,18 @@ with lib;
       internal = true;
       default = [];
       description = ''
-        Search path for NSS (Name Service Switch) modules.  This allows
-        several DNS resolution methods to be specified via
+        Path containing NSS (Name Service Switch) modules.
+        This allows several DNS resolution methods to be specified via
         <filename>/etc/nsswitch.conf</filename>.
       '';
       apply = list:
         {
           inherit list;
-          path = makeLibraryPath list;
+          path = pkgs.symlinkJoin
+            {
+              name = "nss-modules";
+              paths = list;
+            } + "/lib";
         };
     };
 

--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -33,9 +33,6 @@ let
       ${smbToString (map shareConfig (attrNames cfg.shares))}
     '');
 
-  # This may include nss_ldap, needed for samba if it has to use ldap.
-  nssModulesPath = config.system.nssModules.path;
-
   daemonService = appName: args:
     { description = "Samba Service Daemon ${appName}";
 
@@ -44,7 +41,6 @@ let
       partOf = [ "samba.target" ];
 
       environment = {
-        LD_LIBRARY_PATH = nssModulesPath;
         LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
       };
 

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -264,10 +264,6 @@ in
       wantedBy = [ "multi-user.target" ];
       requires = [ "avahi-daemon.socket" ];
 
-      # Make NSS modules visible so that `avahi_nss_support ()' can
-      # return a sensible value.
-      environment.LD_LIBRARY_PATH = config.system.nssModules.path;
-
       path = [ pkgs.coreutils pkgs.avahi ];
 
       serviceConfig = {

--- a/nixos/modules/services/networking/ssh/lshd.nix
+++ b/nixos/modules/services/networking/ssh/lshd.nix
@@ -137,10 +137,6 @@ in
 
       wantedBy = [ "multi-user.target" ];
 
-      environment = {
-        LD_LIBRARY_PATH = config.system.nssModules.path;
-      };
-
       preStart = ''
         test -d /etc/lsh || mkdir -m 0755 -p /etc/lsh
         test -d /var/spool/lsh || mkdir -m 0755 -p /var/spool/lsh

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -24,8 +24,6 @@ let
   cfg  = config.services.openssh;
   cfgc = config.programs.ssh;
 
-  nssModulesPath = config.system.nssModules.path;
-
   userOptions = {
 
     options.openssh.authorizedKeys = {
@@ -421,7 +419,6 @@ in
             after = [ "network.target" ];
             stopIfChanged = false;
             path = [ cfgc.package pkgs.gawk ];
-            environment.LD_LIBRARY_PATH = nssModulesPath;
 
             restartTriggers = optionals (!cfg.startWhenNeeded) [
               config.environment.etc."ssh/sshd_config".source

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -122,7 +122,6 @@ in
       # Don't restart dbus-daemon. Bad things tend to happen if we do.
       reloadIfChanged = true;
       restartTriggers = [ configDir ];
-      environment = { LD_LIBRARY_PATH = config.system.nssModules.path; };
     };
 
     systemd.user = {

--- a/nixos/modules/services/system/nscd.conf
+++ b/nixos/modules/services/system/nscd.conf
@@ -1,11 +1,3 @@
-# We basically use nscd as a proxy for forwarding nss requests to appropriate
-# nss modules, as we run nscd with LD_LIBRARY_PATH set to the directory
-# containing all such modules
-# Note that we can not use `enable-cache no` As this will actually cause nscd
-# to just reject the nss requests it receives, which then causes glibc to
-# fallback to trying to handle the request by itself. Which won't work as glibc
-# is not aware of the path in which the nss modules live.  As a workaround, we
-# have `enable-cache yes` with an explicit ttl of 0
 server-user             nscd
 
 enable-cache            passwd          yes

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -4,7 +4,6 @@ with lib;
 
 let
 
-  nssModulesPath = config.system.nssModules.path;
   cfg = config.services.nscd;
 
   nscd = if pkgs.stdenv.hostPlatform.libc == "glibc"
@@ -23,11 +22,9 @@ in
 
       enable = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           Whether to enable the Name Service Cache Daemon.
-          Disabling this is strongly discouraged, as this effectively disables NSS Lookups
-          from all non-glibc NSS modules, including the ones provided by systemd.
         '';
       };
 
@@ -48,11 +45,10 @@ in
     environment.etc."nscd.conf".text = cfg.config;
 
     systemd.services.nscd =
-      { description = "Name Service Cache Daemon";
+      {
+        description = "Name Service Cache Daemon";
 
         wantedBy = [ "nss-lookup.target" "nss-user-lookup.target" ];
-
-        environment = { LD_LIBRARY_PATH = nssModulesPath; };
 
         restartTriggers = [
           config.environment.etc.hosts.source
@@ -67,14 +63,16 @@ in
         # files. So prefix the ExecStart command with "!" to prevent systemd
         # from dropping privileges early. See ExecStart in systemd.service(5).
         serviceConfig =
-          { ExecStart = "!@${nscd}/sbin/nscd nscd";
+          {
+            ExecStart = "!@${nscd}/sbin/nscd nscd";
             Type = "forking";
             DynamicUser = true;
             RuntimeDirectory = "nscd";
             PIDFile = "/run/nscd/nscd.pid";
             Restart = "always";
             ExecReload =
-              [ "${nscd}/sbin/nscd --invalidate passwd"
+              [
+                "${nscd}/sbin/nscd --invalidate passwd"
                 "${nscd}/sbin/nscd --invalidate group"
                 "${nscd}/sbin/nscd --invalidate hosts"
               ];

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -138,7 +138,6 @@ in
 
     users.users.systemd-resolve.group = "systemd-resolve";
 
-    # add resolve to nss hosts database if enabled and nscd enabled
     # system.nssModules is configured in nixos/modules/system/boot/systemd.nix
     # added with order 501 to allow modules to go before with mkBefore
     system.nssDatabases.hosts = (mkOrder 501 ["resolve [!UNAVAIL=return]"]);

--- a/nixos/tests/resolv.nix
+++ b/nixos/tests/resolv.nix
@@ -29,7 +29,6 @@ import ./make-test-python.nix ({ pkgs, ... } : {
 
 
     start_all()
-    resolv.wait_for_unit("nscd")
 
     ipv4 = ["192.0.2.1", "192.0.2.2"]
     ipv6 = ["2001:db8::2:1", "2001:db8::2:2"]

--- a/pkgs/development/libraries/glibc/0001-nss_module.c-try-loading-NSS-modules-from-run-nss-mo.patch
+++ b/pkgs/development/libraries/glibc/0001-nss_module.c-try-loading-NSS-modules-from-run-nss-mo.patch
@@ -1,0 +1,51 @@
+From 65a211ee3604733dceba13062f956256a573f27c Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Sun, 19 Sep 2021 13:26:33 +0200
+Subject: [PATCH] nss_module.c: try loading NSS modules from /run/nss-modules
+ as a fallback
+
+Previously, glibc only looked for NSS modules in ${glibc.out}/lib
+and LD_LIBRARY_PATH.
+
+LD_LIBRARY_PATH is very invasive, so we don't want to set that globally
+on NixOS. We previously worked around this by running nscd with
+LD_LIBRARY_PATH set, but nscd has some caching issues, and leaks DNS
+requests across network namespaces, so it's cleaner to have glibc look
+for NSS modules in an additional path that's provided by NixOS.
+
+On non-NixOS distributions, this shouldn't change behaviour, as the path
+doesn't exist there.
+---
+ nss/nss_module.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/nss/nss_module.c b/nss/nss_module.c
+index 6c5f341f..44cfc2a4 100644
+--- a/nss/nss_module.c
++++ b/nss/nss_module.c
+@@ -133,6 +133,22 @@ module_load (struct nss_module *module)
+       return false;
+ 
+     handle = __libc_dlopen (shlib_name);
++
++    /* After loading from the default locations, try loading from
++       /run/nss-modules, to allow loading NixOS-provided NSS modules. */
++    if(handle == NULL)
++      {
++        const char *nix_glibc_nss_path = "/run/nss-modules/lib/";
++        char shlib_path[1024];
++        size_t shlib_pathlen = strlen(nix_glibc_nss_path) + strlen(shlib_name);
++
++        if (shlib_pathlen < sizeof (shlib_path))
++          {
++            __stpcpy (__stpcpy (&shlib_path[0], nix_glibc_nss_path), shlib_name);
++            handle = __libc_dlopen (shlib_path);
++          }
++      }
++
+     free (shlib_name);
+   }
+ 
+-- 
+2.32.0
+

--- a/pkgs/development/libraries/glibc/0001-nss_module.c-try-loading-NSS-modules-from-run-nss-mo.patch
+++ b/pkgs/development/libraries/glibc/0001-nss_module.c-try-loading-NSS-modules-from-run-nss-mo.patch
@@ -1,7 +1,7 @@
 From 65a211ee3604733dceba13062f956256a573f27c Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sun, 19 Sep 2021 13:26:33 +0200
-Subject: [PATCH] nss_module.c: try loading NSS modules from /run/nss-modules
+Subject: [PATCH] nss_module.c: try loading NSS modules from /nix/var/nix/profiles/system/sw/lib/
  as a fallback
 
 Previously, glibc only looked for NSS modules in ${glibc.out}/lib
@@ -32,7 +32,7 @@ index 6c5f341f..44cfc2a4 100644
 +       /run/nss-modules, to allow loading NixOS-provided NSS modules. */
 +    if(handle == NULL)
 +      {
-+        const char *nix_glibc_nss_path = "/run/nss-modules/lib/";
++        const char *nix_glibc_nss_path = "/nix/var/nix/profiles/system/sw/lib/";
 +        char shlib_path[1024];
 +        size_t shlib_pathlen = strlen(nix_glibc_nss_path) + strlen(shlib_name);
 +

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -120,6 +120,8 @@ stdenv.mkDerivation ({
       })
 
       ./fix-x64-abi.patch
+
+      ./0001-nss_module.c-try-loading-NSS-modules-from-run-nss-mo.patch
     ]
     ++ lib.optional stdenv.hostPlatform.isMusl ./fix-rpc-types-musl-conflicts.patch
     ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is WIP to discuss a better path for https://github.com/NixOS/nixpkgs/pull/138178/files
as flokli wants to rush with https://github.com/NixOS/nixpkgs/pull/138178 getting being merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
