### PR TITLE
ledger-live-desktop: fix libudev handling in fhs-env

### DIFF
--- a/pkgs/applications/blockchains/ledger-live-desktop/systemd.patch
+++ b/pkgs/applications/blockchains/ledger-live-desktop/systemd.patch
@@ -1,0 +1,14 @@
+diff --git a/src/libsystemd/sd-device/device-monitor.c b/src/libsystemd/sd-device/device-monitor.c
+index fd5900704d..f9106fdbe5 100644
+--- a/src/libsystemd/sd-device/device-monitor.c
++++ b/src/libsystemd/sd-device/device-monitor.c
+@@ -445,9 +445,6 @@ int device_monitor_receive_device(sd_device_monitor *m, sd_device **ret) {
+                                        "sd-device-monitor: No sender credentials received, message ignored.");
+ 
+         cred = (struct ucred*) CMSG_DATA(cmsg);
+-        if (cred->uid != 0)
+-                return log_debug_errno(SYNTHETIC_ERRNO(EAGAIN),
+-                                       "sd-device-monitor: Sender uid="UID_FMT", message ignored.", cred->uid);
+
+         if (streq(buf.raw, "libudev")) {
+                 /* udev message needs proper version magic */


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #116361.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
