### PR TITLE
terraform-providers.teleport: init at 7.3.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -57,6 +57,7 @@ let
     libvirt = callPackage ./libvirt { };
     linuxbox = callPackage ./linuxbox { };
     lxd = callPackage ./lxd { };
+    teleport = callPackage ./teleport { };
     vpsadmin = callPackage ./vpsadmin { };
     vercel = callPackage ./vercel { };
   } // (lib.optionalAttrs (config.allowAliases or false) {

--- a/pkgs/applications/networking/cluster/terraform-providers/teleport/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/teleport/default.nix
@@ -1,4 +1,5 @@
 { lib, fetchFromGitHub, buildGoModule }:
+
 buildGoModule rec {
   pname = "terraform-provider-teleport";
   version = "7.3.0";

--- a/pkgs/applications/networking/cluster/terraform-providers/teleport/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/teleport/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+buildGoModule rec {
+  pname = "terraform-provider-teleport";
+  version = "7.3.0";
+
+  src = fetchFromGitHub {
+    owner = "gravitational";
+    repo = "teleport-plugins";
+    rev = "v${version}";
+    sha256 = "19zn78nn64gc0nm7ycblzi4549a0asql07pfxvrphi6s9fjr5m3y";
+  };
+  vendorSha256 = null;
+
+  sourceRoot = "source/terraform";
+
+  # Terraform allow checking the provider versions, but this breaks
+  # if the versions are not provided via file paths.
+  postBuild = ''
+    mv $NIX_BUILD_TOP/go/bin/{terraform,terraform-provider-teleport_v${version}}
+  '';
+
+  passthru.provider-source-address = "gravitational.com/teleport/teleport";
+
+  meta = with lib; {
+    description = "Provider for managing resources in Teleport, a SSH CA management suite";
+    homepage = "https://github.com/gravitational/teleport-plugins";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ justinas ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Adding the [Teleport Terraform provider](https://goteleport.com/docs/setup/guides/terraform-provider/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
