### PR TITLE
grsync: 1.2.8 -> 1.3.0

### DIFF
--- a/pkgs/applications/misc/grsync/default.nix
+++ b/pkgs/applications/misc/grsync/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, fetchurl, dee, gtk2, intltool, libdbusmenu-gtk2, libunity, pkg-config, rsync }:
+{ lib, stdenv, fetchurl, dee, gtk3, intltool, libdbusmenu-gtk3, libunity, pkg-config, rsync }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.8";
+  version = "1.3.0";
   pname = "grsync";
 
   src = fetchurl {
     url = "mirror://sourceforge/grsync/grsync-${version}.tar.gz";
-    sha256 = "1c86jch73cy7ig9k4shvcd3jnaxk7jppfcr8nmkz8gbylsn5zsll";
+    sha256 = "sha256-t8fGpi4FMC2DF8OHQefXHvmrRjnuW/8mIqODsgQ6Nfw=";
   };
 
   nativeBuildInputs = [
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dee
-    gtk2
-    libdbusmenu-gtk2
+    gtk3
+    libdbusmenu-gtk3
     libunity
     rsync
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```
Version 1.3.0
	Gtk3 compatibility (some compile warnings left) (thanks Balló and Ganael)
	Removed Maemo support, platform is obsolete
	Added escaping of arguments containing spaces when printing rsync command line output
	Updated Spanish translation (thanks Charles)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
