### PR TITLE
illum: 0.4 -> 0.5

### DIFF
--- a/pkgs/tools/system/illum/default.nix
+++ b/pkgs/tools/system/illum/default.nix
@@ -1,18 +1,19 @@
-{ lib, stdenv, fetchgit, pkg-config, ninja, libevdev, libev }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, ninja, libevdev, libev, udev }:
 
-stdenv.mkDerivation {
-  version = "0.4";
+stdenv.mkDerivation rec {
   pname = "illum";
+  version = "0.5";
 
-  src = fetchgit {
-    url = "https://github.com/jmesmon/illum.git";
+  src = fetchFromGitHub {
+    owner = "jmesmon";
+    repo = "illum";
+    rev = "v${version}";
+    sha256 = "S4lUBeRnZlRUpIxFdN/bh979xvdS7roF6/6Dk0ZUrnM=";
     fetchSubmodules = true;
-    rev = "48ce8631346b1c88a901a8e4fa5fa7e8ffe8e418";
-    sha256 = "05v3hz7n6b1mlhc6zqijblh1vpl0ja1y8y0lafw7mjdz03wxhfdb";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ninja libevdev libev ];
+  buildInputs = [ ninja libevdev libev udev ];
 
   configurePhase = ''
     bash ./configure


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Recently,`illum` has been often breaking for me and I noticed there is a newer version (which I hope fixes the issue).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
