### PR TITLE
gd: 2.3.3 -> 2.3.2 + patch for partial CVE-2021-40812 fix

### DIFF
--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -14,25 +14,19 @@
 
 stdenv.mkDerivation rec {
   pname = "gd";
-  version = "2.3.0";
+  version = "2.3.2";
 
   src = fetchurl {
     url = "https://github.com/libgd/libgd/releases/download/${pname}-${version}/libgd-${version}.tar.xz";
-    sha256 = "0n5czhxzinvjvmhkf5l9fwjdx5ip69k5k7pj6zwb6zs1k9dibngc";
+    sha256 = "1yypywkh8vphcy4qqpf51kxpb0a3r7rjqk3fc61rpn70hiq092j7";
   };
 
   hardeningDisable = [ "format" ];
   patches = [
-    # Fixes an issue where some other packages would fail to build
-    # their documentation with an error like:
-    # "Error: Problem doing text layout"
-    #
-    # Can be removed if Wayland can still be built successfully with
-    # documentation.
     (fetchpatch {
-      url = "https://github.com/libgd/libgd/commit/3dd0e308cbd2c24fde2fc9e9b707181252a2de95.patch";
-      excludes = [ "tests/gdimagestringft/.gitignore" ];
-      sha256 = "12iqlanl9czig9d7c3rvizrigw2iacimnmimfcny392dv9iazhl1";
+      name = "CVE-2021-40812.partial.patch";
+      url = "https://github.com/libgd/libgd/commit/6f5136821be86e7068fcdf651ae9420b5d42e9a9.patch";
+      sha256 = "11rvhd23bl05ksj8z39hwrhqqjm66svr4hl3y230wrc64rvnd2d2";
     })
   ];
 

--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -14,14 +14,27 @@
 
 stdenv.mkDerivation rec {
   pname = "gd";
-  version = "2.3.3";
+  version = "2.3.0";
 
   src = fetchurl {
     url = "https://github.com/libgd/libgd/releases/download/${pname}-${version}/libgd-${version}.tar.xz";
-    sha256 = "0qas3q9xz3wgw06dm2fj0i189rain6n60z1vyq50d5h7wbn25s1z";
+    sha256 = "0n5czhxzinvjvmhkf5l9fwjdx5ip69k5k7pj6zwb6zs1k9dibngc";
   };
 
   hardeningDisable = [ "format" ];
+  patches = [
+    # Fixes an issue where some other packages would fail to build
+    # their documentation with an error like:
+    # "Error: Problem doing text layout"
+    #
+    # Can be removed if Wayland can still be built successfully with
+    # documentation.
+    (fetchpatch {
+      url = "https://github.com/libgd/libgd/commit/3dd0e308cbd2c24fde2fc9e9b707181252a2de95.patch";
+      excludes = [ "tests/gdimagestringft/.gitignore" ];
+      sha256 = "12iqlanl9czig9d7c3rvizrigw2iacimnmimfcny392dv9iazhl1";
+    })
+  ];
 
   # -pthread gets passed to clang, causing warnings
   configureFlags = lib.optional stdenv.isDarwin "--enable-werror=no";


### PR DESCRIPTION
###### Motivation for this change
2.3.3 breaks some php builds - see https://github.com/NixOS/nixpkgs/pull/138417#issuecomment-924456709

The patch for the partial https://nvd.nist.gov/vuln/detail/CVE-2021-40812 fix applies cleanly to 2.3.2 and is quite clearly still valid. `gd_bmp.c` hadn't even seen any other changes since 2.3.2.

This doesn't actually fix a vulnerability itself, but marked with `severity: security` because once this is merged I can backport it to make up for reverting the `staging-21.05` backport in #138851, and we can roll out the partial fix to stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
