### PR TITLE
vimpager: supply runtimeShell to Makefile

### DIFF
--- a/pkgs/tools/misc/vimpager/build.nix
+++ b/pkgs/tools/misc/vimpager/build.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , coreutils
 , sharutils
+, runtimeShell
 , version
 , sha256
 }:

--- a/pkgs/tools/misc/vimpager/latest.nix
+++ b/pkgs/tools/misc/vimpager/latest.nix
@@ -1,7 +1,10 @@
-{ callPackage }:
+{ callPackage, runtimeShell }:
 
-callPackage ./build.nix {
+(callPackage ./build.nix {
   version = "a4da4dfac44d1bbc6986c5c76fea45a60ebdd8e5";
   sha256  = "0gcjpw2q263hh8w2sjvq3f3k2d28qpkkv0jnl8hw1l7v604i8zxg";
-}
-
+}).overrideAttrs (old: {
+  postPatch = old.postPatch or "" + ''
+    echo 'echo ${runtimeShell}' > scripts/find_shell
+  '';
+})


### PR DESCRIPTION
Cross-compiles will otherwise detect an incorrect shell. A follow-up to #138323.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

vimpager's build [uses a script](https://github.com/rkitover/vimpager/blob/master/Makefile#L178) to determine what shell to place in the shebang line. In cross compiles, this script detects the builder's shell, which of course results in a broken output.

Alternatives might be to patch the Makefile instead?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
