### PR TITLE
linux_testing_bcachefs: 5.13-2021-07-08 -> 5.13.2021-09-22

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,9 +1,9 @@
 { lib
 , fetchpatch
 , kernel
-, date ? "2021-07-08"
-, commit ? "3693b2ca83ff9eda49660b31299d2bebe3a1075f"
-, diffHash ? "1sfq3vwc2kxa761s292f2cqrm0vvqvkdx6drpyn5yaxwnapwidcw"
+, date ? "2021-09-22"
+, commit ? "bd6ed9fb42c0aa36d1f4a21eeab45fe12e1fb792"
+, diffHash ? "0wml259g1z990kg3bdl1rpmlvcazdpv1fc8vm3kjxpncdp7637wp"
 , kernelPatches # must always be defined in bcachefs' all-packages.nix entry because it's also a top-level attribute supplied by callPackage
 , argsOverride ? {}
 , ...

--- a/pkgs/tools/filesystems/bcachefs-tools/default.nix
+++ b/pkgs/tools/filesystems/bcachefs-tools/default.nix
@@ -22,20 +22,21 @@
 
 stdenv.mkDerivation {
   pname = "bcachefs-tools";
-  version = "unstable-2021-07-08";
+  version = "unstable-2021-09-22";
 
   src = fetchFromGitHub {
     owner = "koverstreet";
     repo = "bcachefs-tools";
-    rev = "050d5f7bcf08bd02f5077a1c5559f352fa449e1e";
-    sha256 = "15bl9ni0ckmvs5d7hi6v26z690rrmkb7dx00skn6gwq87ffz3imw";
+    rev = "9942fc82d43baf261342d2550cd22609bf4f81b1";
+    sha256 = "0dqr0cghzggy9xk90bmw27i7ni83lrsnfrvbyvh11k9fv3211wnk";
   };
 
   postPatch = ''
     substituteInPlace Makefile \
       --replace "pytest-3" "pytest --verbose" \
       --replace "INITRAMFS_DIR=/etc/initramfs-tools" \
-                "INITRAMFS_DIR=${placeholder "out"}/etc/initramfs-tools"
+                "INITRAMFS_DIR=${placeholder "out"}/etc/initramfs-tools" \
+      --replace "doc/macro2rst.py" "python3 doc/macro2rst.py"
   '';
 
   nativeBuildInputs = [ pkg-config docutils ];


### PR DESCRIPTION
###### Motivation for this change
bcachefs needs to be updated as there have been lot of developments.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
