### PR TITLE
kalker: use system gmp to fix aarch64-darwin

### DIFF
--- a/pkgs/tools/misc/kalker/default.nix
+++ b/pkgs/tools/misc/kalker/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
-, m4
+, gcc
+, gmp, mpfr, libmpc
 , rustPlatform
 }:
 rustPlatform.buildRustPackage rec {
@@ -16,13 +17,17 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-fBWnMlOLgwrOBPS2GIfOUDHQHcMMaU5r9JZVMbA+W58=";
 
-  nativeBuildInputs = [ m4 ];
+  # https://gitlab.com/tspiteri/gmp-mpfr-sys/-/issues/20
+  nativeBuildInputs = [ gcc ];
+  buildInputs = [ gmp mpfr libmpc ];
 
   outputs = [ "out" "lib" ];
 
   postInstall = ''
     moveToOutput "lib" "$lib"
   '';
+
+  CARGO_FEATURE_USE_SYSTEM_LIBS = "1";
 
   meta = with lib; {
     homepage = "https://kalker.strct.net";


### PR DESCRIPTION
###### Motivation for this change
aarch64-darwin build failure.
https://github.com/PaddiM8/kalker/pull/61

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC: @lovesegfault 
