### PR TITLE
npiet: init at 1.3f

### DIFF
--- a/pkgs/development/interpreters/npiet/default.nix
+++ b/pkgs/development/interpreters/npiet/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchurl
+, gd
+, giflib
+, groff
+, libpng
+, tk
+}:
+
+stdenv.mkDerivation rec {
+  pname = "npiet";
+  version = "1.3f";
+
+  src = fetchurl {
+    url = "https://www.bertnase.de/npiet/npiet-${version}.tar.gz";
+    sha256 = "sha256-Le2FYGKr1zWZ6F4edozmvGC6LbItx9aptidj3KBLhVo=";
+  };
+
+  buildInputs = [ gd giflib libpng ];
+
+  nativeBuildInputs = [ groff ];
+
+  postPatch = ''
+    # malloc.h is not needed because stdlib.h is already included.
+    # On macOS, malloc.h does not even exist, resulting in an error.
+    substituteInPlace npiet-foogol.c \
+        --replace '#include <malloc.h>' ""
+
+    substituteInPlace npietedit \
+        --replace 'exec wish' 'exec ${tk}/bin/wish'
+  '';
+
+  meta = with lib; {
+    description = "An interpreter for piet programs. Also includes npietedit and npiet-foogol";
+    longDescription = ''
+      npiet is an interpreter for the piet programming language.
+      Instead of text, piet programs are pictures. Commands are determined based on changes in color.
+    '';
+    homepage = "https://www.bertnase.de/npiet/";
+    license = licenses.gpl2Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7674,6 +7674,8 @@ with pkgs;
 
   npapi_sdk = callPackage ../development/libraries/npapi-sdk {};
 
+  npiet = callPackage ../development/interpreters/npiet { };
+
   npth = callPackage ../development/libraries/npth {};
 
   nmap = callPackage ../tools/security/nmap { };


### PR DESCRIPTION
###### Motivation for this change
Add npiet, an interpreter for the esoteric programming language piet where the programs are images.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).