### PR TITLE
llvm_5: disable print_context.c (fails on gcc-11 / dwarf-5)

### DIFF
--- a/pkgs/development/compilers/llvm/5/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/5/llvm/default.nix
@@ -82,6 +82,9 @@ stdenv.mkDerivation ({
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "Path.cpp" ""
     rm unittests/Support/Path.cpp
+
+    # llvm-5 does not support dwarf-5 style info, fails on gcc-11.
+    rm test/tools/llvm-symbolizer/print_context.c
   '' + optionalString stdenv.isAarch64 ''
     patch -p0 < ${../../aarch64.patch}
   '' + optionalString stdenv.hostPlatform.isMusl ''


### PR DESCRIPTION
gcc-11 defaults to -gdwarf-5 and makes llvm symbolizer test fail.
As it's the only failing test let's just skip it for llvm-5.