### PR TITLE
python3Packages.marshmallow-polyfield: 5.9 -> 5.10, python3Packages.marshmallow: 3.11.1 -> 3.13.0

### DIFF
--- a/pkgs/development/python-modules/marshmallow-polyfield/default.nix
+++ b/pkgs/development/python-modules/marshmallow-polyfield/default.nix
@@ -1,32 +1,43 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchFromGitHub
-, lib
 , marshmallow
-  # Check Inputs
+, pythonOlder
 , pytestCheckHook
-, pytest-cov
 }:
 
 buildPythonPackage rec {
   pname = "marshmallow-polyfield";
-  version = "5.9";
+  version = "5.10";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "Bachmann1234";
     repo = pname;
     rev = "v${version}";
-    sha256 = "15yx8ib5yx1xx6kq8wnfdmv9zm43k7y33c6zpq5rba6a30v4lcnd";
+    sha256 = "sha256-oF5LBuDK4kqsAcKwidju+wFjigjy4CNbJ6bfWpGO1yQ=";
   };
 
   propagatedBuildInputs = [
     marshmallow
   ];
 
-  # setuptools check can run, but won't find tests
-  checkInputs = [ pytestCheckHook pytest-cov ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=marshmallow_polyfield" ""
+  '';
+
+  pythonImportsCheck = [
+    "marshmallow"
+  ];
 
   meta = with lib; {
-    description = "An unofficial extension to Marshmallow to allow for polymorphic fields";
+    description = "Extension to Marshmallow to allow for polymorphic fields";
     homepage = "https://github.com/Bachmann1234/marshmallow-polyfield";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];

--- a/pkgs/development/python-modules/marshmallow/default.nix
+++ b/pkgs/development/python-modules/marshmallow/default.nix
@@ -9,24 +9,25 @@
 
 buildPythonPackage rec {
   pname = "marshmallow";
-  version = "3.11.1";
-  disabled = pythonOlder "3.5";
+  version = "3.13.0";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "marshmallow-code";
     repo = pname;
     rev = version;
-    sha256 = "1ypm142y3giaqydc7fkigm9r057yp2sd1ng5zr2x3w3wbbj5yfm6";
+    sha256 = "sha256-tP/RKo2Hzxz2bT7ybRs9wGzq7TpsmzmOPi3BGuSLDA0=";
   };
-
-  pythonImportsCheck = [
-    "marshmallow"
-  ];
 
   checkInputs = [
     pytestCheckHook
     pytz
     simplejson
+  ];
+
+  pythonImportsCheck = [
+    "marshmallow"
   ];
 
   meta = with lib; {
@@ -38,5 +39,4 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ cript0nauta ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Change log:
- https://github.com/marshmallow-code/marshmallow/blob/dev/CHANGELOG.rst#3130-2021-07-21
- https://github.com/Bachmann1234/marshmallow-polyfield/releases/tag/v5.7

This should fix the build failure of `apispec` (e.g., https://hydra.nixos.org/build/153134728).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
