### PR TITLE
awscli2: 2.2.39 -> 2.2.40

### DIFF
--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -11,12 +11,12 @@ let
         };
       });
       botocore = super.botocore.overridePythonAttrs (oldAttrs: rec {
-        version = "2.0.0dev147";
+        version = "2.0.0dev148";
         src = fetchFromGitHub {
           owner = "boto";
           repo = "botocore";
-          rev = "afa015418df6b3aeef0f5645e8704de64adea3d7";
-          sha256 = "sha256-ypqDhCQXPqG8JCsLWt1V/4s95Hm+lClz+eOA2GnIhYg=";
+          rev = "c0734f100f61bbef413cb04d9890bbffbccd230f";
+          sha256 = "sha256-ndSJdBF3NMNtpyHgYAksCUBDqlwPhugTkIK6Nby20oI=";
         };
         propagatedBuildInputs = super.botocore.propagatedBuildInputs ++ [py.pkgs.awscrt];
       });
@@ -27,19 +27,26 @@ let
           sha256 = "1nr990i4b04rnlw1ghd0xmgvvvhih698mb6lb6jylr76cs7zcnpi";
         };
       });
+      s3transfer = super.s3transfer.overridePythonAttrs (oldAttrs: rec {
+        version = "0.4.2";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "sha256-ywIvSxZVHt67sxo3fT8JYA262nNj2MXbeXbn9Hcy4bI=";
+        };
+      });
     };
   };
 
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli2";
-  version = "2.2.39"; # N.B: if you change this, change botocore to a matching version too
+  version = "2.2.40"; # N.B: if you change this, change botocore to a matching version too
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-cli";
     rev = version;
-    sha256 = "sha256-3GYj6+08J05Lu17jjydmzlypI5TUuV+5HA398oExkiU=";
+    sha256 = "sha256-IHnNRER9ePKVI9ez15HgxLDR1n6QR0iRESgNqbxQPx8=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

awscli2 is broken on master due to 6b43ab7b901e54fdce74e7e08652a3cf80144182.
I'm updating the package version & freezing s3transfer until it is supported in awscli2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
