### PR TITLE
llvm_8, llvm_9, llvm_10: apply upstream fix for gcc-11

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -65,6 +65,14 @@ in stdenv.mkDerivation (rec {
       sha256 = "sha256:12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
       stripLen = 1;
     })
+
+    # Fix missing includes for GCC 11
+    (fetchpatch {
+      name = "headers-gcc-11.patch";
+      url = "https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1.patch";
+      sha256 = "0nh123kld0dgz2h941lng331dkj3wbm5lfxm375k1f569gv83hlk";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/8/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/8/llvm/default.nix
@@ -63,6 +63,14 @@ in stdenv.mkDerivation ({
       sha256 = "0rwx6jpqq4xnf4mvfm8v2d4r34y1yi05am0mx5k2d5bha9j64lqg";
     })
     ./gnu-install-dirs.patch
+
+    # Fix missing includes for GCC 11
+    (fetchpatch {
+      name = "headers-gcc-11.patch";
+      url = "https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1.patch";
+      sha256 = "0nh123kld0dgz2h941lng331dkj3wbm5lfxm375k1f569gv83hlk";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/llvm/9/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/9/llvm/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, llvm_meta
 , pkgsBuildBuild
 , fetch
+, fetchpatch
 , cmake
 , python3
 , libffi
@@ -60,6 +61,14 @@ in stdenv.mkDerivation (rec {
     # Force a test to evaluate the saved benchmark for a CPU for which LLVM has
     # an execution model. See NixOS/nixpkgs#119673.
     ../../exegesis-force-bdver2.patch
+
+    # Fix missing includes for GCC 11
+    (fetchpatch {
+      name = "headers-gcc-11.patch";
+      url = "https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1.patch";
+      sha256 = "0nh123kld0dgz2h941lng331dkj3wbm5lfxm375k1f569gv83hlk";
+      stripLen = 1;
+    })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
 
   postPatch = optionalString stdenv.isDarwin ''


### PR DESCRIPTION
On gcc-11 build fails due to missing <limits> include.
The fix pulls upstream change as is.