### PR TITLE
[backport release-20.09] ghc 8.10.7: init

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.6.nix
+++ b/pkgs/development/compilers/ghc/8.10.6.nix
@@ -1,0 +1,276 @@
+{ lib, stdenv, pkgsBuildTarget, targetPackages
+
+# build-tools
+, bootPkgs
+, autoconf, automake, coreutils, fetchpatch, fetchurl, perl, python3, m4, sphinx, xattr
+, bash
+
+, libiconv ? null, ncurses
+
+, # GHC can be built with system libffi or a bundled one.
+  libffi ? null
+
+, useLLVM ? !stdenv.targetPlatform.isx86
+, # LLVM is conceptually a run-time-only depedendency, but for
+  # non-x86, we need LLVM to bootstrap later stages, so it becomes a
+  # build-time dependency too.
+  buildLlvmPackages, llvmPackages
+
+, # If enabled, GHC will be built with the GPL-free but slower integer-simple
+  # library instead of the faster but GPLed integer-gmp library.
+  enableIntegerSimple ? !(lib.any (lib.meta.platformMatch stdenv.hostPlatform) gmp.meta.platforms), gmp
+
+, # If enabled, use -fPIC when compiling static libs.
+  enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
+
+  # aarch64 outputs otherwise exceed 2GB limit
+, enableProfiledLibs ? !stdenv.targetPlatform.isAarch64
+
+, # Whether to build dynamic libs for the standard library (on the target
+  # platform). Static libs are always built.
+  enableShared ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.useiOSPrebuilt
+
+, # Whether to build terminfo.
+  enableTerminfo ? !stdenv.targetPlatform.isWindows
+
+, # What flavour to build. An empty string indicates no
+  # specific flavour and falls back to ghc default values.
+  ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
+    (if useLLVM then "perf-cross" else "perf-cross-ncg")
+
+, # Whether to disable the large address space allocator
+  # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+  disableLargeAddressSpace ? stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64
+}:
+
+assert !enableIntegerSimple -> gmp != null;
+
+let
+  inherit (stdenv) buildPlatform hostPlatform targetPlatform;
+
+  inherit (bootPkgs) ghc;
+
+  # TODO(@Ericson2314) Make unconditional
+  targetPrefix = lib.optionalString
+    (targetPlatform != hostPlatform)
+    "${targetPlatform.config}-";
+
+  buildMK = ''
+    BuildFlavour = ${ghcFlavour}
+    ifneq \"\$(BuildFlavour)\" \"\"
+    include mk/flavours/\$(BuildFlavour).mk
+    endif
+    DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
+    INTEGER_LIBRARY = ${if enableIntegerSimple then "integer-simple" else "integer-gmp"}
+  '' + lib.optionalString (targetPlatform != hostPlatform) ''
+    Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
+    CrossCompilePrefix = ${targetPrefix}
+    HADDOCK_DOCS = NO
+    BUILD_SPHINX_HTML = NO
+    BUILD_SPHINX_PDF = NO
+  '' + lib.optionalString (!enableProfiledLibs) ''
+    GhcLibWays = "v dyn"
+  '' + lib.optionalString enableRelocatedStaticLibs ''
+    GhcLibHcOpts += -fPIC
+    GhcRtsHcOpts += -fPIC
+  '' + lib.optionalString targetPlatform.useAndroidPrebuilt ''
+    EXTRA_CC_OPTS += -std=gnu99
+  '';
+
+  # Splicer will pull out correct variations
+  libDeps = platform: lib.optional enableTerminfo ncurses
+    ++ [libffi]
+    ++ lib.optional (!enableIntegerSimple) gmp
+    ++ lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
+
+  toolsForTarget = [
+    pkgsBuildTarget.targetPackages.stdenv.cc
+  ] ++ lib.optional useLLVM buildLlvmPackages.llvm;
+
+  targetCC = builtins.head toolsForTarget;
+
+  # ld.gold is disabled for musl libc due to https://sourceware.org/bugzilla/show_bug.cgi?id=23856
+  # see #84670 and #49071 for more background.
+  useLdGold = targetPlatform.isLinux && !(targetPlatform.useLLVM or false) && !targetPlatform.isMusl;
+
+  runtimeDeps = [
+    targetPackages.stdenv.cc.bintools
+    coreutils
+  ]
+  # On darwin, we need unwrapped bintools as well (for otool)
+  ++ lib.optionals (stdenv.targetPlatform.isDarwin) [
+    targetPackages.stdenv.cc.bintools.bintools
+  ];
+
+in
+stdenv.mkDerivation (rec {
+  version = "8.10.6";
+  name = "${targetPrefix}ghc-${version}";
+
+  src = fetchurl {
+    url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";
+    sha256 = "43afba72a533408b42c1492bd047b5e37e5f7204e41a5cedd3182cc841610ce9";
+  };
+
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "doc" ];
+
+  patches = [
+    # See upstream patch at
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4885. Since we build
+    # from source distributions, the auto-generated configure script needs to be
+    # patched as well, therefore we use an in-tree patch instead of pulling the
+    # upstream patch. Don't forget to check backport status of the upstream patch
+    # when adding new GHC releases in nixpkgs.
+    ./respect-ar-path.patch
+  ] ++ lib.optionals stdenv.isDarwin [
+    # Make Block.h compile with c++ compilers. Remove with the next release
+    (fetchpatch {
+      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/97d0b0a367e4c6a52a17c3299439ac7de129da24.patch";
+      sha256 = "0r4zjj0bv1x1m2dgxp3adsf2xkr94fjnyj1igsivd9ilbs5ja0b5";
+    })
+  ];
+
+  postPatch = "patchShebangs .";
+
+  # GHC is a bit confused on its cross terminology.
+  preConfigure = ''
+    for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
+      export "''${env#TARGET_}=''${!env}"
+    done
+    # GHC is a bit confused on its cross terminology, as these would normally be
+    # the *host* tools.
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${lib.optionalString useLdGold ".gold"}"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+
+    echo -n "${buildMK}" > mk/build.mk
+    sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
+  '' + lib.optionalString stdenv.isDarwin ''
+    export NIX_LDFLAGS+=" -no_dtrace_dof"
+
+    # GHC tries the host xattr /usr/bin/xattr by default which fails since it expects python to be 2.7
+    export XATTR=${lib.getBin xattr}/bin/xattr
+  '' + lib.optionalString targetPlatform.useAndroidPrebuilt ''
+    sed -i -e '5i ,("armv7a-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "cortex-a8", ""))' llvm-targets
+  '' + lib.optionalString targetPlatform.isMusl ''
+      echo "patching llvm-targets for musl targets..."
+      echo "Cloning these existing '*-linux-gnu*' targets:"
+      grep linux-gnu llvm-targets | sed 's/^/  /'
+      echo "(go go gadget sed)"
+      sed -i 's,\(^.*linux-\)gnu\(.*\)$,\0\n\1musl\2,' llvm-targets
+      echo "llvm-targets now contains these '*-linux-musl*' targets:"
+      grep linux-musl llvm-targets | sed 's/^/  /'
+
+      echo "And now patching to preserve '-musleabi' as done with '-gnueabi'"
+      # (aclocal.m4 is actual source, but patch configure as well since we don't re-gen)
+      for x in configure aclocal.m4; do
+        substituteInPlace $x \
+          --replace '*-android*|*-gnueabi*)' \
+                    '*-android*|*-gnueabi*|*-musleabi*)'
+      done
+  '';
+
+  # TODO(@Ericson2314): Always pass "--target" and always prefix.
+  configurePlatforms = [ "build" "host" ]
+    ++ lib.optional (targetPlatform != hostPlatform) "target";
+
+  # `--with` flags for libraries needed for RTS linker
+  configureFlags = [
+    "--datadir=$doc/share/doc/ghc"
+    "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+  ] ++ lib.optionals (libffi != null) [
+    "--with-system-libffi"
+    "--with-ffi-includes=${targetPackages.libffi.dev}/include"
+    "--with-ffi-libraries=${targetPackages.libffi.out}/lib"
+  ] ++ lib.optionals (targetPlatform == hostPlatform && !enableIntegerSimple) [
+    "--with-gmp-includes=${targetPackages.gmp.dev}/include"
+    "--with-gmp-libraries=${targetPackages.gmp.out}/lib"
+  ] ++ lib.optionals (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [
+    "--with-iconv-includes=${libiconv}/include"
+    "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ lib.optionals (targetPlatform != hostPlatform) [
+    "--enable-bootstrap-with-devel-snapshot"
+  ] ++ lib.optionals useLdGold [
+    "CFLAGS=-fuse-ld=gold"
+    "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
+    "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
+  ] ++ lib.optionals (disableLargeAddressSpace) [
+    "--disable-large-address-space"
+  ];
+
+  # Make sure we never relax`$PATH` and hooks support for compatibility.
+  strictDeps = true;
+
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
+  nativeBuildInputs = [
+    perl autoconf automake m4 python3 sphinx
+    ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+  ];
+
+  # For building runtime libs
+  depsBuildTarget = toolsForTarget;
+
+  buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
+
+  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
+    ++ lib.optional useLLVM llvmPackages.llvm;
+
+  depsTargetTarget = map lib.getDev (libDeps targetPlatform);
+  depsTargetTargetPropagated = map (lib.getOutput "out") (libDeps targetPlatform);
+
+  # required, because otherwise all symbols from HSffi.o are stripped, and
+  # that in turn causes GHCi to abort
+  stripDebugFlags = [ "-S" ] ++ lib.optional (!targetPlatform.isDarwin) "--keep-file-symbols";
+
+  checkTarget = "test";
+
+  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+
+  postInstall = ''
+    # Install the bash completion file.
+    install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
+
+    # Patch scripts to include "readelf" and "cat" in $PATH.
+    for i in "$out/bin/"*; do
+      test ! -h $i || continue
+      egrep --quiet '^#!' <(head -n 1 $i) || continue
+      sed -i -e '2i export PATH="$PATH:${lib.makeBinPath runtimeDeps}"' $i
+    done
+  '';
+
+  passthru = {
+    inherit bootPkgs targetPrefix;
+
+    inherit llvmPackages;
+    inherit enableShared;
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc-${version}";
+  };
+
+  meta = {
+    homepage = "http://haskell.org/ghc";
+    description = "The Glasgow Haskell Compiler";
+    maintainers = with lib.maintainers; [ marcweber andres peti ];
+    timeout = 24 * 3600;
+    inherit (ghc.meta) license platforms;
+  };
+
+} // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {
+  dontStrip = true;
+  dontPatchELF = true;
+  noAuditTmpdir = true;
+})

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -137,6 +137,15 @@ stdenv.mkDerivation (rec {
             url = "https://raw.githubusercontent.com/input-output-hk/haskell.nix/122bd81150386867da07fdc9ad5096db6719545a/overlays/patches/ghc/cabal-host.patch";
       sha256 = "sha256:0yd0sajgi24sc1w5m55lkg2lp6kfkgpp3lgija2c8y3cmkwfpdc1";
     })
+
+    # In order to build ghcjs packages, the Cabal of the ghc used for the ghcjs
+    # needs to be patched. Ref https://github.com/haskell/cabal/pull/7575
+    (fetchpatch {
+      url = "https://github.com/haskell/cabal/commit/369c4a0a54ad08a9e6b0d3bd303fedd7b5e5a336.patch";
+      sha256 = "120f11hwyaqa0pq9g5l1300crqij49jg0rh83hnp9sa49zfdwx1n";
+      stripLen = 3;
+      extraPrefix = "libraries/Cabal/Cabal/";
+    })
   ] ++ lib.optionals stdenv.isDarwin [
     # Make Block.h compile with c++ compilers. Remove with the next release
     (fetchpatch {

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -75,6 +75,12 @@ let
     GhcRtsHcOpts += -fPIC
   '' + lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
+  ''
+  # While split sections are now enabled by default in ghc 8.8 for windows,
+  # they seem to lead to `too many sections` errors when building base for
+  # profiling.
+  + lib.optionalString targetPlatform.isWindows ''
+    SplitSections = NO
   '';
 
   # Splicer will pull out correct variations
@@ -91,7 +97,7 @@ let
 
   # ld.gold is disabled for musl libc due to https://sourceware.org/bugzilla/show_bug.cgi?id=23856
   # see #84670 and #49071 for more background.
-  useLdGold = targetPlatform.isLinux && !(targetPlatform.useLLVM or false) && !targetPlatform.isMusl;
+  useLdGold = targetPlatform.isLinux && !(targetPlatform.useLLVM or false) && !targetPlatform.isMusl && !targetPlatform.isWindows;
 
   runtimeDeps = [
     targetPackages.stdenv.cc.bintools
@@ -124,6 +130,13 @@ stdenv.mkDerivation (rec {
     # upstream patch. Don't forget to check backport status of the upstream patch
     # when adding new GHC releases in nixpkgs.
     ./respect-ar-path.patch
+
+    # cabal passes incorrect --host= when cross-compiling
+    # https://github.com/haskell/cabal/issues/5887
+    (fetchpatch {
+            url = "https://raw.githubusercontent.com/input-output-hk/haskell.nix/122bd81150386867da07fdc9ad5096db6719545a/overlays/patches/ghc/cabal-host.patch";
+      sha256 = "sha256:0yd0sajgi24sc1w5m55lkg2lp6kfkgpp3lgija2c8y3cmkwfpdc1";
+    })
   ] ++ lib.optionals stdenv.isDarwin [
     # Make Block.h compile with c++ compilers. Remove with the next release
     (fetchpatch {

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -104,12 +104,12 @@ let
 
 in
 stdenv.mkDerivation (rec {
-  version = "8.10.6";
+  version = "8.10.7";
   name = "${targetPrefix}ghc-${version}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";
-    sha256 = "43afba72a533408b42c1492bd047b5e37e5f7204e41a5cedd3182cc841610ce9";
+    sha256 = "e3eef6229ce9908dfe1ea41436befb0455fefb1932559e860ad4c606b0d03c9d";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/ghc/respect-ar-path.patch
+++ b/pkgs/development/compilers/ghc/respect-ar-path.patch
@@ -1,0 +1,25 @@
+diff -urd a/aclocal.m4 b/aclocal.m4
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -1199,7 +1199,8 @@
+ # thinks that target == host so it never checks the unqualified
+ # tools for Windows. See #14274.
+ AC_DEFUN([FP_PROG_AR],
+-[if test -z "$fp_prog_ar"; then
++[AC_SUBST(fp_prog_ar,$AR)
++if test -z "$fp_prog_ar"; then
+   if test "$HostOS" = "mingw32"
+   then
+     AC_PATH_PROG([fp_prog_ar], [ar])
+diff -urd a/configure b/configure
+--- a/configure
++++ b/configure
+@@ -10744,6 +10744,8 @@
+ test -z "$INSTALL_DATA" && INSTALL_DATA='${INSTALL} -m 644'
+ 
+ 
++fp_prog_ar=$AR
++
+ if test -z "$fp_prog_ar"; then
+   if test "$HostOS" = "mingw32"
+   then

--- a/pkgs/os-specific/darwin/xattr/default.nix
+++ b/pkgs/os-specific/darwin/xattr/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchzip
+, buildPythonPackage
+, python
+, ed
+, unifdef
+}:
+
+buildPythonPackage rec {
+  pname = "xattr";
+  version = "61.60.1";
+
+  src = fetchzip rec {
+    url = "https://opensource.apple.com/tarballs/python_modules/python_modules-${version}.tar.gz";
+    sha256 = "19kydl7w4vpdi7zmfd5z9vjkq24jfk2cv4j0pppw69j06czhdwwi";
+  };
+
+  sourceRoot = "${src.name}/Modules/xattr-0.6.4";
+  format = "other";
+
+  nativeBuildInputs = [
+    ed
+    unifdef
+  ];
+
+  makeFlags = [
+    "OBJROOT=$(PWD)"
+    "DSTROOT=${placeholder "out"}"
+    "OSL=${placeholder "doc"}/share/xattr/OpenSourceLicenses"
+    "OSV=${placeholder "doc"}/share/xattr/OpenSourceVersions"
+  ];
+
+  # need to use `out` instead of `bin` since buildPythonPackage ignores the latter
+  outputs = [ "out" "doc" "python" ];
+
+  # We need to patch a reference to gnutar in an included Makefile
+  postUnpack = ''
+    chmod u+w $sourceRoot/..
+  '';
+
+  postPatch = ''
+    substituteInPlace ../Makefile.inc --replace gnutar tar
+    substituteInPlace Makefile --replace "/usr" ""
+  '';
+
+  preInstall = ''
+    # prevent setup.py from trying to download setuptools
+    sed -i xattr-*/setup.py -e '/ez_setup/d'
+
+    # create our custom target dirs we patch in
+    mkdir -p "$doc/share/xattr/"OpenSource{Licenses,Versions}
+    mkdir -p "$python/lib/${python.libPrefix}"
+  '';
+
+  # move python package to its own output to reduce clutter
+  postInstall = ''
+    mv "$out/lib/python" "$python/${python.sitePackages}"
+    rmdir "$out/lib"
+  '';
+
+  makeWrapperArgs = [
+    "--prefix" "PYTHONPATH" ":" "${placeholder "python"}/${python.sitePackages}"
+  ];
+
+  meta = with lib; {
+    description = "Display and manipulate extended attributes";
+    license = [ licenses.psfl licenses.mit ]; # see $doc/share/xattr/OpenSourceLicenses
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://opensource.apple.com/source/python_modules/";
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -68,6 +68,8 @@ in
 
   usr-include = callPackage ../os-specific/darwin/usr-include { };
 
+  xattr = pkgs.python3Packages.callPackage ../os-specific/darwin/xattr { };
+
   inherit (callPackages ../os-specific/darwin/xcode { })
     xcode_8_1 xcode_8_2
     xcode_9_1 xcode_9_2 xcode_9_4 xcode_9_4_1

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -124,7 +124,7 @@ in {
       buildLlvmPackages = buildPackages.llvmPackages_9;
       llvmPackages = pkgs.llvmPackages_9;
     };
-    ghc8106 = callPackage ../development/compilers/ghc/8.10.6.nix {
+    ghc8107 = callPackage ../development/compilers/ghc/8.10.7.nix {
       # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
       bootPkgs = if stdenv.isAarch64 || stdenv.isAarch32 then
           packages.ghc8102BinaryMinimal
@@ -244,9 +244,9 @@ in {
       ghc = bh.compiler.ghc8104;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
     };
-    ghc8106 = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc8106;
-      ghc = bh.compiler.ghc8106;
+    ghc8107 = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc8107;
+      ghc = bh.compiler.ghc8107;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
     };
     ghcHEAD = callPackage ../development/haskell-modules {

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -124,6 +124,20 @@ in {
       buildLlvmPackages = buildPackages.llvmPackages_9;
       llvmPackages = pkgs.llvmPackages_9;
     };
+    ghc8106 = callPackage ../development/compilers/ghc/8.10.6.nix {
+      # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
+      bootPkgs = if stdenv.isAarch64 || stdenv.isAarch32 then
+          packages.ghc8102BinaryMinimal
+        else
+          packages.ghc865Binary;
+      inherit (buildPackages.python3Packages) sphinx;
+      # Need to use apple's patched xattr until
+      # https://github.com/xattr/xattr/issues/44 and
+      # https://github.com/xattr/xattr/issues/55 are solved.
+      inherit (buildPackages.darwin) xattr;
+      buildLlvmPackages = buildPackages.llvmPackages_9;
+      llvmPackages = pkgs.llvmPackages_9;
+    };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
       bootPkgs = packages.ghc883; # no binary yet
       inherit (buildPackages.python3Packages) sphinx;
@@ -228,6 +242,11 @@ in {
     ghc8104 = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghc8104;
       ghc = bh.compiler.ghc8104;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
+    };
+    ghc8106 = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc8106;
+      ghc = bh.compiler.ghc8106;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
     };
     ghcHEAD = callPackage ../development/haskell-modules {


### PR DESCRIPTION
###### Motivation for this change

I want to backport GHCJS to stable release(s), and that requires this version. Making it and additional version rather than update so as not to break anything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
