### PR TITLE
llvmPackages_13.lld: add postPatch to fix Darwin build

### DIFF
--- a/pkgs/development/compilers/llvm/13/lld/default.nix
+++ b/pkgs/development/compilers/llvm/13/lld/default.nix
@@ -18,6 +18,14 @@ stdenv.mkDerivation rec {
     ./gnu-install-dirs.patch
   ];
 
+  # On Darwin the llvm-config is perhaps not working fine as the
+  # LLVM_MAIN_SRC_DIR is not getting set correctly, and the build fails as the
+  # include path is not correct.
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace MachO/CMakeLists.txt --replace \
+      '(''${LLVM_MAIN_SRC_DIR}/' '(../'
+  '';
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libllvm libxml2 ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This allows building emscripten on Darwin, and thus ghcjs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
