### PR TITLE
[staging-next] netbsd.compat: fix libs by using cctools strip as objcopy

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -188,8 +188,6 @@ in lib.makeScopeWithSplicing
       bsdSetupHook netbsdSetupHook
       makeMinimal
       rsync
-    ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
-      buildPackages.binutils
     ];
 
     buildInputs = with self; commonDeps;
@@ -204,8 +202,14 @@ in lib.makeScopeWithSplicing
       "TSORT=cat"
       # Can't process man pages yet
       "MKSHARE=no"
+    ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # GNU objcopy produces broken .a libs which won't link into dependers.
+      # Makefiles only invoke `$OBJCOPY -x/-X`, so cctools strip works here.
+      "OBJCOPY=${buildPackages.darwin.cctools}/bin/strip"
     ];
     RENAME = "-D";
+
+    passthru.tests = { netbsd-install = self.install; };
 
     patches = [
       ./compat-cxx-safe-header.patch


### PR DESCRIPTION
Reverts d43df749ac4779cdb3f53146c8c1ef66b4f33e33

NetBSD makefiles strip local symbols from libs using `OBJCOPY?=objcopy`,
which is missing on macOS. GNU objcopy appears to succeed but produces
broken .a libs which do not link into dependers.

(As this issue does not fail the netbsd.compat build,
downstream netbsd.install is added to passthru.tests.)

Since `OBJCOPY` is only used for stripping, we can:
* skip stripping with the hacky `OBJCOPY=echo`
* use cctools strip, which is invoked in the same way

The latter is obviously preferable if it works.
Indeed, locals are stripped, although it doesn't affect size much.
Comparison:

`OBJCOPY=echo`:
```
$ du -b result/lib/*.a
347784	result/lib/libnbcompat.a
357120	result/lib/libnbcompat_p.a
```

`OBJCOPY=${cctools}/bin/strip`:
```
$ du -b result/lib/*.a
347008	result/lib/libnbcompat.a
357120	result/lib/libnbcompat_p.a
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

For https://github.com/NixOS/nixpkgs/pull/138268

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
