### PR TITLE
netbsd.compat: don't use objcopy on Darwin

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -188,8 +188,6 @@ in lib.makeScopeWithSplicing
       bsdSetupHook netbsdSetupHook
       makeMinimal
       rsync
-    ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
-      buildPackages.binutils
     ];
 
     buildInputs = with self; commonDeps;
@@ -204,6 +202,8 @@ in lib.makeScopeWithSplicing
       "TSORT=cat"
       # Can't process man pages yet
       "MKSHARE=no"
+    ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
+      "OBJCOPY=echo"
     ];
     RENAME = "-D";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

objcopy on Darwin is a tale of woe and misery. As far as I can tell,
the NetBSD toolchain wants to use it to strip a bunch of sections from
the files it's outputting, but this doesn't work properly, at least on
aarch64-darwin.

The GCC version of objcopy appears to know how to read and write Mach-O
files, but reads in the Mach-O 64-bit file and writes it in a Mach-O 32-bit
container, which later causes ld to barf when it tries to link against it.

The LLVM version of objcopy just explodes when it finds some unimplemented
load commands.

In any case, just dropping the `objcopy -x` invocation _seems_ harmless enough,
and gets netbsd.xinstall building, which should fix a bunch of Python packages.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
