### PR TITLE
fishfight: init at 0.1

### DIFF
--- a/pkgs/games/fishfight/default.nix
+++ b/pkgs/games/fishfight/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, alsa-lib
+, libGL
+, libX11
+, libXi
+, AudioToolbox
+, Cocoa
+, CoreAudio
+, CoreFoundation
+, IOKit
+, OpenGL
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fishfight";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "fishfight";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0mbg9zshyg9hlbsk5npslbnwjf8fh6gxszi5hxks380z080cjxs2";
+  };
+
+  cargoSha256 = "sha256-fZXqJ6a2erAQSgAZRwmkor94eMryjiq3gbY102pJb9Q=";
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    alsa-lib
+    libGL
+    libX11
+    libXi
+  ] ++ lib.optionals stdenv.isDarwin [
+    AudioToolbox
+    Cocoa
+    CoreAudio
+    CoreFoundation
+    IOKit
+    OpenGL
+  ];
+
+  postPatch = ''
+    substituteInPlace assets/levels/levels.toml --replace assets $out/share/assets
+    substituteInPlace src/gui.rs --replace \"assets \"$out/share/assets
+    substituteInPlace src/main.rs --replace \"assets \"$out/share/assets
+  '';
+
+  postInstall = ''
+    mkdir $out/share
+    cp -r assets $out/share
+  '';
+
+  meta = with lib; {
+    description = "A tactical 2D shooter played by up to 4 players online or on a shared screen";
+    homepage = "https://fishfight.org/";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = with maintainers; [ figsoda ];
+    mainProgram = "fishgame";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29258,6 +29258,11 @@ with pkgs;
 
   fish-fillets-ng = callPackage ../games/fish-fillets-ng {};
 
+  fishfight = callPackage ../games/fishfight {
+    inherit (xorg) libX11 libXi;
+    inherit (darwin.apple_sdk.frameworks) AudioToolbox Cocoa CoreAudio CoreFoundation IOKit OpenGL;
+  };
+
   flightgear = libsForQt5.callPackage ../games/flightgear { };
 
   flock = callPackage ../development/tools/flock { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fish Fight is a tactical 2D shooter, played by up to 4 players online or on a shared screen

Tested on linux with x11 and pipewire+alsa, i don't think it has native support for wayland yet

~~Not tested on darwin, i might make changes after i see the ofborg build~~

https://github.com/fishfight/fishfight

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
