### PR TITLE
roc-toolkit: init at master

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4623,6 +4623,12 @@
     githubId = 3661115;
     name = "Ingo Blechschmidt";
   };
+  iclanzan = {
+    name = "Sorin Iclanzan";
+    email = "sorin+nixos@iclanzan.com";
+    github = "iclanzan";
+    githubId = 1806943;
+  };
   icy-thought = {
     name = "Icy-Thought";
     email = "gilganyx@pm.me";

--- a/pkgs/applications/audio/roc-toolkit/default.nix
+++ b/pkgs/applications/audio/roc-toolkit/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, scons
+, python
+, ragel
+, gengetopt
+, libuv
+, libpulseaudio
+, libunwind
+, openfec
+, sox
+}:
+
+stdenv.mkDerivation {
+  pname = "roc-toolkit";
+  version = "unstable-2021-06-15";
+
+  src = fetchFromGitHub {
+    owner = "roc-streaming";
+    repo = "roc-toolkit";
+    rev = "c89687330bfce6f4dce79826f7a235b581f2b49d";
+    sha256 = "1j2gqfpsh0hrwrwvanv6b893b9pds93rv7bl7am2050j3jqmfjrw";
+  };
+
+  nativeBuildInputs = [ scons python ragel gengetopt ];
+  buildInputs = [ libuv libpulseaudio libunwind openfec sox ];
+
+  prefixKey = "--prefix=";
+
+  sconsFlags = [
+    "--jobs=1"
+    "--disable-tests"
+    "--disable-doc"
+    "--with-openfec-includes=${openfec}/include/openfec"
+  ];
+
+  meta = with lib; {
+    description = "Toolkit for real-time audio streaming over the network";
+    homepage = "https://roc-streaming.org/";
+    license = licenses.mpl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ iclanzan ];
+  };
+}

--- a/pkgs/development/libraries/openfec/default.nix
+++ b/pkgs/development/libraries/openfec/default.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "openfec";
+  version = "1.4.2.4";
+
+  src = fetchFromGitHub {
+    owner = "roc-streaming";
+    repo = "openfec";
+    rev = "v${version}";
+    sha256 = "0aj0dabqymf9rxqir21jsk8n2rhfwywqiwwafyw3dq2123xapim3";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DDEBUG:STRING=OFF"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib $out/include
+    cp -d ../bin/Release/eperftool \
+      ../bin/Release/simple_client \
+      ../bin/Release/simple_server \
+      ../bin/Release/test_code_params \
+      ../bin/Release/test_create_instance \
+      ../bin/Release/test_encoder_instance \
+      $out/bin
+    cp -d ../bin/Release/libopenfec.so \
+      ../bin/Release/libopenfec.so.1 \
+      ../bin/Release/libopenfec.so.1.4.2 \
+      $out/lib
+    cp -R -d ../src $out/include/openfec
+  '';
+
+  meta = with lib; {
+    description = "Application-level Forward Erasure Correction codes";
+    homepage = "https://github.com/roc-streaming/openfec";
+    license = licenses.cecill-c;
+    maintainers = with maintainers; [ iclanzan ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26521,6 +26521,8 @@ with pkgs;
 
   opencpn = callPackage ../applications/misc/opencpn { };
 
+  openfec = callPackage ../development/libraries/openfec { };
+
   openfx = callPackage ../development/libraries/openfx {};
 
   openimageio = callPackage ../applications/graphics/openimageio { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27117,6 +27117,8 @@ with pkgs;
 
   rkdeveloptool = callPackage ../misc/rkdeveloptool { };
 
+  roc-toolkit = callPackage ../applications/audio/roc-toolkit { };
+
   rofi-unwrapped = callPackage ../applications/misc/rofi {
     autoreconfHook = buildPackages.autoreconfHook269;
   };


### PR DESCRIPTION
I have not had success compiling the latest tagged release which is v0.1.5 from
April 2020. Latest master, with last commit dated Jun 15, compiles
successfully however. I disabled OpenFEC for this initial version since
I couldn’t get it to compile properly.

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/129567

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
