### PR TITLE
Pantheon updates 2021-09-22

### DIFF
--- a/pkgs/desktops/gnome/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome/core/epiphany/default.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation rec {
 
   patches = lib.optionals withPantheon [
     # https://github.com/elementary/browser
-    # FIXME: Update the patches when https://github.com/elementary/browser/pull/41 merged
     ./dark-style.patch
     ./navigation-buttons.patch
   ];

--- a/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
@@ -28,7 +28,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-calendar";
-  version = "6.0.1";
+  version = "6.0.2";
 
   repoName = "calendar";
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "1caxc42jrys5s4x9qai5wdpcwpkmyvnqx9z75974g7swiz1lrzq6";
+    sha256 = "16xp8gfgpyz9xpjsxm6jlk4skkknj65g0q4x0qvw9sg9f1p6a514";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/sideload/default.nix
+++ b/pkgs/desktops/pantheon/apps/sideload/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sideload";
-  version = "6.0.1";
+  version = "6.0.2";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0mwcaayzcm5pjcwdd61can93y66jiz4wyz9wr8j5fbns5hbk3z5m";
+    sha256 = "0abpcawmmv5mgzk2i5n9rlairmjr2v9rg9b8c9g7xa085s496bi9";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -21,22 +21,16 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-keyboard";
-  version = "2.5.0";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "1nsy9fh6qj5kyg22bs1hm6kpsvarwc63q0hl0nbwymvnhfjf6swp";
+    sha256 = "1p1l7dx5v1zzz89hhhkm6n3ls7ig4cf2prh1099f1c054qiy9b0y";
   };
 
   patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/switchboard-plug-keyboard/pull/377
-    (fetchpatch {
-      url = "https://github.com/elementary/switchboard-plug-keyboard/commit/6d8bcadba05b4ee1115b891448b0de31bcba3749.patch";
-      sha256 = "1bppxakj71r3cfy8sw19xbyngb7r6nyirc4g6pjf02cdidhw3v8l";
-    })
     ./0001-Remove-Install-Unlisted-Engines-function.patch
     (substituteAll {
       src = ./fix-paths.patch;

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-mouse-touchpad";
-  version = "6.0.0";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "19kiwrdpan8hr5r79y591591qjx7pm3x814xfkg9vi11ndbcrznr";
+    sha256 = "0nqgbpk1knvbj5xa078i0ka6lzqmaaa873gwj3mhjr5q2gzkw7y5";
   };
 
   passthru = {
@@ -59,12 +59,6 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths.patch;
       touchegg = touchegg;
-    })
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/switchboard-plug-mouse-touchpad/pull/185
-    (fetchpatch {
-      url = "https://github.com/elementary/switchboard-plug-mouse-touchpad/commit/a6f84dc08be5dc6f7535082bacfa24e2dff4ef67.patch";
-      sha256 = "0fxl894dzw1f84n36mb9y7gshs69xcb0samvs2gsa0pcdlzfp3cy";
     })
   ];
 

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -32,7 +32,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-greeter";
-  version = "6.0.0";
+  version = "6.0.1";
 
   repoName = "greeter";
 
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "1ny1003bbpdscc4kr2d94zc5vxm30y64dpj3fpd5zz2p2g0cq2h9";
+    sha256 = "1f606ds56sp1c58q8dblfpaq9pwwkqw9i4gkwksw45m2xkwlbflq";
   };
 
   passthru = {
@@ -89,12 +89,6 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/greeter/pull/545
-    (fetchpatch {
-      url = "https://github.com/elementary/greeter/commit/d1373a7db827bc753bfcd70d0c8f25460ea9f1de.patch";
-      sha256 = "0s8l7ycd2s307d3dh1p4vdk33dbzjzqwxs6msyb9w0ycfyxlwdvp";
-    })
     ./sysconfdir-install.patch
     # Needed until https://github.com/elementary/greeter/issues/360 is fixed
     (substituteAll {


### PR DESCRIPTION
###### Motivation for this change

Part of Pantheon 6.0.2 updates (previous one at https://github.com/NixOS/nixpkgs/pull/138874).

###### Things done

- [x] Rebuilt NixOS to test the change.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
