### PR TITLE
iqueue: init at 0.1.0

### DIFF
--- a/pkgs/development/libraries/iqueue/default.nix
+++ b/pkgs/development/libraries/iqueue/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "iqueue";
   version = "0.1.0";
   src = fetchurl {
-    url = "https://github.com/twosigma/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
+    url = "https://github.com/twosigma/iqueue/releases/download/v${version}/iqueue-${version}.tar.gz";
     sha256 = "0049fnr02k15gr21adav33swrwxrpbananilnrp63vp5zs5v9m4x";
   };
 

--- a/pkgs/development/libraries/iqueue/default.nix
+++ b/pkgs/development/libraries/iqueue/default.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, fetchurl, pkg-config, libbsd, microsoft_gsl }:
+
+stdenv.mkDerivation rec {
+  pname = "iqueue";
+  version = "0.1.0";
+  src = fetchurl {
+    url = "https://github.com/twosigma/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
+    sha256 = "0049fnr02k15gr21adav33swrwxrpbananilnrp63vp5zs5v9m4x";
+  };
+
+  doCheck = true;
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libbsd microsoft_gsl ];
+
+  meta = with lib; {
+    homepage = "https://github.com/twosigma/iqueue";
+    description = "Indexed queue";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.catern ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -993,6 +993,8 @@ with pkgs;
 
   hyper = callPackage ../applications/terminal-emulators/hyper { };
 
+  iqueue = callPackage ../development/libraries/iqueue {};
+
   iterm2 = callPackage ../applications/terminal-emulators/iterm2 {};
 
   kitty = callPackage ../applications/terminal-emulators/kitty {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a new package I use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
