### PR TITLE
cvehound: init at 1.0.4

### DIFF
--- a/pkgs/development/tools/analysis/cvehound/default.nix
+++ b/pkgs/development/tools/analysis/cvehound/default.nix
@@ -1,0 +1,41 @@
+{ lib, fetchFromGitHub, coccinelle, gnugrep, python3Packages }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "cvehound";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "evdenis";
+    repo = "cvehound";
+    rev = version;
+    sha256 = "sha256-m8vpea02flQ8elSvGWv9FqBhsEcBzRYjcUk+dc4kb2M=";
+  };
+
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ coccinelle gnugrep ]}"
+  ];
+
+  propagatedBuildInputs = [
+    psutil
+    setuptools
+    sympy
+  ];
+
+  checkInputs = [
+    GitPython
+    pytestCheckHook
+  ];
+
+  # Tries to clone the kernel sources
+  doCheck = false;
+
+  meta = with lib; {
+    description = "tool to check linux kernel source dump for known CVEs";
+    homepage = "https://github.com/evdenis/cvehound";
+    # See https://github.com/evdenis/cvehound/issues/22
+    license = with licenses; [ gpl2Only gpl3Only ];
+    maintainers = with maintainers; [ ambroisie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13796,6 +13796,8 @@ with pkgs;
 
   css-html-js-minify = with python3Packages; toPythonApplication css-html-js-minify;
 
+  cvehound = callPackage ../development/tools/analysis/cvehound { };
+
   cvise = python3Packages.callPackage ../development/tools/misc/cvise {
     inherit (llvmPackages_11) llvm libclang;
   };


### PR DESCRIPTION
###### Motivation for this change

Add `cvehound` to the package set.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
