### PR TITLE
nix-index: remove null check, build on hydra

### DIFF
--- a/pkgs/tools/package-management/nix-index/wrapper.nix
+++ b/pkgs/tools/package-management/nix-index/wrapper.nix
@@ -1,8 +1,7 @@
 { lib, symlinkJoin, nix-index-unwrapped, makeWrapper, nix }:
 
-if nix == null then nix-index-unwrapped else
 symlinkJoin {
-  inherit (nix-index-unwrapped) name;
+  inherit (nix-index-unwrapped) name meta;
 
   paths = [ nix-index-unwrapped ];
 
@@ -12,8 +11,4 @@ symlinkJoin {
     wrapProgram $out/bin/nix-index \
       --prefix PATH : ${lib.makeBinPath [ nix ]}
   '';
-
-  meta = nix-index-unwrapped.meta // {
-    hydraPlatforms = [];
-  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
