### PR TITLE
Pantheon updates 2021-09-23

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pantheon
 , meson
 , ninja
 , pkg-config
-, vala
+, vala_0_52
 , desktop-file-utils
 , gtk3
 , libaccounts-glib
@@ -35,7 +34,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-photos";
-  version = "2.7.1";
+  version = "2.7.2";
 
   repoName = "photos";
 
@@ -43,17 +42,8 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "1dql14k43rv3in451amiwv4z71hz3ailx67hd8gw1ka3yw12128p";
+    sha256 = "1zq9zfsc987vvrzadw9xqi3rlbi4jv2s82axkgy7ijm3ibi58ddc";
   };
-
-  patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/photos/pull/629
-    (fetchpatch {
-      url = "https://github.com/elementary/photos/commit/e5230a4305381734e93f1e3d1177da21a8a4121b.patch";
-      sha256 = "1igqq51sj1sx6rl8yrw037jsgnaxfwzfs0m6pqzb9q4jvfdimzfi";
-    })
-  ];
 
   passthru = {
     updateScript = nix-update-script {
@@ -68,7 +58,9 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    vala
+    # Does not build with vala 0.54
+    # https://github.com/elementary/photos/issues/638
+    vala_0_52
     wrapGAppsHook
   ];
 

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -2,7 +2,6 @@
 , fetchFromGitHub
 , nix-update-script
 , pantheon
-, fetchpatch
 , substituteAll
 , meson
 , ninja

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , substituteAll
 , pantheon

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , linkFarm
 , substituteAll

--- a/pkgs/desktops/pantheon/desktop/gala/default.nix
+++ b/pkgs/desktops/pantheon/desktop/gala/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
 , nix-update-script
-, fetchpatch
 , pantheon
 , pkg-config
 , meson
@@ -30,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gala";
-  version = "6.0.1";
+  version = "6.2.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0xp9vviamzdwlcnx4836sxaz2pyfkxswgvjm73ppn7fkdm0zjpzx";
+    sha256 = "1yxsfshahaxiqs5waj4v96rhjhdgyd1za4pwlg3vqq51p75k2b1g";
   };
 
   passthru = {
@@ -75,12 +74,6 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/gala/pull/1205
-    (fetchpatch {
-      url = "https://github.com/elementary/gala/commit/605aa10ea2a78650e001b2a247c5f7afce478b05.patch";
-      sha256 = "0bg67wzrnmx8nlw93i35vhyfx8al0bj0lacgci98vwlp2m1jgbd2";
-    })
     ./plugins-dir.patch
   ];
 

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
@@ -7,7 +7,7 @@
 , meson
 , python3
 , ninja
-, vala
+, vala_0_52
 , gtk3
 , granite
 , wingpanel
@@ -50,7 +50,9 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    vala
+    # Does not build with vala 0.54
+    # https://github.com/elementary/wingpanel-indicator-sound/issues/219
+    vala_0_52
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Part of Pantheon 6.0.2 updates (previous one at https://github.com/NixOS/nixpkgs/pull/139057).

We pinned vala to 0.52 for 2 packages as they don't build with vala 0.54, see:

- https://github.com/elementary/wingpanel-indicator-sound/issues/219
- https://github.com/elementary/photos/issues/638

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Rebuilt NixOS to test the change.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
