### PR TITLE
haskell.compiler.ghc*: refactor how derivation names work

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -138,8 +138,7 @@ in
 
 stdenv.mkDerivation rec {
   inherit version;
-
-  name = "ghc-${version}-binary";
+  pname = "ghc-binary";
 
   src = fetchurl binDistUsed.src;
 

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -40,6 +40,7 @@ let
     # nixpkgs uses for the respective system.
     defaultLibc = {
       i686-linux = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-i386-deb9-linux.tar.xz";
           sha256 = "0bvwisl4w0z5z8z0da10m9sv0mhm9na2qm43qxr8zl23mn32mblx";
@@ -54,6 +55,7 @@ let
         ];
       };
       x86_64-linux = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-deb10-linux.tar.xz";
           sha256 = "0chnzy9j23b2wa8clx5arwz8wnjfxyjmz9qkj548z14cqf13slcl";
@@ -65,6 +67,7 @@ let
         ];
       };
       armv7l-linux = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-armv7-deb10-linux.tar.xz";
           sha256 = "1j41cq5d3rmlgz7hzw8f908fs79gc5mn3q5wz277lk8zdf19g75v";
@@ -76,6 +79,7 @@ let
         ];
       };
       aarch64-linux = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-deb10-linux.tar.xz";
           sha256 = "14smwl3741ixnbgi0l51a7kh7xjkiannfqx15b72svky0y4l3wjw";
@@ -88,6 +92,7 @@ let
         ];
       };
       x86_64-darwin = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
           sha256 = "1hngyq14l4f950hzhh2d204ca2gfc98pc9xdasxihzqd1jq75dzd";
@@ -103,6 +108,7 @@ let
     # Binary distributions for the musl libc for the respective system.
     musl = {
       x86_64-linux = {
+        variantSuffix = "-musl";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-alpine3.10-linux-integer-simple.tar.xz";
           sha256 = "0xpcbyaxqyhbl6f0i3s4rp2jm67nqpkfh2qlbj3i2fiaix89ml0l";
@@ -138,7 +144,7 @@ in
 
 stdenv.mkDerivation rec {
   inherit version;
-  pname = "ghc-binary";
+  pname = "ghc-binary${binDistUsed.variantSuffix}";
 
   src = fetchurl binDistUsed.src;
 

--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -152,8 +152,7 @@ in
 
 stdenv.mkDerivation rec {
   inherit version;
-
-  name = "ghc-${version}-binary";
+  pname = "ghc-binary";
 
   src = fetchurl binDistUsed.src;
 

--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -41,6 +41,7 @@ let
     # nixpkgs uses for the respective system.
     defaultLibc = {
       i686-linux = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-i386-deb9-linux.tar.xz";
           sha256 = "fbfc1ef194f4e7a4c0da8c11cc69b17458a4b928b609b3622c97acc4acd5c5ab";
@@ -55,6 +56,7 @@ let
         ];
       };
       x86_64-linux = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-deb10-linux.tar.xz";
           sha256 = "a13719bca87a0d3ac0c7d4157a4e60887009a7f1a8dbe95c4759ec413e086d30";
@@ -66,6 +68,7 @@ let
         ];
       };
       armv7l-linux = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-armv7-deb10-linux.tar.xz";
           sha256 = "3949c31bdf7d3b4afb765ea8246bca4ca9707c5d988d9961a244f0da100956a2";
@@ -77,6 +80,7 @@ let
         ];
       };
       aarch64-linux = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-deb10-linux.tar.xz";
           sha256 = "fad2417f9b295233bf8ade79c0e6140896359e87be46cb61cd1d35863d9d0e55";
@@ -89,6 +93,7 @@ let
         ];
       };
       x86_64-darwin = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
           sha256 = "287db0f9c338c9f53123bfa8731b0996803ee50f6ee847fe388092e5e5132047";
@@ -101,6 +106,7 @@ let
         ];
       };
       aarch64-darwin = {
+        variantSuffix = "";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-apple-darwin.tar.xz";
           sha256 = "dc469fc3c35fd2a33a5a575ffce87f13de7b98c2d349a41002e200a56d9bba1c";
@@ -116,6 +122,7 @@ let
     # Binary distributions for the musl libc for the respective system.
     musl = {
       x86_64-linux = {
+        variantSuffix = "-musl-integer-simple";
         src = {
           url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-alpine3.10-linux-integer-simple.tar.xz";
           sha256 = "16903df850ef73d5246f2ff169cbf57ecab76c2ac5acfa9928934282cfad575c";
@@ -152,7 +159,7 @@ in
 
 stdenv.mkDerivation rec {
   inherit version;
-  pname = "ghc-binary";
+  pname = "ghc-binary${binDistUsed.variantSuffix}";
 
   src = fetchurl binDistUsed.src;
 

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -144,7 +144,7 @@ let
 in
 stdenv.mkDerivation (rec {
   version = "8.10.7";
-  name = "${targetPrefix}ghc-${version}";
+  pname = "${targetPrefix}ghc";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -141,10 +141,16 @@ let
     targetPackages.stdenv.cc.bintools.bintools
   ];
 
+  # Makes debugging easier to see which variant is at play in `nix-store -q --tree`.
+  variantSuffix = lib.concatStrings [
+    (lib.optionalString stdenv.hostPlatform.isMusl "-musl")
+    (lib.optionalString enableIntegerSimple "-integer-simple")
+  ];
+
 in
 stdenv.mkDerivation (rec {
   version = "8.10.7";
-  pname = "${targetPrefix}ghc";
+  pname = "${targetPrefix}ghc${variantSuffix}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";

--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -34,8 +34,7 @@ in
 
 stdenv.mkDerivation rec {
   version = "8.6.5";
-
-  name = "ghc-${version}-binary";
+  pname = "ghc-binary";
 
   # https://downloads.haskell.org/~ghc/8.6.5/
   src = fetchurl ({

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -149,10 +149,16 @@ let
     targetPackages.stdenv.cc.bintools.bintools
   ];
 
+  # Makes debugging easier to see which variant is at play in `nix-store -q --tree`.
+  variantSuffix = lib.concatStrings [
+    (lib.optionalString stdenv.hostPlatform.isMusl "-musl")
+    (lib.optionalString enableIntegerSimple "-integer-simple")
+  ];
+
 in
 stdenv.mkDerivation (rec {
   version = "8.8.4";
-  pname = "${targetPrefix}ghc";
+  pname = "${targetPrefix}ghc${variantSuffix}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -152,7 +152,7 @@ let
 in
 stdenv.mkDerivation (rec {
   version = "8.8.4";
-  name = "${targetPrefix}ghc-${version}";
+  pname = "${targetPrefix}ghc";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -135,10 +135,16 @@ let
     targetPackages.stdenv.cc.bintools.bintools
   ];
 
+  # Makes debugging easier to see which variant is at play in `nix-store -q --tree`.
+  variantSuffix = lib.concatStrings [
+    (lib.optionalString stdenv.hostPlatform.isMusl "-musl")
+    (lib.optionalString enableIntegerSimple "-integer-simple")
+  ];
+
 in
 stdenv.mkDerivation (rec {
   version = "9.0.1";
-  pname = "${targetPrefix}ghc";
+  pname = "${targetPrefix}ghc${variantSuffix}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -138,7 +138,7 @@ let
 in
 stdenv.mkDerivation (rec {
   version = "9.0.1";
-  name = "${targetPrefix}ghc-${version}";
+  pname = "${targetPrefix}ghc";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/${version}/ghc-${version}-src.tar.xz";

--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -137,7 +137,7 @@ let
 in
 stdenv.mkDerivation (rec {
   version = "9.2.0.20210821";
-  name = "${targetPrefix}ghc-${version}";
+  pname = "${targetPrefix}ghc";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/9.2.1-rc1/ghc-${version}-src.tar.xz";

--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -134,10 +134,16 @@ let
     targetPackages.stdenv.cc.bintools.bintools
   ];
 
+  # Makes debugging easier to see which variant is at play in `nix-store -q --tree`.
+  variantSuffix = lib.concatStrings [
+    (lib.optionalString stdenv.hostPlatform.isMusl "-musl")
+    (lib.optionalString enableIntegerSimple "-integer-simple")
+  ];
+
 in
 stdenv.mkDerivation (rec {
   version = "9.2.0.20210821";
-  pname = "${targetPrefix}ghc";
+  pname = "${targetPrefix}ghc${variantSuffix}";
 
   src = fetchurl {
     url = "https://downloads.haskell.org/ghc/9.2.1-rc1/ghc-${version}-src.tar.xz";

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -149,7 +149,7 @@ in
 stdenv.mkDerivation (rec {
   inherit version;
   inherit (src) rev;
-  name = "${targetPrefix}ghc-${version}";
+  pname = "${targetPrefix}ghc";
 
   src = fetchgit {
     url = "https://gitlab.haskell.org/ghc/ghc.git/";

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -145,11 +145,17 @@ let
     targetPackages.stdenv.cc.bintools.bintools
   ];
 
+  # Makes debugging easier to see which variant is at play in `nix-store -q --tree`.
+  variantSuffix = lib.concatStrings [
+    (lib.optionalString stdenv.hostPlatform.isMusl "-musl")
+    (lib.optionalString enableNativeBignum "-native-bignum")
+  ];
+
 in
 stdenv.mkDerivation (rec {
   inherit version;
   inherit (src) rev;
-  pname = "${targetPrefix}ghc";
+  pname = "${targetPrefix}ghc${variantSuffix}";
 
   src = fetchgit {
     url = "https://gitlab.haskell.org/ghc/ghc.git/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Use `pname` and `version` everywhere
* Move `-binary` suffix *before* the version in order to not confuse `parseDrvName` etc.
* Add `variantSuffix` as contributed by @nh2 (with a fix for GHC HEAD which no longer has `integer-simple`, but bignum backend `native`)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
