### PR TITLE
treewide: remove superfluous sha256:, convert hash = "sha256:..." to sha256 = "sha256:..."

### DIFF
--- a/doc/builders/images/dockertools.section.md
+++ b/doc/builders/images/dockertools.section.md
@@ -222,8 +222,7 @@ Its parameters are described in the example below:
 ```nix
 pullImage {
   imageName = "nixos/nix";
-  imageDigest =
-    "sha256:20d9485b25ecfd89204e843a962c1bd70e9cc6858d65d7f5fadc340246e2116b";
+  imageDigest = "sha256:20d9485b25ecfd89204e843a962c1bd70e9cc6858d65d7f5fadc340246e2116b";
   finalImageName = "nix";
   finalImageTag = "1.11";
   sha256 = "0mqjy3zq2v6rrhizgb9nvhczl87lcfphq9601wcprdika2jz7qh8";

--- a/pkgs/applications/audio/cheesecutter/default.nix
+++ b/pkgs/applications/audio/cheesecutter/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "theyamo";
     repo = "CheeseCutter";
     rev = "84450d3614b8fb2cabda87033baab7bedd5a5c98";
-    sha256 = "sha256:0q4a791nayya6n01l0f4kk497rdq6kiq0n72fqdpwqy138pfwydn";
+    sha256 = "0q4a791nayya6n01l0f4kk497rdq6kiq0n72fqdpwqy138pfwydn";
   };
 
   patches = [

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -30,7 +30,7 @@ mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${pname}-${version}.tar.xz";
-    hash = "sha256:18dr577nv7ijw3ar6mrk2xrc54mlrqkaj5jrc6s5sirl0710fdfg";
+    sha256 = "18dr577nv7ijw3ar6mrk2xrc54mlrqkaj5jrc6s5sirl0710fdfg";
   };
 
   patches = [

--- a/pkgs/applications/misc/coursera-dl/default.nix
+++ b/pkgs/applications/misc/coursera-dl/default.nix
@@ -39,7 +39,7 @@ in pythonPackages.buildPythonApplication rec {
   patches = [
     (fetchpatch {
       url = "https://github.com/coursera-dl/coursera-dl/pull/789.patch";
-      sha256 = "sha256:07ca6zdyw3ypv7yzfv2kzmjvv86h0rwzllcg0zky27qppqz917bv";
+      sha256 = "07ca6zdyw3ypv7yzfv2kzmjvv86h0rwzllcg0zky27qppqz917bv";
     })
   ];
 

--- a/pkgs/applications/misc/smos/default.nix
+++ b/pkgs/applications/misc/smos/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/NorfairKing/smos/releases/download/v${version}/smos-release.zip";
-    sha256 = "sha256:07yavk7xl92yjwwjdig90yq421n8ldv4fjfw7izd4hfpzw849a12";
+    sha256 = "07yavk7xl92yjwwjdig90yq421n8ldv4fjfw7izd4hfpzw849a12";
   };
 
   dontInstall = true;

--- a/pkgs/applications/networking/mailreaders/meli/default.nix
+++ b/pkgs/applications/networking/mailreaders/meli/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0ycyksrrp4llwklzx3ipac8hmpfxa1pa7dqsm82wic0f6p5d1dp6";
   };
 
-  cargoSha256 = "sha256:0lxwhb2c16w5z7rqzch0ij8n8hxb5xcin31w9i28mzv1xm7sg8ks";
+  cargoSha256 = "0lxwhb2c16w5z7rqzch0ij8n8hxb5xcin31w9i28mzv1xm7sg8ks";
 
   cargoBuildFlags = lib.optional withNotmuch "--features=notmuch";
 

--- a/pkgs/applications/office/zanshin/default.nix
+++ b/pkgs/applications/office/zanshin/default.nix
@@ -30,7 +30,7 @@ mkDerivation rec {
     # Remove after next release.
     (fetchpatch {
       url = "https://invent.kde.org/pim/zanshin/-/commit/4850c08998b33b37af99c3312d193b063b3e8174.diff";
-      sha256 = "sha256:0lh0a035alhmws3zyfnkb814drq5cqxvzpwl4g1g5d435gy8k4ps";
+      sha256 = "0lh0a035alhmws3zyfnkb814drq5cqxvzpwl4g1g5d435gy8k4ps";
     })
   ];
 

--- a/pkgs/applications/qubes/qubes-core-vchan-xen/default.nix
+++ b/pkgs/applications/qubes/qubes-core-vchan-xen/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "QubesOS";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256:02l1vs5c2jfw22gxvl2fb66m0d99n8ya1i7rphsb5cxsljvxary0";
+    sha256 = "02l1vs5c2jfw22gxvl2fb66m0d99n8ya1i7rphsb5cxsljvxary0";
   };
 
   buildInputs = [ xen_4_10 ];

--- a/pkgs/applications/science/misc/graphia/default.nix
+++ b/pkgs/applications/science/misc/graphia/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "graphia-app";
     repo = "graphia";
     rev = version;
-    sha256 = "sha256:05givvvg743sawqy2vhljkfgn5v1s907sflsnsv11ddx6x51na1w";
+    sha256 = "05givvvg743sawqy2vhljkfgn5v1s907sflsnsv11ddx6x51na1w";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/terminal-emulators/tilix/default.nix
+++ b/pkgs/applications/terminal-emulators/tilix/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "gnunn1";
     repo = "tilix";
     rev = "${version}";
-    sha256 = "sha256:020gr4q7kmqq8vnsh8rw97gf1p2n1yq4d7ncyjjh9l13zkaxqqv9";
+    sha256 = "020gr4q7kmqq8vnsh8rw97gf1p2n1yq4d7ncyjjh9l13zkaxqqv9";
   };
 
   # Default upstream else LDC fails to link

--- a/pkgs/applications/version-management/monotone/default.nix
+++ b/pkgs/applications/version-management/monotone/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "7c6f434c";
     repo = "monotone-mirror";
     rev = "b30b0e1c16def043d2dad57d1467d5bfdecdb070";
-    hash = "sha256:1hfy8vaap3184cd7h3qhz0da7c992idkc6q2nz9frhma45c5vgmd";
+    sha256 = "1hfy8vaap3184cd7h3qhz0da7c992idkc6q2nz9frhma45c5vgmd";
   };
 
   patches = [

--- a/pkgs/applications/video/freetube/default.nix
+++ b/pkgs/applications/video/freetube/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${version}-beta/freetube_${version}_amd64.AppImage";
-    sha256 = "sha256:0qaghj70ffc90wck1i4217ky5d6cryrmgna2ipsc4v8dcvbyc1lh";
+    sha256 = "0qaghj70ffc90wck1i4217ky5d6cryrmgna2ipsc4v8dcvbyc1lh";
   };
 
   appimageContents = appimageTools.extractType2 {

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "audio-fix-ffmpeg-4_4";
       url = "https://github.com/HandBrake/HandBrake/commit/f28289fb06ab461ea082b4be56d6d1504c0c31c2.patch";
-      sha256 = "sha256:1zcwa4h97d8wjspb8kbd8b1jg0a9vvmv9zaphzry4m9q0bj3h3kz";
+      sha256 = "1zcwa4h97d8wjspb8kbd8b1jg0a9vvmv9zaphzry4m9q0bj3h3kz";
     })
   ];
 

--- a/pkgs/development/compilers/elm/packages/elm-json.nix
+++ b/pkgs/development/compilers/elm/packages/elm-json.nix
@@ -5,7 +5,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchurl {
     url = "https://github.com/zwilias/elm-json/archive/v${version}.tar.gz";
-    sha256 = "sha256:03azh7wvl60h6w7ffpvl49s7jr7bxpladcm4fzcasakg26i5a71x";
+    sha256 = "03azh7wvl60h6w7ffpvl49s7jr7bxpladcm4fzcasakg26i5a71x";
   };
 
   cargoPatches = [ ./elm-json.patch ];

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -168,7 +168,7 @@ stdenv.mkDerivation (rec {
     # https://github.com/haskell/cabal/issues/5887
     (fetchpatch {
             url = "https://raw.githubusercontent.com/input-output-hk/haskell.nix/122bd81150386867da07fdc9ad5096db6719545a/overlays/patches/ghc/cabal-host.patch";
-      sha256 = "sha256:0yd0sajgi24sc1w5m55lkg2lp6kfkgpp3lgija2c8y3cmkwfpdc1";
+      sha256 = "0yd0sajgi24sc1w5m55lkg2lp6kfkgpp3lgija2c8y3cmkwfpdc1";
     })
 
     # In order to build ghcjs packages, the Cabal of the ghc used for the ghcjs

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -178,7 +178,7 @@ stdenv.mkDerivation (rec {
     # https://github.com/haskell/cabal/issues/5887
     (fetchpatch {
             url = "https://raw.githubusercontent.com/input-output-hk/haskell.nix/122bd81150386867da07fdc9ad5096db6719545a/overlays/patches/ghc/cabal-host.patch";
-      sha256 = "sha256:0yd0sajgi24sc1w5m55lkg2lp6kfkgpp3lgija2c8y3cmkwfpdc1";
+      sha256 = "0yd0sajgi24sc1w5m55lkg2lp6kfkgpp3lgija2c8y3cmkwfpdc1";
     })
 
     # error: 'VirtualAllocExNuma' redeclared as different kind of symbol

--- a/pkgs/development/compilers/ghcjs/8.10/git.json
+++ b/pkgs/development/compilers/ghcjs/8.10/git.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/obsidiansystems/ghcjs",
   "rev": "9fc935f2c3ba6c33ec62eb83afc9f52a893eb68c",
-  "sha256": "sha256:063dmir39c4i1z8ypnmq86g1x2vhqndmdpzc4hyzsy5jjqcbx6i3",
+  "sha256": "063dmir39c4i1z8ypnmq86g1x2vhqndmdpzc4hyzsy5jjqcbx6i3",
   "fetchSubmodules": true
 }

--- a/pkgs/development/compilers/go/2-dev.nix
+++ b/pkgs/development/compilers/go/2-dev.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "https://go.googlesource.com/go";
     rev = "9cd52cf2a93a958e8e001aea36886e7846c91f2f";
-    sha256 = "sha256:0hybm93y4i4j7bs86y7h73nc1wqnspkq75if7n1032zf9bs8sm96";
+    sha256 = "0hybm93y4i4j7bs86y7h73nc1wqnspkq75if7n1032zf9bs8sm96";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -62,7 +62,7 @@ in stdenv.mkDerivation (rec {
     (fetchpatch {
       name = "uops-CMOV16rm-noreg.diff";
       url = "https://github.com/llvm/llvm-project/commit/9e9f991ac033.diff";
-      sha256 = "sha256:12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
+      sha256 = "12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
       stripLen = 1;
     })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -62,7 +62,7 @@ in stdenv.mkDerivation (rec {
     (fetchpatch {
       name = "uops-CMOV16rm-noreg.diff";
       url = "https://github.com/llvm/llvm-project/commit/9e9f991ac033.diff";
-      sha256 = "sha256:12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
+      sha256 = "12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
       stripLen = 1;
     })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -63,7 +63,7 @@ in stdenv.mkDerivation (rec {
     (fetchpatch {
       name = "uops-CMOV16rm-noreg.diff";
       url = "https://github.com/llvm/llvm-project/commit/9e9f991ac033.diff";
-      sha256 = "sha256:12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
+      sha256 = "12s8vr6ibri8b48h2z38f3afhwam10arfiqfy4yg37bmc054p5hi";
       stripLen = 1;
     })
   ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;

--- a/pkgs/development/compilers/sbcl/2.1.2.nix
+++ b/pkgs/development/compilers/sbcl/2.1.2.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
   version = "2.1.2";
-  sha256 = "sha256:02scrqyp2izsd8xjm2k5j5lhn4pdhd202jlcb54ysmcqjd80awdp";
+  sha256 = "02scrqyp2izsd8xjm2k5j5lhn4pdhd202jlcb54ysmcqjd80awdp";
 }

--- a/pkgs/development/coq-modules/addition-chains/default.nix
+++ b/pkgs/development/coq-modules/addition-chains/default.nix
@@ -6,7 +6,7 @@ mkCoqDerivation {
   pname = "addition-chains";
   repo = "hydra-battles";
 
-  release."0.4".sha256 = "sha256:1f7pc4w3kir4c9p0fjx5l77401bx12y72nmqxrqs3qqd3iynvqlp";
+  release."0.4".sha256 = "1f7pc4w3kir4c9p0fjx5l77401bx12y72nmqxrqs3qqd3iynvqlp";
   releaseRev = (v: "v${v}");
 
   inherit version;

--- a/pkgs/development/coq-modules/ceres/default.nix
+++ b/pkgs/development/coq-modules/ceres/default.nix
@@ -9,7 +9,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = if versions.isGe "8.8" coq.version then "0.4.0" else null;
-  release."0.4.0".sha256 = "sha256:0zwp3pn6fdj0qdig734zdczrls886al06mxqhhabms0jvvqijmbi";
+  release."0.4.0".sha256 = "0zwp3pn6fdj0qdig734zdczrls886al06mxqhhabms0jvvqijmbi";
 
   meta = {
     description = "Library for serialization to S-expressions";

--- a/pkgs/development/coq-modules/gaia/default.nix
+++ b/pkgs/development/coq-modules/gaia/default.nix
@@ -3,8 +3,8 @@
 with lib; mkCoqDerivation {
   pname = "gaia";
 
-  release."1.11".sha256 = "sha256:0gwb0blf37sv9gb0qpn34dab71zdcx7jsnqm3j9p58qw65cgsqn5";
-  release."1.12".sha256 = "sha256:0c6cim4x6f9944g8v0cp0lxs244lrhb04ms4y2s6y1wh321zj5mi";
+  release."1.11".sha256 = "0gwb0blf37sv9gb0qpn34dab71zdcx7jsnqm3j9p58qw65cgsqn5";
+  release."1.12".sha256 = "0c6cim4x6f9944g8v0cp0lxs244lrhb04ms4y2s6y1wh321zj5mi";
   releaseRev = (v: "v${v}");
 
   inherit version;

--- a/pkgs/development/coq-modules/hydra-battles/default.nix
+++ b/pkgs/development/coq-modules/hydra-battles/default.nix
@@ -5,7 +5,7 @@ mkCoqDerivation {
   pname = "hydra-battles";
   owner = "coq-community";
 
-  release."0.4".sha256 = "sha256:1f7pc4w3kir4c9p0fjx5l77401bx12y72nmqxrqs3qqd3iynvqlp";
+  release."0.4".sha256 = "1f7pc4w3kir4c9p0fjx5l77401bx12y72nmqxrqs3qqd3iynvqlp";
   releaseRev = (v: "v${v}");
 
   inherit version;

--- a/pkgs/development/coq-modules/parsec/default.nix
+++ b/pkgs/development/coq-modules/parsec/default.nix
@@ -12,7 +12,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = if versions.isGe "8.12" coq.version then "0.1.0" else null;
-  release."0.1.0".sha256 = "sha256:01avfcqirz2b9wjzi9iywbhz9szybpnnj3672dgkfsimyg9jgnsr";
+  release."0.1.0".sha256 = "01avfcqirz2b9wjzi9iywbhz9szybpnnj3672dgkfsimyg9jgnsr";
 
   meta = {
     description = "Library for serialization to S-expressions";

--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -15,9 +15,9 @@ let
       });
 
   release = {
-    "8.13.0+0.13.0".sha256 = "sha256:0k69907xn4k61w4mkhwf8kh8drw9pijk9ynijsppihw98j8w38fy";
-    "8.12.0+0.12.1".sha256 = "sha256:048x3sgcq4h845hi6hm4j4dsfca8zfj70dm42w68n63qcm6xf9hn";
-    "8.11.0+0.11.1".sha256 = "sha256:1phmh99yqv71vlwklqgfxiq2vj99zrzxmryj2j4qvg5vav3y3y6c";
+    "8.13.0+0.13.0".sha256 = "0k69907xn4k61w4mkhwf8kh8drw9pijk9ynijsppihw98j8w38fy";
+    "8.12.0+0.12.1".sha256 = "048x3sgcq4h845hi6hm4j4dsfca8zfj70dm42w68n63qcm6xf9hn";
+    "8.11.0+0.11.1".sha256 = "1phmh99yqv71vlwklqgfxiq2vj99zrzxmryj2j4qvg5vav3y3y6c";
     "8.10.0+0.7.2".sha256  = "sha256:1ljzm63hpd0ksvkyxcbh8rdf7p90vg91gb4h0zz0941v1zh40k8c";
   };
 in

--- a/pkgs/development/coq-modules/topology/default.nix
+++ b/pkgs/development/coq-modules/topology/default.nix
@@ -6,7 +6,7 @@ mkCoqDerivation rec {
 
   releaseRev = v: "v${v}";
 
-  release."9.0.0".sha256 = "sha256:03lgy53xg9pmrdd3d8qb4087k5qjnk260655svp6d79x4p2lxr8c";
+  release."9.0.0".sha256 = "03lgy53xg9pmrdd3d8qb4087k5qjnk260655svp6d79x4p2lxr8c";
   release."8.12.0".sha256 = "sha256-ypHmHwzwZ6MQPYwuS3QyZmVOEPUCSbO2lhVaA6TypgQ=";
   release."8.10.0".sha256 = "sha256-mCLF3JYIiO3AEW9yvlcLeF7zN4SjW3LG+Y5vYB0l55A=";
   release."8.9.0".sha256 = "sha256-ZJh1BM34iZOQ75zqLIA+KtBjO2y33y0UpAw/ydCWQYc=";

--- a/pkgs/development/coq-modules/zorns-lemma/default.nix
+++ b/pkgs/development/coq-modules/zorns-lemma/default.nix
@@ -7,7 +7,7 @@ mkCoqDerivation {
 
   releaseRev = v: "v${v}";
 
-  release."9.0.0".sha256 = "sha256:03lgy53xg9pmrdd3d8qb4087k5qjnk260655svp6d79x4p2lxr8c";
+  release."9.0.0".sha256 = "03lgy53xg9pmrdd3d8qb4087k5qjnk260655svp6d79x4p2lxr8c";
   release."8.11.0".sha256 = "sha256-2Hf7YwRcFmP/DqwFtF1p78MCNV50qUWfMVQtZbwKd0k=";
   release."8.10.0".sha256 = "sha256-qLPLK2ZLJQ4SmJX2ADqFiP4kgHuQFJTeNXkBbjiFS+4=";
   release."8.9.0".sha256 = "sha256-lEh978cXehglFX9D92RVltEuvN8umfPo/hvmFZm2NGo=";

--- a/pkgs/development/interpreters/red/default.nix
+++ b/pkgs/development/interpreters/red/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     rev = "755eb943ccea9e78c2cab0f20b313a52404355cb";
     owner = "red";
     repo = "red";
-    sha256 = "sha256:045rrg9666zczgrwyyyglivzdzja103s52b0fzj7hqmr1fz68q37";
+    sha256 = "045rrg9666zczgrwyyyglivzdzja103s52b0fzj7hqmr1fz68q37";
   };
 
   rebol = fetchurl {

--- a/pkgs/development/libraries/appindicator-sharp/default.nix
+++ b/pkgs/development/libraries/appindicator-sharp/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     owner = "stsundermann";
     repo = "appindicator-sharp";
     rev = version;
-    sha256 = "sha256:1i0vqbp05l29f5v9ygp7flm4s05pcnn5ivl578mxmhb51s7ncw6l";
+    sha256 = "1i0vqbp05l29f5v9ygp7flm4s05pcnn5ivl578mxmhb51s7ncw6l";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -761,7 +761,7 @@ in rec {
 
     src = fetchurl {
       url = "https://stavekontrolden.dk/dictionaries/da_DK/da_DK-${version}.oxt";
-      sha256 = "sha256:0i1cw0nfg24b0sg2yc3q7315ng5vc5245nvh0l1cndkn2c9z4978";
+      sha256 = "0i1cw0nfg24b0sg2yc3q7315ng5vc5245nvh0l1cndkn2c9z4978";
     };
 
     shortName = "da-dk";

--- a/pkgs/development/libraries/vtk/7.x.nix
+++ b/pkgs/development/libraries/vtk/7.x.nix
@@ -10,7 +10,7 @@ import ./generic.nix {
 
     {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/vtk/files/vtk-8.2.0-gcc-10.patch?id=c4256f68d3589570443075eccbbafacf661f785f";
-      sha256 = "sha256:0bpwrdfmi15grsg4jy7bzj2z6511a0c160cmw5lsi65aabyh7cl5";
+      sha256 = "0bpwrdfmi15grsg4jy7bzj2z6511a0c160cmw5lsi65aabyh7cl5";
     }
 
     # Add missing include required with recent Qt.

--- a/pkgs/development/libraries/vtk/8.x.nix
+++ b/pkgs/development/libraries/vtk/8.x.nix
@@ -8,11 +8,11 @@ import ./generic.nix {
   }
   {
     url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/vtk/files/vtk-8.2.0-gcc-10.patch?id=c4256f68d3589570443075eccbbafacf661f785f";
-    sha256 = "sha256:0bpwrdfmi15grsg4jy7bzj2z6511a0c160cmw5lsi65aabyh7cl5";
+    sha256 = "0bpwrdfmi15grsg4jy7bzj2z6511a0c160cmw5lsi65aabyh7cl5";
   }
   {
     url = "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/6943.diff";
-    sha256 = "sha256:1nzdw3f6bsri04y528zj2klqkb9p8s4lnl9g5zvm119m1cmyhn04";
+    sha256 = "1nzdw3f6bsri04y528zj2klqkb9p8s4lnl9g5zvm119m1cmyhn04";
   }
   ];
 }

--- a/pkgs/development/libraries/webkit2-sharp/default.nix
+++ b/pkgs/development/libraries/webkit2-sharp/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "hbons";
     repo = "webkit2-sharp";
     rev = version;
-    sha256 = "sha256:0a7vx81zvzn2wq4q2mqrxvlps1mqk28lm1gpfndqryxm4iiw28vc";
+    sha256 = "0a7vx81zvzn2wq4q2mqrxvlps1mqk28lm1gpfndqryxm4iiw28vc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-wlr/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "emersion";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256:13fbzh8bjnhk4xs8j9bpc01q3hy27zpbf0gkk1fnh3hm5pnyfyiv";
+    sha256 = "13fbzh8bjnhk4xs8j9bpc01q3hy27zpbf0gkk1fnh3hm5pnyfyiv";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config wayland-protocols makeWrapper ];

--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -17,7 +17,7 @@ let lispPackages = rec {
     src = pkgs.fetchgit {
       url = "https://github.com/quicklisp/quicklisp-client/";
       rev = "refs/tags/version-${version}";
-      sha256 = "sha256:102f1chpx12h5dcf659a9kzifgfjc482ylf73fg1cs3w34zdawnl";
+      sha256 = "102f1chpx12h5dcf659a9kzifgfjc482ylf73fg1cs3w34zdawnl";
     };
     overrides = x: rec {
       inherit clwrapper;
@@ -25,7 +25,7 @@ let lispPackages = rec {
         # Will usually be replaced with a fresh version anyway, but needs to be
         # a valid distinfo.txt
         url = "https://beta.quicklisp.org/dist/quicklisp/2021-04-11/distinfo.txt";
-        sha256 = "sha256:1z7a7m9cm7iv4m9ajvyqphsw30s3qwb0l8g8ayfmkvmvhlj79g86";
+        sha256 = "1z7a7m9cm7iv4m9ajvyqphsw30s3qwb0l8g8ayfmkvmvhlj79g86";
       };
       buildPhase = "true; ";
       postInstall = ''

--- a/pkgs/development/ocaml-modules/alcotest/default.nix
+++ b/pkgs/development/ocaml-modules/alcotest/default.nix
@@ -10,7 +10,7 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/mirage/alcotest/releases/download/${version}/alcotest-mirage-${version}.tbz";
-    sha256 = "sha256:1h9yp44snb6sgm5g1x3wg4gwjscic7i56jf0j8jr07355pxwrami";
+    sha256 = "1h9yp44snb6sgm5g1x3wg4gwjscic7i56jf0j8jr07355pxwrami";
   };
 
   propagatedBuildInputs = [ astring cmdliner fmt uuidm re stdlib-shims uutf ];

--- a/pkgs/development/python-modules/alectryon/default.nix
+++ b/pkgs/development/python-modules/alectryon/default.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256:0mca25jv917myb4n91ccpl5fz058aiqsn8cniflwfw5pp6lqnfg7";
+    sha256 = "0mca25jv917myb4n91ccpl5fz058aiqsn8cniflwfw5pp6lqnfg7";
   };
 
   patches = [

--- a/pkgs/development/python-modules/emv/default.nix
+++ b/pkgs/development/python-modules/emv/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     owner = "russss";
     repo = "python-emv";
     rev = "v${version}";
-    hash = "sha256:1715hcba3fdi0i5awnrjdjnk74p66sxm9349pd8bb717zrh4gpj7";
+    sha256 = "1715hcba3fdi0i5awnrjdjnk74p66sxm9349pd8bb717zrh4gpj7";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/hydra/default.nix
+++ b/pkgs/development/python-modules/hydra/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     owner = "facebookresearch";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256:1svzysrjg47gb6lxx66fzd8wbhpbbsppprpbqssf5aqvhxgay3qk";
+    sha256 = "1svzysrjg47gb6lxx66fzd8wbhpbbsppprpbqssf5aqvhxgay3qk";
   };
 
   nativeBuildInputs = [ jre_headless ];

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -39,11 +39,11 @@ buildPythonPackage rec {
   src = {
     cpu = fetchurl {
       url = "https://storage.googleapis.com/jax-releases/nocuda/jaxlib-${version}-cp39-none-manylinux2010_x86_64.whl";
-      sha256 = "sha256:0rqhs6qabydizlv5d3rb20dbv6612rr7dqfniy9r6h4kazdinsn6";
+      sha256 = "0rqhs6qabydizlv5d3rb20dbv6612rr7dqfniy9r6h4kazdinsn6";
     };
     gpu = fetchurl {
       url = "https://storage.googleapis.com/jax-releases/cuda111/jaxlib-${version}+cuda111-cp39-none-manylinux2010_x86_64.whl";
-      sha256 = "sha256:065kyzjsk9m84d138p99iymdiiicm1qz8a3iwxz8rspl43rwrw89";
+      sha256 = "065kyzjsk9m84d138p99iymdiiicm1qz8a3iwxz8rspl43rwrw89";
     };
   }.${device};
 

--- a/pkgs/development/python-modules/precis-i18n/default.nix
+++ b/pkgs/development/python-modules/precis-i18n/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "byllyfish";
     repo = "precis_i18n";
     rev = "v${version}";
-    hash = "sha256:1r9pah1kgik6valf15ac7ybw0szr92cq84kwjvm6mq3z46j1pmkr";
+    sha256 = "1r9pah1kgik6valf15ac7ybw0szr92cq84kwjvm6mq3z46j1pmkr";
   };
 
   meta = {

--- a/pkgs/development/python-modules/pubnubsub-handler/default.nix
+++ b/pkgs/development/python-modules/pubnubsub-handler/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256:1c44x19zi709sazgl060nkqa7vbaf3iyhwcnwdykhsbipvp6bscy";
+    sha256 = "1c44x19zi709sazgl060nkqa7vbaf3iyhwcnwdykhsbipvp6bscy";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/sphinxcontrib-excel-table/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-excel-table/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256:1q79byn3k3ribvwqafbpixwabjhymk46ns8ym0hxcn8vhf5nljzd";
+    sha256 = "1q79byn3k3ribvwqafbpixwabjhymk46ns8ym0hxcn8vhf5nljzd";
   };
 
   propagatedBuildInputs = [ sphinx openpyxl ];

--- a/pkgs/development/tools/capnproto-java/default.nix
+++ b/pkgs/development/tools/capnproto-java/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "capnproto";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256:1512x70xa6mlg9dmr84r8xbf0jzysjal51ivhhh2ppl97yiqjgls";
+    sha256 = "1512x70xa6mlg9dmr84r8xbf0jzysjal51ivhhh2ppl97yiqjgls";
   };
 
   patches = [

--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -9,14 +9,14 @@ stdenv.mkDerivation rec {
       owner = "dlang";
       repo = "dmd";
       rev = "v${version}";
-      sha256 = "sha256:0faca1y42a1h16aml4lb7z118mh9k9fjx3xlw3ki5f1h3ln91xhk";
+      sha256 = "0faca1y42a1h16aml4lb7z118mh9k9fjx3xlw3ki5f1h3ln91xhk";
       name = "dmd";
     })
     (fetchFromGitHub {
       owner = "dlang";
       repo = "tools";
       rev = "v${version}";
-      sha256 = "sha256:0rdfk3mh3fjrb0h8pr8skwlq6ac9hdl1fkrkdl7n1fa2806b740b";
+      sha256 = "0rdfk3mh3fjrb0h8pr8skwlq6ac9hdl1fkrkdl7n1fa2806b740b";
       name = "dtools";
     })
   ];

--- a/pkgs/development/tools/mold/default.nix
+++ b/pkgs/development/tools/mold/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "rui314";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256:1z9i8nvdl9h0zydh1gd9244q96n9x1gh5y90m71bghnh7nws0zmd";
+    sha256 = "1z9i8nvdl9h0zydh1gd9244q96n9x1gh5y90m71bghnh7nws0zmd";
   };
 
   patches = [

--- a/pkgs/development/tools/parsing/bisonc++/default.nix
+++ b/pkgs/development/tools/parsing/bisonc++/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "fbb-git";
     repo = "bisoncpp";
     rev = "6.04.00";
-    sha256 = "sha256:0aa9bij4g08ilsk6cgrbgi03vyhqr9fn6j2164sjin93m63212wl";
+    sha256 = "0aa9bij4g08ilsk6cgrbgi03vyhqr9fn6j2164sjin93m63212wl";
   };
 
   buildInputs = [ bobcat ];
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   gpl = fetchurl {
     url = "https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt";
-    sha256 = "sha256:0hq6i0dm4420825fdm0lnnppbil6z67ls67n5kgjcd912dszjxw1";
+    sha256 = "0hq6i0dm4420825fdm0lnnppbil6z67ls67n5kgjcd912dszjxw1";
   };
 
   postPatch = ''

--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -4,7 +4,7 @@ let
   buildNum = "97";
   jar = fetchurl {
     url = "https://papermc.io/api/v1/paper/${mcVersion}/${buildNum}/download";
-    sha256 = "sha256:0d7q6v5w872phcgkha7j5sxniqq9wqbh1jxdvyvy6d2jl74g1gzw";
+    sha256 = "0d7q6v5w872phcgkha7j5sxniqq9wqbh1jxdvyvy6d2jl74g1gzw";
   };
 in stdenv.mkDerivation {
   pname = "papermc";

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -20,9 +20,9 @@ rec {
   stable = if stdenv.hostPlatform.system == "x86_64-linux"
     then generic {
       version = "470.74";
-      sha256_64bit = "sha256:0snzrb78f283rl92r5cqnr7bdk3yfkqpjac80sqskwi9wgg17r9k";
-      settingsSha256 = "sha256:0hd9973l0zd8a0ia1dysfrk30jqxff1rr07b79ggvqd1xnvv0iqn";
-      persistencedSha256 = "sha256:0i8wfhz53hdnabdcx9awki3nk6xa6dadzn91iswhmfm4jj6964jf";
+      sha256_64bit = "0snzrb78f283rl92r5cqnr7bdk3yfkqpjac80sqskwi9wgg17r9k";
+      settingsSha256 = "0hd9973l0zd8a0ia1dysfrk30jqxff1rr07b79ggvqd1xnvv0iqn";
+      persistencedSha256 = "0i8wfhz53hdnabdcx9awki3nk6xa6dadzn91iswhmfm4jj6964jf";
     }
     else legacy_390;
 

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -28,7 +28,7 @@ buildBazelPackage rec {
     owner = "envoyproxy";
     repo = "envoy";
     rev = srcVer.commit;
-    hash = "sha256:09zzr4h3zjsb2rkxrvlazpx0jy33yn9j65ilxiqbvv0ckaralqfc";
+    sha256 = "09zzr4h3zjsb2rkxrvlazpx0jy33yn9j65ilxiqbvv0ckaralqfc";
 
     extraPostFetch = ''
       chmod -R +w $out
@@ -58,7 +58,7 @@ buildBazelPackage rec {
   ];
 
   fetchAttrs = {
-    sha256 = "sha256:1cy2b73x8jzczq9z9c1kl7zrg5iasvsakb50zxn4mswpmajkbj5h";
+    sha256 = "1cy2b73x8jzczq9z9c1kl7zrg5iasvsakb50zxn4mswpmajkbj5h";
     dontUseCmakeConfigure = true;
     dontUseGnConfigure = true;
     preInstall = ''

--- a/pkgs/servers/http/pomerium/default.nix
+++ b/pkgs/servers/http/pomerium/default.nix
@@ -16,10 +16,10 @@ buildGoModule rec {
     owner = "pomerium";
     repo = "pomerium";
     rev = "v${version}";
-    hash = "sha256:1jb96jk5qmary4fi1z9zwmppdyskj0qb6qii8s8mwazjjxqj1z2s";
+    sha256 = "1jb96jk5qmary4fi1z9zwmppdyskj0qb6qii8s8mwazjjxqj1z2s";
   };
 
-  vendorSha256 = "sha256:1daabi9qc9nx8bafn26iw6rv4vx2xpd0nnk06265aqaksx26db0s";
+  vendorSha256 = "1daabi9qc9nx8bafn26iw6rv4vx2xpd0nnk06265aqaksx26db0s";
   subPackages = [
     "cmd/pomerium"
     "cmd/pomerium-cli"

--- a/pkgs/tools/admin/amazon-ec2-utils/default.nix
+++ b/pkgs/tools/admin/amazon-ec2-utils/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "aws";
     repo = "amazon-ec2-utils";
     rev = version;
-    hash = "sha256:04dpxaaca144a74r6d93q4lp0d5l32v07rldj7v2v1c6s9nsf4mv";
+    sha256 = "04dpxaaca144a74r6d93q4lp0d5l32v07rldj7v2v1c6s9nsf4mv";
   };
 
   buildInputs = [

--- a/pkgs/tools/graphics/asymptote/default.nix
+++ b/pkgs/tools/graphics/asymptote/default.nix
@@ -16,14 +16,14 @@ stdenv.mkDerivation rec {
     owner = "vectorgraphics";
     repo = pname;
     rev = version;
-    sha256 = "sha256:1lawj2gf0985clzbyym26s5mxxp2syl1dqqxfzk0sq9s30l2rj3l";
+    sha256 = "1lawj2gf0985clzbyym26s5mxxp2syl1dqqxfzk0sq9s30l2rj3l";
   };
 
   patches =
     (lib.optional (lib.versionOlder version "2.68")
       (fetchpatch {
         url = "https://github.com/vectorgraphics/asymptote/commit/3361214340d58235f4dbb8f24017d0cd5d94da72.patch";
-        sha256 = "sha256:1z2b41x8v7683myd45lq6niixpdjy0b185x0xl61130vrijhq5nm";
+        sha256 = "1z2b41x8v7683myd45lq6niixpdjy0b185x0xl61130vrijhq5nm";
       }))
   ;
 

--- a/pkgs/tools/misc/flexoptix-app/default.nix
+++ b/pkgs/tools/misc/flexoptix-app/default.nix
@@ -6,7 +6,7 @@
   src = fetchurl {
     name = "${name}.AppImage";
     url = "https://flexbox.reconfigure.me/download/electron/linux/x64/FLEXOPTIX%20App.${version}.AppImage";
-    sha256 = "sha256:1hzdb2fbkwpsf0d3ws4z32blk6549jwhf1lrlqmcxhzqfvkr4gin";
+    sha256 = "1hzdb2fbkwpsf0d3ws4z32blk6549jwhf1lrlqmcxhzqfvkr4gin";
   };
 
   udevRules = fetchurl {

--- a/pkgs/tools/misc/fx_cast/default.nix
+++ b/pkgs/tools/misc/fx_cast/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     owner = "hensm";
     repo = "fx_cast";
     rev = "v${version}";
-    hash = "sha256:1prgk9669xgwkdl39clq0l75n0gnkkpn27gp9rbgl4bafrhvmg9a";
+    sha256 = "1prgk9669xgwkdl39clq0l75n0gnkkpn27gp9rbgl4bafrhvmg9a";
   };
 
   buildInputs = with pkgs; [

--- a/pkgs/tools/misc/wlc/default.nix
+++ b/pkgs/tools/misc/wlc/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256:01c1qxq6dxvpn8rgpbqs4iw5daa0rmlgygb3xhhfj7xpqv1v84ir";
+    sha256 = "01c1qxq6dxvpn8rgpbqs4iw5daa0rmlgygb3xhhfj7xpqv1v84ir";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -8,7 +8,7 @@ python3Packages.buildPythonPackage rec {
     repo = "yubikey-manager";
     rev = version;
     owner = "Yubico";
-    sha256 = "sha256:0ycp7k6lkxzqwkc16fifhyqaqi7hl3351pwddsn18r5l83jnzdn2";
+    sha256 = "0ycp7k6lkxzqwkc16fifhyqaqi7hl3351pwddsn18r5l83jnzdn2";
   };
 
   postPatch = ''

--- a/pkgs/tools/networking/openapi-generator-cli/example.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/example.nix
@@ -4,7 +4,7 @@ runCommand "openapi-generator-cli-test" {
   nativeBuildInputs = [ openapi-generator-cli ];
   petstore = fetchurl {
     url = "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/14c0908becbccd78252be49bd92be8c53cd2b9e3/examples/v3.0/petstore.yaml";
-    sha256 = "sha256:1mgdbzv42alv0b1a18dqbabqyvyhrg3brynr5hqsrm3qljfzaq5b";
+    sha256 = "1mgdbzv42alv0b1a18dqbabqyvyhrg3brynr5hqsrm3qljfzaq5b";
   };
   config = builtins.toJSON {
     elmVersion = "0.19";

--- a/pkgs/tools/package-management/cargo-edit/default.nix
+++ b/pkgs/tools/package-management/cargo-edit/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     owner = "killercup";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256:0fh1lq793k4ddpqsf2av447hcb74vcq53afkm3g4672k48mjjw1y";
+    sha256 = "0fh1lq793k4ddpqsf2av447hcb74vcq53afkm3g4672k48mjjw1y";
   };
 
   cargoSha256 = "0ah3zjx36ibax4gi66g13finh4m2k0aidxkg2nxx1c2aqj847mm1";

--- a/pkgs/tools/security/softhsm/default.nix
+++ b/pkgs/tools/security/softhsm/default.nix
@@ -1,13 +1,12 @@
 { lib, stdenv, fetchurl, botan2, libobjc, Security }:
 
 stdenv.mkDerivation rec {
-
   pname = "softhsm";
   version = "2.6.1";
 
   src = fetchurl {
     url = "https://dist.opendnssec.org/source/${pname}-${version}.tar.gz";
-    hash = "sha256:1wkmyi6n3z2pak1cj5yk6v6bv9w0m24skycya48iikab0mrr8931";
+    sha256 = "1wkmyi6n3z2pak1cj5yk6v6bv9w0m24skycya48iikab0mrr8931";
   };
 
   configureFlags = [

--- a/pkgs/tools/security/softhsm/default.nix
+++ b/pkgs/tools/security/softhsm/default.nix
@@ -17,8 +17,7 @@ stdenv.mkDerivation rec {
     "--localstatedir=$out/var"
     ];
 
-  propagatedBuildInputs =
-    lib.optionals stdenv.isDarwin [ libobjc Security ];
+  propagatedBuildInputs = lib.optionals stdenv.isDarwin [ libobjc Security ];
 
   buildInputs = [ botan2 ];
 

--- a/pkgs/tools/system/retry/default.nix
+++ b/pkgs/tools/system/retry/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "minfrin";
     repo = "retry";
     rev = "${pname}-${version}";
-    sha256 = "sha256:0jrx4yrwlf4fn3309kxraj7zgwk7gq6rz5ibswq3w3b3jfvxi8qb";
+    sha256 = "0jrx4yrwlf4fn3309kxraj7zgwk7gq6rz5ibswq3w3b3jfvxi8qb";
   };
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
