### PR TITLE
haskell.compiler.ghc*: Use 8.10.7 bindist for bootstrapping. 

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -347,10 +347,6 @@ stdenv.mkDerivation (rec {
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
-
-    # integer-simple builds are broken when GHC links against musl.
-    # See https://github.com/NixOS/nixpkgs/pull/129606#issuecomment-881323743.
-    broken = enableIntegerSimple && hostPlatform.isMusl;
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -346,10 +346,6 @@ stdenv.mkDerivation (rec {
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
-
-    # integer-simple builds are broken when GHC links against musl.
-    # See https://github.com/NixOS/nixpkgs/pull/129606#issuecomment-881323743.
-    broken = enableIntegerSimple && hostPlatform.isMusl;
   };
 
   dontStrip = (targetPlatform.useAndroidPrebuilt || targetPlatform.isWasm);

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -309,10 +309,6 @@ stdenv.mkDerivation (rec {
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
-
-    # integer-simple builds are broken when GHC links against musl.
-    # See https://github.com/NixOS/nixpkgs/pull/129606#issuecomment-881323743.
-    broken = enableIntegerSimple && hostPlatform.isMusl;
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -322,10 +322,6 @@ stdenv.mkDerivation (rec {
     ] ++ lib.teams.haskell.members;
     timeout = 24 * 3600;
     inherit (ghc.meta) license platforms;
-
-    # integer-simple builds are broken when GHC links against musl.
-    # See https://github.com/NixOS/nixpkgs/pull/129606#issuecomment-881323743.
-    broken = enableIntegerSimple && hostPlatform.isMusl;
   };
 
 } // lib.optionalAttrs targetPlatform.useAndroidPrebuilt {

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -71,13 +71,12 @@ in {
     };
 
     ghc884 = callPackage ../development/compilers/ghc/8.8.4.nix {
-      # the oldest ghc with aarch64-darwin support is 8.10.5
-      bootPkgs = if stdenv.isDarwin && stdenv.isAarch64 then
-          packages.ghc8107BinaryMinimal
+      bootPkgs =
         # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
+        # the oldest ghc with aarch64-darwin support is 8.10.5
         # Musl bindists do not exist for ghc 8.6.5, so we use 8.10.* for them
-        else if stdenv.isAarch64 || stdenv.targetPlatform.isMusl then
-          packages.ghc8102BinaryMinimal
+        if stdenv.isAarch64 || stdenv.hostPlatform.isMusl then
+          packages.ghc8107BinaryMinimal
         else
           packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -85,13 +84,12 @@ in {
       llvmPackages = pkgs.llvmPackages_7;
     };
     ghc8107 = callPackage ../development/compilers/ghc/8.10.7.nix {
-      # the oldest ghc with aarch64-darwin support is 8.10.5
-      bootPkgs = if stdenv.isDarwin && stdenv.isAarch64 then
-          packages.ghc8107BinaryMinimal
+      bootPkgs =
         # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
+        # the oldest ghc with aarch64-darwin support is 8.10.5
         # Musl bindists do not exist for ghc 8.6.5, so we use 8.10.* for them
-        else if stdenv.isAarch64 || stdenv.isAarch32 || stdenv.targetPlatform.isMusl then
-          packages.ghc8102BinaryMinimal
+        if stdenv.isAarch64 || stdenv.isAarch32 || stdenv.targetPlatform.isMusl then
+          packages.ghc8107BinaryMinimal
         else
           packages.ghc865Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -103,24 +101,24 @@ in {
       llvmPackages = pkgs.llvmPackages_9;
     };
     ghc901 = callPackage ../development/compilers/ghc/9.0.1.nix {
-      # the oldest ghc with aarch64-darwin support is 8.10.5
-      bootPkgs = if stdenv.isDarwin && stdenv.isAarch64 then
+      bootPkgs =
+        # aarch64 ghc8107Binary exceeds max output size on hydra
+        # the oldest ghc with aarch64-darwin support is 8.10.5
+        if stdenv.isAarch64 || stdenv.isAarch32 then
           packages.ghc8107BinaryMinimal
-        # aarch64 ghc8102Binary exceeds max output size on hydra
-        else if stdenv.isAarch64 || stdenv.isAarch32 then
-          packages.ghc8102BinaryMinimal
         else
-          packages.ghc8102Binary;
+          packages.ghc8107Binary;
       inherit (buildPackages.python3Packages) sphinx;
       buildLlvmPackages = buildPackages.llvmPackages_10;
       llvmPackages = pkgs.llvmPackages_10;
     };
     ghc921 = callPackage ../development/compilers/ghc/9.2.1.nix {
-      # aarch64 ghc8102Binary exceeds max output size on hydra
-      bootPkgs = if stdenv.isAarch64 || stdenv.isAarch32 then
-          packages.ghc8102BinaryMinimal
+      bootPkgs =
+        # aarch64 ghc8107Binary exceeds max output size on hydra
+        if stdenv.isAarch64 || stdenv.isAarch32 then
+          packages.ghc8107BinaryMinimal
         else
-          packages.ghc8102Binary;
+          packages.ghc8107Binary;
       inherit (buildPackages.python3Packages) sphinx;
       # Need to use apple's patched xattr until
       # https://github.com/xattr/xattr/issues/44 and

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -88,10 +88,10 @@ in {
         # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
         # the oldest ghc with aarch64-darwin support is 8.10.5
         # Musl bindists do not exist for ghc 8.6.5, so we use 8.10.* for them
-        if stdenv.isAarch64 || stdenv.isAarch32 || stdenv.targetPlatform.isMusl then
+        if stdenv.isAarch64 || stdenv.isAarch32 then
           packages.ghc8107BinaryMinimal
         else
-          packages.ghc865Binary;
+          packages.ghc8107Binary;
       inherit (buildPackages.python3Packages) sphinx;
       # Need to use apple's patched xattr until
       # https://github.com/xattr/xattr/issues/44 and

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -249,10 +249,6 @@ let
         # TODO: remove ghc865Binary altogether and use ghc8102Binary
         ghc865Binary = {};
 
-        # remove integer-simple because it appears to be broken with
-        # musl and non-static-linking.
-        integer-simple = {};
-
         ghcjs = {};
         ghcjs810 = {};
       };
@@ -380,6 +376,7 @@ let
         };
         constituents = accumulateDerivations [
           jobs.pkgsMusl.haskell.compiler.ghc8102Binary
+          jobs.pkgsMusl.haskell.compiler.ghc8107Binary
           jobs.pkgsMusl.haskell.compiler.ghc884
           jobs.pkgsMusl.haskell.compiler.ghc8107
           jobs.pkgsMusl.haskell.compiler.ghc901


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#138524, rebased on top of haskell-updates with a few cleanups.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
