### PR TITLE
runescape: init at 2.2.9

### DIFF
--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -1,24 +1,19 @@
 { stdenv, lib, buildFHSUserEnv, dpkg, glibc, gcc-unwrapped, autoPatchelfHook, fetchurl, wrapGAppsHook
-  , gnome2, xorg
-  , libSM, libXxf86vm, libX11, glib, pango, cairo, gtk2-x11, zlib, openssl
-  , libpulseaudio
-  , SDL2, xorg_sys_opengl, libGL
+, gnome2, xorg
+, libSM, libXxf86vm, libX11, glib, pango, cairo, gtk2-x11, zlib, openssl
+, libpulseaudio
+, SDL2, xorg_sys_opengl, libGL
 }:
 let
 
-  version = "2.2.9";
-  pname = "runescape-launcher";
+  runescape = stdenv.mkDerivation rec {
+    version = "2.2.9";
+    pname = "runescape-launcher";
 
-  src = fetchurl {
-    url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb";
-    sha256 = "0r5v1pwh0aas31b1d3pkrc8lqmqz9b4fml2b4kxmg5xzp677h271";
-  };
-
-  runescape = stdenv.mkDerivation {
-    name = pname;
-    system = "x86_64-linux";
-
-    inherit src;
+    src = fetchurl {
+      url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb";
+      sha256 = "0r5v1pwh0aas31b1d3pkrc8lqmqz9b4fml2b4kxmg5xzp677h271";
+    };
 
     nativeBuildInputs = [
       autoPatchelfHook
@@ -41,18 +36,17 @@ let
     ];
 
     runtimeDependencies = [
-      libpulseaudio.out
-
-      libGL.out
-      SDL2.out
-      xorg_sys_opengl.out
-      openssl.out
-      zlib.out
+      libpulseaudio
+      libGL
+      SDL2
+      xorg_sys_opengl
+      openssl
+      zlib
     ];
 
-    unpackPhase = "true";
+    dontUnpack = true;
 
-    preBuildPhase = ''
+    preBuild = ''
       export DH_VERBOSE=1
     '';
 
@@ -66,15 +60,15 @@ let
       mkdir -p $out/bin $out/share
       dpkg -x $src $out
 
+      patchShebangs $out/usr/bin/runescape-launcher
       substituteInPlace $out/usr/bin/runescape-launcher \
-        --replace "/bin/sh" "/usr/bin/env sh" \
         --replace "unset XMODIFIERS" "$envVarsWithXmodifiers" \
         --replace "/usr/share/games/runescape-launcher/runescape" "$out/share/games/runescape-launcher/runescape"
 
       cp -r $out/usr/bin $out/
       cp -r $out/usr/share $out/
 
-      rm -rf $out/usr
+      rm -r $out/usr
     '';
 
 

--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -7,8 +7,8 @@
 let
 
   runescape = stdenv.mkDerivation rec {
-    version = "2.2.9";
     pname = "runescape-launcher";
+    version = "2.2.9";
 
     src = fetchurl {
       url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb";

--- a/pkgs/games/runescape3/default.nix
+++ b/pkgs/games/runescape3/default.nix
@@ -3,28 +3,29 @@
   , libSM, libXxf86vm, libX11, glib, pango, gdk_pixbuf, cairo, gtk2-x11, zlib, libcap_progs, openssl, openssl_1_0_2
   , libpulseaudio
   , SDL2, xorg_sys_opengl, libGL
+  , xdg_utils
 }:
 let
 
   # Please keep the version x.y.0.z and do not update to x.y.76.z because the
   # source of the latter disappears much faster.
-  version = "2.2.7";
+  version = "2.2.9";
+  pname = "runescape-launcher";
 
   src = fetchurl {
-    url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/runescape-launcher/runescape-launcher_2.2.7_amd64.deb";
-    sha256 = "0m5ydk7aynkdaxifh8pwn1ckanibnf50i4p3vv2159cqpzpf6wgc";
+    url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb";
+    sha256 = "01v37mjpx55zcbm87v90k4vfc6vdgsr5jyj6xf6cpim4q47wy97c";
   };
 
   runescape = stdenv.mkDerivation {
-    # name = "runescape-launcher-${version}";
-    name = "runescape-launcher";
+    name = pname;
     system = "x86_64-linux";
 
     inherit src;
 
     # Required for compilation
     nativeBuildInputs = [
-      autoPatchelfHook # Automatically setup the loader, and do the magic
+      autoPatchelfHook # Automatically setup the loader, and do the magic (see at bottom)
       wrapGAppsHook
       dpkg
     ];
@@ -44,6 +45,7 @@ let
       zlib
       libcap_progs
       openssl
+      xdg_utils
     ];
 
     runtimeDependencies = [
@@ -100,6 +102,7 @@ in
   /*
   * We can patch the runescape launcher, but it downloads a client at runtime and checks it for changes.
   * For that we need use a buildFHSUserEnv.
+  * FHS simulates a classic linux shell
   */
   buildFHSUserEnv {
    name = "RuneScape";
@@ -115,7 +118,7 @@ in
    runScript = "runescape-launcher";
 }
 
-# rs2client
+# rs2client manual patching (what autoPatchelfHook gives you)
 
 # missing libs:
 # > ldd rs2client | grep 'not found' | cut -d '=' -f1

--- a/pkgs/games/runescape3/default.nix
+++ b/pkgs/games/runescape3/default.nix
@@ -7,8 +7,6 @@
 }:
 let
 
-  # Please keep the version x.y.0.z and do not update to x.y.76.z because the
-  # source of the latter disappears much faster.
   version = "2.2.9";
   pname = "runescape-launcher";
 
@@ -23,14 +21,12 @@ let
 
     inherit src;
 
-    # Required for compilation
     nativeBuildInputs = [
-      autoPatchelfHook # Automatically setup the loader, and do the magic (see at bottom)
+      autoPatchelfHook
       wrapGAppsHook
       dpkg
     ];
 
-    # Required at running time
     buildInputs = [
       glibc
       gcc-unwrapped
@@ -70,8 +66,6 @@ let
       unset XMODIFIERS
     '';
 
-    # setcap cap_setfcap+ep /usr/share/games/runescape-launcher/runescape 
-    # Extract and copy executable in $out/bin
     installPhase = ''
       mkdir -p $out/bin $out/share
       dpkg -x $src $out
@@ -117,21 +111,3 @@ in
    multiPkgs = pkgs: [ libGL ];
    runScript = "runescape-launcher";
 }
-
-# rs2client manual patching (what autoPatchelfHook gives you)
-
-# missing libs:
-# > ldd rs2client | grep 'not found' | cut -d '=' -f1
-# => libSDL2-2.0.so.0 libGL.so.1 libcrypto.so.1.1 libssl.so.1.1 libz.so.1 
-
-# get missing libs:
-# > for dep in libSDL2-2.0.so.0 libGL.so.1 libcrypto.so.1.1 libssl.so.1.1 libz.so.1 ; do echo "~ $dep ~"; nix-locate -1 -w lib/${dep}; echo " "; done
-# => SDL2 xorg_sys_opengl libglvnd openssl zlib
-
-# library paths
-# > run nix repl '<nixpkgs>'
-# >> with pkgs; lib.makeLibraryPath [ SDL2 xorg_sys_opengl libglvnd openssl zlib ]
-
-# patch
-# > nix-shell -p binutils stdenv wget dpkg nix-index stdenv.cc
-# >> patchelf  --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "/nix/store/h4bjldjkw2mkmw478vbl3c4d8bg6zhfr-SDL2-2.0.12/lib:/nix/store/18wjma10bj945s84ign49386pixlsrhm-xorg-sys-opengl-3/lib:/nix/store/bnydnhhi4vib1f17han6bdjm8f08hjz2-libglvnd-1.2.0/lib:/nix/store/s54w52i1my3039krfvhyizwpbxcmiadi-openssl-1.1.1f/lib:/nix/store/hk87010wz87bqvg5az5vzpsxhq9bl9ky-zlib-1.2.11/lib" ~/Jagex/launcher/rs2client

--- a/pkgs/games/runescape3/default.nix
+++ b/pkgs/games/runescape3/default.nix
@@ -1,9 +1,8 @@
 { stdenv, lib, buildFHSUserEnv, dpkg, glibc, gcc-unwrapped, autoPatchelfHook, fetchurl, wrapGAppsHook
-  , xlibs, gnome2, xorg
-  , libSM, libXxf86vm, libX11, glib, pango, gdk_pixbuf, cairo, gtk2-x11, zlib, libcap_progs, openssl, openssl_1_0_2
+  , gnome2, xorg
+  , libSM, libXxf86vm, libX11, glib, pango, cairo, gtk2-x11, zlib, openssl
   , libpulseaudio
   , SDL2, xorg_sys_opengl, libGL
-  , xdg_utils
 }:
 let
 
@@ -35,13 +34,10 @@ let
       libX11
       glib
       pango
-      gdk_pixbuf
       cairo
       gtk2-x11
       zlib
-      libcap_progs
       openssl
-      xdg_utils
     ];
 
     runtimeDependencies = [
@@ -103,7 +99,7 @@ in
    targetPkgs = pkgs: [
      runescape
      dpkg glibc gcc-unwrapped
-     libSM libXxf86vm libX11 glib pango gdk_pixbuf cairo gtk2-x11 zlib libcap_progs openssl openssl_1_0_2
+     libSM libXxf86vm libX11 glib pango cairo gtk2-x11 zlib openssl
      libpulseaudio
      xorg.libX11
      SDL2 xorg_sys_opengl libGL

--- a/pkgs/games/runescape3/default.nix
+++ b/pkgs/games/runescape3/default.nix
@@ -1,0 +1,134 @@
+{ stdenv, buildFHSUserEnv, dpkg, glibc, gcc-unwrapped, autoPatchelfHook, fetchurl, wrapGAppsHook
+  , xlibs, gnome2, xorg
+  , libSM, libXxf86vm, libX11, glib, pango, gdk_pixbuf, cairo, gtk2-x11, zlib, libcap_progs, openssl, openssl_1_0_2
+  , libpulseaudio
+  , SDL2, xorg_sys_opengl, libGL
+}:
+let
+
+  # Please keep the version x.y.0.z and do not update to x.y.76.z because the
+  # source of the latter disappears much faster.
+  version = "2.2.7";
+
+  src = fetchurl {
+    url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/runescape-launcher/runescape-launcher_2.2.7_amd64.deb";
+    sha256 = "0m5ydk7aynkdaxifh8pwn1ckanibnf50i4p3vv2159cqpzpf6wgc";
+  };
+
+  runescape = stdenv.mkDerivation {
+    # name = "runescape-launcher-${version}";
+    name = "runescape-launcher";
+    system = "x86_64-linux";
+
+    inherit src;
+
+    # Required for compilation
+    nativeBuildInputs = [
+      autoPatchelfHook # Automatically setup the loader, and do the magic
+      wrapGAppsHook
+      dpkg
+    ];
+
+    # Required at running time
+    buildInputs = [
+      glibc
+      gcc-unwrapped
+      libSM
+      libXxf86vm
+      libX11
+      glib
+      pango
+      gdk_pixbuf
+      cairo
+      gtk2-x11
+      zlib
+      libcap_progs
+      openssl
+    ];
+
+    runtimeDependencies = [
+      libpulseaudio.out
+
+      libGL.out
+      SDL2.out
+      xorg_sys_opengl.out
+      openssl.out
+      zlib.out
+    ];
+
+    unpackPhase = "true";
+
+    preBuildPhase = ''
+      export DH_VERBOSE=1
+    '';
+
+    envVarsWithXmodifiers = ''
+      export MESA_GLSL_CACHE_DIR=~/Jagex
+      export GDK_SCALE=2
+      unset XMODIFIERS
+    '';
+
+    # setcap cap_setfcap+ep /usr/share/games/runescape-launcher/runescape 
+    # Extract and copy executable in $out/bin
+    installPhase = ''
+      mkdir -p $out/bin $out/share
+      dpkg -x $src $out
+
+      substituteInPlace $out/usr/bin/runescape-launcher \
+        --replace "/bin/sh" "/usr/bin/env sh" \
+        --replace "unset XMODIFIERS" "$envVarsWithXmodifiers" \
+        --replace "/usr/share/games/runescape-launcher/runescape" "$out/share/games/runescape-launcher/runescape"
+
+      cp -r $out/usr/bin $out/
+      cp -r $out/usr/share $out/
+
+      rm -rf $out/usr
+    '';
+
+
+    meta = with stdenv.lib; {
+      description = "Launcher for RuneScape 3, the current main RuneScape";
+      homepage = "https://www.runescape.com/";
+      license = licenses.unfree;
+      maintainers = with stdenv.lib.maintainers; [ grburst ];
+      platforms = [ "x86_64-linux" ];
+    };
+  };
+
+in
+
+  /*
+  * We can patch the runescape launcher, but it downloads a client at runtime and checks it for changes.
+  * For that we need use a buildFHSUserEnv.
+  */
+  buildFHSUserEnv {
+   name = "RuneScape";
+   targetPkgs = pkgs: [
+     runescape
+     dpkg glibc gcc-unwrapped
+     libSM libXxf86vm libX11 glib pango gdk_pixbuf cairo gtk2-x11 zlib libcap_progs openssl openssl_1_0_2
+     libpulseaudio
+     xorg.libX11
+     SDL2 xorg_sys_opengl libGL
+   ];
+   multiPkgs = pkgs: [ libGL ];
+   runScript = "runescape-launcher";
+}
+
+# rs2client
+
+# missing libs:
+# > ldd rs2client | grep 'not found' | cut -d '=' -f1
+# => libSDL2-2.0.so.0 libGL.so.1 libcrypto.so.1.1 libssl.so.1.1 libz.so.1 
+
+# get missing libs:
+# > for dep in libSDL2-2.0.so.0 libGL.so.1 libcrypto.so.1.1 libssl.so.1.1 libz.so.1 ; do echo "~ $dep ~"; nix-locate -1 -w lib/${dep}; echo " "; done
+# => SDL2 xorg_sys_opengl libglvnd openssl zlib
+
+# library paths
+# > run nix repl '<nixpkgs>'
+# >> with pkgs; lib.makeLibraryPath [ SDL2 xorg_sys_opengl libglvnd openssl zlib ]
+
+# patch
+# > nix-shell -p binutils stdenv wget dpkg nix-index stdenv.cc
+# >> patchelf  --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "/nix/store/h4bjldjkw2mkmw478vbl3c4d8bg6zhfr-SDL2-2.0.12/lib:/nix/store/18wjma10bj945s84ign49386pixlsrhm-xorg-sys-opengl-3/lib:/nix/store/bnydnhhi4vib1f17han6bdjm8f08hjz2-libglvnd-1.2.0/lib:/nix/store/s54w52i1my3039krfvhyizwpbxcmiadi-openssl-1.1.1f/lib:/nix/store/hk87010wz87bqvg5az5vzpsxhq9bl9ky-zlib-1.2.11/lib" ~/Jagex/launcher/rs2client

--- a/pkgs/games/runescape3/default.nix
+++ b/pkgs/games/runescape3/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildFHSUserEnv, dpkg, glibc, gcc-unwrapped, autoPatchelfHook, fetchurl, wrapGAppsHook
+{ stdenv, lib, buildFHSUserEnv, dpkg, glibc, gcc-unwrapped, autoPatchelfHook, fetchurl, wrapGAppsHook
   , xlibs, gnome2, xorg
   , libSM, libXxf86vm, libX11, glib, pango, gdk_pixbuf, cairo, gtk2-x11, zlib, libcap_progs, openssl, openssl_1_0_2
   , libpulseaudio
@@ -14,7 +14,7 @@ let
 
   src = fetchurl {
     url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb";
-    sha256 = "01v37mjpx55zcbm87v90k4vfc6vdgsr5jyj6xf6cpim4q47wy97c";
+    sha256 = "0r5v1pwh0aas31b1d3pkrc8lqmqz9b4fml2b4kxmg5xzp677h271";
   };
 
   runescape = stdenv.mkDerivation {
@@ -88,11 +88,11 @@ let
     '';
 
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "Launcher for RuneScape 3, the current main RuneScape";
       homepage = "https://www.runescape.com/";
       license = licenses.unfree;
-      maintainers = with stdenv.lib.maintainers; [ grburst ];
+      maintainers = with lib.maintainers; [ grburst ];
       platforms = [ "x86_64-linux" ];
     };
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8803,6 +8803,8 @@ with pkgs;
 
   runelite = callPackage ../games/runelite { };
 
+  runescape = callPackage ../games/runescape3 { };
+
   runningx = callPackage ../tools/X11/runningx { };
 
   rund = callPackage ../development/tools/rund { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8803,7 +8803,7 @@ with pkgs;
 
   runelite = callPackage ../games/runelite { };
 
-  runescape = callPackage ../games/runescape3 { };
+  runescape = callPackage ../games/runescape-launcher { };
 
   runningx = callPackage ../tools/X11/runningx { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Playing Runescape on NixOS. I've been using it locally for quite some time now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
