### PR TITLE
elfutils: 0.182 -> 0.185

### DIFF
--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, fetchpatch, pkg-config, autoreconfHook, musl-fts
-, musl-obstack, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs
+, musl-obstack, bash, m4, zlib, zstd, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs
 , argp-standalone
 , enableDebuginfod ? false, sqlite, curl, libmicrohttpd_0_9_70, libarchive
 }:
@@ -7,11 +7,11 @@
 # TODO: Look at the hardcoded paths to kernel, modules etc.
 stdenv.mkDerivation rec {
   pname = "elfutils";
-  version = "0.182";
+  version = "0.185";
 
   src = fetchurl {
     url = "https://sourceware.org/elfutils/ftp/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "7MQGkU7fM18Lf8CE6+bEYMTW1Rdb/dZojBx42RRriFg=";
+    sha256 = "3I0+dKsglGXn9Wjhs7uaWhQvhlbitX0QBJpz2irmtaY=";
   };
 
   patches = [
@@ -28,24 +28,9 @@ stdenv.mkDerivation rec {
       sha256 = "8D1wPcdgAkE/TNBOgsHaeTZYhd9l+9TrZg8d5C7kG6k=";
     })
     (fetchpatch {
-      name = "musl-fts-obstack.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-fts-obstack.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
-      sha256 = "3lbC0UtscTIJgT7kOXnnjWrpPAVt2PYMbW+uJK6K350=";
-    })
-    (fetchpatch {
       name = "musl-macros.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-macros.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
       sha256 = "tp6O1TRsTAMsFe8vw3LMENT/vAu6OmyA8+pzgThHeA8=";
-    })
-    (fetchpatch {
-      name = "musl-qsort_r.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-qsort_r.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
-      sha256 = "FPWCkdtFT3zw8aNnz0Jz5Vmu8B/mRfNgfhbM/ej7d8M=";
-    })
-    (fetchpatch {
-      name = "musl-strerror_r.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-strerror_r.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
-      sha256 = "QF6YwWkcT12dZHKzfqFgxy/1fkIllo0AAosbV0sM5PU=";
     })
     (fetchpatch {
       name = "musl-strndupa.patch";
@@ -54,16 +39,20 @@ stdenv.mkDerivation rec {
     })
   ] ++ lib.optional stdenv.hostPlatform.isMusl [ ./musl-error_h.patch ];
 
-  outputs = [ "bin" "dev" "out" "man" ];
+  postPatch = ''
+    for t in tests/*.sh; do
+      substituteInPlace $t --replace "/usr/bin/env bash" "${bash}/bin/bash"
+    done
+  '';
 
-  hardeningDisable = [ "format" ];
+  outputs = [ "bin" "dev" "out" "man" ];
 
   # We need bzip2 in NativeInputs because otherwise we can't unpack the src,
   # as the host-bzip2 will be in the path.
-  nativeBuildInputs = [ m4 bison flex gettext bzip2 ]
+  nativeBuildInputs = [ m4 bash bison flex gettext bzip2 ]
     ++ lib.optional stdenv.hostPlatform.isMusl autoreconfHook
     ++ lib.optional (enableDebuginfod || stdenv.hostPlatform.isMusl) pkg-config;
-  buildInputs = [ zlib bzip2 xz ]
+  buildInputs = [ zlib zstd bzip2 xz ]
     ++ lib.optionals stdenv.hostPlatform.isMusl [
     argp-standalone
     musl-fts
@@ -78,6 +67,7 @@ stdenv.mkDerivation rec {
   propagatedNativeBuildInputs = [ setupDebugInfoDirs ];
 
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
+    # Fails 'readelf.c' build otherwise
     NIX_CFLAGS_COMPILE+=" -Wno-null-dereference"
   '';
 
@@ -91,8 +81,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = false; # fails 3 out of 174 tests
-  doInstallCheck = false; # fails 70 out of 174 tests
+  doCheck = true;
+  doInstallCheck = true;
 
   meta = with lib; {
     homepage = "https://sourceware.org/elfutils/";


### PR DESCRIPTION
While at it:
- Dropped 3 upstreamed musl patches. Tested build on musl as:
    $ nix-build --arg crossSystem '(import ./. {}).lib.systems.examples.ppc64-musl' -A elfutils
- Enabled tests (all pass on x86_64-linux).
- Added optional zstd depend.
