### PR TITLE
auto-cpufreq: fix version output

### DIFF
--- a/pkgs/tools/system/auto-cpufreq/default.nix
+++ b/pkgs/tools/system/auto-cpufreq/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib, python3Packages, fetchFromGitHub, substituteAll }:
 
 python3Packages.buildPythonPackage rec {
   pname = "auto-cpufreq";
@@ -16,8 +16,16 @@ python3Packages.buildPythonPackage rec {
   doCheck = false;
   pythonImportsCheck = [ "auto_cpufreq" ];
 
-  # patch to prevent script copying and to disable install
-  patches = [ ./prevent-install-and-copy.patch ];
+  patches = [
+    # hardcodes version output
+    (substituteAll {
+      src = ./fix-version-output.patch;
+      inherit version;
+    })
+
+    # patch to prevent script copying and to disable install
+    ./prevent-install-and-copy.patch
+  ];
 
   postInstall = ''
     # copy script manually

--- a/pkgs/tools/system/auto-cpufreq/fix-version-output.patch
+++ b/pkgs/tools/system/auto-cpufreq/fix-version-output.patch
@@ -1,0 +1,37 @@
+--- a/auto_cpufreq/core.py
++++ b/auto_cpufreq/core.py
+@@ -68,32 +68,8 @@ dist_name = distro.id()
+ 
+ # display running version of auto-cpufreq
+ def app_version():
+-
+-    print("auto-cpufreq version:")
+-
+-    # snap package
+-    if os.getenv("PKG_MARKER") == "SNAP":
+-        print(getoutput("echo Snap: $SNAP_VERSION"))
+-    # aur package
+-    elif dist_name in ["arch", "manjaro", "garuda"]:
+-        aur_pkg_check = call("pacman -Qs auto-cpufreq > /dev/null", shell=True)
+-        if aur_pkg_check == 1:
+-            print(
+-                "Git commit:",
+-                check_output(["git", "describe", "--always"]).strip().decode(),
+-            )
+-        else:
+-            print(getoutput("pacman -Qi auto-cpufreq | grep Version"))
+-    else:
+-        # source code (auto-cpufreq-installer)
+-        try:
+-            print(
+-                "Git commit:",
+-                check_output(["git", "describe", "--always"]).strip().decode(),
+-            )
+-        except Exception as e:
+-            print(repr(e))
+-            pass
++    print("auto-cpufreq version: @version@")
++    print("Git commit: v@version@")
+ 
+ 
+ def app_res_use():


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

fixes `auto-cpufreq --version`

before
```ShellSession
$ nix run nixpkgs#auto-cpufreq -- --version

-------------------------------------------------------------------------------

Linux distro: NixOS 21.11 porcupine
Linux kernel: 5.14.5
auto-cpufreq version:
fatal: not a git repository (or any of the parent directories): .git
CalledProcessError(128, ['git', 'describe', '--always'])

-------------------------------------------------------------------------------
```

after
```ShellSession
$ result/bin/auto-cpufreq --version

-------------------------------------------------------------------------------

Linux distro: NixOS 21.11 porcupine
Linux kernel: 5.14.5
auto-cpufreq version: 1.6.9
Git commit: v1.6.9

-------------------------------------------------------------------------------
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
