### PR TITLE
python3Packages.kubernetes: fix build, refactor

### DIFF
--- a/pkgs/development/python-modules/kubernetes/default.nix
+++ b/pkgs/development/python-modules/kubernetes/default.nix
@@ -1,34 +1,58 @@
-{ lib, buildPythonPackage, fetchPypi, pythonAtLeast,
-  ipaddress, websocket-client, urllib3, pyyaml, requests_oauthlib, python-dateutil, google-auth, adal,
-  isort, pytest, coverage, mock, sphinx, autopep8, pep8, codecov, recommonmark, nose }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+
+# propgatedBuildInputs
+, adal
+, certifi
+, google-auth
+, python-dateutil
+, pyyaml
+, requests
+, requests_oauthlib
+, urllib3
+, websocket-client
+
+# tests
+, pytestCheckHook
+, mock
+}:
 
 buildPythonPackage rec {
   pname = "kubernetes";
   version = "18.20.0";
+  format = "setuptools";
+  disabled = pythonOlder "3.6";
 
-  prePatch = ''
-    sed -e 's/sphinx>=1.2.1,!=1.3b1,<1.4 # BSD/sphinx/' -i test-requirements.txt
-
-    # This is used to randomize tests, which is not reproducible. Drop it.
-    sed -e '/randomize/d' -i test-requirements.txt
-  ''
-  # This is a python2 and python3.2 only requiremet since it is a backport of a python-3.3 api.
-  + (if (pythonAtLeast "3.3")  then ''
-    sed -e '/ipaddress/d' -i requirements.txt
-  '' else "");
-
-  doCheck = pythonAtLeast "3";
-  checkPhase = ''
-    py.test --ignore=kubernetes/dynamic/test_client.py
-  '';
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0c72d00e7883375bd39ae99758425f5e6cb86388417cf7cc84305c211b2192cf";
+  src = fetchFromGitHub {
+    owner = "kubernetes-client";
+    repo = "python";
+    rev = "v${version}";
+    sha256 = "1sawp62j7h0yksmg9jlv4ik9b9i1a1w9syywc9mv8x89wibf5ql1";
+    fetchSubmodules = true;
   };
 
-  checkInputs = [ isort coverage pytest mock sphinx autopep8 pep8 codecov recommonmark nose ];
-  propagatedBuildInputs = [ ipaddress websocket-client urllib3 pyyaml requests_oauthlib python-dateutil google-auth adal ];
+  propagatedBuildInputs = [
+    adal
+    certifi
+    google-auth
+    python-dateutil
+    pyyaml
+    requests
+    requests_oauthlib
+    urllib3
+    websocket-client
+  ];
+
+  pythonImportsCheck = [
+    "kubernetes"
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "Kubernetes python client";

--- a/pkgs/development/python-modules/openshift/default.nix
+++ b/pkgs/development/python-modules/openshift/default.nix
@@ -1,22 +1,32 @@
-{
-  lib
-  , buildPythonPackage
-  , fetchPypi
-  , jinja2
-  , kubernetes
-  , ruamel-yaml
-  , six
-  , python-string-utils
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, jinja2
+, kubernetes
+, ruamel-yaml
+, six
+, python-string-utils
+, pytest-bdd
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "openshift";
   version = "0.12.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a38957684b17ad0e140a87226249bf26de7267db0c83a6d512b48be258052e1a";
+  src = fetchFromGitHub {
+    owner = "openshift";
+    repo = "openshift-restclient-python";
+    rev = "v${version}";
+    sha256 = "1di55xg3nl4dwrrfw314p4mfm6593kdi7ia517v1sm6x5p4hjl78";
   };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "kubernetes ~= 12.0" "kubernetes"
+
+    sed -i '/--cov/d' setup.cfg
+  '';
 
   propagatedBuildInputs = [
     jinja2
@@ -26,9 +36,17 @@ buildPythonPackage rec {
     six
   ];
 
-  # tries to connect to the network
-  doCheck = false;
   pythonImportsCheck = ["openshift"];
+
+  checkInputs = [
+    pytest-bdd
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # requires docker
+    "test/functional"
+  ];
 
   meta = with lib; {
     description = "Python client for the OpenShift API";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/commit/d033a39ca86c199849fb9cead03013f8a0866b6c#commitcomment-56971679

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
