### PR TITLE
ssh-key-confirmer: init at 0.1

### DIFF
--- a/pkgs/tools/networking/ssh-key-confirmer/default.nix
+++ b/pkgs/tools/networking/ssh-key-confirmer/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "ssh-key-confirmer";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "benjojo";
+    repo = "ssh-key-confirmer";
+    rev = "v${version}";
+    sha256 = "18whj9ds3rpjj5b71lbadi37ps99v13nnmkn3vq28x6cqfdy6w09";
+  };
+
+  vendorSha256 = "0v9yw6v8fj6dqgbkks4pnmvxx9b7jqdy7bn7ywddk396sbsxjiqa";
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = with lib; {
+    description = "Test ssh login key acceptance without having the private key";
+    homepage = "https://github.com/benjojo/ssh-key-confirmer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1828,6 +1828,8 @@ with pkgs;
 
   ssh-import-id = python3Packages.callPackage ../tools/admin/ssh-import-id { };
 
+  ssh-key-confirmer = callPackage ../tools/networking/ssh-key-confirmer { };
+
   sshchecker = callPackage ../tools/security/sshchecker { };
 
   titaniumenv = callPackage ../development/mobile/titaniumenv { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR adds the quite new [ssh-key-confirm](https://github.com/benjojo/ssh-key-confirmer) tool in its first release to the nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
