### PR TITLE
in-formant: init at 2021-06-30

### DIFF
--- a/pkgs/applications/audio/in-formant/default.nix
+++ b/pkgs/applications/audio/in-formant/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, cmake, lib, fetchFromGitHub, qt5, fftw, libtorch-bin, portaudio, eigen
+, xorg, pkg-config, autoPatchelfHook, soxr
+}:
+
+stdenv.mkDerivation rec {
+  pname = "in-formant";
+  version = "2021-06-30";
+
+  # no Qt6 yet, so we're stuck in the last Qt5-supporting commit: https://github.com/NixOS/nixpkgs/issues/108008
+  src = fetchFromGitHub {
+    owner = "in-formant";
+    repo = "in-formant";
+    rev = "e28e628cf5ff0949a7b046d220cc884f6035f31a";
+    sha256 = "sha256-YvtV0wGUNmI/+GGxrIfTk/l8tqUsWgc/LAI17X+AWGI=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config qt5.wrapQtAppsHook autoPatchelfHook ];
+
+  buildInputs = [
+    qt5.qtbase
+    qt5.qtquickcontrols
+    qt5.qtquickcontrols2
+    qt5.qtcharts
+    fftw
+    libtorch-bin
+    portaudio
+    eigen
+    xorg.libxcb
+    soxr
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp in-formant $out/bin
+  '';
+
+  meta = with lib; {
+    description = "A real-time pitch and formant tracking software";
+    homepage = "https://github.com/in-formant/in-formant";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ckie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6279,6 +6279,8 @@ with pkgs;
 
   imgurbash2 = callPackage ../tools/graphics/imgurbash2 { };
 
+  in-formant = callPackage ../applications/audio/in-formant { };
+
   inadyn = callPackage ../tools/networking/inadyn { };
 
   incron = callPackage ../tools/system/incron { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Notes

- Requires merge of #131526 for maintainer username change.
- Pinned to an older version because of missing Qt 6, #108008.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
