### PR TITLE
python3Packages.hiyapyco: allow later Jinja2 releases

### DIFF
--- a/pkgs/development/python-modules/hiyapyco/default.nix
+++ b/pkgs/development/python-modules/hiyapyco/default.nix
@@ -6,7 +6,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "HiYaPyCo";
+  pname = "hiyapyco";
   version = "0.4.16";
 
   src = fetchFromGitHub {
@@ -16,17 +16,29 @@ buildPythonPackage rec {
     sha256 = "1ams9dp05yhgbg6255wrjgchl2mqg0s34d8b8prvql9lsh59s1fj";
   };
 
-  propagatedBuildInputs = [ pyyaml jinja2 ];
+  propagatedBuildInputs = [
+    pyyaml
+    jinja2
+  ];
+
+  postPatch = ''
+    # Should no longer be needed with the next release
+    # https://github.com/zerwes/hiyapyco/pull/42
+    substituteInPlace setup.py \
+      --replace "Jinja2>1,<3" "Jinja2>1"
+  '';
 
   checkPhase = ''
     set -e
     find test -name 'test_*.py' -exec python {} \;
   '';
 
+  pythonImportsCheck = [ "hiyapyco" ];
+
   meta = with lib; {
-    description = "A simple python lib allowing hierarchical overlay of config files in YAML syntax, offering different merge methods and variable interpolation based on jinja2.";
+    description = "Python library allowing hierarchical overlay of config files in YAML syntax";
     homepage = "https://github.com/zerwes/hiyapyco";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ veehaitch ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Allow later Jinja2 releases (fixes https://hydra.nixos.org/build/153097206).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
