### PR TITLE
resholve: 0.6.0 -> 0.6.6, add resholveScript* fns

### DIFF
--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -2,7 +2,8 @@
 
 resholve converts bare executable references in shell scripts to absolute
 paths. This will hopefully make its way into the Nixpkgs manual soon, but
-until then I'll outline how to use the `resholvePackage` function.
+until then I'll outline how to use the `resholvePackage`, `resholveScript`,
+and `resholveScriptBin` functions.
 
 > Fair warning: resholve does *not* aspire to resolving all valid Shell
 > scripts. It depends on the OSH/Oil parser, which aims to support most (but
@@ -21,7 +22,10 @@ Each "solution" (k=v pair) in this attrset describes one resholve invocation.
 > - Packages with scripts that require conflicting directives can use multiple
 >   solutions to resolve the scripts separately, but produce a single package.
 
-## Basic Example
+The `resholveScript` and `resholveScriptBin` functions support a _single_
+`solution` attrset. This is basically the same as any single solution in `resholvePackage`, except that it doesn't need a `scripts` attr (it is automatically added).
+
+## Basic `resholvePackage` Example
 
 Here's a simple example from one of my own projects, with annotations:
 <!--
@@ -66,6 +70,28 @@ resholvePackage rec {
 
   # ...
 }
+```
+
+## Basic `resholveScript` and `resholveScriptBin` examples
+
+Both of these functions have the same basic API. This example is a little
+trivial for now. If you have a real usage that you find helpful, please PR it.
+
+```nix
+resholvedScript = resholveScript "name" {
+    inputs = [ file ];
+    interpreter = "${bash}/bin/bash";
+  } ''
+    echo "Hello"
+    file .
+  '';
+resholvedScriptBin = resholveScriptBin "name" {
+    inputs = [ file ];
+    interpreter = "${bash}/bin/bash";
+  } ''
+    echo "Hello"
+    file .
+  '';
 ```
 
 ## Options
@@ -176,6 +202,11 @@ some of the more common commands.
   either built-in rules for finding the executable, or human triage.
 - "wrapper" lore maps shell exec wrappers to the programs they exec so
   that resholve can substitute an executable's verdict for its wrapper's.
+
+> **Caution:** At least when it comes to common utilities, it's best to treat
+> overrides as a stopgap until they can be properly handled in resholve and/or
+> binlore. Please report things you have to override and, if possible, help
+> get them sorted.
 
 There will be more mechanisms for controlling this process in the future
 (and your reports/experiences will play a role in shaping them...) For now,

--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -179,7 +179,6 @@ fix = {
 # --keep 'source:$HOME /etc/bashrc ~/.bashrc'
 keep = {
   source = [ "$HOME" ];
-  "$LS" = [ "exa" ];
   "/etc/bashrc" = true;
   "~/.bashrc" = true;
 };

--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -186,6 +186,8 @@ keep = {
 };
 ```
 
+> **Note:** For now, at least, you'll need to reference the manpage to completely understand these examples.
+
 ## Controlling nested resolution with lore
 
 Initially, resolution of commands in the arguments to command-executing

--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -105,7 +105,7 @@ that the `resholve` CLI expects. Here's an overview:
 | inputs        | list    | packages to resolve executables from                  |
 | interpreter   | string  | 'none' or abspath for shebang                         |
 | prologue      | file    | text to insert before the first code-line             |
-| epilogue      | file    | text to isnert after the last code-line               |
+| epilogue      | file    | text to insert after the last code-line               |
 | flags         | list    | strings to pass as flags                              |
 | fake          | attrset | [directives](#controlling-resolution-with-directives) |
 | fix           | attrset | [directives](#controlling-resolution-with-directives) |
@@ -161,25 +161,24 @@ from the manpage, and the Nix equivalents:
 ```nix
 # --fake 'f:setUp;tearDown builtin:setopt source:/etc/bashrc'
 fake = {
-  # fake accepts the initial of valid identifier types as a CLI convienience.
+  # fake accepts the initial of valid identifier types as a CLI convenience.
   # Use full names in the Nix API.
   function = [ "setUp" "tearDown" ];
   builtin = [ "setopt" ];
   source = [ "/etc/bashrc" ];
 };
 
-# --fix 'aliases xargs:ls $GIT:gix'
+# --fix 'aliases $GIT:gix /bin/bash'
 fix = {
   # all single-word directives use `true` as value
   aliases = true;
-  xargs = [ "ls" ];
   "$GIT" = [ "gix" ];
+  "/bin/bash";
 };
 
-# --keep 'which:git;ls .:$HOME $LS:exa /etc/bashrc ~/.bashrc'
+# --keep 'source:$HOME /etc/bashrc ~/.bashrc'
 keep = {
-  which = [ "git" "ls" ];
-  "." = [ "$HOME" ];
+  source = [ "$HOME" ];
   "$LS" = [ "exa" ];
   "/etc/bashrc" = true;
   "~/.bashrc" = true;

--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -8,8 +8,7 @@ let
 in
 rec {
   resholve = callPackage ./resholve.nix {
-    inherit (source) rSrc;
-    inherit (source) version;
+    inherit (source) rSrc version;
     inherit (deps.oil) oildev;
   };
   resholve-utils = callPackage ./resholve-utils.nix {

--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -12,7 +12,10 @@ rec {
     inherit (source) version;
     inherit (deps.oil) oildev;
   };
-  resholvePackage = callPackage ./resholve-package.nix {
+  resholve-utils = callPackage ./resholve-utils.nix {
     inherit resholve;
+  };
+  resholvePackage = callPackage ./resholve-package.nix {
+    inherit resholve resholve-utils;
   };
 }

--- a/pkgs/development/misc/resholve/default.nix
+++ b/pkgs/development/misc/resholve/default.nix
@@ -1,5 +1,5 @@
 { callPackage
-, ...
+, writeTextFile
 }:
 
 let
@@ -17,4 +17,37 @@ rec {
   resholvePackage = callPackage ./resholve-package.nix {
     inherit resholve resholve-utils;
   };
+  resholveScript = name: partialSolution: text:
+    writeTextFile {
+      inherit name text;
+      executable = true;
+      checkPhase = ''
+        (
+          PS4=$'\x1f'"\033[33m[resholve context]\033[0m "
+          set -x
+          ${resholve-utils.makeInvocation name (partialSolution // {
+            scripts = [ "${placeholder "out"}" ];
+          })}
+        )
+        ${partialSolution.interpreter} -n $out
+      '';
+    };
+  resholveScriptBin = name: partialSolution: text:
+    writeTextFile rec {
+      inherit name text;
+      executable = true;
+      destination = "/bin/${name}";
+      checkPhase = ''
+        (
+          cd "$out"
+          PS4=$'\x1f'"\033[33m[resholve context]\033[0m "
+          set -x
+          : changing directory to $PWD
+          ${resholve-utils.makeInvocation name (partialSolution // {
+            scripts = [ "bin/${name}" ];
+          })}
+        )
+        ${partialSolution.interpreter} -n $out/bin/${name}
+      '';
+    };
 }

--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -46,6 +46,11 @@ rec {
     nativeBuildInputs = [ git ];
   };
 
+  /*
+    Upstream isn't interested in packaging this as a library
+    (or accepting all of the patches we need to do so).
+    This creates one without disturbing upstream too much.
+  */
   oildev = python27Packages.buildPythonPackage rec {
     pname = "oildev-unstable";
     version = "2021-07-14";
@@ -61,22 +66,21 @@ rec {
         It's not critical to drop most of these; the primary target is
         the vendored fork of Python-2.7.13, which is ~ 55M and over 3200
         files, dozens of which get interpreter script patches in fixup.
+
+        Note: -f is necessary to keep it from being a pain to update
+        hash on rev updates. Command will fail w/o and not print hash.
       */
       extraPostFetch = ''
         rm -rf Python-2.7.13 benchmarks metrics py-yajl rfc gold web testdata services demo devtools cpp
       '';
     };
 
-    # TODO: not sure why I'm having to set this for nix-build...
-    #       can anyone tell if I'm doing something wrong?
-    SOURCE_DATE_EPOCH = 315532800;
-
     # patch to support a python package, pass tests on macOS, etc.
     patchSrc = fetchFromGitHub {
       owner = "abathur";
       repo = "nix-py-dev-oil";
-      rev = "v0.8.12";
-      hash = "sha256-/EvwxL201lGsioL0lIhzM8VTghe6FuVbc3PBJgY8c8E=";
+      rev = "v0.8.12.1";
+      hash = "sha256-7JVnosdcvmVFN3h6SIeeqcJFcyFkai//fFuzi7ThNMY=";
     };
     patches = [
       "${patchSrc}/0001-add_setup_py.patch"
@@ -102,7 +106,12 @@ rec {
       patchShebangs asdl build core doctools frontend native oil_lang
     '';
 
-    # TODO: this may be obsolete?
+    /*
+    We did convince oil to upstream an env for specifying
+    this to support a shell.nix. Would need a patch if they
+    later drop this support. See:
+    https://github.com/oilshell/oil/blob/46900310c7e4a07a6223eb6c08e4f26460aad285/doctools/cmark.py#L30-L34
+    */
     _NIX_SHELL_LIBCMARK = "${cmark}/lib/libcmark${stdenv.hostPlatform.extensions.sharedLibrary}";
 
     # See earlier note on glibcLocales TODO: verify needed?

--- a/pkgs/development/misc/resholve/resholve-package.nix
+++ b/pkgs/development/misc/resholve/resholve-package.nix
@@ -13,7 +13,7 @@ let
   self = (stdenv.mkDerivation ((removeAttrs attrs [ "solutions" ])
     // {
     inherit pname version src;
-    buildInputs = [ resholve ];
+    buildInputs = (lib.optionals (builtins.hasAttr "buildInputs" attrs) attrs.buildInputs) ++ [ resholve ];
 
     # enable below for verbose debug info if needed
     # supports default python.logging levels

--- a/pkgs/development/misc/resholve/resholve-package.nix
+++ b/pkgs/development/misc/resholve/resholve-package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, resholve, binlore }:
+{ stdenv, lib, resholve, resholve-utils }:
 
 { pname
 , src
@@ -9,76 +9,6 @@
 }@attrs:
 let
   inherit stdenv;
-  /* These functions break up the work of partially validating the
-    'solutions' attrset and massaging it into env/cli args.
-
-    Note: some of the left-most args do not *have* to be passed as
-    deep as they are, but I've done so to provide more error context
-  */
-
-  # for brevity / line length
-  spaces = l: builtins.concatStringsSep " " l;
-  semicolons = l: builtins.concatStringsSep ";" l;
-
-  /* Throw a fit with dotted attr path context */
-  nope = path: msg:
-    throw "${builtins.concatStringsSep "." path}: ${msg}";
-
-  /* Special-case directive value representations by type */
-  makeDirective = solution: env: name: val:
-    if builtins.isInt val then builtins.toString val
-    else if builtins.isString val then name
-    else if true == val then name
-    else if false == val then "" # omit!
-    else if null == val then "" # omit!
-    else if builtins.isList val then "${name}:${semicolons val}"
-    else nope [ solution env name ] "unexpected type: ${builtins.typeOf val}";
-
-  /* Build fake/fix/keep directives from Nix types */
-  makeDirectives = solution: env: val:
-    lib.mapAttrsToList (makeDirective solution env) val;
-
-  /* Special-case value representation by type/name */
-  makeEnvVal = solution: env: val:
-    if env == "inputs" then lib.makeBinPath val
-    else if builtins.isString val then val
-    else if builtins.isList val then spaces val
-    else if builtins.isAttrs val then spaces (makeDirectives solution env val)
-    else nope [ solution env ] "unexpected type: ${builtins.typeOf val}";
-
-  /* Shell-format each env value */
-  shellEnv = solution: env: value:
-    lib.escapeShellArg (makeEnvVal solution env value);
-
-  /* Build a single ENV=val pair */
-  makeEnv = solution: env: value:
-    "RESHOLVE_${lib.toUpper env}=${shellEnv solution env value}";
-
-  /* Discard attrs claimed by makeArgs */
-  removeCliArgs = value:
-    removeAttrs value [ "scripts" "flags" ];
-
-  /* Verify required arguments are present */
-  validateSolution = { scripts, inputs, interpreter, ... }: true;
-
-  /* Pull out specific solution keys to build ENV=val pairs */
-  makeEnvs = solution: value:
-    spaces (lib.mapAttrsToList (makeEnv solution) (removeCliArgs value));
-
-  /* Pull out specific solution keys to build CLI argstring */
-  makeArgs = { flags ? [ ], scripts, ... }:
-    spaces (flags ++ scripts);
-
-  /* Build a single resholve invocation */
-  makeInvocation = solution: value:
-    if validateSolution value then
-    # we pass resholve a directory
-      "RESHOLVE_LORE=${binlore.collect { drvs = value.inputs; } } ${makeEnvs solution value} resholve --overwrite ${makeArgs value}"
-    else throw "invalid solution"; # shouldn't trigger for now
-
-  /* Build resholve invocation for each solution. */
-  makeCommands = solutions:
-    lib.mapAttrsToList makeInvocation solutions;
 
   self = (stdenv.mkDerivation ((removeAttrs attrs [ "solutions" ])
     // {
@@ -99,7 +29,7 @@ let
         PS4=$'\x1f'"\033[33m[resholve context]\033[0m "
         set -x
         : changing directory to $PWD
-        ${builtins.concatStringsSep "\n" (makeCommands solutions)}
+        ${builtins.concatStringsSep "\n" (resholve-utils.makeCommands solutions)}
       )
     '';
   }));

--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -1,0 +1,74 @@
+{ lib, resholve, binlore }:
+
+rec {
+  /* These functions break up the work of partially validating the
+    'solutions' attrset and massaging it into env/cli args.
+
+    Note: some of the left-most args do not *have* to be passed as
+    deep as they are, but I've done so to provide more error context
+  */
+
+  # for brevity / line length
+  spaces = l: builtins.concatStringsSep " " l;
+  semicolons = l: builtins.concatStringsSep ";" l;
+
+  /* Throw a fit with dotted attr path context */
+  nope = path: msg:
+    throw "${builtins.concatStringsSep "." path}: ${msg}";
+
+  /* Special-case directive value representations by type */
+  makeDirective = solution: env: name: val:
+    if builtins.isInt val then builtins.toString val
+    else if builtins.isString val then name
+    else if true == val then name
+    else if false == val then "" # omit!
+    else if null == val then "" # omit!
+    else if builtins.isList val then "${name}:${semicolons val}"
+    else nope [ solution env name ] "unexpected type: ${builtins.typeOf val}";
+
+  /* Build fake/fix/keep directives from Nix types */
+  makeDirectives = solution: env: val:
+    lib.mapAttrsToList (makeDirective solution env) val;
+
+  /* Special-case value representation by type/name */
+  makeEnvVal = solution: env: val:
+    if env == "inputs" then lib.makeBinPath val
+    else if builtins.isString val then val
+    else if builtins.isList val then spaces val
+    else if builtins.isAttrs val then spaces (makeDirectives solution env val)
+    else nope [ solution env ] "unexpected type: ${builtins.typeOf val}";
+
+  /* Shell-format each env value */
+  shellEnv = solution: env: value:
+    lib.escapeShellArg (makeEnvVal solution env value);
+
+  /* Build a single ENV=val pair */
+  makeEnv = solution: env: value:
+    "RESHOLVE_${lib.toUpper env}=${shellEnv solution env value}";
+
+  /* Discard attrs claimed by makeArgs */
+  removeCliArgs = value:
+    removeAttrs value [ "scripts" "flags" ];
+
+  /* Verify required arguments are present */
+  validateSolution = { scripts, inputs, interpreter, ... }: true;
+
+  /* Pull out specific solution keys to build ENV=val pairs */
+  makeEnvs = solution: value:
+    spaces (lib.mapAttrsToList (makeEnv solution) (removeCliArgs value));
+
+  /* Pull out specific solution keys to build CLI argstring */
+  makeArgs = { flags ? [ ], scripts, ... }:
+    spaces (flags ++ scripts);
+
+  /* Build a single resholve invocation */
+  makeInvocation = solution: value:
+    if validateSolution value then
+    # we pass resholve a directory
+      "RESHOLVE_LORE=${binlore.collect { drvs = value.inputs; } } ${makeEnvs solution value} ${resholve}/bin/resholve --overwrite ${makeArgs value}"
+    else throw "invalid solution"; # shouldn't trigger for now
+
+  /* Build resholve invocation for each solution. */
+  makeCommands = solutions:
+    lib.mapAttrsToList makeInvocation solutions;
+}

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -3,7 +3,7 @@
 }:
 
 rec {
-  version = "0.6.5";
+  version = "0.6.6";
   rSrc =
     # local build -> `make ci`; `make clean` to restore
     # return to remote source
@@ -14,6 +14,6 @@ rec {
         owner = "abathur";
         repo = "resholve";
         rev = "v${version}";
-        hash = "sha256-4fTACLDsHxVGYMOm08wQs4gFWMu8kv0O12IyOZSROqw=";
+        hash = "sha256-bupf3c9tNPAEMzFEDcvg483bSiwZFuB3ZqveG89dgkE=";
       };
 }

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -3,7 +3,7 @@
 }:
 
 rec {
-  version = "0.6.2";
+  version = "0.6.3";
   rSrc =
     # local build -> `make ci`; `make clean` to restore
     # return to remote source
@@ -14,6 +14,6 @@ rec {
         owner = "abathur";
         repo = "resholve";
         rev = "v${version}";
-        hash = "sha256-NRBk3TdgeoIiwkIOLBezcPROp9JOthdSqJTHx9GJCH4=";
+        hash = "sha256-gkF+l2RB7LPGE1AgiMm+LQSCiMKIntUjz0wcGXKpp4I=";
       };
 }

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -3,7 +3,7 @@
 }:
 
 rec {
-  version = "0.6.4";
+  version = "0.6.5";
   rSrc =
     # local build -> `make ci`; `make clean` to restore
     # return to remote source
@@ -14,6 +14,6 @@ rec {
         owner = "abathur";
         repo = "resholve";
         rev = "v${version}";
-        hash = "sha256-Wq9m67xkTs/8FA1XlwNuNXYSpseQdCa/GtgmsMSLtXI=";
+        hash = "sha256-4fTACLDsHxVGYMOm08wQs4gFWMu8kv0O12IyOZSROqw=";
       };
 }

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -3,7 +3,7 @@
 }:
 
 rec {
-  version = "0.6.3";
+  version = "0.6.4";
   rSrc =
     # local build -> `make ci`; `make clean` to restore
     # return to remote source
@@ -14,6 +14,6 @@ rec {
         owner = "abathur";
         repo = "resholve";
         rev = "v${version}";
-        hash = "sha256-gkF+l2RB7LPGE1AgiMm+LQSCiMKIntUjz0wcGXKpp4I=";
+        hash = "sha256-Wq9m67xkTs/8FA1XlwNuNXYSpseQdCa/GtgmsMSLtXI=";
       };
 }

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -3,7 +3,7 @@
 }:
 
 rec {
-  version = "0.6.1";
+  version = "0.6.2";
   rSrc =
     # local build -> `make ci`; `make clean` to restore
     # return to remote source
@@ -14,6 +14,6 @@ rec {
         owner = "abathur";
         repo = "resholve";
         rev = "v${version}";
-        hash = "sha256-W7pZZBI3740zBSIpL+4MFuo9j5bkURdEjgv1EfKTFHQ=";
+        hash = "sha256-NRBk3TdgeoIiwkIOLBezcPROp9JOthdSqJTHx9GJCH4=";
       };
 }

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -3,7 +3,7 @@
 }:
 
 rec {
-  version = "0.6.0";
+  version = "0.6.1";
   rSrc =
     # local build -> `make ci`; `make clean` to restore
     # return to remote source
@@ -14,6 +14,6 @@ rec {
         owner = "abathur";
         repo = "resholve";
         rev = "v${version}";
-        hash = "sha256-GfhhU9f5kiYcuYTPKWXCIkAGsz7GhAUGjAmIZ8Ww5X4=";
+        hash = "sha256-W7pZZBI3740zBSIpL+4MFuo9j5bkURdEjgv1EfKTFHQ=";
       };
 }

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -23,7 +23,7 @@
 
 let
   inherit (callPackage ./default.nix { })
-    resholve resholvePackage;
+    resholve resholvePackage resholveScript resholveScriptBin;
 
   # ourCoreutils = coreutils.override { singleBinary = false; };
 
@@ -224,4 +224,20 @@ rec {
       fi
     '';
   };
+
+  # Caution: ci.nix asserts the equality of both of these w/ diff
+  resholvedScript = resholveScript "resholved-script" {
+    inputs = [ file ];
+    interpreter = "${bash}/bin/bash";
+  } ''
+    echo "Hello"
+    file .
+  '';
+  resholvedScriptBin = resholveScriptBin "resholved-script-bin" {
+    inputs = [ file ];
+    interpreter = "${bash}/bin/bash";
+  } ''
+    echo "Hello"
+    file .
+  '';
 }


### PR DESCRIPTION
###### Motivation for this change

This tracks a few upstream changes in resholve and dependencies:
1. extract argument-handling functions from `resholvePackage` to enable easier re-use in additional APIs...
2. address minor review feedback in the course of #138080 
3. add `resholveScript` and `resholveScriptBin` functions to close #138442

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
