### PR TITLE
ceres-solver: 2.0.0 split outputs, build dynamic, default with blas

### DIFF
--- a/pkgs/development/libraries/ceres-solver/default.nix
+++ b/pkgs/development/libraries/ceres-solver/default.nix
@@ -2,14 +2,12 @@
 , stdenv
 , fetchpatch
 , fetchurl
-
 , blas
 , cmake
 , eigen
 , gflags
 , glog
 , suitesparse
-
 , runTests ? false
 , enableStatic ? stdenv.hostPlatform.isStatic
 , withBlas ? true
@@ -42,7 +40,9 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ eigen glog ]
   ++ lib.optionals withBlas [ blas suitesparse ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if enableStatic then "OFF" else "ON"}" ];
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if enableStatic then "OFF" else "ON"}"
+  ];
 
   # The Basel BUILD file conflicts with the cmake build directory on
   # case-insensitive filesystems, eg. darwin.

--- a/pkgs/development/libraries/ceres-solver/default.nix
+++ b/pkgs/development/libraries/ceres-solver/default.nix
@@ -1,10 +1,18 @@
-{ lib, stdenv
-, eigen
+{ lib
+, stdenv
+, fetchpatch
 , fetchurl
+
+, blas
 , cmake
+, eigen
 , gflags
 , glog
+, suitesparse
+
 , runTests ? false
+, enableStatic ? stdenv.hostPlatform.isStatic
+, withBlas ? true
 }:
 
 # gflags is required to run tests
@@ -19,9 +27,22 @@ stdenv.mkDerivation rec {
     sha256 = "00vng9vnmdb1qga01m0why90m0041w7bn6kxa2h4m26aflfqla8h";
   };
 
+  outputs = [ "out" "dev" ];
+
+  patches = [
+    # Enable GNUInstallDirs, see: https://github.com/ceres-solver/ceres-solver/pull/706
+    (fetchpatch {
+      url = "https://github.com/ceres-solver/ceres-solver/commit/4998c549396d36a491f1c0638fe57824a40bcb0d.patch";
+      sha256 = "sha256-mF6Zh2fDVzg2kD4nI2dd9rp4NpvPErmwfdYo5JaBmCA=";
+    })
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = lib.optional runTests gflags;
-  propagatedBuildInputs = [ eigen glog ];
+  propagatedBuildInputs = [ eigen glog ]
+  ++ lib.optionals withBlas [ blas suitesparse ];
+
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if enableStatic then "OFF" else "ON"}" ];
 
   # The Basel BUILD file conflicts with the cmake build directory on
   # case-insensitive filesystems, eg. darwin.


### PR DESCRIPTION
###### Motivation for this change

Twofold— building Ceres as a dynamic library, and then including the needed linear algebra dependencies.

**First**, the default upstream configuration for Ceres is (bafflingly) to build a static lib, and this is reflected in the current NixOS package:

```
$ nix build nixpkgs/nixos-unstable#ceres-solver
$ ls result/lib
cmake  libceres.a
```

So the first part of this change adds an `enableStatic` flag which defaults to false in most cases and passes the proper CMake flag to get a shared object instead:

```
$ ls result/lib
cmake  libceres.so  libceres.so.2  libceres.so.2.0.0
```

**Second**, the current nixpkgs configuration excludes the Suitesparse and BLAS dependencies, which pretty significantly cripples the library at runtime:

```
$ nix log nixpkgs/nixos-unstable#ceres-solver | grep Suite
...
-- Failed to find SuiteSparse - Failed to find either: SuiteSparse_config header & library (should be present in all SuiteSparse >= v4 installs), or UFconfig header (should be present in all SuiteSparse < v4 installs).
-- Did not find METIS library (optional SuiteSparse dependency)
-- Failed to find some/all required components of SuiteSparse. (missing: BLAS_FOUND LAPACK_FOUND AMD_FOUND CAMD_FOUND COLAMD_FOUND CCOLAMD_FOUND CHOLMOD_FOUND SUITESPARSEQR_FOUND SUITESPARSE_VERSION)
-- Did not find all SuiteSparse dependencies, disabling SuiteSparse support.
```

So this change also adds an `enableBlas` flag (default true) which includes those dependencies. I'm open to defaulting this to false if people feel strongly; I'm selfishly proposing true because that's what I need. After the change, the runtime dependency is in place:

```
$ nix why-depends .#ceres-solver .#openblasCompat
/nix/store/23zxqjnfiklprh0ggkwpfihqgvacf3pq-ceres-solver-2.0.0
└───lib/libceres.so.2.0.0: …a67-gflags-2.2.2/lib:/nix/store/kd2g87809v6k5mk8bv6is3ch11kl5jph-blas-3/lib:/nix/store/c12nn3iv4…
    → /nix/store/kd2g87809v6k5mk8bv6is3ch11kl5jph-blas-3
    └───lib/libblas.so.3: …ortran-9.3.0-lib/lib:/nix/store/8mbbp0ff4b1dm6nfiqswb48qp1bf0zp6-openblas-0.3.17/lib.GCC: (GNU) …
        → /nix/store/8mbbp0ff4b1dm6nfiqswb48qp1bf0zp6-openblas-0.3.17
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Built on NixOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

fyi @lopsided98