### PR TITLE
sigtool: 0.1.0 -> 0.1.2

### DIFF
--- a/pkgs/os-specific/darwin/sigtool/default.nix
+++ b/pkgs/os-specific/darwin/sigtool/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sigtool";
-  version = "0.1.0";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "thefloweringash";
     repo = "sigtool";
     rev = "v${version}";
-    sha256 = "sha256-GSVkF1BkZEkIF+q0SsoCuE0q48DRclE3E+qKc6JEc/0=";
+    sha256 = "sha256-v4udqW37vwcqBdqfvfwHnoyXpuLFt188ekVCPCPsTPM";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
Fixes build on x86_64-darwin.

See also alternative fix #139271, and (my) [upstream changes](https://github.com/thefloweringash/sigtool/compare/v0.1.0...v0.1.2).


###### Motivation for this change

Fix channel blocking build `stdenvBootstrapTools.aarch64-darwin`.

https://github.com/NixOS/nixpkgs/pull/138453#issuecomment-926269127



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
