### PR TITLE
[staging] eigen: 3.3.9 -> 3.4.0

### DIFF
--- a/pkgs/development/libraries/eigen/default.nix
+++ b/pkgs/development/libraries/eigen/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "eigen";
-  version = "3.3.9";
+  version = "3.4.0";
 
   src = fetchFromGitLab {
     owner = "libeigen";
     repo = pname;
     rev = version;
-    sha256 = "sha256-JMIG7CLMndUsECfbKpXE3BtVFuAjn+CZvf8GXZpLkFQ=";
+    sha256 = "sha256-1/4xMetKMDOgZgzz3WMxfHUEpmdAm52RqZvz6i0mLEw=";
   };
 
   patches = [

--- a/pkgs/development/libraries/eigen/include-dir.patch
+++ b/pkgs/development/libraries/eigen/include-dir.patch
@@ -1,23 +1,22 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,6 +1,6 @@
+@@ -1,5 +1,5 @@
+ # cmake_minimum_require must be the first command of the file
+-cmake_minimum_required(VERSION 3.5.0)
++cmake_minimum_required(VERSION 3.7.0)
+ 
  project(Eigen3)
  
--cmake_minimum_required(VERSION 2.8.5)
-+cmake_minimum_required(VERSION 3.7)
- 
- # guard against in-source builds
- 
-@@ -407,7 +407,7 @@ set(PKGCONFIG_INSTALL_DIR
-     CACHE STRING "The directory relative to CMAKE_PREFIX_PATH where eigen3.pc is installed"
+@@ -443,7 +443,7 @@ set(PKGCONFIG_INSTALL_DIR
+     CACHE PATH "The directory relative to CMAKE_INSTALL_PREFIX where eigen3.pc is installed"
      )
  
 -foreach(var INCLUDE_INSTALL_DIR CMAKEPACKAGE_INSTALL_DIR PKGCONFIG_INSTALL_DIR)
 +foreach(var CMAKEPACKAGE_INSTALL_DIR PKGCONFIG_INSTALL_DIR)
+   # If an absolute path is specified, make it relative to "{CMAKE_INSTALL_PREFIX}".
    if(IS_ABSOLUTE "${${var}}")
-     message(FATAL_ERROR "${var} must be relative to CMAKE_PREFIX_PATH. Got: ${${var}}")
-   endif()
-@@ -429,13 +429,6 @@ install(FILES
+     file(RELATIVE_PATH "${var}" "${CMAKE_INSTALL_PREFIX}" "${${var}}")
+@@ -466,13 +466,6 @@ install(FILES
    DESTINATION ${INCLUDE_INSTALL_DIR} COMPONENT Devel
    )
  
@@ -28,10 +27,10 @@
 -        )
 -endif()
 -
- add_subdirectory(Eigen)
+ install(DIRECTORY Eigen DESTINATION ${INCLUDE_INSTALL_DIR} COMPONENT Devel)
  
- add_subdirectory(doc EXCLUDE_FROM_ALL)
-@@ -531,8 +524,15 @@ set ( EIGEN_VERSION_MAJOR  ${EIGEN_WORLD_VERSION} )
+ 
+@@ -593,8 +586,15 @@ set ( EIGEN_VERSION_MAJOR  ${EIGEN_WORLD_VERSION} )
  set ( EIGEN_VERSION_MINOR  ${EIGEN_MAJOR_VERSION} )
  set ( EIGEN_VERSION_PATCH  ${EIGEN_MINOR_VERSION} )
  set ( EIGEN_DEFINITIONS "")
@@ -46,8 +45,8 @@
 +        )
 +endif()
  
- # Interface libraries require at least CMake 3.0
- if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+ include (CMakePackageConfigHelpers)
+ 
 --- a/eigen3.pc.in
 +++ b/eigen3.pc.in
 @@ -6,4 +6,4 @@ Description: A C++ template library for linear algebra: vectors, matrices, and r


### PR DESCRIPTION
https://eigen.tuxfamily.org/index.php?title=3.4#Changes_that_might_break_existing_code

Built `python3.pkgs.{pybind11,scipy,tensorflow} opencv{2,3,4} ceres-solver libfive arpack`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
