### PR TITLE
python3Packages.huawei-lte-api: 1.4.18 -> 1.5.2

### DIFF
--- a/pkgs/development/python-modules/huawei-lte-api/default.nix
+++ b/pkgs/development/python-modules/huawei-lte-api/default.nix
@@ -2,15 +2,15 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, dicttoxml
+, pycryptodomex
+, pytestCheckHook
 , requests
 , xmltodict
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "huawei-lte-api";
-  version = "1.4.18";
+  version = "1.5.2";
 
   disabled = pythonOlder "3.4";
 
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "Salamek";
     repo = "huawei-lte-api";
     rev = version;
-    sha256 = "1qaqxmh03j10wa9wqbwgc5r3ays8wfr7bldvsm45fycr3qfyn5fg";
+    sha256 = "sha256-xG0QTvjYW0/C/7NNhl/d024TSAe0TzgMknOXvNxrPOY=";
   };
 
   postPatch = ''
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    dicttoxml
+    pycryptodomex
     requests
     xmltodict
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release1.5.2

Change log: 
- https://github.com/Salamek/huawei-lte-api/releases/tag/1.5.2
- https://github.com/Salamek/huawei-lte-api/releases/tag/1.5.1
- https://github.com/Salamek/huawei-lte-api/releases/tag/1.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
