### PR TITLE
nixos/acme: add webroots to ReadWritePaths

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -192,6 +192,14 @@ let
       ++ data.extraLegoRenewFlags
     );
 
+    # We need to collect all the ACME webroots to grant them write
+    # access in the systemd service.
+    webroots =
+      lib.remove null
+        (lib.unique
+            (builtins.map
+            (certAttrs: certAttrs.webroot)
+            (lib.attrValues config.security.acme.certs)));
   in {
     inherit accountHash cert selfsignedDeps;
 
@@ -287,6 +295,8 @@ let
           "acme/.lego/${cert}/${certDir}"
           "acme/.lego/accounts/${accountHash}"
         ];
+
+        ReadWritePaths = commonServiceConfig.ReadWritePaths ++ webroots;
 
         # Needs to be space separated, but can't use a multiline string because that'll include newlines
         BindPaths = [


### PR DESCRIPTION
Since 7a10478ea7b992ffa1f19f389e53df0fe2aa936d, all /var except
/var/lib/acme gets mounted in a read-only fashion. This behavior
breaks the existing acme deployments having a webroot set outside of
/var/lib/acme.

Collecting the webroots and adding them to the paths read/write
mounted to the systemd service runtime tree.

Fixes #139310

Manually tested on my personal deployment.