### PR TITLE
python3Packages.pyroute2: 0.6.4 -> 0.6.5

### DIFF
--- a/pkgs/development/python-modules/pyroute2-core/default.nix
+++ b/pkgs/development/python-modules/pyroute2-core/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-core";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchPypi {
     pname = "pyroute2.core";
     inherit version;
-    sha256 = "1kd5wda7nqcmrwy6b42nqgz570y99yjw3m6a1kxr8ag3859fwga5";
+    sha256 = "sha256-Jm10Dq5A+mTdBFQfAH0022ls7PMVTLpb4w+nWmfUOFI=";
   };
 
   # pyroute2 sub-modules have no tests

--- a/pkgs/development/python-modules/pyroute2-ethtool/default.nix
+++ b/pkgs/development/python-modules/pyroute2-ethtool/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-ethtool";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchPypi {
     pname = "pyroute2.ethtool";
     inherit version;
-    sha256 = "04wxx2nn3rdsjcmck7fidzfdc42gpsjva2jc8p7a987b0j58r17s";
+    sha256 = "sha256-yvgBS2dlIRNcR2DXLPWu72q7x/onUhD36VMzBzzHcVo=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-ipdb/default.nix
+++ b/pkgs/development/python-modules/pyroute2-ipdb/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-ipdb";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchPypi {
     pname = "pyroute2.ipdb";
     inherit version;
-    sha256 = "0r4xq7h39qac309lpl7haaa4rqf6qzsypkgnsiran3w9jgr1hg75";
+    sha256 = "sha256-8gKP0QE9iviIFQ0DPuz3U3ZXpL434MzOqYAICZYetXc=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-ipset/default.nix
+++ b/pkgs/development/python-modules/pyroute2-ipset/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-ipset";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchPypi {
     pname = "pyroute2.ipset";
     inherit version;
-    sha256 = "sha256-V6aUGYv4PGhxHoEjgNuqoRbd6ftqirO/ofNDQEACTy8=";
+    sha256 = "sha256-rlJ8D5mXSCMKH2iNmit8JXst9tdDafROylMNAHeTt50=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-ndb/default.nix
+++ b/pkgs/development/python-modules/pyroute2-ndb/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-ndb";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchPypi {
     pname = "pyroute2.ndb";
     inherit version;
-    sha256 = "0q3py2n6w7nhdxi4l6vx8xpxh5if6hav4lcl5nwk8c4pgcrfd4vn";
+    sha256 = "sha256-pNMJWE6e9seEKvT4MrSPxTRKsiXnDjhLrtG3/iuU2fg=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-nftables/default.nix
+++ b/pkgs/development/python-modules/pyroute2-nftables/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-nftables";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchPypi {
     pname = "pyroute2.nftables";
     inherit version;
-    sha256 = "0mj897h86ifk4ncms71nz6qrrfzfq8hd81198vf1hm41wppgyxn1";
+    sha256 = "sha256-sUVaY6PvwFDRCNVQ0cr9AR7d7W6JTZnnvfoC1ZK/bxY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-nslink/default.nix
+++ b/pkgs/development/python-modules/pyroute2-nslink/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-nslink";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchPypi {
     pname = "pyroute2.nslink";
     inherit version;
-    sha256 = "0iz4vrv05x678ihhl2wdppxda82fxrq3d3sh7mka0pyb66a8mrik";
+    sha256 = "sha256-KS5sKDKnNUTBxtW6cn9xF6qEflX4jXjpS31GB7KZmZ4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-protocols/default.nix
+++ b/pkgs/development/python-modules/pyroute2-protocols/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-protocols";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchPypi {
     pname = "pyroute2.protocols";
     inherit version;
-    sha256 = "0gb5r1msd14fhalfknhmg67l2hm802r4771i1srgl4rix1sk0yw8";
+    sha256 = "sha256-lj9Q8ew+44m+Y72miQyuZhzjHmdLqYB+c2FK+ph1d84=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2/default.nix
+++ b/pkgs/development/python-modules/pyroute2/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "pyroute2";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "560b48a751b1150056ba553c89a31d563cc18ae2675b3793666adcaeb4fabfda";
+    sha256 = "sha256-0JlciuuWwOTu1NYul8nXlQAKGjO3R9bcVDJmZYV88Rw=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.6.5

Chagne log: https://github.com/svinota/pyroute2/blob/master/CHANGELOG.md

Requires #139321

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
