### PR TITLE
python3Packages.jaeger-client: init 4.6.1

### DIFF
--- a/pkgs/development/python-modules/buildout/default.nix
+++ b/pkgs/development/python-modules/buildout/default.nix
@@ -1,18 +1,37 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pip
+, setuptools
+, wheel
+}:
 
 buildPythonPackage rec {
-  pname = "zc.buildout";
-  version = "2.13.4";
+  pname = "zc_buildout";
+  version = "3.0.0b2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b978b2f9317b317ee4191f78fcc4f05b1ac41bdaaae47f0956f14c8285feef63";
+  src = fetchFromGitHub {
+    owner = "buildout";
+    repo = "buildout";
+    rev = version;
+    sha256 = "01sj09xx5kmkzynhq1xd8ahn6xqybfi8lrqjqr5lr45aaxjk2pid";
   };
 
+  propagatedBuildInputs = [
+    setuptools
+    pip
+    wheel
+  ];
+
+  doCheck = false; # Missing package & BLOCKED on "zc.recipe.egg"
+
+  pythonImportsCheck = [ "zc.buildout" ];
+
   meta = with lib; {
-    homepage = "http://www.buildout.org";
     description = "A software build and configuration system";
+    downloadPage = "https://github.com/buildout/buildout";
+    homepage = "https://www.buildout.org";
     license = licenses.zpl21;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ superherointj ];
   };
 }

--- a/pkgs/development/python-modules/buildout/default.nix
+++ b/pkgs/development/python-modules/buildout/default.nix
@@ -7,7 +7,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "zc_buildout";
+  pname = "zc-buildout";
   version = "3.0.0b2";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/jaeger-client/default.nix
+++ b/pkgs/development/python-modules/jaeger-client/default.nix
@@ -1,0 +1,40 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, opentracing
+, threadloop
+, thrift
+, tornado
+}:
+
+buildPythonPackage rec {
+  pname = "jaeger-client";
+  version = "4.6.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3bc27ad77e035efd0899f377a15f180467fec44b2afbf5be0660cc888a2a4ac3";
+  };
+
+  propagatedBuildInputs = [
+    threadloop
+    thrift
+    tornado
+    opentracing
+  ];
+
+  # FIXME: Missing dependencies: tchannel, opentracing_instrumentation
+  # opentracing_instrumentation: Requires "tornado" lower than 6. Current is 6.1.
+  # https://github.com/uber-common/opentracing-python-instrumentation/pull/115
+  doCheck = false;
+
+  pythonImportsCheck = [ "jaeger_client" ];
+
+  meta = with lib; {
+    description = "Jaeger bindings for Python OpenTracing API";
+    downloadPage = "https://pypi.org/project/jaeger-client/";
+    homepage = "https://github.com/jaegertracing/jaeger-client-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/python-modules/threadloop/default.nix
+++ b/pkgs/development/python-modules/threadloop/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, tornado
+}:
+
+buildPythonPackage rec {
+  pname = "threadloop";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8b180aac31013de13c2ad5c834819771992d350267bddb854613ae77ef571944";
+  };
+
+  propagatedBuildInputs = [
+    tornado
+  ];
+
+  doCheck = false; # ImportError: cannot import name 'ThreadLoop' from 'threadloop'
+
+  pythonImportsCheck = [ "threadloop" ];
+
+  meta = with lib; {
+    description = "A library to run tornado coroutines from synchronous Python";
+    homepage = "https://github.com/GoodPete/threadloop";
+    license = licenses.mit;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/python-modules/z3c-checkversions/default.nix
+++ b/pkgs/development/python-modules/z3c-checkversions/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , python
-, zc_buildout
+, zc-buildout
 , zope_testrunner
 }:
 
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "b45bd22ae01ed60933694fb5abede1ff71fe8ffa79b37082b2fcf38a2f0dec9d";
   };
 
-  propagatedBuildInputs = [ zc_buildout ];
+  propagatedBuildInputs = [ zc-buildout ];
   checkInputs = [ zope_testrunner ];
   doCheck = !python.pkgs.isPy27;
   checkPhase = ''

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -84,5 +84,5 @@ mapAliases ({
   tvnamer = throw "python3Packages.tvnamer was moved to tvnamer"; # 2021-07-05
   WazeRouteCalculator = wazeroutecalculator; # 2021-09-29
   websocket_client = websocket-client;
-  zc_buildout221 = zc_buildout; # added 2021-07-21
+  zc-buildout221 = zc-buildout; # added 2021-07-21
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10011,7 +10011,7 @@ in {
 
   zarr = callPackage ../development/python-modules/zarr { };
 
-  zc_buildout = callPackage ../development/python-modules/buildout { };
+  zc-buildout = callPackage ../development/python-modules/buildout { };
 
   zc_buildout_nix = callPackage ../development/python-modules/buildout-nix { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9122,6 +9122,8 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) Accelerate CoreFoundation CoreGraphics CoreVideo;
   };
 
+  threadloop = callPackage ../development/python-modules/threadloop { };
+
   threadpool = callPackage ../development/python-modules/threadpool { };
 
   threadpoolctl = callPackage ../development/python-modules/threadpoolctl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3833,6 +3833,8 @@ in {
 
   j2cli = callPackage ../development/python-modules/j2cli { };
 
+  jaeger-client = callPackage ../development/python-modules/jaeger-client { };
+
   janus = callPackage ../development/python-modules/janus { };
 
   jaraco_classes = callPackage ../development/python-modules/jaraco_classes { };


### PR DESCRIPTION
This PR is ready to be reviewed

--

Fixing:
* python3Packages.zc_buildout: 2.13.4 -> 3.0.0b2

Adding:
* python3Packages.jaeger-client: init 4.6.1
* python3Packages.threadloop: init 1.0.2

I have simplified this PR. To avoid adding too many old python packages. Tests are disabled on purpose. (It is not out of laziness.)

This is a dependency of `sygnal` (#137092) and popped up as inner dependency at OpenStack too (where?), I had scrapped it at PR #136533 . As @Kloenk is in need of it, I'm offering it again.

