### PR TITLE
python3Packages.APScheduler: fix build

### DIFF
--- a/pkgs/development/python-modules/APScheduler/default.nix
+++ b/pkgs/development/python-modules/APScheduler/default.nix
@@ -6,7 +6,6 @@
 , pytestCheckHook
 , pytest-asyncio
 , pytest-tornado
-, pytest-cov
 , sqlalchemy
 , tornado
 , twisted
@@ -23,6 +22,7 @@
 buildPythonPackage rec {
   pname = "APScheduler";
   version = "3.8.0";
+
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-tornado
     pytestCheckHook
-    pytest-cov
     sqlalchemy
     tornado
     twisted
@@ -54,7 +53,14 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace " --cov --tb=short" ""
+  '';
+
+  disabledTests = [
+    "test_broken_pool"
+  ] ++ lib.optionals stdenv.isDarwin [
     "test_submit_job"
     "test_max_instances"
   ];
@@ -65,5 +71,6 @@ buildPythonPackage rec {
     description = "A Python library that lets you schedule your Python code to be executed";
     homepage = "https://github.com/agronholm/apscheduler";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build

- Remove `pytest-cov`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
