### PR TITLE
treewide: fixes for protobuf 3.18+

### DIFF
--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -91,7 +91,11 @@ stdenv.mkDerivation rec {
     inherit (python.sourceVersion) major minor;  # Should be changed in case of PyPy
   });
 
-  postPatch = lib.optionalString (cudaSupport && lib.versionAtLeast cudatoolkit.version "9.0") ''
+  postPatch = ''
+    substituteInPlace src/caffe/util/io.cpp --replace \
+      'SetTotalBytesLimit(kProtoReadBytesLimit, 536870912)' \
+      'SetTotalBytesLimit(kProtoReadBytesLimit)'
+  '' + lib.optionalString (cudaSupport && lib.versionAtLeast cudatoolkit.version "9.0") ''
     # CUDA 9.0 doesn't support sm_20
     sed -i 's,20 21(20) ,,' cmake/Cuda.cmake
   '';

--- a/pkgs/development/libraries/openvino/default.nix
+++ b/pkgs/development/libraries/openvino/default.nix
@@ -3,6 +3,7 @@
 , autoPatchelfHook
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , git
 , protobuf
@@ -10,17 +11,29 @@
 , opencv
 , unzip
 , shellcheck
+, srcOnly
 , python
 , enablePython ? false
 }:
 
 let
 
-  onnx_src = fetchFromGitHub {
-    owner = "onnx";
-    repo = "onnx";
-    rev = "v1.8.1";
-    sha256 = "+1zNnZ4lAyVYRptfk0PV7koIX9FqcfD1Ah33qj/G2rA=";
+  onnx_src = srcOnly {
+    name = "onnx-patched";
+    src = fetchFromGitHub {
+      owner = "onnx";
+      repo = "onnx";
+      rev = "v1.8.1";
+      sha256 = "+1zNnZ4lAyVYRptfk0PV7koIX9FqcfD1Ah33qj/G2rA=";
+    };
+    patches = [
+      # Fix build with protobuf 3.18+
+      # Remove with onnx 1.9 release
+      (fetchpatch {
+        url = "https://github.com/onnx/onnx/commit/d3bc82770474761571f950347560d62a35d519d7.patch";
+        sha256 = "0vdsrklkzhdjaj8wdsl4icn93q3961g8dx35zvff0nhpr08wjb7y";
+      })
+    ];
   };
 
 in

--- a/pkgs/development/libraries/valhalla/default.nix
+++ b/pkgs/development/libraries/valhalla/default.nix
@@ -14,6 +14,15 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  # https://github.com/valhalla/valhalla/issues/2119
+  postPatch = ''
+    for f in valhalla/mjolnir/transitpbf.h \
+             src/mjolnir/valhalla_query_transit.cc; do
+      substituteInPlace $f --replace 'SetTotalBytesLimit(limit, limit)' \
+                                     'SetTotalBytesLimit(limit)'
+    done
+  '';
+
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
     zlib curl protobuf prime-server boost sqlite libspatialite


### PR DESCRIPTION
Protobuf 3.18 finally removed the deprecated two-argument version of SetTotalBytesLimit. Trivially patch the remaining offenders.

###### Motivation for this change

Fixup some individual packages overlooked in https://github.com/NixOS/nixpkgs/pull/138268

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
