### PR TITLE
nixos/documentation: index devman by default if enabled

### DIFF
--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -76,6 +76,10 @@ let
       ];
     };
 
+  # list of man outputs currently active intended for use as default values
+  # for man-related options, thus "man" is included unconditionally.
+  activeManOutputs = [ "man" ] ++ lib.optionals cfg.dev.enable [ "devman" ];
+
 in
 
 {
@@ -126,7 +130,7 @@ in
           name = "man-paths";
           paths = config.environment.systemPackages;
           pathsToLink = [ "/share/man" ];
-          extraOutputsToInstall = ["man"];
+          extraOutputsToInstall = activeManOutputs;
           ignoreCollisions = true;
         };
         defaultText = "all man pages in config.environment.systemPackages";
@@ -222,7 +226,7 @@ in
     (mkIf cfg.man.enable {
       environment.systemPackages = [ pkgs.man-db ];
       environment.pathsToLink = [ "/share/man" ];
-      environment.extraOutputsToInstall = [ "man" ] ++ optional cfg.dev.enable "devman";
+      environment.extraOutputsToInstall = activeManOutputs;
       environment.etc."man_db.conf".text =
         let
           manualCache = pkgs.runCommandLocal "man-cache" { } ''


### PR DESCRIPTION
It's quite ridiculous that we currently require manual intervention just
to have devman indexed if dev.enable == true.

Ideally needs some testing, I don't use the documenation module at the moment.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
