### PR TITLE
ocaml-ng.ocamlPackages_4_13.ocaml: 4.13.0-rc2 → 4.13.0

### DIFF
--- a/pkgs/development/compilers/ocaml/4.13.nix
+++ b/pkgs/development/compilers/ocaml/4.13.nix
@@ -1,9 +1,6 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "13";
-  patch_version = "0-rc2";
-  src = fetchTarball {
-    url = "https://caml.inria.fr/pub/distrib/ocaml-4.13/ocaml-4.13.0~rc2.tar.xz";
-    sha256 = "1w4sdrs5s1bhbisgz44ysi2j1n13qd3slgs34ppglpwmqqw6ply2";
-  };
+  patch_version = "0";
+  sha256 = "sha256:1f7gnndzs6qcyy2gnzalnhm808pifxhvxg2qp5dnsziz6li7x303";
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1601,7 +1601,7 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_4_13 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.13.nix { });
 
-  ocamlPackages_latest = ocamlPackages_4_12;
+  ocamlPackages_latest = ocamlPackages_4_13;
 
   ocamlPackages = ocamlPackages_4_12;
 }


### PR DESCRIPTION
###### Motivation for this change

New release! https://inbox.ocaml.org/caml-list/1326429875.7522342.1632507907690.JavaMail.zimbra@inria.fr/T/#u

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
