### PR TITLE
sasquatch: drop blanket -Werror (fix gcc-11 build)

### DIFF
--- a/pkgs/tools/filesystems/sasquatch/default.nix
+++ b/pkgs/tools/filesystems/sasquatch/default.nix
@@ -43,6 +43,9 @@ stdenv.mkDerivation rec {
   patchFlags = [ "-p0" ];
 
   postPatch = ''
+    # Drop blanket -Werror to avoid build failure on fresh toolchains
+    # like gcc-11.
+    substituteInPlace squashfs-tools/Makefile --replace ' -Werror' ' '
     cd squashfs-tools
   '';
 


### PR DESCRIPTION
Noticed build failure on gcc-11:

    $ nix-build -E 'with import ./.{}; sasquatch.override { stdenv = gcc11Stdenv; }'
    unsquashfs.c:1908:5:
      error: this 'if' clause does not guard... [-Werror=misleading-indentation]
     1908 |     if(swap)
          |     ^~

Let's defer warning squashing and code fixes to upstream.

Cc @Pamplemousse 