### PR TITLE
zabbix: add IPMI support

### DIFF
--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -6,6 +6,7 @@
 , sshSupport ? true, libssh2
 , mysqlSupport ? false, libmysqlclient
 , postgresqlSupport ? false, postgresql
+, ipmiSupport ? false, openipmi
 }:
 
 # ensure exactly one primary database type is selected
@@ -41,7 +42,8 @@ in
       ++ optional snmpSupport net-snmp
       ++ optional sshSupport libssh2
       ++ optional mysqlSupport libmysqlclient
-      ++ optional postgresqlSupport postgresql;
+      ++ optional postgresqlSupport postgresql
+      ++ optional ipmiSupport openipmi;
 
       configureFlags = [
         "--enable-server"
@@ -59,7 +61,8 @@ in
       ++ optional snmpSupport "--with-net-snmp"
       ++ optional sshSupport "--with-ssh2=${libssh2.dev}"
       ++ optional mysqlSupport "--with-mysql"
-      ++ optional postgresqlSupport "--with-postgresql";
+      ++ optional postgresqlSupport "--with-postgresql"
+      ++ optional ipmiSupport "--with-openipmi=${openipmi.dev}";
 
       prePatch = ''
         find database -name data.sql -exec sed -i 's|/usr/bin/||g' {} +


### PR DESCRIPTION
IPMI support for zabbix server.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
