### PR TITLE
mop: fix build on bash-5

### DIFF
--- a/pkgs/applications/misc/mop/default.nix
+++ b/pkgs/applications/misc/mop/default.nix
@@ -9,7 +9,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   preConfigure = ''
-    for i in $(find . -type f);do
+    for i in *.go **/*.go; do
         substituteInPlace $i --replace michaeldv/termbox-go nsf/termbox-go
     done
     substituteInPlace Makefile --replace mop/cmd mop/mop


### PR DESCRIPTION
After 33518fcb453382 "stdenv/setup.sh: fix read -N 0 for bash 5"
build started failing as:

    consumeEntire(): ERROR: Input null bytes, won't process

Let's avoid running substituteInPlace on arbitrary binary files.

Cc @happysalada 