### PR TITLE
python3Packages.renault-api: init at 0.1.4

### DIFF
--- a/pkgs/development/python-modules/marshmallow-dataclass/default.nix
+++ b/pkgs/development/python-modules/marshmallow-dataclass/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, marshmallow
+, marshmallow-enum
+, pytestCheckHook
+, pythonOlder
+, typeguard
+, typing-inspect
+}:
+
+buildPythonPackage rec {
+  pname = "marshmallow-dataclass";
+  version = "8.5.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "lovasoa";
+    repo = "marshmallow_dataclass";
+    rev = "v${version}";
+    sha256 = "0mngkjfs2nxxr0y77n429hb22rmjxbnn95j4vwqr9y6q16bqxs0w";
+  };
+
+  propagatedBuildInputs = [
+    marshmallow
+    typing-inspect
+  ];
+
+  checkInputs = [
+    marshmallow-enum
+    pytestCheckHook
+    typeguard
+  ];
+
+  pythonImportsCheck = [ "marshmallow_dataclass" ];
+
+  meta = with lib; {
+    description = "Automatic generation of marshmallow schemas from dataclasses";
+    homepage = "https://github.com/lovasoa/marshmallow_dataclass";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/renault-api/default.nix
+++ b/pkgs/development/python-modules/renault-api/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, aiohttp
+, aioresponses
+, buildPythonPackage
+, click
+, dateparser
+, fetchFromGitHub
+, fetchpatch
+, marshmallow-dataclass
+, poetry-core
+, pyjwt
+, pythonOlder
+, pytest-asyncio
+, pytestCheckHook
+, tabulate
+}:
+
+buildPythonPackage rec {
+  pname = "renault-api";
+  version = "0.1.4";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "hacf-fr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "049kh63yk0r0falqbl5akcwgzqjrkqqhf9y537rrlzc85ihf28b8";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    click
+    dateparser
+    marshmallow-dataclass
+    pyjwt
+    tabulate
+  ];
+
+  checkInputs = [
+    aioresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/hacf-fr/renault-api/pull/371
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/hacf-fr/renault-api/commit/5457a612b9ff9f323e8449cbe9dbce465bd65a79.patch";
+      sha256 = "0ds9m4j2qpv0nyg9p8dk9klnarl8wckwclddgnii6h47qci362yy";
+    })
+  ];
+
+  pythonImportsCheck = [ "renault_api" ];
+
+  meta = with lib; {
+    description = "Python library to interact with the Renault API";
+    homepage = "https://github.com/hacf-fr/renault-api";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -703,7 +703,7 @@
     "remember_the_milk" = ps: with ps; [ httplib2 ]; # missing inputs: RtmAPI
     "remote" = ps: with ps; [ ];
     "remote_rpi_gpio" = ps: with ps; [ ]; # missing inputs: gpiozero
-    "renault" = ps: with ps; [ ]; # missing inputs: renault-api
+    "renault" = ps: with ps; [ renault-api ];
     "repetier" = ps: with ps; [ ]; # missing inputs: pyrepetier
     "rest" = ps: with ps; [ jsonpath xmltodict ];
     "rest_command" = ps: with ps; [ ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -575,6 +575,7 @@ in with py.pkgs; buildPythonApplication rec {
     "recorder"
     "reddit"
     "remote"
+    "renault"
     "rest"
     "rest_command"
     "rflink"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7799,6 +7799,8 @@ in {
 
   remarshal = callPackage ../development/python-modules/remarshal { };
 
+  renault-api = callPackage ../development/python-modules/renault-api { };
+
   rencode = callPackage ../development/python-modules/rencode { };
 
   reparser = callPackage ../development/python-modules/reparser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4464,6 +4464,8 @@ in {
 
   marshmallow = callPackage ../development/python-modules/marshmallow { };
 
+  marshmallow-dataclass = callPackage ../development/python-modules/marshmallow-dataclass { };
+
   marshmallow-enum = callPackage ../development/python-modules/marshmallow-enum { };
 
   marshmallow-oneofschema = callPackage ../development/python-modules/marshmallow-oneofschema { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to interact with the Renault API

https://github.com/hacf-fr/renault-api

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
