### PR TITLE
[21.05] psi-notify: init at 1.2.1

### DIFF
--- a/pkgs/applications/misc/psi-notify/default.nix
+++ b/pkgs/applications/misc/psi-notify/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub, systemd, libnotify, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "psi-notify";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "cdown";
+    repo = pname;
+    rev = version;
+    sha256 = "0hn37plim1smmlrjjmz8kybyms8pz3wxcgf8vmqjrsqi6bfcym7g";
+  };
+
+  buildInputs = [ systemd libnotify ];
+  nativeBuildInputs = [ pkg-config ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D psi-notify $out/bin/psi-notify
+    substituteInPlace psi-notify.service --replace psi-notify $out/bin/psi-notify
+    install -D psi-notify.service $out/share/systemd/user/psi-notify.service
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Alert on system resource saturation";
+    longDescription = ''
+      psi-notify can alert you when resources on your machine are becoming
+      oversaturated, and allow you to take action before your system slows to a
+      crawl.
+    '';
+    license = licenses.mit;
+    homepage = "https://github.com/cdown/psi-notify";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ eduarrrd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25437,6 +25437,8 @@ in
   prevo-data = callPackage ../applications/misc/prevo/data.nix { };
   prevo-tools = callPackage ../applications/misc/prevo/tools.nix { };
 
+  psi-notify = callPackage ../applications/misc/psi-notify { };
+
   ptex = callPackage ../development/libraries/ptex {};
 
   pyright = nodePackages.pyright;


### PR DESCRIPTION
(cherry picked from commit 37ec684a5c010aa7cf51abaf29691ef2333d6625)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
