### PR TITLE
comby: 1.5.1 -> 1.7.0

### DIFF
--- a/pkgs/development/tools/comby/default.nix
+++ b/pkgs/development/tools/comby/default.nix
@@ -1,5 +1,15 @@
-{ ocamlPackages, fetchFromGitHub, lib, zlib, pkg-config, cacert, gmp, libev
-, autoconf, sqlite, stdenv }:
+{ ocamlPackages
+, fetchFromGitHub
+, lib
+, zlib
+, pkg-config
+, cacert
+, gmp
+, libev
+, autoconf
+, sqlite
+, stdenv
+}:
 let
   mkCombyPackage = { pname, extraBuildInputs ? [ ], extraNativeInputs ? [ ] }:
     ocamlPackages.buildDunePackage rec {
@@ -41,7 +51,8 @@ let
     };
 
   combyKernel = mkCombyPackage { pname = "comby-kernel"; };
-in mkCombyPackage {
+in
+mkCombyPackage {
   pname = "comby";
 
   extraBuildInputs = [
@@ -62,6 +73,7 @@ in mkCombyPackage {
     ocamlPackages.lwt_react
     ocamlPackages.tls
     combyKernel
+    combySemantic
   ] ++ (if !stdenv.isAarch32 && !stdenv.isAarch64 then
     [ ocamlPackages.hack_parallel ]
   else

--- a/pkgs/development/tools/comby/default.nix
+++ b/pkgs/development/tools/comby/default.nix
@@ -11,10 +11,10 @@
 , stdenv
 }:
 let
-  mkCombyPackage = { pname, extraBuildInputs ? [ ], extraNativeInputs ? [ ] }:
+  mkCombyPackage = { pname, extraBuildInputs ? [ ], extraNativeInputs ? [ ], preBuild ? "" }:
     ocamlPackages.buildDunePackage rec {
-      inherit pname;
-      version = "1.5.1";
+      inherit pname preBuild;
+      version = "1.7.0";
       useDune2 = true;
       minimumOcamlVersion = "4.08.1";
       doCheck = true;
@@ -23,7 +23,7 @@ let
         owner = "comby-tools";
         repo = "comby";
         rev = version;
-        sha256 = "1ipfrr6n1jyyryhm9zpn8wwgzfac1zgbjdjzrm00qcwc17r8x2hf";
+        sha256 = "sha256-Y2RcYvJOSqppmxxG8IZ5GlFkXCOIQU+1jJZ6j+PBHC4";
       };
 
       nativeBuildInputs = [
@@ -51,9 +51,20 @@ let
     };
 
   combyKernel = mkCombyPackage { pname = "comby-kernel"; };
+  combySemantic = mkCombyPackage { pname = "comby-semantic"; extraBuildInputs = [ ocamlPackages.cohttp-lwt-unix ]; };
 in
 mkCombyPackage {
   pname = "comby";
+
+  # tests have to be removed before building otherwise installPhase will fail
+  # cli tests expect a path to the built binary
+  preBuild = ''
+    substituteInPlace test/common/dune \
+      --replace "test_cli_list" "" \
+      --replace "test_cli_helper" "" \
+      --replace "test_cli" ""
+    rm test/common/{test_cli_list,test_cli_helper,test_cli}.ml
+  '';
 
   extraBuildInputs = [
     zlib
@@ -86,4 +97,5 @@ mkCombyPackage {
     ocamlPackages.ppx_expect
     ocamlPackages.dune-configurator
   ];
+
 }


### PR DESCRIPTION
###### Motivation for this change

upstream update.

I've disable 3 tests that include a relative path to the comby binary in them.
I would be happy to enable them again, I just didn't know how to do it. Those test include a reference to the built binary. I didn't know what to replace that path with 
https://github.com/comby-tools/comby/blob/ae770938a4f13e5965fa6a84bcc58d02bc105398/test/common/test_cli.ml#L6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
