### PR TITLE
rlaunch: init at 1.3.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2824,6 +2824,15 @@
     githubId = 743057;
     name = "Danylo Hlynskyi";
   };
+  danc86 = {
+    name = "Dan Callaghan";
+    email = "djc@djc.id.au";
+    github = "danc86";
+    githubId = 398575;
+    keys = [{
+      fingerprint = "1C56 01F1 D70A B56F EABB  6BC0 26B5 AA2F DAF2 F30A";
+    }];
+  };
   dancek = {
     email = "hannu.hartikainen@gmail.com";
     github = "dancek";

--- a/pkgs/applications/misc/rlaunch/default.nix
+++ b/pkgs/applications/misc/rlaunch/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, libX11
+, libXft
+, libXinerama
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rlaunch";
+  version = "1.3.13";
+
+  src = fetchFromGitHub {
+    owner = "PonasKovas";
+    repo = pname;
+    rev = version;
+    sha256 = "1w8qvny72l5358wnk4dmqnrv4mrpzxrzf49svav9grzxzzf8mqy2";
+  };
+
+  cargoSha256 = "00lnw48kn97gp45lylv5c6v6pil74flzpsq9k69xgvvjq9yqjzrx";
+
+  # The x11_dl crate dlopen()s these libraries, so we have to inject them into rpath.
+  postFixup = ''
+    patchelf --set-rpath ${lib.makeLibraryPath [ libX11 libXft libXinerama ]} $out/bin/rlaunch
+  '';
+
+  meta = with lib; {
+    description = "A lightweight application launcher for X11";
+    homepage = "https://github.com/PonasKovas/rlaunch";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danc86 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27800,6 +27800,10 @@ with pkgs;
 
   tiramisu = callPackage ../applications/misc/tiramisu { };
 
+  rlaunch = callPackage ../applications/misc/rlaunch {
+    inherit (xorg) libX11 libXft libXinerama;
+  };
+
   rootbar = callPackage ../applications/misc/rootbar {};
 
   waybar = callPackage ../applications/misc/waybar {};


### PR DESCRIPTION
###### Motivation for this change

I like [rlaunch](https://github.com/PonasKovas/rlaunch) and would like to use it on NixOS. :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] ~(Package updates) Added a release notes entry if the change is major or breaking~
  - [ ] ~(Module updates) Added a release notes entry if the change is significant~
  - [ ] ~(Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
