### PR TITLE
python3Packages.airtouch4pyapi: init at 1.0.5

### DIFF
--- a/pkgs/development/python-modules/airtouch4pyapi/default.nix
+++ b/pkgs/development/python-modules/airtouch4pyapi/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "airtouch4pyapi";
+  version = "1.0.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "LonePurpleWolf";
+    repo = pname;
+    # https://github.com/LonePurpleWolf/airtouch4pyapi/issues/5
+    rev = "34783888846783c058fe79cec16feda45504f701";
+    sha256 = "17c7fm72p085pg9msvsfdggbskvm12a6jlb5bw1cndrqsqcrxywx";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "airtouch4pyapi" ];
+
+  meta = with lib; {
+    description = "Python API for Airtouch 4 controllers";
+    homepage = "https://github.com/LonePurpleWolf/airtouch4pyapi";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -20,7 +20,7 @@
     "airly" = ps: with ps; [ airly ];
     "airnow" = ps: with ps; [ pyairnow ];
     "airthings" = ps: with ps; [ airthings-cloud ];
-    "airtouch4" = ps: with ps; [ ]; # missing inputs: airtouch4pyapi
+    "airtouch4" = ps: with ps; [ airtouch4pyapi ];
     "airvisual" = ps: with ps; [ pyairvisual ];
     "aladdin_connect" = ps: with ps; [ aladdin-connect ];
     "alarm_control_panel" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -409,6 +409,8 @@ in {
 
   airthings-cloud = callPackage ../development/python-modules/airthings-cloud { };
 
+  airtouch4pyapi = callPackage ../development/python-modules/airtouch4pyapi { };
+
   ajpy = callPackage ../development/python-modules/ajpy { };
 
   ajsonrpc = callPackage ../development/python-modules/ajsonrpc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API for Airtouch 4 controllers

https://github.com/LonePurpleWolf/airtouch4pyapi

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
