### PR TITLE
python3Packages.flipr-api: init at 1.4.1

### DIFF
--- a/pkgs/development/python-modules/flipr-api/default.nix
+++ b/pkgs/development/python-modules/flipr-api/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, requests-mock
+, pythonOlder
+, pytest-asyncio
+, pytestCheckHook
+, python-dateutil
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "flipr-api";
+  version = "1.4.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "cnico";
+    repo = pname;
+    rev = version;
+    sha256 = "00qkzr2g38fpa7ndnbfx9m4d50lmz0j74nkxif3amnkbl4m6l5vn";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    python-dateutil
+    requests
+  ];
+
+  checkInputs = [
+    requests-mock
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/cnico/flipr-api/pull/4
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/cnico/flipr-api/commit/f14be1dfd4f46d4d43d9ea47e51cafca3cc18e86.patch";
+      sha256 = "1fdi19cq21zcjx4g132k480yhi5y0x5qj2l0h8k5zky5cdxs58r6";
+    })
+  ];
+
+  pythonImportsCheck = [ "flipr_api" ];
+
+  meta = with lib; {
+    description = "Python client for Flipr API";
+    homepage = "https://github.com/cnico/flipr-api";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -272,7 +272,7 @@
     "flexit" = ps: with ps; [ pymodbus ];
     "flic" = ps: with ps; [ pyflic ];
     "flick_electric" = ps: with ps; [ pyflick ];
-    "flipr" = ps: with ps; [ ]; # missing inputs: flipr-api
+    "flipr" = ps: with ps; [ flipr-api ];
     "flo" = ps: with ps; [ aioflo ];
     "flock" = ps: with ps; [ ];
     "flume" = ps: with ps; [ pyflume ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -362,6 +362,7 @@ in with py.pkgs; buildPythonApplication rec {
     "fireservicerota"
     "firmata"
     "flick_electric"
+    "flipr"
     "flo"
     "flume"
     "flunearyou"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2729,6 +2729,8 @@ in {
 
   flickrapi = callPackage ../development/python-modules/flickrapi { };
 
+  flipr-api = callPackage ../development/python-modules/flipr-api { };
+
   flit = callPackage ../development/python-modules/flit { };
 
   flit-core = callPackage ../development/python-modules/flit-core { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for Flipr API

https://github.com/cnico/flipr-api

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
