### PR TITLE
nixos/etc: simplify source path handling

### DIFF
--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -6,9 +6,7 @@ with lib;
 
 let
 
-  # if the source is a local file, it should be imported to the store
-  localToStore = mapAttrs (name: value: if name == "source" then "${value}" else value);
-  etc' = map localToStore (filter (f: f.enable) (attrValues config.environment.etc));
+  etc' = filter (f: f.enable) (attrValues config.environment.etc);
 
   etc = pkgs.runCommandLocal "etc" {
     # This is needed for the systemd module
@@ -55,7 +53,8 @@ let
     mkdir -p "$out/etc"
     ${concatMapStringsSep "\n" (etcEntry: escapeShellArgs [
       "makeEtcEntry"
-      etcEntry.source
+      # Force local source paths to be added to the store
+      "${etcEntry.source}"
       etcEntry.target
       etcEntry.mode
       etcEntry.user


### PR DESCRIPTION
#### Copy of commit msg
This change is strictly functionally equivalent because we're just lifting the transformation of `source` out of `mapAttrs` to the single point of use (in escapeShellArgs).

This is also much faster because we can skip a map over all `etc` items.

#### Discussion
This is an improved implementation of https://github.com/NixOS/nixpkgs/pull/136474.
It's identical to @andir's fix in https://github.com/NixOS/nixpkgs/pull/136687.

Test this with 
```
system() { nix eval github:$1#nixosTests.systemd.outPath; }
# Compare this PR's commit with its parent
diff -u <(system erikarvstedt/nixpkgs/etc-simplify-source) <(system nixos/nixpkgs/f05a99e116df08af551c7c49e7d4aa4020d43acd)
# => no difference
```

cc @nrdxp, @andir, @waldheinz, @Mic92

