### PR TITLE
svdtools: init at 0.1.20

### DIFF
--- a/pkgs/development/python-modules/braceexpand/default.nix
+++ b/pkgs/development/python-modules/braceexpand/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "braceexpand";
+  version = "0.1.7";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "01gpcnksnqv6np28i4x8s3wkngawzgs99zvjfia57spa42ykkrg6";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "braceexpand" ];
+
+  meta = with lib; {
+    description = "Bash-style brace expansion for Python";
+    homepage = "https://github.com/trendels/braceexpand";
+    changelog = "https://github.com/trendels/braceexpand/blob/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ newam ];
+  };
+}

--- a/pkgs/development/python-modules/svdtools/default.nix
+++ b/pkgs/development/python-modules/svdtools/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, braceexpand
+, click
+, pyyaml
+, lxml
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "svdtools";
+  version = "0.1.20";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "028s1bn50mfpaygf1wc2mvf06s50wqfplqrkhrjz6kx8vzrmwj72";
+  };
+
+  propagatedBuildInputs = [
+    braceexpand
+    click
+    pyyaml
+    lxml
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "svdtools" ];
+
+  meta = with lib; {
+    description = "Python package to handle vendor-supplied, often buggy SVD files";
+    homepage = "https://github.com/stm32-rs/svdtools";
+    changelog = "https://github.com/stm32-rs/svdtools/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ newam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12822,6 +12822,8 @@ with pkgs;
 
   svd2rust = callPackage ../development/tools/rust/svd2rust { };
 
+  svdtools = with python3Packages; toPythonApplication svdtools;
+
   swift = callPackage ../development/compilers/swift { };
 
   swiProlog = callPackage ../development/compilers/swi-prolog {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8861,6 +8861,8 @@ in {
 
   suseapi = callPackage ../development/python-modules/suseapi { };
 
+  svdtools = callPackage ../development/python-modules/svdtools { };
+
   svg2tikz = callPackage ../development/python-modules/svg2tikz { };
 
   svglib = callPackage ../development/python-modules/svglib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1236,6 +1236,8 @@ in {
 
   bpython = callPackage ../development/python-modules/bpython { };
 
+  braceexpand = callPackage ../development/python-modules/braceexpand { };
+
   bracex = callPackage ../development/python-modules/bracex { };
 
   braintree = callPackage ../development/python-modules/braintree { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [svdtools](https://github.com/stm32-rs/svdtools), a python package to handle vendor-supplied, often buggy [SVD files](https://www.keil.com/pack/doc/CMSIS/SVD/html/index.html).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
