### PR TITLE
got: init at 0.60

### DIFF
--- a/pkgs/applications/version-management/got/default.nix
+++ b/pkgs/applications/version-management/got/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchurl, pkg-config, openssl, libuuid, libmd, zlib, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "got";
+  version = "0.60";
+
+  src = fetchurl {
+    url =
+      "https://gameoftrees.org/releases/portable/got-portable-${version}.tar.gz";
+    sha256 = "sha256-tT8F3Kx7Rcjd/tWjIXXNWygYlkMddWwrttpjnYLnBdo=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl libuuid libmd zlib ncurses ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    test "$($out/bin/got --version)" = '${pname} "${version}"'
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    description = "A version control system which prioritizes ease of use and simplicity over flexibility";
+    longDescription = ''
+      Game of Trees (Got) is a version control system which prioritizes
+      ease of use and simplicity over flexibility.
+
+      Got uses Git repositories to store versioned data. Git can be used
+      for any functionality which has not yet been implemented in
+      Got. It will always remain possible to work with both Got and Git
+      on the same repository.
+    '';
+    homepage = "https://gameoftrees.org";
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ abbe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24774,6 +24774,8 @@ with pkgs;
 
   goffice = callPackage ../development/libraries/goffice { };
 
+  got = callPackage ../applications/version-management/got { };
+
   gtk-pipe-viewer = perlPackages.callPackage ../applications/video/pipe-viewer { withGtk3 = true; };
 
   hydrus = python3Packages.callPackage ../applications/graphics/hydrus {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`got` ([Game of Trees](https://gameoftrees.org/)) is a VCS which uses git repositories as its backing store.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
