### PR TITLE
libsForQt5.mauikit: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/development/libraries/mauikit-filebrowsing/default.nix
+++ b/pkgs/development/libraries/mauikit-filebrowsing/default.nix
@@ -10,14 +10,14 @@
 
 mkDerivation rec {
   pname = "mauikit-filebrowsing";
-  version = "2.0.1";
+  version = "2.0.2";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "maui";
     repo = "mauikit-filebrowsing";
     rev = "v${version}";
-    sha256 = "sha256-hiR0RbZTduH0noyzpewsNJAtSdCtiSmTP8SLMBgK3uA=";
+    sha256 = "sha256-mpO61VOYTBlAjtIa1gEYChREV2jjd/WG+rbZcJnbM+Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/mauikit/default.nix
+++ b/pkgs/development/libraries/mauikit/default.nix
@@ -9,18 +9,19 @@
 , knotifications
 , qtbase
 , qtquickcontrols2
+, qtx11extras
 }:
 
 mkDerivation rec {
   pname = "mauikit";
-  version = "2.0.1";
+  version = "2.0.2";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "maui";
     repo = "mauikit";
     rev = "v${version}";
-    sha256 = "sha256-qz/MePMvyGR8lzR2xB2f9QENx04UHu0Xef7v0xcKovo=";
+    sha256 = "sha256-skukb9M6jhijCTb+tMIz/3vUCAvVJw+4zTFv9Z7HqWk=";
   };
 
   nativeBuildInputs = [
@@ -34,6 +35,7 @@ mkDerivation rec {
     ki18n
     knotifications
     qtquickcontrols2
+    qtx11extras
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
