### PR TITLE
foreman: add more platform support

### DIFF
--- a/pkgs/tools/system/foreman/Gemfile.lock
+++ b/pkgs/tools/system/foreman/Gemfile.lock
@@ -4,6 +4,10 @@ GEM
     foreman (0.87.2)
 
 PLATFORMS
+  aarch64-darwin
+  aarch64-linux
+  ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
###### Motivation for this change

See
https://www.moncefbelyamani.com/understanding-the-gemfile-lock-file/

Apparently you now have to manually add all the platforms that a gem is
supported on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).