### PR TITLE
cpio: add two subsequent upstream patches

### DIFF
--- a/pkgs/tools/archivers/cpio/default.nix
+++ b/pkgs/tools/archivers/cpio/default.nix
@@ -1,13 +1,11 @@
 { lib, stdenv, fetchurl, fetchpatch }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "cpio";
   version = "2.13";
-  name = "cpio-${version}";
-in stdenv.mkDerivation {
-  inherit name;
 
   src = fetchurl {
-    url = "mirror://gnu/cpio/${name}.tar.bz2";
+    url = "mirror://gnu/cpio/cpio-${version}.tar.bz2";
     sha256 = "0vbgnhkawdllgnkdn6zn1f56fczwk0518krakz2qbwhxmv2vvdga";
   };
 
@@ -26,9 +24,9 @@ in stdenv.mkDerivation {
         "0pidkbxalpj5yz4fr95x8h0rizgjij0xgvjgirfkjk460giawwg6")
   ];
 
-  preConfigure = if stdenv.isCygwin then ''
+  preConfigure = lib.optionalString stdenv.isCygwin ''
     sed -i gnu/fpending.h -e 's,include <stdio_ext.h>,,'
-  '' else null;
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/archivers/cpio/default.nix
+++ b/pkgs/tools/archivers/cpio/default.nix
@@ -11,12 +11,19 @@ in stdenv.mkDerivation {
     sha256 = "0vbgnhkawdllgnkdn6zn1f56fczwk0518krakz2qbwhxmv2vvdga";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "CVE-2021-38185.patch";
-      url = "https://git.savannah.gnu.org/cgit/cpio.git/patch/?id=dd96882877721703e19272fe25034560b794061b";
-      sha256 = "0vmr0qjwj2ldnzsvccl105ckwgx3ssvn9mp3f27ss0kiyigrzz32";
-    })
+  patches = let
+    fp = suffix: rev: sha256: fetchpatch {
+      name = "CVE-2021-38185-${suffix}.patch";
+      url = "https://git.savannah.gnu.org/cgit/cpio.git/patch/?id=${rev}";
+      inherit sha256;
+    };
+  in [
+    (fp "1" "dd96882877721703e19272fe25034560b794061b"
+        "0vmr0qjwj2ldnzsvccl105ckwgx3ssvn9mp3f27ss0kiyigrzz32")
+    (fp "2" "dfc801c44a93bed7b3951905b188823d6a0432c8"
+        "1qkrhi3lbxk6hflp6w3h4sgssc0wblv8r0qgxqzbjrm36pqwxiwh")
+    (fp "3" "236684f6deb3178043fe72a8e2faca538fa2aae1"
+        "0pidkbxalpj5yz4fr95x8h0rizgjij0xgvjgirfkjk460giawwg6")
   ];
 
   preConfigure = if stdenv.isCygwin then ''


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/139399

###### Rebuild plan
I thought we could do a quick `staging-next` iteration just with this, possibly at once with some other high-priority fix if they're found.  (But nothing caught _my_ attention in current `master..staging`.)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I checked that `pkgsi686Linux.linux` build is fixed by this.
- - -
Originally I wanted to just take some version from git, but that turned out to be complicated.  Without tarball we'd also be missing gnulib, and its version even changed since the last release.