### PR TITLE
apfs: unstable-2021-06-25 -> unstable-2021-09-21

### DIFF
--- a/pkgs/os-specific/linux/apfs/default.nix
+++ b/pkgs/os-specific/linux/apfs/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation {
   pname = "apfs";
-  version = "unstable-2021-06-25-${kernel.version}";
+  version = "unstable-2021-09-21-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "linux-apfs";
     repo = "linux-apfs-rw";
-    rev = "2ce6d06dc73036d113da5166c59393233bf54229";
-    sha256 = "sha256-18HFtPr0qcTIZ8njwEtveiPYO+HGlj90bdUoL47UUY0=";
+    rev = "362c4e32ab585b9234a26aa3e49f29b605612a31";
+    sha256 = "sha256-Y8/PGPLirNrICF+Bum60v/DBPa1xpox5VBvt64myZzs=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/linux-apfs/linux-apfs-rw";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "4.19";
+    broken = kernel.kernelOlder "4.9";
     maintainers = with maintainers; [ Luflosi ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
There have been many bug fixes and other improvements since the version from June. It is now also compatible with older kernels.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).