### PR TITLE
python3Packages.xml2rfc: 3.9.1 -> 3.10.0

### DIFF
--- a/pkgs/development/python-modules/xml2rfc/default.nix
+++ b/pkgs/development/python-modules/xml2rfc/default.nix
@@ -1,15 +1,34 @@
-{ lib, fetchPypi, buildPythonPackage, pythonAtLeast, intervaltree, pyflakes, requests, lxml, google-i18n-address
-, pycountry, html5lib, six, kitchen, pypdf2, dict2xml, weasyprint, pyyaml, jinja2, configargparse, appdirs
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, intervaltree
+, pyflakes
+, requests
+, lxml
+, google-i18n-address
+, pycountry
+, html5lib
+, six
+, kitchen
+, pypdf2
+, dict2xml
+, weasyprint
+, pyyaml
+, jinja2
+, configargparse
+, appdirs
 }:
 
 buildPythonPackage rec {
   pname = "xml2rfc";
-  version = "3.9.1";
-  disabled = pythonAtLeast "3.9";
+  version = "3.10.0";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "76cee167e81fc3cc0e0cc696fe58cadd039e19a774c8f4d2e5c0fea724c7aaca";
+    sha256 = "sha256-DJjGQAYFhXjAiJhWzxpQ0jRUSrnsNCcNz1KfPEjBoKE=";
   };
 
   propagatedBuildInputs = [
@@ -31,12 +50,18 @@ buildPythonPackage rec {
     appdirs
   ];
 
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "jinja2>=2.11,<3.0" "jinja2>=2.11"
+  '';
+
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
 
   # lxml tries to fetch from the internet
   doCheck = false;
+
   pythonImportsCheck = [ "xml2rfc" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.10.0

Fix build (https://hydra.nixos.org/build/154321544)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
