### PR TITLE
signald: 0.13.1 -> 0.14.1 and add service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -584,6 +584,7 @@
   ./services/misc/safeeyes.nix
   ./services/misc/sdrplay.nix
   ./services/misc/sickbeard.nix
+  ./services/misc/signald.nix
   ./services/misc/siproxd.nix
   ./services/misc/snapper.nix
   ./services/misc/sonarr.nix

--- a/nixos/modules/services/misc/signald.nix
+++ b/nixos/modules/services/misc/signald.nix
@@ -1,0 +1,105 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.signald;
+  dataDir = "/var/lib/signald";
+  defaultUser = "signald";
+in
+{
+  options.services.signald = {
+    enable = mkEnableOption "the signald service";
+
+    user = mkOption {
+      type = types.str;
+      default = defaultUser;
+      description = "User under which signald runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = defaultUser;
+      description = "Group under which signald runs.";
+    };
+
+    socketPath = mkOption {
+      type = types.str;
+      default = "/run/signald/signald.sock";
+      description = "Path to the signald socket";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users = optionalAttrs (cfg.user == defaultUser) {
+      ${defaultUser} = {
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = optionalAttrs (cfg.group == defaultUser) {
+      ${defaultUser} = { };
+    };
+
+    systemd.services.signald = {
+      description = "A daemon for interacting with the Signal Private Messenger";
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${pkgs.signald}/bin/signald -d ${dataDir} -s ${cfg.socketPath}";
+        Restart = "on-failure";
+        StateDirectory = "signald";
+        RuntimeDirectory = "signald";
+        StateDirectoryMode = "0750";
+        RuntimeDirectoryMode = "0750";
+
+        BindReadOnlyPaths = [
+          "/nix/store"
+          "-/etc/resolv.conf"
+          "-/etc/nsswitch.conf"
+          "-/etc/hosts"
+          "-/etc/localtime"
+        ];
+        CapabilityBoundingSet = "";
+        # ProtectClock= adds DeviceAllow=char-rtc r
+        DeviceAllow = "";
+        # Use a static user so other applications can access the files
+        #DynamicUser = true;
+        LockPersonality = true;
+        # Needed for java
+        #MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        # Needs network access
+        #PrivateNetwork = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        # Would re-mount paths ignored by temporary root
+        #ProtectSystem = "strict";
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" "~@privileged @resources @setuid @keyring" ];
+        TemporaryFileSystem = "/:ro";
+        # Does not work well with the temporary root
+        #UMask = "0066";
+      };
+    };
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchgit, fetchFromGitLab, jre_headless, coreutils, gradle_6, git, perl
+{ lib, stdenv, fetchurl, fetchFromGitLab, jre_headless, coreutils, gradle_6, git, perl
 , makeWrapper }:
 
 let

--- a/pkgs/applications/networking/instant-messengers/signald/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signald/default.nix
@@ -1,25 +1,21 @@
-{ lib, stdenv, fetchurl, fetchgit, jre_headless, coreutils, gradle_6, git, perl
+{ lib, stdenv, fetchurl, fetchgit, fetchFromGitLab, jre_headless, coreutils, gradle_6, git, perl
 , makeWrapper }:
 
 let
   pname = "signald";
+  version = "0.14.1";
 
-  version = "0.13.1";
-
-  # This package uses the .git directory
-  src = fetchgit {
-    url = "https://gitlab.com/signald/signald";
+  src = fetchFromGitLab {
+    owner = pname;
+    repo = pname;
     rev = version;
-    sha256 = "1ilmg0i1kw2yc7m3hxw1bqdpl3i9wwbj8623qmz9cxhhavbcd5i7";
-    leaveDotGit = true;
+    sha256 = "K/G5+w1GINLZwJIG5a7u0TxlGe+Cyp4wQm+pgm28qCA=";
   };
 
   buildConfigJar = fetchurl {
     url = "https://dl.bintray.com/mfuerstenau/maven/gradle/plugin/de/fuerstenau/BuildConfigPlugin/1.1.8/BuildConfigPlugin-1.1.8.jar";
     sha256 = "0y1f42y7ilm3ykgnm6s3ks54d71n8lsy5649xgd9ahv28lj05x9f";
   };
-
-  patches = [ ./git-describe-always.patch ./gradle-plugin.patch ];
 
   postPatch = ''
     patchShebangs gradlew
@@ -29,7 +25,7 @@ let
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {
     name = "${pname}-deps";
-    inherit src version postPatch patches;
+    inherit src version postPatch;
     nativeBuildInputs = [ gradle_6 perl ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
@@ -45,11 +41,17 @@ let
     forceShare = [ "dummy" ];
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "0w8ixp1l0ch1jc2dqzxdx3ljlh17hpgns2ba7qvj43nr4prl71l7";
+    # Downloaded jars differ by platform
+    outputHash = {
+      x86_64-linux = "/gJFoT+vvdSWr33oI44XiZXlFfyUjtRVB1M6CMzSztM=";
+      aarch64-linux = "v71stMWBbNALasfGAHvsVTBaDOZfpKK3sQrjNJ6FG1A=";
+    }.${stdenv.system} or (throw "Unsupported platform");
   };
 
 in stdenv.mkDerivation rec {
-  inherit pname src version postPatch patches;
+  inherit pname src version postPatch;
+
+  patches = [ ./gradle-plugin.patch ];
 
   buildPhase = ''
     runHook preBuild
@@ -90,6 +92,6 @@ in stdenv.mkDerivation rec {
     homepage = "https://signald.org";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ expipiplus1 ];
-    platforms = platforms.unix;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/signald/git-describe-always.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/git-describe-always.patch
@@ -1,9 +1,0 @@
-diff --git a/version.sh b/version.sh
-index 7aeeb3c..060cba3 100755
---- a/version.sh
-+++ b/version.sh
-@@ -1,3 +1,3 @@
- #!/bin/sh
--VERSION=$(git describe --exact-match 2> /dev/null) || VERSION=$(git describe --abbrev=0)+git$(date +%Y-%m-%d)r$(git rev-parse --short=8 HEAD).$(git rev-list $(git describe --abbrev=0)..HEAD --count)
-+VERSION=$(git describe --exact-match 2> /dev/null) || VERSION=$(git describe --always --abbrev=0)+git$(date +%Y-%m-%d)r$(git rev-parse --short=8 HEAD).$(git rev-list $(git describe --always --abbrev=0)..HEAD --count)
- echo $VERSION

--- a/pkgs/applications/networking/instant-messengers/signald/gradle-plugin.patch
+++ b/pkgs/applications/networking/instant-messengers/signald/gradle-plugin.patch
@@ -2,7 +2,7 @@ diff --git a/build.gradle b/build.gradle
 index 11d7a99..66805bb 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -3,9 +3,12 @@ import org.gradle.nativeplatform.platform.internal.OperatingSystemInternal
+@@ -18,9 +18,12 @@ import org.gradle.nativeplatform.platform.internal.OperatingSystemInternal
  import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
  import org.xml.sax.SAXParseException
  
@@ -17,10 +17,3 @@ index 11d7a99..66805bb 100644
  
  apply plugin: 'java'
  apply plugin: 'application'
-@@ -185,4 +188,4 @@ task integrationTest(type: Test) {
-     testClassesDirs = sourceSets.integrationTest.output.classesDirs
-     classpath = sourceSets.integrationTest.runtimeClasspath
-     outputs.upToDateWhen { false }
--}
-\ No newline at end of file
-+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update signald to 0.14.1: https://gitlab.com/signald/signald/-/releases
Also drop the git-describe-always patch and use `fetchFromGitLab`. It doesn’t change anything visible for me and seems to be better style. `signald -V` (also the version that is currently in master) always prints unversioned. (For reference, the initial pr is #119285.)
I’m running the module with mautrix-signal and it seems to be working fine.

The module was originally copied from https://gitlab.com/coffeetables/myrdd/-/blob/master/modules/signald.nix, but it changed quite a bit from there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @Pacman99