### PR TITLE
[21.05] imagej: 150 -> 153

### DIFF
--- a/pkgs/applications/graphics/imagej/default.nix
+++ b/pkgs/applications/graphics/imagej/default.nix
@@ -1,48 +1,51 @@
-{ lib, stdenv, fetchurl, jre, unzip, makeWrapper }:
+{ lib
+, stdenv
+, fetchurl
+, jre
+, unzip
+, makeWrapper
+}:
 
-# Note:
-# - User config dir is hard coded by upstream to $HOME/.imagej on linux systems
-#   and to $HOME/Library/Preferences on macOS.
-#  (The current trend appears to be to use $HOME/.config/imagej
-#    on linux systems, but we here do not attempt to fix it.)
+stdenv.mkDerivation {
+  pname = "imagej";
+  version = "150";
 
-let
-  imagej150 = stdenv.mkDerivation {
-    pname = "imagej";
-    version = "150";
-
-    src = fetchurl {
-      url = "https://wsr.imagej.net/distros/cross-platform/ij150.zip";
-      sha256 = "97aba6fc5eb908f5160243aebcdc4965726693cb1353d9c0d71b8f5dd832cb7b";
-    };
-    nativeBuildInputs = [ makeWrapper unzip ];
-    inherit jre;
-
-    # JAR files that are intended to be used by other packages
-    # should go to $out/share/java.
-    # (Some uses ij.jar as a library not as a standalone program.)
-    installPhase = ''
-      mkdir -p $out/share/java
-      # Read permisssion suffices for the jar and others.
-      # Simple cp shall clear suid bits, if any.
-      cp ij.jar $out/share/java
-      cp -dR luts macros plugins $out/share
-      mkdir $out/bin
-      makeWrapper ${jre}/bin/java $out/bin/imagej \
-        --add-flags "-jar $out/share/java/ij.jar -ijpath $out/share"
-    '';
-    meta = with lib; {
-      homepage = "https://imagej.nih.gov/ij/";
-      description = "Image processing and analysis in Java";
-      longDescription = ''
-        ImageJ is a public domain Java image processing program
-        inspired by NIH Image for the Macintosh.
-        It runs on any computer with a Java 1.4 or later virtual machine.
-      '';
-      license = licenses.publicDomain;
-      platforms = with platforms; linux ++ darwin;
-      maintainers = with maintainers; [ yuriaisaka ];
-    };
+  src = fetchurl {
+    url = "https://wsr.imagej.net/distros/cross-platform/ij${version}.zip";
+    sha256 = "97aba6fc5eb908f5160243aebcdc4965726693cb1353d9c0d71b8f5dd832cb7b";
   };
-in
-  imagej150
+  nativeBuildInputs = [ makeWrapper unzip ];
+  passthru = {
+    inherit jre;
+  };
+
+  # JAR files that are intended to be used by other packages
+  # should go to $out/share/java.
+  # (Some uses ij.jar as a library not as a standalone program.)
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/java $out/bin
+    # Read permisssion suffices for the jar and others.
+    # Simple cp shall clear suid bits, if any.
+    cp ij.jar $out/share/java
+    cp -dR luts macros plugins $out/share
+    makeWrapper ${jre}/bin/java $out/bin/imagej \
+      --add-flags "-jar $out/share/java/ij.jar -ijpath $out/share"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://imagej.nih.gov/ij/";
+    description = "Image processing and analysis in Java";
+    longDescription = ''
+      ImageJ is a public domain Java image processing program
+      inspired by NIH Image for the Macintosh.
+      It runs on any computer with a Java 1.4 or later virtual machine.
+    '';
+    license = licenses.publicDomain;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ yuriaisaka ];
+  };
+}

--- a/pkgs/applications/graphics/imagej/default.nix
+++ b/pkgs/applications/graphics/imagej/default.nix
@@ -15,11 +15,11 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "imagej";
-  version = "150";
+  version = "153";
 
   src = fetchurl {
     url = "https://wsr.imagej.net/distros/cross-platform/ij${version}.zip";
-    sha256 = "97aba6fc5eb908f5160243aebcdc4965726693cb1353d9c0d71b8f5dd832cb7b";
+    sha256 = "sha256-MGuUdUDuW3s/yGC68rHr6xxzmYScUjdXRawDpc1UQqw=";
   };
   nativeBuildInputs = [ copyDesktopItems makeWrapper unzip ];
   desktopItems = lib.optionals stdenv.isLinux [


### PR DESCRIPTION
###### Motivation for this change

Backport of #128077; merges cleanly.

Fixes #139166.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Ping @doronbehar who made the original PR.