### PR TITLE
joshuto: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/misc/joshuto/default.nix
+++ b/pkgs/applications/misc/joshuto/default.nix
@@ -2,23 +2,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "joshuto";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "kamiyaa";
     repo = pname;
     rev = version;
-    sha256 = "08d6h7xwcgycw5bdzwwc6aaikcrw3yc7inkiydgml9q261kql7zl";
-    # upstream includes an outdated Cargo.lock that stops cargo from compiling
-    postFetch = ''
-      mkdir -p $out
-      tar xf $downloadedFile --strip=1 -C $out
-      substituteInPlace $out/Cargo.lock \
-        --replace 0.8.6 ${version}
-    '';
+    sha256 = "sha256-+qKOvFoEF/gZL4ijL8lIRWE9ZWJM2eBlk29Lk46jAfQ=";
   };
 
-  cargoSha256 = "1scrqm7fs8y7anfiigimj7y5rjxcc2qvrxiq8ai7k5cwfc4v1ghm";
+  # upstream includes an outdated Cargo.lock that stops cargo from compiling
+  cargoPatches = [ ./fix-cargo-lock.patch ];
+
+  cargoSha256 = "sha256-JlekxU9pMkHNsIcH3+7b2I6MYUlxRqNX+0wwyVrQMAE=";
 
   buildInputs = lib.optional stdenv.isDarwin SystemConfiguration;
 

--- a/pkgs/applications/misc/joshuto/fix-cargo-lock.patch
+++ b/pkgs/applications/misc/joshuto/fix-cargo-lock.patch
@@ -1,0 +1,11 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -512,7 +512,7 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+ 
+ [[package]]
+ name = "joshuto"
+-version = "0.9.0"
++version = "0.9.1"
+ dependencies = [
+  "alphanumeric-sort",
+  "chrono",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/kamiyaa/joshuto/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
