### PR TITLE
pantheon.gala: fix session crash when taking screenshots with mutter 3.38

### DIFF
--- a/pkgs/desktops/pantheon/desktop/gala/default.nix
+++ b/pkgs/desktops/pantheon/desktop/gala/default.nix
@@ -75,6 +75,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./plugins-dir.patch
+    # https://github.com/elementary/gala/pull/1259
+    # https://github.com/NixOS/nixpkgs/issues/139404
+    # Remove this patch when it is included in a new release
+    # of gala OR when we no longer use mutter 3.38 for pantheon
+    ./fix-session-crash-when-taking-screenshots.patch
   ];
 
   postPatch = ''

--- a/pkgs/desktops/pantheon/desktop/gala/fix-session-crash-when-taking-screenshots.patch
+++ b/pkgs/desktops/pantheon/desktop/gala/fix-session-crash-when-taking-screenshots.patch
@@ -1,0 +1,50 @@
+From fa3c39331d4ef56a13019f45d811bde1fc755c21 Mon Sep 17 00:00:00 2001
+From: Bobby Rong <rjl931189261@126.com>
+Date: Sat, 25 Sep 2021 23:21:01 +0800
+Subject: [PATCH] Fix session crash when taking screenshots with mutter 3.38
+
+---
+ src/ScreenshotManager.vala | 5 ++---
+ vapi/mutter-clutter.vapi   | 2 +-
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/ScreenshotManager.vala b/src/ScreenshotManager.vala
+index 3ffb0123..388fee1a 100644
+--- a/src/ScreenshotManager.vala
++++ b/src/ScreenshotManager.vala
+@@ -354,12 +354,11 @@ namespace Gala {
+                 paint_flags |= Clutter.PaintFlag.FORCE_CURSORS;
+             }
+ 
+-            unowned var data = image.get_data ();
+             if (GLib.ByteOrder.HOST == GLib.ByteOrder.LITTLE_ENDIAN) {
+                 wm.stage.paint_to_buffer (
+                     {x, y, width, height},
+                     scale,
+-                    ref data,
++                    image.get_data (),
+                     image.get_stride (),
+                     Cogl.PixelFormat.BGRA_8888_PRE,
+                     paint_flags
+@@ -368,7 +367,7 @@ namespace Gala {
+                 wm.stage.paint_to_buffer (
+                     {x, y, width, height},
+                     scale,
+-                    ref data,
++                    image.get_data (),
+                     image.get_stride (),
+                     Cogl.PixelFormat.ARGB_8888_PRE,
+                     paint_flags
+diff --git a/vapi/mutter-clutter.vapi b/vapi/mutter-clutter.vapi
+index 5b778cb2..95de24be 100644
+--- a/vapi/mutter-clutter.vapi
++++ b/vapi/mutter-clutter.vapi
+@@ -7336,7 +7336,7 @@ namespace Clutter {
+ 		[Version (since = "1.2")]
+ 		public bool get_use_alpha ();
+ #if HAS_MUTTER338
+-		public bool paint_to_buffer (Cairo.RectangleInt rect, float scale, [CCode (array_length = false)] ref unowned uint8[] data, int stride, Cogl.PixelFormat format, Clutter.PaintFlag paint_flags) throws GLib.Error;
++		public bool paint_to_buffer (Cairo.RectangleInt rect, float scale, [CCode (array_length = false, type = "uint8_t*")] uint8[] data, int stride, Cogl.PixelFormat format, Clutter.PaintFlag paint_flags) throws GLib.Error;
+ 		public void paint_to_framebuffer (Cogl.Framebuffer framebuffer, Cairo.RectangleInt rect, float scale, Clutter.PaintFlag paint_flags);
+ #else
+ 		[Version (since = "0.4")]


### PR DESCRIPTION
###### Motivation for this change

Closes #139404 

cc @davidak

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
