### PR TITLE
Support virtual Nintendo Switch Pro controllers in joycond

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -321,6 +321,14 @@
           <link linkend="opt-programs.pantheon-tweaks.enable">programs.pantheon-tweaks</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/DanielOgorchock/joycond">joycond</link>,
+          a service that uses <literal>hid-nintendo</literal> to provide
+          nintendo joycond pairing and better nintendo switch pro
+          controller support.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -99,6 +99,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [pantheon-tweaks](https://github.com/pantheon-tweaks/pantheon-tweaks), an unofficial system settings panel for Pantheon. Available as [programs.pantheon-tweaks](#opt-programs.pantheon-tweaks.enable).
 
+- [joycond](https://github.com/DanielOgorchock/joycond), a service that uses `hid-nintendo` to provide nintendo joycond pairing and better nintendo switch pro controller support.
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 - The `security.wrappers` option now requires to always specify an owner, group and whether the setuid/setgid bit should be set.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -411,6 +411,7 @@
   ./services/hardware/illum.nix
   ./services/hardware/interception-tools.nix
   ./services/hardware/irqbalance.nix
+  ./services/hardware/joycond.nix
   ./services/hardware/lcd.nix
   ./services/hardware/lirc.nix
   ./services/hardware/nvidia-optimus.nix

--- a/nixos/modules/services/hardware/joycond.nix
+++ b/nixos/modules/services/hardware/joycond.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.joycond;
+  kernelPackages = config.boot.kernelPackages;
+in
+
+with lib;
+
+{
+  options.services.joycond = {
+    enable = mkEnableOption "support for Nintendo Pro Controllers and Joycons";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.joycond;
+      defaultText = "pkgs.joycond";
+      description = ''
+        The joycond package to use.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [
+      kernelPackages.hid-nintendo
+      cfg.package
+    ];
+
+    boot.extraModulePackages = [ kernelPackages.hid-nintendo ];
+    boot.kernelModules = [ "hid_nintendo" ];
+
+    services.udev.packages = [ cfg.package ];
+
+    systemd.packages = [ cfg.package ];
+
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/81138
+    systemd.services.joycond.wantedBy = [ "multi-user.target" ];
+  };
+}

--- a/pkgs/os-specific/linux/joycond/default.nix
+++ b/pkgs/os-specific/linux/joycond/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libevdev, udev }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libevdev, udev, acl }:
 
 stdenv.mkDerivation rec {
   pname = "joycond";
-  version = "unstable-2021-03-27";
+  version = "unstable-2021-07-30";
 
   src = fetchFromGitHub {
     owner = "DanielOgorchock";
     repo = "joycond";
-    rev = "2d3f553060291f1bfee2e49fc2ca4a768b289df8";
-    sha256 = "0dpmwspll9ar3pxg9rgnh224934par8h8bixdz9i2pqqbc3dqib7";
+    rev = "f9a66914622514c13997c2bf7ec20fa98e9dfc1d";
+    sha256 = "sha256-quw7yBHDDZk1+6uHthsfMCej7g5uP0nIAqzvI6436B8=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
 
     substituteInPlace $out/etc/systemd/system/joycond.service --replace \
       "ExecStart=/usr/bin/joycond" "ExecStart=$out/bin/joycond"
+
+    substituteInPlace $out/etc/udev/rules.d/89-joycond.rules --replace \
+      "/bin/setfacl"  "${acl}/bin/setfacl"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

NixOS should be able to support the Nintendo Switch Pro controller for steam and non-steam at the same time. Currently there are two mutually exclusive ways to support the Pro Controller: Steam and `hid-nintendo`.

Unfortunately these don't work together, but there's a workaround in newer versions of `joycond` (described [here](https://wiki.archlinux.org/title/Gamepad#Using_hid-nintendo_pro_controller_with_Steam_Games_(with_joycond)) and [here](https://github.com/ValveSoftware/steam-for-linux/issues/6651#issuecomment-886117867)). To use this workaround `hid-nintendo` and `joycond` need to be updated, and the systemd and udev configuration needs to be made available in NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've also tested this on my personal desktop. Using the nintendo switch pro controller in wine works (for FFXIV), and it also works for Outer Wilds running under steam. 

I did have to change the steam configuration to detect the "Generic Controller" as a "Nintendo Switch Controller" but that's a limitation of `joycond`.