### PR TITLE
wsdd: 0.6.2 -> 0.6.4

### DIFF
--- a/pkgs/servers/wsdd/default.nix
+++ b/pkgs/servers/wsdd/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, nixosTests, python3, fetchpatch }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, nixosTests, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "wsdd";
-  version = "0.6.2";
+  version = "0.6.4";
 
   src = fetchFromGitHub {
     owner = "christgau";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0444xh1r5wd0zfch1hg1f9s4cw68srrm87hqx16qvlgx6jmz5j0p";
+    sha256 = "0lfvpbk1lkri597ac4gz5x4csfyik8axz4b41i03xsqv9bci2vh6";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -16,12 +16,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ python3 ];
 
   patches = [
-    (fetchpatch {
-      # https://github.com/christgau/wsdd/issues/72
-      name = "fix_send_messages_using_correct_socket.patch";
-      url = "https://github.com/christgau/wsdd/commit/1ed74fe73a9fe2e2720859e2822116d65e4ffa5b.patch";
-      sha256 = "1n9bqvh20nhnvnc5pxvzf9kk8nky6rmbmfryg65lfmr1hmg676zg";
-    })
+    # Increase timeout to socket urlopen
+    # See https://github.com/christgau/wsdd/issues/80#issuecomment-76848906
+    ./increase_timeout.patch
   ];
 
   installPhase = ''

--- a/pkgs/servers/wsdd/increase_timeout.patch
+++ b/pkgs/servers/wsdd/increase_timeout.patch
@@ -1,0 +1,13 @@
+diff --git a/src/wsdd.py b/src/wsdd.py
+index 88a7a2a..360e4f7 100755
+--- a/src/wsdd.py
++++ b/src/wsdd.py
+@@ -699,7 +699,7 @@ class WSDClient(WSDUDPMessageHandler):
+             request.add_header('Host', host)
+
+         try:
+-            with urllib.request.urlopen(request, None, 2.0) as stream:
++            with urllib.request.urlopen(request, None, 5.0) as stream:
+                 self.handle_metadata(stream.read(), endpoint, xaddr)
+         except urllib.error.URLError as e:
+             logger.warning('could not fetch metadata from: {} {}'.format(url, e))


### PR DESCRIPTION
###### Motivation for this change
Update wsdd to version 0.6.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
