### PR TITLE
hledger-check-fancyassertions: init at 1.23

### DIFF
--- a/pkgs/applications/office/hledger-check-fancyassertions/default.nix
+++ b/pkgs/applications/office/hledger-check-fancyassertions/default.nix
@@ -1,0 +1,41 @@
+{lib, stdenvNoCC, haskellPackages, fetchurl, writers}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "hledger-check-fancyassertions";
+  version = "1.23";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/simonmichael/hledger/hledger-lib-${version}/bin/hledger-check-fancyassertions.hs";
+    sha256 = "08p2din1j7l4c29ipn68k8vvs3ys004iy8a3zf318lzby4h04h0n";
+  };
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  executable = writers.writeHaskell
+    "hledger-check-fancyassertions"
+    {
+      libraries = with haskellPackages; [
+        base base-compat base-compat-batteries filepath hledger-lib_1_23
+        megaparsec microlens optparse-applicative string-qq text time
+        transformers
+      ];
+      inherit (haskellPackages) ghc;
+    }
+    src;
+
+  installPhase = ''
+    runHook preInstall
+    install -D $executable $out/bin/${pname}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Complex account balance assertions for hledger journals";
+    homepage = "https://hledger.org/";
+    changelog = "https://github.com/simonmichael/hledger/blob/master/CHANGES.md";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.DamienCassou ];
+    platforms = lib.platforms.all; # GHC can cross-compile
+  };
+}

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -856,6 +856,11 @@ self: super: {
       stripLen = 1;
     });
 
+  # hledger-lib 1.23 depends on doctest >= 0.18
+  hledger-lib_1_23 = super.hledger-lib_1_23.override {
+    doctest = self.doctest_0_18_1;
+  };
+
   # Copy hledger man pages from data directory into the proper place. This code
   # should be moved into the cabal2nix generator.
   hledger = overrideCabal super.hledger (drv: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25003,6 +25003,7 @@ with pkgs;
   hivelytracker = callPackage ../applications/audio/hivelytracker { };
 
   hledger = haskell.lib.justStaticExecutables haskellPackages.hledger;
+  hledger-check-fancyassertions = callPackage ../applications/office/hledger-check-fancyassertions { };
   hledger-iadd = haskell.lib.justStaticExecutables haskellPackages.hledger-iadd;
   hledger-interest = haskell.lib.justStaticExecutables haskellPackages.hledger-interest;
   hledger-ui = haskell.lib.justStaticExecutables haskellPackages.hledger-ui;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -175,6 +175,7 @@ let
         hinit
         hedgewars
         hledger
+        hledger-check-fancyassertions
         hledger-iadd
         hledger-interest
         hledger-ui


### PR DESCRIPTION
###### Motivation for this change

Add [hledger-check-fancyassertions](https://github.com/simonmichael/hledger/blob/master/bin/hledger-check-fancyassertions.hs)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
