### PR TITLE
skawarePackages: Fall 2021 release

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -22,7 +22,8 @@
 , postInstall
   # : list Maintainer
 , maintainers ? []
-
+  # : passtrhu arguments (e.g. tests)
+, passthru ? {}
 
 }:
 
@@ -107,5 +108,7 @@ in stdenv.mkDerivation {
     maintainers = with lib.maintainers;
       [ pmahoney Profpatsch qyliss ] ++ maintainers;
   };
+
+  inherit passthru;
 
 }

--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -49,6 +49,8 @@ let
     "CHANGELOG"
     "README"
     "README.*"
+    "DCO"
+    "CONTRIBUTING"
   ];
 
 in stdenv.mkDerivation {

--- a/pkgs/development/libraries/nsss/default.nix
+++ b/pkgs/development/libraries/nsss/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "nsss";
-  version = "0.1.0.1";
-  sha256 = "1nair10m7fddp50mpqnwj0qiggnh5qmnffmyzxis5l1ixcav1ir0";
+  version = "0.2.0.0";
+  sha256 = "0zg0lwkvx9ch4a6h9ryc73nqfz733v2pv4gbf65qzpz7ccniwagi";
 
   description = "An implementation of a subset of the pwd.h, group.h and shadow.h family of functions.";
 

--- a/pkgs/development/libraries/skalibs/2_10.nix
+++ b/pkgs/development/libraries/skalibs/2_10.nix
@@ -1,11 +1,9 @@
-{ skawarePackages, pkgs }:
+{ skawarePackages }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "skalibs";
-  version = "2.11.0.0";
-  sha256 = "1n9l7mb54dlb0iijjaf446jba6nmq1ql9n39s095ngrk5ahcipwq";
+  version = "2.10.0.3";
+  sha256 = "0ka6n5rnxd5sn5lycarf596d5wlak5s535zqqlz0rnhdcnpb105p";
 
   description = "A set of general-purpose C programming libraries";
 
@@ -29,11 +27,5 @@ buildPackage {
 
     mv doc $doc/share/doc/skalibs/html
   '';
-
-  passthru.tests = {
-    # fdtools is one of the few non-skalib packages that depends on skalibs
-    # and might break if skalibs gets an breaking update.
-    fdtools = pkgs.fdtools;
-  };
 
 }

--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "skalibs";
-  version = "2.10.0.3";
-  sha256 = "0ka6n5rnxd5sn5lycarf596d5wlak5s535zqqlz0rnhdcnpb105p";
+  version = "2.11.0.0";
+  sha256 = "1n9l7mb54dlb0iijjaf446jba6nmq1ql9n39s095ngrk5ahcipwq";
 
   description = "A set of general-purpose C programming libraries";
 

--- a/pkgs/development/libraries/utmps/default.nix
+++ b/pkgs/development/libraries/utmps/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "utmps";
-  version = "0.1.0.2";
-  sha256 = "1vjza7m65ziq54q0sv46kb3lss9cmxkkv0n9h3i8505x0h2hlvlb";
+  version = "0.1.0.3";
+  sha256 = "0npgg90lzxmhld6hp296gbnrsixip28s7axirc2g6yjpjz2bvcan";
 
   description = "A secure utmpx and wtmp implementation";
 

--- a/pkgs/os-specific/linux/mdevd/default.nix
+++ b/pkgs/os-specific/linux/mdevd/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "mdevd";
-  version = "0.1.4.0";
-  sha256 = "1lnwk7qa6x7iia0v12i2jckg42ypi35hk3sa7cjm23ngnhiv5lzz";
+  version = "0.1.5.0";
+  sha256 = "01ykxgnbm53wijdrbld10664xy2wkvyzbbs98mfnqnf4h1y064n0";
 
   description = "mdev-compatible Linux hotplug manager daemon";
   platforms = lib.platforms.linux;

--- a/pkgs/os-specific/linux/s6-linux-init/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-init/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-linux-init";
-  version = "1.0.6.3";
-  sha256 = "1idqjcxhl5wgff8yrsvx2812wahjri2hcs7qs6k62g0sdd8niqr9";
+  version = "1.0.6.4";
+  sha256 = "0grqk111d6aqym1c4l9j26fdqcgra1hvwb9vdgylrfbvn1c3hlpb";
 
   description = "A set of minimalistic tools used to create a s6-based init system, including a /sbin/init binary, on a Linux kernel";
   platforms = lib.platforms.linux;

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-linux-utils";
-  version = "2.5.1.5";
-  sha256 = "1fj5ldlrc6bx40pphg29rp3byd6fal6869v85kw86c2kdgrxn063";
+  version = "2.5.1.6";
+  sha256 = "0hr49nl0d7a6i5w8cfg43xzvzayb8kpqij9xg7bmw2fyvc2z338z";
 
   description = "A set of minimalistic Linux-specific system utilities";
   platforms = lib.platforms.linux;

--- a/pkgs/os-specific/linux/sdnotify-wrapper/sdnotify-wrapper.c
+++ b/pkgs/os-specific/linux/sdnotify-wrapper/sdnotify-wrapper.c
@@ -2,9 +2,9 @@
    Copyright: (C)2015-2020 Laurent Bercot.  http://skarnet.org/
    ISC license. See http://opensource.org/licenses/ISC
 
-   Build-time requirements: skalibs.  http://skarnet.org/software/skalibs/
+   Build-time requirements: skalibs.  https://skarnet.org/software/skalibs/
    Run-time requirements: none, if you link skalibs statically.
- 
+
    Compilation:
      gcc -o sdnotify-wrapper -L/usr/lib/skalibs sdnotify-wrapper.c -lskarnet
    Use /usr/lib/skalibs/libskarnet.a instead of -lskarnet to link statically.
@@ -67,8 +67,6 @@
 #include <skalibs/tai.h>
 #include <skalibs/iopause.h>
 #include <skalibs/djbunix.h>
-//#include <skalibs/webipc.h>
-// svanderburg: This header no longer exists, but socket.h provides the functions this module needs
 #include <skalibs/socket.h>
 #include <skalibs/exec.h>
 
@@ -106,7 +104,7 @@ static inline int run_child (int fd, unsigned int timeout, pid_t pid, char const
 {
   char dummy[4096] ;
   iopause_fd x = { .fd = fd, .events = IOPAUSE_READ } ;
-  tain_t deadline ;
+  tain deadline ;
   tain_now_g() ;
   if (timeout) tain_from_millisecs(&deadline, timeout) ;
   else deadline = tain_infinite_relative ;
@@ -135,7 +133,7 @@ int main (int argc, char const *const *argv)
   int df = 1, keep = 0 ;
   PROG = "sdnotify-wrapper" ;
   {
-    subgetopt_t l = SUBGETOPT_ZERO ;
+    subgetopt l = SUBGETOPT_ZERO ;
     for (;;)
     {
       int opt = subgetopt_r(argc, argv, "d:ft:k", &l) ;

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "execline";
-  version = "2.8.0.1";
-  sha256 = "1v9swmhw2rcrr9fmkmd7qh8qq0kslhmvxwz2a3bhan9ksabz8wx3";
+  version = "2.8.1.0";
+  sha256 = "0msmzf5zwjcsgjlvvq28rd2i0fkdb2skmv8ii0ix8dhyckwwjmav";
 
   description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 

--- a/pkgs/tools/misc/fdtools/default.nix
+++ b/pkgs/tools/misc/fdtools/default.nix
@@ -2,8 +2,10 @@
 
 let
   pname = "fdtools";
+  # When you update, check whether we can drop the skalibs pin.
   version = "2020.05.04";
   sha256 = "0lnafcp4yipi0dl8gh33zjs8wlpz0mim8mwmiz9s49id0b0fmlla";
+  skalibs = skawarePackages.skalibs_2_10;
 
 in stdenv.mkDerivation {
   inherit pname version;
@@ -16,7 +18,10 @@ in stdenv.mkDerivation {
   patches = [ ./new-skalibs.patch ];
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
 
-  buildInputs = [ skawarePackages.skalibs ];
+  buildInputs = [
+    # temporary, until fdtools catches up to skalibs
+    skalibs
+  ];
 
   configurePhase = ''
     cd ${pname}-${version}
@@ -27,7 +32,7 @@ in stdenv.mkDerivation {
       conf-compile/defaults/host_compile.sh \
       > conf-compile/host_compile.sh
 
-    echo "${skawarePackages.skalibs.lib}/lib/skalibs/sysdeps" \
+    echo "${skalibs.lib}/lib/skalibs/sysdeps" \
       > conf-compile/depend_skalibs_sysdeps
   '';
 

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-portable-utils";
-  version = "2.2.3.2";
-  sha256 = "173nmygkp7ky3093dg4rx3ahvyl7ll86z8qj6pl3jd96xb9s49v6";
+  version = "2.2.3.3";
+  sha256 = "132jj5qk8x40kw6lrrn7jiqhvqj9d2h6g6mhl8zma1sp37bg0i84";
 
   description = "A set of tiny general Unix utilities optimized for simplicity and small size";
 

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-dns";
-  version = "2.3.5.1";
-  sha256 = "0qsgqwdr5ms337fc9f2b4aa5cr7myvbzndvgkgswnrdwszjm078c";
+  version = "2.3.5.2";
+  sha256 = "0nczzjprvp6wirzycgf5h32dlgx4r8grzkqhif27n3ii6f5g78yw";
 
   description = "A suite of DNS client programs and libraries for Unix systems";
 

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -19,8 +19,8 @@ assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
 buildPackage {
   pname = "s6-networking";
-  version = "2.4.1.1";
-  sha256 = "0m55ibx7k2wgrqbpci1n667ij0h925ajzggxalq2pj65kmwcmyx3";
+  version = "2.5.0.0";
+  sha256 = "1fn3g9gkwgmnxallhk82f5rly81pnkilj7n49g5fbfmaalsq96mh";
 
   description = "A suite of small networking utilities for Unix systems";
 
@@ -57,7 +57,6 @@ buildPackage {
   postInstall = ''
     # remove all s6 executables from build directory
     rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable)
-    rm minidentd
     rm libs6net.* libstls.* libs6tls.* libsbearssl.*
 
     mv doc $doc/share/doc/s6-networking/html

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-rc";
-  version = "0.5.2.2";
-  sha256 = "12bzc483jpd16xmhfsfrib84daj1k3kwy5s5nc18ap60apa1r39a";
+  version = "0.5.2.3";
+  sha256 = "1f92dxw1n8r8avamixi9k0gqbnkpm0r3fmwzz7jd82g6bb2vsg5z";
 
   description = "A service manager for s6-based systems";
   platforms = lib.platforms.unix;

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6";
-  version = "2.10.0.3";
-  sha256 = "0mw7blp8dwr09z58m9mrxwmmvvpnjzq9klcf1vgm0hbha4qkf88x";
+  version = "2.11.0.0";
+  sha256 = "1a3lj0xfhn1w3a4ygqsxy8q4dr3n48hnwml4xzdpz3nrikhy8if5";
 
   description = "skarnet.org's small & secure supervision software suite";
 
@@ -34,6 +34,7 @@ buildPackage {
     # remove all s6 executables from build directory
     rm $(find -type f -mindepth 1 -maxdepth 1 -executable)
     rm libs6.*
+    rm ./libs6lockd.a.xyzzy
 
     mv doc $doc/share/doc/s6/html
     mv examples $doc/share/doc/s6/examples

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18948,6 +18948,7 @@ with pkgs;
   skaffold = callPackage ../development/tools/skaffold { };
 
   skalibs = skawarePackages.skalibs;
+  skalibs_2_10 = skawarePackages.skalibs_2_10;
 
   skawarePackages = recurseIntoAttrs rec {
     cleanPackaging = callPackage ../build-support/skaware/clean-packaging.nix { };
@@ -18957,6 +18958,7 @@ with pkgs;
     buildManPages = callPackage ../build-support/skaware/build-skaware-man-pages.nix { };
 
     skalibs = callPackage ../development/libraries/skalibs { };
+    skalibs_2_10 = callPackage ../development/libraries/skalibs/2_10.nix { };
     execline = callPackage ../tools/misc/execline { };
 
     execline-man-pages = callPackage ../data/documentation/execline-man-pages {


### PR DESCRIPTION
Maintainer’s notes below.

sdnotify-wrapper had to be marked broken for the time being.

Maintainers Notes below.

~~~

 Hello,

 New versions of all the skarnet.org packages are available.

 skalibs has undergone a major update, with a few APIs having disappeared,
and others having changed. Compatibility with previous versions is  *not*
assured.
 Consequently, all the rest of the skarnet.org software has undergone
at least a release bump, in order to build with the new skalibs. But
some packages also have new functionality added (hence, a minor bump),
and others also have their own incompatible changes (hence, a major bump).

 The new versions are the following:

skalibs-2.11.0.0          (major)
nsss-0.2.0.0              (major)
utmps-0.1.0.3             (release)
execline-2.8.1.0          (minor)
s6-2.11.0.0               (major)
s6-rc-0.5.2.3             (release)
s6-portable-utils-2.2.3.3 (release)
s6-linux-utils-2.5.1.6    (release)
s6-linux-init-1.0.6.4     (release)
s6-dns-2.3.5.2            (release)
s6-networking-2.5.0.0     (major)
mdevd-0.1.5.0             (minor)
bcnm-0.0.1.4              (release)
dnsfunnel-0.0.1.2         (release)

Additionally, a new package has been released:
smtpd-starttls-proxy-0.0.1.0

 Dependencies have all been updated to the latest versions. They are,
this time, partially strict: libraries and binaries may build with older
releases of their dependencies, but not across major version bumps. The
safest approach is to upgrade everything at the same time.

 You do not need to recompile your s6-rc service databases or recreate
your s6-linux-init run-images.
 You should restart your supervision tree after upgrading skalibs and s6,
as soon as is convenient for you.

 Details of major and minor package changes follow.

* skalibs-2.11.0.0
  ----------------

 - A lot of obsolete or useless functionality has been removed:
libbiguint, rc4, md5, iobuffer, skasigaction, environ.h and
getpeereid.h headers, various functions that have not proven their
value in a while.
 - Some functions changed signatures or changed names, or both.
 - All custom types ending in _t have been renamed, to avoid treading on
POSIX  namespace. (The same change has not been done yet in other
packages,  but skalibs was the biggest offender by far.)
 - Signal functions have been deeply reworked.
 - cdb has been reworked, the API is now more user-friendly.
 - New functions have been added.

 The deletion of significant portions of code has made skalibs leaner.
libskarnet.so has dropped under 190 kB on x86_64.
 The cdb rewrite on its own has helped reduce an important amount of
boilerplate in cdb-using code.
 All in all, code linked against the new  skalibs should be slightly
smaller and use a tiny bit less RAM.

 https://skarnet.org/software/skalibs/
 git://git.skarnet.org/skalibs

* nsss-0.2.0.0
  ------------

 - Bugfixes.
 - nsss-switch wire protocol slightly modified, which is enough to
warrant a major version bump.
 - _r functions are now entirely thread-safe.
 - Spawned nsssd programs are now persistent and only expire after a
timeout on non-enumeration queries. This saves a lot of forking with
applications that can call  primitives such as getpwnam() repeatedly, as
e.g. mdevd does when  initially parsing its configuration file.
 - New nsssd-switch program, implementing real nsswitch functionality
by dispatching queries to various backends according to a script.
It does not dlopen a single library or read a single config file.

 https://skarnet.org/software/nsss/
 git://git.skarnet.org/nsss

* execline-2.8.1.0
  ----------------

 - Bugfixes.
 - New binary: case. It compares a value against a series of regular
expressions, executing into another command line on the first match.

 https://skarnet.org/software/execline/
 git://git.skarnet.org/execline

* s6-2.11.0.0
  -----------

 - Bugfixes.
 - Some libs6 header names have been simplified.
 - s6-svwait now accepts -r and -R options.
 - s6-supervise now reads an optional lock-fd file in the service
directory; if it finds one, the first action of the service is to take
a blocking lock. This prevents confusion when a controller process dies
while still leaving workers holding resources; it also prevents log
spamming on user mistakes (autobackgrounding services, notably).
 - New binaries: s6-socklog, s6-svlink, s6-svunlink. The former is a
rewrite of smarden.org's socklog program, in order to implement a fully
functional syslogd with only s6 programs. The latter are tools that start
and stop services by symlinking/unlinking service directories from a
scan directory, in order to make it easier to integrate s6-style services
in boot scripts for sequential service managers such as OpenRC.

 https://skarnet.org/software/s6/
 git://git.skarnet.org/s6

* s6-networking-2.5.0.0
  ---------------------

 - Bugfixes.
 - minidentd has been removed. It was an old and somehow still buggy
piece of  code that was only hanging around for nostalgia reasons.
 - Full support for client certificates. Details of the client
certificate are transmitted to the application via environment
variables (or via an environment string in the case of opportunistic
TLS).
 - Full SNI support, including server-side. (That involved a deep dive
into the bearssl internals, which is why it took so long.) The filenames
containing secret keys and certificates for <domain> are read in the
environment variables KEYFILE:<domain> and CERTFILE:<domain>.

 Complete client certificate and SNI support now make the TLS part of
s6-networking a fully viable replacement of stunnel and other similar
TLS tunneling tools. This is most interesting when s6-networking is
built against bearssl, which uses about 1/9 of the resources that OpenSSL
needs.

 https://skarnet.org/software/s6-networking/
 git://git.skarnet.org/s6-networking

* mdevd-0.1.5.0
  -------------

 - A new option to mdevd is available: -O <nlgroups>.
This option makes mdevd rebroadcast uevents to a netlink group (or set
of netlink groups) once they have been handled. This allows applications
to read uevents from a netlink group *after* the device manager is done
with them. This is useful, for instance, when pairing mdevd with
libudev-zero for full udev emulation.
 - The * and & directives, which previously were only triggered by
"add" and "remove" actions, are now triggered by *all* action types.
This gives users full scripting access to any event, which can be
used to implement complex rules similar to udev ones.

 These two changes make it possible to now build a full-featured desktop
system based on mdevd + libudev-zero, without running systemd-udevd or
eudev.

 https://skarnet.org/software/mdevd/
 git://git.skarnet.org/mdevd

* smtpd-starttls-proxy-0.0.1.0
  ----------------------------

 This new package, in conjunction with the latest s6-networking,
implements the STARTTLS functionality for inetd-like mail servers that
do not already support it. (Currently only tested with qmail-smtpd.)
If you have noticed that sending mail to skarnet.org supports STARTTLS
now, it is thanks to this little piece of software.

 https://skarnet.org/software/smtpd-starttls-proxy/
 git://git.skarnet.org/smtpd-starttls-proxy

 Enjoy,
 Bug-reports welcome.

 Laurent

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
