### PR TITLE
libressl: 3.2.5 -> 3.4.0, enable tests, add patch for CVE-2021-41581

### DIFF
--- a/pkgs/development/libraries/libressl/CVE-2021-41581.patch
+++ b/pkgs/development/libraries/libressl/CVE-2021-41581.patch
@@ -1,0 +1,53 @@
+Based on upstream https://github.com/openbsd/src/commit/62ceddea5b1d64a1a362bbb7071d9e15adcde6b1
+with paths switched to apply to libressl-portable and CVS header
+hunk removed.
+
+--- a/crypto/x509/x509_constraints.c
++++ b/crypto/x509/x509_constraints.c
+@@ -339,16 +339,16 @@
+ 			if (c == '.')
+ 				goto bad;
+ 		}
+-		if (wi > DOMAIN_PART_MAX_LEN)
+-			goto bad;
+ 		if (accept) {
++			if (wi >= DOMAIN_PART_MAX_LEN)
++				goto bad;
+ 			working[wi++] = c;
+ 			accept = 0;
+ 			continue;
+ 		}
+ 		if (candidate_local != NULL) {
+ 			/* We are looking for the domain part */
+-			if (wi > DOMAIN_PART_MAX_LEN)
++			if (wi >= DOMAIN_PART_MAX_LEN)
+ 				goto bad;
+ 			working[wi++] = c;
+ 			if (i == len - 1) {
+@@ -363,7 +363,7 @@
+ 			continue;
+ 		}
+ 		/* We are looking for the local part */
+-		if (wi > LOCAL_PART_MAX_LEN)
++		if (wi >= LOCAL_PART_MAX_LEN)
+ 			break;
+ 
+ 		if (quoted) {
+@@ -383,6 +383,8 @@
+ 			 */
+ 			if (c == 9)
+ 				goto bad;
++			if (wi >= LOCAL_PART_MAX_LEN)
++				goto bad;
+ 			working[wi++] = c;
+ 			continue; /* all's good inside our quoted string */
+ 		}
+@@ -412,6 +414,8 @@
+ 		}
+ 		if (!local_part_ok(c))
+ 			goto bad;
++		if (wi >= LOCAL_PART_MAX_LEN)
++			goto bad;
+ 		working[wi++] = c;
+ 	}
+ 	if (candidate_local == NULL || candidate_domain == NULL)

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, lib, cmake, cacert, fetchpatch
+{ stdenv
+, fetchurl
+, lib
+, cmake
+, cacert
 , buildShared ? !stdenv.hostPlatform.isStatic
 }:
 
@@ -66,5 +70,9 @@ in {
   libressl_3_2 = generic {
     version = "3.2.5";
     sha256 = "1zkwrs3b19s1ybz4q9hrb7pqsbsi8vxcs44qanfy11fkc7ynb2kr";
+  };
+  libressl_3_4 = generic {
+    version = "3.4.0";
+    sha256 = "1lhn76nd59p1dfd27b4636zj6wh3f5xsi8b3sxqnl820imsswbp5";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -3,6 +3,7 @@
 , lib
 , cmake
 , cacert
+, fetchpatch
 , buildShared ? !stdenv.hostPlatform.isStatic
 }:
 
@@ -82,9 +83,15 @@ in {
   libressl_3_2 = generic {
     version = "3.2.5";
     sha256 = "1zkwrs3b19s1ybz4q9hrb7pqsbsi8vxcs44qanfy11fkc7ynb2kr";
+    patches = [
+      ./CVE-2021-41581.patch
+    ];
   };
   libressl_3_4 = generic {
     version = "3.4.0";
     sha256 = "1lhn76nd59p1dfd27b4636zj6wh3f5xsi8b3sxqnl820imsswbp5";
+    patches = [
+      ./CVE-2021-41581.patch
+    ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18403,11 +18403,12 @@ with pkgs;
   openvdb = callPackage ../development/libraries/openvdb {};
 
   inherit (callPackages ../development/libraries/libressl { })
-    libressl_3_2;
+    libressl_3_2
+    libressl_3_4;
 
   # Please keep this pointed to the latest version. See also
   # https://discourse.nixos.org/t/nixpkgs-policy-regarding-libraries-available-in-multiple-versions/7026/2
-  libressl = libressl_3_2;
+  libressl = libressl_3_4;
 
   boringssl = callPackage ../development/libraries/boringssl { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32365,6 +32365,7 @@ with pkgs;
 
   wasm-pack = callPackage ../development/tools/wasm-pack {
     inherit (darwin.apple_sdk.frameworks) Security;
+    libressl = libressl_3_2;
   };
 
   wavegain = callPackage ../applications/audio/wavegain { };


### PR DESCRIPTION
###### Motivation for this change
We're falling behind a bit on `libressl` releases, and https://nvd.nist.gov/vuln/detail/CVE-2021-41581 on the horizon is a nudge to keep up (fix isn't released yet, may submit patch separately).

See also #121644 which got forgotten.

Keeping `wasm-pack` on the `libressl_3_2` it still needs here.

Haven't quite finished all macos rebuilds yet...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
