### PR TITLE
apacheKafka: 2.8.0 -> 2.8.1

### DIFF
--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -12,9 +12,9 @@ let
       jre = jre11;
     };
     "2.8" = {
-      kafkaVersion = "2.8.0";
+      kafkaVersion = "2.8.1";
       scalaVersion = "2.13";
-      sha256 = "1iljfjlp29m4s6gkja9fxkzj8a8p0qc0sfy8x4g1318kbnp818rz";
+      sha256 = "0fgil47hxdnc374k0p9sxv6b163xknp3pkihv3r99p977czb1228";
       jre = jre11;
     };
   };


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-38153

This is just a non-constant-time-auth-comparison issue.

Unfortunately since we just grab a jar for this package, we have no ability to patch the 2.7.1 that we also ship. The same goes for stable, which has 2.4, 2.5 & 2.6, all with no fixes. And I think this issue is a bit too lame to annoy people with `knownVulnerabilities` perhaps?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
