### PR TITLE
python3Packages.python3-otr: init at 2.0.1

### DIFF
--- a/pkgs/development/python-modules/python3-otr/default.nix
+++ b/pkgs/development/python-modules/python3-otr/default.nix
@@ -1,0 +1,53 @@
+{ lib, fetchFromGitHub, buildPythonPackage, isPy3k, zope_interface
+, python3-application, cryptography, gmpy2 }:
+
+buildPythonPackage rec {
+  pname = "python3-otr";
+  version = "2.0.1";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "AGProjects";
+    repo = "python3-otr";
+    rev = version;
+    sha256 = "sha256-XsJQIRZj04TkoWIddOc0evXwNFP/IYF/z/nO7mC0aVY=";
+  };
+
+  propagatedBuildInputs = [ python3-application zope_interface cryptography gmpy2 ];
+
+  # remove if https://github.com/AGProjects/python3-otr/pull/1 merged
+  patches = [ ./python3-otr-dep-name.patch ];
+
+  dontUseSetuptoolsCheck = true; # some tests fail with "TypeError: can't concat str to bytes"
+
+  pythonImportsCheck = [ "otr" ];
+
+  meta = with lib; {
+    description = "Off-The-Record Messaging protocol implemented in pure python";
+    homepage = "https://github.com/AGProjects/python3-otr";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ chanley ];
+    longDescription = ''
+      Off-The-Record Messaging (OTR) is a cryptographic protocol that provides
+      encryption for instant messaging conversations. OTR uses a combination of
+      AES symmetric-key algorithm with 128 bits key length, the Diffie-Hellman
+      key exchange with 1536 bits group size, and the SHA-1/SHA-256 hash functions.
+
+      Features of the OTR protocol:
+
+      1. End-to-end encryption: No one else can read your messages.
+      2. Authentication: The correspondent's identity can be verified.
+      3. Deniability: The messages you send do not have digital signatures that can
+         be checked by a third party. Anyone can forge messages after a conversation
+         to make them look like they came from you, however during the conversation
+         your correspondent is assured that the messages he sees coming from you are
+         authentic and unmodified.
+      4. Perfect forward secrecy: If you lose control of your private keys, you are
+         assured that no previous conversation is compromised.
+
+      This package implements the version 2 and 3 of the OTR protocol.
+      For more details see https://otr.cypherpunks.ca/
+    '';
+  };
+}

--- a/pkgs/development/python-modules/python3-otr/python3-otr-dep-name.patch
+++ b/pkgs/development/python-modules/python3-otr/python3-otr-dep-name.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 040c619..2f2f759 100755
+--- a/setup.py
++++ b/setup.py
+@@ -31,6 +31,6 @@ setup(
+ 
+     packages=['otr'],
+     provides=['otr'],
+-    install_requires=['gmpy2', 'zope.interface', 'application', 'cryptography']
++    install_requires=['gmpy2', 'zope.interface', 'python3-application', 'cryptography']
+ )
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7219,6 +7219,8 @@ in {
 
   python3-openid = callPackage ../development/python-modules/python3-openid { };
 
+  python3-otr = callPackage ../development/python-modules/python3-otr { };
+
   python-awair = callPackage ../development/python-modules/python-awair { };
 
   python3-saml = callPackage ../development/python-modules/python3-saml { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Split from #136924. This adds a dependency of blink-qt and sipclients3, which I intend to add.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
