### PR TITLE
python3Packages.python3-xcaplib: init at 2.0.1

### DIFF
--- a/pkgs/development/python-modules/python3-xcaplib/default.nix
+++ b/pkgs/development/python-modules/python3-xcaplib/default.nix
@@ -1,0 +1,39 @@
+{ lib, fetchFromGitHub, buildPythonPackage, isPy3k, python3-application, lxml
+, gevent, python3-eventlib }:
+
+buildPythonPackage rec {
+  pname = "python3-xcaplib";
+  version = "2.0.1";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "AGProjects";
+    repo = "python3-xcaplib";
+    rev = version;
+    sha256 = "sha256-tIHDkseFkLqrdXFPSemYfOMRRhNcqJxCgMSr2xkI/DA=";
+  };
+
+  propagatedBuildInputs = [ lxml gevent python3-eventlib python3-application ];
+
+  pythonImportsCheck = [ "xcaplib" ];
+
+  meta = with lib; {
+    description = "Python XCAP client library";
+    homepage = "https://github.com/AGProjects/python3-xcaplib";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ chanley ];
+    longDescription = ''
+      XCAP protocol, defined in RFC 4825, allows a client to read, write, and
+      modify application configuration data stored in XML format on a server. XCAP
+      maps XML document sub-trees and element attributes to HTTP URIs, so that
+      these components can be directly accessed by HTTP. An XCAP server used by
+      XCAP clients to store data like presence policy in combination with a SIP
+      Presence server that supports PUBLISH/SUBSCRIBE/NOTIFY SIP methods can
+      provide a complete SIP SIMPLE solution.
+
+      The XCAP client example script provided by this package can be used to
+      manage documents on an XCAP server.
+    '';
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7223,6 +7223,8 @@ in {
 
   python3-saml = callPackage ../development/python-modules/python3-saml { };
 
+  python3-xcaplib = callPackage ../development/python-modules/python3-xcaplib { };
+
   python-axolotl = callPackage ../development/python-modules/python-axolotl { };
 
   python-axolotl-curve25519 = callPackage ../development/python-modules/python-axolotl-curve25519 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Split from #136924. This adds a dependency of blink-qt and sipclients3, which I intend to add.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
