### PR TITLE
calligra: fix fontconfig underlinking

### DIFF
--- a/pkgs/applications/office/calligra/default.nix
+++ b/pkgs/applications/office/calligra/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl, extra-cmake-modules, kdoctools
+{ mkDerivation, lib, fetchpatch, fetchurl, extra-cmake-modules, kdoctools
 , boost, qtwebkit, qtx11extras, shared-mime-info
 , breeze-icons, kactivities, karchive, kcodecs, kcompletion, kconfig, kconfigwidgets
 , kcoreaddons, kdbusaddons, kdiagram, kguiaddons, khtml, ki18n
@@ -20,6 +20,17 @@ mkDerivation rec {
     url = "mirror://kde/stable/${pname}/${version}/${pname}-${version}.tar.xz";
     sha256 = "0iqi6z6gkck2afgy200dacgcspq7i7887alcj0pklm08hbmsdy5i";
   };
+
+  patches = [
+    # Fix fontconfig underlinking: https://github.com/NixOS/nixpkgs/issues/137794
+    # Can be dropped on next release.
+    (fetchpatch {
+      name = "fix-fontconfig-linking.patch";
+      url = "https://github.com/KDE/calligra/commit/62f510702ef9c34ac50f8d8601a4290ab558464c.patch";
+      sha256 = "11dzrp9q05dmvnwp4vk4ihcibqcf4xyr0ijscpi716cyy730flma";
+      excludes = [ "CMakeLists.txt" ];
+    })
+  ];
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
 


### PR DESCRIPTION
Pull part of upstream patch related to fontconfig linking fix.

Closes: https://github.com/NixOS/nixpkgs/issues/137794
