### PR TITLE
eli: add missing tk build input

### DIFF
--- a/pkgs/development/compilers/eli/default.nix
+++ b/pkgs/development/compilers/eli/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ncurses
     fontconfig
+    tk
   ] ++ (with xorg; [
     libX11.dev
     libXt.dev


### PR DESCRIPTION
Before the change eli was failing to link against -ltk8.6:
  https://hydra.nixos.org/build/154304087
