### PR TITLE
python3Packages.flask-appbuilder: 3.3.2 -> 3.3.3

### DIFF
--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -25,12 +25,12 @@
 
 buildPythonPackage rec {
   pname = "flask-appbuilder";
-  version = "3.3.2";
+  version = "3.3.3";
 
   src = fetchPypi {
     pname = "Flask-AppBuilder";
     inherit version;
-    sha256 = "1js1nbal020ilqdrmd471zjab9jj6489fxy4583n55bh5fyiac6i";
+    sha256 = "sha256-yjb4dpcQt2se5GT+wodh4UC9LAF4JmYrdX89VIdkk0U=";
   };
 
   # See here: https://github.com/dpgaspar/Flask-AppBuilder/commit/7097a7b133f27c78d2b54d2a46e4a4c24478a066.patch
@@ -63,8 +63,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "apispec[yaml]>=3.3, <4" "apispec[yaml] >=3.3, <5" \
-      --replace "click>=6.7, <8" "click" \
+      --replace "apispec[yaml]>=3.3, <4" "apispec[yaml] >=3.3" \
       --replace "Flask>=0.12, <2" "Flask" \
       --replace "Flask-Login>=0.3, <0.5" "Flask-Login >=0.3, <0.6" \
       --replace "Flask-Babel>=1, <2" "Flask-Babel >=1, <3" \
@@ -72,6 +71,7 @@ buildPythonPackage rec {
       --replace "marshmallow-sqlalchemy>=0.22.0, <0.24.0" "marshmallow-sqlalchemy" \
       --replace "Flask-JWT-Extended>=3.18, <4" "Flask-JWT-Extended>=4.1.0" \
       --replace "PyJWT>=1.7.1, <2.0.0" "PyJWT>=2.0.1" \
+      --replace "prison>=0.2.1, <1.0.0" "prison" \
       --replace "SQLAlchemy<1.4.0" "SQLAlchemy"
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.3.3

Change log: https://github.com/dpgaspar/Flask-AppBuilder/releases/tag/v3.3.3

Fix build (https://hydra.nixos.org/build/154555775)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
