### PR TITLE
dotnet: cleanup; point dotnet-sdk alias to 5.0; remove unsupported SDKs

### DIFF
--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -28,8 +28,7 @@ mkShell {
   packages = [
     (with dotnetCorePackages; combinePackages [
       sdk_3_1
-      sdk_3_0
-      sdk_2_1
+      sdk_5_0
     ])
   ];
 }
@@ -64,9 +63,9 @@ $ dotnet --info
 
 The `dotnetCorePackages.sdk_X_Y` is preferred over the old dotnet-sdk as both major and minor version are very important for a dotnet environment. If a given minor version isn't present (or was changed), then this will likely break your ability to build a project.
 
-## dotnetCorePackages.sdk vs dotnetCorePackages.net vs dotnetCorePackages.netcore vs dotnetCorePackages.aspnetcore {#dotnetcorepackages.sdk-vs-dotnetcorepackages.net-vs-dotnetcorepackages.netcore-vs-dotnetcorepackages.aspnetcore}
+## dotnetCorePackages.sdk vs dotnetCorePackages.runtime vs dotnetCorePackages.aspnetcore {#dotnetcorepackages.sdk-vs-dotnetcorepackages.runtime-vs-dotnetcorepackages.aspnetcore}
 
-The `dotnetCorePackages.sdk` contains both a runtime and the full sdk of a given version. The `net`, `netcore` and `aspnetcore` packages are meant to serve as minimal runtimes to deploy alongside already built applications. For runtime versions >= .NET 5 `net` is used while `netcore` is used for older .NET Core runtime version.
+The `dotnetCorePackages.sdk` contains both a runtime and the full sdk of a given version. The `runtime` and `aspnetcore` packages are meant to serve as minimal runtimes to deploy alongside already built applications.
 
 ## Packaging a Dotnet Application {#packaging-a-dotnet-application}
 

--- a/pkgs/applications/blockchains/wasabiwallet/default.nix
+++ b/pkgs/applications/blockchains/wasabiwallet/default.nix
@@ -2,7 +2,7 @@
 , fetchurl
 , makeDesktopItem
 , curl
-, dotnet-netcore
+, dotnetCorePackages
 , fontconfig
 , krb5
 , openssl
@@ -11,9 +11,10 @@
 }:
 
 let
+  dotnet-runtime = dotnetCorePackages.runtime_5_0;
   libPath = lib.makeLibraryPath [
     curl
-    dotnet-netcore
+    dotnet-runtime
     fontconfig.lib
     krb5
     openssl

--- a/pkgs/build-support/build-dotnet-module/default.nix
+++ b/pkgs/build-support/build-dotnet-module/default.nix
@@ -32,7 +32,7 @@
 # The dotnet SDK to use.
 , dotnet-sdk ? dotnetCorePackages.sdk_5_0
 # The dotnet runtime to use.
-, dotnet-runtime ? dotnetCorePackages.net_5_0
+, dotnet-runtime ? dotnetCorePackages.runtime_5_0
 , ... } @ args:
 
 assert projectFile == null -> throw "Defining the `projectFile` attribute is required. This is usually an `.csproj`, or `.sln` file.";

--- a/pkgs/development/compilers/dotnet/build-dotnet.nix
+++ b/pkgs/development/compilers/dotnet/build-dotnet.nix
@@ -3,7 +3,7 @@
 , sha512
 }:
 
-assert builtins.elem type [ "aspnetcore" "netcore" "sdk"];
+assert builtins.elem type [ "aspnetcore" "runtime" "sdk"];
 { lib, stdenv
 , fetchurl
 , libunwind
@@ -17,7 +17,7 @@ assert builtins.elem type [ "aspnetcore" "netcore" "sdk"];
 let
   pname = if type == "aspnetcore" then
     "aspnetcore-runtime"
-  else if type == "netcore" then
+  else if type == "runtime" then
     "dotnet-runtime"
   else
     "dotnet-sdk";
@@ -30,12 +30,12 @@ let
     "Unsupported system: ${stdenv.hostPlatform.system}");
   urls = {
     aspnetcore = "https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/${pname}-${version}-${platform}-${suffix}.tar.gz";
-    netcore = "https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/${pname}-${version}-${platform}-${suffix}.tar.gz";
+    runtime = "https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/${pname}-${version}-${platform}-${suffix}.tar.gz";
     sdk = "https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/${pname}-${version}-${platform}-${suffix}.tar.gz";
   };
   descriptions = {
-    aspnetcore = "ASP .NET Core runtime ${version}";
-    netcore = ".NET Core runtime ${version}";
+    aspnetcore = "ASP.NET Core Runtime ${version}";
+    runtime = ".NET Runtime ${version}";
     sdk = ".NET SDK ${version}";
   };
 in stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/dotnet/combine-packages.nix
+++ b/pkgs/development/compilers/dotnet/combine-packages.nix
@@ -5,7 +5,7 @@ in
 assert lib.assertMsg ((builtins.length packages) != 0)
     ''You must include at least one package, e.g
       `with dotnetCorePackages; combinePackages [
-          sdk_3_0 aspnetcore_2_1
+          sdk_3_1 aspnetcore_5_0
        ];`'' ;
   buildEnv {
     name = "dotnet-core-combined";

--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -1,6 +1,6 @@
 /*
 How to combine packages for use in development:
-dotnetCombined = with dotnetCorePackages; combinePackages [ sdk_3_1 sdk_2_2 sdk_3_0 sdk aspnetcore_2_1 ];
+dotnetCombined = with dotnetCorePackages; combinePackages [ sdk_3_1 sdk_5_0 aspnetcore_5_0 ];
 
 Hashes below are retrived from:
 https://dotnet.microsoft.com/download/dotnet
@@ -9,75 +9,19 @@ https://dotnet.microsoft.com/download/dotnet
 let
   buildDotnet = attrs: callPackage (import ./build-dotnet.nix attrs) {};
   buildAspNetCore = attrs: buildDotnet (attrs // { type = "aspnetcore"; });
-  buildNetCore = attrs: buildDotnet (attrs // { type = "netcore"; });
-  buildNetCoreSdk = attrs: buildDotnet (attrs // { type = "sdk"; });
+  buildNetRuntime = attrs: buildDotnet (attrs // { type = "runtime"; });
+  buildNetSdk = attrs: buildDotnet (attrs // { type = "sdk"; });
 in
 rec {
   combinePackages = attrs: callPackage (import ./combine-packages.nix attrs) {};
 
-  # v2.1.22 (LTS)
+  # EOL
 
-  aspnetcore_2_1 = buildAspNetCore {
-    version = "2.1.22";
-    sha512 = {
-      x86_64-linux = "27v3a69dgnnb4lz5p2dn2qwadb8vpnqwdy6mnnqfp1dl4kgg3izvriz2268if272sy6flcz5lckjlmn0i0i1jci5zypc7x9kykj991l";
-      aarch64-linux = null; # no aarch64 version of this package is available
-      x86_64-darwin = "0xh06jmzx2cfq51hv9l4h72hbfyh3r0wlla217821gi0hlw6xcc0gb3b4xmqcs240fllqnwrnrwz0axi3xi21wacgn3xbcmzpbi6jml";
-    };
-  };
+  sdk_2_1 = throw "Dotnet SDK 2.1 is EOL, please use 3.1 (LTS) or 5.0 (Current)";
+  sdk_2_2 = throw "Dotnet SDK 2.2 is EOL, please use 3.1 (LTS) or 5.0 (Current)";
+  sdk_3_0 = throw "Dotnet SDK 3.0 is EOL, please use 3.1 (LTS) or 5.0 (Current)";
 
-  netcore_2_1 = buildNetCore {
-    version = "2.1.22";
-    sha512 = {
-      x86_64-linux = "0c2b31l59izcxbhz5wzjpjkdl550s5p3aid4vyghq468vyf67pm0npjny50c172b63vw0ikfbps2b2hj16hpifp116gj4b5llmqjhyc";
-      aarch64-linux = "3llai3d2xpgbr7a4ndg9wqfpnb5zb8k07dicc57a6cmniiqyqigyxinhpx2k0l45mbnihjsr5k1rih3r6bwlj241v67iwd2i0dpqd8a";
-      x86_64-darwin = "106mx6a4rwcvq41v54c1yx89156s43n889im9g0q2pvm7054q8b6xm6qrnymzmj5i2i6awyk0z02j5pfiyh35sw9afxb3695ymsb3v8";
-    };
-  };
-
-  sdk_2_1 = buildNetCoreSdk {
-    version = "2.1.810";
-    sha512 = {
-      x86_64-linux = "388nrba5f7z9syq23xh3k45rzy3iys58s32ya7a0q9mwdf1y3haw7yvbq79cn08741hhqdi73mip8jf50f4s64mbr62ay1p76zsrkj5";
-      aarch64-linux = "2vs8bhk63cjrqkm5n164ahc6bdz58aq9vmhaiyy27krp7wlkz4gpiva9153h7mywhk709l1qc7cddj99qsh2ygv6axjfigbhgrzslqi";
-      x86_64-darwin = "3qxlgbd0np0w8wmp98mhp4cqgva4zglqf7k9kzqbwxfwr5s795kap7rs5w0cy7h0bsvj0ygx3d5nzyn9hp3fsswx4jl4mkvillnvjzy";
-    };
-  };
-
-  # v2.2
-
-  sdk_2_2 = throw "Dotnet SDK 2.2 is EOL, please use 3.1";
-
-  # v3.0.2 (Maintenance)
-
-  aspnetcore_3_0 = buildAspNetCore {
-    version = "3.0.3";
-    sha512 = {
-      x86_64-linux = "342v6kxxbxky09d1c392vvr9rm30lf75wccka1bk2h4advlcga5nlgv93g7vrq48bsyxfi5gc36r3b0dlwl1g409g5mlk1042n6d0yq";
-      aarch64-linux = "2xkg4q88q5jw6jdz6cxj8vsjr475nd0fcvifkv1shdm2j9dsjy233hwpxbr140m5n5ggyh6z99238z9j4kp2az977y8y8irz8m8ppvf";
-      x86_64-darwin = "2p04j6p4j93pan71ih13hv57zxalcirh0n3vfjq0cfb80pbhf1f5cgxl24pw6kifh6hhh38rj62c4mr69lxzlqc8sfcfaws8dyz2avm";
-    };
-  };
-
-  netcore_3_0 = buildNetCore {
-    version = "3.0.3";
-    sha512 = {
-      x86_64-linux = "32ykpcw2xx708r2lxcwcbxnmy4sk159rlfjfvkw990qh7n79pm3lm2qwa3zhqcslznmpg18kwxz8qb5fgsa0h49g843xx4kyai0n7rx";
-      aarch64-linux = "1lp8din7d5jv5fkyq1a7m01i1xg9jwpiljvam1kcyzsnwzvi0cb4ji336cfx4lqrn95gvc75gkzi6q8b4fz0h21gvk6z6kmlcr63nyg";
-      x86_64-darwin = "0s20k7xawwd09xhy4xdcxp1rw6jd418ibrvhb509dnj480g48xryda2203g4mpswd24v2kx0n9qzxgbrbq9lvasfglkxi84bbqayp83";
-    };
-  };
-
-  sdk_3_0 = buildNetCoreSdk {
-    version = "3.0.103";
-    sha512 = {
-      x86_64-linux = "2diiplgxs92fkb6ym68b02d79z4qn63x5qlky5lvr757c1zkh0vfpk3khawdg94kdn4qkn6dmyqr0msxqgmiqyhp63cadzqq4vx7b12";
-      aarch64-linux = "32843q2lj7dgciq62g9v1q31vwfjyv5vaxrz712d942mcg5lyzjygwri106bv4naq3a22131ldzwnsifbdn2vq1iz60raqdb7ss9vnf";
-      x86_64-darwin = "3apswk2bhalgi0hm7h2j9p152jvp39h4xilxxzix5j1n36b442l1pwk7lj7019lxafjqkz5y850xkfcp14ks5wcvs33xs2c0aqwxvcn";
-    };
-  };
-
-  # v3.1.1 (LTS)
+  # v3.1 (LTS)
 
   aspnetcore_3_1 = buildAspNetCore {
     version = "3.1.19";
@@ -88,7 +32,7 @@ rec {
     };
   };
 
-  netcore_3_1 = buildNetCore {
+  runtime_3_1 = buildNetRuntime {
     version = "3.1.19";
     sha512 = {
       x86_64-linux = "2cf268cc13bb4739203a18a9160aac58f2088e8ec275b1f7ef2fe2b74bc16edfdfbeb886a74fc9421edbf2899fa9e3ee7ea2734a83b1800b4a9848fb7e10bbbe";
@@ -97,7 +41,7 @@ rec {
     };
   };
 
-  sdk_3_1 = buildNetCoreSdk {
+  sdk_3_1 = buildNetSdk {
     version = "3.1.413";
     sha512 = {
       x86_64-linux = "2a0824f11aba0b79d3f9a36af0395649bc9b4137e61b240a48dccb671df0a5b8c2086054f8e495430b7ed6c344bb3f27ac3dfda5967d863718a6dadeca951a83";
@@ -106,7 +50,7 @@ rec {
     };
   };
 
-  # v5.0.0
+  # v5.0 (Current)
 
   aspnetcore_5_0 = buildAspNetCore {
     version = "5.0.10";
@@ -117,7 +61,7 @@ rec {
     };
   };
 
-  net_5_0 = buildNetCore {
+  runtime_5_0 = buildNetRuntime {
     version = "5.0.10";
     sha512 = {
       x86_64-linux = "421b00d5751381e6bf829dcba8fa0d781f0efd065be492739d60a4bef2b7b362dbec77fa3289e2ee45cab40616f95318fc214699ffe2f33aa15e77c2d163841c";
@@ -126,7 +70,7 @@ rec {
     };
   };
 
-  sdk_5_0 = buildNetCoreSdk {
+  sdk_5_0 = buildNetSdk {
     version = "5.0.401";
     sha512 = {
       x86_64-linux = "a444d44007709ceb68d8f72dec0531e17f85f800efc0007ace4fa66ba27f095066930e6c6defcd2f85cdedea2fec25e163f5da461c1c2b8563e5cd7cb47091e0";

--- a/pkgs/development/tools/build-managers/msbuild/default.nix
+++ b/pkgs/development/tools/build-managers/msbuild/default.nix
@@ -1,6 +1,8 @@
-{ lib, stdenv, fetchurl, fetchpatch, makeWrapper, glibcLocales, mono, dotnetPackages, unzip, dotnet-sdk, writeText, roslyn }:
+{ lib, stdenv, fetchurl, fetchpatch, makeWrapper, glibcLocales, mono, dotnetPackages, unzip, dotnetCorePackages, writeText, roslyn }:
 
 let
+
+  dotnet-sdk = dotnetCorePackages.sdk_5_0;
 
   xplat = fetchurl {
     url = "https://github.com/mono/msbuild/releases/download/v16.9.0/mono_msbuild_6.12.0.137.zip";

--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -3,13 +3,15 @@
 , fetchurl
 , mono6
 , msbuild
-, dotnet-sdk
+, dotnetCorePackages
 , makeWrapper
 , unzip
 , writeText
 }:
 
 let
+
+  dotnet-sdk = dotnetCorePackages.sdk_5_0;
 
   deps = map (package: stdenv.mkDerivation (with package; {
     pname = name;

--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -9,7 +9,7 @@ let
   ];
 
   dotnet-sdk = dotnetCorePackages.sdk_5_0;
-  dotnet-net = dotnetCorePackages.net_5_0;
+  dotnet-runtime = dotnetCorePackages.runtime_5_0;
 
   # https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#using-rids
   runtimeId = "linux-x64";
@@ -79,7 +79,7 @@ in stdenv.mkDerivation rec {
       --output $out/lib/osu
 
     makeWrapper $out/lib/osu/osu\! $out/bin/osu\! \
-      --set DOTNET_ROOT "${dotnet-net}" \
+      --set DOTNET_ROOT "${dotnet-runtime}" \
       --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDeps}"
     for i in 16 32 48 64 96 128 256 512 1024; do
       install -D ./assets/lazer.png $out/share/icons/hicolor/''${i}x$i/apps/osu\!.png

--- a/pkgs/servers/jellyfin/default.nix
+++ b/pkgs/servers/jellyfin/default.nix
@@ -15,6 +15,8 @@
 }:
 
 let
+  dotnet-sdk = dotnetCorePackages.sdk_5_0;
+  dotnet-aspnetcore = dotnetCorePackages.aspnetcore_5_0;
   runtimeDeps = [
     ffmpeg
     fontconfig
@@ -34,10 +36,6 @@ let
       "musl-");
   # https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#using-rids
   runtimeId = "${os}-${musl}${arch}";
-
-  dotnet-sdk = dotnetCorePackages.sdk_5_0;
-  dotnet-net = dotnetCorePackages.net_5_0;
-  dotnet-aspnetcore = dotnetCorePackages.aspnetcore_5_0;
 in
 stdenv.mkDerivation rec {
   pname = "jellyfin";

--- a/pkgs/servers/nosql/eventstore/default.nix
+++ b/pkgs/servers/nosql/eventstore/default.nix
@@ -2,12 +2,14 @@
 , fetchFromGitHub
 , fetchurl
 , makeWrapper
-, dotnet-sdk
+, dotnetCorePackages
 , mono
 , Nuget
 }:
 
 let
+
+  dotnet-sdk = dotnetCorePackages.sdk_5_0;
 
   deps = import ./deps.nix { inherit fetchurl; };
 

--- a/pkgs/servers/prowlarr/default.nix
+++ b/pkgs/servers/prowlarr/default.nix
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
 
-    makeWrapper "${dotnetCorePackages.netcore_3_1}/bin/dotnet" $out/bin/Prowlarr \
+    makeWrapper "${dotnetCorePackages.runtime_3_1}/bin/dotnet" $out/bin/Prowlarr \
       --add-flags "$out/share/${pname}-${version}/Prowlarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         curl sqlite libmediainfo mono openssl icu ]}

--- a/pkgs/servers/radarr/default.nix
+++ b/pkgs/servers/radarr/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
 
-    makeWrapper "${dotnetCorePackages.netcore_3_1}/bin/dotnet" $out/bin/Radarr \
+    makeWrapper "${dotnetCorePackages.runtime_3_1}/bin/dotnet" $out/bin/Radarr \
       --add-flags "$out/share/${pname}-${version}/Radarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         curl sqlite libmediainfo mono openssl icu ]}

--- a/pkgs/tools/X11/opentabletdriver/default.nix
+++ b/pkgs/tools/X11/opentabletdriver/default.nix
@@ -3,8 +3,7 @@
 , fetchFromGitHub
 , fetchurl
 , linkFarmFromDrvs
-, dotnet-netcore
-, dotnet-sdk
+, dotnetCorePackages
 , dotnetPackages
 , dpkg
 , gtk3
@@ -21,6 +20,10 @@
 , wrapGAppsHook
 }:
 
+let
+  dotnet-sdk = dotnetCorePackages.sdk_5_0;
+  dotnet-runtime = dotnetCorePackages.runtime_5_0;
+in
 stdenv.mkDerivation rec {
   pname = "OpenTabletDriver";
   version = "0.5.3.3";
@@ -114,19 +117,19 @@ stdenv.mkDerivation rec {
     makeWrapper $out/lib/OpenTabletDriver.Console $out/bin/otd \
         "''${gappsWrapperArgs[@]}" \
         --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-        --set DOTNET_ROOT "${dotnet-netcore}" \
+        --set DOTNET_ROOT "${dotnet-runtime}" \
         --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDeps}"
 
     makeWrapper $out/lib/OpenTabletDriver.Daemon $out/bin/otd-daemon \
         "''${gappsWrapperArgs[@]}" \
         --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-        --set DOTNET_ROOT "${dotnet-netcore}" \
+        --set DOTNET_ROOT "${dotnet-runtime}" \
         --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDeps}"
 
     makeWrapper $out/lib/OpenTabletDriver.UX.Gtk $out/bin/otd-gui \
         "''${gappsWrapperArgs[@]}" \
         --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-        --set DOTNET_ROOT "${dotnet-netcore}" \
+        --set DOTNET_ROOT "${dotnet-runtime}" \
         --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDeps}"
 
     mkdir -p $out/lib/OpenTabletDriver

--- a/pkgs/tools/backup/discordchatexporter-cli/default.nix
+++ b/pkgs/tools/backup/discordchatexporter-cli/default.nix
@@ -18,7 +18,7 @@ buildDotnetModule rec {
   };
 
   projectFile = "DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj";
-  dotnet-runtime = dotnetCorePackages.netcore_3_1;
+  dotnet-runtime = dotnetCorePackages.runtime_3_1;
   nugetDeps = ./deps.nix;
 
   nativeBuildInputs = [ autoPatchelfHook ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -204,6 +204,7 @@ mapAliases ({
   dnnl = oneDNN; # added 2020-04-22
   docbook5_xsl = docbook_xsl_ns; # added 2018-04-25
   docbook_xml_xslt = docbook_xsl; # added 2018-04-25
+  dotnet-netcore = dotnet-runtime; # added 2021-10-07
   double_conversion = double-conversion; # 2017-11-22
   docker_compose = docker-compose; # 2018-11-10
   draftsight = throw "draftsight has been removed, no longer available as freeware"; # added 2020-08-14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -405,17 +405,13 @@ with pkgs;
 
   dotnetCorePackages = recurseIntoAttrs (callPackage ../development/compilers/dotnet {});
 
-  dotnet-sdk = dotnetCorePackages.sdk_2_1;
-
   dotnet-sdk_2 = dotnetCorePackages.sdk_2_1;
-
   dotnet-sdk_3 = dotnetCorePackages.sdk_3_1;
-
   dotnet-sdk_5 = dotnetCorePackages.sdk_5_0;
 
-  dotnet-netcore = dotnetCorePackages.netcore_2_1;
-
-  dotnet-aspnetcore = dotnetCorePackages.aspnetcore_2_1;
+  dotnet-sdk = dotnetCorePackages.sdk_5_0;
+  dotnet-runtime = dotnetCorePackages.runtime_5_0;
+  dotnet-aspnetcore = dotnetCorePackages.aspnetcore_5_0;
 
   dumb-init = callPackage ../applications/virtualization/dumb-init {};
 
@@ -12389,7 +12385,7 @@ with pkgs;
 
   roslyn = callPackage ../development/compilers/roslyn { };
 
-  msbuild = callPackage ../development/tools/build-managers/msbuild { dotnet-sdk = dotnet-sdk_5; };
+  msbuild = callPackage ../development/tools/build-managers/msbuild { };
 
   mosml = callPackage ../development/compilers/mosml { };
 
@@ -26890,10 +26886,7 @@ with pkgs;
     libtiff = callPackage ../applications/graphics/opentoonz/libtiff.nix { };
   })).callPackage ../applications/graphics/opentoonz { };
 
-  opentabletdriver = callPackage ../tools/X11/opentabletdriver {
-    dotnet-sdk = dotnetCorePackages.sdk_5_0;
-    dotnet-netcore = dotnetCorePackages.net_5_0;
-  };
+  opentabletdriver = callPackage ../tools/X11/opentabletdriver { };
 
   opentx = libsForQt5.callPackage ../applications/misc/opentx { };
 
@@ -33161,7 +33154,7 @@ with pkgs;
     stdenv = crossLibcStdenv;
   };
 
-  omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { dotnet-sdk = dotnet-sdk_5; };
+  omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };
 
   wasmtime = callPackage ../development/interpreters/wasmtime {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- point dotnet-sdk alias to 5.0
- cleanup by removing unsupported dotnet SDKs (2.1 and 3.0)
- fixes https://github.com/NixOS/nixpkgs/issues/112428

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
