### PR TITLE
dbqn: init at unstable-2021-09-03

### DIFF
--- a/pkgs/development/interpreters/bqn/dbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/dbqn/default.nix
@@ -1,0 +1,91 @@
+{ stdenvNoCC
+, stdenv
+, lib
+, fetchFromGitHub
+, jre
+, makeWrapper
+# Whether to use GraalVM's native image feature to make a standalone
+# executable called "nbqn". This starts faster, but can't compile BQN to
+# JVM bytecode.
+, useNativeImage ? false
+, graalvm11-ce
+# for passthru.tests
+, dbqn
+}:
+
+let
+  java = if useNativeImage then graalvm11-ce else jre;
+  useStdenv = if useNativeImage then stdenv else stdenvNoCC;
+in
+
+useStdenv.mkDerivation {
+  pname = "dbqn" + lib.optionalString useNativeImage "-native";
+  version = "unstable-2021-09-03";
+
+  src = fetchFromGitHub {
+    owner = "dzaima";
+    repo = "BQN";
+    rev = "41dc26f5e9b1adca618a77e6774953c7288cbce0";
+    sha256 = "14vb0k4vjx2f7vgp9sbvgq76v6ljlw2vihs8sqhjfgad1kw2mrkn";
+  };
+
+  nativeBuildInputs = [
+    java
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    patchShebangs --build build8
+
+    # Need to set locale to stop java complaining about UTF-8 chars
+    # Build 8 is for Java > 8, ironically
+    env LC_ALL=C.UTF-8 ./build8
+
+  '' + lib.optionalString useNativeImage ''
+    native-image --report-unsupported-elements-at-runtime -jar BQN.jar nbqn
+  '' + ''
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+  '' + (if !useNativeImage then ''
+    install -Dm644 BQN.jar -t "$out/share/dbqn"
+
+    # script interpreter
+    makeWrapper "${lib.getBin java}/bin/java" "$out/bin/dbqn" \
+      --add-flags "-jar $out/share/dbqn/BQN.jar -f"
+
+    # repl
+    makeWrapper "${lib.getBin java}/bin/java" "$out/bin/dbqn-repl" \
+      --add-flags "-jar $out/share/dbqn/BQN.jar -r"
+  '' else ''
+    install -Dm755 nbqn -t "$out/bin"
+
+    # wrappers like above
+    makeWrapper "$out/bin/nbqn" "$out/bin/dbqn" --add-flags "-f"
+    makeWrapper "$out/bin/nbqn" "$out/bin/dbqn-repl" --add-flags "-r"
+  '') + ''
+    runHook postInstall
+  '';
+
+  doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Only prints results, so we need to check success
+    "$out/bin/dbqn" ./test/test | tee /dev/stderr | grep -v "Passed all" && exit 1
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "A BQN implementation based on dzaima/APL"
+      + lib.optionalString useNativeImage ", compiled as a GraalVM native image";
+    license = lib.licenses.mit;
+    platforms = java.meta.platforms;
+    maintainers = [ lib.maintainers.sternenseemann ];
+    homepage = "https://github.com/dzaima/BQN";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12864,6 +12864,9 @@ with pkgs;
 
   clooj = callPackage ../development/interpreters/clojure/clooj.nix { };
 
+  dbqn = callPackage ../development/interpreters/bqn/dbqn { };
+  dbqn-native = lowPrio (dbqn.override { useNativeImage = true; });
+
   dhall = haskell.lib.justStaticExecutables haskellPackages.dhall;
 
   dhall-bash = haskell.lib.justStaticExecutables haskellPackages.dhall-bash;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add dzaima/BQN, a BQN implementation. This may especially be interesting as another way to bootstrap CBQN (see PR #135665).

Doesn't include the processing based application at the moment, only the (CLI) language implementation itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
