### PR TITLE
cbqn: init at 0.0.0+unstable=2021-09-26

### DIFF
--- a/pkgs/development/interpreters/bqn/cbqn/001-remove-vendoring.diff
+++ b/pkgs/development/interpreters/bqn/cbqn/001-remove-vendoring.diff
@@ -1,0 +1,15 @@
+diff --git a/makefile b/makefile
+index a5f3d75..f617e25 100644
+--- a/makefile
++++ b/makefile
+@@ -109,9 +109,7 @@ ${bd}/%.o: src/builtins/%.c
+ 
+ 
+ src/gen/customRuntime:
+-	@echo "Copying precompiled bytecode from the bytecode branch"
+-	git checkout remotes/origin/bytecode src/gen/{compiler,formatter,runtime0,runtime1,src}
+-	git reset src/gen/{compiler,formatter,runtime0,runtime1,src}
++	echo "src/gen/ files retrieved externally"
+ ${bd}/load.o: src/gen/customRuntime
+ 
+ -include $(bd)/*.d

--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, bqn-path ? null
+}:
+
+let
+  mlochbaum-bqn = fetchFromGitHub {
+    owner = "mlochbaum";
+    repo = "BQN";
+    rev = "97cbdc67fe6a9652c42daefadd658cc41c1e5ae3";
+    hash = "sha256-F2Bv3n3C7zAhqKCMB6hT2iIWTjEqFdLBMyX6/w7V1SY=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "cbqn";
+  version = "0.0.0+unstable=2021-09-29";
+
+  src = fetchFromGitHub {
+    owner = "dzaima";
+    repo = "CBQN";
+    rev = "1c83483d5395e097f60de299274ebe0df590217e";
+    hash = "sha256-C34DpXab08mBm2oCQuaeq4fJPtQ5rVa/HlpL/nB9XjQ=";
+  };
+
+  cbqn-bytecode = fetchFromGitHub {
+    owner = "dzaima";
+    repo = "CBQN";
+    rev = "fdf0b93409d68d5ffd86c5670db27c240e6039e0";
+    hash = "sha256-A0zvpg+G37WNgyfrJuc5rH6L7Wntdbrz8pYEPreqgKE=";
+  };
+
+  dontConfigure = true;
+
+  patches = [
+    # self-explaining
+    ./001-remove-vendoring.diff
+  ];
+
+  postPatch = ''
+    sed -i '/SHELL =.*/ d' makefile
+  '';
+
+  preBuild =
+    if bqn-path == null
+    then ''
+      cp ${cbqn-bytecode}/src/gen/{compiler,formatter,runtime0,runtime1,src} src/gen/
+    ''
+    else ''
+      ${bqn-path} genRuntime ${mlochbaum-bqn}
+    '';
+
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "single-o3"
+  ];
+
+  installPhase = ''
+     runHook preInstall
+
+     mkdir -p $out/bin/
+     cp BQN -t $out/bin/
+     ln -s $out/bin/BQN $out/bin/bqn
+     ln -s $out/bin/BQN $out/bin/cbqn
+
+     runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/dzaima/CBQN/";
+    description = "BQN implementation in C";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.all;
+  };
+}
+# TODO: factor BQN
+# TODO: test suite (dependent on BQN from mlochbaum)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12789,6 +12789,19 @@ with pkgs;
 
   babashka = callPackage ../development/interpreters/clojure/babashka.nix { };
 
+  # BQN interpreters and compilers
+  cbqn = cbqn-phase2;
+  # And the classic bootstrapping process
+  cbqn-phase0 = callPackage ../development/interpreters/bqn/cbqn {
+    bqn-path = null;
+  };
+  cbqn-phase1 = callPackage ../development/interpreters/bqn/cbqn {
+    bqn-path = "${cbqn-phase0}/bin/bqn";
+  };
+  cbqn-phase2 = callPackage ../development/interpreters/bqn/cbqn {
+    bqn-path = "${cbqn-phase1}/bin/bqn";
+  };
+
   chibi = callPackage ../development/interpreters/chibi { };
 
   ceptre = callPackage ../development/interpreters/ceptre { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
