### PR TITLE
bashdb: 4.4-1.0.0 -> 5.0-1.1.2, fix build with bash 5.1

### DIFF
--- a/pkgs/development/tools/misc/bashdb/default.nix
+++ b/pkgs/development/tools/misc/bashdb/default.nix
@@ -1,13 +1,29 @@
-{ lib, stdenv, fetchurl, makeWrapper, python3Packages }:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, makeWrapper
+, python3Packages
+}:
 
 stdenv.mkDerivation rec {
   pname = "bashdb";
-  version = "4.4-1.0.0";
+  version = "5.0-1.1.2";
 
   src = fetchurl {
     url =  "mirror://sourceforge/bashdb/${pname}-${version}.tar.bz2";
-    sha256 = "0p7i7bpzs6q1i7swnkr89kxqgzr146xw8d2acmqwqbslzm9dqlml";
+    sha256 = "sha256-MBdtKtKMWwCy4tIcXqGu+PuvQKj52fcjxnxgUx87czA=";
   };
+
+  patches = [
+    # Enable building with bash 5.1/5.2
+    # Remove with any upstream 5.1-x.y.z release
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/569fbb806d9ee813afa8b27d2098a44f93433922/devel/bashdb/files/patch-configure";
+      sha256 = "19zfzcnxavndyn6kfxp775kjcd0gigsm4y3bnh6fz5ilhnnbbbgr";
+    })
+  ];
+  patchFlags = "-p0";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION


###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/139552

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
