### PR TITLE
erlang: fix nix-env version confusion

### DIFF
--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -84,9 +84,13 @@ let
 
 in
 stdenv.mkDerivation ({
-  name = "${baseName}-${version}"
-    + optionalString javacSupport "-javac"
-    + optionalString odbcSupport "-odbc";
+  # name is used instead of pname to
+  # - not have to pass pnames as argument
+  # - have a separate pname for erlang (main module)
+  name = "${baseName}"
+    + optionalString javacSupport "_javac"
+    + optionalString odbcSupport "_odbc"
+    + "-${version}";
 
   inherit src version;
 


### PR DESCRIPTION
###### Motivation for this change

closes https://github.com/NixOS/nixpkgs/issues/139473

I originally thought about changing name to pname, but that would change the pname of the main erlang module. To not change it, you have to pass a pname argument.
I thought potentially that erlang could just be an alias. It seemed to me that aliases are mostly used for deprecations.
So I made a very small change so as to not confuse nix-env with the version number.
Also I thought having the `odbc` and `javac` qualifiers separated by a `-` was confusing since this is usually used for the version number.

cc @NixOS/beam might be interested

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
