### PR TITLE
alot: 0.9.1 -> 0.10

### DIFF
--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, python, fetchFromGitHub, isPy3k
+{ lib, buildPythonPackage, python, fetchFromGitHub, isPy3k, pytestCheckHook
 , notmuch2, urwid, urwidtrees, twisted, python_magic, configobj, mock, file, gpgme
 , service-identity, gnupg, sphinx, gawk, procps, future , withManpage ? false
 }:
@@ -35,11 +35,14 @@ buildPythonPackage rec {
     gpgme
   ];
 
-  # some twisted tests need the network (test_env_set... )
-  doCheck = true;
   postBuild = lib.optionalString withManpage "make -C docs man";
 
-  checkInputs =  [ gawk future mock gnupg procps ];
+  checkInputs = [ gawk future mock gnupg procps pytestCheckHook ];
+  # some twisted tests need internet access
+  disabledTests = [
+    "test_env_set"
+    "test_no_spawn_no_stdin_attached"
+  ];
 
   postInstall = let
     completionPython = python.withPackages (ps: [ ps.configobj ]);

--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -1,11 +1,11 @@
 { lib, buildPythonPackage, python, fetchFromGitHub, isPy3k
-, notmuch, urwid, urwidtrees, twisted, python_magic, configobj, mock, file, gpgme
+, notmuch2, urwid, urwidtrees, twisted, python_magic, configobj, mock, file, gpgme
 , service-identity, gnupg, sphinx, gawk, procps, future , withManpage ? false
 }:
 
 buildPythonPackage rec {
   pname = "alot";
-  version = "0.9.1";
+  version = "0.10";
   outputs = [ "out" ] ++ lib.optional withManpage "man";
 
   disabled = !isPy3k;
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     owner = "pazz";
     repo = "alot";
     rev = version;
-    sha256 = "0s94m17yph1gq9f2svipb3bbwbw1s4j3zf2xkg5h91006v8286r6";
+    sha256 = "sha256-1reAq8X9VwaaZDY5UfvcFzHDKd71J88CqJgH3+ANjis=";
   };
 
   postPatch = ''
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   nativeBuildInputs = lib.optional withManpage sphinx;
 
   propagatedBuildInputs = [
-    notmuch
+    notmuch2
     urwid
     urwidtrees
     twisted
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   ];
 
   # some twisted tests need the network (test_env_set... )
-  doCheck = false;
+  doCheck = true;
   postBuild = lib.optionalString withManpage "make -C docs man";
 
   checkInputs =  [ gawk future mock gnupg procps ];
@@ -61,7 +61,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/pazz/alot";
     description = "Terminal MUA using notmuch mail";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ edibopp ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New release of alot: https://github.com/pazz/alot/releases/tag/0.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@edibopp please review.