### PR TITLE
nixos/nextcloud: Add option for using object storage as primary storage

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -368,8 +368,8 @@ in {
             '';
           };
           useSsl = mkOption {
-            type = types.nullOr types.bool;
-            default = null;
+            type = types.bool;
+            default = true;
             description = ''
               Use SSL for objectstore access.
             '';
@@ -573,7 +573,7 @@ in {
               'secret' => nix_read_secret('${s3.secretFile}'),
               ${optionalString (s3.hostname != null) "'hostname' => '${s3.hostname}',"}
               ${optionalString (s3.port != null) "'port' => ${toString s3.port},"}
-              ${optionalString (s3.useSsl != null) "'use_ssl' => ${boolToString s3.useSsl},"}
+              'use_ssl' => ${boolToString s3.useSsl},
               ${optionalString (s3.region != null) "'region' => '${s3.region}',"}
               'use_path_style' => ${boolToString s3.usePathStyle},
             ],

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -585,7 +585,7 @@ in {
               function nix_read_secret($file) {
                 if (!file_exists($file)) {
                   throw new \RuntimeException(sprintf(
-                    "Cannot start Nextcloud, dbpass file %s set by NixOS doesn't seem to "
+                    "Cannot start Nextcloud, secret file %s set by NixOS doesn't seem to "
                     . "exist! Please make sure that the file exists and has appropriate "
                     . "permissions for user & group 'nextcloud'!",
                     $file

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -564,20 +564,22 @@ in {
           c = cfg.config;
           writePhpArrary = a: "[${concatMapStringsSep "," (val: ''"${toString val}"'') a}]";
           requiresReadSecretFunction = c.dbpassFile != null || c.objectstore.s3.enable;
-          objectstoreConfig = let s3 = c.objectstore.s3; in optionalString s3.enable '''objectstore' => [
-            'class' => '\\OC\\Files\\ObjectStore\\S3',
-            'arguments' => [
-              'bucket' => '${s3.bucket}',
-              'autocreate' => ${boolToString s3.autocreate},
-              'key' => '${s3.key}',
-              'secret' => nix_read_secret('${s3.secretFile}'),
-              ${optionalString (s3.hostname != null) "'hostname' => '${s3.hostname}',"}
-              ${optionalString (s3.port != null) "'port' => ${toString s3.port},"}
-              'use_ssl' => ${boolToString s3.useSsl},
-              ${optionalString (s3.region != null) "'region' => '${s3.region}',"}
-              'use_path_style' => ${boolToString s3.usePathStyle},
-            ],
-          ]'';
+          objectstoreConfig = let s3 = c.objectstore.s3; in optionalString s3.enable ''
+            'objectstore' => [
+              'class' => '\\OC\\Files\\ObjectStore\\S3',
+              'arguments' => [
+                'bucket' => '${s3.bucket}',
+                'autocreate' => ${boolToString s3.autocreate},
+                'key' => '${s3.key}',
+                'secret' => nix_read_secret('${s3.secretFile}'),
+                ${optionalString (s3.hostname != null) "'hostname' => '${s3.hostname}',"}
+                ${optionalString (s3.port != null) "'port' => ${toString s3.port},"}
+                'use_ssl' => ${boolToString s3.useSsl},
+                ${optionalString (s3.region != null) "'region' => '${s3.region}',"}
+                'use_path_style' => ${boolToString s3.usePathStyle},
+              ],
+            ]
+          '';
 
           overrideConfig = pkgs.writeText "nextcloud-config.php" ''
             <?php


### PR DESCRIPTION
This allows to declaratively configure an S3 class object storage as the
primary storage for the nextcloud service. Previously, this could only
be achieved by manually editing the `config.php`.

I've started testing this today with my own digitalocean nextcloud
instance, which now points to my digitalocean S3-compatible "Space" and
all appears to be working smoothly.

My motivation for this change is my recent discovery of how much cheaper
some S3-compatible object storage options are compared to digitalocean's
"Volume" options.

Implementation follows the "Simple Storage Service" instructions here:

https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html

I have neglected to implement a submodule for the OpenStack Swift
object storage as I don't personally have a use case for it or a method
to test it, however the new `nextcloud.objectstore.s3` submodule should
act as a useful guide for anyone who does wish to implement it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
