### PR TITLE
httpie: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -1,88 +1,67 @@
-{ lib, fetchFromGitHub, python3Packages, docutils }:
+{ lib
+, fetchFromGitHub
+, installShellFiles
+, python3Packages
+, pandoc
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "httpie";
-  version = "2.4.0";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "httpie";
     repo = "httpie";
     rev = version;
-    sha256 = "00lafjqg9nfnak0nhcr2l2hzzkwn2y6qv0wdkm6r6f69snizy3hf";
+    sha256 = "sha256-GwwZLXf9CH024gKfWsYPnr/oqQcxR/lQIToFRh59B+E=";
   };
 
-  patches = [
-    ./strip-venv.patch
+  nativeBuildInputs = [
+    installShellFiles
+    pandoc
   ];
 
-  outputs = [ "out" "doc" "man" ];
-
-  nativeBuildInputs = [ docutils ];
-
-  propagatedBuildInputs = with python3Packages; [ pygments requests requests-toolbelt setuptools ];
+  propagatedBuildInputs = with python3Packages; [
+    defusedxml
+    pygments
+    requests
+    requests-toolbelt
+    setuptools
+  ];
 
   checkInputs = with python3Packages; [
     mock
     pytest
     pytest-httpbin
     pytestCheckHook
+    responses
   ];
 
   postInstall = ''
     # install completions
-    install -Dm555 \
-      extras/httpie-completion.bash \
-      $out/share/bash-completion/completions/http.bash
-    install -Dm555 \
-      extras/httpie-completion.fish \
-      $out/share/fish/vendor_completions.d/http.fish
+    installShellCompletion --bash \
+      --name http.bash extras/httpie-completion.bash
+    installShellCompletion --fish \
+      --name http.fish extras/httpie-completion.fish
 
-    mkdir -p $man/share/man/man1
-
-    docdir=$doc/share/doc/httpie
-    mkdir -p $docdir/html
-
-    cp AUTHORS.rst CHANGELOG.rst CONTRIBUTING.rst $docdir
-
-    # helpfully, the readme has a `no-web` class to exclude
-    # the parts that are not relevant for offline docs
-
-    # this one build link was not marked however
-    sed -e 's/^|build|//g' -i README.rst
-
-    toHtml() {
-      rst2html5 \
-        --strip-elements-with-class=no-web \
-        --title=http \
-        --no-generator \
-        --no-datestamp \
-        --no-source-link \
-        "$1" \
-        "$2"
-    }
-
-    toHtml README.rst $docdir/html/index.html
-    toHtml CHANGELOG.rst $docdir/html/CHANGELOG.html
-    toHtml CONTRIBUTING.rst $docdir/html/CONTRIBUTING.html
-
-    rst2man \
-      --strip-elements-with-class=no-web \
-      --title=http \
-      --no-generator \
-      --no-datestamp \
-      --no-source-link \
-      README.rst \
-      $man/share/man/man1/http.1
+    # convert the docs/README.md file
+    pandoc --standalone -f markdown -t man docs/README.md -o docs/http.1
+    installManPage docs/http.1
   '';
 
-  # the tests call rst2pseudoxml.py from docutils
-  preCheck = ''
-    export PATH=${docutils}/bin:$PATH
-  '';
+  pytestFlagsArray = [
+    "httpie"
+    "tests"
+  ];
 
-  checkPhase = ''
-    py.test ./httpie ./tests --doctest-modules --verbose ./httpie ./tests -k 'not test_chunked and not test_verbose_chunked and not test_multipart_chunked and not test_request_body_from_file_by_path_chunked'
-  '';
+  disabledTests = [
+    "test_chunked"
+    "test_verbose_chunked"
+    "test_multipart_chunked"
+    "test_request_body_from_file_by_path_chunked"
+  ];
+
+  pythonImportsCheck = [ "httpie" ];
 
   meta = with lib; {
     description = "A command line HTTP client whose goal is to make CLI human-friendly";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.5.0

Change log: https://github.com/httpie/httpie/releases/tag/2.5.0

- Switch from `docutils` to `pandoc` (upstream uses Markdown now for the docs instead of rst)
- Use `installShellFiles` for man page and bash completions
- Use `disabledTests` and `pytestFlagsArray`
- No longer ship `AUTHORS.md`, `CHANGELOG.md` and `CONTRIBUTING.md`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
