### PR TITLE
flex-n{cat,dax}: init

### DIFF
--- a/pkgs/applications/radio/flex-ncat/default.nix
+++ b/pkgs/applications/radio/flex-ncat/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "flex-ncat";
+  version = "0.0-20210420.0";
+
+  src = fetchFromGitHub {
+    owner = "kc2g-flex-tools";
+    repo = "nCAT";
+    rev = "v${version}";
+    sha256 = "0wrdmlp9rrr4n0g9pj0j20ddskllyr59dr3p5fm9z0avkncn3a0m";
+  };
+
+  vendorSha256 = "0npzhvpyaxvfaivycnscvh45lp0ycdg9xrlfm8vhfr835yj2adiv";
+
+  meta = with lib; {
+    homepage = "https://github.com/kc2g-flex-tools/nCAT";
+    description = "FlexRadio remote control (CAT) via hamlib/rigctl protocol";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mvs ];
+  };
+}

--- a/pkgs/applications/radio/flex-ndax/default.nix
+++ b/pkgs/applications/radio/flex-ndax/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub, pulseaudio }:
+
+buildGoModule rec {
+  pname = "flex-ndax";
+  version = "0.1-20210714.0";
+
+  src = fetchFromGitHub {
+    owner = "kc2g-flex-tools";
+    repo = "nDAX";
+    rev = "v${version}";
+    sha256 = "16zx6kbax59rcxyz9dhq7m8yx214knz3xayna1gzb85m6maly8v8";
+  };
+
+  buildInputs = [ pulseaudio ];
+
+  vendorSha256 = "0qn8vg84j9kp0ycn24lkaqjnnk339j3vis4bn48ia3z5vfc22gi5";
+
+  meta = with lib; {
+    homepage = "https://github.com/kc2g-flex-tools/nDAX";
+    description = "FlexRadio digital audio transport (DAX) connector for PulseAudio";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mvs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24545,6 +24545,8 @@ with pkgs;
 
   flex-ncat = callPackage ../applications/radio/flex-ncat { };
 
+  flex-ndax = callPackage ../applications/radio/flex-ndax { };
+
   fluxbox = callPackage ../applications/window-managers/fluxbox { };
 
   fme = callPackage ../applications/misc/fme {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24543,6 +24543,8 @@ with pkgs;
 
   flameshot = libsForQt5.callPackage ../tools/misc/flameshot { };
 
+  flex-ncat = callPackage ../applications/radio/flex-ncat { };
+
   fluxbox = callPackage ../applications/window-managers/fluxbox { };
 
   fme = callPackage ../applications/misc/fme {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Addition of `flex-ncat` and `flex-ndax` derivations for remote control of FlexRadio amateur radio transceivers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
