### PR TITLE
opencv2: don't build unfree libraries by default

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1051,6 +1051,16 @@ Superuser created successfully.
           changelog</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>opencv2</literal> no longer includes the non-free
+          libraries by default, and consequently
+          <literal>pfstools</literal> no longer includes OpenCV support
+          by default. Both packages now support an
+          <literal>enableUnfree</literal> option to re-enable this
+          functionality.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -330,6 +330,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   respectively. As a result `services.datadog-agent` has had breaking changes to the
   configuration file. For details, see the [upstream changelog](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst).
 
+- `opencv2` no longer includes the non-free libraries by default, and consequently `pfstools` no longer includes OpenCV support by default.  Both packages now support an `enableUnfree` option to re-enable this functionality.
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 - The linux kernel package infrastructure was moved out of `all-packages.nix`, and restructured. Linux related functions and attributes now live under the `pkgs.linuxKernel` attribute set.

--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -9,6 +9,7 @@
 , enableFfmpeg ? false, ffmpeg
 , enableGStreamer ? false, gst_all_1
 , enableEigen ? true, eigen
+, enableUnfree ? false
 , Cocoa, QTKit
 }:
 
@@ -67,7 +68,7 @@ stdenv.mkDerivation rec {
     (opencvFlag "PNG" enablePNG)
     (opencvFlag "OPENEXR" enableEXR)
     (opencvFlag "GSTREAMER" enableGStreamer)
-  ];
+  ] ++ lib.optional (!enableUnfree) "-DBUILD_opencv_nonfree=OFF";
 
   hardeningDisable = [ "bindnow" "relro" ];
 
@@ -82,7 +83,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open Computer Vision Library with more than 500 algorithms";
     homepage = "https://opencv.org/";
-    license = licenses.bsd3;
+    license = if enableUnfree then licenses.unfree else licenses.bsd3;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/graphics/pfstools/default.nix
+++ b/pkgs/tools/graphics/pfstools/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, mkDerivation, fetchurl, cmake, pkg-config, darwin
 , openexr, zlib, imagemagick6, libGLU, libGL, freeglut, fftwFloat
-, fftw, gsl, libexif, perl, opencv2, qtbase, netpbm
+, fftw, gsl, libexif, perl, qtbase, netpbm
+, enableUnfree ? false, opencv2
 }:
 
 mkDerivation rec {
@@ -28,12 +29,12 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
     openexr zlib imagemagick6 fftwFloat
-    fftw gsl libexif perl opencv2 qtbase netpbm
+    fftw gsl libexif perl qtbase netpbm
   ] ++ (if stdenv.isDarwin then (with darwin.apple_sdk.frameworks; [
     OpenGL GLUT
   ]) else [
     libGLU libGL freeglut
-  ]);
+  ]) ++ lib.optional enableUnfree (opencv2.override { enableUnfree = true; });
 
   patches = [ ./threads.patch ./pfstools.patch ./pfsalign.patch ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In opencv 2.x, unfree libraries are built by default.  The package should therefore have been marked as unfree, but wasn't.

I've disabled the non-free libraries by default, and added an option to enable them.  There are three programs in Nixpkgs that depend on opencv2: mathematica, pfstools, and p2pvc.  pfstools requires the non-free libraries if it's built with opencv support, so I've disabled opencv by default there and added an option to enable it.  p2pvc links fine, so presumably doesn't need the non-free libraries.  I can't test mathematica, so I'm just going to leave it alone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
