### PR TITLE
yosys: 0.9+4276 -> 0.10

### DIFF
--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -15,32 +15,15 @@
 , zlib
 }:
 
-# NOTE: as of late 2020, yosys has switched to an automation robot that
-# automatically tags their repository Makefile with a new build number every
-# day when changes are committed. please MAKE SURE that the version number in
-# the 'version' field exactly matches the YOSYS_VER field in the Yosys
-# makefile!
-#
-# if a change in yosys isn't yet available under a build number like this (i.e.
-# it was very recently merged, within an hour), wait a few hours for the
-# automation robot to tag the new version, like so:
-#
-#     https://github.com/YosysHQ/yosys/commit/71ca9a825309635511b64b3ec40e5e5e9b6ad49b
-#
-# note that while most nix packages for "unstable versions" use a date-based
-# version scheme, synchronizing the nix package version here with the unstable
-# yosys version number helps users report better bugs upstream, and is
-# ultimately less confusing than using dates.
-
 stdenv.mkDerivation rec {
   pname   = "yosys";
-  version = "0.9+4276";
+  version = "0.10";
 
   src = fetchFromGitHub {
     owner  = "YosysHQ";
     repo   = "yosys";
-    rev    = "75a4cdfc8afc10fed80e43fb1ba31c7edaf6e361";
-    sha256 = "13xb7ny6i0kr6z6xkj9wmmcj551si7w05r3cghq8h8wkikyh6c8p";
+    rev    = "yosys-${version}";
+    sha256 = "1x51avmi516id1hv37my3pvzpcligrp9hjcw2f48fgffag4lqgwb";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- new release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
