### PR TITLE
ocamlPackages.ppx_deriving_yaml: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildDunePackage, fetchurl, ppxlib, alcotest
+, ppx_deriving, yaml
+}:
+
+buildDunePackage rec {
+  pname = "ppx_deriving_yaml";
+  version = "0.1.0";
+
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v${version}/ppx_deriving_yaml-v${version}.tbz";
+    sha256 = "kdonUD4Y8QhVSAFAafIpXBFPkS4pSScYwJbaWMn/6pA=";
+  };
+
+  propagatedBuildInputs = [ ppxlib ppx_deriving yaml ];
+
+  doCheck = true;
+  checkInputs = [ alcotest ];
+
+  meta = {
+    description = "A YAML codec generator for OCaml";
+    inherit (src.meta) homepage;
+    license = lib.licenses.isc;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
@@ -8,7 +8,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v${version}/ppx_deriving_yaml-v${version}.tbz";
@@ -22,7 +22,7 @@ buildDunePackage rec {
 
   meta = {
     description = "A YAML codec generator for OCaml";
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/patricoferris/ppx_deriving_yaml";
     license = lib.licenses.isc;
     maintainers = [ ];
   };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1126,6 +1126,8 @@ let
 
     ppx_deriving_yojson = callPackage ../development/ocaml-modules/ppx_deriving_yojson {};
 
+    ppx_deriving_yaml = callPackage ../development/ocaml-modules/ppx_deriving_yaml {};
+
     ppx_deriving_cmdliner = callPackage ../development/ocaml-modules/ppx_deriving_cmdliner {};
 
     ppx_gen_rec = callPackage ../development/ocaml-modules/ppx_gen_rec {};


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
