### PR TITLE
[21.05 staging] astroid: 2.5.1 -> 2.5.3

### DIFF
--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "astroid";
-  version = "2.5.1";
+  version = "2.5.3";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "cfc35498ee64017be059ceffab0a25bedf7548ab76f2bea691c5565896e7128d";
+    sha256 = "sha256-rWO4VSxwk5VolmgRoIjvC8iA+ZokoAg0q9DjaBtRT5E=";
   };
 
   # From astroid/__pkginfo__.py


### PR DESCRIPTION
###### Motivation for this change

The build for astroid (with python 3.9) was broken.

Was looking at hydra and this seemed like low-hanging fruit. I tried building:

- python37Packages.pylint (+ astroid)
- python38Packages.pylint (+ astroid)
- python39Packages.pylint (+ astroid)
- some random leaf packages that mentioned astroid or pylint from python39Packages.

I didn't see any issues.

Should fix quite some hydra builds for release-21.05.

See commit message for some more info.

I chose to not bump this more than 2 patch revisions to reduce any breakage as much as possible. Someone that's actually using this package could bump it higher if needed.

Changelogs:

- https://github.com/PyCQA/astroid/releases/tag/astroid-2.5.2
- https://github.com/PyCQA/astroid/releases/tag/astroid-2.5.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
