### PR TITLE
ocamlPackages: tls: 0.13.2 -> 0.14.0; x509: 0.14.0 -> 0.15.0; macaddr: 5.1.0 -> 5.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -1,18 +1,20 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchFromGitHub, buildDunePackage
 , ppx_sexp_conv, ounit
 }:
 
 buildDunePackage rec {
   pname = "macaddr";
-  version = "5.1.0";
+  version = "5.2.0";
 
   useDune2 = true;
 
   minimumOCamlVersion = "4.04";
 
-  src = fetchurl {
-    url = "https://github.com/mirage/ocaml-ipaddr/releases/download/v${version}/ipaddr-v${version}.tbz";
-    sha256 = "7e9328222c1a5f39b0751baecd7e27a842bdb0082fd48126eacbbad8816fbf5a";
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-ipaddr";
+    rev = "v${version}";
+    sha256 = "QE2OxeFS7Vo4fmosFjKJG/nqEvVxb80y86c+Dg4Kpa8=";
   };
 
   checkInputs = [ ppx_sexp_conv ounit ];

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -1,15 +1,17 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchFromGitHub, buildDunePackage
 , cstruct, cstruct-sexp, domain-name, fmt, ppx_cstruct, ppx_sexp_conv, logs, hkdf, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk, mirage-crypto-rng, ocaml_lwt, ptime, rresult, sexplib, x509
 , alcotest, cstruct-unix, ounit2, randomconv
 }:
 
 buildDunePackage rec {
   pname = "tls";
-  version = "0.13.2";
+  version = "0.14.1";
 
-  src = fetchurl {
-    url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-v${version}.tbz";
-    sha256 = "sha256-IE6Fuvem8A3lZ/M8GLNYNwCG+v7BbPQ4QdYS+fKT50c=";
+  src = fetchFromGitHub {
+    owner = "mirleft";
+    repo = "ocaml-tls";
+    rev = "v${version}";
+    sha256 = "vzWFGSvymliUwkyeaF3BIIq8VO5MTnKLUzm7mI34c5g=";
   };
 
   minimumOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -1,24 +1,26 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchFromGitHub, buildDunePackage
 , alcotest, cstruct-unix
 , asn1-combinators, domain-name, fmt, gmap, pbkdf, rresult, mirage-crypto, mirage-crypto-ec, mirage-crypto-pk
-, logs, base64
+, logs, base64, ipaddr
 }:
 
 buildDunePackage rec {
   minimumOCamlVersion = "4.07";
 
   pname = "x509";
-  version = "0.14.0";
+  version = "0.15.0";
 
-  src = fetchurl {
-    url = "https://github.com/mirleft/ocaml-x509/releases/download/v${version}/x509-v${version}.tbz";
-    sha256 = "9b42f34171261b2193ee662f096566c48c48e087949c186c288f90c9b3b9f498";
+  src = fetchFromGitHub {
+    owner = "mirleft";
+    repo = "ocaml-x509";
+    rev = "v${version}";
+    sha256 = "7QjcGHbsilvy1Kw62t9TDib+92BULyoBiwBwe91GPeY=";
   };
 
   useDune2 = true;
 
   buildInputs = [ alcotest cstruct-unix ];
-  propagatedBuildInputs = [ asn1-combinators domain-name fmt gmap mirage-crypto mirage-crypto-pk mirage-crypto-ec pbkdf rresult logs base64 ];
+  propagatedBuildInputs = [ asn1-combinators domain-name fmt gmap mirage-crypto mirage-crypto-pk mirage-crypto-ec pbkdf rresult logs base64 ipaddr ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

Update `tls` to 0.14.0 and `x509` to 0.15.0, the latter also requires a newer `ipaddr` module

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
