### PR TITLE
calibre-web: 0.6.12 -> 0.6.13

### DIFF
--- a/nixos/tests/calibre-web.nix
+++ b/nixos/tests/calibre-web.nix
@@ -11,10 +11,6 @@ import ./make-test-python.nix (
         meta.maintainers = with pkgs.lib.maintainers; [ pborzenkov ];
 
         nodes = {
-          default = { ... }: {
-            services.calibre-web.enable = true;
-          };
-
           customized = { pkgs, ... }: {
             services.calibre-web = {
               enable = true;
@@ -32,12 +28,6 @@ import ./make-test-python.nix (
         };
         testScript = ''
           start_all()
-
-          default.wait_for_unit("calibre-web.service")
-          default.wait_for_open_port(${toString defaultPort})
-          default.succeed(
-              "curl --fail 'http://localhost:${toString defaultPort}/basicconfig' | grep 'Basic Configuration'"
-          )
 
           customized.succeed(
               "mkdir /tmp/books && calibredb --library-path /tmp/books add -e --title test-book"

--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -7,13 +7,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "calibre-web";
-  version = "0.6.12";
+  version = "0.6.13";
 
   src = fetchFromGitHub {
     owner = "janeczku";
     repo = "calibre-web";
     rev = version;
-    sha256 = "sha256-IgS281qDxG302UznC63nZH8/ty4fgFtn+lLYdakGA4w=";
+    sha256 = "sha256-zU7ujvFPi4UaaEglIK3YX3TJxBME35NEKKblnJRt0tM=";
   };
 
   prePatch = ''
@@ -52,6 +52,7 @@ python3.pkgs.buildPythonApplication rec {
     flask_login
     flask_principal
     iso-639
+    lxml
     pypdf3
     requests
     sqlalchemy


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The PR updates calibre-web from 0.6.12 to 0.6.13

calibre-web no longer starts without proper calibre DB path configured,
so the default testcase (completely unconfigured) is removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
