### PR TITLE
img: init 0.5.11

### DIFF
--- a/pkgs/development/tools/img/default.nix
+++ b/pkgs/development/tools/img/default.nix
@@ -1,0 +1,52 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, makeWrapper
+, runc
+}:
+
+buildGoModule rec {
+  pname = "img";
+  version = "0.5.11";
+
+  src = fetchFromGitHub {
+    owner = "genuinetools";
+    repo = "img";
+    rev = "v${version}";
+    sha256 = "0r5hihzp2679ki9hr3p0f085rafy2hc8kpkdhnd4m5k4iibqib08";
+  };
+
+  vendorSha256 = null;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  propagatedBuildInputs = [
+    runc
+  ];
+
+  tags = [
+    "seccomp"
+    "noembed" # disables embedded `runc`
+  ];
+
+  ldflags = [
+    "-X github.com/genuinetools/img/version.VERSION=v${version}"
+    "-s -w"
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/img" --prefix PATH : ${lib.makeBinPath [ runc ]}
+  '';
+
+  # Tests fail as: internal/binutils/install.go:57:15: undefined: Asset
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Standalone, daemon-less, unprivileged Dockerfile and OCI compatible container image builder. ";
+    license = licenses.mit;
+    homepage = "https://github.com/genuinetools/img";
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14245,6 +14245,8 @@ with pkgs;
     inherit (llvmPackages_9) stdenv clang llvm;
   };
 
+  img = callPackage ../development/tools/img { };
+
   include-what-you-use = callPackage ../development/tools/analysis/include-what-you-use {
     llvmPackages = llvmPackages_12;
   };


### PR DESCRIPTION
* img: init 0.5.11

Current problems:
* ```
  $ ./result/bin/img du
    WARN[0000] Process sandbox is not available, consider unmasking procfs: mount: /nix/store/yx5zifiwsc7zbd54zs7l8i4a6nrrg6wf-wrapper.c:195: main: Assertion `!(st.st_mode & S_ISUID) || (st.st_uid == geteuid())' failed.
  ```
* Tests are failing.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
