### PR TITLE
python3Packages.karton-classifier: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/karton-classifier/default.nix
+++ b/pkgs/development/python-modules/karton-classifier/default.nix
@@ -3,19 +3,22 @@
 , chardet
 , fetchFromGitHub
 , karton-core
-, python
+, pytestCheckHook
 , python_magic
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "karton-classifier";
-  version = "1.1.0";
+  version = "1.2.0";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0s09mzsw546klnvm59wzj9vdwd2hyzgxvapi20k86q3prs9ncds6";
+    sha256 = "sha256-AG2CtNMgXYfbdlOqB1ZdjMT8H67fsSMXTgiFg6K41IQ=";
   };
 
   propagatedBuildInputs = [
@@ -30,11 +33,9 @@ buildPythonPackage rec {
       --replace "python-magic==0.4.18" "python-magic"
   '';
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m unittest discover
-    runHook postCheck
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "karton.classifier" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.2.0

Change log: https://github.com/CERT-Polska/karton-classifier/releases/tag/v1.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
