### PR TITLE
roon-{bridge,server}: use stable src urls

### DIFF
--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation rec {
     homepage = "https://roonlabs.com";
     license = licenses.unfree;
     maintainers = with maintainers; [ lovesegfault ];
-    platforms = platforms.linux;
+    platforms = [ "aarch64-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -15,20 +15,20 @@ stdenv.mkDerivation rec {
   pname = "roon-bridge";
   version = "1.8-814";
 
-  # N.B. The URL is unstable. I've asked for them to provide a stable URL but
-  # they have ignored me. If this package fails to build for you, you may need
-  # to update the version and sha256.
-  # c.f. https://community.roonlabs.com/t/latest-roon-server-is-not-available-for-download-on-nixos/118129
-  src = {
-    x86_64-linux = fetchurl {
-      url = "https://web.archive.org/web/20210729154257/http://download.roonlabs.com/builds/RoonBridge_linuxx64.tar.bz2";
-      sha256 = "sha256-dersaP/8qkl9k81FrgMieB0P4nKmDwjLW5poqKhEn7A=";
-    };
-    aarch64-linux = fetchurl {
-      url = "https://web.archive.org/web/20210803071334/http://download.roonlabs.com/builds/RoonBridge_linuxarmv8.tar.bz2";
-      sha256 = "sha256-zZj7PkLUYYHo3dngqErv1RqynSXi6/D5VPZWfrppX5U=";
-    };
-  }.${system} or throwSystem;
+  src =
+    let
+      urlVersion = builtins.replaceStrings [ "." "-" ] [ "00" "00" ] version;
+    in
+      {
+        x86_64-linux = fetchurl {
+          url = "http://download.roonlabs.com/builds/RoonBridge_linuxx64_${urlVersion}.tar.bz2";
+          sha256 = "sha256-dersaP/8qkl9k81FrgMieB0P4nKmDwjLW5poqKhEn7A=";
+        };
+        aarch64-linux = fetchurl {
+          url = "http://download.roonlabs.com/builds/RoonBridge_linuxarmv8_${urlVersion}.tar.bz2";
+          sha256 = "sha256-zZj7PkLUYYHo3dngqErv1RqynSXi6/D5VPZWfrppX5U=";
+        };
+      }.${system} or throwSystem;
 
   buildInputs = [
     alsa-lib

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -9,18 +9,19 @@
 , makeWrapper
 , stdenv
 , zlib
-}: stdenv.mkDerivation rec {
+}:
+stdenv.mkDerivation rec {
   pname = "roon-server";
   version = "1.8-831";
 
-  # N.B. The URL is unstable. I've asked for them to provide a stable URL but
-  # they have ignored me. If this package fails to build for you, you may need
-  # to update the version and sha256.
-  # c.f. https://community.roonlabs.com/t/latest-roon-server-is-not-available-for-download-on-nixos/118129
-  src = fetchurl {
-    url = "https://web.archive.org/web/20210921161727/http://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2";
-    sha256 = "sha256-SeMSC7K6DV7rVr1w/SqMnLvipoWbypS/gJnSZmpfXZk=";
-  };
+  src =
+    let
+      urlVersion = builtins.replaceStrings [ "." "-" ] [ "00" "00" ] version;
+    in
+    fetchurl {
+      url = "http://download.roonlabs.com/builds/RoonServer_linuxx64_${urlVersion}.tar.bz2";
+      sha256 = "sha256-SeMSC7K6DV7rVr1w/SqMnLvipoWbypS/gJnSZmpfXZk=";
+    };
 
   buildInputs = [
     alsa-lib

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -69,6 +69,6 @@ stdenv.mkDerivation rec {
     homepage = "https://roonlabs.com";
     license = licenses.unfree;
     maintainers = with maintainers; [ lovesegfault steell ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
- roon-server: use upstream stable URL for src
- roon-bridge: use upstream stable URL for src

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
