### PR TITLE
[21.05] rnix-lsp: 0.1.0 -> 0.2.1

### DIFF
--- a/pkgs/development/tools/rnix-lsp/default.nix
+++ b/pkgs/development/tools/rnix-lsp/default.nix
@@ -1,22 +1,23 @@
-{ callPackage, lib, fetchFromGitHub, rustPlatform }:
+{ lib, fetchFromGitHub, rustPlatform, nixUnstable }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rnix-lsp";
-  version = "0.1.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "rnix-lsp";
     rev = "v${version}";
-
-    sha256 = "0fy620c34kxl27sd62x9mj0555bcdmnmbsxavmyiwb497z1m9wnn";
+    sha256 = "sha256-54dtLkGAbQ4Sln/bs/sI0GaCbXyK8+vDD8QBgxaiCXg=";
   };
 
-  cargoSha256 = "1akapxrh38g44531r25dgik8y5qyy9y6zb031hg8v61px2ajs39s";
+  cargoSha256 = "sha256-Tw05eOIMJj+zX0fqtn6wJwolKNkYqfVuo/WO/WvYu2k=";
+
+  checkInputs = [ nixUnstable ];
 
   meta = with lib; {
     description = "A work-in-progress language server for Nix, with syntax checking and basic completion";
     license = licenses.mit;
-    maintainers = with maintainers; [ jD91mZM2 ];
+    maintainers = with maintainers; [ ma27 ];
   };
 }


### PR DESCRIPTION
ChangeLog: https://github.com/nix-community/rnix-lsp/blob/v0.2.1/CHANGELOG.md#v021---2021-09-23
(cherry picked from commit 3bcfecc268071364a6a781ef1b2ad6a6655c7d57)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Manual backport of #139154.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
