### PR TITLE
curl: add patch for CVE-2021-22945

### DIFF
--- a/pkgs/tools/networking/curl/CVE-2021-22945.patch
+++ b/pkgs/tools/networking/curl/CVE-2021-22945.patch
@@ -1,0 +1,27 @@
+From 43157490a5054bd24256fe12876931e8abc9df49 Mon Sep 17 00:00:00 2001
+From: z2_ on hackerone <>
+Date: Tue, 24 Aug 2021 09:50:33 +0200
+Subject: [PATCH] mqtt: clear the leftovers pointer when sending succeeds
+
+CVE-2021-22945
+
+Bug: https://curl.se/docs/CVE-2021-22945.html
+---
+ lib/mqtt.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/mqtt.c b/lib/mqtt.c
+index f077e6c3dc44..fcd40b41e600 100644
+--- a/lib/mqtt.c
++++ b/lib/mqtt.c
+@@ -128,6 +128,10 @@ static CURLcode mqtt_send(struct Curl_easy *data,
+     mq->sendleftovers = sendleftovers;
+     mq->nsend = nsend;
+   }
++  else {
++    mq->sendleftovers = NULL;
++    mq->nsend = 0;
++  }
+   return result;
+ }
+ 

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -57,6 +57,7 @@ stdenv.mkDerivation rec {
     ./CVE-2021-22897.patch
     ./CVE-2021-22898.patch
     ./CVE-2021-22901.patch
+    ./CVE-2021-22945.patch
   ];
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
###### Motivation for this change
https://curl.se/docs/CVE-2021-22945.html

Included patch as all curl patches need to be in-repo due to bootstrapping issues.

Patching instead of bumping because we're still stuck in a log jam over curl (#124502).

(Only built the anonymous early-stage curl on darwin as the bootstrap loop is so big)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
