### PR TITLE
linux-manual: init at 5.14.14

### DIFF
--- a/pkgs/data/documentation/linux-manual/default.nix
+++ b/pkgs/data/documentation/linux-manual/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchurl, perl, linuxPackages_latest }:
+
+stdenv.mkDerivation rec {
+  pname = "linux-manual";
+  inherit (linuxPackages_latest.kernel) version src;
+
+  nativeBuildInputs = [ perl ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  postPatch = ''
+    patchShebangs --build \
+      scripts/kernel-doc \
+      scripts/split-man.pl
+  '';
+
+  installPhase = ''
+    mandir=$out/share/man/man9
+    mkdir -p $mandir
+
+    KBUILD_BUILD_TIMESTAMP=$(stat -c %Y Makefile) \
+    grep -F -l -Z \
+      --exclude-dir Documentation \
+      --exclude-dir tools \
+      -R '/**' \
+      | xargs -0 -n 256 -P $NIX_BUILD_CORES \
+        $SHELL -c '{ scripts/kernel-doc -man "$@" || :; } \
+          | scripts/split-man.pl '$mandir kernel-doc
+
+    test -f $mandir/kmalloc.9
+  '';
+
+  meta = with lib; {
+    homepage = "https://kernel.org/";
+    description = "Linux kernel API manual pages";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ mvs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23081,6 +23081,8 @@ with pkgs;
 
   line-awesome = callPackage ../data/fonts/line-awesome { };
 
+  linux-manual = callPackage ../data/documentation/linux-manual { };
+
   lmmath = callPackage ../data/fonts/lmmath {};
 
   lmodern = callPackage ../data/fonts/lmodern { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Resolves #127424.

Package name chosen to match other Linux distributions (e.g. <https://packages.debian.org/stretch/linux-manual-4.9>).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
