### PR TITLE
[staging-next] pythonPackages.sh: disable flaky fd_leak test

### DIFF
--- a/pkgs/development/python-modules/sh/disable-broken-tests-darwin.patch
+++ b/pkgs/development/python-modules/sh/disable-broken-tests-darwin.patch
@@ -4,15 +4,9 @@ Date: Mon, 20 Jul 2020 19:51:20 +0200
 Subject: [PATCH] Disable tests that fail on Darwin (macOS) or with sandboxing
 
 Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>
----
- test.py | 4 ++++
- 1 file changed, 4 insertions(+)
-
-diff --git a/test.py b/test.py
-index f8029c0..ba1d141 100644
 --- a/test.py
 +++ b/test.py
-@@ -404,6 +404,7 @@ exit(3)
+@@ -377,6 +377,7 @@ exit(3)
          self.assertEqual(sed(_in="one test three", e="s/test/two/").strip(),
                           "one two three")
  
@@ -20,7 +14,7 @@ index f8029c0..ba1d141 100644
      def test_ok_code(self):
          from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
  
-@@ -1004,6 +1005,7 @@ print(sys.argv[1])
+@@ -982,6 +983,7 @@ print(sys.argv[1])
          now = time.time()
          self.assertGreater(now - start, sleep_time)
  
@@ -28,7 +22,7 @@ index f8029c0..ba1d141 100644
      def test_background_exception(self):
          from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
          p = ls("/ofawjeofj", _bg=True, _bg_exc=False)  # should not raise
-@@ -1801,6 +1803,7 @@ exit(49)
+@@ -1779,6 +1781,7 @@ exit(49)
          p = python(py.name, _ok_code=49, _bg=True)
          self.assertEqual(49, p.exit_code)
  
@@ -36,7 +30,15 @@ index f8029c0..ba1d141 100644
      def test_cwd(self):
          from sh import pwd
          from os.path import realpath
-@@ -2899,6 +2902,7 @@ print("hi")
+@@ -2777,6 +2780,7 @@ print("cool")
+     # on osx.  so skip it for now if osx
+     @not_macos
+     @requires_progs("lsof")
++    @skipUnless(False, "Flaky on Hydra")
+     def test_no_fd_leak(self):
+         import sh
+         import os
+@@ -2879,6 +2883,7 @@ print("hi")
          python(py.name, _in=stdin)
  
      @requires_utf8
@@ -44,6 +46,3 @@ index f8029c0..ba1d141 100644
      def test_unicode_path(self):
          from sh import Command
  
--- 
-2.27.0
-


### PR DESCRIPTION
https://hydra.nixos.org/build/154671181/nixlog/1

* This was not actually an fd leak, but a failure
  to determine a stable baseline number of open fds.
* An fd leak in this package should not prevent us
  from building its many dependers.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

For https://github.com/NixOS/nixpkgs/pull/139554

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
