### PR TITLE
pict-rs: init at 0.3.0-alpha.37

### DIFF
--- a/pkgs/servers/web-apps/pict-rs/default.nix
+++ b/pkgs/servers/web-apps/pict-rs/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitea
+, rustPlatform
+, makeWrapper
+, protobuf
+, Security
+, imagemagick
+, ffmpeg
+, exiftool
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pict-rs";
+  version = "0.3.0-alpha.37";
+
+  src = fetchFromGitea {
+    domain = "git.asonix.dog";
+    owner = "asonix";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-21yfsCicn2bjSNEMMWDG8wvnw10uT3M1L3cXCUhc24c=";
+  };
+
+  cargoSha256 = "sha256-F/mqdIjF5QOq5Plnq0DyeFP1+b7dCBcoU9iFxzcaZws=";
+
+  # needed for internal protobuf c wrapper library
+  PROTOC = "${protobuf}/bin/protoc";
+  PROTOC_INCLUDE = "${protobuf}/include";
+
+  buildInputs = [ makeWrapper ] ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/pict-rs" \
+        --prefix PATH : "${lib.makeBinPath [ imagemagick ffmpeg exiftool ]}"
+  '';
+
+  meta = with lib; {
+    description = "a simple image hosting service";
+    homepage = "https://git.asonix.dog/asonix/pict-rs";
+    license = with licenses; [ agpl3Plus ];
+    maintainers = with maintainers; [ happysalada ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20447,6 +20447,11 @@ with pkgs;
 
   petidomo = callPackage ../servers/mail/petidomo { };
 
+  pict-rs = callPackage ../servers/web-apps/pict-rs {
+    inherit (darwin.apple_sdk.frameworks) Security;
+    ffmpeg = ffmpeg_4;
+  };
+
   popa3d = callPackage ../servers/mail/popa3d { };
 
   postfix = callPackage ../servers/mail/postfix { };


### PR DESCRIPTION
###### Motivation for this change

This is package is needed for the lemmy service

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
