### PR TITLE
python3Packages.awslambdaric: fix build following simplejson upgrade

### DIFF
--- a/pkgs/development/python-modules/awslambdaric/default.nix
+++ b/pkgs/development/python-modules/awslambdaric/default.nix
@@ -1,5 +1,17 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy27, pytestCheckHook, autoconf
-, automake, cmake, gcc, libtool, perl, simplejson }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, isPy27
+, pytestCheckHook
+, autoconf
+, automake
+, cmake
+, gcc
+, libtool
+, perl
+, simplejson
+}:
 
 buildPythonPackage rec {
   pname = "awslambdaric";
@@ -12,6 +24,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "1r4b4w5xhf6p4vs7yx89kighlqim9f96v2ryknmrnmblgr4kg0h1";
   };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/aws/aws-lambda-python-runtime-interface-client/pull/58
+      url = "https://github.com/aws/aws-lambda-python-runtime-interface-client/commit/162c3c0051bb9daa92e4a2a4af7e90aea60ee405.patch";
+      sha256 = "09qqq5x6npc9jw2qbhzifqn5sqiby4smiin1aw30psmlp21fv7j8";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace requirements/base.txt \


### PR DESCRIPTION
###### Motivation for this change

`awslambdaric` fails to build following the upgrade to `simplejson` 3.17.5 in nixpkgs. See https://github.com/aws/aws-lambda-python-runtime-interface-client/pull/58.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).