### PR TITLE
linuxPackages.system76*: updates

### DIFF
--- a/pkgs/os-specific/linux/system76-power/default.nix
+++ b/pkgs/os-specific/linux/system76-power/default.nix
@@ -2,19 +2,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "system76-power";
-  version = "1.1.17";
+  version = "1.1.18";
 
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "system76-power";
     rev = version;
-    sha256 = "sha256-9ndukZPNB0qtU0hA9eUYpiAC8Tw1eF16W+sVU7XKvsg=";
+    sha256 = "1zm06ywc3siwh2fpb8p7lp3xqjy4c08j8c8lipd6dyy3bakjh4r1";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dbus libusb1 ];
 
-  cargoSha256 = "sha256-6mtBY77d2WAwTpj+g0KVpW/n39uanAL2GNHWC8Qbtqk=";
+  cargoSha256 = "0hda8cxa1pjz90bg215qmx5x2scz9mawq7irxbsw6zmcm7wahlii";
 
   postInstall = ''
     install -D -m 0644 data/system76-power.conf $out/etc/dbus-1/system.d/system76-power.conf

--- a/pkgs/os-specific/linux/system76/default.nix
+++ b/pkgs/os-specific/linux/system76/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, kernel }:
 let
-  version = "1.0.12";
-  sha256 = "0k098zkxa8spj5rbmzpndxs0cf5i2n22g3ym6kq4j43kvs18x6c7";
+  version = "1.0.13";
+  sha256 = "162hhmnww8z9k0795ffs8v3f61hlfm375law156sk5l08if19a4r";
 in
 stdenv.mkDerivation {
   name = "system76-module-${version}-${kernel.version}";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Noticed these were out of date again already when I merged the last PR for them.

As a reminder, I don't have system76 hardware, so need somebody else to test this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
