### PR TITLE
coqPackages.StructTact: 20181102 → 20210328; coqPackages.Verdi: 20200131 → 20210524

### DIFF
--- a/pkgs/development/coq-modules/StructTact/default.nix
+++ b/pkgs/development/coq-modules/StructTact/default.nix
@@ -4,7 +4,12 @@ with lib; mkCoqDerivation {
   pname = "StructTact";
   owner = "uwplse";
   inherit version;
-  defaultVersion = if versions.isGe "8.5" coq.coq-version then "20181102" else null;
+  defaultVersion = with versions; switch coq.coq-version [
+    { case = range "8.6" "8.14"; out = "20210328"; }
+    { case = range "8.5" "8.13"; out = "20181102"; }
+  ] null;
+  release."20210328".rev =    "179bd5312e9d8b63fc3f4071c628cddfc496d741";
+  release."20210328".sha256 = "sha256:1y5r1zm3hli10ah6lnj7n8hxad6rb6rgldd0g7m2fjibzvwqzhdg";
   release."20181102".rev =    "82a85b7ec07e71fa6b30cfc05f6a7bfb09ef2510";
   release."20181102".sha256 = "08zry20flgj7qq37xk32kzmg4fg6d4wi9m7pf9aph8fd3j2a0b5v";
   preConfigure = "patchShebangs ./configure";

--- a/pkgs/development/coq-modules/Verdi/default.nix
+++ b/pkgs/development/coq-modules/Verdi/default.nix
@@ -6,9 +6,12 @@ with lib; mkCoqDerivation {
   owner = "uwplse";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = isGe "8.7"; out = "20200131"; }
-    { case = isEq "8.6"; out = "20181102"; }
+    { case = range "8.7" "8.14"; out = "20210524"; }
+    { case = range "8.7" "8.13"; out = "20200131"; }
+    { case = "8.6"; out = "20181102"; }
   ] null;
+  release."20210524".rev    = "54597d8ac7ab7dd4dae683f651237644bf77701e";
+  release."20210524".sha256 = "sha256:05wb0km2jkhvi8807glxk9fi1kll4lwisiyzkxhqvymz4x6v8xqv";
   release."20200131".rev    = "fdb4ede19d2150c254f0ebcfbed4fb9547a734b0";
   release."20200131".sha256 = "1a2k19f9q5k5djbxplqmmpwck49kw3lrm3aax920h4yb40czkd8m";
   release."20181102".rev    = "25b79cf1be5527ab8dc1b8314fcee93e76a2e564";


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.14

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
