### PR TITLE
python3Packages.pytransportnsw: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/gtfs-realtime-bindings/default.nix
+++ b/pkgs/development/python-modules/gtfs-realtime-bindings/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, protobuf
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "gtfs-realtime-bindings";
+  version = "0.0.7";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vav7ah6gpkpi44rk202bwpl345rydg6n9zibzx5p7gcsblcwd45";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [
+    protobuf
+  ];
+
+  # Tests are not shipped, only a tarball for Java is present
+  doCheck = false;
+
+  pythonImportsCheck = [ "google.transit" ];
+
+  meta = with lib; {
+    description = "Python bindings generated from the GTFS Realtime protocol buffer spec";
+    homepage = "https://github.com/andystewart999/TransportNSW";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pytransportnsw/default.nix
+++ b/pkgs/development/python-modules/pytransportnsw/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pytransportnsw";
+  version = "0.1.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    pname = "PyTransportNSW";
+    inherit version;
+    sha256 = "00jklgjirmc58hiaqqc2n2rgixvx91bgrd6lv6hv28k51kid10f3";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "TransportNSW" ];
+
+  meta = with lib; {
+    description = "Python module to access Transport NSW information";
+    homepage = "https://github.com/Dav0815/TransportNSW";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pytransportnswv2/default.nix
+++ b/pkgs/development/python-modules/pytransportnswv2/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, gtfs-realtime-bindings
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pytransportnswv2";
+  version = "0.2.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    pname = "PyTransportNSWv2";
+    inherit version;
+    sha256 = "129rrqckqgfrwdx0b83dqphcv55cxs5i8jl1ascia7rpzjn109ah";
+  };
+
+  propagatedBuildInputs = [
+    gtfs-realtime-bindings
+    requests
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "TransportNSW" ];
+
+  meta = with lib; {
+    description = "Python module to access Transport NSW information";
+    homepage = "https://github.com/andystewart999/TransportNSW";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -899,7 +899,7 @@
     "trafikverket_train" = ps: with ps; [ pytrafikverket ];
     "trafikverket_weatherstation" = ps: with ps; [ pytrafikverket ];
     "transmission" = ps: with ps; [ transmissionrpc ];
-    "transport_nsw" = ps: with ps; [ ]; # missing inputs: PyTransportNSW
+    "transport_nsw" = ps: with ps; [ pytransportnsw ];
     "travisci" = ps: with ps; [ ]; # missing inputs: TravisPy
     "trend" = ps: with ps; [ numpy ];
     "tts" = ps: with ps; [ aiohttp-cors mutagen ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -677,6 +677,7 @@ in with py.pkgs; buildPythonApplication rec {
     "trace"
     "tradfri"
     "transmission"
+    "transport_nsw"
     "trend"
     "tts"
     "tuya"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7527,6 +7527,8 @@ in {
 
   pytrafikverket = callPackage ../development/python-modules/pytrafikverket { };
 
+  pytransportnsw = callPackage ../development/python-modules/pytransportnsw { };
+
   pytrends = callPackage ../development/python-modules/pytrends { };
 
   pytricia = callPackage ../development/python-modules/pytricia { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7531,6 +7531,8 @@ in {
 
   pytransportnsw = callPackage ../development/python-modules/pytransportnsw { };
 
+  pytransportnswv2 = callPackage ../development/python-modules/pytransportnswv2 { };
+
   pytrends = callPackage ../development/python-modules/pytrends { };
 
   pytricia = callPackage ../development/python-modules/pytricia { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3259,6 +3259,8 @@ in {
     gst-plugins-base = pkgs.gst_all_1.gst-plugins-base;
   };
 
+  gtfs-realtime-bindings = callPackage ../development/python-modules/gtfs-realtime-bindings { };
+
   gtimelog = callPackage ../development/python-modules/gtimelog { };
 
   gtts = callPackage ../development/python-modules/gtts { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to access Transport NSW information

https://github.com/Dav0815/TransportNSW

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
