### PR TITLE
{s6,s6-networking,execline}-man-pages: Fall Update 2021

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-man-pages.nix
+++ b/pkgs/build-support/skaware/build-skaware-man-pages.nix
@@ -7,8 +7,6 @@
 , version
   # : string
 , sha256
-  # : list (int | string)
-, sections
   # : string
 , description
   # : list Maintainer
@@ -38,10 +36,6 @@ stdenv.mkDerivation {
   ];
 
   dontBuild = true;
-
-  preInstall = lib.concatMapStringsSep "\n"
-    (section: "mkdir -p \"${manDir}/man${builtins.toString section}\"")
-    sections;
 
   meta = with lib; {
     inherit description license maintainers;

--- a/pkgs/data/documentation/execline-man-pages/default.nix
+++ b/pkgs/data/documentation/execline-man-pages/default.nix
@@ -5,6 +5,5 @@ buildManPages {
   version = "2.8.1.0.1";
   sha256 = "0d3lzxy7wv91q3nr6bw1wfmrfj285i15wmj4c8v9k9pxjg42iwwx";
   description = "Port of the documentation for the execline suite to mdoc";
-  sections = [ 1 7 ];
   maintainers = [ lib.maintainers.sternenseemann ];
 }

--- a/pkgs/data/documentation/execline-man-pages/default.nix
+++ b/pkgs/data/documentation/execline-man-pages/default.nix
@@ -2,8 +2,8 @@
 
 buildManPages {
   pname = "execline-man-pages";
-  version = "2.8.0.1.1";
-  sha256 = "0xv9v39na1qnd8cm4v7xb8wa4ap3djq20iws0lrqz7vn1w40i8b4";
+  version = "2.8.1.0.1";
+  sha256 = "0d3lzxy7wv91q3nr6bw1wfmrfj285i15wmj4c8v9k9pxjg42iwwx";
   description = "Port of the documentation for the execline suite to mdoc";
   sections = [ 1 7 ];
   maintainers = [ lib.maintainers.sternenseemann ];

--- a/pkgs/data/documentation/s6-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-man-pages/default.nix
@@ -2,8 +2,8 @@
 
 buildManPages {
   pname = "s6-man-pages";
-  version = "2.10.0.3.1";
-  sha256 = "0q9b6v7kbyjsh390s4bw80kjdp92kih609vlmnpl1qzyrr6kivsg";
+  version = "2.11.0.0.1";
+  sha256 = "00nxlpdf0kkdadyv84vj5w66y926pccqls8prkbip3zmcmnqgghs";
   description = "Port of the documentation for the s6 supervision suite to mdoc";
   sections = [ 1 7 ];
   maintainers = [ lib.maintainers.sternenseemann ];

--- a/pkgs/data/documentation/s6-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-man-pages/default.nix
@@ -5,6 +5,5 @@ buildManPages {
   version = "2.11.0.0.1";
   sha256 = "00nxlpdf0kkdadyv84vj5w66y926pccqls8prkbip3zmcmnqgghs";
   description = "Port of the documentation for the s6 supervision suite to mdoc";
-  sections = [ 1 7 ];
   maintainers = [ lib.maintainers.sternenseemann ];
 }

--- a/pkgs/data/documentation/s6-networking-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-networking-man-pages/default.nix
@@ -5,6 +5,5 @@ buildManPages {
   version = "2.5.0.0.1";
   sha256 = "02xvyby23b2x30jxd4nw9c5629j4hdaxq9sph3qhajlhl53yiyf2";
   description = "Port of the documentation for the s6-networking suite to mdoc";
-  sections = [ 1 7 ];
   maintainers = [ lib.maintainers.sternenseemann ];
 }

--- a/pkgs/data/documentation/s6-networking-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-networking-man-pages/default.nix
@@ -2,8 +2,8 @@
 
 buildManPages {
   pname = "s6-networking-man-pages";
-  version = "2.4.1.1.1";
-  sha256 = "1qrqzm2r4rxf8hglz8k4laknjqcx1y0z1kjf636z91w1077qg0pn";
+  version = "2.5.0.0.1";
+  sha256 = "02xvyby23b2x30jxd4nw9c5629j4hdaxq9sph3qhajlhl53yiyf2";
   description = "Port of the documentation for the s6-networking suite to mdoc";
   sections = [ 1 7 ];
   maintainers = [ lib.maintainers.sternenseemann ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

After #139544, the man pages have also updated to reflect the upstream changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
