### PR TITLE
timeshift: init at 21.09.1

### DIFF
--- a/pkgs/tools/backup/timeshift/default.nix
+++ b/pkgs/tools/backup/timeshift/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, util-linux, libgee, libsoup, json-glib, desktop-file-utils, vte, rsync, vala, dpkg, diffutils, coreutils, which, pkg-config, psmisc}:
+
+stdenv.mkDerivation rec {
+  pname = "timeshift";
+  version = "21.09.1";
+
+  src = fetchFromGitHub {
+    owner = "teejee2008";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1z55dw3sd2cil9akms3m7wd70pijys5cgj39hsrkcrzz1ql9pcn7";
+  };
+
+  postPatch = ''
+    substituteInPlace src/makefile --replace "prefix=/usr" "prefix=$out"
+    substituteInPlace src/makefile --replace "sysconfdir=/etc" "sysconfdir=$out/etc"
+    substituteInPlace src/Core/Main.vala --replace "/sbin/blkid" "${util-linux}/bin/blkid"
+    substituteInPlace src/Core/Main.vala --replace "fuser" "${psmisc}/bin/fuser"
+  '';
+
+  buildInputs = [ libgee libsoup json-glib desktop-file-utils vte rsync ];
+  nativeBuildInputs = [ vala dpkg diffutils coreutils which pkg-config ];
+  propagatedBuildInputs = [ psmisc rsync which ];
+
+  meta = with lib; {
+    description = "System snapshot tool for Linux.";
+    homepage    = "https://github.com/teejee2008/timeshift";
+    license     = with licenses; [ lgpl3Only ];
+    maintainers = with maintainers; [  ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27748,6 +27748,8 @@ with pkgs;
     fftw = fftwSinglePrec;
   };
 
+  timeshift  = callPackage ../tools/backup/timeshift { };
+
   timewarrior = callPackage ../applications/misc/timewarrior { };
 
   timew-sync-server = callPackage ../applications/misc/timew-sync-server { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/139659

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 139738"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
