### PR TITLE
py3c: unconditionally drop -Werror (fix gcc-11 build)

### DIFF
--- a/pkgs/development/libraries/py3c/default.nix
+++ b/pkgs/development/libraries/py3c/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "04i2z7hrig78clc59q3i1z2hh24g7z1bfvxznlzxv00d4s57nhpi";
   };
 
-  postPatch = lib.optionalString stdenv.cc.isClang ''
+  postPatch = ''
+    # clang and gcc-11 complain about 'register' keywords used by
+    # python-2.7. Let's avoid blanket -Werror.
     substituteInPlace test/setup.py \
       --replace "'-Werror', " ""
   '';


### PR DESCRIPTION
On gcc-11 build fails as:

    $ nix-build -E 'with import ./. {}; py3c.override { stdenv = gcc11Stdenv; }'

    gcc -fno-strict-aliasing ... -Werror -Wall
    cc1plus: warning:
      command-line option '-Wstrict-prototypes' is valid for C/ObjC but not for C++
    In file included from /nix/store/...-python-2.7.18/include/python2.7/Python.h:88,
                     from test_py3c.cpp:4:
    /nix/store/...-python-2.7.18/include/python2.7/unicodeobject.h:534:24:
      error: ISO C++17 does not allow 'register' storage class specifier [-Werror=register]
      534 |     register PyObject *obj,     /* Object */
          |                        ^~~

The fix was already present o clang toolchain. Let's extendt it to all toolchains.