### PR TITLE
openocd: enable libgpiod bit-banging driver

### DIFF
--- a/pkgs/development/embedded/openocd/default.nix
+++ b/pkgs/development/embedded/openocd/default.nix
@@ -5,6 +5,7 @@
 , hidapi
 , libftdi1
 , libusb1
+, libgpiod
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ hidapi libftdi1 libusb1 ];
+  buildInputs = [ hidapi libftdi1 libusb1 libgpiod ];
 
   configureFlags = [
     "--enable-jtag_vpi"
@@ -29,6 +30,7 @@ stdenv.mkDerivation rec {
     (lib.enableFeature (! stdenv.isDarwin) "oocd_trace")
     "--enable-buspirate"
     (lib.enableFeature stdenv.isLinux "sysfsgpio")
+    (lib.enableFeature stdenv.isLinux "linuxgpiod")
     "--enable-remote-bitbang"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Can be useful for low-speed debugging via USB-serial adapters that expose GPIOs on chips like CP2104. Also for "future-proof" GPIO debugging with a Pi.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux (no change in drv)
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).