### PR TITLE
ocamlPackages.lustre-v6: init at 6.103.3

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -240,6 +240,11 @@ in mkLicense lset) ({
     fullName = "CeCILL Free Software License Agreement v2.0";
   };
 
+  cecill21 = {
+    spdxId = "CECILL-2.1";
+    fullName = "CeCILL Free Software License Agreement v2.1";
+  };
+
   cecill-b = {
     spdxId = "CECILL-B";
     fullName  = "CeCILL-B Free Software License Agreement";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2599,6 +2599,10 @@
     githubId = 202798;
     name = "Pierre Bourdon";
   };
+  delta = {
+    email = "d4delta@outlook.fr";
+    name = "Delta";
+  };
   deltaevo = {
     email = "deltaduartedavid@gmail.com";
     github = "DeltaEvo";

--- a/pkgs/development/ocaml-modules/lustre-v6/default.nix
+++ b/pkgs/development/ocaml-modules/lustre-v6/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildDunePackage, fetchurl, ocaml_extlib, lutils, rdbg }:
+
+buildDunePackage rec {
+  pname = "lustre-v6";
+  version = "6.103.3";
+
+  useDune2 = true;
+
+  minimalOCamlVersion = "4.05";
+
+  src = fetchurl {
+    url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lustre-v6.6.103.3.tgz";
+    sha512 = "8d452184ee68edda1b5a50717e6a5b13fb21f9204634fc5898280e27a1d79c97a6e7cc04424fc22f34cdd02ed3cc8774dca4f982faf342980b5f9fe0dc1a017d";
+  };
+
+  propagatedBuildInputs = [
+    ocaml_extlib
+    lutils
+    rdbg
+  ];
+
+  meta = with lib; {
+    homepage = "http://www-verimag.imag.fr/lustre-v6.html";
+    description = "Lustre V6 compiler";
+    license = lib.licenses.cecill21;
+    maintainers = [ lib.maintainers.delta ];
+  };
+}

--- a/pkgs/development/ocaml-modules/lutils/default.nix
+++ b/pkgs/development/ocaml-modules/lutils/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchurl, num }:
+
+buildDunePackage rec {
+  pname = "lutils";
+  version = "1.51.2";
+
+  useDune2 = true;
+
+  minimalOCamlVersion = "4.02";
+
+  src = fetchurl {
+    url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutils.1.51.2.tgz";
+    sha512 = "f94696be379c62e888410ec3d940c888ca4b607cf59c2e364e93a2a694da65ebe6d531107198b795e80eecc3c6865eedb02659c7e7c4e15c9b28d74aa35d09f8";
+  };
+
+  propagatedBuildInputs = [
+    num
+  ];
+
+  meta = with lib; {
+    homepage = "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/";
+    description = "Tools and libs shared by Verimag/synchronous tools (lustre, lutin, rdbg)";
+    license = lib.licenses.cecill21;
+  };
+}

--- a/pkgs/development/ocaml-modules/rdbg/default.nix
+++ b/pkgs/development/ocaml-modules/rdbg/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildDunePackage, fetchurl, num, lutils, ounit}:
+
+buildDunePackage rec {
+  pname = "rdbg";
+  version = "1.196.12";
+
+  useDune2 = true;
+
+  minimalOCamlVersion = "4.07";
+
+  src = fetchurl {
+    url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/rdbg.1.196.12.tgz";
+    sha512 = "8e88034b1eda8f1233b4990adc9746782148254c93d8d0c99c246c0d50f306eeb6aa4afcfca8834acb3e268860647f47a24cc6a2d29fb45cac11f098e2ede275";
+  };
+
+  buildInputs = [
+    num
+    ounit
+  ];
+
+  propagatedBuildInputs = [
+    lutils
+  ];
+
+  meta = with lib; {
+    homepage = "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg";
+    description = "A programmable debugger that targets reactive programs for which a rdbg-plugin exists. Currently two plugins exist : one for Lustre, and one for Lutin (nb: both are synchronous programming languages)";
+    license = lib.licenses.cecill21;
+    maintainers = [ lib.maintainers.delta ];
+  };
+}

--- a/pkgs/tools/misc/ledit/default.nix
+++ b/pkgs/tools/misc/ledit/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchzip, ocaml, camlp5}:
+
+stdenv.mkDerivation {
+  pname = "ledit";
+  version = "2.04";
+
+  src = fetchzip {
+    url = "http://pauillac.inria.fr/~ddr/ledit/distrib/src/ledit-2.04.tgz";
+    sha512 = "16vlv6rcsddwrvsqqiwxdfv5rxvblhrx0k84g7pjibi0an241yx8aqf8cj4f4sgl5xfs3frqrdf12zqwjf2h4jvk8jyhyar8n0nj3g0";
+  };
+
+  preBuild = ''
+    mkdir -p $out/bin
+    substituteInPlace Makefile --replace /bin/rm rm --replace BINDIR=/usr/local/bin BINDIR=$out/bin
+  '';
+
+  buildInputs = [
+    ocaml
+    camlp5
+  ];
+
+  meta = with lib; {
+    homepage = "http://pauillac.inria.fr/~ddr/ledit/";
+    description = "A line editor, allowing to use shell commands with control characters like in emacs";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.delta ];
+    broken = lib.versionOlder ocaml.version "4.03";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6903,6 +6903,10 @@ with pkgs;
 
   leatherman = callPackage ../development/libraries/leatherman { };
 
+  ledit = callPackage ../tools/misc/ledit {
+    inherit (ocamlPackages) camlp5;
+  };
+
   ledmon = callPackage ../tools/system/ledmon { };
 
   leela = callPackage ../tools/graphics/leela { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -623,6 +623,10 @@ let
 
     lua-ml = callPackage ../development/ocaml-modules/lua-ml { };
 
+    lustre-v6 = callPackage ../development/ocaml-modules/lustre-v6 { };
+
+    lutils = callPackage ../development/ocaml-modules/lutils { };
+
     luv = callPackage ../development/ocaml-modules/luv {
       inherit (pkgs) file;
     };
@@ -1171,6 +1175,8 @@ let
     qtest = callPackage ../development/ocaml-modules/qtest { };
 
     randomconv = callPackage ../development/ocaml-modules/randomconv { };
+
+    rdbg = callPackage ../development/ocaml-modules/rdbg { };
 
     re = callPackage ../development/ocaml-modules/re { };
 


### PR DESCRIPTION
###### Motivation for this change
I need lustre

###### Things done
The following packages were added, because lustre-v6 depend on them:

- ocamlPackages.ledit: init at 2.04
- ocamlPackages.rdbg: init at 1.196.12


The following licenses were added:

- cecill21, used by lustre, rdbg, and lutils
- inria-ledit, used by ledit

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
