### PR TITLE
threejs-sage: install in expected location

### DIFF
--- a/pkgs/applications/science/math/sage/threejs-sage.nix
+++ b/pkgs/applications/science/math/sage/threejs-sage.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/lib/node_modules/three
-    cp -r build version $out/lib/node_modules/three
+    mkdir -p "$out/lib/node_modules/three/"
+    cp version "$out/lib/node_modules/three"
+    cp -r build "$out/lib/node_modules/three/$(cat version)"
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

The threejs-sage installation directory was changed upstream in https://trac.sagemath.org/ticket/30972, which landed in 9.4. Fixes #139478.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
