### PR TITLE
shellz: init at 1.6.0

### DIFF
--- a/pkgs/tools/security/shellz/default.nix
+++ b/pkgs/tools/security/shellz/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "shellz";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "evilsocket";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1mhl1y0jkycyl1hgwxavxkm1f6kdx1sz3bvpmkr46sdijji06imi";
+  };
+
+  vendorSha256 = "14rd9xd7s5sfmxgv5p9ka8x12xcimv5hrq7hzy0d1c3ddf50rr7n";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = with lib; {
+    description = "Utility to manage your SSH, telnet, kubernetes, winrm, web or any custom shell";
+    homepage = "https://github.com/evilsocket/shellz";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32069,6 +32069,8 @@ with pkgs;
 
   shc = callPackage ../tools/security/shc { };
 
+  shellz = callPackage ../tools/security/shellz { };
+
   canon-cups-ufr2 = callPackage ../misc/cups/drivers/canon { };
 
   hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
shellz is a small utility to manage your ssh, telnet, kubernetes, winrm, web or any custom shell in a single place.

https://github.com/evilsocket/shellz

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
