### PR TITLE
qt: use isELF and isMachO in wrapQtAppsHook

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -30,13 +30,9 @@ mkDerivation rec {
 
   postConfigure = "make qmake_all";
 
-  # 1. installs app bundle on darwin, move to app bundle dir & link binary to bin
-  # 2. wrapQtAppsHook fails to wrap mach-o binaries automatically, manually call wrapper
-  #    (see https://github.com/NixOS/nixpkgs/issues/102044)
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/Applications
     mv $out/{bin,Applications}/BambooTracker.app
-    wrapQtApp $out/Applications/BambooTracker.app/Contents/MacOS/BambooTracker
     ln -s $out/{Applications/BambooTracker.app/Contents/MacOS,bin}/BambooTracker
   '';
 

--- a/pkgs/applications/audio/munt/default.nix
+++ b/pkgs/applications/audio/munt/default.nix
@@ -36,7 +36,6 @@ mkDerivation rec {
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir $out/Applications
     mv $out/bin/${mainProgram}.app $out/Applications/
-    wrapQtApp $out/Applications/${mainProgram}.app/Contents/MacOS/${mainProgram}
     ln -s $out/{Applications/${mainProgram}.app/Contents/MacOS,bin}/${mainProgram}
   '';
 

--- a/pkgs/applications/editors/mindforger/default.nix
+++ b/pkgs/applications/editors/mindforger/default.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir "$out"/Applications
     mv app/mindforger.app "$out"/Applications/
-    wrapQtApp "$out"/Applications/mindforger.app/Contents/MacOS/mindforger
   '';
 
   meta = with lib; {

--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -76,9 +76,6 @@ mkDerivation rec {
   postInstall = with stdenv; lib.optionalString isDarwin ''
     mkdir -p $out/Applications
     mv $out/Mapper.app $out/Applications
-    # Fixes "This application failed to start because it could not find or load the Qt
-    # platform plugin "cocoa"."
-    wrapQtApp $out/Applications/Mapper.app/Contents/MacOS/Mapper
     mkdir -p $out/bin
     ln -s $out/Applications/Mapper.app/Contents/MacOS/Mapper $out/bin/mapper
   '';

--- a/pkgs/applications/graphics/openscad/default.nix
+++ b/pkgs/applications/graphics/openscad/default.nix
@@ -65,8 +65,6 @@ mkDerivation rec {
     mv $out/bin/*.app $out/Applications
     rmdir $out/bin || true
 
-    wrapQtApp "$out"/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD
-
     mv --target-directory=$out/Applications/OpenSCAD.app/Contents/Resources \
       $out/share/openscad/{examples,color-schemes,locale,libraries,fonts,templates}
 

--- a/pkgs/applications/misc/goldendict/default.nix
+++ b/pkgs/applications/misc/goldendict/default.nix
@@ -56,7 +56,6 @@ mkDerivation rec {
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications
     mv GoldenDict.app $out/Applications
-    wrapQtApp $out/Applications/GoldenDict.app/Contents/MacOS/GoldenDict
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/gpxlab/default.nix
+++ b/pkgs/applications/misc/gpxlab/default.nix
@@ -28,7 +28,6 @@ mkDerivation rec {
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications
     mv GPXLab/GPXLab.app $out/Applications
-    wrapQtApp $out/Applications/GPXLab.app/Contents/MacOS/GPXLab
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/gpxsee/default.nix
+++ b/pkgs/applications/misc/gpxsee/default.nix
@@ -26,7 +26,6 @@ mkDerivation rec {
   postInstall = with stdenv; lib.optionalString isDarwin ''
     mkdir -p $out/Applications
     mv GPXSee.app $out/Applications
-    wrapQtApp $out/Applications/GPXSee.app/Contents/MacOS/GPXSee
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -115,11 +115,6 @@ stdenv.mkDerivation rec {
   ++ optional (stdenv.isDarwin && withKeePassTouchID)
     darwin.apple_sdk.frameworks.LocalAuthentication;
 
-  preFixup = optionalString stdenv.isDarwin ''
-    # Make it work without Qt in PATH.
-    wrapQtApp $out/Applications/KeePassXC.app/Contents/MacOS/KeePassXC
-  '';
-
   passthru.tests = nixosTests.keepassxc;
 
   meta = {

--- a/pkgs/applications/misc/lsd2dsl/default.nix
+++ b/pkgs/applications/misc/lsd2dsl/default.nix
@@ -30,9 +30,6 @@ mkDerivation rec {
 
   installPhase = ''
     install -Dm755 console/lsd2dsl gui/lsd2dsl-qtgui -t $out/bin
-  '' + lib.optionalString stdenv.isDarwin ''
-    wrapQtApp $out/bin/lsd2dsl
-    wrapQtApp $out/bin/lsd2dsl-qtgui
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/merkaartor/default.nix
+++ b/pkgs/applications/misc/merkaartor/default.nix
@@ -50,7 +50,6 @@ mkDerivation rec {
     mkdir -p $out/Applications
     mv binaries/bin/merkaartor.app $out/Applications
     mv binaries/bin/plugins $out/Applications/merkaartor.app/Contents
-    wrapQtApp $out/Applications/merkaartor.app/Contents/MacOS/merkaartor
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/sleepyhead/default.nix
+++ b/pkgs/applications/misc/sleepyhead/default.nix
@@ -33,10 +33,6 @@ in mkDerivation {
     cp sleepyhead/SleepyHead $out/bin
   '';
 
-  postFixup = lib.optionalString stdenv.isDarwin ''
-    wrapQtApp "$out/Applications/SleepyHead.app/Contents/MacOS/SleepyHead"
-  '';
-
   meta = with lib; {
     homepage = "https://sleepyhead.jedimark.net/";
     description = "Review and explore data produced by CPAP and related machines";

--- a/pkgs/applications/misc/xpdf/default.nix
+++ b/pkgs/applications/misc/xpdf/default.nix
@@ -51,11 +51,6 @@ stdenv.mkDerivation rec {
     install -Dm644 $src/xpdf-qt/xpdf-icon.svg $out/share/pixmaps/xpdf.svg
   '';
 
-  # wrapQtAppsHook broken on macOS (https://github.com/NixOS/nixpkgs/issues/102044)
-  postFixup = lib.optionalString stdenv.isDarwin ''
-    wrapQtApp $out/bin/xpdf
-  '';
-
   meta = with lib; {
     homepage = "https://www.xpdfreader.com";
     description = "Viewer for Portable Document Format (PDF) files";

--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -16,9 +16,6 @@ mkDerivation rec {
     mkdir -p "$out/Applications"
     mv bin/chatterino.app "$out/Applications/"
   '';
-  postFixup = lib.optionalString stdenv.isDarwin ''
-    wrapQtApp "$out/Applications/chatterino.app/Contents/MacOS/chatterino"
-  '';
   meta = with lib; {
     description = "A chat client for Twitch chat";
     longDescription = ''

--- a/pkgs/applications/networking/instant-messengers/tensor/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tensor/default.nix
@@ -34,7 +34,6 @@ mkDerivation rec {
 
     mkdir -p $out/Applications
     cp -r tensor.app $out/Applications/tensor.app
-    wrapQtApp $out/Applications/tensor.app/Contents/MacOS/tensor
 
     runHook postInstall
   '' else ''

--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -38,8 +38,6 @@ stdenv.mkDerivation rec {
     install_name_tool \
       -add_rpath @executable_path/../Frameworks \
       $out/Applications/Communi.app/Contents/MacOS/Communi
-
-    wrapQtApp $out/Applications/Communi.app/Contents/MacOS/Communi
   '' else ''
     substituteInPlace "$out/share/applications/communi.desktop" \
       --replace "/usr/bin" "$out/bin"

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -66,8 +66,6 @@ in stdenv.mkDerivation {
             install_name_tool -change "$dylib" "$out/lib/$dylib" "$f"
         done
     done
-
-    wrapQtApp $out/Applications/Wireshark.app/Contents/MacOS/Wireshark
   '' else optionalString withQt ''
     install -Dm644 -t $out/share/applications ../wireshark.desktop
 

--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -37,10 +37,6 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  postInstall = lib.optionalString stdenv.isDarwin ''
-    wrapQtApp "$out"/bin/beamerpresenter.app/Contents/MacOS/beamerpresenter
-  '';
-
   meta = with lib; {
     description = "Modular multi screen pdf presentation software respecting your window manager";
     homepage = "https://github.com/stiglers-eponym/BeamerPresenter";

--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -28,10 +28,6 @@ mkDerivation rec {
                 'SET(CMAKE_INSTALL_PREFIX "${placeholder "out"}/Stellarium.app/Contents")'
   '';
 
-  postFixup = lib.optionalString stdenv.isDarwin ''
-    wrapQtApp "$out"/Stellarium.app/Contents/MacOS/stellarium
-  '';
-
   meta = with lib; {
     description = "Free open-source planetarium";
     homepage = "http://stellarium.org/";

--- a/pkgs/applications/video/jellyfin-media-player/default.nix
+++ b/pkgs/applications/video/jellyfin-media-player/default.nix
@@ -94,9 +94,6 @@ mkDerivation rec {
     mv $out/Resources/* "$out/Applications/Jellyfin Media Player.app/Contents/Resources/"
     rmdir $out/Resources
 
-    # fix 'Could not find the Qt platform plugin "cocoa" in ""' error
-    wrapQtApp "$out/Applications/Jellyfin Media Player.app/Contents/MacOS/Jellyfin Media Player"
-
     ln -s "$out/Applications/Jellyfin Media Player.app/Contents/MacOS/Jellyfin Media Player" $out/bin/jellyfinmediaplayer
   '';
 

--- a/pkgs/development/libraries/libfive/default.nix
+++ b/pkgs/development/libraries/libfive/default.nix
@@ -36,8 +36,6 @@ mkDerivation {
       -change libfive.dylib $out/lib/libfive.dylib \
       -change libfive-guile.dylib $out/lib/libfive-guile.dylib \
       $out/Applications/Studio.app/Contents/MacOS/Studio
-
-    wrapQtApp $out/Applications/Studio.app/Contents/MacOS/Studio
   '' else ''
     # Link "Studio" binary to "libfive-studio" to be more obvious:
     ln -s "$out/bin/Studio" "$out/bin/libfive-studio"

--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -85,7 +85,7 @@ wrapQtAppsHook() {
 
         find "$targetDir" ! -type d -executable -print0 | while IFS= read -r -d '' file
         do
-            patchelf --print-interpreter "$file" >/dev/null 2>&1 || continue
+            ifELF "$file" || isMachO "$file" || continue
 
             if [ -f "$file" ]
             then

--- a/pkgs/tools/audio/opl3bankeditor/common.nix
+++ b/pkgs/tools/audio/opl3bankeditor/common.nix
@@ -53,7 +53,6 @@ mkDerivation rec {
     mv "${binname}.app" $out/Applications/
 
     install_name_tool -change {,${qwt}/lib/}libqwt.6.dylib "$out/Applications/${binname}.app/Contents/MacOS/${binname}"
-    wrapQtApp "$out/Applications/${binname}.app/Contents/MacOS/${binname}"
 
     ln -s "$out/Applications/${binname}.app/Contents/MacOS/${binname}" $out/bin/${mainProgram}
   '';

--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -29,9 +29,6 @@ mkDerivation rec {
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir $out/Applications
     mv $out/*.app $out/Applications
-    for f in $out/Applications/android-file-transfer.app/Contents/MacOS/*; do
-      wrapQtApp "$f"
-    done
   '';
 
   meta = with lib; {

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -58,8 +58,6 @@ in
        --prefix PATH : '${coreutils}/bin' \
        --prefix PATH : '${fontconfig.bin}/bin' \
        --run '. ${./set-gdfontpath-from-fontconfig.sh}'
-  '' + lib.optionalString (stdenv.isDarwin && withQt) ''
-     wrapQtApp $out/bin/gnuplot
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/tools/text/glogg/default.nix
+++ b/pkgs/tools/text/glogg/default.nix
@@ -25,7 +25,6 @@ mkDerivation rec {
     mkdir -p $out/Applications
     mv $out/bin/glogg.app $out/Applications/glogg.app
     rm -fr $out/{bin,share}
-    wrapQtApp $out/Applications/glogg.app/Contents/MacOS/glogg
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: #102044
Closes: #131378

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
