### PR TITLE
nixos/bitlbee: added bitlbee to bitlbee group

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -48,7 +48,7 @@ in
       #disk = 6; # unused
       #vsftpd = 7; # dynamically allocated ass of 2021-09-14
       ftp = 8;
-      bitlbee = 9;
+      # bitlbee = 9; # removed 2021-10-05 #139765
       #avahi = 10; # removed 2019-05-22
       nagios = 11;
       atd = 12;
@@ -368,7 +368,7 @@ in
       disk = 6;
       #vsftpd = 7; # dynamically allocated as of 2021-09-14
       ftp = 8;
-      bitlbee = 9;
+      # bitlbee = 9; # removed 2021-10-05 #139765
       #avahi = 10; # removed 2019-05-22
       #nagios = 11; # unused
       atd = 12;

--- a/nixos/modules/services/networking/bitlbee.nix
+++ b/nixos/modules/services/networking/bitlbee.nix
@@ -16,7 +16,6 @@ let
     ''
     [settings]
     RunMode = Daemon
-    User = bitlbee
     ConfigDir = ${cfg.configDir}
     DaemonInterface = ${cfg.interface}
     DaemonPort = ${toString cfg.portNumber}
@@ -166,24 +165,17 @@ in
 
   config =  mkMerge [
     (mkIf config.services.bitlbee.enable {
-      users.users.bitlbee = {
-        uid = bitlbeeUid;
-        description = "BitlBee user";
-        home = "/var/lib/bitlbee";
-        createHome = true;
-      };
-
-      users.groups.bitlbee = {
-        gid = config.ids.gids.bitlbee;
-      };
-
       systemd.services.bitlbee = {
         environment.PURPLE_PLUGIN_PATH = purple_plugin_path;
         description = "BitlBee IRC to other chat networks gateway";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
-        serviceConfig.User = "bitlbee";
-        serviceConfig.ExecStart = "${bitlbeePkg}/sbin/bitlbee -F -n -c ${bitlbeeConfig}";
+
+        serviceConfig = {
+          DynamicUser = true;
+          StateDirectory = "bitlbee";
+          ExecStart = "${bitlbeePkg}/sbin/bitlbee -F -n -c ${bitlbeeConfig}";
+        };
       };
 
       environment.systemPackages = [ bitlbeePkg ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Since the latest enforcement of user groups, the Bitlbee will give this error

```
eyjhb@eos ~/p/n/nixus-setup (master) [1]> nix-build -A config.nodes.srtutti.deployScript deploy/
error: 
Failed assertions:
- users.users.bitlbee.group is unset. This used to default to
nogroup, but this is unsafe. For example you can create a group
for this user with:
users.users.bitlbee.group = "bitlbee";
users.groups.bitlbee = {};

(use '--show-trace' to show detailed location information)
```

This PR fixes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
