### PR TITLE
python3Packages.warcio: init at 1.7.4

### DIFF
--- a/pkgs/development/python-modules/warcio/default.nix
+++ b/pkgs/development/python-modules/warcio/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, six
+, setuptools
+, pytestCheckHook
+, httpbin
+, requests
+, wsgiprox
+, multidict
+}:
+
+buildPythonPackage rec {
+  pname = "warcio";
+  version = "1.7.4";
+
+  src = fetchFromGitHub {
+    owner = "webrecorder";
+    repo = "warcio";
+    rev = "aa702cb321621b233c6e5d2a4780151282a778be"; # Repo has no git tags, see https://github.com/webrecorder/warcio/issues/126
+    sha256 = "sha256-wn2rd73wRfOqHu9H0GIn76tmEsERBBCQatnk4b/JToU=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "add-offline-option.patch";
+      url = "https://github.com/webrecorder/warcio/pull/135/commits/2546fe457c57ab0b391764a4ce419656458d9d07.patch";
+      sha256 = "sha256-3izm9LvAeOFixiIUUqmd5flZIxH92+NxL7jeu35aObQ=";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    six
+    setuptools
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    httpbin
+    requests
+    wsgiprox
+    multidict # Optional. Without this, one test in test/test_utils.py is skipped.
+  ];
+
+  pytestFlagsArray = [ "--offline" ];
+
+  pythonImportsCheck = [ "warcio" ];
+
+  meta = with lib; {
+    description = "Streaming WARC/ARC library for fast web archive IO";
+    homepage = "https://github.com/webrecorder/warcio";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10308,6 +10308,8 @@ in {
 
   wandb = callPackage ../development/python-modules/wandb { };
 
+  warcio = callPackage ../development/python-modules/warcio { };
+
   warlock = callPackage ../development/python-modules/warlock { };
 
   warrant = callPackage ../development/python-modules/warrant { };


### PR DESCRIPTION
###### Motivation for this change
This is a dependency of ipwb, which I plan to add in the future.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).