### PR TITLE
python3Packages.renault-api: 0.1.4 -> 0.1.5

### DIFF
--- a/pkgs/development/python-modules/renault-api/default.nix
+++ b/pkgs/development/python-modules/renault-api/default.nix
@@ -5,7 +5,6 @@
 , click
 , dateparser
 , fetchFromGitHub
-, fetchpatch
 , marshmallow-dataclass
 , poetry-core
 , pyjwt
@@ -17,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "renault-api";
-  version = "0.1.4";
+  version = "0.1.5";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -26,7 +25,7 @@ buildPythonPackage rec {
     owner = "hacf-fr";
     repo = pname;
     rev = "v${version}";
-    sha256 = "049kh63yk0r0falqbl5akcwgzqjrkqqhf9y537rrlzc85ihf28b8";
+    sha256 = "sha256-b3oHpERUqeIw0yOxZytQuRE4jVUcahWlMQ+7ZBX0KL8=";
   };
 
   nativeBuildInputs = [
@@ -46,15 +45,6 @@ buildPythonPackage rec {
     aioresponses
     pytest-asyncio
     pytestCheckHook
-  ];
-
-  patches = [
-    # Switch to poetry-core, https://github.com/hacf-fr/renault-api/pull/371
-    (fetchpatch {
-      name = "switch-to-poetry-core.patch";
-      url = "https://github.com/hacf-fr/renault-api/commit/5457a612b9ff9f323e8449cbe9dbce465bd65a79.patch";
-      sha256 = "0ds9m4j2qpv0nyg9p8dk9klnarl8wckwclddgnii6h47qci362yy";
-    })
   ];
 
   pythonImportsCheck = [ "renault_api" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.1.5

Change log: https://github.com/hacf-fr/renault-api/releases/tag/v0.1.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
