### PR TITLE
wshowkeys: switch to a working fork

### DIFF
--- a/pkgs/tools/wayland/wshowkeys/default.nix
+++ b/pkgs/tools/wayland/wshowkeys/default.nix
@@ -1,20 +1,17 @@
-{ lib, stdenv, fetchFromSourcehut
+{ lib, stdenv, fetchFromGitHub
 , meson, pkg-config, wayland-scanner, ninja
 , cairo, libinput, pango, wayland, wayland-protocols, libxkbcommon
 }:
 
-let
-  version = "2020-03-29";
-  commit = "6388a49e0f431d6d5fcbd152b8ae4fa8e87884ee";
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "wshowkeys-unstable";
-  inherit version;
+  version = "2021-08-01";
 
-  src = fetchFromSourcehut {
-    owner = "~sircmpwn";
+  src = fetchFromGitHub {
+    owner = "ammgws";
     repo = "wshowkeys";
-    rev = commit;
-    sha256 = "10kafdja5cwbypspwhvaxjz3hvf51vqjzbgdasl977193cvxgmbs";
+    rev = "e8bfc78f08ebdd1316daae59ecc77e62bba68b2b";
+    sha256 = "sha256-/HvNCQWsXOJZeCxHWmsLlbBDhBzF7XP/SPLdDiWMDC4=";
   };
 
   nativeBuildInputs = [ meson pkg-config wayland-scanner ninja ];
@@ -29,13 +26,11 @@ in stdenv.mkDerivation rec {
       permissions are dropped after startup. The NixOS module provides such a
       setuid binary (use "programs.wshowkeys.enable = true;").
     '';
-    homepage = "https://git.sr.ht/~sircmpwn/wshowkeys";
+    homepage = "https://github.com/ammgws/wshowkeys";
     license = with licenses; [ gpl3Only mit ];
     # Some portions of the code are taken from Sway which is MIT licensed.
     # TODO: gpl3Only or gpl3Plus (ask upstream)?
     platforms = platforms.unix;
     maintainers = with maintainers; [ primeos berbiche ];
-    broken = true; # Unmaintained and fails to run (Wayland protocol error)
-    # TODO (@primeos): Remove this package after the NixOS 21.11 branch-off
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
