### PR TITLE
tcl.mkTclDerivation: fix exec prefix

### DIFF
--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -32,7 +32,7 @@ let
   defaultTclPkgConfigureFlags = [
     "--with-tcl=${tcl}/lib"
     "--with-tclinclude=${tcl}/include"
-    "--exec-prefix=\${out}"
+    "--exec-prefix=${placeholder "out"}"
   ];
 
   self = (stdenv.mkDerivation ((builtins.removeAttrs attrs [


### PR DESCRIPTION
###### Motivation for this change

Shell variables are not expanded, so the old value was just the literal
string `${out}`.

Fixes #139566

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
