### PR TITLE
onlyoffice: wrap correctly and force xcb since onlyoffice doesn't

### DIFF
--- a/pkgs/applications/office/onlyoffice-bin/default.nix
+++ b/pkgs/applications/office/onlyoffice-bin/default.nix
@@ -147,10 +147,6 @@ stdenv.mkDerivation rec {
 
     ln -s $out/share/desktopeditors/DesktopEditors $out/bin/DesktopEditors
 
-    wrapProgram $out/bin/DesktopEditors \
-        --set QT_XKB_CONFIG_ROOT ${xkeyboard_config}/share/X11/xkb \
-        --set QTCOMPOSE ${xorg.libX11.out}/share/X11/locale
-
     substituteInPlace $out/share/applications/onlyoffice-desktopeditors.desktop \
       --replace "/usr/bin/onlyoffice-desktopeditor" "$out/bin/DesktopEditor"
 
@@ -158,7 +154,13 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${runtimeLibs}" )
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb" \
+      --set QTCOMPOSE "${xorg.libX11.out}/share/X11/locale" \
+      --set QT_QPA_PLATFORM "xcb"
+      # the bundled version of qt does not support wayland
+    )
   '';
 
   passthru.updateScript = ./update.sh;


### PR DESCRIPTION
support wayland

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #128485

also fixes the errors in https://github.com/NixOS/nixpkgs/issues/128485#issuecomment-869650296
```
xkbcommon: ERROR: failed to add default include path /usr/share/X11/xkb
Qt: Failed to create XKB context!
Use QT_XKB_CONFIG_ROOT environmental variable to provide an additional search path, add ':' as separator to provide several search paths and/or make sure that XKB configuration data directory contains recent enough contents, to update please see http://cgit.freedesktop.org/xkeyboard-config/ .
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
