### PR TITLE
nixos/testing: factor out VM functionality

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -1,4 +1,5 @@
 #! /somewhere/python3
+from abc import ABC, abstractmethod
 from contextlib import contextmanager, _GeneratorContextManager
 from queue import Queue, Empty
 from typing import Tuple, Any, Callable, Dict, Iterator, Optional, List, Iterable
@@ -389,9 +390,8 @@ class LegacyStartCommand(StartCommand):
             self._cmd += f" {qemuFlags}"
 
 
-class Machine:
-    """A handle to the machine with this name, that also knows how to manage
-    the machine lifecycle with the help of a start script / command."""
+class Machine(ABC):
+    """Minimal abstract base class that contains functions required by multiple subclasses"""
 
     name: str
     tmp_dir: pathlib.Path
@@ -1048,6 +1048,21 @@ class Machine:
         self.shell.close()
         self.monitor.close()
         self.serial_thread.join()
+
+
+class ExecuteMixin(Machine):
+    """Contains methods that only need access to execute() in addition to the base Machine interface"""
+
+
+class MonitorMixin(Machine):
+    """Contains methods that only need access to send_monitor_command() in addition to the base Machine interface"""
+
+
+class PrivateVM(Machine):
+    """Manages a VM's lifecycle with the help of a start script / command. Only methods that require access to VM instance variables should be added here"""
+
+
+class VM(PrivateVM, MonitorMixin, ExecuteMixin):
 
 
 class VLan:

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -1081,14 +1081,14 @@ class VM(PrivateVM, MonitorMixin, ExecuteMixin):
         self,
         tmp_dir: pathlib.Path,
         start_command: StartCommand,
-        name: str = "machine",
+        name: str = "VM",
         keep_vm_state: bool = False,
     ) -> None:
         Machine.__init__(self, name)
         PrivateVM.__init__(self, tmp_dir, start_command, keep_vm_state)
 
     def __repr__(self) -> str:
-        return f"<Machine '{self.name}'>"
+        return f"<VM '{self.name}'>"
 
 
 class VLan:
@@ -1148,7 +1148,7 @@ class Driver:
 
     tests: str
     vlans: List[VLan]
-    machines: List[Machine]
+    machines: List[VM]
 
     def __init__(
         self,
@@ -1170,7 +1170,7 @@ class Driver:
                 yield NixStartScript(s)
 
         self.machines = [
-            Machine(
+            VM(
                 start_command=cmd,
                 keep_vm_state=keep_vm_state,
                 name=cmd.machine_name,
@@ -1277,7 +1277,7 @@ class Driver:
             cmd = Machine.create_startcommand(args)  # type: ignore
             name = args.get("name", "machine")
 
-        return Machine(
+        return VM(
             tmp_dir=tmp_dir,
             start_command=cmd,
             name=name,

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -401,7 +401,6 @@ class Machine:
     shell_path: pathlib.Path
 
     start_command: StartCommand
-    keep_vm_state: bool
 
     process: Optional[subprocess.Popen]
     pid: Optional[int]
@@ -426,7 +425,6 @@ class Machine:
         keep_vm_state: bool = False,
     ) -> None:
         self.tmp_dir = tmp_dir
-        self.keep_vm_state = keep_vm_state
         self.name = name
         self.start_command = start_command
 
@@ -437,7 +435,7 @@ class Machine:
         self.state_dir = self.tmp_dir / f"vm-state-{self.name}"
         self.monitor_path = self.state_dir / "monitor"
         self.shell_path = self.state_dir / "shell"
-        if (not self.keep_vm_state) and self.state_dir.exists():
+        if (not keep_vm_state) and self.state_dir.exists():
             self.cleanup_statedir()
         self.state_dir.mkdir(mode=0o700, exist_ok=True)
 

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -404,6 +404,10 @@ class Machine(ABC):
     ) -> None:
         self.name = name
 
+    @abstractmethod
+    def succeed(self, *commands: str) -> str:
+        pass
+
     @staticmethod
     def create_startcommand(args: Dict[str, str]) -> StartCommand:
         rootlog.warning(
@@ -1009,9 +1013,17 @@ class Machine(ABC):
 class ExecuteMixin(Machine):
     """Contains methods that only need access to execute() in addition to the base Machine interface"""
 
+    @abstractmethod
+    def execute(self, command: str, check_return: bool = True) -> Tuple[int, str]:
+        pass
+
 
 class MonitorMixin(Machine):
     """Contains methods that only need access to send_monitor_command() in addition to the base Machine interface"""
+
+    @abstractmethod
+    def send_monitor_command(self, command: str) -> str:
+        pass
 
 
 class PrivateVM(Machine):

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -438,10 +438,6 @@ class Machine(ABC):
         my_attrs.update(attrs)
         return rootlog.nested(msg, my_attrs)
 
-    def sleep(self, secs: int) -> None:
-        # We want to sleep in *guest* time, not *host* time.
-        self.succeed(f"sleep {secs}")
-
     def forward_port(self, host_port: int = 8080, guest_port: int = 80) -> None:
         """Forward a TCP port on the host to a TCP port on the guest.
         Useful during interactive testing.
@@ -1074,6 +1070,10 @@ class PrivateVM(Machine):
         self.log("forced crash")
         self.send_monitor_command("quit")
         self.wait_for_shutdown()
+
+    def sleep(self, secs: int) -> None:
+        # We want to sleep in *guest* time, not *host* time.
+        self.succeed(f"sleep {secs}")
 
 
 class VM(PrivateVM, MonitorMixin, ExecuteMixin):

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -402,7 +402,6 @@ class Machine:
 
     start_command: StartCommand
     keep_vm_state: bool
-    allow_reboot: bool
 
     process: Optional[subprocess.Popen]
     pid: Optional[int]
@@ -425,11 +424,9 @@ class Machine:
         start_command: StartCommand,
         name: str = "machine",
         keep_vm_state: bool = False,
-        allow_reboot: bool = False,
     ) -> None:
         self.tmp_dir = tmp_dir
         self.keep_vm_state = keep_vm_state
-        self.allow_reboot = allow_reboot
         self.name = name
         self.start_command = start_command
 
@@ -1246,7 +1243,6 @@ class Driver:
             start_command=cmd,
             name=name,
             keep_vm_state=args.get("keep_vm_state", False),
-            allow_reboot=args.get("allow_reboot", False),
         )
 
     def serial_stdout_on(self) -> None:


### PR DESCRIPTION


###### Motivation for this change
- The first commit is just a cleanup and should be easy to merge.

- The second doesn't change any functionality, but it's a step towards allowing
Nixos tests to be run in containers. Splitting out VM functionality from
Machine functionality will allow easily creating a Container subclass
for running tests in containers.

  - The external interface of test-driver is changed from create_machine()
to VM().

- The third commit has the only real code changes I had to make. Not sure why but I had to add some types and assertions for tests to pass. I can squash it if it looks good

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
