### PR TITLE
source-han-*: install instead of ln

### DIFF
--- a/pkgs/data/fonts/source-han/default.nix
+++ b/pkgs/data/fonts/source-han/default.nix
@@ -1,72 +1,61 @@
 { stdenvNoCC
 , lib
 , fetchzip
-, fetchurl
 }:
 
 let
-  makePackage = { family, description, rev, sha256 }: let
-    Family =
+  makePackage =
+    { family
+    , description
+    , rev
+    , sha256
+    , postFetch ? ''
+        install -m444 -Dt $out/share/fonts/opentype/source-han-${family} $downloadedFile
+      ''
+    , zip ? ""
+    }:
+    let Family =
       lib.toUpper (lib.substring 0 1 family) +
       lib.substring 1 (lib.stringLength family) family;
+    in
+    fetchzip {
+      name = "source-han-${family}-${lib.removeSuffix "R" rev}";
 
-    ttc = fetchurl {
-      url = "https://github.com/adobe-fonts/source-han-${family}/releases/download/${rev}/SourceHan${Family}.ttc";
-      inherit sha256;
+      url = "https://github.com/adobe-fonts/source-han-${family}/releases/download/${rev}/SourceHan${Family}.ttc${zip}";
+      inherit sha256 postFetch;
+
+      meta = {
+        description = "An open source Pan-CJK ${description} typeface";
+        homepage = "https://github.com/adobe-fonts/source-han-${family}";
+        license = lib.licenses.ofl;
+        maintainers = with lib.maintainers; [ taku0 emily ];
+      };
     };
-  in stdenvNoCC.mkDerivation {
-    pname = "source-han-${family}";
-    version = lib.removeSuffix "R" rev;
-
-    buildCommand = ''
-      install -m444 -Dt $out/share/fonts/opentype/source-han-${family} ${ttc}
-    '';
-
-    meta = {
-      description = "An open source Pan-CJK ${description} typeface";
-      homepage = "https://github.com/adobe-fonts/source-han-${family}";
-      license = lib.licenses.ofl;
-      maintainers = with lib.maintainers; [ taku0 emily ];
-    };
-  };
 in
 {
-  sans = let
-    rev = "2.004R";
+  sans = makePackage {
     family = "sans";
-    Family = "Sans";
-    zip = fetchzip {
-      url = "https://github.com/adobe-fonts/source-han-${family}/releases/download/${rev}/SourceHan${Family}.ttc.zip";
-      stripRoot = false;
-      sha256 = "0z852kzb84vqk57icfaxbfxhf43awcn8w39byfypxaxigzhy78l7";
-    };
-  in stdenvNoCC.mkDerivation {
-    pname = "source-han-sans";
-    version = lib.removeSuffix "R" rev;
-
-    buildCommand = ''
-      install -m444 -Dt $out/share/fonts/opentype/source-han-sans ${zip}/SourceHanSans.ttc
+    description = "sans-serif";
+    rev = "2.004R";
+    sha256 = "052d17hvz435zc4r2y1p9cgkkgn0ps8g74mfbvnbm1pv8ykj40m9";
+    postFetch = ''
+      mkdir -p $out/share/fonts/opentype/source-han-sans
+      unzip $downloadedFile -d $out/share/fonts/opentype/source-han-sans
     '';
-
-    meta = {
-      description = "An open source Pan-CJK sans-serif typeface";
-      homepage = "https://github.com/adobe-fonts/source-han-${family}";
-      license = lib.licenses.ofl;
-      maintainers = with lib.maintainers; [ taku0 emily ];
-    };
+    zip = ".zip";
   };
 
   serif = makePackage {
     family = "serif";
     description = "serif";
     rev = "1.001R";
-    sha256 = "1d968h30qvvwy3s77m9y3f1glq8zlr6bnfw00yinqa18l97n7k45";
+    sha256 = "0nnsb2w140ih0cnp1fh7s4csvzp9y0cavz9df2ryhv215mh9z4m0";
   };
 
   mono = makePackage {
     family = "mono";
     description = "monospaced";
     rev = "1.002";
-    sha256 = "1haqffkcgz0cc24y8rc9bg36v8x9hdl8fdl3xc8qz14hvr42868c";
+    sha256 = "010h1y469c21bjavwdmkpbwk3ny686inz8i062wh1dhcv8cnqk3c";
   };
 }

--- a/pkgs/data/fonts/source-han/default.nix
+++ b/pkgs/data/fonts/source-han/default.nix
@@ -19,8 +19,7 @@ let
     version = lib.removeSuffix "R" rev;
 
     buildCommand = ''
-      mkdir -p $out/share/fonts/opentype/source-han-${family}
-      ln -s ${ttc} $out/share/fonts/opentype/source-han-${family}/SourceHan${Family}.ttc
+      install -m444 -Dt $out/share/fonts/opentype/source-han-${family} ${ttc}
     '';
 
     meta = {

--- a/pkgs/data/fonts/source-han/default.nix
+++ b/pkgs/data/fonts/source-han/default.nix
@@ -31,11 +31,29 @@ let
   };
 in
 {
-  sans = makePackage {
+  sans = let
+    rev = "2.004R";
     family = "sans";
-    description = "sans-serif";
-    rev = "2.001R";
-    sha256 = "101p8q0sagf1sd1yzwdrmmxvkqq7j0b8hi0ywsfck9w56r4zx54y";
+    Family = "Sans";
+    zip = fetchzip {
+      url = "https://github.com/adobe-fonts/source-han-${family}/releases/download/${rev}/SourceHan${Family}.ttc.zip";
+      stripRoot = false;
+      sha256 = "0z852kzb84vqk57icfaxbfxhf43awcn8w39byfypxaxigzhy78l7";
+    };
+  in stdenvNoCC.mkDerivation {
+    pname = "source-han-sans";
+    version = lib.removeSuffix "R" rev;
+
+    buildCommand = ''
+      install -m444 -Dt $out/share/fonts/opentype/source-han-sans ${zip}/SourceHanSans.ttc
+    '';
+
+    meta = {
+      description = "An open source Pan-CJK sans-serif typeface";
+      homepage = "https://github.com/adobe-fonts/source-han-${family}";
+      license = lib.licenses.ofl;
+      maintainers = with lib.maintainers; [ taku0 emily ];
+    };
   };
 
   serif = makePackage {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The LibreOffice can't recognize the symlink for some unknown reasons so I revert https://github.com/NixOS/nixpkgs/pull/95701

CC @taku0 @emilazy @gebner

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
