### PR TITLE
privoxy: switch to openssl

### DIFF
--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -2,7 +2,7 @@
 , nixosTests
 , fetchurl, autoreconfHook
 , zlib, pcre, w3m, man
-, mbedtls, brotli
+, openssl, brotli
 }:
 
 stdenv.mkDerivation rec {
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
   hardeningEnable = [ "pie" ];
 
   nativeBuildInputs = [ autoreconfHook w3m man ];
-  buildInputs = [ zlib pcre mbedtls brotli ];
+  buildInputs = [ zlib pcre openssl brotli ];
 
   makeFlags = [ "STRIP=" ];
   configureFlags = [
-    "--with-mbedtls"
+    "--with-openssl"
     "--with-brotli"
     "--enable-external-filters"
     "--enable-compression"
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "Non-caching web proxy with advanced filtering capabilities";
     # When linked with mbedtls, the license becomes GPLv3 (or later), otherwise
     # GPLv2 (or later). See https://www.privoxy.org/user-manual/copyright.html
-    license = licenses.gpl3Plus;
+    license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.phreedom ];
   };


### PR DESCRIPTION
###### Motivation for this change

mbedtls lacks a number of features (like TLS 1.3 and fragmented handshakes) that makes everyday browsing a bit unpractical.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested via `privoxy.tests`
- [x] Tested compilation of all packages that depend on this change (`privoxy`)
- [x] Tested execution of all binary files
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
