### PR TITLE
volatility3: init at 1.0.1

### DIFF
--- a/pkgs/tools/security/volatility3/default.nix
+++ b/pkgs/tools/security/volatility3/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "volatility3";
+  version = "1.0.1";
+
+  disabled = python3.pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "volatilityfoundation";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1k56izgkla9mrjrkp1saavajdx9x1wkqpwmbpvxv9rw5k80m5a4a";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    capstone
+    jsonschema
+    pefile
+    pycryptodome
+    yara-python
+  ];
+
+  preBuild = ''
+    export HOME=$(mktemp -d);
+  '';
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "volatility3" ];
+
+  meta = with lib; {
+    description = "Volatile memory extraction frameworks";
+    homepage = "https://www.volatilityfoundation.org/";
+    license = {
+      # Volatility Software License 1.0
+      free = false;
+      url = "https://www.volatilityfoundation.org/license/vsl-v1.0";
+    };
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9975,6 +9975,8 @@ with pkgs;
 
   volatility = callPackage ../tools/security/volatility { };
 
+  volatility3 = callPackage ../tools/security/volatility3 { };
+
   vbetool = callPackage ../tools/system/vbetool { };
 
   vcsi = callPackage ../tools/video/vcsi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Volatile memory extraction frameworks

https://www.volatilityfoundation.org/

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [xxx] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
