### PR TITLE
python3Packages.torchaudio-bin: init at 0.9.1

### DIFF
--- a/pkgs/development/python-modules/torchaudio/bin.nix
+++ b/pkgs/development/python-modules/torchaudio/bin.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchurl
+, patchelf
+, python
+, pytorch-bin
+, pythonOlder
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  pname = "torchaudio";
+  version = "0.9.1";
+  format = "wheel";
+
+  src =
+    let pyVerNoDot = lib.replaceStrings [ "." ] [ "" ] python.pythonVersion;
+        unsupported = throw "Unsupported system";
+        srcs = (import ./binary-hashes.nix version)."${stdenv.system}-${pyVerNoDot}" or unsupported;
+    in fetchurl srcs;
+
+  disabled = ! (pythonAtLeast "3.7" && pythonOlder "3.10");
+
+  propagatedBuildInputs = [
+    pytorch-bin
+  ];
+
+  # The wheel-binary is not stripped to avoid the error of `ImportError: libtorch_cuda_cpp.so: ELF load command address/offset not properly aligned.`.
+  dontStrip = true;
+
+  pythonImportsCheck = [ "torchaudio" ];
+
+  postFixup = ''
+    # Note: after patchelf'ing, libcudart can still not be found. However, this should
+    #       not be an issue, because PyTorch is loaded before torchvision and brings
+    #       in the necessary symbols.
+    patchelf --set-rpath "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}:${pytorch-bin}/${python.sitePackages}/torch/lib:" \
+      "$out/${python.sitePackages}/torchaudio/_torchaudio.so"
+  '';
+
+  meta = with lib; {
+    description = "PyTorch audio library";
+    homepage = "https://pytorch.org/";
+    changelog = "https://github.com/pytorch/audio/releases/tag/v${version}";
+    # Includes CUDA and Intel MKL, but redistributions of the binary are not limited.
+    # https://docs.nvidia.com/cuda/eula/index.html
+    # https://www.intel.com/content/www/us/en/developer/articles/license/onemkl-license-faq.html
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ junjihashimoto ];
+  };
+}

--- a/pkgs/development/python-modules/torchaudio/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchaudio/binary-hashes.nix
@@ -1,0 +1,26 @@
+# Warning: Need to update at the same time as pytorch-bin
+#
+# Precompiled wheels can be found at:
+# https://download.pytorch.org/whl/torch_stable.html
+
+# To add a new version, run "prefetch.sh 'new-version'" to paste the generated file as follows.
+
+version : builtins.getAttr version {
+  "0.9.1" = {
+    x86_64-linux-37 = {
+      name = "torchaudio-0.9.1-cp37-cp37m-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.9.1-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-Vr7rQJlt0OMyKsnAbgiu26puE+3pW1UG8e8la/sBC3g=";
+    };
+    x86_64-linux-38 = {
+      name = "torchaudio-0.9.1-cp38-cp38-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.9.1-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-tcWMR2UHe7H8jB9d9tEaZAb2WBhYieou4dmW+JBh9GU=";
+    };
+    x86_64-linux-39 = {
+      name = "torchaudio-0.9.1-cp39-cp39-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.9.1-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-vxr1Nr0/QGH6Ej+O9bafZOgdplSzRNeRaod4o0EmzhQ=";
+    };
+  };
+}

--- a/pkgs/development/python-modules/torchaudio/prefetch.sh
+++ b/pkgs/development/python-modules/torchaudio/prefetch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-prefetch-scripts
+
+version=$1
+
+bucket="https://download.pytorch.org/whl"
+
+url_and_key_list=(
+  "x86_64-linux-37 $bucket/torchaudio-${version}-cp37-cp37m-linux_x86_64.whl torchaudio-${version}-cp37-cp37m-linux_x86_64.whl"
+  "x86_64-linux-38 $bucket/torchaudio-${version}-cp38-cp38-linux_x86_64.whl torchaudio-${version}-cp38-cp38-linux_x86_64.whl"
+  "x86_64-linux-39 $bucket/torchaudio-${version}-cp39-cp39-linux_x86_64.whl torchaudio-${version}-cp39-cp39-linux_x86_64.whl"
+)
+
+hashfile=binary-hashes-"$version".nix
+echo "  \"$version\" = {" >> $hashfile
+
+for url_and_key in "${url_and_key_list[@]}"; do
+  key=$(echo "$url_and_key" | cut -d' ' -f1)
+  url=$(echo "$url_and_key" | cut -d' ' -f2)
+  name=$(echo "$url_and_key" | cut -d' ' -f3)
+
+  echo "prefetching ${url}..."
+  hash=$(nix hash to-sri --type sha256 `nix-prefetch-url "$url" --name "$name"`)
+
+  echo "    $key = {" >> $hashfile
+  echo "      name = \"$name\";" >> $hashfile
+  echo "      url = \"$url\";" >> $hashfile
+  echo "      hash = \"$hash\";" >> $hashfile
+  echo "    };" >> $hashfile
+
+  echo
+done
+
+echo "  };" >> $hashfile
+echo "done."

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9068,6 +9068,8 @@ in {
 
   toposort = callPackage ../development/python-modules/toposort { };
 
+  torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix { };
+
   torchgpipe = callPackage ../development/python-modules/torchgpipe { };
 
   torchvision = callPackage ../development/python-modules/torchvision { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

As with torchvision-bin, this derivation is used with pytorch-bin to avoid the long build time of PyTorch CUDA builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
