### PR TITLE
yascreen: init at 1.86

### DIFF
--- a/pkgs/development/libraries/yascreen/default.nix
+++ b/pkgs/development/libraries/yascreen/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, go-md2man, fetchFromGitHub, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  pname = "yascreen";
+  version = "1.86";
+
+  src = fetchFromGitHub {
+    owner = "bbonev";
+    repo = "yascreen";
+    rev = "v${version}";
+    sha256 = "sha256-z7j2yceiUyJNdyoVXAPiINln2/MUMqVJh+VwQnmzO2A=";
+  };
+
+  nativeBuildInputs = [ go-md2man ];
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/bbonev/yascreen/commit/a30b8fce66a3db9f1194fede30a48424ed3d696b.patch";
+      sha256 = "sha256-Bnaf3OVMlqyYMdGsJ6fF3oYsWT01FcjuRzxi6xfbnZg=";
+    })
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/bbonev/yascreen";
+    description = "Yet Another Screen Library (curses replacement for daemons and embedded apps)";
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.arezvov ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10608,6 +10608,8 @@ with pkgs;
     mkYarnModules
     fixup_yarn_lock;
 
+  yascreen = callPackage ../development/libraries/yascreen { };
+
   yasr = callPackage ../applications/audio/yasr { };
 
   yank = callPackage ../tools/misc/yank { };


### PR DESCRIPTION
I need this library for [bpfmon](https://github.com/bbonev/bpfmon) (I'll add bpfmon in next PR). 

Patch is a temporary solution. In master branch problem already resolved and I'll remove this patch after next release.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
