### PR TITLE
compiler-rt: cont. remove <cyclades.h> from libsanitizer

### DIFF
--- a/pkgs/development/compilers/llvm/rocm/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/compiler-rt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, version, src, cmake, python3, llvm, libcxxabi }:
+{ stdenv, lib, version, src, cmake, python3, llvm, libcxxabi, fetchpatch }:
 stdenv.mkDerivation rec {
   pname = "compiler-rt";
   inherit version src;
@@ -31,7 +31,13 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-  ];
+    (fetchpatch {
+      name = "libsanitizer-no-cyclades-rocm.patch";
+      url = "https://reviews.llvm.org/file/data/nrhbpc5axblqwx2xyyzv/PHID-FILE-wwcpjvquusomoddmqcwo/file";
+      sha256 = "sha256-PMMSLr2zHuNDn1OWqumqHwB74ktJSHxhJWkqEKB7Z64=";
+      stripLen = 1;
+     })
+    ];
 
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks


### PR DESCRIPTION
From commit 199b7c505b0390429b08edf68552e8a6ff4a08ce for the
original issue:

>  linux-headers-5.13 removed <cyclades.h> along with device support.
    Backport a single https://reviews.llvm.org/D102059 upstream change to
    fix compiler-rt build.

This only unique thing here is the patch is from the upstream rocm llvm repo:
https://reviews.llvm.org/rG884040db086936107ec81656aa5b4c607235fb9a

With the patch, the  llvmPackages_rocm.compiler-rt package does compile. Once hydra shows the build failure I can open an issue if needed.
 
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
