### PR TITLE
python3Packages.urlextract: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4671,6 +4671,12 @@
     githubId = 36193715;
     name = "Lassi Haasio";
   };
+  ilkecan = {
+    email = "ilkecan@protonmail.com";
+    github = "ilkecan";
+    githubId = 40234257;
+    name = "ilkecan bozdogan";
+  };
   illegalprime = {
     email = "themichaeleden@gmail.com";
     github = "illegalprime";

--- a/pkgs/development/python-modules/urlextract/default.nix
+++ b/pkgs/development/python-modules/urlextract/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, appdirs
+, buildPythonPackage
+, dnspython
+, fetchPypi
+, filelock
+, idna
+, pytestCheckHook
+, uritools
+}:
+
+buildPythonPackage rec {
+  pname = "urlextract";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-yxOuiswFOJnAvxwTT++Zhk8nZWK2f4ePsQpUYI7EYS4=";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    filelock
+    idna
+    uritools
+  ];
+
+  checkInputs = [
+    dnspython
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # fails with dns.resolver.NoResolverConfiguration due to network sandboxing
+    "test_check_dns_enabled"
+    "test_check_dns_find_urls"
+    "test_dns_cache_init"
+    "test_dns_cache_negative"
+    "test_dns_cache_reuse"
+  ];
+
+  pythonImportsCheck = [ "urlextract" ];
+
+  meta = with lib; {
+    description = "Collects and extracts URLs from given text";
+    homepage = "https://github.com/lipoja/URLExtract";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ilkecan ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9364,6 +9364,8 @@ in {
 
   url-normalize = callPackage ../development/python-modules/url-normalize { };
 
+  urlextract = callPackage ../development/python-modules/urlextract { };
+
   urlgrabber = callPackage ../development/python-modules/urlgrabber { };
 
   urllib3 = callPackage ../development/python-modules/urllib3 { };


### PR DESCRIPTION
###### Motivation for this change
Package [URLExtract](https://pypi.org/project/urlextract/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
