### PR TITLE
Pantheon updates 2021-09-28

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-code/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-code/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pantheon
 , pkg-config
@@ -31,7 +30,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-code";
-  version = "6.0.0";
+  version = "6.0.1";
 
   repoName = "code";
 
@@ -39,17 +38,8 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "1w1m52mq3zr9alkxk1c0s4ncscka1km5ppd0r6zm86qan9cjwq0f";
+    sha256 = "120328pprzqj4587yj54yya9v2mv1rfwylpmxyr5l2qf80cjxi9d";
   };
-
-  patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/code/pull/1090
-    (fetchpatch {
-      url = "https://github.com/elementary/code/commit/88dc40d7bbcc2288ada6673eb8f4fab345d97882.patch";
-      sha256 = "16y20bvslcm390irlib759703lvf7w6rz4xzaiazjj1r1njwinvv";
-    })
-  ];
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/desktops/pantheon/apps/elementary-files/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-files/default.nix
@@ -32,7 +32,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-files";
-  version = "6.0.2";
+  version = "6.0.3";
 
   repoName = "files";
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "1i514r3adypmcwinmv4c1kybims16xi4i3akx0yy04dib92hbk7c";
+    sha256 = "10hgj5rrqxzk4q8jlhkwwrs4hgyavlhz3z1pqf36y663bq3h0izv";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
@@ -26,7 +26,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-mail";
-  version = "6.1.1";
+  version = "6.2.0";
 
   repoName = "mail";
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "15ai0x9236pjx76m0756nyc1by78v0lg1dgdiifk868krdvipzzx";
+    sha256 = "1ab620zhwqqjq1bs1alvpcw9jmdxjij0ywczvwbg8gqvcsc80lkn";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-tasks/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-tasks/default.nix
@@ -26,7 +26,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-tasks";
-  version = "6.0.3";
+  version = "6.0.4";
 
   repoName = "tasks";
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "0a6zgf7di4jyl764pn78wbanm0i5vrkk5ks3cfsvi3baprf3j9d5";
+    sha256 = "1gb51gm8qgd8yzhqb7v69p2f1fgm3qf534if4lc85jrjsb8hgmhl";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pantheon
 , meson
@@ -16,23 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-applications";
-  version = "6.0.0";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0hgvmrgg6g2sjb3sda7kzfcd3zgngd5w982drl6ll44k1mh16gsj";
+    sha256 = "18izmzhqp6x5ivha9yl8gyz9adyrsylw7w5p0cwm1bndgqbi7yh5";
   };
-
-  patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/switchboard-plug-applications/pull/163
-    (fetchpatch {
-      url = "https://github.com/elementary/switchboard-plug-applications/commit/25db490654ab41694be7b7ba19218376f42fbb8d.patch";
-      sha256 = "16y8zcwnnjsh72ifpyqcdb9f5ajdj0iy8kb5sj6v77c1cxdhrv29";
-    })
-  ];
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-onlineaccounts";
-  version = "6.2.0";
+  version = "6.2.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "1lp3i31jzp21n43d1mh4d4i8zgim3q3j4inw4hmyimyql2s83cc3";
+    sha256 = "1q3f7zr04p2100mb255zy38il2i47l6vqdc9a9acjbk3n7q5sf92";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
@@ -12,7 +12,6 @@
 , libgee
 , gettext
 , gtk3
-, appstream
 , gnome-menus
 , json-glib
 , elementary-dock
@@ -27,7 +26,7 @@
 
 stdenv.mkDerivation rec {
   pname = "wingpanel-applications-menu";
-  version = "2.8.2";
+  version = "2.9.0";
 
   repoName = "applications-menu";
 
@@ -35,7 +34,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "1pm3dnq35vbvyxqapmfy4frfwhc1l2zh634annlmbjiyfp5mzk0q";
+    sha256 = "0mwjw2ghbdj336ax5srxbqnjprdhj1if7sm9k9idqkmifpzccs7i";
   };
 
   passthru = {
@@ -45,7 +44,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    appstream
     gettext
     meson
     ninja

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
@@ -3,7 +3,6 @@
 , nix-update-script
 , pantheon
 , pkg-config
-, fetchpatch
 , meson
 , ninja
 , vala
@@ -17,23 +16,14 @@
 
 stdenv.mkDerivation rec {
   pname = "wingpanel-indicator-notifications";
-  version = "6.0.0";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "1pvcpk1d2zh9pvw0clv3bhf2plcww6nbxs6j7xjbvnaqs7d6i1k2";
+    sha256 = "1qrbg8l3ifz09jx6v5j7hmgw0hmirj6mh3z634yl1cadz45p8fc9";
   };
-
-  patches = [
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/wingpanel-indicator-notifications/pull/218
-    (fetchpatch {
-      url = "https://github.com/elementary/wingpanel-indicator-notifications/commit/c7e73f0683561345935a959dafa2083b7e22fe99.patch";
-      sha256 = "10xiyq42bqfmih1jgqpq64nha3n0y7ra3j7j0q27rn5hhhgbyjs7";
-    })
-  ];
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wingpanel";
-  version = "3.0.0";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0ycys24y1rrz0ydpvs4mc89p4k986q1ziwbvziinxr1wsli9v1dj";
+    sha256 = "078yi36r452sc33mv2ck8z0icya1lhzhickllrlhc60rdri36sb8";
   };
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

Part of Pantheon 6.0.2 updates (previous one at #139163).

| Package | Change log | Diff |
|:---:|:---:|:---:|
| pantheon.elementary-code | [6.0.1](https://github.com/elementary/code/releases/tag/6.0.1) | [6.0.0...6.0.1](https://github.com/elementary/code/compare/6.0.0...6.0.1) |
| pantheon.switchboard-plug-onlineaccounts | [6.2.1](https://github.com/elementary/switchboard-plug-onlineaccounts/releases/tag/6.2.1) | [6.2.0...6.2.1](https://github.com/elementary/switchboard-plug-onlineaccounts/compare/6.2.0...6.2.1) |
| pantheon.elementary-files | [6.0.3](https://github.com/elementary/files/releases/tag/6.0.3) | [6.0.2...6.0.3](https://github.com/elementary/files/compare/6.0.2...6.0.3) |
| pantheon.elementary-mail | [6.2.0](https://github.com/elementary/mail/releases/tag/6.2.0) | [6.1.1...6.2.0](https://github.com/elementary/mail/compare/6.1.1...6.2.0) |
| pantheon.wingpanel-indicator-notifications | [6.0.1](https://github.com/elementary/wingpanel-indicator-notifications/releases/tag/6.0.1) | [6.0.0...6.0.1](https://github.com/elementary/wingpanel-indicator-notifications/compare/6.0.0...6.0.1) |
| pantheon.elementary-tasks | [6.0.4](https://github.com/elementary/tasks/releases/tag/6.0.4) | [6.0.3...6.0.4](https://github.com/elementary/tasks/compare/6.0.3...6.0.4) |
| pantheon.wingpanel | [3.0.1](https://github.com/elementary/wingpanel/releases/tag/3.0.1) | [3.0.0...3.0.1](https://github.com/elementary/wingpanel/compare/3.0.0...3.0.1) |
| pantheon.switchboard-plug-applications | [6.0.1](https://github.com/elementary/switchboard-plug-applications/releases/tag/6.0.1) | [6.0.0...6.0.1](https://github.com/elementary/switchboard-plug-applications/compare/6.0.0...6.0.1) |
| pantheon.wingpanel-applications-menu | [2.9.0](https://github.com/elementary/applications-menu/releases/tag/2.9.0) | [2.8.2...2.9.0](https://github.com/elementary/applications-menu/compare/2.8.2...2.9.0) |

Dependency update:

- https://github.com/elementary/applications-menu/pull/506

###### Things done

- [x] Rebuilt NixOS from this PR to test the change.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
