### PR TITLE
uboot: increase rpi kernel size patch

### DIFF
--- a/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
+++ b/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
@@ -17,12 +17,12 @@ index 834f1cd..10ab1e7 100644
   * parameter given to the kernel. So reserving memory from low to high
 - * satisfies this constraint again. Reserving 1M at 0x02600000-0x02700000 for
 - * the DTB leaves rest of the free RAM to the initrd starting at 0x02700000.
-+ * satisfies this constraint again. Reserving 1M at 0x02e00000-0x02f00000 for
-+ * the DTB leaves rest of the free RAM to the initrd starting at 0x02f00000.
++ * satisfies this constraint again. Reserving 1M at 0x03700000-0x03800000 for
++ * the DTB leaves rest of the free RAM to the initrd starting at 0x03800000.
   * Even with the smallest possible CPU-GPU memory split of the CPU getting
 - * only 64M, the remaining 25M starting at 0x02700000 should allow quite
 - * large initrds before they start colliding with U-Boot.
-+ * only 64M, the remaining 17M starting at 0x02f00000 should allow reasonably
++ * only 64M, the remaining 9M starting at 0x03800000 should allow reasonably
 + * sized initrds before they start colliding with U-Boot.
   */
  #define ENV_MEM_LAYOUT_SETTINGS \
@@ -33,10 +33,10 @@ index 834f1cd..10ab1e7 100644
 -	"pxefile_addr_r=0x02500000\0" \
 -	"fdt_addr_r=0x02600000\0" \
 -	"ramdisk_addr_r=0x02700000\0"
-+	"scriptaddr=0x02c00000\0" \
-+	"pxefile_addr_r=0x02d00000\0" \
-+	"fdt_addr_r=0x02e00000\0" \
-+	"ramdisk_addr_r=0x02f00000\0"
++	"scriptaddr=0x03500000\0" \
++	"pxefile_addr_r=0x03600000\0" \
++	"fdt_addr_r=0x03700000\0" \
++	"ramdisk_addr_r=0x03800000\0"
  
  #if CONFIG_IS_ENABLED(CMD_MMC)
  	#define BOOT_TARGET_MMC(func) \


### PR DESCRIPTION
###### Motivation for this change
When trying to boot my Pi 4B with a fresh [sd img from hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.sd_image.aarch64-linux), i got an `ERROR: RD image overlaps OS image (OS=0x200000..0x3100000)`, that would end up in a `Cannot load any image` error, preventing the boot process altogether. Which seems to be similar to https://github.com/NixOS/nixpkgs/issues/97064

Following @samueldr's [recommendation](https://matrix.to/#/!RjBlCIbsLDzHBIzmaA:nixos.org/$vfRFgZv-8WOUUdMqua9zvgpNPJhmnXveZ09I6Ad2_jM?via=nixos.org&via=matrix.org&via=nixos.dev), i've increased the patch's offset by 8MB.

I can confirm compiling it with `nix build` and moving the resulting `u-boot.bin` to the firmware partition on my sd card as `u-boot-rpi4.bin` completely solves the issue on my pi.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
