### PR TITLE
vimPlugins.markdown-preview-nvim: fix node dependencies

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -174,6 +174,7 @@
 , "madoko"
 , "markdownlint-cli"
 , "markdown-link-check"
+, {"markdown-preview-nvim": "../../misc/vim-plugins/markdown-preview-nvim"}
 , "mastodon-bot"
 , "mathjax"
 , "meat"

--- a/pkgs/misc/vim-plugins/markdown-preview-nvim/fix-node-paths.patch
+++ b/pkgs/misc/vim-plugins/markdown-preview-nvim/fix-node-paths.patch
@@ -1,0 +1,46 @@
+diff --git a/autoload/health/mkdp.vim b/autoload/health/mkdp.vim
+index 9eebb56..0700333 100644
+--- a/autoload/health/mkdp.vim
++++ b/autoload/health/mkdp.vim
+@@ -9,8 +9,8 @@ function! health#mkdp#check() abort
+     call health#report_info('Pre build: ' . l:mkdp_server_script)
+     call health#report_info('Pre build version: ' . mkdp#util#pre_build_version())
+     call health#report_ok('Using pre build')
+-  elseif executable('node')
+-    call health#report_info('Node version: ' . system('node --version'))
++  elseif executable('@node@')
++    call health#report_info('Node version: ' . system('@node@ --version'))
+     let l:mkdp_server_script = s:mkdp_root_dir . '/app/server.js'
+     call health#report_info('Script: ' . l:mkdp_server_script)
+     call health#report_info('Script exists: ' . filereadable(l:mkdp_server_script))
+diff --git a/autoload/mkdp/nvim/rpc.vim b/autoload/mkdp/nvim/rpc.vim
+index 5abd807..db1067b 100644
+--- a/autoload/mkdp/nvim/rpc.vim
++++ b/autoload/mkdp/nvim/rpc.vim
+@@ -53,8 +53,8 @@ function! mkdp#nvim#rpc#get_command() abort
+   let l:pre_build = s:root_dir . '/app/bin/markdown-preview-' . mkdp#util#get_platform()
+   if executable(l:pre_build)
+     let l:cmd = [l:pre_build, '--path', s:script]
+-  elseif executable('node')
+-    let l:cmd = ['node', s:root_dir . '/app/index.js', '--path', s:script]
++  elseif executable('@node@')
++    let l:cmd = ['@node@', s:root_dir . '/app/index.js', '--path', s:script]
+   endif
+   if !exists('l:cmd')
+     echohl Error | echon '[vim-node-rpc] pre build and node not found!' | echohl None
+diff --git a/autoload/mkdp/rpc.vim b/autoload/mkdp/rpc.vim
+index a3361ec..d42f7a6 100644
+--- a/autoload/mkdp/rpc.vim
++++ b/autoload/mkdp/rpc.vim
+@@ -59,9 +59,9 @@ function! mkdp#rpc#start_server() abort
+   let l:mkdp_server_script = s:mkdp_root_dir . '/app/bin/markdown-preview-' . mkdp#util#get_platform()
+   if executable(l:mkdp_server_script)
+     let l:cmd = [l:mkdp_server_script, '--path', s:mkdp_root_dir . '/app/server.js']
+-  elseif executable('node')
++  elseif executable('@node@')
+     let l:mkdp_server_script = s:mkdp_root_dir . '/app/index.js'
+-    let l:cmd = ['node', l:mkdp_server_script, '--path', s:mkdp_root_dir . '/app/server.js']
++    let l:cmd = ['@node@', l:mkdp_server_script, '--path', s:mkdp_root_dir . '/app/server.js']
+   endif
+   if exists('l:cmd')
+     if s:is_vim

--- a/pkgs/misc/vim-plugins/markdown-preview-nvim/fix-node-paths.patch
+++ b/pkgs/misc/vim-plugins/markdown-preview-nvim/fix-node-paths.patch
@@ -8,7 +8,7 @@ index 9eebb56..0700333 100644
      call health#report_ok('Using pre build')
 -  elseif executable('node')
 -    call health#report_info('Node version: ' . system('node --version'))
-+  elseif executable('@node@')
++  else
 +    call health#report_info('Node version: ' . system('@node@ --version'))
      let l:mkdp_server_script = s:mkdp_root_dir . '/app/server.js'
      call health#report_info('Script: ' . l:mkdp_server_script)
@@ -23,7 +23,7 @@ index 5abd807..db1067b 100644
      let l:cmd = [l:pre_build, '--path', s:script]
 -  elseif executable('node')
 -    let l:cmd = ['node', s:root_dir . '/app/index.js', '--path', s:script]
-+  elseif executable('@node@')
++  else
 +    let l:cmd = ['@node@', s:root_dir . '/app/index.js', '--path', s:script]
    endif
    if !exists('l:cmd')
@@ -37,7 +37,7 @@ index a3361ec..d42f7a6 100644
    if executable(l:mkdp_server_script)
      let l:cmd = [l:mkdp_server_script, '--path', s:mkdp_root_dir . '/app/server.js']
 -  elseif executable('node')
-+  elseif executable('@node@')
++  else
      let l:mkdp_server_script = s:mkdp_root_dir . '/app/index.js'
 -    let l:cmd = ['node', l:mkdp_server_script, '--path', s:mkdp_root_dir . '/app/server.js']
 +    let l:cmd = ['@node@', l:mkdp_server_script, '--path', s:mkdp_root_dir . '/app/server.js']

--- a/pkgs/misc/vim-plugins/markdown-preview-nvim/package.json
+++ b/pkgs/misc/vim-plugins/markdown-preview-nvim/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "markdown-preview-vim",
+  "version": "0.0.1",
+  "description": "markdown preview plugin for (neo)vim",
+  "bin": "./index.js",
+  "repository": "https://github.com/iamcco/markdown-preview.vim.git",
+  "author": "年糕小豆汤 <ooiss@qq.com>",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "log4js": "3.0.6",
+    "neovim": "4.2.1",
+    "socket.io": "2.1.1",
+    "tslib": "1.9.3",
+    "vim-node-rpc": "0.1.24"
+  }
+}

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -36,6 +36,7 @@
 , which
 , xkb-switch
 , ycmd
+, nodejs
 
 # test dependencies
 , neovim-unwrapped
@@ -380,6 +381,30 @@ self: super: {
 
   lir-nvim = super.lir-nvim.overrideAttrs (old: {
     dependencies = with self; [ plenary-nvim ];
+  });
+
+  markdown-preview-nvim = super.markdown-preview-nvim.overrideAttrs (old: let
+    # We only need its dependencies `node-modules`.
+    nodeDep = nodePackages."markdown-preview-nvim-../../misc/vim-plugins/markdown-preview-nvim".overrideAttrs (old: {
+      dontNpmInstall = true;
+    });
+  in {
+    patches = [
+      (substituteAll {
+        src = ./markdown-preview-nvim/fix-node-paths.patch;
+        node = "${nodejs}/bin/node";
+      })
+    ];
+    postInstall = ''
+      # The node package name is `*-vim` not `*-nvim`.
+      ln -s ${nodeDep}/lib/node_modules/markdown-preview-vim/node_modules $out/app
+    '';
+
+    nativeBuildInputs = [ nodejs ];
+    doInstallCheck = true;
+    installCheckPhase = ''
+      node $out/app/index.js --version
+    '';
   });
 
   meson = buildVimPluginFrom2Nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #137239 and also add installCheck.
Tested to work with `vim` and `neovim`.

The `package.json` is from https://github.com/iamcco/markdown-preview.nvim/blob/master/app/package.json but I'm not sure how to keep it in sync when auto-update vim plugins. If we fetch the file in vim update script, we may also need to update (all) node packages if dependencies changed, which is quite costly. Also currently no vim plugins requires extra update script besides updating the repo.
Note: the `package.json` need to update only when its dependencies change, since it's only used for `node_modules`. Otherwise, it's fine to be out of sync with upstream.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
