### PR TITLE
haskell.packages.ghc921: use hashable_1_3_3_0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -58,7 +58,6 @@ self: super: {
   dec = doJailbreak super.dec;
   ed25519 = doJailbreak super.ed25519;
   hackage-security = doJailbreak super.hackage-security;
-  hashable = overrideCabal (doJailbreak (dontCheck super.hashable)) (drv: { postPatch = "sed -i -e 's,integer-gmp .*<1.1,integer-gmp < 2,' hashable.cabal"; });
   hashable-time = doJailbreak super.hashable-time;
   HTTP = overrideCabal (doJailbreak super.HTTP) (drv: { postPatch = "sed -i -e 's,! Socket,!Socket,' Network/TCP.hs"; });
   integer-logarithms = overrideCabal (doJailbreak super.integer-logarithms) (drv: { postPatch = "sed -i -e 's,integer-gmp <1.1,integer-gmp < 2,' integer-logarithms.cabal"; });
@@ -87,7 +86,11 @@ self: super: {
     sha256 = "0rgzrq0513nlc1vw7nw4km4bcwn4ivxcgi33jly4a7n3c1r32v1f";
   });
 
-  # The test suite depends on ChasingBottoms, which is broken with ghc-9.0.x.
+  # 1.3.0 (on stackage) defines instances for the Option-type, which has been removed from base in GHC 9.2.x
+  # Tests fail because random hasn't been updated for GHC 9.2.x
+  hashable = dontCheck super.hashable_1_3_3_0;
+
+  # Tests fail because random hasn't been updated for GHC 9.2.x
   unordered-containers = dontCheck super.unordered-containers;
 
   # The test suite seems pretty broken.


### PR DESCRIPTION
###### Motivation for this change
hashable 1.3.0 (the current stackage version) is broken on GHC 9.2.1 because it defines an instance for `Option`, which has been removed from base. hashable_1_3_3_0 (already available in nixpkgs) includes a fix.

Tests are still broken because `random` (required by `QuickCheck`) has not yet been updated for GHC 9.2.1.

With this change it is possible to build `unordered-containers` (tests also won't compile because of `random`).


@cdepillabout I was motivated by your [comment](https://github.com/NixOS/nixpkgs/pull/137334#issuecomment-917317946) to fix this :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
