### PR TITLE
rar: init at 6.0.2

### DIFF
--- a/pkgs/tools/archivers/rar/default.nix
+++ b/pkgs/tools/archivers/rar/default.nix
@@ -1,0 +1,55 @@
+{ lib, stdenv, fetchurl, autoPatchelfHook, installShellFiles }:
+
+let
+  version = "6.0.2";
+  # TODO: add support for macOS
+  srcUrl =
+    if stdenv.isi686 then {
+      url = "https://www.rarlab.com/rar/rarlinux-${version}.tar.gz";
+      sha256 = "sha256-5iqK7eOo+hgLtGSCqUoB+wOFZHUqZ0M/8Jf7bxdf9qA=";
+    } else if stdenv.isx86_64 then {
+      url = "https://www.rarlab.com/rar/rarlinux-x64-${version}.tar.gz";
+      sha256 = "sha256-WAvrUGCgfwI51Mo/RYSSF0OLPPrTegUCuDEsnBeR9uQ=";
+    }
+    else throw "Unknown architecture";
+  manSrc = fetchurl {
+    url = "https://aur.archlinux.org/cgit/aur.git/plain/rar.1?h=rar&id=8e39a12e88d8a3b168c496c44c18d443c876dd10";
+    name = "rar.1";
+    sha256 = "sha256-93cSr9oAsi+xHUtMsUvICyHJe66vAImS2tLie7nt8Uw=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "rar";
+  inherit version;
+
+  src = fetchurl srcUrl;
+
+  dontBuild = true;
+
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  nativeBuildInputs = [ autoPatchelfHook installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 {rar,unrar} -t "$out/bin"
+    install -Dm755 default.sfx -t "$out/lib"
+    install -Dm644 {acknow.txt,license.txt} -t "$out/share/doc/rar"
+    install -Dm644 rarfiles.lst -t "$out/etc"
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installManPage ${manSrc}
+  '';
+
+  meta = with lib; {
+    description = "Utility for RAR archives";
+    homepage = "https://www.rarlab.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ thiagokokada ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8630,6 +8630,8 @@ with pkgs;
 
   ranger = callPackage ../applications/misc/ranger { };
 
+  rar = callPackage ../tools/archivers/rar { };
+
   rarcrack = callPackage ../tools/security/rarcrack { };
 
   rarian = callPackage ../development/libraries/rarian { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There is already `unrar` and `unar` for decompress RAR files, however there were no options if you need to **compress** RAR files.

This PR adds `rar`, allowing compressing of RAR files.

Based on: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=rar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
