### PR TITLE
fluxbox: fix build on gcc-11 (c++17 compat)

### DIFF
--- a/pkgs/applications/window-managers/fluxbox/default.nix
+++ b/pkgs/applications/window-managers/fluxbox/default.nix
@@ -15,6 +15,15 @@ stdenv.mkDerivation rec {
     sha256 = "1h1f70y40qd225dqx937vzb4k2cz219agm1zvnjxakn5jkz7b37w";
   };
 
+  patches = [
+    # Upstream fix to build against gcc-11.
+    (fetchurl {
+      name = "gcc-11.patch";
+      url = "http://git.fluxbox.org/fluxbox.git/patch/?id=22866c4d30f5b289c429c5ca88d800200db4fc4f";
+      sha256 = "1x7126rlmzky51lk370fczssgnjs7i6wgfaikfib9pvn4vv945ai";
+    })
+  ];
+
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ freetype fribidi libXext libXft libXpm libXrandr libXrender xorgproto libXinerama imlib2 ];


### PR DESCRIPTION
On gcc-11 build fails as:

    $ nix-build -E 'with import ./. { }; fluxbox.override { stdenv = gcc11Stdenv; }'

    util/fluxbox-remote.cc: In function 'int main(int, char**)':
    util/fluxbox-remote.cc:76:32:
      error: ordered comparison of pointer with integer zero ('unsigned char*' and 'int')
       76 |             && text_prop.value > 0
          |                ~~~~~~~~~~~~~~~~^~~

The change pull upstream fix.