### PR TITLE
blanket: init at 0.5.0

### DIFF
--- a/pkgs/applications/audio/blanket/default.nix
+++ b/pkgs/applications/audio/blanket/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+, desktop-file-utils
+, appstream-glib
+, python3Packages
+, glib
+, gtk3
+, libhandy
+, gobject-introspection
+, gst_all_1
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "blanket";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "rafaelmardojai";
+    repo = "blanket";
+    rev = version;
+    sha256 = "00i821zqfbigxmc709322r16z75qsw4rg23yhv35gza9sl65bzkg";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+    desktop-file-utils
+    appstream-glib
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libhandy
+    gobject-introspection
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+  ];
+
+  # Broken with gobject-introspection setup hook
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+  format = "other";
+
+  postPatch = ''
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/rafaelmardojai/blanket";
+    description = "Listen to different sounds";
+    maintainers = with maintainers; [ onny ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1325,6 +1325,8 @@ with pkgs;
 
   bitwise = callPackage ../tools/misc/bitwise { };
 
+  blanket = callPackage ../applications/audio/blanket { };
+
   brakeman = callPackage ../development/tools/analysis/brakeman { };
 
   brewtarget = libsForQt514.callPackage ../applications/misc/brewtarget { } ;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/102650 . Adds package for Gnome app [Blanket](https://github.com/rafaelmardojai/blanket). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
