### PR TITLE
systemd: add missing TPM2 build dependencies

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -429,6 +429,7 @@ in
   systemd-binfmt = handleTestOn ["x86_64-linux"] ./systemd-binfmt.nix {};
   systemd-boot = handleTest ./systemd-boot.nix {};
   systemd-confinement = handleTest ./systemd-confinement.nix {};
+  systemd-cryptenroll = handleTest ./systemd-cryptenroll.nix {};
   systemd-journal = handleTest ./systemd-journal.nix {};
   systemd-networkd = handleTest ./systemd-networkd.nix {};
   systemd-networkd-dhcpserver = handleTest ./systemd-networkd-dhcpserver.nix {};

--- a/nixos/tests/systemd-cryptenroll.nix
+++ b/nixos/tests/systemd-cryptenroll.nix
@@ -1,0 +1,55 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "systemd-cryptenroll";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ ymatsiuk ];
+  };
+
+  machine = { pkgs, lib, ... }: {
+    environment.systemPackages = [ pkgs.cryptsetup ];
+    virtualisation = {
+      emptyDiskImages = [ 512 ];
+      memorySize = 1024;
+      qemu.options = [
+        "-chardev socket,id=chrtpm,path=/tmp/swtpm-sock"
+        "-tpmdev emulator,id=tpm0,chardev=chrtpm"
+        "-device tpm-tis,tpmdev=tpm0"
+      ];
+    };
+  };
+
+  testScript = ''
+    import subprocess
+    import tempfile
+
+    def start_swtpm(tpmstate):
+        subprocess.Popen(["${pkgs.swtpm}/bin/swtpm", "socket", "--tpmstate", "dir="+tpmstate, "--ctrl", "type=unixio,path=/tmp/swtpm-sock", "--log", "level=0", "--tpm2"])
+
+    with tempfile.TemporaryDirectory() as tpmstate:
+        start_swtpm(tpmstate)
+        machine.start()
+
+        # Verify the TPM device is available and accessible by systemd-cryptenroll
+        machine.succeed("test -e /dev/tpm0")
+        machine.succeed("test -e /dev/tpmrm0")
+        machine.succeed("systemd-cryptenroll --tpm2-device=list")
+
+        # Create LUKS partition
+        machine.succeed("echo -n lukspass | cryptsetup luksFormat -q /dev/vdb -")
+        # Enroll new LUKS key and bind it to Secure Boot state
+        # For more details on PASSWORD variable, check the following issue:
+        # https://github.com/systemd/systemd/issues/20955
+        machine.succeed("PASSWORD=lukspass systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7 /dev/vdb")
+        # Add LUKS partition to /etc/crypttab to test auto unlock
+        machine.succeed("echo 'luks /dev/vdb - tpm2-device=auto' >> /etc/crypttab")
+        machine.shutdown()
+
+        start_swtpm(tpmstate)
+        machine.start()
+
+        # Test LUKS partition automatic unlock on boot
+        machine.wait_for_unit("systemd-cryptsetup@luks.service")
+        # Wipe TPM2 slot
+        machine.succeed("systemd-cryptenroll --wipe-slot=tpm2 /dev/vdb")
+  '';
+})
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
before:
```
result/bin/systemd-cryptenroll --tpm2-device=list
TPM2 not supported on this build.
```
after:
```
result/bin/systemd-cryptenroll --tpm2-device=list
PATH        DEVICE     DRIVER
/dev/tpmrm0 STM0125:00 tpm_tis
```

Fixes #139433.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
