### PR TITLE
ubootRaspberryPi4: backport fix for C0 revisions

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -109,6 +109,15 @@ let
     } // extraMeta;
   } // removeAttrs args [ "extraMeta" ]);
 
+  # Make U-Boot forward some important settings from the firmware-provided FDT. Fixes booting on BCM2711C0 boards.
+  # See also: https://github.com/NixOS/nixpkgs/issues/135828
+  # Source: https://patchwork.ozlabs.org/project/uboot/patch/20210822143656.289891-1-sjoerd@collabora.com/
+  pi4ExtraPatches = [
+    (fetchpatch {
+      url = "https://patchwork.ozlabs.org/series/259129/mbox/";
+      sha256 = "04x55a62a5p4mv0ddpx7dnsh5pnx46vibnq8cry7hgwf4krl64gl";
+    })
+  ];
 in {
   inherit buildUBoot;
 
@@ -355,12 +364,14 @@ in {
   ubootRaspberryPi4_32bit = buildUBoot {
     defconfig = "rpi_4_32b_defconfig";
     extraMeta.platforms = ["armv7l-linux"];
+    extraPatches = pi4ExtraPatches;
     filesToInstall = ["u-boot.bin"];
   };
 
   ubootRaspberryPi4_64bit = buildUBoot {
     defconfig = "rpi_4_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
+    extraPatches = pi4ExtraPatches;
     filesToInstall = ["u-boot.bin"];
   };
 


### PR DESCRIPTION
Backport a (yet unmerged) patch that allows NixOS to boot correctly on new Pi4 boards using the BCM2711C0 SoC. Revert this when the patch is available in mainline U-Boot.

A precompiled binary is available here: https://static.0upti.me/pi4/ if anyone wants to test - just drop it into your firmware partition.

To easily reproduce the build locally, use this Nix expression:

```nix
{ pkgs ? import <nixpkgs> { } }:
pkgs.ubootRaspberryPi4_64bit.overrideAttrs (old: {
  patches = old.patches ++ [
    (pkgs.fetchpatch {
      url = "https://patchwork.ozlabs.org/series/259129/mbox/";
      sha256 = "04x55a62a5p4mv0ddpx7dnsh5pnx46vibnq8cry7hgwf4krl64gl";
    })
  ];
})
```

(save it to `uboot.nix`, then `nix-build uboot.nix`, the final binary will be in `result/`, drop it into the firmware partition and rename to `u-boot-rpi4.bin`)

**NB**: to cross-compile from a desktop, use `pkgs.pkgsCross.aarch64-multiplatform.ubootRaspberryPi4_64bit` instead of `pkgs.ubootRaspberryPi4_64bit`.

###### Motivation for this change
See #135828 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).