### PR TITLE
dnstake: init at 0.0.2

### DIFF
--- a/pkgs/tools/networking/dnstake/default.nix
+++ b/pkgs/tools/networking/dnstake/default.nix
@@ -16,7 +16,6 @@ buildGoModule rec {
 
   vendorSha256 = "1xhzalx1x8js449w1qs2qdwbnz2s8mmypz9maj7jzl5mqfyhlwlp";
 
-
   meta = with lib; {
     description = "Tool to check missing hosted DNS zones";
     homepage = "https://github.com/pwnesia/dnstake";

--- a/pkgs/tools/networking/dnstake/default.nix
+++ b/pkgs/tools/networking/dnstake/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "dnstake";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "pwnesia";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0mjwnb0zyqnwk26f32v9vqxc9k6zcks9nn1595mf2hck5xwn86yk";
+  };
+
+  vendorSha256 = "1xhzalx1x8js449w1qs2qdwbnz2s8mmypz9maj7jzl5mqfyhlwlp";
+
+
+  meta = with lib; {
+    description = "Tool to check missing hosted DNS zones";
+    homepage = "https://github.com/pwnesia/dnstake";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32726,6 +32726,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };
 
+  dnstake = callPackage ../tools/networking/dnstake {};
+
   dnstracer = callPackage ../tools/networking/dnstracer {
     inherit (darwin) libresolv;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to check missing hosted DNS zones

https://github.com/pwnesia/dnstake

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
