### PR TITLE
Submit/fix vega lite

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -387,18 +387,20 @@ let
     };
 
     vega-lite = super.vega-lite.override {
-        # npx tries to install vega from scratch at vegalite runtime if it
-        # can't find it. We thus replace it with a direct call to the nix
-        # derivation. This might not be necessary anymore in future vl
-        # versions: https://github.com/vega/vega-lite/issues/6863.
         postInstall = ''
-          substituteInPlace $out/lib/node_modules/vega-lite/bin/vl2pdf \
-            --replace "npx -p vega vg2pdf"  "${self.vega-cli}/bin/vg2pdf"
-          substituteInPlace $out/lib/node_modules/vega-lite/bin/vl2svg \
-            --replace "npx -p vega vg2svg"  "${self.vega-cli}/bin/vg2svg"
-          substituteInPlace $out/lib/node_modules/vega-lite/bin/vl2png \
-            --replace "npx -p vega vg2png"  "${self.vega-cli}/bin/vg2png"
+          cd node_modules
+          vega_dependencies=$(ls ${self.vega-cli}/lib/node_modules/vega-cli/node_modules)
+          for dep in $vega_dependencies; do
+            if [[ ! -d $dep ]]; then
+              ln -s "${self.vega-cli}/lib/node_modules/vega-cli/node_modules/$dep"
+            fi
+          done
         '';
+        passthru.tests = {
+          simple-execution = pkgs.callPackage ./package-tests/vega-lite.nix {
+            inherit (self) vega-lite;
+          };
+        };
     };
 
     webtorrent-cli = super.webtorrent-cli.override {

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -389,8 +389,7 @@ let
     vega-lite = super.vega-lite.override {
         postInstall = ''
           cd node_modules
-          vega_dependencies=$(ls ${self.vega-cli}/lib/node_modules/vega-cli/node_modules)
-          for dep in $vega_dependencies; do
+          for dep in ${self.vega-cli}/lib/node_modules/vega-cli/node_modules/*; do
             if [[ ! -d $dep ]]; then
               ln -s "${self.vega-cli}/lib/node_modules/vega-cli/node_modules/$dep"
             fi

--- a/pkgs/development/node-packages/package-tests/vega-lite.nix
+++ b/pkgs/development/node-packages/package-tests/vega-lite.nix
@@ -1,0 +1,24 @@
+{ runCommand, vega-lite }:
+
+let
+  inherit (vega-lite) packageName version;
+in
+
+runCommand "${packageName}-tests" { meta.timeout = 60; }
+  ''
+    # get version of installed program and compare with package version
+    claimed_version="$(${vega-lite}/bin/vl2vg --version)"
+    if [[ "$claimed_version" != "${version}" ]]; then
+      echo "Error: program version does not match package version ($claimed_version != ${version})"
+      exit 1
+    fi
+
+    # run dummy commands
+    ${vega-lite}/bin/vl2vg --help > /dev/null
+    ${vega-lite}/bin/vl2svg --help > /dev/null
+    ${vega-lite}/bin/vl2png --help > /dev/null
+    ${vega-lite}/bin/vl2pdf --help > /dev/null
+
+    # needed for Nix to register the command as successful
+    touch $out
+  ''


### PR DESCRIPTION
###### Motivation for this change
vega-lite binaries were not able to run, because they could not find the vega dependency. This change fixes this and adds a test to assure future changes will provide running executables.

###### Things done

- Built on platform(s)
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
