### PR TITLE
python3Packages.python-engineio: 4.2.0 -> 4.2.1, python3Packages.python-socketio: 5.3.0 -> 5.4.0

### DIFF
--- a/pkgs/development/python-modules/python-engineio/default.nix
+++ b/pkgs/development/python-modules/python-engineio/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "python-engineio";
-  version = "4.2.0";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "miguelgrinberg";
     repo = "python-engineio";
     rev = "v${version}";
-    sha256 = "sha256-QfX8Volz5nabGVhQLXfSD/QooxLsU6DvCq1WRkRZ6hU=";
+    sha256 = "sha256-aAoTeQZCtxddVBPwlyv2j4aACMO9p0vQ/ESkkv4E3VE=";
   };
 
   checkInputs = [

--- a/pkgs/development/python-modules/python-socketio/default.nix
+++ b/pkgs/development/python-modules/python-socketio/default.nix
@@ -3,19 +3,20 @@
 , buildPythonPackage
 , fetchFromGitHub
 , mock
+, msgpack
 , pytestCheckHook
 , python-engineio
 }:
 
 buildPythonPackage rec {
   pname = "python-socketio";
-  version = "5.3.0";
+  version = "5.4.0";
 
   src = fetchFromGitHub {
     owner = "miguelgrinberg";
     repo = "python-socketio";
     rev = "v${version}";
-    sha256 = "sha256-jyTTWxShLDDnbT+MYIJIjwpn3xfIB04je78doIOG+FQ=";
+    sha256 = "sha256-0Q1R8XPciU5AEkj7Exlc906eyA5juYKzzA/Ygnzx7XU=";
   };
 
   propagatedBuildInputs = [
@@ -25,6 +26,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     mock
+    msgpack
     pytestCheckHook
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream releases

Change log:
- https://github.com/miguelgrinberg/python-socketio/blob/main/CHANGES.md
- https://github.com/miguelgrinberg/python-engineio/blob/main/CHANGES.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
