### PR TITLE
rustcat: init at 1.3.0

### DIFF
--- a/pkgs/tools/networking/rustcat/default.nix
+++ b/pkgs/tools/networking/rustcat/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rustcat";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "robiot";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0f4g0fk3i9p403r21w1cdz4r9778pkz58y8h7w2fmj27bamsyfhb";
+  };
+
+  cargoSha256 = "0zlgnnlnglix0qrjc5v0g91v083lm20iw1fhvjpvjlfq7shdkhyd";
+
+  buildInputs = lib.optional stdenv.isDarwin Security;
+
+  meta = with lib; {
+    description = "Port listener and reverse shell";
+    homepage = "https://github.com/robiot/rustcat";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8869,6 +8869,10 @@ with pkgs;
 
   rust-petname = callPackage ../tools/text/rust-petname { };
 
+  rustcat = callPackage ../tools/networking/rustcat {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   rustscan = callPackage ../tools/security/rustscan {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Rustcat is a modern port listener & Reverse Shell that is very easy to use.

https://github.com/robiot/rustcat

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
