### PR TITLE
neofetch: apply patch to fix neofetch returning wrong icon theme

### DIFF
--- a/pkgs/tools/misc/neofetch/default.nix
+++ b/pkgs/tools/misc/neofetch/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenvNoCC, fetchFromGitHub, bash, makeWrapper, pciutils
-, x11Support ? true, ueberzug
+, x11Support ? true, ueberzug, fetchpatch
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -12,6 +12,14 @@ stdenvNoCC.mkDerivation rec {
     rev = "6dd85d67fc0d4ede9248f2df31b2cd554cca6c2f";
     sha256 = "sha256-PZjFF/K7bvPIjGVoGqaoR8pWE6Di/qJVKFNcIz7G8xE=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/dylanaraps/neofetch/commit/413c32e55dc16f0360f8e84af2b59fe45505f81b.patch";
+      sha256 = "1fapdg9z79f0j3vw7fgi72b54aw4brn42bjsj48brbvg3ixsciph";
+      name = "avoid_overwriting_gio_extra_modules_env_var.patch";
+    })
+  ];
 
   strictDeps = true;
   buildInputs = [ bash ];


### PR DESCRIPTION
###### Motivation for this change

Fixes issue #108903.

Since upstream hasn't merged the open dylanaraps/neofetch#1873 I've added a patch that fixes the mentioned issue.

cc: @lilyinstarlight 

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
