### PR TITLE
scorecard: 2.1.3 -> 2.2.8

### DIFF
--- a/pkgs/tools/security/scorecard/default.nix
+++ b/pkgs/tools/security/scorecard/default.nix
@@ -2,22 +2,27 @@
 
 buildGoModule rec {
   pname = "scorecard";
-  version = "2.1.3";
+  version = "2.2.8";
 
   src = fetchFromGitHub {
     owner = "ossf";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-lTaFSQ3yyzQGdiKwev38iEpV+ELKg9f1rMYdbqVuiSs=";
+    sha256 = "sha256-U29NCZFXOhu0xLfDlJ1Q7m8TbAm+C6+ecYFhcI5gg6s=";
   };
-  vendorSha256 = "sha256-eFu954gwoL5z99cJGhSnvliAzwxv3JJxfjmBF+cx7Dg=";
-
-  subPackages = [ "." ];
-
-  ldflags = [ "-s" "-w" "-X github.com/ossf/scorecard/v2/cmd.gitVersion=v${version}" ];
+  vendorSha256 = "sha256-hOATCXjBE0doHnY2BaRKZocQ6SIigL0q4m9eEJGKh6Q=";
 
   # Install completions post-install
   nativeBuildInputs = [ installShellFiles ];
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/ossf/scorecard/v2/pkg.gitVersion=v${version}"
+    "-X github.com/ossf/scorecard/v2/pkg.gitTreeState=clean"
+  ];
 
   preCheck = ''
     # Feed in all but the e2e tests for testing


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump scorecard to `2.2.8`

Had to fix the ldflags version injection path since it moved
Added some of the new ones

Note: Next version will also want `SOURCE_DATE_EPOCH` after a move towards reproducability

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
