### PR TITLE
ioccheck: init at unstable-2021-09-29

### DIFF
--- a/pkgs/development/python-modules/vt-py/default.nix
+++ b/pkgs/development/python-modules/vt-py/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytest-httpserver
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "vt-py";
+  version = "0.7.4";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "VirusTotal";
+    repo = pname;
+    rev = version;
+    sha256 = "149fgrqnwf8nyv3msj6p614zbdi7m7s785y3fvh8fm8k7lmgqk8w";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-httpserver
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'" ""
+  '';
+
+  pythonImportsCheck = [ "vt" ];
+
+  meta = with lib; {
+    description = "Python client library for VirusTotal";
+    homepage = "https://virustotal.github.io/vt-py/";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/ioccheck/default.nix
+++ b/pkgs/tools/security/ioccheck/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "ioccheck";
+  version = "unstable-2021-09-29";
+  format = "pyproject";
+
+  disabled = python3.pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ranguli";
+    repo = pname;
+    rev = "db02d921e2519b77523a200ca2d78417802463db";
+    sha256 = "0lgqypcd5lzb2yqd5lr02pba24m26ghly4immxgz13svi8f6vzm9";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    backoff
+    click
+    emoji
+    jinja2
+    pyfiglet
+    ratelimit
+    requests
+    shodan
+    tabulate
+    termcolor
+    tweepy
+    vt-py
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # Can be removed with the next release
+    substituteInPlace pyproject.toml \
+      --replace '"hurry.filesize" = "^0.9"' ""
+  '';
+
+  pythonImportsCheck = [ "ioccheck" ];
+
+  meta = with lib; {
+    description = "Tool for researching IOCs";
+    homepage = "https://github.com/ranguli/ioccheck";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6234,6 +6234,8 @@ with pkgs;
 
   iodine = callPackage ../tools/networking/iodine { };
 
+  ioccheck = callPackage ../tools/security/ioccheck { };
+
   ioping = callPackage ../tools/system/ioping { };
 
   iops = callPackage ../tools/system/iops { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9477,6 +9477,8 @@ in {
 
   vsure = callPackage ../development/python-modules/vsure { };
 
+  vt-py = callPackage ../development/python-modules/vt-py { };
+
   vtk = toPythonModule (pkgs.vtk.override {
     pythonInterpreter = python;
     enablePython = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool for researching IOCs

https://github.com/ranguli/ioccheck

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
