### PR TITLE
lispPackages.hunchensocket: init at 20180711-git

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/hunchensocket.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/hunchensocket.nix
@@ -1,0 +1,48 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "hunchensocket";
+  version = "20180711-git";
+
+  parasites = [ "hunchensocket-tests" ];
+
+  description = "WebSockets for Hunchentoot";
+
+  deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."chunga" args."cl_plus_ssl" args."cl-base64" args."cl-fad" args."cl-ppcre" args."fiasco" args."flexi-streams" args."hunchentoot" args."ironclad" args."md5" args."rfc2388" args."split-sequence" args."trivial-backtrace" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."trivial-utf-8" args."usocket" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/hunchensocket/2018-07-11/hunchensocket-20180711-git.tgz";
+    sha256 = "03igrp8svb4gkwhhhgmxwrnp5vq5ndp15mxqsafyi065xj3ppw48";
+  };
+
+  packageName = "hunchensocket";
+
+  asdFilesToKeep = ["hunchensocket.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM hunchensocket DESCRIPTION WebSockets for Hunchentoot SHA256
+    03igrp8svb4gkwhhhgmxwrnp5vq5ndp15mxqsafyi065xj3ppw48 URL
+    http://beta.quicklisp.org/archive/hunchensocket/2018-07-11/hunchensocket-20180711-git.tgz
+    MD5 bf6cd52c13e3b1f464c8a45a8bac85b8 NAME hunchensocket FILENAME
+    hunchensocket DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi) (NAME chunga FILENAME chunga)
+     (NAME cl+ssl FILENAME cl_plus_ssl) (NAME cl-base64 FILENAME cl-base64)
+     (NAME cl-fad FILENAME cl-fad) (NAME cl-ppcre FILENAME cl-ppcre)
+     (NAME fiasco FILENAME fiasco) (NAME flexi-streams FILENAME flexi-streams)
+     (NAME hunchentoot FILENAME hunchentoot) (NAME ironclad FILENAME ironclad)
+     (NAME md5 FILENAME md5) (NAME rfc2388 FILENAME rfc2388)
+     (NAME split-sequence FILENAME split-sequence)
+     (NAME trivial-backtrace FILENAME trivial-backtrace)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams)
+     (NAME trivial-utf-8 FILENAME trivial-utf-8)
+     (NAME usocket FILENAME usocket))
+    DEPENDENCIES
+    (alexandria babel bordeaux-threads cffi chunga cl+ssl cl-base64 cl-fad
+     cl-ppcre fiasco flexi-streams hunchentoot ironclad md5 rfc2388
+     split-sequence trivial-backtrace trivial-features trivial-garbage
+     trivial-gray-streams trivial-utf-8 usocket)
+    VERSION 20180711-git SIBLINGS NIL PARASITES (hunchensocket-tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -128,6 +128,7 @@ gettext
 http-body
 hu.dwim.asdf
 hu.dwim.defclass-star
+hunchensocket
 hunchentoot
 idna
 ieee-floats

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -2523,6 +2523,36 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "hunchensocket" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."hunchensocket" or (x: {}))
+       (import ./quicklisp-to-nix-output/hunchensocket.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "chunga" = quicklisp-to-nix-packages."chunga";
+           "cl_plus_ssl" = quicklisp-to-nix-packages."cl_plus_ssl";
+           "cl-base64" = quicklisp-to-nix-packages."cl-base64";
+           "cl-fad" = quicklisp-to-nix-packages."cl-fad";
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "fiasco" = quicklisp-to-nix-packages."fiasco";
+           "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
+           "hunchentoot" = quicklisp-to-nix-packages."hunchentoot";
+           "ironclad" = quicklisp-to-nix-packages."ironclad";
+           "md5" = quicklisp-to-nix-packages."md5";
+           "rfc2388" = quicklisp-to-nix-packages."rfc2388";
+           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
+           "trivial-backtrace" = quicklisp-to-nix-packages."trivial-backtrace";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
+           "trivial-utf-8" = quicklisp-to-nix-packages."trivial-utf-8";
+           "usocket" = quicklisp-to-nix-packages."usocket";
+       }));
+
+
   "hu_dot_dwim_dot_defclass-star" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."hu_dot_dwim_dot_defclass-star" or (x: {}))


### PR DESCRIPTION
###### Motivation for this change


###### Things done

I just edited the txt file and run the update script.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).