### PR TITLE
python3Packages.testfixtures: 6.18.1 -> 6.18.3

### DIFF
--- a/pkgs/development/python-modules/testfixtures/default.nix
+++ b/pkgs/development/python-modules/testfixtures/default.nix
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "testfixtures";
-  version = "6.18.1";
+  version = "6.18.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-CmQic39tibRc3vHi31V29SrQ9QeVYALOECDaqfRCEdY=";
+    sha256 = "sha256-JgAQCulv/QgjNLN441VVD++LSlKab6TDT0cTCQXHQm0=";
   };
 
   checkInputs = [

--- a/pkgs/development/python-modules/werkzeug/1.nix
+++ b/pkgs/development/python-modules/werkzeug/1.nix
@@ -39,6 +39,7 @@ buildPythonPackage rec {
     # E     return Headers(result)
     # E ResourceWarning: unclosed file <_io.FileIO name=11 mode='rb+' closefd=True>
     "TestMultiPart"
+    "TestHTTPUtility"
   ] ++ lib.optionals stdenv.isDarwin [
     "test_get_machine_id"
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 6.18.3

CHange log: https://github.com/simplistix/testfixtures/blob/master/CHANGELOG.rst#6183-29-sep-2021

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
