### PR TITLE
nixos/tests: fix for memorySize being an integer

### DIFF
--- a/nixos/tests/custom-ca.nix
+++ b/nixos/tests/custom-ca.nix
@@ -82,7 +82,7 @@ in
       # chromium-based browsers refuse to run as root
       test-support.displayManager.auto.user = "alice";
       # browsers may hang with the default memory
-      virtualisation.memorySize = "500";
+      virtualisation.memorySize = 500;
 
       networking.hosts."127.0.0.1" = [ "good.example.com" "bad.example.com" ];
       security.pki.certificateFiles = [ "${example-good-cert}/ca.crt" ];

--- a/nixos/tests/custom-ca.nix
+++ b/nixos/tests/custom-ca.nix
@@ -113,7 +113,7 @@ in
         # which is why it will not use the system certificate store for the time being.
         # firefox
         chromium
-        falkon
+        qutebrowser
         midori
       ];
     };
@@ -152,21 +152,21 @@ in
     with subtest("Unknown CA is untrusted in curl"):
         machine.fail("curl -fv https://bad.example.com")
 
-    browsers = [
+    browsers = {
       # Firefox was disabled here, because we needed to disable p11-kit support in nss,
       # which is why it will not use the system certificate store for the time being.
-      # "firefox",
-      "chromium",
-      "falkon",
-      "midori"
-    ]
-    errors = ["Security Risk", "not private", "Certificate Error", "Security"]
+      #"firefox": "Security Risk",
+      "chromium": "not private",
+      "qutebrowser -T": "Certificate error",
+      "midori": "Security"
+    }
 
     machine.wait_for_x()
-    for browser, error in zip(browsers, errors):
+    for command, error in browsers.items():
+        browser = command.split()[0]
         with subtest("Good certificate is trusted in " + browser):
             execute_as(
-                "alice", f"env P11_KIT_DEBUG=trust {browser} https://good.example.com & >&2"
+                "alice", f"env P11_KIT_DEBUG=trust {command} https://good.example.com & >&2"
             )
             wait_for_window_as("alice", browser)
             machine.wait_for_text("It works!")
@@ -174,7 +174,7 @@ in
             execute_as("alice", "xdotool key ctrl+w")  # close tab
 
         with subtest("Unknown CA is untrusted in " + browser):
-            execute_as("alice", f"{browser} https://bad.example.com & >&2")
+            execute_as("alice", f"{command} https://bad.example.com & >&2")
             machine.wait_for_text(error)
             machine.screenshot("bad" + browser)
             machine.succeed("pkill " + browser)

--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -14,7 +14,7 @@ import ./make-test-python.nix ({ pkgs, firefoxPackage, ... }: {
       ];
 
       # Need some more memory to record audio.
-      virtualisation.memorySize = "500";
+      virtualisation.memorySize = 500;
 
       # Create a virtual sound device, with mixing
       # and all, for recording audio.


### PR DESCRIPTION
###### Motivation for this change

Fix the tests after https://github.com/NixOS/nixpkgs/pull/127933

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via `nixosTests.firefox` `nixosTests.custom-ca`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
