### PR TITLE
img: init 0.5.11

### DIFF
--- a/pkgs/development/tools/img/default.nix
+++ b/pkgs/development/tools/img/default.nix
@@ -1,0 +1,55 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, makeWrapper
+, runc
+, wrapperDir ? "/run/wrappers/bin" # Default for NixOS, other systems might need customization.
+}:
+
+buildGoModule rec {
+  pname = "img";
+  version = "0.5.11";
+
+  src = fetchFromGitHub {
+    owner = "genuinetools";
+    repo = "img";
+    rev = "v${version}";
+    sha256 = "0r5hihzp2679ki9hr3p0f085rafy2hc8kpkdhnd4m5k4iibqib08";
+  };
+
+  vendorSha256 = null;
+
+  postPatch = ''
+    V={newgidmap,newgidmap} \
+      substituteInPlace ./internal/unshare/unshare.c \
+        --replace "/usr/bin/$V" "${wrapperDir}/$V"
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  tags = [
+    "seccomp"
+    "noembed" # disables embedded `runc`
+  ];
+
+  ldflags = [
+    "-X github.com/genuinetools/img/version.VERSION=v${version}"
+    "-s -w"
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/img" --prefix PATH : ${lib.makeBinPath [ runc ]}
+  '';
+
+  # Tests fail as: internal/binutils/install.go:57:15: undefined: Asset
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Standalone, daemon-less, unprivileged Dockerfile and OCI compatible container image builder. ";
+    license = licenses.mit;
+    homepage = "https://github.com/genuinetools/img";
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14245,6 +14245,8 @@ with pkgs;
     inherit (llvmPackages_9) stdenv clang llvm;
   };
 
+  img = callPackage ../development/tools/img { };
+
   include-what-you-use = callPackage ../development/tools/analysis/include-what-you-use {
     llvmPackages = llvmPackages_12;
   };


### PR DESCRIPTION
img: init 0.5.11

Co-authored-by: @jnetod @thiagokokada

* Tests are failing: `undefined: Asset`
  * Will tests need to be wrapped for runc (as install did)?