### PR TITLE
psi-notify: move systemd unit to $out/lib

### DIFF
--- a/pkgs/applications/misc/psi-notify/default.nix
+++ b/pkgs/applications/misc/psi-notify/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
     install -D psi-notify $out/bin/psi-notify
     substituteInPlace psi-notify.service --replace psi-notify $out/bin/psi-notify
-    install -D psi-notify.service $out/share/systemd/user/psi-notify.service
+    install -D psi-notify.service $out/lib/systemd/user/psi-notify.service
 
     runHook postInstall
   '';


### PR DESCRIPTION
In `$out/share` it is NOT picked up into `/etc/systemd/...` when psi-notify is
added to `configuration.systemd.packages` .

(Originally put in `$out/share` b/c a hook copies from `$out/lib` into there
... so why not just put there in the first place? This is why.)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See above.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
