### PR TITLE
rambox: 0.7.8 -> 0.7.9

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -1,19 +1,20 @@
 { stdenv, callPackage, fetchurl, lib }:
 
 let
-  mkRambox = opts: callPackage (import ./rambox.nix opts) { };
-in mkRambox rec {
+  mkRambox = opts: callPackage (import ./rambox.nix opts) {};
+in
+mkRambox rec {
   pname = "rambox";
-  version = "0.7.8";
+  version = "0.7.9";
 
   src = {
     x86_64-linux = fetchurl {
       url = "https://github.com/ramboxapp/community-edition/releases/download/${version}/Rambox-${version}-linux-x86_64.AppImage";
-      sha256 = "1y3c9xh8594ay95rj9vaqxxzibwpc38n7ixxi2wnsrdbrqrwlc63";
+      sha256 = "19y4cmrfp79dr4hgl698imp4f3l1nhgvhh76j5laxg46ld71knil";
     };
     i686-linux = fetchurl {
       url = "https://github.com/ramboxapp/community-edition/releases/download/${version}/Rambox-${version}-linux-i386.AppImage";
-      sha256 = "07sv384nd2i701fkjgsrlib8jfsa01bvj60gnqdwlnpphlknga3h";
+      sha256 = "13wiciyshyrabq2mvnssl2d6svia1kdvwx3dl26249iyif96xxvq";
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
 
@@ -21,8 +22,8 @@ in mkRambox rec {
     description = "Free and Open Source messaging and emailing app that combines common web applications into one";
     homepage = "https://rambox.pro";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
-    platforms = ["i686-linux" "x86_64-linux"];
+    maintainers = with maintainers; [];
+    platforms = [ "i686-linux" "x86_64-linux" ];
     hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
Upstream changelog https://github.com/ramboxapp/community-edition/releases/tag/0.7.9

###### Motivation for this change

Use lastest released rambox to fix this issue: https://github.com/ramboxapp/community-edition/issues/3063

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
