### PR TITLE
discourse.plugins.discourse-openid-connect: init at unstable

### DIFF
--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -11,6 +11,7 @@ in
   discourse-ldap-auth = callPackage ./discourse-ldap-auth {};
   discourse-math = callPackage ./discourse-math {};
   discourse-migratepassword = callPackage ./discourse-migratepassword {};
+  discourse-openid-connect = callPackage ./discourse-openid-connect {};
   discourse-solved = callPackage ./discourse-solved {};
   discourse-spoiler-alert = callPackage ./discourse-spoiler-alert {};
   discourse-yearly-review = callPackage ./discourse-yearly-review {};

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/Gemfile
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+group :development do
+  gem 'rubocop-discourse'
+end

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.1)
+    parallel (1.19.2)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    regexp_parser (1.8.1)
+    rexml (3.2.5)
+    rubocop (0.93.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 0.6.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.7.1)
+      parser (>= 2.7.1.5)
+    rubocop-discourse (2.3.2)
+      rubocop (>= 0.69.0)
+      rubocop-rspec (>= 1.39.0)
+    rubocop-rspec (1.43.2)
+      rubocop (~> 0.87)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rubocop-discourse
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/default.nix
@@ -1,0 +1,19 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-openid-connect";
+  bundlerEnvArgs.gemdir = ./.;
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-openid-connect";
+    rev = "615038bd65f4fbe4dfdf8444b2f5eb06986b80b8";
+    sha256 = "n8feZkP80iNc+BzTPyKD7kEgFSIkk091eJYuqonN/NU=";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/discourse/discourse-openid-connect";
+    maintainers = with maintainers; [ mkg20001 ];
+    license = licenses.mit;
+    description = "Discourse plugin to integrate Discourse with an openid-connect login provider.";
+  };
+}
+

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-openid-connect/gemset.nix
@@ -1,0 +1,127 @@
+{
+  ast = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1l3468czzjmxl93ap40hp7z94yxp4nbag0bxqs789bm30md90m2a";
+      type = "gem";
+    };
+    version = "2.4.1";
+  };
+  parallel = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17b127xxmm2yqdz146qwbs57046kn0js1h8synv01dwqz2z1kp2l";
+      type = "gem";
+    };
+    version = "1.19.2";
+  };
+  parser = {
+    dependencies = ["ast"];
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1f7gmm60yla325wlnd3qkxs59qm2y0aan8ljpg6k18rwzrrfil6z";
+      type = "gem";
+    };
+    version = "2.7.2.0";
+  };
+  rainbow = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bb2fpjspydr6x0s8pn1pqkzmxszvkfapv0p4627mywl7ky4zkhk";
+      type = "gem";
+    };
+    version = "3.0.0";
+  };
+  regexp_parser = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0n9d14ppshnx71i3mi1pnm3hwhcbb6m6vsc0b0dqgsab8r2rs96n";
+      type = "gem";
+    };
+    version = "1.8.1";
+  };
+  rexml = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08ximcyfjy94pm1rhcx04ny1vx2sk0x4y185gzn86yfsbzwkng53";
+      type = "gem";
+    };
+    version = "3.2.5";
+  };
+  rubocop = {
+    dependencies = ["parallel" "parser" "rainbow" "regexp_parser" "rexml" "rubocop-ast" "ruby-progressbar" "unicode-display_width"];
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nrv7i81549addig09grw17qkab3l4319dcsf9y7psl7aa76ng3a";
+      type = "gem";
+    };
+    version = "0.93.0";
+  };
+  rubocop-ast = {
+    dependencies = ["parser"];
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "129hgz4swc8n0g01715v7y00k0h4mlzkxh63q7z27q7mjp54rl74";
+      type = "gem";
+    };
+    version = "0.7.1";
+  };
+  rubocop-discourse = {
+    dependencies = ["rubocop" "rubocop-rspec"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10l2wwnvd4xccgqsyhxrhc5bw10b7an4awl0v90fw5xf2qdjiflw";
+      type = "gem";
+    };
+    version = "2.3.2";
+  };
+  rubocop-rspec = {
+    dependencies = ["rubocop"];
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sc0bwdxzfr8byxzwvfyf22lwzqcaa6ca7wzxx31mk7vvy7r7dhl";
+      type = "gem";
+    };
+    version = "1.43.2";
+  };
+  ruby-progressbar = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k77i0d4wsn23ggdd2msrcwfy0i376cglfqypkk2q77r2l3408zf";
+      type = "gem";
+    };
+    version = "1.10.1";
+  };
+  unicode-display_width = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06i3id27s60141x6fdnjn5rar1cywdwy64ilc59cz937303q3mna";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/up-plugin.sh
+++ b/pkgs/servers/web-apps/discourse/plugins/up-plugin.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl ruby.devEnv git sqlite libpcap postgresql libxml2 libxslt pkg-config bundix gnumake
+# src https://nixos.wiki/wiki/Packaging/Ruby
+
+# This script should be ran afte rupdating a plugin that has a gemset.nix
+# Usage: ./up-plugin.sh <plugin-id>
+# NOTE: Script must be ran directly as ./up-plugin, otherwise the nix-shell won't work
+
+set -exuo pipefail
+
+PLUGIN="$1"
+SELF="$(dirname "$(readlink -f "$0")")"
+
+PL_DIR="$SELF/$PLUGIN"
+TOP="$SELF/../../../../.."
+TMP=$(mktemp -d)
+
+pushd "$TMP"
+
+if cat "$PL_DIR/default.nix" | grep gemdir >/dev/null; then
+  nix-build -A discourse.plugins.$PLUGIN.src "$TOP"
+  if [ -e result/Gemfile ]; then
+    cp result/Gemfile Gemfile
+    if [ -e result/Gemfile.lock ]; then
+      cp result/Gemfile.lock Gemfile.lock
+    fi
+  else
+    echo '# frozen_string_literal: true
+
+source "https://rubygems.org"' > Gemfile
+    cat result/plugin.rb | grep "^gem" >> Gemfile
+  fi
+  if [ ! -e Gemfile.lock ]; then
+    bundle install
+  fi
+  bundix
+  cp Gemfile Gemfile.lock gemset.nix "$PL_DIR"
+fi
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add discourse-openid-plugin and plugin update script

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
