### PR TITLE
go-containerregistry: 0.4.1 -> 0.6.0

### DIFF
--- a/pkgs/development/tools/go-containerregistry/default.nix
+++ b/pkgs/development/tools/go-containerregistry/default.nix
@@ -1,22 +1,35 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
+let bins = [ "crane" "gcrane" ]; in
+
 buildGoModule rec {
   pname = "go-containerregistry";
-  version = "0.4.1";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-3mvGHAPKDUmrQkBKwlxnF6PG0ZpZDqlM9SMkCyC5ytE=";
+    sha256 = "0sk3g1i4w8sh40y1ffa61ap7jsscdvnhvh09k8nznydi465csbmq";
   };
   vendorSha256 = null;
 
   subPackages = [ "cmd/crane" "cmd/gcrane" ];
 
+  outputs = [ "out" ] ++ bins;
+
   ldflags =
     let t = "github.com/google/go-containerregistry"; in
     [ "-s" "-w" "-X ${t}/cmd/crane/cmd.Version=v${version}" "-X ${t}/pkg/v1/remote/transport.Version=${version}" ];
+
+  postInstall =
+    lib.concatStringsSep "\n" (
+      map (bin: ''
+        mkdir -p ''$${bin}/bin &&
+        mv $out/bin/${bin} ''$${bin}/bin/ &&
+        ln -s ''$${bin}/bin/${bin} $out/bin/
+      '') bins
+    );
 
   # NOTE: no tests
   doCheck = false;
@@ -25,6 +38,6 @@ buildGoModule rec {
     description = "Tools for interacting with remote images and registries including crane and gcrane";
     homepage = "https://github.com/google/go-containerregistry";
     license = licenses.apsl20;
-    maintainers = with maintainers; [ yurrriq ];
+    maintainers = with maintainers; [ superherointj yurrriq ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2871,6 +2871,7 @@ with pkgs;
   go-chromecast = callPackage ../applications/video/go-chromecast { };
 
   go-containerregistry = callPackage ../development/tools/go-containerregistry { };
+  inherit (go-containerregistry) crane gcrane;
 
   go-rice = callPackage ../tools/misc/go.rice {};
 


### PR DESCRIPTION
go-containerregistry: 0.4.1 -> 0.6.0
* Unbundled crane & gcrane.
* Add superherointj as maintainer.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
