### PR TITLE
git-quickfix: init at 0.0.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-quickfix/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-quickfix/default.nix
@@ -1,0 +1,38 @@
+{ lib, fetchFromGitHub
+, libiconv
+, openssl
+, pkg-config
+, rustPlatform
+, stdenv
+, Security
+, SystemConfiguration
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-quickfix";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "siedentop";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-JdRlrNzWMPS3yG1UvKKtHVRix3buSm9jfSoAUxP35BY=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [
+    Security
+    SystemConfiguration
+    libiconv
+  ];
+
+  cargoSha256 = "sha256-ENeHPhEBniR9L3J5el6QZrIS1Q4O0pNiSzJqP1aQS9Q=";
+
+  meta = with lib; {
+    description = "Quickfix allows you to commit changes in your git repository to a new branch without leaving the current branch";
+    homepage = "https://github.com/siedentop/git-quickfix";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ msfjarvis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5431,6 +5431,10 @@ with pkgs;
 
   git-open = callPackage ../applications/version-management/git-and-tools/git-open { };
 
+  git-quickfix = callPackage ../applications/version-management/git-and-tools/git-quickfix {
+    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
+  };
+
   git-radar = callPackage ../applications/version-management/git-and-tools/git-radar { };
 
   git-recent = callPackage ../applications/version-management/git-and-tools/git-recent {


### PR DESCRIPTION
###### Motivation for this change

Adds the [git-quickfix](https://github.com/siedentop/git-quickfix) tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
