### PR TITLE
regclient: init 0.3.8

### DIFF
--- a/pkgs/development/tools/regclient/default.nix
+++ b/pkgs/development/tools/regclient/default.nix
@@ -1,0 +1,41 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+let bins = [ "regbot" "regctl" "regsync" ]; in
+
+buildGoModule rec {
+  pname = "regclient";
+  version = "0.3.8";
+  tag = "v${version}";
+
+  src = fetchFromGitHub {
+    owner = "regclient";
+    repo = "regclient";
+    rev = tag;
+    sha256 = "14w0g24sgphgib33sdvrvwk86p7km2pasb5fmr3p48i7sc71ja3h";
+  };
+  vendorSha256 = "sha256-9sRjP7lxMRdt9D9ElIX+mbYIvCaknWMgDyYl+1/q0/g=";
+
+  outputs = [ "out" ] ++ bins;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.VCSTag=${tag}"
+  ];
+
+  postInstall =
+    lib.concatStringsSep "\n" (
+      map (bin: ''
+        mkdir -p ''$${bin}/bin &&
+        mv $out/bin/${bin} ''$${bin}/bin/ &&
+        ln -s ''$${bin}/bin/${bin} $out/bin/
+      '') bins
+    );
+
+  meta = with lib; {
+    description = "Docker and OCI Registry Client in Go and tooling using those libraries";
+    homepage = "https://github.com/regclient/regclient";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14660,6 +14660,9 @@ with pkgs;
 
   redo-sh = callPackage ../development/tools/build-managers/redo-sh { };
 
+  regclient = callPackage ../development/tools/regclient { };
+  inherit (regclient) regbot regctl regsync;
+
   reno = callPackage ../development/tools/reno { };
 
   re2c = callPackage ../development/tools/parsing/re2c { };


### PR DESCRIPTION
regclient: init 0.3.8

* Unbundled regbot, regctl, regsync

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
