### PR TITLE
gdome2: fix build on -fno-common toolchains

### DIFF
--- a/pkgs/development/libraries/gdome2/default.nix
+++ b/pkgs/development/libraries/gdome2/default.nix
@@ -18,7 +18,10 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ glib libxml2 gtk-doc ];
   propagatedBuildInputs = [glib libxml2];
-  patches = [ ./xml-document.patch ];
+  patches = [
+    ./xml-document.patch
+    ./fno-common.patch
+  ];
 
   meta = with lib; {
     homepage = "http://gdome2.cs.unibo.it/";

--- a/pkgs/development/libraries/gdome2/fno-common.patch
+++ b/pkgs/development/libraries/gdome2/fno-common.patch
@@ -1,0 +1,11 @@
+On gcc-10 -fno-common is the default which forbids miltiple definitions.
+--- a/libgdome/xpath/gdome-xpath-xpnsresolv.h
++++ b/libgdome/xpath/gdome-xpath-xpnsresolv.h
+@@ -42,6 +42,6 @@ void gdome_xpath_xpnsresolv_ref (GdomeXPathNSResolver *self, GdomeException *exc
+ void gdome_xpath_xpnsresolv_unref (GdomeXPathNSResolver *self, GdomeException *exc);
+ GdomeDOMString * gdome_xpath_xpnsresolv_lookupNamespaceURI( GdomeXPathNSResolver *self, GdomeDOMString *prefix, GdomeException *exc);
+ 
+-const GdomeXPathNSResolverVtab gdome_xpath_xpnsresolv_vtab;
++extern const GdomeXPathNSResolverVtab gdome_xpath_xpnsresolv_vtab;
+ 
+ #endif /* GDOME_XPNSRESOLV_FILE */


### PR DESCRIPTION
Example of such toolchain is clang-12:

    $ nix-build -E 'with import ./. { }; gdome2.override { stdenv = clang12Stdenv; }'
    ...
    libgdome/xpath/gdome-xpath-xpnsresolv.c:33:
      multiple definition of `gdome_xpath_xpnsresolv_vtab';
      gdome-xpath.lo:libgdome/xpath/gdome-xpath-xpnsresolv.h:45: first defined here
