### PR TITLE
Provide submodule to `security.wrappers` for older kernels

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1139,10 +1139,12 @@ in
         source = "${pkgs.iputils.out}/bin/ping";
       };
     } else {
-      setuid = true;
-      owner = "root";
-      group = "root";
-      source = "${pkgs.iputils.out}/bin/ping";
+      ping = {
+        setuid = true;
+        owner = "root";
+        group = "root";
+        source = "${pkgs.iputils.out}/bin/ping";
+      };
     };
     security.apparmor.policies."bin.ping".profile = lib.mkIf config.security.apparmor.policies."bin.ping".enable (lib.mkAfter ''
       /run/wrappers/bin/ping {


### PR DESCRIPTION
Fixes a regression from #126289

###### Motivation for this change

Fixes evaluation errors in Mobile NixOS.

 - https://hydra.nixos.org/eval/1708581#tabs-errors

```
in job ‘[...]’:
error: A definition for option `security.wrappers.group' is not of type `submodule'. Definition values:
       - In `/nix/store/mzr7r470gdi10n363c8axn8v5nk1miy4-source/nixos/modules/tasks/network-interfaces.nix': "root"
```

I understand that testing against a config with kernels older than 4.3 is a tough thing to ask, so I am not really concerned about how this slipped through.

Though I wonder if there's something more universal that could be done to help point out all NixOS configuration conditionals that affect changed code paths.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Additional things done:

 - [x] Tested eval of Mobile NixOS.

cc @rnhmjoj (author of the change)
cc @symphorien (who merged)