### PR TITLE
pamixer: 1.4 -> unstable-2021-03-29

### DIFF
--- a/pkgs/applications/audio/pamixer/default.nix
+++ b/pkgs/applications/audio/pamixer/default.nix
@@ -1,20 +1,30 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, boost, libpulseaudio }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, boost, libpulseaudio, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "pamixer";
-  version = "1.4";
+  version = "unstable-2021-03-29";
 
   src = fetchFromGitHub {
     owner = "cdemoulins";
     repo = "pamixer";
-    rev = version;
-    sha256 = "1i14550n8paijwwnhksv5izgfqm3s5q2773bdfp6vyqybkll55f7";
+    rev = "4ea2594cb8c605dccd00a381ba19680eba368e94";
+    sha256 = "sha256-kV4wIxm1WZvqqyfmgQ2cSbRJwJR154OW0MMDg2ntf6g=";
   };
 
   buildInputs = [ boost libpulseaudio ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 pamixer -t $out/bin
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installManPage pamixer.1
   '';
 
   meta = with lib; {
@@ -29,7 +39,9 @@ stdenv.mkDerivation rec {
         - Mute or unmute a device
     '';
     homepage = "https://github.com/cdemoulins/pamixer";
+    maintainers = with maintainers; [ thiagokokada ];
     license = licenses.gpl3;
     platforms = platforms.linux;
+    mainProgram = "pamixer";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump `pamixer` to latest commit on git.

This brings some bugfixes (like a [memory leak](https://github.com/cdemoulins/pamixer/commit/607df34a630f2485dee03cb3cee7552b84025566)) and also some new features (like `--get-default-sink`, `--set-limit`).

Also add missing manpage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
