### PR TITLE
[21.05] routinator: 0.8.3 -> 0.10.1

### DIFF
--- a/pkgs/servers/routinator/Cargo.toml.patch
+++ b/pkgs/servers/routinator/Cargo.toml.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 7f07b3b..7d7af0a 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -48,7 +48,7 @@ syslog          = "5.0.0"
+ rustc_version   = "0.4.0"
+ 
+ [features]
+-default = [ "socks", "ui"]
++default = [ "socks" ]
+ extra-debug = ["rpki/extra-debug"]
+ socks = [ "reqwest/socks" ]
+ rta = []

--- a/pkgs/servers/routinator/default.nix
+++ b/pkgs/servers/routinator/default.nix
@@ -1,18 +1,27 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform, Security }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, Security
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "routinator";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "NLnetLabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "171zmqqkgdpbspn70sgsypnyw7m6q2x8izwxrzbyi5xslsgd24i4";
+    sha256 = "sha256-ThgTGtTZ0LGm9nHJoy0KhnBFWNvKRjk7hoNTVVTeL/Y=";
   };
 
+  cargoPatches = [
+    ./Cargo.toml.patch
+  ];
+  cargoSha256 = "sha256-mcx+qUtTUxeYP0PeJp1eOQwsdS6PPUx/m7TfAyqFiIM=";
+
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
-  cargoSha256 = "0r1m1zv3mkmmaalln3ny6m33dyjqzdyfbmkcav05kz12xjdd94fs";
 
   meta = with lib; {
     description = "An RPKI Validator written in Rust";

--- a/pkgs/servers/routinator/default.nix
+++ b/pkgs/servers/routinator/default.nix
@@ -2,17 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "routinator";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "NLnetLabs";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-8CBsLOAF0JnRMe7qLod6UDPGLMPwqDm0Z5BjB4KCkBc=";
+    rev = "v${version}";
+    sha256 = "171zmqqkgdpbspn70sgsypnyw7m6q2x8izwxrzbyi5xslsgd24i4";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
-  cargoSha256 = "sha256-S/RAt3tCIlaSqIHqP5C+QK9aQq+4CO/MW2toUo9kVKk=";
+  cargoSha256 = "0r1m1zv3mkmmaalln3ny6m33dyjqzdyfbmkcav05kz12xjdd94fs";
 
   meta = with lib; {
     description = "An RPKI Validator written in Rust";

--- a/pkgs/servers/routinator/default.nix
+++ b/pkgs/servers/routinator/default.nix
@@ -2,17 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "routinator";
-  version = "0.8.3";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "NLnetLabs";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-JwPAwhD+Pkx8Kx24m7z/RbEvDnI2YR8dnTgAV7TMsFE=";
+    rev = version;
+    sha256 = "sha256-8CBsLOAF0JnRMe7qLod6UDPGLMPwqDm0Z5BjB4KCkBc=";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
-  cargoSha256 = "sha256-NtugqvaickcEowxGwotGuh6jb2NTK95csJxtjezy90s=";
+  cargoSha256 = "sha256-S/RAt3tCIlaSqIHqP5C+QK9aQq+4CO/MW2toUo9kVKk=";
 
   meta = with lib; {
     description = "An RPKI Validator written in Rust";


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-41531
https://www.nlnetlabs.nl/downloads/routinator/CVE-2021-41531.txt

This is a bigger bump than I'd _like_ to introduce to the stable branch, but I can't see patching being feasible without a much better understanding of the codebase. The fix is actually in a crate used by routinator @ https://github.com/NLnetLabs/rpki-rs/pull/154, but bumping the crate doesn't seem an option as there are api changes between the two used versions. Leaving this to the maintainer to decide how disruptive this bump would be and whether the criticality of the issue warrants it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
