### PR TITLE
google-java-format: init at 1.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3251,6 +3251,12 @@
     githubId = 13485450;
     name = "Emmanuel Rosa";
   };
+  emptyflask = {
+    email = "jon@emptyflask.dev";
+    github = "emptyflask";
+    githubId = 28287;
+    name = "Jon Roberts";
+  };
   endgame = {
     email = "jack@jackkelly.name";
     github = "endgame";

--- a/pkgs/development/tools/google-java-format/default.nix
+++ b/pkgs/development/tools/google-java-format/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "google-java-format";
+  version = "1.11.0";
+
+  src = fetchurl {
+    url = "https://github.com/google/google-java-format/releases/download/v${version}/google-java-format-${version}-all-deps.jar";
+    sha256 = "1ixpg8ljg819fq94mxyypknmslva3rkifphbnq3ic71b7iip6lia";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jre ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/google-java-format}
+    install -D ${src} $out/share/google-java-format/google-java-format.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/google-java-format \
+      --add-flags "-jar $out/share/google-java-format/google-java-format.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Java source formatter by Google";
+    longDescription = ''
+      A program that reformats Java source code to comply with Google Java Style.
+    '';
+    homepage = "https://github.com/google/google-java-format";
+    license = licenses.asl20;
+    maintainers = [ maintainers.emptyflask ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5677,6 +5677,8 @@ with pkgs;
 
   google-cloud-cpp = callPackage ../development/libraries/google-cloud-cpp { };
 
+  google-java-format = callPackage ../development/tools/google-java-format { };
+
   gdown = with python3Packages; toPythonApplication gdown;
 
   gopro = callPackage ../tools/video/gopro { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Need to use this formatter for work, and I don't use an IDE.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
