### PR TITLE
[21.05] wolfssl: add patch for CVE-2021-38597

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/wolfSSL/wolfssl/commit/822aa92fccf77558e250131c1c6e9bb84d07afe8.patch";
       sha256 = "1n7774hy9ybbxmg8dldqnhw279k7fkxwvw1s2mjjhkzra9w5x2zy";
     })
+    (fetchpatch {
+      name = "CVE-2021-38597.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/f93083be72a3b3d956b52a7ec13f307a27b6e093.patch";
+      sha256 = "1b9zxisc15mm1s6sl8dmpaw520hcndymf6b003xpwsb5070xcld0";
+    })
   ];
 
   # almost same as Debian but for now using --enable-all --enable-reproducible-build instead of --enable-distro to ensure options.h gets installed


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-38597

Previously checked out the validity for this in https://github.com/NixOS/nixpkgs/pull/133154#issuecomment-894822636 and I'm quite happy with it.

Fixed in master with 4.8.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
