### PR TITLE
keystore-explorer: use latest available lts java version to run

### DIFF
--- a/pkgs/applications/misc/keystore-explorer/default.nix
+++ b/pkgs/applications/misc/keystore-explorer/default.nix
@@ -1,4 +1,4 @@
-{ fetchzip, lib, stdenv, jdk8, runtimeShell }:
+{ fetchzip, lib, stdenv, jdk, runtimeShell }:
 
 stdenv.mkDerivation rec {
   version = "5.4.4";
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
     # Python on Darwin; just write our own start script to avoid unnecessary dependencies
     cat > $out/bin/keystore-explorer <<EOF
     #!${runtimeShell}
-    export JAVA_HOME=${jdk8.home}
-    exec ${jdk8}/bin/java -jar $out/share/keystore-explorer/kse.jar "\$@"
+    export JAVA_HOME=${jdk.home}
+    exec ${jdk}/bin/java -jar $out/share/keystore-explorer/kse.jar "\$@"
     EOF
     chmod +x $out/bin/keystore-explorer
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6485,7 +6485,9 @@ with pkgs;
 
   keyfuzz = callPackage ../tools/inputmethods/keyfuzz { };
 
-  keystore-explorer = callPackage ../applications/misc/keystore-explorer { };
+  keystore-explorer = callPackage ../applications/misc/keystore-explorer {
+    jdk = jdk11;
+  };
 
   kfctl = callPackage ../applications/networking/cluster/kfctl { };
 


### PR DESCRIPTION
###### Motivation for this change
Use latest available java lts release to run keystore-explorer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
