### PR TITLE
wget2: 1.99.2 → 2.0.0

### DIFF
--- a/pkgs/tools/networking/wget2/default.nix
+++ b/pkgs/tools/networking/wget2/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitLab
-, fetchpatch
   # build support
 , autoreconfHook
 , flex
@@ -28,27 +27,14 @@
 
 stdenv.mkDerivation rec {
   pname = "wget2";
-  version = "1.99.2";
+  version = "2.0.0";
 
   src = fetchFromGitLab {
     owner = "gnuwget";
     repo = pname;
-    rev = version;
-    sha256 = "1gws8y3z8xzi46c48n7jb162mr3ar4c34s7yy8kjcs14yzq951qz";
+    rev = "v${version}";
+    sha256 = "07zs2x2k62836l0arzc333j96yjpwal1v4mr8j99x6qxgmmssrbj";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-autotools-2.70.patch";
-      url = "https://gitlab.com/gnuwget/wget2/-/commit/580af869093cfda6bc8a9d5901850354a16b3666.patch";
-      sha256 = "1x6wq4wxvvy6174d52qrhxkcgmv366f8smxyki49zb6rs4gqhskd";
-    })
-    (fetchpatch {
-      name = "update-potfiles-for-gnulib-2020-11-28.patch";
-      url = "https://gitlab.com/gnuwget/wget2/-/commit/368deb9fcca0c281f9c76333607cc878c3945ad0.patch";
-      sha256 = "1qsz8hbzbgg14wikxsbjjlq0cp3jw4pajbaz9wdn6ny617hdvi8y";
-    })
-  ];
 
   # wget2_noinstall contains forbidden reference to /build/
   postPatch = ''
@@ -68,9 +54,6 @@ stdenv.mkDerivation rec {
     rmdir gnulib
     cp -r ${gnulib} gnulib
     chmod -R u+w gnulib/{build-aux,lib}
-
-    # fix bashisms can be removed when https://gitlab.com/gnuwget/wget2/-/commit/c9499dcf2f58983d03e659e2a1a7f21225141edf is in the release
-    sed 's|==|=|g' -i configure.ac
 
     ./bootstrap --no-git --gnulib-srcdir=gnulib --skip-po
   '';


### PR DESCRIPTION
###### Motivation for this change

Upgrade wget2 from 1.99.2 to 2.0.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
