### PR TITLE
treewide: clean up fedorahosted.org URLs

### DIFF
--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "0.52.21";
 
   src = fetchurl {
-    url = "https://fedorahosted.org/releases/n/e/${pname}/${pname}-${version}.tar.gz";
+    url = "https://releases.pagure.org/${pname}/${pname}-${version}.tar.gz";
     sha256 = "0cdvbancr7y4nrj8257y5n45hmhizr8isynagy4fpsnpammv8pi6";
   };
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://fedorahosted.org/newt/";
+    homepage = "https://pagure.io/newt";
     description = "Library for color text mode, widget based user interfaces";
 
     license = licenses.lgpl2;

--- a/pkgs/os-specific/linux/numad/default.nix
+++ b/pkgs/os-specific/linux/numad/default.nix
@@ -1,12 +1,13 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchgit }:
 
 stdenv.mkDerivation rec {
   pname = "numad";
   version = "0.5";
 
-  src = fetchurl {
-    url = "https://git.fedorahosted.org/cgit/numad.git/snapshot/numad-${version}.tar.xz";
-    sha256 = "08zd1yc3w00yv4mvvz5sq1gf91f6p2s9ljcd72m33xgnkglj60v4";
+  src = fetchgit {
+    url = "https://pagure.io/numad.git";
+    rev = "334278ff3d774d105939743436d7378a189e8693";
+    sha256 = "sha256-6nrbfooUI1ufJhsPf68li5584oKQcznXQlxfpStuX5I=";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/tools/misc/ding-libs/default.nix
+++ b/pkgs/tools/misc/ding-libs/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.6.1";
 
   src = fetchurl {
-    url = "https://fedorahosted.org/released/ding-libs/ding-libs-${version}.tar.gz";
+    url = "https://releases.pagure.org/SSSD/${pname}/${pname}-${version}.tar.gz";
     sha256 = "1h97mx2jdv4caiz4r7y8rxfsq78fx0k4jjnfp7x2s7xqvqks66d3";
   };
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "'D is not GLib' utility libraries";
-    homepage = "https://fedorahosted.org/sssd/";
+    homepage = "https://pagure.io/SSSD/ding-libs";
     platforms = with lib.platforms; linux;
     maintainers = with lib.maintainers; [ e-user ];
     license = [ lib.licenses.gpl3 lib.licenses.lgpl3 ];

--- a/pkgs/tools/misc/tmpwatch/default.nix
+++ b/pkgs/tools/misc/tmpwatch/default.nix
@@ -5,14 +5,14 @@ stdenv.mkDerivation rec {
   version = "2.11";
 
   src = fetchurl {
-    url = "https://fedorahosted.org/releases/t/m/tmpwatch/tmpwatch-${version}.tar.bz2";
+    url = "https://releases.pagure.org/${pname}/${pname}-${version}.tar.bz2";
     sha256 = "1m5859ngwx61l1i4s6fja2avf1hyv6w170by273w8nsin89825lk";
   };
 
   configureFlags = [ "--with-fuser=${psmisc}/bin/fuser" ];
 
   meta = with lib; {
-    homepage = "https://fedorahosted.org/tmpwatch/";
+    homepage = "https://pagure.io/tmpwatch";
     description = "Recursively searches through specified directories and removes files which have not been accessed in a specified period of time";
     license = licenses.gpl2;
     maintainers = with maintainers; [ vlstill ];

--- a/pkgs/tools/system/logrotate/default.nix
+++ b/pkgs/tools/system/logrotate/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ popt ] ++ lib.optionals aclSupport [ acl ];
 
   meta = with lib; {
-    homepage = "https://fedorahosted.org/releases/l/o/logrotate/";
+    homepage = "https://github.com/logrotate/logrotate";
     description = "Rotates and compresses system logs";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.viric ];

--- a/pkgs/tools/typesetting/xmlto/default.nix
+++ b/pkgs/tools/typesetting/xmlto/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     '';
 
     license = lib.licenses.gpl2Plus;
-    homepage = "https://fedorahosted.org/xmlto/";
+    homepage = "https://pagure.io/xmlto/";
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Fedorahosted.org has apparently [been dead since 2017](https://fedoraproject.org/wiki/Infrastructure/Fedorahosted-retirement). I grepped through Nixpkgs and changed the `meta.homepage` URLs to where projects are hosted now, where that was easy to figure out. Since links to tarballs hosted on fedorahosted.org are also dead, I switched those to new URLs that produce the same hashes.   

numad doesn't offer tarballs and doesn't tag releases, so I picked the revision that the cached tarball on Hydra (/nix/store/7w0wnw97jh2n0v2bqsx0fivlbnbgh0m0-numad-0.5.tar.xz) was taken from. 

There are some leftovers that seem like unmaintained projects with no replacement URLs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
