### PR TITLE
home-manager: 2021-03-21 -> 2021-09-13

### DIFF
--- a/pkgs/tools/package-management/home-manager/default.nix
+++ b/pkgs/tools/package-management/home-manager/default.nix
@@ -4,7 +4,6 @@
 { bash, coreutils, findutils, gnused, less, lib, stdenv, makeWrapper, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-
   pname = "home-manager";
   version = "2021-09-13";
 

--- a/pkgs/tools/package-management/home-manager/default.nix
+++ b/pkgs/tools/package-management/home-manager/default.nix
@@ -6,13 +6,13 @@
 stdenv.mkDerivation rec {
 
   pname = "home-manager";
-  version = "2021-03-21";
+  version = "2021-09-13";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "home-manager";
-    rev = "ddcd476603dfd3388b1dc8234fa9d550156a51f5";
-    sha256 = "sha256-E6ABXtzw6bHmrIirB1sJL6S2MEa3sfcvRLzRa92frCo=";
+    rev = "7d9ba15214004c979d2c8733f8be12ce6502cf8a";
+    sha256 = "sha256-u2E/wstadWNcn6vOIoK1xY86QPOzzBZQfT1FbePfdaI=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION

###### Motivation for this change
This package is over 6 months out of date. I've updated it to its `release-21.05` branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
