### PR TITLE
pythonPackages.requests: fix dependencies for python2

### DIFF
--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -36,10 +36,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    brotlicffi
     certifi
-    charset-normalizer
-    chardet
     idna
     urllib3
   ] ++ lib.optionals (isPy3k) [
@@ -47,6 +44,7 @@ buildPythonPackage rec {
     charset-normalizer
   ] ++ lib.optionals (isPy27) [
     brotli
+    chardet
   ];
 
   checkInputs = [


### PR DESCRIPTION
* brotlicffi does not support python 2, so only include it as a build
  input of requests if requests is being built for python 3.
  otherwise, fall back to brotli.

* requests 2.26 release notes specify that charset-normalizer is only
  for python 3, while chardet is only for python 2.  correct build
  inputs to reflect this.  (charset-normalizer does not build with
  python 2.)

fixes #138584

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

get nixops building again

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
