### PR TITLE
poetry2nix: 1.20.0 -> 1.21.0

### DIFF
--- a/pkgs/development/tools/poetry2nix/poetry2nix/default.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/default.nix
@@ -5,7 +5,7 @@
 }:
 let
   # Poetry2nix version
-  version = "1.20.0";
+  version = "1.21.0";
 
   inherit (poetryLib) isCompatible readTOML moduleName;
 
@@ -338,6 +338,9 @@ lib.makeScope pkgs.newScope (self: {
                 py.buildEnv.override args)
             ) { inherit app; };
           };
+
+          # Extract position from explicitly passed attrs so meta.position won't point to poetry2nix internals
+          pos = builtins.unsafeGetAttrPos (lib.elemAt (lib.attrNames attrs) 0) attrs;
 
           meta = lib.optionalAttrs (lib.hasAttr "description" pyProject.tool.poetry)
             {

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
@@ -156,6 +156,12 @@ self: super:
     }
   );
 
+  cheroot = super.cheroot.overridePythonAttrs (
+    old: {
+      dontPreferSetupPy = true;
+    }
+  );
+
   colour = super.colour.overridePythonAttrs (
     old: {
       buildInputs = (old.buildInputs or [ ]) ++ [ self.d2to1 ];
@@ -547,6 +553,7 @@ self: super:
         self.pytestrunner
         self.cryptography
         self.pyjwt
+        self.setuptools-scm-git-archive
       ];
     }
   );


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/139951.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
