### PR TITLE
less: improve default settings

### DIFF
--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -18,8 +18,9 @@ in
 
     environment.variables =
       { NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
+        # note: many programs exec() this directly, so default options for less must not
+        # be specified here; do so in the default value of programs.less.envVariables instead
         PAGER = mkDefault "less";
-        LESS = mkDefault "-R";
         EDITOR = mkDefault "nano";
         XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
       };

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -25,6 +25,9 @@ in
         XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
       };
 
+    # since we set PAGER to this above, make sure it's installed
+    programs.less.enable = true;
+
     environment.profiles = mkAfter
       [ "/nix/var/nix/profiles/default"
         "/run/current-system/sw"

--- a/nixos/modules/programs/less.nix
+++ b/nixos/modules/programs/less.nix
@@ -35,7 +35,8 @@ in
 
     programs.less = {
 
-      enable = mkEnableOption "less";
+      # since environment.nix sets PAGER=less, enable the less module by default
+      enable = mkEnableOption "less" // { default = true; };
 
       configFile = mkOption {
         type = types.nullOr types.path;
@@ -81,7 +82,9 @@ in
 
       envVariables = mkOption {
         type = types.attrsOf types.str;
-        default = {};
+        default = {
+          LESS = "-R";
+        };
         example = {
           LESS = "--quit-if-one-screen";
         };

--- a/nixos/modules/programs/less.nix
+++ b/nixos/modules/programs/less.nix
@@ -24,9 +24,7 @@ let
     }
   '';
 
-  lessKey = pkgs.runCommand "lesskey"
-            { src = pkgs.writeText "lessconfig" configText; preferLocalBuild = true; }
-            "${pkgs.less}/bin/lesskey -o $out $src";
+  lessKey = pkgs.writeText "lessconfig" configText;
 
 in
 
@@ -114,7 +112,7 @@ in
     environment.systemPackages = [ pkgs.less ];
 
     environment.variables = {
-      LESSKEY_SYSTEM = toString lessKey;
+      LESSKEYIN_SYSTEM = toString lessKey;
     } // optionalAttrs (cfg.lessopen != null) {
       LESSOPEN = cfg.lessopen;
     } // optionalAttrs (cfg.lessclose != null) {

--- a/nixos/modules/programs/less.nix
+++ b/nixos/modules/programs/less.nix
@@ -33,8 +33,9 @@ in
 
     programs.less = {
 
-      # since environment.nix sets PAGER=less, enable the less module by default
-      enable = mkEnableOption "less" // { default = true; };
+      # note that environment.nix sets PAGER=less, and
+      # therefore also enables this module
+      enable = mkEnableOption "less";
 
       configFile = mkOption {
         type = types.nullOr types.path;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`git` and `less` were interacting poorly after #128916; this restores the old behaviour.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
