### PR TITLE
rar: add support to x86_64-darwin

### DIFF
--- a/pkgs/tools/archivers/rar/default.nix
+++ b/pkgs/tools/archivers/rar/default.nix
@@ -2,16 +2,20 @@
 
 let
   version = "6.0.2";
-  # TODO: add support for macOS
-  srcUrl =
-    if stdenv.isi686 then {
+  srcUrl = {
+    i686-linux = {
       url = "https://www.rarlab.com/rar/rarlinux-${version}.tar.gz";
-      sha256 = "sha256-5iqK7eOo+hgLtGSCqUoB+wOFZHUqZ0M/8Jf7bxdf9qA=";
-    } else if stdenv.isx86_64 then {
+      sha256 = "sha256-5iqk7eoo+hgltgscquob+wofzhuqz0m/8jf7bxdf9qa=";
+    };
+    x86_64-linux = {
       url = "https://www.rarlab.com/rar/rarlinux-x64-${version}.tar.gz";
       sha256 = "sha256-WAvrUGCgfwI51Mo/RYSSF0OLPPrTegUCuDEsnBeR9uQ=";
-    }
-    else throw "Unknown architecture";
+    };
+    x86_64-darwin = {
+      url = "https://www.rarlab.com/rar/rarosx-${version}.tar.gz";
+      sha256 = "sha256-baZ71vYXIGs25f7PJ0ujoGUrsWZRmFLhvDI0KoVktsg=";
+    };
+  }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
   manSrc = fetchurl {
     url = "https://aur.archlinux.org/cgit/aur.git/plain/rar.1?h=rar&id=8e39a12e88d8a3b168c496c44c18d443c876dd10";
     name = "rar.1";
@@ -50,6 +54,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.rarlab.com/";
     license = licenses.unfree;
     maintainers = with maintainers; [ thiagokokada ];
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add support to `x86_64-darwin` for `rar`.

This is mostly a test for my Hackintosh bench to allow me porting some macOS packages. Maybe more to come later?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
