### PR TITLE
google-java-format: fix for jdk 16

### DIFF
--- a/pkgs/development/tools/google-java-format/default.nix
+++ b/pkgs/development/tools/google-java-format/default.nix
@@ -17,11 +17,17 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,share/google-java-format}
-    install -D ${src} $out/share/google-java-format/google-java-format.jar
+    mkdir -p $out/{bin,share/${pname}}
+    install -D ${src} $out/share/${pname}/google-java-format-${version}-all-deps.jar
 
-    makeWrapper ${jre}/bin/java $out/bin/google-java-format \
-      --add-flags "-jar $out/share/google-java-format/google-java-format.jar"
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --argv0 ${pname} \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED" \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED" \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED" \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED" \
+      --add-flags "-jar $out/share/${pname}/google-java-format-${version}-all-deps.jar"
 
     runHook postInstall
   '';


### PR DESCRIPTION
JDK 16 requires some extra flags to actually format code:
https://github.com/google/google-java-format#jdk-16

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
With JDK 16 the program runs, but throws an error when actually parsing code.
These additional flags are recommended by the authors, and it works now.

I should have done more thorough testing earlier :/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
