### PR TITLE
qt5.qtbase: add patch from 363880 to fix MySQL support

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -111,6 +111,11 @@ let
         url = "https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=patch;h=049e14870c13235cd066758f29c42dc96c1ccdf8";
         sha256 = "1cb2hwi859hds0fa2cbap014qaa7mah9p0rcxcm2cvj2ybl33qfc";
       })
+      (fetchpatch { # This can be removed when https://codereview.qt-project.org/c/qt/qtbase/+/363880/3 is included in an release.
+        name = "qtbase-mysql-version-vs-functionality-check.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=patch;h=211369133cf40b2f522caaff259c19069ed23ca4";
+        sha256 = "19kq9h10qm344fpdqa9basrbzh1y5kr48c6jzz3nvk61pk4ja1k4";
+      })
     ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];


### PR DESCRIPTION
Without this patch, a MariaDB upgrade to 10.6.3 will break Qt's MySQL
support, as it was using version-based feature flags instead of
functional tests.
This breaks the conversion of QDateTime values in queries, resulting in
the breakage of e.g. Akonadi.

###### Motivation for this change
Akonadi stopped working, I want my KMail/Akonadi back :)
See [KDE-Bug#439769](https://bugs.kde.org/show_bug.cgi?id=439769) for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
