### PR TITLE
python3Packages.total-connect-client: 2021.7.1 -> 2021.8.3

### DIFF
--- a/pkgs/development/python-modules/total-connect-client/default.nix
+++ b/pkgs/development/python-modules/total-connect-client/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "total-connect-client";
-  version = "2021.7.1";
+  version = "2021.8.3";
 
   src = fetchFromGitHub {
     owner = "craigjmidwinter";
     repo = "total-connect-client";
     rev = version;
-    sha256 = "sha256-F7qVvQVU6OlVU98zmFSQ1SLVCAx+lhz+cFS//d0SHUQ=";
+    sha256 = "sha256-2iTH/Him4iMZadkmBR8Rwlt3RCqDXzR6ZqNHciNiHIk=";
   };
 
   propagatedBuildInputs = [
@@ -27,6 +27,11 @@ buildPythonPackage rec {
   preCheck = ''
     export PYTHONPATH="total_connect_client:$PYTHONPATH"
   '';
+
+  disabledTests = [
+    # Tests require network access
+    "tests_request"
+  ];
 
   pythonImportsCheck = [ "total_connect_client" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2021.8.3

Change log: https://github.com/craigjmidwinter/total-connect-client/releases/tag/2021.8.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
