### PR TITLE
python3Packages.cryptography: 3.4.8 -> 35.0.0

### DIFF
--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -23,18 +23,18 @@
 
 buildPythonPackage rec {
   pname = "cryptography";
-  version = "3.4.8"; # Also update the hash in vectors.nix
+  version = "35.0.0"; # Also update the hash in vectors.nix
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "072awar70cwfd2hnx0pvp1dkc7gw45mbm3wcyddvxz5frva5xk4l";
+    sha256 = "0v88w3rpspnzkffla5clqkm98854vmk63qvxpn37clfhf27z4cwr";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     sourceRoot = "${pname}-${version}/${cargoRoot}";
     name = "${pname}-${version}";
-    sha256 = "01h511h6l4qvjxbaw662m1l84pb4wrhwxmnb3qj6ik13mx2m477m";
+    sha256 = "1ck0cyv8zw7xixifx2lm510cvwlgf9f60fmgg608l0lkixz102mm";
   };
 
   cargoRoot = "src/rust";

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1wl0ynh3lzhc6q59g8mybvijmnp195x7fjxlb3h3sgcraw14312c";
+    sha256 = "1z3vjms5w5vp0b3zl35mcwfypngvxaq7w66qlfh0gq6049ldk2lp";
   };
 
   # No tests included

--- a/pkgs/development/python-modules/python-miio/default.nix
+++ b/pkgs/development/python-modules/python-miio/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
     substituteInPlace pyproject.toml \
       --replace 'click = "^7"' 'click = "*"' \
       --replace 'croniter = "^0"' 'croniter = "*"' \
+      --replace 'cryptography = "^3"' 'cryptography = "*"' \
       --replace 'defusedxml = "^0.6"' 'defusedxml = "*"'
   '';
 
@@ -74,4 +75,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ flyfloh ];
   };
 }
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrade `python3Packages.cryptography` from `3.4.8` to `35.0.0`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
