### PR TITLE
electrs: fix missing metrics feature

### DIFF
--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
   # link rocksdb dynamically
   ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
   ROCKSDB_LIB_DIR = "${rocksdb}/lib";
-  cargoBuildFlags = "--no-default-features";
 
   buildInputs = lib.optionals stdenv.isDarwin [ Security ];
 


### PR DESCRIPTION
See https://github.com/romanz/electrs/issues/517

#### Copy of commit msg
With electrs 0.9.0, option `--no-default-features` disables the `metrics`
feature, which brakes electrs option `--monitoring-addr`.

Fix this by removing `--no-default-features`, which is no longer needed
for dynamic linking in 0.9.0.