### PR TITLE
mopidy-ytmusic: init at 0.3.2

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -37,5 +37,7 @@ lib.makeScope newScope (self: with self; {
 
   mopidy-youtube = callPackage ./youtube.nix { };
 
+  mopidy-ytmusic = callPackage ./ytmusic.nix { };
+
   mopidy-subidy = callPackage ./subidy.nix { };
 })

--- a/pkgs/applications/audio/mopidy/mpd.nix
+++ b/pkgs/applications/audio/mopidy/mpd.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "Mopidy-MPD";
-  version = "3.0.0";
+  version = "3.2.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0prjli4352521igcsfcgmk97jmzgbfy4ik8hnli37wgvv252wiac";
+    sha256 = "sha256-oZvKr61lyu7CmXP2A/xtYng1FIUPyveVJMqUuv6UnaM=";
   };
 
   propagatedBuildInputs = [mopidy];

--- a/pkgs/applications/audio/mopidy/mpris.nix
+++ b/pkgs/applications/audio/mopidy/mpris.nix
@@ -2,12 +2,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mopidy-mpris";
-  version = "3.0.2";
+  version = "3.0.3";
 
   src = python3Packages.fetchPypi {
     inherit version;
     pname = "Mopidy-MPRIS";
-    sha256 = "0mmdaikw00f43gzjdbvlcvzff6yppm7v8mv012r79adzd992q9y0";
+    sha256 = "sha256-rHQgNIyludTEL7RDC8dIpyGTMOt1Tazn6i/orKlSP4U=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -1,0 +1,26 @@
+{ lib, python3Packages, mopidy }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mopidy-ytmusic";
+  version = "0.3.2";
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "Mopidy-YTMusic";
+    sha256 = "sha256-BZtW+qHsTnOMj+jdAFI8ZMwGxJc9lNosgPJZGbt4JgU=";
+  };
+
+  propagatedBuildInputs = [
+    mopidy
+    python3Packages.ytmusicapi
+    python3Packages.pytube
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Mopidy extension for playing music from YouTube Music";
+    license = licenses.asl20;
+    maintainers = [ maintainers.nickhu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26091,7 +26091,8 @@ with pkgs;
     mopidy-spotify-tunigo
     mopidy-subidy
     mopidy-tunein
-    mopidy-youtube;
+    mopidy-youtube
+    mopidy-ytmusic;
 
   motif = callPackage ../development/libraries/motif { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package the Mopidy-YTMusic extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
