### PR TITLE
diffoscope: 183 -> 185

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -9,17 +9,22 @@
 # Note: when upgrading this package, please run the list-missing-tools.sh script as described below!
 python3Packages.buildPythonApplication rec {
   pname = "diffoscope";
-  version = "183";
+  version = "185";
 
   src = fetchurl {
     url = "https://diffoscope.org/archive/diffoscope-${version}.tar.bz2";
-    sha256 = "sha256-XFFrRmCpE2UvZRCELfPaotLklyjLiCDWkyFWkISOHZM=";
+    sha256 = "sha256-Spw7/+vQ1jd3rMZ792du04di0zleRNp8LUEki1374O8=";
   };
 
   outputs = [ "out" "man" ];
 
   patches = [
     ./ignore_links.patch
+
+    # due to https://salsa.debian.org/reproducible-builds/diffoscope/-/commit/953a599c2b903298b038b34abf515cea69f4fc19
+    # the version detection of LLVM is broken and the comparison result is compared against
+    # the expected result from LLVM 10 (rather than 7 which is our default).
+    ./fix-tests.patch
   ];
 
   postPatch = ''

--- a/pkgs/tools/misc/diffoscope/fix-tests.patch
+++ b/pkgs/tools/misc/diffoscope/fix-tests.patch
@@ -1,0 +1,14 @@
+diff --git a/tests/comparators/test_rlib.py b/tests/comparators/test_rlib.py
+index 8d201ab..05960aa 100644
+--- a/tests/comparators/test_rlib.py
++++ b/tests/comparators/test_rlib.py
+@@ -81,9 +81,6 @@ def rlib_dis_expected_diff():
+     if actual_ver >= "7.0":
+         diff_file = "rlib_llvm_dis_expected_diff_7"
+ 
+-    if actual_ver >= "10.0":
+-        diff_file = "rlib_llvm_dis_expected_diff_10"
+-
+     return get_data(diff_file)
+ 
+ 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ChangeLog: https://diffoscope.org/news/diffoscope-184-released/
ChangeLog: https://diffoscope.org/news/diffoscope-185-released/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
