### PR TITLE
gocryptfs: ensure fusermount setuid wrapper is used if present

### DIFF
--- a/pkgs/tools/filesystems/gocryptfs/default.nix
+++ b/pkgs/tools/filesystems/gocryptfs/default.nix
@@ -51,9 +51,11 @@ buildGoModule rec {
     popd
   '';
 
+  # use --suffix here to ensure we don't shadow /run/wrappers/bin/fusermount,
+  # as the setuid wrapper is required to use gocryptfs as non-root on NixOS
   postInstall = ''
     wrapProgram $out/bin/gocryptfs \
-      --prefix PATH : ${lib.makeBinPath [ fuse ]}
+      --suffix PATH : ${lib.makeBinPath [ fuse ]}
     ln -s $out/bin/gocryptfs $out/bin/mount.fuse.gocryptfs
   '';
 


### PR DESCRIPTION
###### Motivation for this change
#138532 added fusermount to PATH in the wrapper as a prefix, which shadows the /run/wrappers/bin/fusermount setuid wrapper. Adding fusermount to the end of PATH ensures we have the setuid wrapper available first, and thus makes it possible to use gocryptfs as non-root on NixOS.

Thanks to @Artturin for [this solution](https://github.com/NixOS/nixpkgs/issues/139939#issuecomment-930910304).

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Resolves #139939