### PR TITLE
starsector: init at 0.95a-RC15

### DIFF
--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, alsa-lib
+, fetchzip
+, libXxf86vm
+, makeWrapper
+, openjdk
+, stdenv
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "starsector";
+  version = "0.95a-RC15";
+
+  src = fetchzip {
+    url = "https://s3.amazonaws.com/fractalsoftworks/starsector/starsector_linux-${version}.zip";
+    sha256 = "sha256-/5ij/079aOad7otXSFFcmVmiYQnMX/0RXGOr1j0rkGY=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = with xorg; [
+    alsa-lib
+    libXxf86vm
+  ];
+
+  dontBuild = true;
+
+  # need to cd into $out in order for classpath to pick up correct jar files
+  installPhase = ''
+    mkdir -p $out/bin
+    rm -r jre_linux # remove jre7
+    rm starfarer.api.zip
+    cp -r ./* $out
+
+    wrapProgram $out/starsector.sh \
+      --prefix PATH : ${lib.makeBinPath [ openjdk ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
+      --run "mkdir -p \$XDG_DATA_HOME/starsector; cd $out"
+    ln -s $out/starsector.sh $out/bin/starsector
+  '';
+
+  # it tries to run everything with relative paths, which makes it CWD dependent
+  # also point mod, screenshot, and save directory to $XDG_DATA_HOME
+  postPatch = ''
+    substituteInPlace starsector.sh \
+      --replace "./jre_linux/bin/java" "${openjdk}/bin/java" \
+      --replace "./native/linux" "$out/native/linux" \
+      --replace "./" "\$XDG_DATA_HOME/starsector/"
+  '';
+
+  meta = with lib; {
+    description = "Open-world single-player space-combat, roleplaying, exploration, and economic game";
+    homepage = "https://fractalsoftworks.com";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ bbigras ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9288,6 +9288,10 @@ with pkgs;
 
   sqls = callPackage ../applications/misc/sqls { };
 
+  starsector = callPackage ../games/starsector {
+    openjdk = openjdk8;
+  };
+
   stdman = callPackage ../data/documentation/stdman { };
 
   steck = callPackage ../servers/pinnwand/steck.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Note that this game is unfree.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
