### PR TITLE
teamviewer: fix #96633, #44307 and #97148 + 15.15.5 -> 15.18.5 -> 15.22.3

### DIFF
--- a/nixos/modules/services/monitoring/teamviewer.nix
+++ b/nixos/modules/services/monitoring/teamviewer.nix
@@ -30,14 +30,15 @@ in
       description = "TeamViewer remote control daemon";
 
       wantedBy = [ "multi-user.target" ];
-      after = [ "NetworkManager-wait-online.service" "network.target" ];
+      after = [ "NetworkManager-wait-online.service" "network.target" "dbus.service" ];
+      requires = [ "dbus.service" ];
       preStart = "mkdir -pv /var/lib/teamviewer /var/log/teamviewer";
 
       startLimitIntervalSec = 60;
       startLimitBurst = 10;
       serviceConfig = {
-        Type = "forking";
-        ExecStart = "${pkgs.teamviewer}/bin/teamviewerd -d";
+        Type = "simple";
+        ExecStart = "${pkgs.teamviewer}/bin/teamviewerd -f";
         PIDFile = "/run/teamviewerd.pid";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         Restart = "on-abort";

--- a/nixos/modules/services/monitoring/teamviewer.nix
+++ b/nixos/modules/services/monitoring/teamviewer.nix
@@ -24,6 +24,8 @@ in
 
     environment.systemPackages = [ pkgs.teamviewer ];
 
+    services.dbus.packages = [ pkgs.teamviewer ];
+
     systemd.services.teamviewerd = {
       description = "TeamViewer remote control daemon";
 

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -6,11 +6,11 @@
 
 mkDerivation rec {
   pname = "teamviewer";
-  version = "15.18.5";
+  version = "15.22.3";
 
   src = fetchurl {
     url = "https://dl.tvcdn.de/download/linux/version_15x/teamviewer_${version}_amd64.deb";
-    sha256 = "03m8k6qr3mgylik1gqi8qlm0dngb3vf4p6gdwd5hyvz7gh5mdm2r";
+    sha256 = "15fvzhdq7mnx2l2w4byvij8ww16qwdlkbadal60rm66yzv79mv9w";
   };
 
   unpackPhase = ''
@@ -28,6 +28,7 @@ mkDerivation rec {
     rm -R \
       $out/share/teamviewer/logfiles \
       $out/share/teamviewer/config \
+      $out/share/teamviewer/tv_bin/RTlib \
       $out/share/teamviewer/tv_bin/xdg-utils \
       $out/share/teamviewer/tv_bin/script/{teamviewer_setup,teamviewerd.sysv,teamviewerd.service,teamviewerd.*.conf,libdepend,tv-delayed-start.sh}
 

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, lib, fetchurl, autoPatchelfHook, makeWrapper, xdg-utils, dbus
 , qtbase, qtwebkit, qtwebengine, qtx11extras, qtquickcontrols, getconf, glibc
-, libXrandr, libX11, libXext, libXdamage, libXtst, libSM, libXfixes
+, libXrandr, libX11, libXext, libXdamage, libXtst, libSM, libXfixes, coreutils
 , wrapQtAppsHook
 }:
 
@@ -75,7 +75,7 @@ mkDerivation rec {
   '';
 
   makeWrapperArgs = [
-    "--prefix PATH : ${lib.makeBinPath [ getconf ]}"
+    "--prefix PATH : ${lib.makeBinPath [ getconf coreutils ]}"
     "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libXrandr libX11 libXext libXdamage libXtst libSM libXfixes dbus ]}"
   ];
 

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -72,19 +72,19 @@ mkDerivation rec {
       --replace '/lib64/ld-linux-x86-64.so.2' '${glibc.out}/lib/ld-linux-x86-64.so.2'
     substituteInPlace $out/share/teamviewer/tv_bin/script/tvw_config \
       --replace '/var/run/' '/run/'
+  '';
 
-    wrapProgram $out/share/teamviewer/tv_bin/script/teamviewer \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXrandr libX11 dbus ]}"
-    wrapProgram $out/share/teamviewer/tv_bin/teamviewerd \
-      --prefix PATH : "${lib.makeBinPath [ getconf ]}" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXrandr libX11 dbus ]}"
-    wrapProgram $out/share/teamviewer/tv_bin/TeamViewer \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXrandr libX11 dbus ]}"
-    wrapProgram $out/share/teamviewer/tv_bin/TeamViewer_Desktop \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [libXrandr libX11 libXext libXdamage libXtst libSM libXfixes dbus ]}"
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ getconf ]}"
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libXrandr libX11 libXext libXdamage libXtst libSM libXfixes dbus ]}"
+  ];
 
-    wrapQtApp $out/share/teamviewer/tv_bin/script/teamviewer
-    wrapQtApp $out/bin/teamviewer
+  postFixup = ''
+    wrapProgram $out/share/teamviewer/tv_bin/teamviewerd ''${makeWrapperArgs[@]}
+    # tv_bin/script/teamviewer runs tvw_main which runs tv_bin/TeamViewer
+    wrapProgram $out/share/teamviewer/tv_bin/script/teamviewer ''${makeWrapperArgs[@]} ''${qtWrapperArgs[@]}
+    wrapProgram $out/share/teamviewer/tv_bin/teamviewer-config ''${makeWrapperArgs[@]} ''${qtWrapperArgs[@]}
+    wrapProgram $out/share/teamviewer/tv_bin/TeamViewer_Desktop ''${makeWrapperArgs[@]} ''${qtWrapperArgs[@]}
   '';
 
   dontStrip = true;

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -1,16 +1,16 @@
 { mkDerivation, lib, fetchurl, autoPatchelfHook, makeWrapper, xdg-utils, dbus
-, qtbase, qtwebkit, qtx11extras, qtquickcontrols, glibc
+, qtbase, qtwebkit, qtwebengine, qtx11extras, qtquickcontrols, getconf, glibc
 , libXrandr, libX11, libXext, libXdamage, libXtst, libSM, libXfixes
 , wrapQtAppsHook
 }:
 
 mkDerivation rec {
   pname = "teamviewer";
-  version = "15.15.5";
+  version = "15.18.5";
 
   src = fetchurl {
     url = "https://dl.tvcdn.de/download/linux/version_15x/teamviewer_${version}_amd64.deb";
-    sha256 = "sha256-H/CSc2RcjI+Fm8awYcXm3ioAJpbSNEMwGVrTozMux3A=";
+    sha256 = "03m8k6qr3mgylik1gqi8qlm0dngb3vf4p6gdwd5hyvz7gh5mdm2r";
   };
 
   unpackPhase = ''
@@ -19,7 +19,7 @@ mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapQtAppsHook ];
-  buildInputs = [ dbus qtbase qtwebkit qtx11extras libX11 ];
+  buildInputs = [ dbus getconf qtbase qtwebkit qtwebengine qtx11extras libX11 ];
   propagatedBuildInputs = [ qtquickcontrols ];
 
   installPhase = ''
@@ -73,10 +73,15 @@ mkDerivation rec {
     substituteInPlace $out/share/teamviewer/tv_bin/script/tvw_config \
       --replace '/var/run/' '/run/'
 
-    wrapProgram $out/share/teamviewer/tv_bin/script/teamviewer --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXrandr libX11 dbus ]}"
-    wrapProgram $out/share/teamviewer/tv_bin/teamviewerd --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXrandr libX11 dbus ]}"
-    wrapProgram $out/share/teamviewer/tv_bin/TeamViewer --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXrandr libX11 dbus ]}"
-    wrapProgram $out/share/teamviewer/tv_bin/TeamViewer_Desktop --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [libXrandr libX11 libXext libXdamage libXtst libSM libXfixes dbus ]}"
+    wrapProgram $out/share/teamviewer/tv_bin/script/teamviewer \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXrandr libX11 dbus ]}"
+    wrapProgram $out/share/teamviewer/tv_bin/teamviewerd \
+      --prefix PATH : "${lib.makeBinPath [ getconf ]}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXrandr libX11 dbus ]}"
+    wrapProgram $out/share/teamviewer/tv_bin/TeamViewer \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libXrandr libX11 dbus ]}"
+    wrapProgram $out/share/teamviewer/tv_bin/TeamViewer_Desktop \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [libXrandr libX11 libXext libXdamage libXtst libSM libXfixes dbus ]}"
 
     wrapQtApp $out/share/teamviewer/tv_bin/script/teamviewer
     wrapQtApp $out/bin/teamviewer

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9583,7 +9583,7 @@ with pkgs;
 
   ted = callPackage ../tools/typesetting/ted { };
 
-  teamviewer = libsForQt514.callPackage ../applications/networking/remote/teamviewer { };
+  teamviewer = libsForQt515.callPackage ../applications/networking/remote/teamviewer { };
 
   teleconsole = callPackage ../tools/misc/teleconsole { };
 


### PR DESCRIPTION
###### Motivation for this change

 -  Fixing issue #96633
 -  Fixing issue #44307
 -  Fixing observed service stop issue
 -  Updating the package to latest possible version backportable to 21.05 (bound by nixpkgs qt5.14) 
 -  Some refactors suggested by @Artturin
 -  Fixing issue #97148 as suggested by @Artturin 
 -  For unstable: Updated to latest which requires qt5.15 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested the service with these 2 patches applied on top of my current 21.05 config. Works fine.

Tested client server launching these manually from package built from this branch. Works fine and fix the bug.


Note that `nixpkgs-review` raise an error which I am completely unable to understand:

```bash
$ nix-shell -I nixpkgs=. -p nixpkgs-review --run "nixpkgs-review rev HEAD^"
# ,,
1 package updated:
teamviewer
# ..
builder for '/nix/store/r86mqdfpqpi87kq3zb4d5fdzpa22r33x-review-shell.drv' failed with exit code 1; last 2 log lines:
  qtPreHook
  Error: wrapQtAppsHook is not used, and dontWrapQtApps is not set.
error: build of '/nix/store/r86mqdfpqpi87kq3zb4d5fdzpa22r33x-review-shell.drv' failed
1 package built:
teamviewer
# ..
```

If you look at the package, it effectively sets `dontWrapQtApps = true;`. 