### PR TITLE
[staging-next] imagemagick: unbreak for aarch64

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -37,7 +37,9 @@ stdenv.mkDerivation rec {
     ++ (if arch != null then [ "--with-gcc-arch=${arch}" ] else [ "--without-gcc-arch" ])
     ++ lib.optional (librsvg != null) "--with-rsvg"
     ++ lib.optional (liblqr1 != null) "--with-lqr"
-    ++ lib.optional (libjxl != null) "--with-jxl"
+    # libjxl is broken on aarch64 (see meta.broken in libjxl) for now,
+    # let's disable it for now to unbreak the imagemagick build.
+    ++ lib.optional (libjxl != null && !stdenv.isAarch64) "--with-jxl"
     ++ lib.optionals (ghostscript != null)
       [ "--with-gs-font-dir=${ghostscript}/share/ghostscript/fonts"
         "--with-gslib"
@@ -50,8 +52,12 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ zlib fontconfig freetype ghostscript
-      libjxl liblqr1 libpng libtiff libxml2 libheif djvulibre
+      liblqr1 libpng libtiff libxml2 libheif djvulibre
     ]
+    # libjxl is broken on aarch64 (see meta.broken in libjxl) for now,
+    # let's disable it for now to unbreak the imagemagick build.
+    ++ lib.optionals (!stdenv.isAarch64)
+      [ libjxl ]
     ++ lib.optionals (!stdenv.hostPlatform.isMinGW)
       [ openexr librsvg openjpeg ]
     ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
###### Motivation for this change

With the newly added libjxl dependency it was broken, since libjxl
doesn't build on aarch64 (https://github.com/NixOS/nixpkgs/pull/103160#issuecomment-866388610). Remove that dependency if we're building for
aarch64 for now, until the compiler / library is fixed.

I'm not sure if this is the right approach, or if there's some way I can use the meta.broken tags to determine if libjxl should be included. I'd like some guidance on that.

Merging in staging-next since jxl was added in staging, and this should only affect aarch64.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
