### PR TITLE
ums: 9.4.2 -> 10.12.0

### DIFF
--- a/pkgs/servers/ums/default.nix
+++ b/pkgs/servers/ums/default.nix
@@ -4,16 +4,16 @@
 
 stdenv.mkDerivation rec {
   pname = "ums";
-  version = "9.4.2";
+  version = "10.12.0";
 
   src = {
     i686-linux = fetchurl {
       url =  "mirror://sourceforge/project/unimediaserver/${version}/" + lib.toUpper "${pname}-${version}" + "-x86.tgz";
-      sha256 = "0i319g2c3z9j131nwh5m92clgnxxxs3izplzhjb30bx4lldmjs1j";
+      sha256 = "0j3d5zcwwswlcr2vicmvnnr7n8cg3q46svz0mbmga4j3da4473i6";
     };
     x86_64-linux = fetchurl {
       url =  "mirror://sourceforge/project/unimediaserver/${version}/" + lib.toUpper "${pname}-${version}" + "-x86_64.tgz";
-      sha256 = "07wc0is86fdfyz4as3f17q8pfzl8x55ci65zvpls0a9rfyyvjjw3";
+      sha256 = "06f96vkf593aasyfw458fa4x3rnai2k83vpgzc83hlwr0rw70qfn";
    };
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
     # ums >= 9.0.0 ships its own JRE in the package. if we remove it, the `UMS.sh`
     # script will correctly fall back to the JRE specified by JAVA_HOME
-    rm -rf $out/jre
+    rm -rf $out/jre8
 
     makeWrapper "$out/UMS.sh" "$out/bin/ums" \
       --prefix LD_LIBRARY_PATH ":" "${lib.makeLibraryPath [ libzen libmediainfo] }" \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package upgrade.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
