### PR TITLE
[staging-21.05] openssh: Fix CVE-2021-41617

### DIFF
--- a/pkgs/tools/networking/openssh/CVE-2021-41617-1.patch
+++ b/pkgs/tools/networking/openssh/CVE-2021-41617-1.patch
@@ -1,0 +1,30 @@
+From f3cbe43e28fe71427d41cfe3a17125b972710455 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Sun, 26 Sep 2021 14:01:03 +0000
+Subject: [PATCH] upstream: need initgroups() before setresgid(); reported by
+ anton@,
+
+ok deraadt@
+
+OpenBSD-Commit-ID: 6aa003ee658b316960d94078f2a16edbc25087ce
+---
+ misc.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/misc.c b/misc.c
+index b8d1040d1e..d94438da65 100644
+--- a/misc.c
++++ b/misc.c
+@@ -2695,6 +2695,12 @@ subprocess(const char *tag, const char *command,
+ 		}
+ 		closefrom(STDERR_FILENO + 1);
+ 
++		if (geteuid() == 0 &&
++		    initgroups(pw->pw_name, pw->pw_gid) == -1) {
++			error("%s: initgroups(%s, %u): %s", tag,
++			    pw->pw_name, (u_int)pw->pw_gid, strerror(errno));
++			_exit(1);
++		}
+ 		if (setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) == -1) {
+ 			error("%s: setresgid %u: %s", tag, (u_int)pw->pw_gid,
+ 			    strerror(errno));

--- a/pkgs/tools/networking/openssh/CVE-2021-41617-2.patch
+++ b/pkgs/tools/networking/openssh/CVE-2021-41617-2.patch
@@ -1,0 +1,21 @@
+From bf944e3794eff5413f2df1ef37cddf96918c6bde Mon Sep 17 00:00:00 2001
+From: Damien Miller <djm@mindrot.org>
+Date: Mon, 27 Sep 2021 00:03:19 +1000
+Subject: [PATCH] initgroups needs grp.h
+
+---
+ misc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/misc.c b/misc.c
+index d94438da65..0134d69492 100644
+--- a/misc.c
++++ b/misc.c
+@@ -56,6 +56,7 @@
+ #ifdef HAVE_PATHS_H
+ # include <paths.h>
+ #include <pwd.h>
++#include <grp.h>
+ #endif
+ #ifdef SSH_TUN_OPENBSD
+ #include <net/if.h>

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -12,7 +12,11 @@ in {
       sha256 = "1bnpivgk98h2f9afpp88jv6g9ps83vnpxd031n2jqxi12vdf9rn3";
     };
 
-    extraPatches = [ ./ssh-keysign-8.5.patch ];
+    extraPatches = [
+      ./ssh-keysign-8.5.patch
+      ./CVE-2021-41617-1.patch
+      ./CVE-2021-41617-2.patch
+    ];
   };
 
   openssh_hpn = common rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A new CVE, a new PR \o/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
