### PR TITLE
resholve: actually include resholveScript* in all-packages.nix

### DIFF
--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -3,6 +3,8 @@
 , callPackage
 , resholve
 , resholvePackage
+, resholveScript
+, resholveScriptBin
 , shunit2
 , coreutils
 , gnused
@@ -22,35 +24,6 @@
 }:
 
 let
-  inherit (callPackage ./default.nix { })
-    resholve resholvePackage resholveScript resholveScriptBin;
-
-  # ourCoreutils = coreutils.override { singleBinary = false; };
-
-  /*
-    TODO: wrapped copy of find so that we can eventually test
-    our ability to see through wrappers. Unused for now.
-    Note: grep can serve the negative case; grep doesn't match, and
-    egrep is a shell wrapper for grep.
-  */
-  # wrapfind = runCommand "wrapped-find" { } ''
-  #   source ${makeWrapper}/nix-support/setup-hook
-  #   makeWrapper ${findutils}/bin/find $out/bin/wrapped-find
-  # '';
-  /* TODO:
-    unrelated, but is there already a function (or would
-    there be demand for one?) along the lines of:
-    wrap = { drv, executable(s?), args ? { } }: that:
-    - generates a sane output name
-    - sources makewrapper
-    - retargets real executable if already wrapped
-    - wraps the executable
-
-    I wonder because my first thought here was overrideAttrs,
-    but I realized rebuilding just for a custom wrapper is an
-    ongoing waste of time. If it is a common pattern in the
-    wild, it would be a nice QoL improvement.
-  */
 
 in
 rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8767,7 +8767,7 @@ with pkgs;
   rescuetime = libsForQt5.callPackage ../applications/misc/rescuetime { };
 
   inherit (callPackage ../development/misc/resholve { })
-    resholve resholvePackage;
+    resholve resholvePackage resholveScript resholveScriptBin;
 
   restool = callPackage ../os-specific/linux/restool {};
 


### PR DESCRIPTION
###### Motivation for this change

- I'm a goober and forgot to add the all-packages inherits for `resholveScript` and `resholveScriptBin` in #139253
- Fix part of test.nix that masked this omission.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@DeeUnderscore @happysalada 