### PR TITLE
emu2: unstable-2020-06-04 -> 0.0.0+unstable=2021-09-22

### DIFF
--- a/pkgs/misc/emulators/emu2/default.nix
+++ b/pkgs/misc/emulators/emu2/default.nix
@@ -1,14 +1,17 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
 
 stdenv.mkDerivation rec {
   pname = "emu2";
-  version = "unstable-2020-06-04";
+  version = "0.0.0+unstable=2021-09-22";
 
   src = fetchFromGitHub {
-    owner  = "dmsc";
-    repo   = "emu2";
-    rev    = "f9599d347aab07d9281400ec8b214aabd187fbcd";
-    sha256 = "0d8fb3wp477kfi0p4mmr69lxsbgb4gl9pqmm68g9ixzrfch837v4";
+    owner = "dmsc";
+    repo = "emu2";
+    rev = "8d01b53f154d6bfc9561a44b9c281b46e00a4e87";
+    hash = "sha256-Jafl0Pw2k5RCF9GgpdAWcQ+HBTsiX7dOKSMCWPHQ+2E=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
@@ -17,7 +20,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/dmsc/emu2/";
     description = "A simple text-mode x86 + DOS emulator";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ dramaturg ];
-    license = licenses.gpl2;
+    maintainers = with maintainers; [ AndersonTorres ];
+    license = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
