### PR TITLE
multus-cni: fix version ouput, clean up

### DIFF
--- a/pkgs/applications/networking/cluster/multus-cni/default.nix
+++ b/pkgs/applications/networking/cluster/multus-cni/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildGoModule }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "multus-cni";
@@ -11,15 +11,14 @@ buildGoModule rec {
     sha256 = "sha256-wG6SRts3+bmeMkfScyNorsBvRl/hxe+CUnL0rwfknpc=";
   };
 
-  ldflags = let
-    multus = "gopkg.in/intel/multus-cni.v3/pkg/multus";
-    commit = "f6298a3a294a79f9fbda0b8f175e521799d5f8d7";
-  in [
-    "-s" "-w" "-X ${multus}.version=v${version}" "-X ${multus}.commit=${commit}"
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/multus.version=${version}"
   ];
 
   preInstall = ''
-      mv $GOPATH/bin/cmd $GOPATH/bin/multus
+    mv $GOPATH/bin/cmd $GOPATH/bin/multus
   '';
 
   vendorSha256 = null;
@@ -28,10 +27,11 @@ buildGoModule rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Multus CNI is a container network interface (CNI) plugin for Kubernetes that enables attaching multiple network interfaces to pods. ";
+    description = "Multus CNI is a container network interface (CNI) plugin for Kubernetes that enables attaching multiple network interfaces to pods";
     homepage = "https://github.com/k8snetworkplumbingwg/multus-cni";
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = with maintainers; [ onixie ];
+    mainProgram = "multus";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

fixes version output
sets meta.mainProgram
and minor styling changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
