### PR TITLE
vim-utils: fix dependency graph

### DIFF
--- a/pkgs/applications/editors/neovim/tests.nix
+++ b/pkgs/applications/editors/neovim/tests.nix
@@ -97,7 +97,7 @@ rec {
 
   run_nvim_with_plug = runTest nvim_with_plug ''
     export HOME=$TMPDIR
-    ${nvim_with_plug}/bin/nvim -i NONE -c 'color base16-tomorrow-night'  +quit!
+    ${nvim_with_plug}/bin/nvim -i NONE -c 'color base16-tomorrow-night'  +quit! -e
   '';
 
 

--- a/pkgs/applications/editors/neovim/tests.nix
+++ b/pkgs/applications/editors/neovim/tests.nix
@@ -87,7 +87,7 @@ rec {
   nvim_with_plug = neovim.override {
     extraName = "-with-plug";
     configure.plug.plugins = with pkgs.vimPlugins; [
-      base16-vim
+      (base16-vim.overrideAttrs(old: { pname = old.pname + "-unique-for-tests-please-dont-use"; }))
     ];
     configure.customRC = ''
       color base16-tomorrow-night

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -292,14 +292,12 @@ let
 
       /* vim-plug is an extremely popular vim plugin manager.
       */
-      /* Remove repeated "/." suffixes from a path */
-      stripDots = path: lib.head (builtins.split "(/\\.)*$" path);
       plugImpl =
       (''
         source ${vimPlugins.vim-plug.rtp}/plug.vim
         silent! call plug#begin('/dev/null')
 
-        '' + (lib.concatMapStringsSep "\n" (pkg: "Plug '${stripDots pkg.rtp}'") plug.plugins) + ''
+        '' + (lib.concatMapStringsSep "\n" (pkg: "Plug '${pkg.rtp}'") plug.plugins) + ''
 
         call plug#end()
       '');


### PR DESCRIPTION
###### Motivation for this change

when #138349 got merged, it broke the dependency graph between the vim
config and its plugins.

By rewriting the path it seems the edge gets removed. This makes the
configuration file inherit a correct path but without the plugin backing
it.

See https://github.com/NixOS/nixpkgs/pull/138349#issuecomment-931907960
cc @anirudhb @teto

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
