### PR TITLE
mopidy-jellyfin: Init at 1.0.2

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -9,6 +9,8 @@ lib.makeScope newScope (self: with self; {
 
   mopidy-iris = callPackage ./iris.nix { };
 
+  mopidy-jellyfin = callPackage ./jellyfin.nix { };
+
   mopidy-local = callPackage ./local.nix { };
 
   mopidy-moped = callPackage ./moped.nix { };

--- a/pkgs/applications/audio/mopidy/jellyfin.nix
+++ b/pkgs/applications/audio/mopidy/jellyfin.nix
@@ -1,0 +1,25 @@
+{ lib, python3Packages, mopidy }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mopidy-jellyfin";
+  version = "1.0.2";
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "Mopidy-Jellyfin";
+    sha256 = "0j7v5xx3c401r5dw1sqm1n2263chjga1d3ml85rg79hjhhhacy75";
+  };
+
+  propagatedBuildInputs = [ mopidy python3Packages.unidecode python3Packages.websocket-client ];
+
+  # no tests implemented
+  doCheck = false;
+  pythonImportsCheck = [ "mopidy_jellyfin" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/jellyfin/mopidy-jellyfin";
+    description = "Mopidy extension for playing audio files from Jellyfin";
+    license = licenses.asl20;
+    maintainers = [ maintainers.pstn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26099,6 +26099,7 @@ with pkgs;
   inherit (mopidyPackages)
     mopidy
     mopidy-iris
+    mopidy-jellyfin
     mopidy-local
     mopidy-moped
     mopidy-mopify


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
We have excellent jellyfin and mopidy support. Leaving out the adapter between the two would be a shame.

ping @eyJhb  since you were interested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
