### PR TITLE
discourse: Make sure the notification email setting applies

### DIFF
--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -263,6 +263,9 @@ let
       # defaults to the plugin's directory and isn't writable at the
       # time of asset generation
       ./auto_generated_path.patch
+
+      # Make sure the notification email setting applies
+      ./notification_email.patch
     ];
 
     postPatch = ''

--- a/pkgs/servers/web-apps/discourse/notification_email.patch
+++ b/pkgs/servers/web-apps/discourse/notification_email.patch
@@ -1,0 +1,18 @@
+diff --git a/db/fixtures/990_settings.rb b/db/fixtures/990_settings.rb
+deleted file mode 100644
+index 6f21e58813..0000000000
+--- a/db/fixtures/990_settings.rb
++++ /dev/null
+@@ -1,12 +0,0 @@
+-# frozen_string_literal: true
+-
+-if SiteSetting.notification_email == SiteSetting.defaults[:notification_email]
+-  # don't crash for invalid hostname, which is possible in dev
+-  begin
+-    SiteSetting.notification_email = "noreply@#{Discourse.current_hostname}"
+-  rescue Discourse::InvalidParameters
+-    if Rails.env.production?
+-      STDERR.puts "WARNING: Discourse hostname: #{Discourse.current_hostname} is not a valid domain for emails!"
+-    end
+-  end
+-end


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Discourse normally overrides the default notification email setting, which makes the `notificationEmailAddress` setting ineffective. Add a patch to remove this override.

Fixes #140114.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
