### PR TITLE
haskell.packages.ghc921: use random_1_2_1 (and related fixes)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -97,6 +97,10 @@ self: super: {
   # The test suite seems pretty broken.
   base64-bytestring = dontCheck super.base64-bytestring;
 
+  # 1.2.1 introduced support for GHC 9.2.1, stackage has 1.2.0
+  # The test suite indirectly depends on random, which leads to infinite recursion
+  random = dontCheck super.random_1_2_1;
+
   # 5 introduced support for GHC 9.0.x, but hasn't landed in stackage yet
   lens = super.lens_5_0_1;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -53,7 +53,7 @@ self: super: {
 
   # Jailbreaks & Version Updates
   async = doJailbreak super.async;
-  ChasingBottoms = markBrokenVersion "1.3.1.9" super.ChasingBottoms;
+  ChasingBottoms = doJailbreak super.ChasingBottoms;
   data-fix = doJailbreak super.data-fix;
   dec = doJailbreak super.dec;
   ed25519 = doJailbreak super.ed25519;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -63,6 +63,7 @@ self: super: {
   HTTP = overrideCabal (doJailbreak super.HTTP) (drv: { postPatch = "sed -i -e 's,! Socket,!Socket,' Network/TCP.hs"; });
   integer-logarithms = overrideCabal (doJailbreak super.integer-logarithms) (drv: { postPatch = "sed -i -e 's,integer-gmp <1.1,integer-gmp < 2,' integer-logarithms.cabal"; });
   lukko = doJailbreak super.lukko;
+  network = super.network_3_1_2_2;
   parallel = doJailbreak super.parallel;
   primitive = doJailbreak super.primitive;
   regex-posix = doJailbreak super.regex-posix;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -53,6 +53,7 @@ self: super: {
 
   # Jailbreaks & Version Updates
   async = doJailbreak super.async;
+  base64-bytestring = doJailbreak super.base64-bytestring;
   ChasingBottoms = doJailbreak super.ChasingBottoms;
   data-fix = doJailbreak super.data-fix;
   dec = doJailbreak super.dec;
@@ -63,7 +64,7 @@ self: super: {
   integer-logarithms = overrideCabal (doJailbreak super.integer-logarithms) (drv: { postPatch = "sed -i -e 's,integer-gmp <1.1,integer-gmp < 2,' integer-logarithms.cabal"; });
   lukko = doJailbreak super.lukko;
   parallel = doJailbreak super.parallel;
-  primitive = doJailbreak (dontCheck super.primitive);
+  primitive = doJailbreak super.primitive;
   regex-posix = doJailbreak super.regex-posix;
   resolv = doJailbreak super.resolv;
   singleton-bool = doJailbreak super.singleton-bool;
@@ -88,14 +89,7 @@ self: super: {
   });
 
   # 1.3.0 (on stackage) defines instances for the Option-type, which has been removed from base in GHC 9.2.x
-  # Tests fail because random hasn't been updated for GHC 9.2.x
-  hashable = dontCheck super.hashable_1_3_3_0;
-
-  # Tests fail because random hasn't been updated for GHC 9.2.x
-  unordered-containers = dontCheck super.unordered-containers;
-
-  # The test suite seems pretty broken.
-  base64-bytestring = dontCheck super.base64-bytestring;
+  hashable = super.hashable_1_3_3_0;
 
   # 1.2.1 introduced support for GHC 9.2.1, stackage has 1.2.0
   # The test suite indirectly depends on random, which leads to infinite recursion


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
@sternenseemann As promised, `random` ;)

`QuickCheck` and `hspec` were blocked by this, so this should fix a lot of packages.

I've removed the `dontCheck`s that were directly blocked by random, but it looks like it might be possible to remove more by adding some jailbreaks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
