### PR TITLE
kalker: 1.0.0 -> 1.0.1-2

### DIFF
--- a/pkgs/tools/misc/kalker/default.nix
+++ b/pkgs/tools/misc/kalker/default.nix
@@ -6,19 +6,17 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "kalker";
-  version = "1.0.0";
+  version = "1.0.1-2";
 
   src = fetchFromGitHub {
     owner = "PaddiM8";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-1iZvp30/V0bw9NBxiKNiDgOMYJkDsGhTGdBsAPggdEg=";
+    sha256 = "sha256-fXTsCHqm+wO/ygyg0y+44G9pgaaEEH9fgePCDH86/vU=";
   };
 
-  cargoSha256 = "sha256-fBWnMlOLgwrOBPS2GIfOUDHQHcMMaU5r9JZVMbA+W58=";
+  cargoSha256 = "sha256-Ul21otEYCJuX5GnfV9OTpk/+3y32biASYZQpOecr8aU=";
 
-  # https://gitlab.com/tspiteri/gmp-mpfr-sys/-/issues/20
-  nativeBuildInputs = [ gcc ];
   buildInputs = [ gmp mpfr libmpc ];
 
   outputs = [ "out" "lib" ];


### PR DESCRIPTION
###### Motivation for this change
kalker update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
