### PR TITLE
[staging-21.05] vim: Fix CVE-2021-3770, CVE-2021-3778, CVE-2021-3796

### DIFF
--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, callPackage, ncurses, gettext, pkg-config
+{ lib, stdenv, fetchurl, fetchpatch, callPackage, ncurses, gettext, pkg-config
 # default vimrc
 , vimrc ? fetchurl {
     name = "default-vimrc";
@@ -20,6 +20,24 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ gettext pkg-config ];
   buildInputs = [ ncurses ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ Carbon Cocoa ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/vim/vim/commit/b7081e135a16091c93f6f5f7525a5c58fb7ca9f9.patch";
+      name = "CVE-2021-3770.patch";
+      sha256 = "0xk5q1lsq99hinrwnfdi01i0zzr9s9f0bfq8244bb0nvwadlq302";
+    })
+    (fetchpatch {
+      url = "https://github.com/vim/vim/commit/65b605665997fad54ef39a93199e305af2fe4d7f.patch";
+      name = "CVE-2021-3778.patch";
+      sha256 = "1s4nbaz2nfl96zdnh8xwf6vsrby7xf6pjbfkc4c5y3h0mf2llb2h";
+    })
+    (fetchpatch {
+      url = "https://github.com/vim/vim/commit/35a9a00afcb20897d462a766793ff45534810dc3.patch";
+      name = "CVE-2021-3796.patch";
+      sha256 = "0d538dkgkdfp3z501bifgm4c8amlqdp3mjqjmhdd9cadza4amix9";
+    })
+  ];
 
   configureFlags = [
     "--enable-multibyte"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.openwall.com/lists/oss-security/2021/10/01/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) → vim starts and I can do `:retab`
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
