### PR TITLE
nixos: add networking.includeFQDNAndHostnameEntries

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -37,7 +37,7 @@ in
       default = true;
       description = ''
         Whether to add the FQDN and hostname entries to /etc/hosts,
-        mapping FQDN and hostname to 127.0.0.2 and optionally ::1 if
+        mapping them to 127.0.0.2 and optionally ::1 if
         IPv6 is enabled.
 
         Setting this to false prevents DNS entries from being

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -43,8 +43,6 @@ in
         Setting this to false prevents DNS entries from being
         overridden (when FQDN should resolve to the public IP address
         instead of 127.0.0.1)
-
-        Useful for e.g. `services.zookeeper`.
       '';
     };
 

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -175,7 +175,7 @@ in
       hostnames = # Note: The FQDN (canonical hostname) has to come first:
         optional (cfg.hostName != "" && cfg.domain != null) "${cfg.hostName}.${cfg.domain}"
         ++ optional (cfg.hostName != "") cfg.hostName; # Then the hostname (without the domain)
-    in optionalAttrs cfg.addFQDNAndHostnameEntries ({
+    in optionalAttrs cfg.includeFQDNAndHostnameEntries ({
       "127.0.0.2" = hostnames;
     } // optionalAttrs cfg.enableIPv6 {
       "::1" = hostnames;

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -32,7 +32,7 @@ in
       '';
     };
 
-    networking.addFQDNAndHostnameEntries = lib.mkOption {
+    networking.includeFQDNAndHostnameEntries = lib.mkOption {
       type = types.bool;
       default = true;
       description = ''

--- a/nixos/modules/services/misc/zookeeper.nix
+++ b/nixos/modules/services/misc/zookeeper.nix
@@ -61,7 +61,12 @@ in {
     };
 
     servers = mkOption {
-      description = "All Zookeeper Servers.";
+      description = ''
+        All Zookeeper Servers.
+
+        Set `networking.includeFQDNAndHostnameEntries` to false to
+        prevent each peer binding on 127.0.0.2
+      '';
       default = "";
       type = types.lines;
       example = ''


### PR DESCRIPTION
(See 234d95a6fc75208266049fa2f57641d6f4e5bd2)

When set to false, this option prevents DNS entries from being overridden (when FQDN should resolve to the public IP address instead of 127.0.0.1) 

I had this problem when deploying multiple machines with nixops (e.g. a Zookeeper cluster doesn't work without this, because each peer binds on 127.0.0.2)

