### PR TITLE
rpl: update to 4467bd4

### DIFF
--- a/pkgs/tools/text/rpl/default.nix
+++ b/pkgs/tools/text/rpl/default.nix
@@ -1,22 +1,41 @@
-{ lib, fetchFromGitHub, pythonPackages }:
+{ lib, fetchFromGitHub, python3Packages }:
 
-pythonPackages.buildPythonApplication rec {
+let
+  rev = "4467bd46a7a798f738247a7f090c1505176bd597";
+  sha256 = "0yf3pc3fws4nnh4nd8d3jpglmsyi69d17qqgpcnkpqca5l4cd25w";
+in
+
+python3Packages.buildPythonApplication rec {
   pname = "rpl";
-  version = "1.5.7";
+  version = builtins.substring 0 7 rev;
 
   # Tests not included in pip package.
   doCheck = false;
 
+
   src = fetchFromGitHub {
-    owner  = "kcoyner";
+    owner  = "rrthomas";
     repo   = "rpl";
-    rev    = "v${version}";
-    sha256 = "1xhpgcmq91ivy9ijfyz5ilg51m7fz8ar2077r7gq246j8gbf8ggr";
+    inherit rev sha256;
   };
+
+  patches = [
+    ./remove-argparse-manpage.diff # quickfix for ImportError: No module named build_manpages.build_manpages
+  ];
+
+  buildInputs = [
+    #python3Packages.argparse-manpage # TODO
+    python3Packages.chardet
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv rpl $out/bin
+  '';
 
   meta = with lib; {
     description = "Replace strings in files";
-    homepage    = "https://github.com/kcoyner/rpl";
+    homepage    = "https://github.com/rrthomas/rpl";
     license     = licenses.gpl2;
     maintainers = with maintainers; [ teto ];
   };

--- a/pkgs/tools/text/rpl/default.nix
+++ b/pkgs/tools/text/rpl/default.nix
@@ -7,7 +7,7 @@ in
 
 python3Packages.buildPythonApplication rec {
   pname = "rpl";
-  version = builtins.substring 0 7 rev;
+  version = "1.10";
 
   # Tests not included in pip package.
   doCheck = false;

--- a/pkgs/tools/text/rpl/remove-argparse-manpage.diff
+++ b/pkgs/tools/text/rpl/remove-argparse-manpage.diff
@@ -1,0 +1,27 @@
+diff --git a/setup.cfg b/setup.cfg
+index 12e9198..38e5376 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -15,7 +15,6 @@ classifiers =
+ [options]
+ scripts = rpl
+ python_requires = >=3
+-setup_requires = argparse-manpage
+ install_requires = chardet
+ 
+ [options.extras_require]
+diff --git a/setup.py b/setup.py
+index 96cade6..879fc44 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,9 +1,8 @@
+-from build_manpages.build_manpages import get_install_cmd
+ from setuptools import setup
+ from setuptools.command.install import install
+ 
+ setup(
+     cmdclass={
+-        'install': get_install_cmd(install),
++        'install': install,
+     }
+ )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32100,9 +32100,7 @@ with pkgs;
     inherit glib gtk3 gobject-introspection wrapGAppsHook;
   };
 
-  rpl = callPackage ../tools/text/rpl {
-    pythonPackages = python3Packages;
-  };
+  rpl = callPackage ../tools/text/rpl { };
 
   ricty = callPackage ../data/fonts/ricty { };
 


### PR DESCRIPTION
old version is unmaintained, see https://github.com/kcoyner/rpl/issues/7

im too lazy to package [argparse-manpage](https://github.com/praiskup/argparse-manpage) for [this useless manpage](https://github.com/rrthomas/rpl/blob/master/man-include.1), so i simply removed `argparse-manpage` via patch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

maintainer @teto 