### PR TITLE
htmltest: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/development/tools/htmltest/default.nix
+++ b/pkgs/development/tools/htmltest/default.nix
@@ -5,13 +5,13 @@
 
 buildGoModule rec {
   pname = "htmltest";
-  version = "0.14.0";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "wjdp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0z2j54ywim1nl10vidcnbwhywyzanj4qd93ai533808wrm3ghwb6";
+    sha256 = "sha256-lj+bR27huswHemF8M+G69PblqnQQUWsg4jtLfz89yVY=";
   };
 
   vendorSha256 = "0zx3ii9crick647kslzwg4d39li6jds938f9j9dp287rhrlzjfbm";

--- a/pkgs/development/tools/htmltest/default.nix
+++ b/pkgs/development/tools/htmltest/default.nix
@@ -16,6 +16,12 @@ buildGoModule rec {
 
   vendorSha256 = "0zx3ii9crick647kslzwg4d39li6jds938f9j9dp287rhrlzjfbm";
 
+  ldflags = [
+    "-w"
+    "-s"
+    "-X main.version=${version}"
+  ];
+
   # tests require network access
   doCheck = false;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.15.0

- Add `ldflags` for version output

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
