### PR TITLE
pytest-check-hook.sh: delete pytest bytecode after install

### DIFF
--- a/pkgs/development/python-modules/pytest/4.nix
+++ b/pkgs/development/python-modules/pytest/4.nix
@@ -43,6 +43,19 @@ buildPythonPackage rec {
     }
 
     preDistPhases+=" pytestcachePhase"
+
+    # pytest generates it's own bytecode files to improve assertion messages.
+    # These files similar to cpython's bytecode files but are never laoded
+    # by python interpreter directly. We remove them for a few reasons:
+    # - files are non-deterministic: https://github.com/NixOS/nixpkgs/issues/139292
+    #   (file headers are generatedt by pytest directly and contain timestamps)
+    # - files are not needed after tests are finished
+    pytestRemoveBytecodePhase () {
+        # suffix is defined at:
+        #    https://github.com/pytest-dev/pytest/blob/4.6.11/src/_pytest/assertion/rewrite.py#L32-L47
+        find $out -name "*-PYTEST.py[co]" -delete
+    }
+    preDistPhases+=" pytestRemoveBytecodePhase"
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pytest/5.nix
+++ b/pkgs/development/python-modules/pytest/5.nix
@@ -70,6 +70,19 @@ buildPythonPackage rec {
         find $out -name .pytest_cache -type d -exec rm -rf {} +
     }
     preDistPhases+=" pytestcachePhase"
+
+    # pytest generates it's own bytecode files to improve assertion messages.
+    # These files similar to cpython's bytecode files but are never laoded
+    # by python interpreter directly. We remove them for a few reasons:
+    # - files are non-deterministic: https://github.com/NixOS/nixpkgs/issues/139292
+    #   (file headers are generatedt by pytest directly and contain timestamps)
+    # - files are not needed after tests are finished
+    pytestRemoveBytecodePhase () {
+        # suffix is defined at:
+        #    https://github.com/pytest-dev/pytest/blob/5.4.3/src/_pytest/assertion/rewrite.py#L42-L45
+        find $out -name "*-pytest-*.py[co]" -delete
+    }
+    preDistPhases+=" pytestRemoveBytecodePhase"
   '';
 
   pythonImportsCheck = [


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/issues/139292 we found out that
pytest leaves pytest-generated bytecode in install directory
(as tests are ran after install). That bytecode is:
- non-deterministic (was copied from cpython before cpython got
  support for deterministic bytecode)
- unneeded after test run

The change cleans bytecode up and provides a hook variable to avoid it
if needed.

Tested on `python39Packages.pytest-xdist` as:

    $ nix build -f. python39Packages.pytest-xdist
    $ nix build -f. python39Packages.pytest-xdist --rebuild

Closes: https://github.com/NixOS/nixpkgs/issues/139292
