### PR TITLE
python3Packages.django_taggit: add djangorestframework

### DIFF
--- a/pkgs/development/python-modules/django_taggit/default.nix
+++ b/pkgs/development/python-modules/django_taggit/default.nix
@@ -4,6 +4,7 @@
 , fetchPypi
 , pythonOlder
 , django
+, djangorestframework
 , mock
 , isort
 , isPy3k
@@ -19,12 +20,15 @@ buildPythonPackage rec {
     sha256 = "e5bb62891f458d55332e36a32e19c08d20142c43f74bc5656c803f8af25c084a";
   };
 
-  propagatedBuildInputs = [ isort django ];
+  propagatedBuildInputs = [ isort django djangorestframework ];
 
   checkInputs = [ mock ];
   checkPhase = ''
     # prove we're running tests against installed package, not build dir
     rm -r taggit
+    # Replace directory of locale
+    substituteInPlace ./tests/test_utils.py \
+      --replace 'os.path.dirname(__file__), ".."' "\"$out/lib/python${lib.versions.majorMinor python.version}/site-packages/\""
     ${python.interpreter} -m django test --settings=tests.settings
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix building python3Packages.django_taggit

###### Things done
It builds by calling `nix-build` or `nix build` directly, however it fails to build with `nixpkgs-review`
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
