### PR TITLE
python3Packages.python-kasa: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/asyncclick/default.nix
+++ b/pkgs/development/python-modules/asyncclick/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, anyio
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools-scm
+, pytestCheckHook
+, pythonOlder
+, trio
+}:
+
+buildPythonPackage rec {
+  pname = "asyncclick";
+  version = "8.0.1.3";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "python-trio";
+    repo = pname;
+    rev = version;
+    sha256 = "03b8zz8i3aqzxr3ffzb4sxnrcm3gsk9r4hmr0fkml1ahi754bx2r";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    anyio
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    trio
+  ];
+
+  disabledTests = [
+    # RuntimeWarning: coroutine 'Context.invoke' was never awaited
+    "test_context_invoke_type"
+  ];
+
+  pythonImportsCheck = [ "asyncclick" ];
+
+  meta = with lib; {
+    description = "Python composable command line utility";
+    homepage = "https://github.com/python-trio/asyncclick";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/python-kasa/default.nix
+++ b/pkgs/development/python-modules/python-kasa/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, asyncclick
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, importlib-metadata
+, poetry-core
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, voluptuous
+}:
+
+buildPythonPackage rec {
+  pname = "python-kasa";
+  version = "0.4.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "08blmz5kg826l08pf6yrvl8gc8iz3hfb6wsfqih606dal08kdhdi";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    asyncclick
+    importlib-metadata
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+    voluptuous
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/python-kasa/python-kasa/pull/226
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/python-kasa/python-kasa/commit/05c2a4a7dedbd60038e177b4d3f5ac5798544d11.patch";
+      sha256 = "0cla11yqx88wj2s50s3xxxhv4nz4h3wd9pi12v79778hzdlg58rr";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'asyncclick = "^7"' 'asyncclick = "*"'
+  '';
+
+  disabledTestPaths = [
+    # Skip the examples tests
+    "kasa/tests/test_readme_examples.py"
+  ];
+
+  pythonImportsCheck = [ "kasa" ];
+
+  meta = with lib; {
+    description = "Python API for TP-Link Kasa Smarthome products";
+    homepage = "https://python-kasa.readthedocs.io/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -621,6 +621,8 @@ in {
 
   async-lru = callPackage ../development/python-modules/async-lru { };
 
+  asyncclick = callPackage ../development/python-modules/asyncclick { };
+
   asynccmd = callPackage ../development/python-modules/asynccmd { };
 
   asyncio-dgram = callPackage ../development/python-modules/asyncio-dgram { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5635,6 +5635,8 @@ in {
 
   python-juicenet = callPackage ../development/python-modules/python-juicenet { };
 
+  python-kasa = callPackage ../development/python-modules/python-kasa { };
+
   python-keystoneclient = callPackage ../development/python-modules/python-keystoneclient { };
 
   python-lsp-black = callPackage ../development/python-modules/python-lsp-black { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API for TP-Link Kasa Smarthome product

https://python-kasa.readthedocs.io/

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
