### PR TITLE
libsmu: init at 1.0.3

### DIFF
--- a/pkgs/development/libraries/libsmu/default.nix
+++ b/pkgs/development/libraries/libsmu/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, libusb
+, boost
+, doxygen
+, pythonSupport ? false
+, python
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libsmu";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "analogdevicesinc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0m3bfrs1ipv2mvfhvfsmaw30xl5f7pdw70pd5ahj3lgiyfss74z3";
+  };
+
+  patchPhase = ''
+    substituteInPlace CMakeLists.txt --replace "/etc/udev/rules.d" "${placeholder "out"}/etc/udev/rules.d"
+  '';
+
+  nativeBuildInputs = with python.pkgs; [
+    cmake
+    pkgconfig
+    doxygen
+  ]
+  ++ lib.optionals (pythonSupport) [
+    python
+    cython
+    python.pkgs.setuptools
+  ]
+  ;
+
+  buildInputs = [
+    libusb
+    boost
+  ];
+
+  meta = with lib; {
+    description = "Software abstractions for the ADALM1000 USB SMU";
+    homepage = "https://analogdevicesinc.github.io/libsmu/";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/development/libraries/libsmu/default.nix
+++ b/pkgs/development/libraries/libsmu/default.nix
@@ -6,36 +6,51 @@
 , libusb
 , boost
 , doxygen
-, pythonSupport ? false
+, gtest
+, pythonSupport ? false # currently tries to install pip packages in $HOME
 , python
 }:
 
 stdenv.mkDerivation rec {
   pname = "libsmu";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "analogdevicesinc";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0m3bfrs1ipv2mvfhvfsmaw30xl5f7pdw70pd5ahj3lgiyfss74z3";
+    rev = "dbb484f004d9eb5251aa4667f5cf09b3ff5610e2"; # v1.0.4 but not ambiguous with the branch by that name
+    hash = "sha256-Ko3szo7Oa0k7W/sAj3M7FAifIJR7mG40oy6QF2gzMmQ=";
   };
 
-  patchPhase = ''
-    substituteInPlace CMakeLists.txt --replace "/etc/udev/rules.d" "${placeholder "out"}/etc/udev/rules.d"
-  '';
+  patches = [ ./libsmu-pc.patch ];
+
+  cmakeFlags = [
+    "-DBUILD_CLI=ON"
+    "-DWITH_DOC=ON"
+    "-DBUILD_EXAMPLES=OFF"
+    "-DINSTALL_UDEV_RULES=ON"
+    "-DUDEV_RULES_PATH=${placeholder "out"}/etc/udev/rules.d"
+    "-DBUILD_TESTS=ON"
+  ]
+  ++ (if (pythonSupport) then [
+    "-DBUILD_PYTHON=ON"
+  ]
+  else [
+    "-DBUILD_PYTHON=OFF"
+  ]);
 
   nativeBuildInputs = with python.pkgs; [
     cmake
     pkgconfig
     doxygen
+    gtest
   ]
   ++ lib.optionals (pythonSupport) [
     python
     cython
     python.pkgs.setuptools
-  ]
-  ;
+    build
+  ];
 
   buildInputs = [
     libusb

--- a/pkgs/development/libraries/libsmu/libsmu-pc.patch
+++ b/pkgs/development/libraries/libsmu/libsmu-pc.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/libsmu.pc.cmakein b/dist/libsmu.pc.cmakein
+index f89dad9..4ad9b0a 100644
+--- a/dist/libsmu.pc.cmakein
++++ b/dist/libsmu.pc.cmakein
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+ Name: libsmu
+ Description: Library for interfacing with M1K devices

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20650,6 +20650,8 @@ with pkgs;
 
   libslirp = callPackage ../development/libraries/libslirp { };
 
+  libsmu = callPackage ../development/libraries/libsmu { };
+
   libsndfile = callPackage ../development/libraries/libsndfile {
     inherit (darwin.apple_sdk.frameworks) Carbon AudioToolbox;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20650,7 +20650,9 @@ with pkgs;
 
   libslirp = callPackage ../development/libraries/libslirp { };
 
-  libsmu = callPackage ../development/libraries/libsmu { };
+  libsmu = callPackage ../development/libraries/libsmu {
+    python = python3;
+  };
 
   libsndfile = callPackage ../development/libraries/libsndfile {
     inherit (darwin.apple_sdk.frameworks) Carbon AudioToolbox;

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -154,6 +154,7 @@ mapAliases ({
   pysmart-smartx = pysmart; # added 2021-10-22
   pyspotify = throw "pyspotify has been removed because Spotify stopped supporting libspotify"; # added 2022-05-29
   pytest_6 = pytest; # added 2022-02-10
+  pysmu = libsmu; # added 2021-09-19
   pytestcov = pytest-cov; # added 2021-01-04
   pytest-pep8 = pytestpep8; # added 2021-01-04
   pytest-pep257 = throw "pytest-pep257 was removed, as the pep257 package was migrated into pycodestyle"; # added 2022-04-12

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5205,6 +5205,11 @@ self: super: with self; {
     (p: p.py)
   ];
 
+  libsmu = toPythonModule (pkgs.libsmu.override {
+    pythonSupport = true;
+    inherit python;
+  });
+
   libsoundtouch = callPackage ../development/python-modules/libsoundtouch { };
 
   libthumbor = callPackage ../development/python-modules/libthumbor { };


### PR DESCRIPTION
with optional python module as python.pkgs.pysmu

###### Motivation for this change
library for interacting with the Analog Devices [ADALM1000](https://wiki.analog.com/university/tools/m1k) USB SMU hardware

needed to run AD's [alice](https://github.com/analogdevicesinc/alice) software
(which i'm able to run with `nix-shell -p 'python38.withPackages(ps: with ps; [ pysmu numpy tkinter ])'`, but haven't figured out how to package yet)
also needed for AD's [pixelpulse](https://github.com/analogdevicesinc/Pixelpulse2) software (which i'm also trying to package [here](https://github.com/evils/nixpkgs/tree/ad-alice))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
