### PR TITLE
Add Waydroid

### DIFF
--- a/pkgs/development/libraries/libgbinder/default.nix
+++ b/pkgs/development/libraries/libgbinder/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchFromGitHub, pkg-config, glib, libglibutil }:
+
+stdenv.mkDerivation rec {
+  pname = "libgbinder";
+  version = "1.1.12";
+
+  src = fetchFromGitHub {
+    owner = "mer-hybris";
+    repo = pname;
+    rev = version;
+    sha256 = "03p5ala9lnfcizh7832ax5phdvfzrdxw6acw8zib8wj0s133wyhb";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    libglibutil
+  ];
+
+  makeFlags = [
+    "LIBDIR=$(out)/lib"
+    "INSTALL_INCLUDE_DIR=$(dev)/include/gbinder"
+    "INSTALL_PKGCONFIG_DIR=$(dev)/lib/pkgconfig"
+  ];
+
+  installTargets = [ "install" "install-dev" ];
+
+  postInstall = ''
+    sed -i -e "s@includedir=/usr@includedir=$dev@g" $dev/lib/pkgconfig/$pname.pc
+    sed -i -e "s@Cflags: @Cflags: $($PKG_CONFIG --cflags libglibutil) @g" $dev/lib/pkgconfig/$pname.pc
+  '';
+
+  meta = with lib; {
+    description = "GLib-style interface to binder";
+    homepage = "https://github.com/mer-hybris/libgbinder";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/development/libraries/libglibutil/default.nix
+++ b/pkgs/development/libraries/libglibutil/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchFromGitLab, pkg-config, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "libglibutil";
+  version = "1.0.55";
+
+  src = fetchFromGitLab {
+    domain = "git.sailfishos.org";
+    owner = "mer-core";
+    repo = pname;
+    rev = version;
+    sha256 = "0zrxccpyfz4jf14zr6fj9b88p340s66lw5cnqkapfa72kl1rnp4q";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+  ];
+
+  makeFlags = [
+    "LIBDIR=$(out)/lib"
+    "INSTALL_INCLUDE_DIR=$(dev)/include/gutil"
+    "INSTALL_PKGCONFIG_DIR=$(dev)/lib/pkgconfig"
+  ];
+
+  installTargets = [ "install" "install-dev" ];
+
+  postInstall = ''
+    sed -i -e "s@includedir=/usr@includedir=$dev@g" $dev/lib/pkgconfig/$pname.pc
+    sed -i -e "s@Cflags: @Cflags: $($PKG_CONFIG --cflags glib-2.0) @g" $dev/lib/pkgconfig/$pname.pc
+  '';
+
+  meta = with lib; {
+    description = "Library of glib utilities.";
+    homepage = "https://git.sailfishos.org/mer-core/libglibutil";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/development/python-modules/gbinder-python/default.nix
+++ b/pkgs/development/python-modules/gbinder-python/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildPythonPackage
+, cython
+, pkg-config
+, libgbinder
+}:
+
+buildPythonPackage rec {
+  pname = "gbinder-python";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "erfanoabdi";
+    repo = pname;
+    rev = version;
+    sha256 = "0jgblzakjgsy0cj93bmh5gr7qnl2xgsrm0wzc6xjvzry9lrbs360";
+  };
+
+  buildInputs = [
+    libgbinder
+  ];
+
+  nativeBuildInputs = [
+    cython
+    pkg-config
+  ];
+
+  setupPyGlobalFlags = [ "--cython" ];
+
+  meta = with lib; {
+    description = "Python bindings for libgbinder";
+    homepage = "https://github.com/erfanoabdi/gbinder-python";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mcaju ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/waydroid/default.nix
+++ b/pkgs/os-specific/linux/waydroid/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, python3Packages
+, dnsmasq
+, lxc
+, nftables
+, python
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "waydroid";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "0cabh7rysh2v15wrxg250370mw26s5d073yxmczxsarbp4ri2pl4";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    gbinder-python
+    pygobject3
+  ];
+
+  dontUseSetuptoolsBuild = true;
+  dontUsePipInstall = true;
+  dontUseSetuptoolsCheck = true;
+  dontWrapPythonPrograms = true;
+
+  installPhase = ''
+    mkdir -p $out/${python3Packages.python.sitePackages}
+
+    cp -ra tools $out/${python3Packages.python.sitePackages}/tools
+
+    cp -ra data $out/${python3Packages.python.sitePackages}/data
+    wrapProgram $out/${python3Packages.python.sitePackages}/data/scripts/waydroid-net.sh \
+       --prefix PATH ":" ${lib.makeBinPath [ dnsmasq nftables ]}
+
+    mkdir -p $out/share/waydroid/gbinder.d
+    cp gbinder/anbox.conf $out/share/waydroid/gbinder.d/anbox.conf
+
+    mkdir $out/bin
+    cp -a waydroid.py $out/${python3Packages.python.sitePackages}/waydroid.py
+    ln -s $out/${python3Packages.python.sitePackages}/waydroid.py $out/bin/waydroid
+
+    wrapPythonProgramsIn $out/${python3Packages.python.sitePackages} "$out ${python3Packages.gbinder-python} ${python3Packages.pygobject3} ${lxc}"
+  '';
+
+  meta = with lib; {
+    description = "Waydroid is a container-based approach to boot a full Android system on a regular GNU/Linux system like Ubuntu.";
+    homepage = "https://github.com/waydroid/waydroid";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1828,6 +1828,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
+  waydroid = callPackage ../os-specific/linux/waydroid { };
+
   wiiload = callPackage ../development/tools/wiiload { };
 
   wiimms-iso-tools = callPackage ../tools/filesystems/wiimms-iso-tools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17057,6 +17057,8 @@ with pkgs;
 
   libgadu = callPackage ../development/libraries/libgadu { };
 
+  libgbinder = callPackage ../development/libraries/libgbinder { };
+
   libgda = callPackage ../development/libraries/libgda { };
 
   libgda6 = callPackage ../development/libraries/libgda/6.x.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17071,6 +17071,8 @@ with pkgs;
 
   libgig = callPackage ../development/libraries/libgig { };
 
+  libglibutil = callPackage ../development/libraries/libglibutil { };
+
   libgnome-keyring = callPackage ../development/libraries/libgnome-keyring { };
   libgnome-keyring3 = gnome.libgnome-keyring;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2882,6 +2882,8 @@ in {
 
   garages-amsterdam = callPackage ../development/python-modules/garages-amsterdam { };
 
+  gbinder-python = callPackage ../development/python-modules/gbinder-python { };
+
   gcovr = callPackage ../development/python-modules/gcovr { };
 
   gcsfs = callPackage ../development/python-modules/gcsfs { };


### PR DESCRIPTION
###### Motivation for this change
Waydroid was requested for packaging at #139140

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
