### PR TITLE
webcat: init at unstable-2021-09-06

### DIFF
--- a/pkgs/tools/misc/webcat/default.nix
+++ b/pkgs/tools/misc/webcat/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoModule, fetchFromGitea, asciidoctor, installShellFiles }:
+
+buildGoModule rec {
+  pname = "webcat";
+  version = "unstable-2021-09-06";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "rumpelsepp";
+    repo = "webcat";
+    rev = "57a65558f0affac0b2f8f4831c52964eb9ad5386";
+    sha256 = "15c62sjr15l5hwkvc4xarfn76341wi16pjv9qbr1agaz1vqgr6rd";
+  };
+
+  vendorSha256 = "1apnra58mqrazbq53f0qlqnyyhjdvvdz995yridxva0fxmwpwcjy";
+
+  nativeBuildInputs = [ asciidoctor installShellFiles ];
+
+  postInstall = ''
+    make -C man man
+    installManPage man/webcat.1
+  '';
+
+  meta = with lib; {
+    homepage = "https://rumpelsepp.org/blog/ssh-through-websocket/";
+    description = "The lightweight swiss army knife for websockets";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ montag451 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31587,6 +31587,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  webcat = callPackage ../tools/misc/webcat { };
+
   websocat = callPackage ../tools/misc/websocat {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
