### PR TITLE
packer: 1.7.5 -> 1.7.6

### DIFF
--- a/pkgs/development/tools/packer/default.nix
+++ b/pkgs/development/tools/packer/default.nix
@@ -1,25 +1,17 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, fetchpatch }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "packer";
-  version = "1.7.5";
+  version = "1.7.6";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "packer";
     rev = "v${version}";
-    sha256 = "15kw4zy0p7hr6jm0202s0fk5ja3ff0pdir37qdifngm1x7id1vxc";
+    sha256 = "sha256-nZeOtV6sbgzUhDOlWJ5eLzOh0gsaukXFrPg3y8x9ce4=";
   };
 
-  vendorSha256 = "1785yv48sn504zcig9szjw9s4dxb55dg9idh10i2gzfgbda2c3nf";
-
-  patches = [
-    # https://github.com/hashicorp/packer/pull/11282
-    (fetchpatch {
-      url = "https://github.com/hashicorp/packer/commit/dbf13803217e18c6cb567ffefc9476c4e0149e02.patch";
-      sha256 = "1n038x6qnr75c5ci2jp8jcwp6yvlchcf2nydksb2s75ffvidjrsa";
-    })
-  ];
+  vendorSha256 = "sha256-zg4mVFvP/SciCLDF9FopqzeiE5dfpxfZJ6BYjcj2BZ0=";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
- https://github.com/hashicorp/packer/releases/tag/v1.7.6
- https://github.com/hashicorp/packer/blob/v1.7.6/CHANGELOG.md

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Just a release that contains the previously included patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
