### PR TITLE
libdecor: init at 0.1.0

### DIFF
--- a/pkgs/development/libraries/libdecor/default.nix
+++ b/pkgs/development/libraries/libdecor/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, pkg-config
+, meson
+, ninja
+, wayland
+, wayland-protocols
+, cairo
+, dbus
+, pango
+, libxkbcommon
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libdecor";
+  version = "0.1.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "jadahl";
+    repo = "libdecor";
+    rev = "${version}";
+    hash = "sha256:0qdg3r7k086wzszr969s0ljlqdvfqm31zpl8p5h397bw076zr6p2";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [
+    wayland
+    wayland-protocols
+    cairo
+    dbus
+    pango
+    libxkbcommon
+  ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.gnome.org/jadahl/libdecor";
+    description = "Client-side decorations library for Wayland clients";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ artturin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16959,6 +16959,8 @@ with pkgs;
     libGL = null;
   };
 
+  libdecor = callPackage ../development/libraries/libdecor { };
+
   libdigidoc = callPackage ../development/libraries/libdigidoc {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
for sdl2 #136166
Closes #133724
@jakobrs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
