### PR TITLE
emacsPackages.bqn-mode: 0.0.0+unstable=2021-09-26 -> 0.0.0+unstable=2021-09-27

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/bqn-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/bqn-mode/default.nix
@@ -5,23 +5,18 @@
 
 trivialBuild {
   pname = "bqn-mode";
-  version = "0.0.0+unstable=2021-09-26";
+  version = "0.0.0+unstable=2021-09-27";
 
   src = fetchFromGitHub {
-    owner = "mlochbaum";
-    repo = "BQN";
-    rev = "97cbdc67fe6a9652c42daefadd658cc41c1e5ae3";
-    sha256 = "09nmsl7gzyi56g0x459a6571c8nsafl0g350m0hk1vy2gpg6yq0p";
+    owner = "AndersonTorres";
+    repo = "bqn-mode";
+    rev = "5bdc713ade78f11d756231739429440552d7faf8";
+    hash = "sha256-ztGHWKVgMP9N4hV9k0PY9LxqXgHxkycyF3N0eZ+jIZs=";
   };
 
-  postUnpack = ''
-    sourceRoot="$sourceRoot/editors/emacs"
-  '';
-
   meta = with lib; {
-    homepage = "https://mlochbaum.github.io/BQN/editors/index.html";
-    description = "Emacs mode for BQN";
+    description = "Emacs mode for BQN programming language";
     license = licenses.gpl3Only;
-    maintainers = [ maintainers.sternenseemann ];
+    maintainers = with maintainers; [ sternenseemann AndersonTorres ];
   };
 }


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Shameful self-promotion!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
