### PR TITLE
rustPackages.rls: Fix 1.55 build on Darwin

### DIFF
--- a/pkgs/development/compilers/rust/1_45.nix
+++ b/pkgs/development/compilers/rust/1_45.nix
@@ -10,7 +10,7 @@
 { stdenv, lib
 , buildPackages
 , newScope, callPackage
-, CoreFoundation, Security
+, CoreFoundation, Security, SystemConfiguration
 , pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
 , makeRustPlatform
 , llvmPackages_5, llvm_10

--- a/pkgs/development/compilers/rust/1_55.nix
+++ b/pkgs/development/compilers/rust/1_55.nix
@@ -12,7 +12,7 @@
 { stdenv, lib
 , buildPackages
 , newScope, callPackage
-, CoreFoundation, Security
+, CoreFoundation, Security, SystemConfiguration
 , pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
 , makeRustPlatform
 , llvmPackages_11

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -14,7 +14,7 @@
 { stdenv, lib
 , buildPackages
 , newScope, callPackage
-, CoreFoundation, Security
+, CoreFoundation, Security, SystemConfiguration
 , pkgsBuildTarget, pkgsBuildBuild
 , makeRustPlatform
 }: rec {
@@ -104,7 +104,7 @@
         inherit CoreFoundation Security;
       };
       clippy = self.callPackage ./clippy.nix { inherit Security; };
-      rls = self.callPackage ./rls { inherit CoreFoundation Security; };
+      rls = self.callPackage ./rls { inherit CoreFoundation Security SystemConfiguration; };
     });
   };
 }

--- a/pkgs/development/compilers/rust/rls/default.nix
+++ b/pkgs/development/compilers/rust/rls/default.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config cmake makeWrapper ];
   buildInputs = [ openssh openssl curl zlib libiconv rustPlatform.rust.rustc.llvm ]
-    ++ (lib.optionals stdenv.isDarwin [ CoreFoundation Security SystemConfiguration ]);
+    ++ lib.optionals stdenv.isDarwin [ CoreFoundation Security SystemConfiguration ];
 
   doCheck = true;
 

--- a/pkgs/development/compilers/rust/rls/default.nix
+++ b/pkgs/development/compilers/rust/rls/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, makeWrapper, fetchFromGitHub, rustPlatform
 , openssh, openssl, pkg-config, cmake, zlib, curl, libiconv
-, CoreFoundation, Security }:
+, CoreFoundation, Security, SystemConfiguration }:
 
 rustPlatform.buildRustPackage rec {
   pname = "rls";
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config cmake makeWrapper ];
   buildInputs = [ openssh openssl curl zlib libiconv rustPlatform.rust.rustc.llvm ]
-    ++ (lib.optionals stdenv.isDarwin [ CoreFoundation Security ]);
+    ++ (lib.optionals stdenv.isDarwin [ CoreFoundation Security SystemConfiguration ]);
 
   doCheck = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12372,7 +12372,7 @@ with pkgs;
   #
   # So this commit doesn't remove the 1.45.2 release.
   rust_1_45 = callPackage ../development/compilers/rust/1_45.nix {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_10 = llvmPackages_10.libllvm;
   };
   rust_1_55 = callPackage ../development/compilers/rust/1_55.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12376,7 +12376,7 @@ with pkgs;
     llvm_10 = llvmPackages_10.libllvm;
   };
   rust_1_55 = callPackage ../development/compilers/rust/1_55.nix {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_12 = llvmPackages_12.libllvm;
   };
   rust = rust_1_55;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

fixes #140229 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
