### PR TITLE
pythonPackages.obspy: init at 1.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -578,6 +578,16 @@
     githubId = 2626481;
     name = "Ambroz Bizjak";
   };
+  ametrine = {
+    name = "Matilde Ametrine";
+    email = "matilde@diffyq.xyz";
+    github = "matilde-ametrine";
+    githubId = 90799677;
+    keys = [{
+      longkeyid = "rsa3072/0x07EE1FFCA58A11C5";
+      fingerprint = "7931 EB4E 4712 D7BE 04F8  6D34 07EE 1FFC A58A 11C5";
+    }];
+  };
   amiddelk = {
     email = "amiddelk@gmail.com";
     github = "amiddelk";

--- a/pkgs/development/python-modules/obspy/default.nix
+++ b/pkgs/development/python-modules/obspy/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, decorator
+, future
+, lxml
+, matplotlib
+, numpy
+, requests
+, scipy
+, sqlalchemy
+}:
+
+buildPythonPackage rec {
+  pname = "obspy";
+  version = "1.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "a0f2b0915beeb597762563fa0358aa1b4d6b09ffda49909c760b5cdf5bdc419e";
+  };
+
+  propagatedBuildInputs = [
+    decorator
+    future
+    lxml
+    matplotlib
+    numpy
+    requests
+    scipy
+    sqlalchemy
+  ];
+
+  # Tests require Internet access.
+  doCheck = false;
+
+  pythonImportsCheck = [ "obspy" ];
+
+  meta = with lib; {
+    description = "Python framework for seismological observatories";
+    homepage = "https://www.obspy.org";
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.ametrine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5096,6 +5096,8 @@ in {
     graphvizPkgs = pkgs.graphviz;
   };
 
+  obspy = callPackage ../development/python-modules/obspy { };
+
   oci = callPackage ../development/python-modules/oci { };
 
   ocrmypdf = callPackage ../development/python-modules/ocrmypdf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ObsPy is not (yet) part of nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
