### PR TITLE
ultimate-oldschool-pc-font-pack: link to changelog

### DIFF
--- a/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
+++ b/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
@@ -16,6 +16,7 @@ fetchzip {
   meta = with lib; {
     description = "The Ultimate Oldschool PC Font Pack (TTF Fonts)";
     homepage = "https://int10h.org/oldschool-pc-fonts/";
+    changelog = "https://int10h.org/oldschool-pc-fonts/readme/#history";
     license = licenses.cc-by-sa-40;
     maintainers = [ maintainers.endgame ];
   };


### PR DESCRIPTION
Add changelog to meta for ultimate-oldschool-pc-font-pack. If accepted, please label as `hacktoberfest-accepted`.
###### Motivation for this change
Getting credit for hacktober fest hopefully
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
