### PR TITLE
nixos/modules/.../systemd-boot: allow systemd with point releases

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -218,7 +218,7 @@ def main() -> None:
         sdboot_status = subprocess.check_output(["@systemd@/bin/bootctl", "--path=@efiSysMountPoint@", "status"], universal_newlines=True)
 
         # See status_binaries() in systemd bootctl.c for code which generates this
-        m = re.search("^\W+File:.*/EFI/(BOOT|systemd)/.*\.efi \(systemd-boot (\d+)\)$",
+        m = re.search("^\W+File:.*/EFI/(BOOT|systemd)/.*\.efi \(systemd-boot (\d+([.]\d+)*)\)$",
                       sdboot_status, re.IGNORECASE | re.MULTILINE)
         if m is None:
             print("could not find any previously installed systemd-boot")


### PR DESCRIPTION
Before the change nixos-rebuild was failing as:

    # nixos-rebuild switch
    building Nix...
    building the system configuration...
    could not find any previously installed systemd-boot

It happens because systemt version does not match regex:

    $ bootctl | fgrep systemd-boot
    File: └─/EFI/systemd/systemd-bootx64.efi (systemd-boot 249.4)

While regex assumes:

    m = re.search("^\W+File:.*/EFI/(BOOT|systemd)/.*\.efi \(systemd-boot (\d+)\)$",

The change allows more point digits for systemd.