### PR TITLE
openjdk17: init at 17.0.1+12

### DIFF
--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -1,0 +1,162 @@
+{ stdenv, lib, fetchurl, fetchFromGitHub, bash, pkg-config, autoconf, cpio
+, file, which, unzip, zip, perl, cups, freetype, alsa-lib, libjpeg, giflib
+, libpng, zlib, lcms2, libX11, libICE, libXrender, libXext, libXt, libXtst
+, libXi, libXinerama, libXcursor, libXrandr, fontconfig, openjdk17-bootstrap
+, setJavaClassPath
+, headless ? false
+, enableJavaFX ? openjfx.meta.available, openjfx
+, enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
+}:
+
+let
+  version = {
+    feature = "17";
+    interim = ".0.1";
+    build = "12";
+  };
+
+  openjdk = stdenv.mkDerivation {
+    pname = "openjdk" + lib.optionalString headless "-headless";
+    version = "${version.feature}${version.interim}+${version.build}";
+
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jdk${version.feature}u";
+      rev = "jdk-${version.feature}${version.interim}+${version.build}";
+      sha256 = "1l1jgbz8q7zq66npfg88r0l5xga427vrz35iys09j44b6qllrldd";
+    };
+
+    nativeBuildInputs = [ pkg-config autoconf unzip ];
+    buildInputs = [
+      cpio file which zip perl zlib cups freetype alsa-lib libjpeg giflib
+      libpng zlib lcms2 libX11 libICE libXrender libXext libXtst libXt libXtst
+      libXi libXinerama libXcursor libXrandr fontconfig openjdk17-bootstrap
+    ] ++ lib.optionals (!headless && enableGnome2) [
+      gtk3 gnome_vfs GConf glib
+    ];
+
+    patches = [
+      ./fix-java-home-jdk10.patch
+      ./read-truststore-from-env-jdk10.patch
+      ./currency-date-range-jdk10.patch
+      ./increase-javadoc-heap-jdk13.patch
+      ./ignore-LegalNoticeFilePlugin.patch
+
+      # -Wformat etc. are stricter in newer gccs, per
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79677
+      # so grab the work-around from
+      # https://src.fedoraproject.org/rpms/java-openjdk/pull-request/24
+      (fetchurl {
+        url = "https://src.fedoraproject.org/rpms/java-openjdk/raw/06c001c7d87f2e9fe4fedeef2d993bcd5d7afa2a/f/rh1673833-remove_removal_of_wformat_during_test_compilation.patch";
+        sha256 = "082lmc30x64x583vqq00c8y0wqih3y4r0mp1c4bqq36l22qv6b6r";
+      })
+    ] ++ lib.optionals (!headless && enableGnome2) [
+      ./swing-use-gtk-jdk13.patch
+    ];
+
+    postPatch = ''
+      chmod +x configure
+      patchShebangs --build configure
+    '';
+
+    configureFlags = [
+      "--with-boot-jdk=${openjdk17-bootstrap.home}"
+      "--with-version-build=${version.build}"
+      "--with-version-opt=nixos"
+      "--with-version-pre="
+      "--enable-unlimited-crypto"
+      "--with-native-debug-symbols=internal"
+      "--with-libjpeg=system"
+      "--with-giflib=system"
+      "--with-libpng=system"
+      "--with-zlib=system"
+      "--with-lcms=system"
+      "--with-stdc++lib=dynamic"
+    ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
+      ++ lib.optional headless "--enable-headless-only"
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+
+    separateDebugInfo = true;
+
+    NIX_CFLAGS_COMPILE = "-Wno-error";
+
+    NIX_LDFLAGS = toString (lib.optionals (!headless) [
+      "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"
+    ] ++ lib.optionals (!headless && enableGnome2) [
+      "-lgtk-3" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
+    ]);
+
+    buildFlags = [ "images" ];
+
+    installPhase = ''
+      mkdir -p $out/lib
+
+      mv build/*/images/jdk $out/lib/openjdk
+
+      # Remove some broken manpages.
+      rm -rf $out/lib/openjdk/man/ja*
+
+      # Mirror some stuff in top-level.
+      mkdir -p $out/share
+      ln -s $out/lib/openjdk/include $out/include
+      ln -s $out/lib/openjdk/man $out/share/man
+
+      # IDEs use the provided src.zip to navigate the Java codebase (https://github.com/NixOS/nixpkgs/pull/95081)
+      ln -s $out/lib/openjdk/lib/src.zip $out/lib/src.zip
+
+      # jni.h expects jni_md.h to be in the header search path.
+      ln -s $out/include/linux/*_md.h $out/include/
+
+      # Remove crap from the installation.
+      rm -rf $out/lib/openjdk/demo
+      ${lib.optionalString headless ''
+        rm $out/lib/openjdk/lib/{libjsound,libfontmanager}.so
+      ''}
+
+      ln -s $out/lib/openjdk/bin $out/bin
+    '';
+
+    preFixup = ''
+      # Propagate the setJavaClassPath setup hook so that any package
+      # that depends on the JDK has $CLASSPATH set up properly.
+      mkdir -p $out/nix-support
+      #TODO or printWords?  cf https://github.com/NixOS/nixpkgs/pull/27427#issuecomment-317293040
+      echo -n "${setJavaClassPath}" > $out/nix-support/propagated-build-inputs
+
+      # Set JAVA_HOME automatically.
+      mkdir -p $out/nix-support
+      cat <<EOF > $out/nix-support/setup-hook
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      EOF
+    '';
+
+    postFixup = ''
+      # Build the set of output library directories to rpath against
+      LIBDIRS=""
+      for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
+        LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
+      done
+      # Add the local library paths to remove dependencies on the bootstrap
+      for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
+        OUTPUTDIR=$(eval echo \$$output)
+        BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
+        echo "$BINLIBS" | while read i; do
+          patchelf --set-rpath "$LIBDIRS:$(patchelf --print-rpath "$i")" "$i" || true
+          patchelf --shrink-rpath "$i" || true
+        done
+      done
+    '';
+
+    disallowedReferences = [ openjdk17-bootstrap ];
+
+    meta = import ./meta.nix lib;
+
+    passthru = {
+      architecture = "";
+      home = "${openjdk}/lib/openjdk";
+      inherit gtk3;
+    };
+  };
+in openjdk

--- a/pkgs/development/compilers/openjdk/ignore-LegalNoticeFilePlugin.patch
+++ b/pkgs/development/compilers/openjdk/ignore-LegalNoticeFilePlugin.patch
@@ -1,0 +1,21 @@
+--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/LegalNoticeFilePlugin.java
++++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/LegalNoticeFilePlugin.java
+@@ -112,18 +112,6 @@
+             .filter(e -> Arrays.equals(e.contentBytes(), entry.contentBytes()))
+             .findFirst();
+         if (!otarget.isPresent()) {
+-            if (errorIfNotSameContent) {
+-                // all legal notices of the same file name are expected
+-                // to contain the same content
+-                Optional<ResourcePoolEntry> ores =
+-                    entries.stream().filter(e -> e.linkedTarget() == null)
+-                           .findAny();
+-
+-                if (ores.isPresent()) {
+-                    throw new PluginException(ores.get().path() + " " +
+-                        entry.path() + " contain different content");
+-                }
+-            }
+             entries.add(entry);
+         } else {
+             entries.add(ResourcePoolEntry.createSymLink(entry.path(),

--- a/pkgs/servers/pufferpanel/default.nix
+++ b/pkgs/servers/pufferpanel/default.nix
@@ -5,7 +5,7 @@
 , pkgs
 , stdenv
 , fetchzip
-, openjdk16
+, jdk
 , nodejs
 , pathDeps ? [ ]
 }:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11671,7 +11671,6 @@ with pkgs;
     else
       callPackage ../development/compilers/openjdk/bootstrap.nix { version = "10"; };
 
-  /* currently maintained LTS JDK */
   openjdk11 =
     if stdenv.isDarwin then
       callPackage ../development/compilers/openjdk/darwin/11.nix { }
@@ -11687,32 +11686,38 @@ with pkgs;
     else
       openjdk11.override { headless = true; };
 
-  openjdk16-bootstrap =
-    if adoptopenjdk-hotspot-bin-15.meta.available then
-      adoptopenjdk-hotspot-bin-15
+  openjdk17-bootstrap =
+    if adoptopenjdk-hotspot-bin-16.meta.available then
+      adoptopenjdk-hotspot-bin-16
     else
-      /* adoptopenjdk not available for i686, so fall back to our old builds of 12, 13, & 14 for bootstrapping */
-      callPackage ../development/compilers/openjdk/15.nix {
+      /* adoptopenjdk not available for i686, so fall back to our old builds for bootstrapping */
+      callPackage ../development/compilers/openjdk/16.nix {
         openjfx = openjfx11; /* need this despite next line :-( */
         enableJavaFX = false;
         headless = true;
         inherit (gnome2) GConf gnome_vfs;
-        openjdk15-bootstrap = callPackage ../development/compilers/openjdk/14.nix {
+        openjdk16-bootstrap = callPackage ../development/compilers/openjdk/15.nix {
           openjfx = openjfx11; /* need this despite next line :-( */
           enableJavaFX = false;
           headless = true;
           inherit (gnome2) GConf gnome_vfs;
-          openjdk14-bootstrap = callPackage ../development/compilers/openjdk/13.nix {
+          openjdk15-bootstrap = callPackage ../development/compilers/openjdk/14.nix {
             openjfx = openjfx11; /* need this despite next line :-( */
             enableJavaFX = false;
             headless = true;
             inherit (gnome2) GConf gnome_vfs;
-            openjdk13-bootstrap = callPackage ../development/compilers/openjdk/12.nix {
-              stdenv = gcc8Stdenv; /* build segfaults with gcc9 or newer, so use gcc8 like Debian does */
+            openjdk14-bootstrap = callPackage ../development/compilers/openjdk/13.nix {
               openjfx = openjfx11; /* need this despite next line :-( */
               enableJavaFX = false;
               headless = true;
               inherit (gnome2) GConf gnome_vfs;
+              openjdk13-bootstrap = callPackage ../development/compilers/openjdk/12.nix {
+                stdenv = gcc8Stdenv; /* build segfaults with gcc9 or newer, so use gcc8 like Debian does */
+                openjfx = openjfx11; /* need this despite next line :-( */
+                enableJavaFX = false;
+                headless = true;
+                inherit (gnome2) GConf gnome_vfs;
+              };
             };
           };
         };
@@ -11722,27 +11727,26 @@ with pkgs;
   jdk11_headless = openjdk11_headless;
 
   /* Latest JDK */
-  openjdk16 =
+  openjdk17 =
     if stdenv.isDarwin then
       callPackage ../development/compilers/openjdk/darwin { }
     else
-      callPackage ../development/compilers/openjdk/16.nix {
+      callPackage ../development/compilers/openjdk/17.nix {
         openjfx = openjfx15;
         inherit (gnome2) GConf gnome_vfs;
       };
 
-  openjdk16_headless =
+  openjdk17_headless =
     if stdenv.isDarwin then
-      openjdk16
+      openjdk17
     else
-      openjdk16.override { headless = true; };
+      openjdk17.override { headless = true; };
 
-  jdk16 = openjdk16;
-  jdk16_headless = openjdk16_headless;
+  jdk17 = openjdk17;
+  jdk17_headless = openjdk17_headless;
 
   /* default JDK */
-
-  jdk = jdk16;
+  jdk = jdk17;
 
   # Since the introduction of the Java Platform Module System in Java 9, Java
   # no longer ships a separate JRE package.
@@ -11751,13 +11755,13 @@ with pkgs;
   # 'jre_minimal' to build a bespoke JRE containing only the modules you need.
   #
   # For a general-purpose system, 'jre' defaults to the full JDK:
-  jre = jdk16;
-  jre_headless = jdk16_headless;
+  jre = jdk17;
+  jre_headless = jdk17_headless;
 
   jre_minimal = callPackage ../development/compilers/openjdk/jre.nix { };
 
-  openjdk = openjdk16;
-  openjdk_headless = openjdk16_headless;
+  openjdk = openjdk17;
+  openjdk_headless = openjdk17_headless;
 
   inherit (callPackages ../development/compilers/graalvm {
     gcc = if stdenv.targetPlatform.isDarwin then gcc8 else gcc;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package OpenJDK 17 LTS https://github.com/NixOS/nixpkgs/issues/137956

Notify maintainers: @edwtjo  @asbachb 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
