### PR TITLE
blackshades: 1.3.1 -> 2.4.7

### DIFF
--- a/pkgs/games/blackshades/default.nix
+++ b/pkgs/games/blackshades/default.nix
@@ -1,29 +1,27 @@
 { lib, stdenv, fetchFromSourcehut
-, SDL, stb, libGLU, libGL, openal, libvorbis, freealut }:
+, zig, glfw, libGLU, libGL, openal, libsndfile }:
 
 stdenv.mkDerivation rec {
   pname = "blackshades";
-  version = "1.3.1";
+  version = "2.4.7";
 
   src = fetchFromSourcehut {
     owner = "~cnx";
     repo = pname;
     rev = version;
-    sha256 = "0yzp74ynkcp6hh5m4zmvrgx5gwm186hq7p3m7qkww54qdyijb3rv";
+    fetchSubmodules = true;
+    sha256 = "sha256-hvJwWUUmGeb7MQgKe79cPS2ckPZ9z0Yc5S9IiwuXPD8=";
   };
 
-  buildInputs = [ SDL stb libGLU libGL openal libvorbis freealut ];
+  nativeBuildInputs = [ zig ];
+  buildInputs = [ glfw libGLU libGL openal libsndfile ];
 
-  postPatch = ''
-    sed -i -e s,Data/,$out/share/$pname/,g \
-      -e s,Data:,$out/share/$pname/,g \
-      src/*.cpp
+  preBuild = ''
+    export HOME=$TMPDIR
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/share
-    cp build/blackshades $out/bin
-    cp -R Data $out/share/$pname
+    zig build -Drelease-fast -Dcpu=baseline --prefix $out install
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

The new version fixed data location which used to be patched downstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
