### PR TITLE
cbqn: make nix-env happy, allow cross, run tests

### DIFF
--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -11,8 +11,16 @@ let
     rev = "97cbdc67fe6a9652c42daefadd658cc41c1e5ae3";
     hash = "sha256-F2Bv3n3C7zAhqKCMB6hT2iIWTjEqFdLBMyX6/w7V1SY=";
   };
+
+  cbqn-bytecode = fetchFromGitHub {
+    owner = "dzaima";
+    repo = "CBQN";
+    rev = "fdf0b93409d68d5ffd86c5670db27c240e6039e0";
+    hash = "sha256-A0zvpg+G37WNgyfrJuc5rH6L7Wntdbrz8pYEPreqgKE=";
+  };
 in
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation {
   pname = "cbqn";
   version = "0.0.0+unstable=2021-09-29";
 
@@ -21,13 +29,6 @@ stdenv.mkDerivation rec {
     repo = "CBQN";
     rev = "1c83483d5395e097f60de299274ebe0df590217e";
     hash = "sha256-C34DpXab08mBm2oCQuaeq4fJPtQ5rVa/HlpL/nB9XjQ=";
-  };
-
-  cbqn-bytecode = fetchFromGitHub {
-    owner = "dzaima";
-    repo = "CBQN";
-    rev = "fdf0b93409d68d5ffd86c5670db27c240e6039e0";
-    hash = "sha256-A0zvpg+G37WNgyfrJuc5rH6L7Wntdbrz8pYEPreqgKE=";
   };
 
   dontConfigure = true;

--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -21,7 +21,7 @@ let
 in
 
 stdenv.mkDerivation {
-  pname = "cbqn";
+  pname = "cbqn" + lib.optionalString (bqn-path == null) "-bytecode";
   version = "0.0.0+unstable=2021-09-29";
 
   src = fetchFromGitHub {

--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -66,6 +66,13 @@ stdenv.mkDerivation rec {
      runHook postInstall
   '';
 
+  doInstallCheck = with stdenv; hostPlatform.isCompatible buildPlatform;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    "$out/bin/bqn" "${mlochbaum-bqn}/test/this.bqn" | grep "All passed"
+    runHook postInstallCheck
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/dzaima/CBQN/";
     description = "BQN implementation in C";
@@ -75,4 +82,3 @@ stdenv.mkDerivation rec {
   };
 }
 # TODO: factor BQN
-# TODO: test suite (dependent on BQN from mlochbaum)

--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -53,7 +53,6 @@ stdenv.mkDerivation {
 
   makeFlags = [
     "CC=${stdenv.cc.targetPrefix}cc"
-    "single-o3"
   ];
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12827,17 +12827,20 @@ with pkgs;
 
   babashka = callPackage ../development/interpreters/clojure/babashka.nix { };
 
-  # BQN interpreters and compilers
-  cbqn = cbqn-phase2;
-  # And the classic bootstrapping process
-  cbqn-phase0 = callPackage ../development/interpreters/bqn/cbqn {
-    bqn-path = null;
-  };
-  cbqn-phase1 = callPackage ../development/interpreters/bqn/cbqn {
-    bqn-path = "${cbqn-phase0}/bin/bqn";
-  };
-  cbqn-phase2 = callPackage ../development/interpreters/bqn/cbqn {
-    bqn-path = "${cbqn-phase1}/bin/bqn";
+  cbqn = cbqnBootstrap.phase2;
+
+  cbqnBootstrap = lib.dontRecurseIntoAttrs {
+    phase0 = callPackage ../development/interpreters/bqn/cbqn {
+      bqn-path = null;
+    };
+
+    phase1 = callPackage ../development/interpreters/bqn/cbqn {
+      bqn-path = "${buildPackages.cbqnBootstrap.phase0}/bin/bqn";
+    };
+
+    phase2 = callPackage ../development/interpreters/bqn/cbqn {
+      bqn-path = "${buildPackages.cbqnBootstrap.phase1}/bin/bqn";
+    };
   };
 
   chibi = callPackage ../development/interpreters/chibi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12830,15 +12830,25 @@ with pkgs;
   cbqn = cbqnBootstrap.phase2;
 
   cbqnBootstrap = lib.dontRecurseIntoAttrs {
+    # use clang since it produces less speculative warnings when compiling,
+    # but avoid bootstrapping a clang stdenv just for CBQN in the cross case
+    stdenv =
+      if stdenv.hostPlatform == stdenv.buildPlatform
+      then llvmPackages_latest.stdenv
+      else stdenv;
+
     phase0 = callPackage ../development/interpreters/bqn/cbqn {
+      inherit (cbqnBootstrap) stdenv;
       bqn-path = null;
     };
 
     phase1 = callPackage ../development/interpreters/bqn/cbqn {
+      inherit (cbqnBootstrap) stdenv;
       bqn-path = "${buildPackages.cbqnBootstrap.phase0}/bin/bqn";
     };
 
     phase2 = callPackage ../development/interpreters/bqn/cbqn {
+      inherit (cbqnBootstrap) stdenv;
       bqn-path = "${buildPackages.cbqnBootstrap.phase1}/bin/bqn";
     };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Prevent `nix-env` getting confused by three derivations name `cbqn` with the same priority
* Use clang to compile since it is much less noisy compared to gcc
* Allow cross compiling (tested `aarch64`, `riscv64` and `pkgsStatic` (fully static cbqn!))
* run tests
* misc cleanups

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
