### PR TITLE
coreboot-toolchain: Update runtime dependencies

### DIFF
--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -1,6 +1,18 @@
-{ callPackage, fetchgit, lib, stdenvNoCC
-, bison, curl, git, perl
-, flex, gnat11, zlib
+{ bison
+, callPackage
+, curl
+, fetchgit
+, flex
+, git
+, gnat11
+, lib
+, ncurses
+, perl
+, pkg-config
+, python3Minimal
+, stdenvNoCC
+, zlib
+, installExtraPackages ? true
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -13,8 +25,14 @@ stdenvNoCC.mkDerivation rec {
     sha256 = "00xr74yc0kj9rrqa1a8b7bih865qlp9i4zs67ysavkfrjrwwssxm";
   };
 
-  nativeBuildInputs = [ bison curl git perl ];
+  nativeBuildInputs = [ bison curl perl ];
   buildInputs = [ flex gnat11 zlib ];
+  propagatedBuildInputs = lib.optionals installExtraPackages [
+    git
+    ncurses
+    pkg-config
+    python3Minimal
+  ];
 
   enableParallelBuilding = true;
   dontConfigure = true;


### PR DESCRIPTION
###### Motivation for this change
Add the build option `installExtraPackages`, which allows switching
between a "basic" and an "extended" toolchain. This option is set to
true by default adding additional packages to propagatedBuildInputs.
These packages are essential to make the toolchain fully functional.
Most developers and users will need them. For some usecases, these
packages might not be needed. So this option can be set to false.

This includes:

  * git
  * ncurses
  * pkg-config
  * python3Minimal

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
