### PR TITLE
stdenv.mkDerivation: be less strict about check execution for cross

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -34,8 +34,10 @@ rec {
       # Either of these can be losslessly-extracted from `parsed` iff parsing succeeds.
       system = parse.doubleFromSystem final.parsed;
       config = parse.tripleFromSystem final.parsed;
-      # Determine whether we are compatible with the provided CPU
-      isCompatible = platform: parse.isCompatible final.parsed.cpu platform.parsed.cpu;
+      # Determine whether we can execute binaries built for the provided platform.
+      canExecute = platform:
+        parse.isCompatible final.parsed.cpu platform.parsed.cpu
+        && final.parsed.kernel == platform.parsed.kernel;
       # Derived meta-data
       libc =
         /**/ if final.isDarwin              then "libSystem"

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -38,6 +38,7 @@ rec {
       canExecute = platform:
         parse.isCompatible final.parsed.cpu platform.parsed.cpu
         && final.parsed.kernel == platform.parsed.kernel;
+      isCompatible = _: throw "2022-05-23: isCompatible has been removed in favor of canExecute, refer to the 22.11 changelog for details";
       # Derived meta-data
       libc =
         /**/ if final.isDarwin              then "libSystem"

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -148,8 +148,10 @@ rec {
   #   Every CPU is compatible with itself.
   # - (transitivity)
   #   If A is compatible with B and B is compatible with C then A is compatible with C.
-  # - (compatible under multiple endianness)
-  #   CPUs with multiple modes of endianness are pairwise compatible.
+  #
+  # Note: Since 22.11 the archs of a mode switching CPU are no longer considered
+  # pairwise compatible. Mode switching implies that binaries built for A
+  # and B respectively can't be executed at the same time.
   isCompatible = a: b: with cpuTypes; lib.any lib.id [
     # x86
     (b == i386 && isCompatible a i486)
@@ -191,22 +193,13 @@ rec {
     (b == aarch64 && a == armv8a)
     (b == armv8a && isCompatible a aarch64)
 
-    (b == aarch64 && a == aarch64_be)
-    (b == aarch64_be && isCompatible a aarch64)
-
     # PowerPC
     (b == powerpc && isCompatible a powerpc64)
-    (b == powerpcle && isCompatible a powerpc)
-    (b == powerpc && a == powerpcle)
-    (b == powerpc64le && isCompatible a powerpc64)
-    (b == powerpc64 && a == powerpc64le)
+    (b == powerpcle && isCompatible a powerpc64le)
 
     # MIPS
     (b == mips && isCompatible a mips64)
-    (b == mips && a == mipsel)
-    (b == mipsel && isCompatible a mips)
-    (b == mips64 && a == mips64el)
-    (b == mips64el && isCompatible a mips64)
+    (b == mipsel && isCompatible a mips64el)
 
     # RISCV
     (b == riscv32 && isCompatible a riscv64)

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -13,8 +13,22 @@
     <itemizedlist spacing="compact">
       <listitem>
         <para>
-          Please remove this line when you add the first item since
-          docbook requires the section to be non-empty
+          During cross-compilation, tests are now executed if the test
+          suite can be executed by the build platform. This is the case
+          when doing “native” cross-compilation where the build and host
+          platforms are largely the same, but the nixpkgs’ cross
+          compilation infrastructure is used, e.g.
+          <literal>pkgsStatic</literal> and <literal>pkgsLLVM</literal>.
+          Another possibility is that the build platform is a superset
+          of the host platform, e.g. when cross-compiling from
+          <literal>x86_64-unknown-linux</literal> to
+          <literal>i686-unknown-linux</literal>. The predicate gating
+          test suite execution is the newly added
+          <literal>canExecute</literal> predicate: You can e.g. check if
+          <literal>stdenv.buildPlatform</literal> can execute binaries
+          built for <literal>stdenv.hostPlatform</literal> (i.e.
+          produced by <literal>stdenv.cc</literal>) by evaluating
+          <literal>stdenv.buildPlatform.canExecute stdenv.hostPlatform</literal>.
         </para>
       </listitem>
     </itemizedlist>
@@ -35,8 +49,19 @@
     <itemizedlist spacing="compact">
       <listitem>
         <para>
-          Please remove this line when you add the first item since
-          docbook requires the section to be non-empty
+          The <literal>isCompatible</literal> predicate checking CPU
+          compatibility is no longer exposed by the platform sets
+          generated using <literal>lib.systems.elaborate</literal>. In
+          most cases you will want to use the new
+          <literal>canExecute</literal> predicate instead which also
+          considers the kernel / syscall interface. It is briefly
+          described in the release’s
+          <link linkend="sec-release-22.11-highlights">highlights
+          section</link>.
+          <literal>lib.systems.parse.isCompatible</literal> still
+          exists, but has changed semantically: Architectures with
+          differing endianness modes are <emphasis>no longer considered
+          compatible</emphasis>.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -6,7 +6,16 @@ Support is planned until the end of June 2023, handing over to 23.05.
 
 In addition to numerous new and upgraded packages, this release has the following highlights:
 
-- Please remove this line when you add the first item since docbook requires the section to be non-empty
+- During cross-compilation, tests are now executed if the test suite can be executed
+  by the build platform. This is the case when doing “native” cross-compilation
+  where the build and host platforms are largely the same, but the nixpkgs' cross
+  compilation infrastructure is used, e.g. `pkgsStatic` and `pkgsLLVM`. Another
+  possibility is that the build platform is a superset of the host platform, e.g. when
+  cross-compiling from `x86_64-unknown-linux` to `i686-unknown-linux`.
+  The predicate gating test suite execution is the newly added `canExecute`
+  predicate: You can e.g. check if `stdenv.buildPlatform` can execute binaries
+  built for `stdenv.hostPlatform` (i.e. produced by `stdenv.cc`) by evaluating
+  `stdenv.buildPlatform.canExecute stdenv.hostPlatform`.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
@@ -18,7 +27,14 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 ## Backward Incompatibilities {#sec-release-22.11-incompatibilities}
 
-- Please remove this line when you add the first item since docbook requires the section to be non-empty
+- The `isCompatible` predicate checking CPU compatibility is no longer exposed
+  by the platform sets generated using `lib.systems.elaborate`. In most cases
+  you will want to use the new `canExecute` predicate instead which also
+  considers the kernel / syscall interface. It is briefly described in the
+  release's [highlights section](#sec-release-22.11-highlights).
+  `lib.systems.parse.isCompatible` still exists, but has changed semantically:
+  Architectures with differing endianness modes are *no longer considered compatible*.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Other Notable Changes {#sec-release-22.11-notable-changes}

--- a/pkgs/development/libraries/capnproto/default.nix
+++ b/pkgs/development/libraries/capnproto/default.nix
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ]
-    ++ lib.optional (!(stdenv.hostPlatform.isCompatible stdenv.buildPlatform)) capnproto;
+    ++ lib.optional (!(stdenv.buildPlatform.canExecute stdenv.hostPlatform)) capnproto;
 
-  cmakeFlags = lib.optional (!(stdenv.hostPlatform.isCompatible stdenv.buildPlatform)) "-DEXTERNAL_CAPNP";
+  cmakeFlags = lib.optional (!(stdenv.buildPlatform.canExecute stdenv.hostPlatform)) "-DEXTERNAL_CAPNP";
 
   # Upstream 77ac9154440bcc216fda1092fd5bb51da62ae09c, modified to apply to v0.9.1.  Drop on update.
   patches = lib.optional stdenv.hostPlatform.isMusl ./musl-no-fibers.patch;

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -1,7 +1,9 @@
 { lib, stdenv, fetchurl, fetchpatch
 , autoreconfHook
 
-, doCheck ? true # test suite depends on dejagnu which cannot be used during bootstrapping
+  # test suite depends on dejagnu which cannot be used during bootstrapping
+  # dejagnu also requires tcl which can't be built statically at the moment
+, doCheck ? !(stdenv.hostPlatform.isStatic)
 , dejagnu
 }:
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -167,8 +167,8 @@ makeOverlayable (overrideAttrs:
 let
   # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when
   # no package has `doCheck = true`.
-  doCheck' = doCheck && stdenv.hostPlatform == stdenv.buildPlatform;
-  doInstallCheck' = doInstallCheck && stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck' = doCheck && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  doInstallCheck' = doInstallCheck && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   separateDebugInfo' = separateDebugInfo && stdenv.hostPlatform.isLinux && !(stdenv.hostPlatform.useLLVM or false);
   outputs' = outputs ++ lib.optional separateDebugInfo' "debug";

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -31,7 +31,7 @@
   # compatible with or current architecture.
   getCompatibleTools = lib.foldl (v: system:
     if v != null then v
-    else if localSystem.isCompatible (lib.systems.elaborate { inherit system; }) then archLookupTable.${system}
+    else if localSystem.canExecute (lib.systems.elaborate { inherit system; }) then archLookupTable.${system}
     else null) null (lib.attrNames archLookupTable);
 
   archLookupTable = table.${localSystem.libc}


### PR DESCRIPTION
**DO NOT MERGE BEFORE BRANCH-OFF**

Instead of requiring the platforms be equal, use `isCompatible` to
determine if we can execute tests. The upside of this is that we now
can execute tests for natively cross compiled package sets like
pkgsStatic, pkgsLLVM and pkgsCross.musl64 etc.

Not sure how many edge cases there will be with this. To test this
change so far, I've compiled `pkgsLLVM.nix` and `nixStatic`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
