### PR TITLE
babashka: reduce closure size

### DIFF
--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, graalvm11-ce, glibcLocales }:
+{ lib, stdenv, fetchurl, graalvm11-ce, glibc, glibcLocales }:
 
 stdenv.mkDerivation rec {
   pname = "babashka";
@@ -23,6 +23,9 @@ stdenv.mkDerivation rec {
 
     # https://github.com/babashka/babashka/blob/v0.6.1/script/compile#L41-L52
     args=("-jar" "$BABASHKA_JAR"
+          # Reduce closure size by linking using glibc directly
+          # instead of using GraalVM copies
+          "-H:CLibraryPath=${glibc}/lib"
           # Required to build babashka on darwin. Do not remove.
           "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
           "-H:Name=$BABASHKA_BINARY"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Nowadays the babashka closure is huge:

```
$ nix path-info -S ./result -h
/nix/store/yfnnfs75vh01sw6aqcrix1rgk919c4sb-babashka-0.6.1	  2.0G
```

The reason for this is that babashka links with the internal libraries available on the GraalVM closure:

```
$ ldd ./result/bin/bb
	linux-vdso.so.1 (0x00007ffe9bf56000)
	libstdc++.so.6 => /nix/store/bg7pq2k5i1ylpq5czsh7zym5nijpj30q-gcc-10.3.0-lib/lib/libstdc++.so.6 (0x00007f8e7a926000)
	libm.so.6 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/libm.so.6 (0x00007f8e7a7e5000)
	libpthread.so.0 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/libpthread.so.0 (0x00007f8e7a7c5000)
	libdl.so.2 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/libdl.so.2 (0x00007f8e7a7c0000)
	librt.so.1 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/librt.so.1 (0x00007f8e7a7b5000)
	libc.so.6 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/libc.so.6 (0x00007f8e7a5ee000)
	/nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib/ld-linux-x86-64.so.2 => /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib64/ld-linux-x86-64.so.2 (0x00007f8e7aafd000)
	libgcc_s.so.1 => /nix/store/bg7pq2k5i1ylpq5czsh7zym5nijpj30q-gcc-10.3.0-lib/lib/libgcc_s.so.1 (0x00007f8e7a5d4000)
```

However if we change it to explicitly use the libraries from glibc, this can reduce the closure size a lot:

```
$ nix path-info -S ./result -h
/nix/store/c3678gamrj7sd34l0j0bwcvchjsa8p4k-babashka-0.6.1	120.9M
```

Because now it no longer tries to link with the GraalVM versions of those libraries:

```
$ ldd ./result/bin/bb
	linux-vdso.so.1 (0x00007ffd8f2e2000)
	libstdc++.so.6 => /nix/store/bg7pq2k5i1ylpq5czsh7zym5nijpj30q-gcc-10.3.0-lib/lib/libstdc++.so.6 (0x00007f9cafd9b000)
	libm.so.6 => /nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib/libm.so.6 (0x00007f9cafc5a000)
	libpthread.so.0 => /nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib/libpthread.so.0 (0x00007f9cafc3a000)
	libdl.so.2 => /nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib/libdl.so.2 (0x00007f9cafc35000)
	librt.so.1 => /nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib/librt.so.1 (0x00007f9cafc2a000)
	libc.so.6 => /nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib/libc.so.6 (0x00007f9cafa63000)
	/nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib/ld-linux-x86-64.so.2 => /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib64/ld-linux-x86-64.so.2 (0x00007f9caff72000)
	libgcc_s.so.1 => /nix/store/bg7pq2k5i1ylpq5czsh7zym5nijpj30q-gcc-10.3.0-lib/lib/libgcc_s.so.1 (0x00007f9cafa49000)

```

This is safe because we actually link the glibc libraries on GraalVM closure:

https://github.com/NixOS/nixpkgs/blob/ac27d4a7a48fd5223fb18c205fa2cfbe44189f4d/pkgs/development/compilers/graalvm/community-edition.nix#L173-L176

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
