### PR TITLE
python3Packages.tuya-iot-py-sdk: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/tuya-iot-py-sdk/default.nix
+++ b/pkgs/development/python-modules/tuya-iot-py-sdk/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, paho-mqtt
+, pycryptodome
+, pythonOlder
+, requests
+, websocket-client
+}:
+
+buildPythonPackage rec {
+  pname = "tuya-iot-py-sdk";
+  version = "0.5.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "tuya";
+    repo = "tuya-iot-python-sdk";
+    rev = "v${version}";
+    sha256 = "1qfjq4h62phsrmrfb11xwd6gjc28vhs90g3mmx7d8ikgsgnqlvza";
+  };
+
+  propagatedBuildInputs = [
+    paho-mqtt
+    pycryptodome
+    requests
+    websocket-client
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "tuya_iot" ];
+
+  meta = with lib; {
+    description = "Tuya IoT Python SDK for Tuya Open API";
+    homepage = "https://github.com/tuya/tuya-iot-python-sdk";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9174,6 +9174,8 @@ in {
 
   tumpa = callPackage ../development/python-modules/tumpa { };
 
+  tuya-iot-py-sdk = callPackage ../development/python-modules/tuya-iot-py-sdk { };
+
   tuyaha = callPackage ../development/python-modules/tuyaha { };
 
   tvdb_api = callPackage ../development/python-modules/tvdb_api { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tuya IoT Python SDK for Tuya Open API

https://github.com/tuya/tuya-iot-python-sdk

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
