### PR TITLE
lib/types: Make types.anything merge functions

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -254,8 +254,10 @@ checkConfigOutput / config.value.path ./types-anything/equal-atoms.nix
 checkConfigOutput null config.value.null ./types-anything/equal-atoms.nix
 checkConfigOutput 0.1 config.value.float ./types-anything/equal-atoms.nix
 # Functions can't be merged together
-checkConfigError "The option .* has conflicting definition values" config.value.multiple-lambdas ./types-anything/functions.nix
+checkConfigError "The option .value.multiple-lambdas.<function body>. has conflicting option types" config.applied.multiple-lambdas ./types-anything/functions.nix
 checkConfigOutput '<LAMBDA>' config.value.single-lambda ./types-anything/functions.nix
+checkConfigOutput 'null' config.applied.merging-lambdas.x ./types-anything/functions.nix
+checkConfigOutput 'null' config.applied.merging-lambdas.y ./types-anything/functions.nix
 # Check that all mk* modifiers are applied
 checkConfigError 'attribute .* not found' config.value.mkiffalse ./types-anything/mk-mods.nix
 checkConfigOutput '{ }' config.value.mkiftrue ./types-anything/mk-mods.nix

--- a/lib/tests/modules/types-anything/functions.nix
+++ b/lib/tests/modules/types-anything/functions.nix
@@ -1,16 +1,22 @@
-{ lib, ... }: {
+{ lib, config, ... }: {
 
   options.value = lib.mkOption {
     type = lib.types.anything;
   };
 
+  options.applied = lib.mkOption {
+    default = lib.mapAttrs (name: fun: fun null) config.value;
+  };
+
   config = lib.mkMerge [
     {
       value.single-lambda = x: x;
-      value.multiple-lambdas = x: x;
+      value.multiple-lambdas = x: { inherit x; };
+      value.merging-lambdas = x: { inherit x; };
     }
     {
-      value.multiple-lambdas = x: x;
+      value.multiple-lambdas = x: [ x ];
+      value.merging-lambdas = y: { inherit y; };
     }
   ];
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -192,6 +192,12 @@ rec {
               else (listOf anything).merge;
             # This is the type of packages, only accept a single definition
             stringCoercibleSet = mergeOneOption;
+            lambda = loc: defs: arg: anything.merge
+              (loc ++ [ "<function body>" ])
+              (map (def: {
+                file = def.file;
+                value = def.value arg;
+              }) defs);
             # Otherwise fall back to only allowing all equal definitions
           }.${commonType} or mergeEqualOption;
         in mergeFunction loc defs;


### PR DESCRIPTION
###### Motivation for this change
Previously it would give an error if there were multiple function definitions.

Ping @roberth @blaggacao 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
