### PR TITLE
graalvm-{8,11}-ce: reduce closure sizes on Linux for packages that builds on it

### DIFF
--- a/pkgs/development/compilers/graalvm/community-edition/repository.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/repository.nix
@@ -174,6 +174,8 @@ let
         ${copyClibrariesToLib}
       '';
       "11-darwin-amd64" = ''
+        # create empty $lib/lib to avoid breaking builds
+        mkdir -p $lib/lib
         ${nativePRNGWorkaround "$out/conf/security/java.security"}
       '';
     }.${javaVersionPlatform} + ''

--- a/pkgs/development/compilers/graalvm/community-edition/repository.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/repository.nix
@@ -130,37 +130,51 @@ let
       unpack_jar ''${arr[4]}
     '';
 
-    installPhase = {
-      "8-linux-amd64" = ''
+    outputs = [ "out" "lib" ];
+
+    installPhase = let
+      nativePRNGWorkaround = path: ''
         # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
-        substituteInPlace $out/jre/lib/security/java.security \
+        substituteInPlace ${path} \
           --replace file:/dev/random    file:/dev/./urandom \
           --replace NativePRNGBlocking  SHA1PRNG
-
+      '';
+      copyClibrariesToOut = basepath: ''
         # provide libraries needed for static compilation
         for f in ${glibc}/lib/* ${glibc.static}/lib/* ${zlib.static}/lib/*; do
-          ln -s $f $out/jre/lib/svm/clibraries/${platform}/$(basename $f)
+          ln -s $f ${basepath}/${platform}/$(basename $f)
         done
+      '';
+
+      copyClibrariesToLib = ''
+        # add those libraries to $lib output too, so we can use them with
+        # `native-image -H:CLibraryPath=''${graalvm11-ce.lib}/lib ...` and reduce
+        # closure size by not depending on GraalVM $out (that is much bigger)
+        mkdir -p $lib/lib
+        for f in ${glibc}/lib/*; do
+          ln -s $f $lib/lib/$(basename $f)
+        done
+      '';
+    in {
+      "8-linux-amd64" = ''
+        ${nativePRNGWorkaround "$out/jre/lib/security/java.security"}
+
+        ${copyClibrariesToOut "$out/jre/lib/svm/clibraries"}
+
+        ${copyClibrariesToLib}
 
         # allow using external truffle-api.jar and languages not included in the distrubution
         rm $out/jre/lib/jvmci/parentClassLoader.classpath
       '';
       "11-linux-amd64" = ''
-        # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
-        substituteInPlace $out/conf/security/java.security \
-          --replace file:/dev/random    file:/dev/./urandom \
-          --replace NativePRNGBlocking  SHA1PRNG
+        ${nativePRNGWorkaround "$out/conf/security/java.security"}
 
-        # provide libraries needed for static compilation
-        for f in ${glibc}/lib/* ${glibc.static}/lib/* ${zlib.static}/lib/*; do
-          ln -s $f $out/lib/svm/clibraries/${platform}/$(basename $f)
-        done
+        ${copyClibrariesToOut "$out/lib/svm/clibraries"}
+
+        ${copyClibrariesToLib}
       '';
       "11-darwin-amd64" = ''
-        # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
-        substituteInPlace $out/conf/security/java.security \
-          --replace file:/dev/random    file:/dev/./urandom \
-          --replace NativePRNGBlocking  SHA1PRNG
+        ${nativePRNGWorkaround "$out/conf/security/java.security"}
       '';
     }.${javaVersionPlatform} + ''
       # jni.h expects jni_md.h to be in the header search path.

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
 
     # https://github.com/babashka/babashka/blob/v0.6.1/script/compile#L41-L52
     args=("-jar" "$BABASHKA_JAR"
+          "-H:CLibraryPath=${graalvm11-ce.lib}/lib"
           # Required to build babashka on darwin. Do not remove.
           "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
           "-H:Name=$BABASHKA_BINARY"

--- a/pkgs/development/tools/clj-kondo/default.nix
+++ b/pkgs/development/tools/clj-kondo/default.nix
@@ -4,12 +4,6 @@ stdenv.mkDerivation rec {
   pname = "clj-kondo";
   version = "2021.09.25";
 
-  reflectionJson = fetchurl {
-    name = "reflection.json";
-    url = "https://raw.githubusercontent.com/clj-kondo/${pname}/v${version}/reflection.json";
-    sha256 = "sha256-C4QYk5lLienCHKnWXXZPcKmsCTMtIIkXOkvCrZfyIhA=";
-  };
-
   src = fetchurl {
     url = "https://github.com/clj-kondo/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
     sha256 = "sha256-kS6bwsYH/cbjJlIeiDAy6QsAw+D1uHp26d4NBLfStjg=";
@@ -20,21 +14,21 @@ stdenv.mkDerivation rec {
   buildInputs = [ graalvm11-ce ];
 
   buildPhase = ''
-    native-image  \
-      -jar ${src} \
-      -H:Name=clj-kondo \
-      ${lib.optionalString stdenv.isDarwin ''-H:-CheckToolchain''} \
-      -H:+ReportExceptionStackTraces \
-      -J-Dclojure.spec.skip-macros=true \
-      -J-Dclojure.compiler.direct-linking=true \
-      "-H:IncludeResources=clj_kondo/impl/cache/built_in/.*" \
-      -H:ReflectionConfigurationFiles=${reflectionJson} \
-      --initialize-at-build-time  \
-      -H:Log=registerResource: \
-      --verbose \
-      --no-fallback \
-      --no-server \
-      "-J-Xmx3g"
+    runHook preBuild
+
+    # https://github.com/clj-kondo/clj-kondo/blob/v2021.09.25/script/compile#L17-L21
+    args=("-jar" "$src"
+          "-H:CLibraryPath=${graalvm11-ce.lib}/lib"
+          # Required to build babashka on darwin. Do not remove.
+          "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
+          "-H:+ReportExceptionStackTraces"
+          "--verbose"
+          "--no-fallback"
+          "-J-Xmx3g")
+
+     native-image ''${args[@]}
+
+     runHook postBuild
   '';
 
   installPhase = ''
@@ -47,6 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/clj-kondo/clj-kondo";
     license = licenses.epl10;
     platforms = graalvm11-ce.meta.platforms;
-    maintainers = with maintainers; [ jlesquembre bandresen ];
+    maintainers = with maintainers; [ jlesquembre bandresen thiagokokada ];
   };
 }

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -28,8 +28,6 @@ stdenv.mkDerivation rec {
     # https://github.com/clojure-lsp/clojure-lsp/blob/2021.09.30-15.28.01/graalvm/native-unix-compile.sh#L19-L24
     args=("-jar" "$CLOJURE_LSP_JAR"
           "-H:CLibraryPath=${graalvm11-ce.lib}/lib"
-          # Required to build babashka on darwin. Do not remove.
-          "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
           "-H:+ReportExceptionStackTraces"
           "--verbose"
           "--no-fallback"

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -25,7 +25,18 @@ stdenv.mkDerivation rec {
   buildPhase = with lib; ''
     runHook preBuild
 
-    bash ./graalvm/native-unix-compile.sh
+    # https://github.com/clojure-lsp/clojure-lsp/blob/2021.09.30-15.28.01/graalvm/native-unix-compile.sh#L19-L24
+    args=("-jar" "$CLOJURE_LSP_JAR"
+          "-H:CLibraryPath=${graalvm11-ce.lib}/lib"
+          # Required to build babashka on darwin. Do not remove.
+          "${lib.optionalString stdenv.isDarwin "-H:-CheckToolchain"}"
+          "-H:+ReportExceptionStackTraces"
+          "--verbose"
+          "--no-fallback"
+          "--native-image-info"
+          "$CLOJURE_LSP_XMX")
+
+    native-image ''${args[@]}
 
     runHook postBuild
   '';

--- a/pkgs/development/tools/zprint/default.nix
+++ b/pkgs/development/tools/zprint/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     -H:Name=${pname} \
     -H:EnableURLProtocols=https,http \
     -H:+ReportExceptionStackTraces \
+    -H:CLibraryPath=${graalvm11-ce.lib}/lib \
     ${lib.optionalString stdenv.isDarwin ''-H:-CheckToolchain''} \
     --report-unsupported-elements-at-runtime \
     --initialize-at-build-time \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Nowadays most packages builds from GraalVM Native Image have huge closures. For example, `babashka`:

```
$ nix path-info -S ./result -h
/nix/store/yfnnfs75vh01sw6aqcrix1rgk919c4sb-babashka-0.6.1	  2.0G
```

The reason for this is that any GraalVM Native Image package links to C libraries that are located inside GraalVM closure:

```
$ ldd ./result/bin/bb
	linux-vdso.so.1 (0x00007ffe9bf56000)
	libstdc++.so.6 => /nix/store/bg7pq2k5i1ylpq5czsh7zym5nijpj30q-gcc-10.3.0-lib/lib/libstdc++.so.6 (0x00007f8e7a926000)
	libm.so.6 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/libm.so.6 (0x00007f8e7a7e5000)
	libpthread.so.0 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/libpthread.so.0 (0x00007f8e7a7c5000)
	libdl.so.2 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/libdl.so.2 (0x00007f8e7a7c0000)
	librt.so.1 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/librt.so.1 (0x00007f8e7a7b5000)
	libc.so.6 => /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce/lib/svm/clibraries/linux-amd64/libc.so.6 (0x00007f8e7a5ee000)
	/nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib/ld-linux-x86-64.so.2 => /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib64/ld-linux-x86-64.so.2 (0x00007f8e7aafd000)
	libgcc_s.so.1 => /nix/store/bg7pq2k5i1ylpq5czsh7zym5nijpj30q-gcc-10.3.0-lib/lib/libgcc_s.so.1 (0x00007f8e7a5d4000)

$ nix path-info -S /nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce -h
/nix/store/sc9vbxw116p9pa0knh0cq7nwzrwq5sya-graalvm11-ce	  1.9G
```

However, if you look at the `graalvm-*-ce` derivations, you can see that those C libraries are just `glibc` (and some `glibc.static` and `zlib.static`, but they only matter for static compilation):

https://github.com/NixOS/nixpkgs/blob/ac27d4a7a48fd5223fb18c205fa2cfbe44189f4d/pkgs/development/compilers/graalvm/community-edition.nix#L173-L176

To fix it, we could add `-H:CLibraryPath=${glibc}/lib` to make GraalVM to depend on the libraries from `glibc` instead their internal copies. However this approach is fragile. If for some reason GraalVM adds more libraries as dependencies, we will need to go back and fix all packages that depends on it.

So this PR introduces another approach: it adds a `lib` output to `graalvm-{8,11}-ce` and adds `-H:CLibraryPath=${graalvm-11-ce}/lib` to all(?) packages that builds from it. `lib` for now it is just `glibc` (the only dynamic dependency of GraalVM, the other ones are static ones). GraalVM itself always include the default C library location  (e.g.: `-H:CLibraryPath=${graalvm-11-ce}/lib/svm/clibraries/${platform}`) on its path, so this shouldn't break anything.

The above changes result in:

```
$ nix path-info -S results/babashka -h
/nix/store/fay0p3hiiic4kd4fk0xyczl1ff8sjcp1-babashka-0.6.1	116.6M

$ ldd results/babashka/bin/bb
	linux-vdso.so.1 (0x00007ffe2737d000)
	libstdc++.so.6 => /nix/store/bg7pq2k5i1ylpq5czsh7zym5nijpj30q-gcc-10.3.0-lib/lib/libstdc++.so.6 (0x00007f7deef0a000)
	libm.so.6 => /nix/store/9qf2plvypbk93q2gw742dr0wdkw8jqj0-graalvm11-ce-lib/lib/libm.so.6 (0x00007f7deedc9000)
	libpthread.so.0 => /nix/store/9qf2plvypbk93q2gw742dr0wdkw8jqj0-graalvm11-ce-lib/lib/libpthread.so.0 (0x00007f7deeda9000)
	libdl.so.2 => /nix/store/9qf2plvypbk93q2gw742dr0wdkw8jqj0-graalvm11-ce-lib/lib/libdl.so.2 (0x00007f7deeda4000)
	librt.so.1 => /nix/store/9qf2plvypbk93q2gw742dr0wdkw8jqj0-graalvm11-ce-lib/lib/librt.so.1 (0x00007f7deed99000)
	libc.so.6 => /nix/store/9qf2plvypbk93q2gw742dr0wdkw8jqj0-graalvm11-ce-lib/lib/libc.so.6 (0x00007f7deebd2000)
	/nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib/ld-linux-x86-64.so.2 => /nix/store/2jfn3d7vyj7h0h6lmh510rz31db68l1i-glibc-2.33-50/lib64/ld-linux-x86-64.so.2 (0x00007f7def0e1000)
	libgcc_s.so.1 => /nix/store/bg7pq2k5i1ylpq5czsh7zym5nijpj30q-gcc-10.3.0-lib/lib/libgcc_s.so.1 (0x00007f7deebb8000)

$ nix path-info -S /nix/store/9qf2plvypbk93q2gw742dr0wdkw8jqj0-graalvm11-ce-lib -h
/nix/store/9qf2plvypbk93q2gw742dr0wdkw8jqj0-graalvm11-ce-lib	 31.6M
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
