### PR TITLE
beam: mix-release: do not use substituteInPlace on binaries

### DIFF
--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -104,8 +104,12 @@ stdenv.mkDerivation (overridable // {
     if [ -e $out/erts-* ]; then
       echo "ERTS found in $out - removing references to erlang to reduce closure size"
       # there is a link in $out/erts-*/bin/start always
+      # TODO:
       # sometimes there are links in dependencies like bcrypt compiled binaries
-      for file in $(rg "${erlang}/lib/erlang" "$out" --text --files-with-matches); do
+      # at the moment those are not removed since substituteInPlace will
+      # error on binaries
+      for file in $(rg "${erlang}/lib/erlang" "$out" --files-with-matches); do
+        echo "removing reference to erlang in $file"
         substituteInPlace "$file" --replace "${erlang}/lib/erlang" "$out"
       done
     fi


### PR DESCRIPTION
###### Motivation for this change

in mix-release post fixup phase there is a portion dedicated to removing erlang references to reduce closure size.
removing those reference was done on binaries as well using substituteInPlace.
This should have been failing, substituteInPlace is meant to error out when being run on binaries.
One of the recent bash update makes this problem apparent.
references to erlang in binaries are not substituted anymore. This has the unfortunate effect that some closures are bigger now (by about 300 MB, just tested on plausible).

@NixOS/beam I'm happy to take another approach if you have other ideas.
The failure can be tested on plausible.

@Ma27 cc ing you since this affect plausible, hopefully it should be mergeable soon and you won't have to do a thing. (just hold off from updating nixpkgs for a little bit).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
