### PR TITLE
python3Packages.crownstone-cloud: init at 1.4.5, python3Packages.crownstone-uart: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/crownstone-cloud/default.nix
+++ b/pkgs/development/python-modules/crownstone-cloud/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, aiohttp
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
+, certifi
+, pythonOlder
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "crownstone-cloud";
+  version = "1.4.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "crownstone";
+    repo = "crownstone-lib-python-cloud";
+    rev = "v${version}";
+    sha256 = "1a8bkqkrc7iyggr5rr20qdqg67sycdx2d94dd1ylkmr7627r34ys";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    asynctest
+    certifi
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "codecov>=2.1.10" ""
+  '';
+
+  pythonImportsCheck = [
+    "crownstone_cloud"
+  ];
+
+  meta = with lib; {
+    description = "Python module for communicating with Crownstone Cloud and devices";
+    homepage = "https://github.com/crownstone/crownstone-lib-python-cloud";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/crownstone-core/default.nix
+++ b/pkgs/development/python-modules/crownstone-core/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyaes
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "crownstone-core";
+  version = "3.0.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "crownstone";
+    repo = "crownstone-lib-python-core";
+    rev = version;
+    sha256 = "138lignv7c8kkqbqfkdcfpg39gm9x44h7r2j403m4ib7gq420hsn";
+  };
+
+  propagatedBuildInputs = [
+    pyaes
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "crownstone_core"
+  ];
+
+  meta = with lib; {
+    description = "Python module with shared classes, util functions and definition of Crownstone";
+    homepage = "https://github.com/crownstone/crownstone-lib-python-core";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/crownstone-sse/default.nix
+++ b/pkgs/development/python-modules/crownstone-sse/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, aiohttp
+, asynctest
+, buildPythonPackage
+, certifi
+, fetchFromGitHub
+, pythonOlder
+, coverage
+}:
+
+buildPythonPackage rec {
+  pname = "crownstone-sse";
+  version = "2.0.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "crownstone";
+    repo = "crownstone-lib-python-sse";
+    rev = version;
+    sha256 = "0rrr92j8pi5annrfa22k1hggsyyacl9asi9i8yrj4jqdjvwjn2gc";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    asynctest
+    certifi
+  ];
+
+  # Tests are only providing coverage
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "crownstone_sse"
+  ];
+
+  meta = with lib; {
+    description = "Python module for listening to Crownstone SSE events";
+    homepage = "https://github.com/crownstone/crownstone-lib-python-sse";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/crownstone-uart/default.nix
+++ b/pkgs/development/python-modules/crownstone-uart/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, crownstone-core
+, buildPythonPackage
+, pyserial
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "crownstone-uart";
+  version = "2.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "crownstone";
+    repo = "crownstone-lib-python-uart";
+    rev = version;
+    sha256 = "0sdz131vmrfp6hrm9iwqw8mj9qazsxg7b85yadib1122w9f3b1zc";
+  };
+
+  propagatedBuildInputs = [
+    crownstone-core
+    pyserial
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "crownstone_uart"
+  ];
+
+  meta = with lib; {
+    description = "Python module for communicating with Crownstone USB dongles";
+    homepage = "https://github.com/crownstone/crownstone-lib-python-uart";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1743,6 +1743,8 @@ in {
 
   crownstone-core = callPackage ../development/python-modules/crownstone-core { };
 
+  crownstone-uart = callPackage ../development/python-modules/crownstone-uart { };
+
   cryptacular = callPackage ../development/python-modules/cryptacular { };
 
   cryptography = callPackage ../development/python-modules/cryptography {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1741,6 +1741,8 @@ in {
 
   crownstone-cloud = callPackage ../development/python-modules/crownstone-cloud { };
 
+  crownstone-core = callPackage ../development/python-modules/crownstone-core { };
+
   cryptacular = callPackage ../development/python-modules/cryptacular { };
 
   cryptography = callPackage ../development/python-modules/cryptography {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1743,6 +1743,8 @@ in {
 
   crownstone-core = callPackage ../development/python-modules/crownstone-core { };
 
+  crownstone-sse = callPackage ../development/python-modules/crownstone-sse { };
+
   crownstone-uart = callPackage ../development/python-modules/crownstone-uart { };
 
   cryptacular = callPackage ../development/python-modules/cryptacular { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1739,6 +1739,8 @@ in {
 
   croniter = callPackage ../development/python-modules/croniter { };
 
+  crownstone-cloud = callPackage ../development/python-modules/crownstone-cloud { };
+
   cryptacular = callPackage ../development/python-modules/cryptacular { };
 
   cryptography = callPackage ../development/python-modules/cryptography {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add Crownstone python modules.

https://github.com/crownstone

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
