### PR TITLE
serd + sord: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/serd/default.nix
+++ b/pkgs/development/libraries/serd/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-r/qA3ux4kh+GM15vw/GLgK7+z0JPaldV6fL6DrBxDt8=";
   };
 
+  dontAddWafCrossFlags = true;
+
   nativeBuildInputs = [ pkg-config python3 wafHook ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/sord/default.nix
+++ b/pkgs/development/libraries/sord/default.nix
@@ -13,9 +13,14 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  preConfigure = ''
+    export PKGCONFIG="$PKG_CONFIG"
+  '';
+
   nativeBuildInputs = [ pkg-config python3 wafHook ];
   buildInputs = [ pcre ];
   propagatedBuildInputs = [ serd ];
+  dontAddWafCrossFlags = true;
 
   meta = with lib; {
     homepage = "http://drobilla.net/software/sord";


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation for these packages from drobilla. There are some more packages to be done, but those have a dependency on gtk2, which currently doesn't cross-compile (I have a patch in my tree to be upstreamed...).

(those TBD packages are lilv and sratom for those wondering)

It seems like those cross-compilation flags are not supported in most packages using waf (to me), so the hook is slightly weird to me (maybe explicitly adding might be better even). However, I haven't actually checked how much packages do vs. don't, so let's just enable adding the flags for now.

Tested building and executing `pkgsCross.aarch64-multiplatform.{sord,serd}`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) -> via qemu-aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
