### PR TITLE
Fix escape on updateScript of fluxcd, k3s, linode-cli

### DIFF
--- a/pkgs/applications/networking/cluster/fluxcd/update.sh
+++ b/pkgs/applications/networking/cluster/fluxcd/update.sh
@@ -14,7 +14,7 @@ SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/archi
 SPEC_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/releases/download/${TAG}/manifests.tar.gz)
 
 setKV () {
-  sed -i "s/$1 = \".*\"/$1 = \"$2\"/" ./default.nix
+    sed -i "s|$1 = \".*\"|$1 = \"$2\"|" ./default.nix
 }
 
 setKV version ${VERSION}

--- a/pkgs/applications/networking/cluster/k3s/update.sh
+++ b/pkgs/applications/networking/cluster/k3s/update.sh
@@ -44,8 +44,9 @@ CNIPLUGINS_VERSION=$(grep VERSION_CNIPLUGINS= $FILE_SCRIPTS_VERSION \
 CNIPLUGINS_SHA256=$(nix-prefetch-url --quiet --unpack \
     "https://github.com/rancher/plugins/archive/refs/tags/v${CNIPLUGINS_VERSION}.tar.gz")
 
+
 setKV () {
-  sed -i "s/$1 = \".*\"/$1 = \"$2\"/" ./default.nix
+    sed -i "s|$1 = \".*\"|$1 = \"$2\"|" ./default.nix
 }
 
 setKV k3sVersion ${K3S_VERSION}

--- a/pkgs/applications/networking/cluster/k3s/update.sh
+++ b/pkgs/applications/networking/cluster/k3s/update.sh
@@ -44,7 +44,6 @@ CNIPLUGINS_VERSION=$(grep VERSION_CNIPLUGINS= $FILE_SCRIPTS_VERSION \
 CNIPLUGINS_SHA256=$(nix-prefetch-url --quiet --unpack \
     "https://github.com/rancher/plugins/archive/refs/tags/v${CNIPLUGINS_VERSION}.tar.gz")
 
-
 setKV () {
     sed -i "s|$1 = \".*\"|$1 = \"$2\"|" ./default.nix
 }

--- a/pkgs/tools/virtualization/linode-cli/update.sh
+++ b/pkgs/tools/virtualization/linode-cli/update.sh
@@ -21,7 +21,7 @@ VERSION=$(curl -s ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
 SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/linode/linode-cli/archive/refs/tags/${VERSION}.tar.gz)
 
 setKV () {
-  sed -i "s/$1 = \".*\"/$1 = \"$2\"/" default.nix
+    sed -i "s|$1 = \".*\"|$1 = \"$2\"|" ./default.nix
 }
 
 setKV specVersion ${SPEC_VERSION}


### PR DESCRIPTION
Escape value for sed on updateScript at:
* k3s
* fluxcd
* linode-cli

Derivation hash occasionally has `"\"` character leading `sed` to fail.

--

updateScript `fluxcd` logs at:
https://r.ryantm.com/log/updatescript/fluxcd/2021-10-01.log
  * Notice:
    /var/cache/nixpkgs-update/updatescript/nixpkgs/pkgs/applications/networking/cluster/fluxcd/update.sh: line 17: $2: *unbound variable*

Hopefully it will fix it, tested locally only.

--
On `linode-cli`, updateScript seems to be working but package build errors as:
```
nix build failed.
# ...
No spec baked.  Please bake by calling this script as follows:
  python3 gen_cli.py bake /path/to/spec
Baking...
Could not load spec: unacceptable character #x0000: special characters are not allowed
  in "<unicode string>", position 781759
``` 
Logs at: https://r.ryantm.com/log/updatescript/linode-cli/2021-10-01.log
I have compared outputs of updateScript with manually updating and it matches, values are correct. Less likely to be a problem on the script.
On my host `linode-cli` (updated) builds and runs fine using the values the script outputs. But it fails when run by the bot.

Question is. Why?

@jnetod could reproduce problem by adding Null char to openapi.yaml.

Like this:
```
  postConfigure = ''
    echo -ne '\0' | cat ${spec} - > openapi.yaml
    python3 -m linodecli bake openapi.yaml --skip-config
    cp data-3 linodecli/
  '';
```
I've reproduced it too.
Question: What is causing this?

--

k3s, logs at:
https://r.ryantm.com/log/updatescript/k3s/2021-10-01.log

No idea!