### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,20 +8,20 @@ jobs:
     if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         with:
           # required to find all branches
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs
         # should be kept in sync with `version`
-        uses: zeebe-io/backport-action@v0.0.5
+        uses: zeebe-io/backport-action@e5d4d7c39c94b65670847d11d259b2f574fa3d30 # pin@v0.0.5
         with:
           # Config README: https://github.com/zeebe-io/backport-action#backport-action
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_workspace: ${{ github.workspace }}
           # should be kept in sync with `uses`
-          version: v0.0.5
+          version: e5d4d7c39c94b65670847d11d259b2f574fa3d30
           pull_description: |-
             Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
 

--- a/.github/workflows/basic-eval.yml
+++ b/.github/workflows/basic-eval.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     # we don't limit this action to only NixOS repo since the checks are cheap and useful developer feedback
     steps:
-    - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v14
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+    - uses: cachix/install-nix-action@11e5400eccd6f89582f7da71e36b86e2b0924252 # pin@v14
     # explicit list of supportedSystems is needed until aarch64-darwin becomes part of the trunk jobset
     - run: nix-build pkgs/top-level/release.nix -A tarball.nixpkgs-basic-release-checks --arg supportedSystems '[ "aarch64-darwin" "aarch64-linux" "x86_64-linux" "x86_64-darwin"  ]'

--- a/.github/workflows/direct-push.yml
+++ b/.github/workflows/direct-push.yml
@@ -22,7 +22,7 @@ jobs:
       if: steps.ismerge.outputs.ismerge != 'true'
     - name: Warn if the commit was a direct push
       if: steps.ismerge.outputs.ismerge != 'true'
-      uses: peter-evans/commit-comment@v1
+      uses: peter-evans/commit-comment@024efe46f6e45f651301d75870c4bd8fbe17cbc8 # pin@v1
       with:
         body: |
           @${{ github.actor }}, you pushed a commit directly to master/release branch

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -23,12 +23,12 @@ jobs:
           | jq '.[] | select(.status != "removed") | .filename' \
           >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       with:
         # pull_request_target checks out the base branch by default
         ref: refs/pull/${{ github.event.pull_request.number }}/merge
       if: env.PR_DIFF
-    - uses: cachix/install-nix-action@v14
+    - uses: cachix/install-nix-action@11e5400eccd6f89582f7da71e36b86e2b0924252 # pin@v14
       if: env.PR_DIFF
       with:
         # nixpkgs commit is pinned so that it doesn't break

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NixOS'
     steps:
-    - uses: actions/labeler@v3
+    - uses: actions/labeler@e54d1c08bb51b1826c8da4b05eb3fbfbc5cc4943 # pin@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         sync-labels: true

--- a/.github/workflows/manual-nixos.yml
+++ b/.github/workflows/manual-nixos.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NixOS'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         with:
           # pull_request_target checks out the base branch by default
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
-      - uses: cachix/install-nix-action@v14
+      - uses: cachix/install-nix-action@11e5400eccd6f89582f7da71e36b86e2b0924252 # pin@v14
         with:
           # explicitly enable sandbox
           extra_nix_config: sandbox = true
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@73e75d1a0cd4330597a571e8f9dedb41faa2fc4e # pin@v10
         with:
           # This cache is for the nixos/nixpkgs manual builds and should not be trusted or used elsewhere.
           name: nixpkgs-ci

--- a/.github/workflows/manual-nixpkgs.yml
+++ b/.github/workflows/manual-nixpkgs.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NixOS'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         with:
           # pull_request_target checks out the base branch by default
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
-      - uses: cachix/install-nix-action@v14
+      - uses: cachix/install-nix-action@11e5400eccd6f89582f7da71e36b86e2b0924252 # pin@v14
         with:
           # explicitly enable sandbox
           extra_nix_config: sandbox = true
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@73e75d1a0cd4330597a571e8f9dedb41faa2fc4e # pin@v10
         with:
           # This cache is for the nixos/nixpkgs manual builds and should not be trusted or used elsewhere.
           name: nixpkgs-ci

--- a/.github/workflows/nixos-manual.yml
+++ b/.github/workflows/nixos-manual.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'NixOS'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       with:
         # pull_request_target checks out the base branch by default
         ref: refs/pull/${{ github.event.pull_request.number }}/merge
-    - uses: cachix/install-nix-action@v14
+    - uses: cachix/install-nix-action@11e5400eccd6f89582f7da71e36b86e2b0924252 # pin@v14
     - name: Check DocBook files generated from Markdown are consistent
       run: |
         nixos/doc/manual/md-to-db.sh

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -30,10 +30,10 @@ jobs:
             into: haskell-updates
     name: ${{ matrix.pairs.from }} → ${{ matrix.pairs.into }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       - name: ${{ matrix.pairs.from }} → ${{ matrix.pairs.into }}
-        uses: devmasx/merge-branch@1.4.0
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # pin@1.4.0
         with:
           type: now
           from_branch: ${{ matrix.pairs.from }}
@@ -41,7 +41,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on failure
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae # pin@v1
         if: ${{ failure() }}
         with:
           issue-number: 105153

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -36,10 +36,10 @@ jobs:
             into: staging-21.05
     name: ${{ matrix.pairs.from }} → ${{ matrix.pairs.into }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       - name: ${{ matrix.pairs.from }} → ${{ matrix.pairs.into }}
-        uses: devmasx/merge-branch@1.4.0
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # pin@1.4.0
         with:
           type: now
           from_branch: ${{ matrix.pairs.from }}
@@ -47,7 +47,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on failure
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae # pin@v1
         if: ${{ failure() }}
         with:
           issue-number: 105153


### PR DESCRIPTION

###### Motivation for this change

Pinning an action to a full length commit SHA is currently the only way to use an action as
an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a
backdoor to the action's repository, as they would need to generate a SHA-1 collision for
a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
