### PR TITLE
aerospike: drop blanket -Werror

### DIFF
--- a/pkgs/servers/nosql/aerospike/default.nix
+++ b/pkgs/servers/nosql/aerospike/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     substituteInPlace build/gen_version --replace 'git describe' 'echo ${version}'
 
     # drop blanket -Werror
-    substituteInPlace make_in/Makefile.in --replace '-Werror' ' '
+    substituteInPlace make_in/Makefile.in --replace '-Werror' ''
   '';
 
   installPhase = ''

--- a/pkgs/servers/nosql/aerospike/default.nix
+++ b/pkgs/servers/nosql/aerospike/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     substituteInPlace build/gen_version --replace 'git describe' 'echo ${version}'
 
     # drop blanket -Werror
-    substituteInPlace make_in/Makefile.in --replace '-Werror' ''
+    substituteInPlace make_in/Makefile.in --replace '-Werror' ""
   '';
 
   installPhase = ''

--- a/pkgs/servers/nosql/aerospike/default.nix
+++ b/pkgs/servers/nosql/aerospike/default.nix
@@ -15,16 +15,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake libtool ];
   buildInputs = [ openssl zlib ];
 
-  NIX_CFLAGS_COMPILE = [
-    "-Wno-error=format-truncation"
-    "-Wno-error=address-of-packed-member"
-    "-Wno-error=format-overflow"
-    "-Wno-error=stringop-truncation"
-  ];
-
   preBuild = ''
     patchShebangs build/gen_version
     substituteInPlace build/gen_version --replace 'git describe' 'echo ${version}'
+
+    # drop blanket -Werror
+    substituteInPlace make_in/Makefile.in --replace '-Werror' ' '
   '';
 
   installPhase = ''


### PR DESCRIPTION
This time -Werror causes build error on gcc-11:

    $ nix build --impure --expr 'with import ./. {}; aerospike.override { stdenv = gcc11Stdenv; }'
    ...
    fabric/clustering.c: In function 'msg_succession_list_field_set.constprop':
    fabric/clustering.c:3750:9: error: '<unknown>' may be used uninitialized [-Werror=maybe-uninitialized]
     3750 |         msg_set_buf(msg, field, (uint8_t*)succession_buffer, buffer_size,
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3751 |                         MSG_SET_COPY);
          |                         ~~~~~~~~~~~~~

Let's drop -Werror and stop adding downstream -Wno-error= workarounds.