### PR TITLE
gkraken: init at 1.1.6, nixos/gkraken: init

### DIFF
--- a/nixos/modules/hardware/gkraken.nix
+++ b/nixos/modules/hardware/gkraken.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.gkraken;
+in
+{
+  options.hardware.gkraken = {
+    enable = mkEnableOption "gkraken's udev rules for NZXT AIO liquid coolers";
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.packages = with pkgs; [
+      gkraken
+    ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -48,6 +48,7 @@
   ./hardware/corectrl.nix
   ./hardware/digitalbitbox.nix
   ./hardware/device-tree.nix
+  ./hardware/gkraken.nix
   ./hardware/i2c.nix
   ./hardware/sensor/hddtemp.nix
   ./hardware/sensor/iio.nix

--- a/pkgs/tools/system/gkraken/default.nix
+++ b/pkgs/tools/system/gkraken/default.nix
@@ -1,0 +1,86 @@
+{ python3Packages
+, lib
+, fetchFromGitLab
+, meson
+, pkg-config
+, glib
+, ninja
+, desktop-file-utils
+, gobject-introspection
+, gtk3
+, libnotify
+, dbus
+, wrapGAppsHook
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "gkraken";
+  version = "1.1.6";
+
+  src = fetchFromGitLab {
+    owner = "leinardi";
+    repo = "gkraken";
+    rev = version;
+    sha256 = "085zz6m7c3xzsrvkw50gbbz8l9fmswxj2hjya2f52dvgs8daijdy";
+  };
+
+  format = "other";
+
+  postPatch = ''
+    patchShebangs scripts/meson_post_install.py
+  '';
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    glib
+    ninja
+    gtk3
+    desktop-file-utils
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gobject-introspection
+    glib
+    gtk3
+    libnotify
+    dbus
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    peewee
+    rx
+    injector
+    liquidctl
+    pyxdg
+    requests
+    matplotlib
+    dbus-python
+  ];
+
+  dontWrapGApps = true;
+
+  # Extract udev rules from python code
+  postInstall = ''
+    mkdir -p $out/lib/udev/rules.d
+    sed -e '/\s*\(from\|@singleton\|@inject\)/d' $src/gkraken/interactor/udev_interactor.py > udev_interactor.py
+    python -c 'from udev_interactor import _UDEV_RULE; print(_UDEV_RULE)' > $out/lib/udev/rules.d/60-gkraken.rules
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+    )
+  '';
+
+  meta = with lib; {
+    description = "GUI that allows to control the cooling (fan and/or pump profiles) of NZXT Kraken AIO liquid coolers from Linux";
+    homepage = "https://gitlab.com/leinardi/gkraken";
+    changelog = "https://gitlab.com/leinardi/gkraken/-/tags/${version}";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5853,6 +5853,8 @@ with pkgs;
 
   gbenchmark = callPackage ../development/libraries/gbenchmark {};
 
+  gkraken = callPackage ../tools/system/gkraken { };
+
   gtkdatabox = callPackage ../development/libraries/gtkdatabox {};
 
   gtklick = callPackage ../applications/audio/gtklick {};


### PR DESCRIPTION
###### Motivation for this change
Closes #132993

Been using a backport to stable of this for awhile, no problems so far.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
