### PR TITLE
openssh: enable tests

### DIFF
--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -18,10 +18,12 @@
 , libedit
 , pkg-config
 , pam
+, libredirect
 , etcDir ? null
 , withKerberos ? !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
 , libkrb5
 , libfido2
+, hostname
 , nixosTests
 , withFIDO ? stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isMusl
 , linkOpenssl ? true
@@ -99,6 +101,58 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   hardeningEnable = [ "pie" ];
+
+  doCheck = true;
+  checkInputs = optional (!stdenv.isDarwin) hostname;
+  preCheck = ''
+    # construct a dummy HOME
+    export HOME=$(realpath ../dummy-home)
+    mkdir -p ~/.ssh
+
+    # construct a dummy /etc/passwd file for the sshd under test
+    # to use to look up the connecting user
+    DUMMY_PASSWD=$(realpath ../dummy-passwd)
+    cat > $DUMMY_PASSWD <<EOF
+    $(whoami)::$(id -u):$(id -g)::$HOME:$SHELL
+    EOF
+
+    # we need to NIX_REDIRECTS /etc/passwd both for processes
+    # invoked directly and those invoked by the "remote" session
+    cat > ~/.ssh/environment.base <<EOF
+    NIX_REDIRECTS=/etc/passwd=$DUMMY_PASSWD
+    LD_PRELOAD=${libredirect}/lib/libredirect.so
+    EOF
+
+    # use an ssh environment file to ensure environment is set
+    # up appropriately for build environment even when no shell
+    # is invoked by the ssh session. otherwise the PATH will
+    # only contain default unix paths like /bin which we don't
+    # have in our build environment
+    cat - regress/test-exec.sh > regress/test-exec.sh.new <<EOF
+    cp $HOME/.ssh/environment.base $HOME/.ssh/environment
+    echo "PATH=\$PATH" >> $HOME/.ssh/environment
+    EOF
+    mv regress/test-exec.sh.new regress/test-exec.sh
+
+    # explicitly enable the PermitUserEnvironment feature
+    substituteInPlace regress/test-exec.sh \
+      --replace \
+        'cat << EOF > $OBJ/sshd_config' \
+        $'cat << EOF > $OBJ/sshd_config\n\tPermitUserEnvironment yes'
+
+    # some tests want to use files under /bin as example files
+    for f in regress/sftp-cmds.sh regress/forwarding.sh; do
+      substituteInPlace $f --replace '/bin' "$(dirname $(type -p ls))"
+    done
+
+    # set up NIX_REDIRECTS for direct invocations
+    set -a; source ~/.ssh/environment.base; set +a
+  '';
+  # integration tests hard to get working on darwin with its shaky
+  # sandbox
+  checkTarget = optional (!stdenv.isDarwin) "t-exec"
+    # other tests are less demanding of the environment
+    ++ [ "unit" "file-tests" "interop-tests" ];
 
   postInstall = ''
     # Install ssh-copy-id, it's very useful.


### PR DESCRIPTION
###### Motivation for this change
:tada: 

This will obviously need a lot of testing across different platforms. Have successfully built `openssh`, `openssh_hpn` and `openssh_gssapi` on linux x86_64 and macos 10.15.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
