### PR TITLE
python3Packages.pyserial-asyncio: 0.5 -> 0.6

### DIFF
--- a/pkgs/development/python-modules/pyserial-asyncio/default.nix
+++ b/pkgs/development/python-modules/pyserial-asyncio/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonPackage rec {
   pname = "pyserial-asyncio";
-  version = "0.5";
+  version = "0.6";
 
   disabled = !isPy3k; # Doesn't support python older than 3.4
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1641e5433a866eeaf6464b3ab88b741e7a89dd8cd0f851b3343b15f425138d33";
+    sha256 = "sha256-tgMpI+BenXXsF6WvmphCnEbSg5rfr4BgTVLg+qzXoy8=";
   };
 
   propagatedBuildInputs = [ pyserial ];

--- a/pkgs/development/python-modules/pyserial-asyncio/default.nix
+++ b/pkgs/development/python-modules/pyserial-asyncio/default.nix
@@ -1,21 +1,31 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k
-, pyserial }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pyserial
+}:
 
 buildPythonPackage rec {
   pname = "pyserial-asyncio";
   version = "0.6";
 
-  disabled = !isPy3k; # Doesn't support python older than 3.4
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-tgMpI+BenXXsF6WvmphCnEbSg5rfr4BgTVLg+qzXoy8=";
   };
 
-  propagatedBuildInputs = [ pyserial ];
+  propagatedBuildInputs = [
+    pyserial
+  ];
+
+  pythonImportsCheck = [
+    "serial_asyncio"
+  ];
 
   meta = with lib; {
-    description = "asyncio extension package for pyserial";
+    description = "Asyncio extension package for pyserial";
     homepage = "https://github.com/pyserial/pyserial-asyncio";
     license = licenses.bsd3;
     maintainers = with maintainers; [ etu ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
