### PR TITLE
Stdenv overhaul `broken` flag

### DIFF
--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -190,7 +190,7 @@ meta.hydraPlatforms = [];
 
 ### `broken` {#var-meta-broken}
 
-If set to `true`, the package is marked as "broken", meaning that it won’t show up in `nix-env -qa`, and cannot be built or installed. Such packages should be removed from Nixpkgs eventually unless they are fixed.
+If set to `true`, the package is marked as "broken", meaning that it won’t show up in `nix-env -qa`, and cannot be built or installed. The same happens when set to a non empty string value, in which case the text will be included in the error message shown when trying to build this package. Such packages should be removed from Nixpkgs eventually unless they are fixed.
 
 ### `updateWalker` {#var-meta-updateWalker}
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -97,12 +97,6 @@
 
 , ... } @ attrs:
 
-
-# Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
-if disabled
-then throw "${name} not supported for interpreter ${python.executable}"
-else
-
 let
   inherit (python) stdenv;
 
@@ -176,6 +170,7 @@ let
       # default to python's platforms
       platforms = python.meta.platforms;
       isBuildPythonPackage = python.meta.platforms;
+      broken = lib.optionalString disabled "interpreter ${python.executable} is not supported by this version";
     } // lib.optionalAttrs (attrs?pname) {
       mainProgram = attrs.pname;
     } // meta;

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -64,7 +64,7 @@ in buildPythonPackage {
     platform = if stdenv.isDarwin then "mac" else "linux";
     unit = if cudaSupport then "gpu" else "cpu";
     key = "${platform}_py_${pyVerNoDot}_${unit}";
-  in fetchurl packages.${key};
+  in fetchurl packages.${key} or { };
 
   propagatedBuildInputs = [
     astunparse

--- a/pkgs/development/python-modules/zipfile36/default.nix
+++ b/pkgs/development/python-modules/zipfile36/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     description = "Read and write ZIP files - backport of the zipfile module from Python 3.6";
     homepage = "https://gitlab.com/takluyver/zipfile36";
     license = lib.licenses.psfl;
-    maintainers = lib.maintainers.fridh;
+    maintainers = [lib.maintainers.fridh];
   };
 }

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -53,7 +53,7 @@ let
     hasLicense attrs &&
     isUnfree (lib.lists.toList attrs.meta.license);
 
-  isMarkedBroken = attrs: attrs.meta.broken or false;
+  isMarkedBroken = attrs: !builtins.elem attrs.meta.broken or false [ false "" ];
 
   hasUnsupportedPlatform = attrs:
     (!lib.lists.elem hostPlatform.system (attrs.meta.platforms or lib.platforms.all) ||
@@ -214,7 +214,7 @@ let
     priority = int;
     platforms = listOf str;
     hydraPlatforms = listOf str;
-    broken = bool;
+    broken = either bool str;
     unfree = bool;
     unsupported = bool;
     insecure = bool;
@@ -283,8 +283,9 @@ let
       { valid = false; reason = "unfree"; errormsg = "has an unfree license (‘${showLicense attrs.meta.license}’)"; }
     else if hasBlocklistedLicense attrs then
       { valid = false; reason = "blocklisted"; errormsg = "has a blocklisted license (‘${showLicense attrs.meta.license}’)"; }
-    else if !allowBroken && attrs.meta.broken or false then
-      { valid = false; reason = "broken"; errormsg = "is marked as broken"; }
+    else if !allowBroken && isMarkedBroken attrs then
+      let because = if lib.types.str.check attrs.meta.broken then " because ${attrs.meta.broken}" else ""; in
+      { valid = false; reason = "broken"; errormsg = "is marked as broken${because}"; }
     else if !allowUnsupportedSystem && hasUnsupportedPlatform attrs then
       { valid = false; reason = "unsupported"; errormsg = "is not supported on ‘${hostPlatform.system}’"; }
     else if !(hasAllowedInsecure attrs) then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a rebased version of https://github.com/NixOS/nixpkgs/pull/109407 because I would love to have this to present why luaPackages are not available (wrong interpreters) and  for haskell packages where there are many broken packages: if we could save what's wrong in the broken field, I wouldn't have to attempt building the package to have an idea of what's wrong.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
