### PR TITLE
vivaldi-ffmpeg-codecs: 78.0.3904.70 -> 94.0.4606.50

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -3,12 +3,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "chromium-codecs-ffmpeg";
-  version = "78.0.3904.70";
+  pname = "chromium-codecs-ffmpeg-extra";
+  version = "94.0.4606.50";
 
   src = fetchurl {
-    url = "https://launchpadlibrarian.net/449403909/${name}-extra_${version}-0ubuntu0.16.04.2_amd64.deb";
-    sha256 = "00j604nm49z6hbyw7xsxcvmdjf7117kb478plkpizzvmm3w72b9v";
+    url = "https://launchpadlibrarian.net/558847674/${pname}_${version}-0ubuntu0.18.04.1_amd64.deb";
+    sha256 = "sha256-H7Tzd8tkaoLClXtNiwEO5nD4+PPt7Jgs+gtLiag/KN4=";
   };
 
   buildInputs = [ dpkg ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Needed for the latest few snapshots, I don't think the latest stable has any missing symbol errors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
