### PR TITLE
qtwebengine: 5.15.5 -> 5.15.6

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -45,10 +45,9 @@ let
       };
       version = "5.212.0-alpha4";
     };
-
     qtwebengine =
       let
-        branchName = "5.15.5";
+        branchName = "5.15.6";
         rev = "v${branchName}-lts";
       in
       {
@@ -56,24 +55,26 @@ let
 
         src = fetchgit {
           url = "https://github.com/qt/qtwebengine.git";
-          sha256 = "12wf30d34sgn82mbz91xybxyn3j1mhvxda452cfkxm232n1f2kjb";
+          sha256 = "17bw9yf04zmr9ck5jkrd435c8b03zpf937vn2nwgsr8p78wkg3kr";
           inherit rev branchName;
           fetchSubmodules = true;
           leaveDotGit = true;
           name = "qtwebengine-${lib.substring 0 7 rev}.tar.gz";
           postFetch = ''
             # remove submodule .git directory
-            rm -rf $out/src/3rdparty/.git
+            rm -rf "$out/src/3rdparty/.git"
 
             # compress to not exceed the 2GB output limit
-            mv $out source
             # try to make a deterministic tarball
             tar -I 'gzip -n' \
-              --sort name \
-              --mtime 1970-01-01 \
+              --sort=name \
+              --mtime=1970-01-01 \
               --owner=root --group=root \
               --numeric-owner --mode=go=rX,u+rw,a-s \
-              -cf $out source
+              --transform='s@^@source/@' \
+              -cf temp  -C "$out" .
+            rm -r "$out"
+            mv temp "$out"
           '';
         };
       };


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested via qutebrowser
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
