### PR TITLE
fetchfirefoxaddon: Allow overriding the src and add a test for it

### DIFF
--- a/pkgs/build-support/fetchfirefoxaddon/default.nix
+++ b/pkgs/build-support/fetchfirefoxaddon/default.nix
@@ -2,19 +2,26 @@
 
 {
   name
-, url
+, url ? null
 , md5 ? ""
 , sha1 ? ""
 , sha256 ? ""
 , sha512 ? ""
 , fixedExtid ? null
 , hash ? ""
+, src ? ""
 }:
 
-stdenv.mkDerivation rec {
-
-  inherit name;
+let
   extid = if fixedExtid == null then "nixos@${name}" else fixedExtid;
+  source = if url == null then src else fetchurl {
+    url = url;
+    inherit md5 sha1 sha256 sha512 hash;
+  };
+in
+stdenv.mkDerivation {
+  inherit name;
+
   passthru = {
     inherit extid;
   };
@@ -26,16 +33,12 @@ stdenv.mkDerivation rec {
 
     UUID="${extid}"
     mkdir -p "$out/$UUID"
-    unzip -q ${src} -d "$out/$UUID"
+    unzip -q ${source} -d "$out/$UUID"
     NEW_MANIFEST=$(jq '. + {"applications": { "gecko": { "id": "${extid}" }}, "browser_specific_settings":{"gecko":{"id": "${extid}"}}}' "$out/$UUID/manifest.json")
     echo "$NEW_MANIFEST" > "$out/$UUID/manifest.json"
     cd "$out/$UUID"
     zip -r -q -FS "$out/$UUID.xpi" *
     rm -r "$out/$UUID"
   '';
-  src = fetchurl {
-    url = url;
-    inherit md5 sha1 sha256 sha512 hash;
-  };
   nativeBuildInputs = [ coreutils unzip zip jq  ];
 }

--- a/pkgs/build-support/fetchfirefoxaddon/tests.nix
+++ b/pkgs/build-support/fetchfirefoxaddon/tests.nix
@@ -1,4 +1,4 @@
-{ invalidateFetcherByDrvHash, fetchFirefoxAddon, ... }:
+{ invalidateFetcherByDrvHash, fetchFirefoxAddon, fetchurl, ... }:
 
 {
   simple = invalidateFetcherByDrvHash fetchFirefoxAddon {
@@ -7,4 +7,15 @@
     url = "https://addons.mozilla.org/firefox/downloads/file/3059971/image_search_options-3.0.12-fx.xpi";
     sha256 = "sha256-H73YWX/DKxvhEwKpWOo7orAQ7c/rQywpljeyxYxv0Gg=";
   };
+  overidden-source =
+    let
+      image-search-options = fetchurl {
+        url = "https://addons.mozilla.org/firefox/downloads/file/3059971/image_search_options-3.0.12-fx.xpi";
+        sha256 = "sha256-H73YWX/DKxvhEwKpWOo7orAQ7c/rQywpljeyxYxv0Gg=";
+      };
+    in
+    invalidateFetcherByDrvHash fetchFirefoxAddon {
+      name = "image-search-options";
+      src = image-search-options;
+    };
 }


### PR DESCRIPTION
Co-authored-by: Thomas Sean Dominic Kelly <thomassdk@pm.me>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Supersedes #134427

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
