### PR TITLE
lemmy-ui: add static assets

### DIFF
--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -4,7 +4,6 @@
 , nodejs
 , python3
 , pkg-config
-, writeShellScriptBin
 , fetchFromGitHub
 }:
 
@@ -22,53 +21,53 @@ let
 
   name = "lemmy-ui";
   version = "0.12.2";
-  unwrapped = mkYarnPackage {
-
-    src = fetchFromGitHub {
-      owner = "LemmyNet";
-      repo = name;
-      rev = version;
-      fetchSubmodules = true;
-      sha256 = "sha256-iFLJqUnz4m9/JTSaJSUugzY5KkiKtH0sMYY4ALm2Ebk=";
-    };
-
-    inherit pkgConfig name version;
-
-    extraBuildInputs = [ libsass ];
-
-    yarnNix = ./yarn.nix;
-
-    # Fails mysteriously on source/package.json
-    # Upstream package.json is missing a newline at the end
-    packageJSON = ./package.json;
-
-    yarnPreBuild = ''
-      export npm_config_nodedir=${nodejs}
-    '';
-
-    buildPhase = ''
-      # Yarn writes cache directories etc to $HOME.
-      export HOME=$PWD/yarn_home
-
-      ln -sf $PWD/node_modules $PWD/deps/lemmy-ui/
-
-      yarn --offline build:prod
-    '';
-
-    distPhase = "true";
-
-    meta = with lib; {
-      description = "Building a federated alternative to reddit in rust";
-      homepage = "https://join-lemmy.org/";
-      license = licenses.agpl3Only;
-      maintainers = with maintainers; [ happysalada billewanick ];
-      platforms = platforms.linux;
-    };
-  };
 in
-(writeShellScriptBin "lemmy-ui" ''
-  ${nodejs}/bin/node ${unwrapped}/libexec/lemmy-ui/node_modules/lemmy-ui/dist/js/server.js
-'').overrideAttrs (oldAttrs: {
-  passthru = { inherit unwrapped; };
-})
+mkYarnPackage {
+
+  src = fetchFromGitHub {
+    owner = "LemmyNet";
+    repo = name;
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "sha256-iFLJqUnz4m9/JTSaJSUugzY5KkiKtH0sMYY4ALm2Ebk=";
+  };
+
+  inherit pkgConfig name version;
+
+  extraBuildInputs = [ libsass ];
+
+  yarnNix = ./yarn.nix;
+
+  # Fails mysteriously on source/package.json
+  # Upstream package.json is missing a newline at the end
+  packageJSON = ./package.json;
+
+  yarnPreBuild = ''
+    export npm_config_nodedir=${nodejs}
+  '';
+
+  buildPhase = ''
+    # Yarn writes cache directories etc to $HOME.
+    export HOME=$PWD/yarn_home
+
+    ln -sf $PWD/node_modules $PWD/deps/lemmy-ui/
+
+    yarn --offline build:prod
+  '';
+
+  preInstall = ''
+    mkdir $out
+    cp -R ./deps/lemmy-ui/dist/assets $out
+  '';
+
+  distPhase = "true";
+
+  meta = with lib; {
+    description = "Building a federated alternative to reddit in rust";
+    homepage = "https://join-lemmy.org/";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ happysalada billewanick ];
+    platforms = platforms.linux;
+  };
+}
 


### PR DESCRIPTION
###### Motivation for this change

static assets are missing from the out directory (css). Those are needed to render the ui.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
