### PR TITLE
linux_testing_bcachefs: upstream tarballs rather patchsets (fixes build)

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,33 +1,23 @@
-{ lib
-, fetchpatch
-, kernel
-, date ? "2021-07-08"
-, commit ? "3693b2ca83ff9eda49660b31299d2bebe3a1075f"
-, diffHash ? "1sfq3vwc2kxa761s292f2cqrm0vvqvkdx6drpyn5yaxwnapwidcw"
-, kernelPatches # must always be defined in bcachefs' all-packages.nix entry because it's also a top-level attribute supplied by callPackage
-, argsOverride ? {}
-, ...
-} @ args:
+{ lib, buildPackages, fetchFromGitHub, fetchpatch, perl, buildLinux, ... } @ args:
 
-(kernel.override ( args // {
+buildLinux (args // {
+  version = "5.13.0-2021.10.01";
+  modDirVersion = "5.13.0";
 
-  argsOverride = {
-    version = "${kernel.version}-bcachefs-unstable-${date}";
-    extraMeta = {
-      branch = "master";
-      maintainers = with lib.maintainers; [ davidak chiiruno ];
-      platforms = [ "x86_64-linux" ];
-    };
-  } // argsOverride;
+  src = fetchFromGitHub {
+    owner = "koverstreet";
+    repo = "bcachefs";
+    rev = "4114ced1db465b8f4e7f4d6a78aa11416a9ab5d9";
+    sha256 = "sha256-viFC3HHIcjUTDPvloSKKsz9PuSLyvxfYnrtkVUB79mQ=";
+  };
 
-  kernelPatches = [ {
-      name = "bcachefs-${commit}";
-      patch = fetchpatch {
-        name = "bcachefs-${commit}.diff";
-        url = "https://evilpiepirate.org/git/bcachefs.git/rawdiff/?id=${commit}&id2=v${lib.versions.majorMinor kernel.version}";
-        sha256 = diffHash;
-      };
-      extraConfig = "BCACHEFS_FS m";
-    } ] ++ kernelPatches;
+  extraConfig = "BCACHEFS_FS m";
 
-})).overrideAttrs ({ meta ? {}, ... }: { meta = meta // { broken = true; }; })
+  extraMeta = {
+    branch = "master";
+    hydraPlatforms = []; # Should the testing kernels ever be built on Hydra?
+    maintainers = with lib.maintainers; [ davidak chiiruno ];
+    platforms = [ "x86_64-linux" ];
+  };
+
+} // (args.argsOverride or {}))


### PR DESCRIPTION
This reverts commit cb1b1cf9c69ed49c617747fd8a168a8933fbe4ce.

bcachefs lacks behind kernel mainline, so we need to use upstream
commits rather than patchsets.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
