### PR TITLE
checkmate: 0.4.1 -> 0.4.5

### DIFF
--- a/pkgs/development/tools/checkmate/default.nix
+++ b/pkgs/development/tools/checkmate/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "checkmate";
-  version = "0.4.1";
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "adedayo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "15rf01q19q34qkafklpzig1x3c3p16fygswab1hnmzldg6jwaf3x";
+    sha256 = "sha256-0s2WyY17xk/tGIKMUoJYcpOm510PtZZMxLLFdYAZAmI=";
   };
 
-  vendorSha256 = "1n47k2ibamsv9ig84l2a4pri2pph3k0xlavbpmcv0lgbf4zd50z9";
+  vendorSha256 = "sha256-AEjSuG5qmsyzkEubxKYF1/MTG91Nxdz83X0ucZmZQxU=";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update t o latest upstream release 0.4.5

Change log:
- https://github.com/adedayo/checkmate/releases/tag/v0.4.5
- https://github.com/adedayo/checkmate/releases/tag/v0.4.4
- https://github.com/adedayo/checkmate/releases/tag/v0.4.3
- https://github.com/adedayo/checkmate/releases/tag/v0.4.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
