### PR TITLE
lib: add function escapeXML

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -91,7 +91,7 @@ let
       concatImapStringsSep makeSearchPath makeSearchPathOutput
       makeLibraryPath makeBinPath optionalString
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
-      escapeShellArg escapeShellArgs escapeRegex replaceChars lowerChars
+      escapeShellArg escapeShellArgs escapeRegex escapeXML replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast
       getName getVersion

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -362,6 +362,19 @@ rec {
     if match "[a-zA-Z_][a-zA-Z0-9_'-]*" s != null
     then s else escapeNixString s;
 
+  /* Escapes a string such that it is safe to include verbatim in an XML
+     document.
+
+     Type: string -> string
+
+     Example:
+       escapeXML ''"test" 'test' < & >''
+       => "\\[\\^a-z]\\*"
+  */
+  escapeXML = builtins.replaceStrings
+    ["\"" "'" "<" ">" "&"]
+    ["&quot;" "&apos;" "&lt;" "&gt;" "&amp;"];
+
   # Obsolete - use replaceStrings instead.
   replaceChars = builtins.replaceStrings or (
     del: new: s:

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -246,6 +246,11 @@ runTests {
     };
   };
 
+  testEscapeXML = {
+    expr = escapeXML ''"test" 'test' < & >'';
+    expected = "&quot;test&quot; &apos;test&apos; &lt; &amp; &gt;";
+  };
+
 # LISTS
 
   testFilter = {


### PR DESCRIPTION
###### Motivation for this change

Given a string, this function returns a string that can be inserted verbatim in an XML document. This is handy when generating XML configurations and going through `builtins.toXML` and `xsltproc` is a bit too much. Could, e.g., be used in `toPlist`.

Edit: See https://github.com/NixOS/nixpkgs/issues/121571