### PR TITLE
nixos: make setgid wrappers root-owned

### DIFF
--- a/nixos/modules/programs/ccache.nix
+++ b/nixos/modules/programs/ccache.nix
@@ -28,7 +28,7 @@ in {
 
       # "nix-ccache --show-stats" and "nix-ccache --clear"
       security.wrappers.nix-ccache = {
-        owner = "nobody";
+        owner = "root";
         group = "nixbld";
         setuid = false;
         setgid = true;

--- a/nixos/modules/programs/mosh.nix
+++ b/nixos/modules/programs/mosh.nix
@@ -33,7 +33,7 @@ in
     security.wrappers = mkIf cfg.withUtempter {
       utempter = {
         source = "${pkgs.libutempter}/lib/utempter/utempter";
-        owner = "nobody";
+        owner = "root";
         group = "utmp";
         setuid = false;
         setgid = true;

--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -103,7 +103,7 @@ in {
     };
 
     security.wrappers.smtpctl = {
-      owner = "nobody";
+      owner = "root";
       group = "smtpq";
       setuid = false;
       setgid = true;

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -673,7 +673,7 @@ in
       services.mail.sendmailSetuidWrapper = mkIf config.services.postfix.setSendmail {
         program = "sendmail";
         source = "${pkgs.postfix}/bin/sendmail";
-        owner = "nobody";
+        owner = "root";
         group = setgidGroup;
         setuid = false;
         setgid = true;
@@ -682,7 +682,7 @@ in
       security.wrappers.mailq = {
         program = "mailq";
         source = "${pkgs.postfix}/bin/mailq";
-        owner = "nobody";
+        owner = "root";
         group = setgidGroup;
         setuid = false;
         setgid = true;
@@ -691,7 +691,7 @@ in
       security.wrappers.postqueue = {
         program = "postqueue";
         source = "${pkgs.postfix}/bin/postqueue";
-        owner = "nobody";
+        owner = "root";
         group = setgidGroup;
         setuid = false;
         setgid = true;
@@ -700,7 +700,7 @@ in
       security.wrappers.postdrop = {
         program = "postdrop";
         source = "${pkgs.postfix}/bin/postdrop";
-        owner = "nobody";
+        owner = "root";
         group = setgidGroup;
         setuid = false;
         setgid = true;

--- a/nixos/modules/services/x11/desktop-managers/cde.nix
+++ b/nixos/modules/services/x11/desktop-managers/cde.nix
@@ -50,7 +50,7 @@ in {
     security.wrappers = {
       dtmail = {
         setgid = true;
-        owner = "nobody";
+        owner = "root";
         group = "mail";
         source = "${pkgs.cdesktopenv}/bin/dtmail";
       };


### PR DESCRIPTION
###### Motivation for this change

Part of https://github.com/NixOS/nixpkgs/issues/55370

It should be safe to use root for wrappers that are setgid but not setuid.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
