### PR TITLE
taskwarrior: 2.5.3 -> 2.6.0

### DIFF
--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -1,34 +1,27 @@
-{ lib, stdenv, fetchurl, cmake, libuuid, gnutls, python3, bash }:
+{ lib, stdenv, fetchFromGitHub, cmake, libuuid, gnutls, python3, xdg-utils }:
 
 stdenv.mkDerivation rec {
   pname = "taskwarrior";
-  version = "2.5.3";
+  version = "2.6.0";
 
-  srcs = [
-    (fetchurl {
-      url = "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/${sourceRoot}.tar.gz";
-      sha256 = "0fwnxshhlha21hlgg5z1ad01w13zm1hlmncs274y5n8i15gdfhvj";
-    })
-    (fetchurl {
-      url = "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v${version}/tests-${version}.tar.gz";
-      sha256 = "165xmf9h6rb7l6l9nlyygj0mx9bi1zyd78z0lrl3nadhmgzggv0b";
-    })
-  ];
+  src = fetchFromGitHub {
+    owner = "GothenburgBitFactory";
+    repo = "taskwarrior";
+    rev = "v${version}";
+    sha256 = "sha256-2wVjRecfIlNFAxXFaiKfxy9zArDIYDTfDdrnSM7H8fM=";
+    fetchSubmodules = true;
+  };
 
-  sourceRoot = "task-${version}";
-
-  postUnpack = ''
-    mv test ${sourceRoot}
+  postPatch = ''
+    substituteInPlace src/commands/CmdNews.cpp \
+      --replace "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
   '';
 
-  nativeBuildInputs = [ cmake libuuid gnutls ];
+  nativeBuildInputs = [ cmake libuuid gnutls python3 ];
 
   doCheck = true;
   preCheck = ''
-    find test -type f -exec sed -i \
-      -e "s|/usr/bin/env python3|${python3.interpreter}|" \
-      -e "s|/usr/bin/env bash|${bash}/bin/bash|" \
-      {} +
+    patchShebangs --build test
   '';
   checkTarget = "test";
 
@@ -37,15 +30,13 @@ stdenv.mkDerivation rec {
     ln -s "../../doc/task/scripts/bash/task.sh" "$out/share/bash-completion/completions/task.bash"
     mkdir -p "$out/share/fish/vendor_completions.d"
     ln -s "../../../share/doc/task/scripts/fish/task.fish" "$out/share/fish/vendor_completions.d/"
-    mkdir -p "$out/share/zsh/site-functions"
-    ln -s "../../../share/doc/task/scripts/zsh/_task" "$out/share/zsh/site-functions/"
   '';
 
   meta = with lib; {
     description = "Highly flexible command-line tool to manage TODO lists";
     homepage = "https://taskwarrior.org";
     license = licenses.mit;
-    maintainers = with maintainers; [ marcweber ];
+    maintainers = with maintainers; [ marcweber oxalica ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Release note: https://github.com/GothenburgBitFactory/taskwarrior/releases/tag/v2.6.0

It's now deterministic since `__DATE__` usage is removed from upstream, checked with `nix build --repeat 3`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
