### PR TITLE
nixos/hqplayerd: do not make manual depend on (unfree) hqplayerd

### DIFF
--- a/nixos/modules/services/audio/hqplayerd.nix
+++ b/nixos/modules/services/audio/hqplayerd.nix
@@ -63,7 +63,7 @@ in
         description = ''
           HQplayer daemon configuration, written to /etc/hqplayer/hqplayerd.xml.
 
-          Refer to ${pkg}/share/doc/hqplayerd/readme.txt for possible values.
+          Refer to share/doc/hqplayerd/readme.txt in the hqplayerd derivation for possible values.
         '';
       };
     };


### PR DESCRIPTION
###### Motivation for this change

building the manual currently depends on unfree software.

cc @lovesegfault  who introduced this in e5aa9403053aec8b9aafe38acd4aeb79a6c86490

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
