### PR TITLE
mopidy-youtube: 3.2 -> 3.4

### DIFF
--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -2,22 +2,22 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mopidy-youtube";
-  version = "3.2";
+  version = "3.4";
 
   src = python3Packages.fetchPypi {
     inherit version;
     pname = "Mopidy-YouTube";
-    sha256 = "0wmalfqnskglssq3gj6kkrq6h6c9yab503y72afhkm7n9r5c57zz";
+    sha256 = "sha256-996MNByMcKq1woDGK6jsmAHS9TOoBrwSGgPmcShvTRw=";
   };
 
-  patchPhase = "sed s/bs4/beautifulsoup4/ -i setup.cfg";
+  postPatch = "sed s/bs4/beautifulsoup4/ -i setup.cfg";
 
-  propagatedBuildInputs = [
-    mopidy
-    python3Packages.beautifulsoup4
-    python3Packages.cachetools
-    python3Packages.youtube-dl
-  ];
+  propagatedBuildInputs = with python3Packages; [
+    beautifulsoup4
+    cachetools
+    youtube-dl
+    ytmusicapi
+  ] ++ [ mopidy ];
 
   doCheck = false;
 


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
