### PR TITLE
mpdevil: add missing libnotify dependency

### DIFF
--- a/pkgs/applications/audio/mpdevil/default.nix
+++ b/pkgs/applications/audio/mpdevil/default.nix
@@ -1,6 +1,7 @@
 { lib, fetchFromGitHub
 , python3Packages
 , gdk-pixbuf, glib, gobject-introspection, gtk3
+, libnotify
 , intltool
 , wrapGAppsHook }:
 
@@ -20,7 +21,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   buildInputs = [
-    gdk-pixbuf glib
+    gdk-pixbuf glib libnotify
   ];
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

mpdevil failed to start:
```
Traceback (most recent call last):
  File "/nix/store/cmmngaplxh68bf3h9h689z4a92gqh3zx-mpdevil-1.1.1/bin/.mpdevil-wrapped", line 23, in <module>
    gi.require_version("Notify", "0.7")
  File "/nix/store/amydw6xlknv139g3ggh1h5hbv3na4yz0-python3.9-pygobject-3.40.1/lib/python3.9/site-packages/gi/
__init__.py", line 126, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Notify not available
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
