### PR TITLE
added Kodi elementum plugin(binary)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12638,5 +12638,11 @@
     github = "mbprtpmnr";
     githubId = 88109321;
   };
+  almostnobody = {
+    name = "AlmostNobody";
+    email = "almost0nobody@gmail.com";
+    github = "almostnobody";
+    githubId = 1583339;
+  };
 
-}
+  }

--- a/pkgs/applications/video/kodi-packages/elementum/default.nix
+++ b/pkgs/applications/video/kodi-packages/elementum/default.nix
@@ -1,7 +1,6 @@
-{ stdenv, lib, pkgs, autoPatchelfHook, buildKodiAddon, ... }:
+{ stdenv, lib, autoPatchelfHook, buildKodiAddon, addonDir, kodi, fetchurl, unzip }:
 let
-  addonDir = "/share/kodi/addons";
-  python = pkgs.kodi.pythonPackages.python.withPackages (p: with p; [ flake8 ]);
+  python = kodi.pythonPackages.python.withPackages (p: with p; [ flake8 ]);
   os = "${stdenv.hostPlatform.system}";
   osname = {
     x86_64-linux = "linux_x64";
@@ -24,7 +23,7 @@ buildKodiAddon rec {
   namespace = "plugin.video.elementum";
   version = "0.1.83";
 
-  src = pkgs.fetchurl {
+  src = fetchurl {
     url = "https://github.com/elgatito/plugin.video.elementum/releases/download/v${version}/plugin.video.elementum-${version}.${osname}.zip";
     sha256 = hash;
   };
@@ -32,30 +31,23 @@ buildKodiAddon rec {
   nativeBuildInputs = [
     autoPatchelfHook
     python
-    pkgs.unzip
+    unzip
   ];
-  buildInputs = with pkgs; [
+  buildInputs = [
     stdenv.cc.cc.lib
   ];
 
-  patchPhase = ''
-    rm Makefile
-  '';
-
-  buildPHase = ":";
+  dontBuild = true;
 
   installPhase = ''
     mkdir -p $out${addonDir}/${namespace}/
     cp -r ./ $out${addonDir}/${namespace}/
   '';
 
-  propagatedBuildInputs = [
-  ];
-
   meta = with lib; {
     homepage = "https://elementumorg.github.io/";
     description = "Elementum addon is an addon for Kodi, that manages your virtual library, syncs with your Trakt account .";
     license = licenses.gpl2;
-    maintainers = teams.kodi.members;
+    maintainers = almostnobody;
   };
 }

--- a/pkgs/applications/video/kodi-packages/elementum/default.nix
+++ b/pkgs/applications/video/kodi-packages/elementum/default.nix
@@ -47,7 +47,7 @@ buildKodiAddon rec {
   meta = with lib; {
     homepage = "https://elementumorg.github.io/";
     description = "Elementum addon is an addon for Kodi, that manages your virtual library, syncs with your Trakt account .";
-    license = licenses.gpl2;
+    license = lib.licenses.unfree;
     maintainers = with maintainers; [ almostnobody ];
   };
 }

--- a/pkgs/applications/video/kodi-packages/elementum/default.nix
+++ b/pkgs/applications/video/kodi-packages/elementum/default.nix
@@ -48,6 +48,6 @@ buildKodiAddon rec {
     homepage = "https://elementumorg.github.io/";
     description = "Elementum addon is an addon for Kodi, that manages your virtual library, syncs with your Trakt account .";
     license = licenses.gpl2;
-    maintainers = almostnobody;
+    maintainers = with maintainers; [ almostnobody ];
   };
 }

--- a/pkgs/applications/video/kodi-packages/elementum/default.nix
+++ b/pkgs/applications/video/kodi-packages/elementum/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, lib, pkgs, autoPatchelfHook, buildKodiAddon, ... }:
+let
+  addonDir = "/share/kodi/addons";
+  python = pkgs.kodi.pythonPackages.python.withPackages (p: with p; [ flake8 ]);
+  os = "${stdenv.hostPlatform.system}";
+  osname = {
+    x86_64-linux = "linux_x64";
+    x86_64-darwin = "darwin_x64";
+    i686-linux = "linux_x86";
+    armv7l-linux = "linux_armv7";
+    aarch64-linux = "linux_arm64";
+  }."${os}" or (throw "Unsupported system: ${os}");
+  hash = {
+    x86_64-linux = "sha256-lmaDBKX0zkMVHnKyH6RPBd1TKINoO3guD15v7OoX094=";
+    x86_64-darwin = "sha256-yw3HZdWB+Cm+uUhURWnM5PVKBajAcM/9EiAX+q/aE2Q=";
+    i686-linux = "sha256-D9ahCGwOmPi6hCD1k98pN1EyaiX7msgGnA8sc6VAcmo=";
+    armv7l-linux = "sha256-FIM1YmVg/S65HZOD4qZp3Qv21YsmALMu5jpH3w1x8h0=";
+    aarch64-linux = "sha256-heIjCEjADD9Jj2igcXWO9rizopql6b2d8ycdAo/cQ4k=";
+  }."${os}" or (throw "Unsupported system: ${os}");
+
+in
+buildKodiAddon rec {
+  pname = "elementum";
+  namespace = "plugin.video.elementum";
+  version = "0.1.83";
+
+  src = pkgs.fetchurl {
+    url = "https://github.com/elgatito/plugin.video.elementum/releases/download/v${version}/plugin.video.elementum-${version}.${osname}.zip";
+    sha256 = hash;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    python
+    pkgs.unzip
+  ];
+  buildInputs = with pkgs; [
+    stdenv.cc.cc.lib
+  ];
+
+  patchPhase = ''
+    rm Makefile
+  '';
+
+  buildPHase = ":";
+
+  installPhase = ''
+    mkdir -p $out${addonDir}/${namespace}/
+    cp -r ./ $out${addonDir}/${namespace}/
+  '';
+
+  propagatedBuildInputs = [
+  ];
+
+  meta = with lib; {
+    homepage = "https://elementumorg.github.io/";
+    description = "Elementum addon is an addon for Kodi, that manages your virtual library, syncs with your Trakt account .";
+    license = licenses.gpl2;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -68,6 +68,8 @@ let self = rec {
     snes = callPackage ../applications/video/kodi-packages/controllers { controller = "snes"; };
   };
 
+  elementum = callPackage ../applications/video/kodi-packages/elementum { };
+
   jellyfin = callPackage ../applications/video/kodi-packages/jellyfin { };
 
   joystick = callPackage ../applications/video/kodi-packages/joystick { };


### PR DESCRIPTION


###### Motivation for this change

added elementum plugin, wanted to package it properly, but their build system is quite complicated and involves creation of docker containers in their makefile, so decided to go binary patching route.

###### Things done

haven't built/tested anything but x86_64 build, but x86_64 works great, and it's unlikely it wouldn't on other arch's
Haven't checked/wrote any tests for it, but it's not like it really important for a kodi addon


- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
