### PR TITLE
actionlint: init at 1.6.4

### DIFF
--- a/pkgs/development/tools/analysis/actionlint/default.nix
+++ b/pkgs/development/tools/analysis/actionlint/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub, ronn, installShellFiles }:
+
+buildGoModule rec {
+  pname = "actionlint";
+  version = "1.6.4";
+
+  subPackages = [ "cmd/actionlint" ];
+
+  src = fetchFromGitHub {
+    owner = "rhysd";
+    repo = "actionlint";
+    rev = "v${version}";
+    sha256 = "1516892wikz3zda0la57s8nbm6459pf4vd123rv09s4nivznbmcx";
+  };
+
+  vendorSha256 = "1i7442n621jmc974b73pfz1gyqw74ilpg1zz16yxqpfh5c958m7n";
+
+  nativeBuildInputs = [ ronn installShellFiles ];
+
+  postInstall = ''
+    ronn --roff man/actionlint.1.ronn
+    installManPage man/actionlint.1
+  '';
+
+  ldflags = [ "-s" "-w" "-X github.com/rhysd/actionlint.version=${version}" ];
+
+  meta = with lib; {
+    homepage = "https://rhysd.github.io/actionlint/";
+    description = "Static checker for GitHub Actions workflow files";
+    changelog = "https://github.com/rhysd/actionlint/raw/v${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13457,6 +13457,8 @@ with pkgs;
 
   abuild = callPackage ../development/tools/abuild { };
 
+  actionlint = callPackage ../development/tools/analysis/actionlint { };
+
   adtool = callPackage ../tools/admin/adtool { };
 
   inherit (callPackage ../development/tools/alloy {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add https://github.com/rhysd/actionlint

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
