### PR TITLE
treewide: remove trailing whitespaces

### DIFF
--- a/pkgs/build-support/upstream-updater/attrset-to-dir.nix
+++ b/pkgs/build-support/upstream-updater/attrset-to-dir.nix
@@ -1,8 +1,7 @@
-a :  
+a :
 a.stdenv.mkDerivation {
   buildCommand = ''
     mkdir -p "$out/attributes"
-    
   '' + (a.lib.concatStrings (map
     (n: ''
       ln -s "${a.writeTextFile {name=n; text=builtins.getAttr n a.theAttrSet;}}" $out/attributes/${n};

--- a/pkgs/development/libraries/languagemachines/test.nix
+++ b/pkgs/development/libraries/languagemachines/test.nix
@@ -5,7 +5,7 @@
 runCommand "frog-test" {} ''
   ${languageMachines.frog}/bin/frog >$out <<EOF
   Dit is een test
-  
+
   EOF
   echo "Frog output:"
   cat $out

--- a/pkgs/development/libraries/science/math/clmagma/default.nix
+++ b/pkgs/development/libraries/science/math/clmagma/default.nix
@@ -2,12 +2,12 @@
 
 with lib;
 
-let 
+let
   version = "1.3.0";
   incfile = builtins.toFile "make.inc.custom" ''
     CC        = g++
     FORT      = gfortran
-    
+
     ARCH      = ar
     ARCHFLAGS = cr
     RANLIB    = ranlib
@@ -16,22 +16,22 @@ let
     FOPTS     = -fPIC -O3 -DADD_ -Wall -x f95-cpp-input
     F77OPTS   = -fPIC -O3 -DADD_ -Wall
     LDOPTS    = -fPIC
-   
+
     -include make.check-mkl
     -include make.check-clblas
-    
+
     # Gnu mkl is not available I guess?
     #LIB       = -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lpthread -lm -fopenmp
     LIB        = -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -liomp5 -lm -fopenmp
     LIB       += -lclBLAS -lOpenCL
-    
+
     LIBDIR    = -L$(MKLROOT)/lib/intel64 \
                 -L$(MKLROOT)/../compiler/lib/intel64 \
                 -L$(clBLAS)/lib64
-    
-    INC       = -I$(clBLAS)/include 
+
+    INC       = -I$(clBLAS)/include
                #-I$(AMDAPP)/include
-  '';  
+  '';
 in stdenv.mkDerivation {
   name = "clmagma-${version}";
   src = fetchurl {
@@ -40,11 +40,11 @@ in stdenv.mkDerivation {
     name = "clmagma-${version}.tar.gz";
   };
 
-  buildInputs = [ 
-    gfortran 
-    clblas 
-    opencl-headers 
-    ocl-icd  
+  buildInputs = [
+    gfortran
+    clblas
+    opencl-headers
+    ocl-icd
     mkl
     intel-ocl
   ];
@@ -54,13 +54,13 @@ in stdenv.mkDerivation {
   MKLROOT   = "${mkl}";
   clBLAS    = "${clblas}";
 
-  # Otherwise build looks for it in /run/opengl-driver/etc/OpenCL/vendors, 
+  # Otherwise build looks for it in /run/opengl-driver/etc/OpenCL/vendors,
   # which is not available.
   OPENCL_VENDOR_PATH="${intel-ocl}/etc/OpenCL/vendors";
 
-  preBuild = ''  
+  preBuild = ''
     # By default it tries to use GPU, and thus fails for CPUs
-    sed -i "s/CL_DEVICE_TYPE_GPU/CL_DEVICE_TYPE_DEFAULT/" interface_opencl/clmagma_runtime.cpp   
+    sed -i "s/CL_DEVICE_TYPE_GPU/CL_DEVICE_TYPE_DEFAULT/" interface_opencl/clmagma_runtime.cpp
     sed -i "s%/usr/local/clmagma%/$out%" Makefile.internal
     cp ${incfile} make.inc
   '';

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -28,8 +28,8 @@ rec {
           libjson-c.a \
           -o ./test1.js
 
-        echo "Using node to execute the test which basically outputs an error on stderr which we grep for" 
-        ${pkgs.nodejs}/bin/node ./test1.js 
+        echo "Using node to execute the test which basically outputs an error on stderr which we grep for"
+        ${pkgs.nodejs}/bin/node ./test1.js
 
         set +x
         if [ $? -ne 0 ]; then
@@ -41,17 +41,17 @@ rec {
         echo "================= /testing json_c using node ================="
       '';
     });
-  
+
   libxml2 = (pkgs.libxml2.override {
     stdenv = emscriptenStdenv;
     pythonSupport = false;
   }).overrideDerivation
-    (old: { 
+    (old: {
       propagatedBuildInputs = [ zlib ];
       buildInputs = old.buildInputs ++ [ pkg-config ];
 
       # just override it with nothing so it does not fail
-      autoreconfPhase = "echo autoreconfPhase not used..."; 
+      autoreconfPhase = "echo autoreconfPhase not used...";
       configurePhase = ''
         HOME=$TMPDIR
         emconfigure ./configure --prefix=$out --without-python
@@ -63,10 +63,10 @@ rec {
         set -x
         emcc -O2 -s EMULATE_FUNCTION_POINTER_CASTS=1 xmllint.o \
         ./.libs/libxml2.a `pkg-config zlib --cflags` `pkg-config zlib --libs` -o ./xmllint.test.js \
-        --embed-file ./test/xmlid/id_err1.xml  
+        --embed-file ./test/xmlid/id_err1.xml
 
-        echo "Using node to execute the test which basically outputs an error on stderr which we grep for" 
-        ${pkgs.nodejs}/bin/node ./xmllint.test.js --noout test/xmlid/id_err1.xml 2>&1 | grep 0bar   
+        echo "Using node to execute the test which basically outputs an error on stderr which we grep for"
+        ${pkgs.nodejs}/bin/node ./xmllint.test.js --noout test/xmlid/id_err1.xml 2>&1 | grep 0bar
 
         set +x
         if [ $? -ne 0 ]; then
@@ -77,8 +77,8 @@ rec {
         fi
         echo "================= /testing libxml2 using node ================="
       '';
-    });            
-  
+    });
+
   xmlmirror = pkgs.buildEmscriptenPackage rec {
     pname = "xmlmirror";
     version = "unstable-2016-06-05";
@@ -91,7 +91,7 @@ rec {
       rev = "4fd7e86f7c9526b8f4c1733e5c8b45175860a8fd";
       sha256 = "1jasdqnbdnb83wbcnyrp32f36w3xwhwp0wq8lwwmhqagxrij1r4b";
     };
-     
+
     configurePhase = ''
       rm -f fastXmlLint.js*
       # a fix for ERROR:root:For asm.js, TOTAL_MEMORY must be a multiple of 16MB, was 234217728
@@ -103,18 +103,18 @@ rec {
       # https://gitlab.com/odfplugfest/xmlmirror/issues/11
       sed -e "s/-o fastXmlLint.js/-s EXTRA_EXPORTED_RUNTIME_METHODS='[\"ccall\", \"cwrap\"]' -o fastXmlLint.js/g" -i Makefile.emEnv
     '';
-    
+
     buildPhase = ''
       HOME=$TMPDIR
       make -f Makefile.emEnv
     '';
-    
+
     outputs = [ "out" "doc" ];
-    
+
     installPhase = ''
       mkdir -p $out/share
       mkdir -p $doc/share/${pname}
-      
+
       cp Demo* $out/share
       cp -R codemirror-5.12 $out/share
       cp fastXmlLint.js* $out/share
@@ -127,14 +127,13 @@ rec {
       cp README.md $doc/share/${pname}
     '';
     checkPhase = ''
-      
     '';
-  };  
+  };
 
   zlib = (pkgs.zlib.override {
     stdenv = pkgs.emscriptenStdenv;
   }).overrideDerivation
-    (old: { 
+    (old: {
       buildInputs = old.buildInputs ++ [ pkg-config ];
       # we need to reset this setting!
       NIX_CFLAGS_COMPILE="";
@@ -165,7 +164,7 @@ rec {
         -L. libz.so.${old.version} -I . -o example.js
 
         echo "Using node to execute the test"
-        ${pkgs.nodejs}/bin/node ./example.js 
+        ${pkgs.nodejs}/bin/node ./example.js
 
         set +x
         if [ $? -ne 0 ]; then
@@ -183,6 +182,6 @@ rec {
           --replace 'AR="libtool"' 'AR="ar"' \
           --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
       '';
-    }); 
-  
+    });
+
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Manually remove trailing white spaces in `**.nix` with an editor.

Auto-generated nix expressions containing trailing whitespaces:

*   pkgs/development/haskell-modules/hackage-packages.nix
    *   See issue https://github.com/NixOS/cabal2nix/issues/208

*   pkgs/**/eggs.nix (I'm not sure)
    *   I'm not sure how they are generated. Seems to be Python-related.

Packages corrected:

*   clmagma
    *   CC: @volhovm 

*   emscripten-packages
    *   CC: @qknight 

*   languagemachines
    *   CC: @roberth

*   pkgs/build-support/upstream-updater/attrset-to-dir.nix
    *   CC: @7c6f434c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
