### PR TITLE
rewritefs: 2020-02-21 -> 2021-10-03

### DIFF
--- a/pkgs/os-specific/linux/rewritefs/default.nix
+++ b/pkgs/os-specific/linux/rewritefs/default.nix
@@ -1,21 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, fuse3, fuse, pcre }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, fuse3, pcre }:
 
 stdenv.mkDerivation {
   pname = "rewritefs";
-  version = "2020-02-21";
+  version = "2021-10-03";
 
   src = fetchFromGitHub {
     owner  = "sloonz";
     repo   = "rewritefs";
-    rev    = "bc241c7f81e626766786b56cf71d32c1a6ad510c";
-    sha256 = "0zj2560hcbg5az0r8apnv0zz9b22i9r9w6rlih0rbrn673xp7q2i";
+    rev    = "3a56de8b5a2d44968b8bc3885c7d661d46367306";
+    sha256 = "1w2rik0lhqm3wr68x51zs45gqfx79l7fi4p0sqznlfq7sz5s8xxn";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  # Note: fuse is needed solely because (unlike fuse3) it exports ulockmgr.h.
-  # This library was removed in fuse 3 to be distributed separately, but
-  # apparently it's not.
-  buildInputs = [ fuse3 fuse pcre ];
+  buildInputs = [ fuse3 pcre ];
 
   prePatch = ''
     # do not set sticky bit in nix store


### PR DESCRIPTION
###### Motivation for this change

Removing the fuse2 dependency and fixing a file locking bug.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change
- [x] Tested execution of all binary files
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
