### PR TITLE
pulumi-bin: 3.12.0 -> 3.13.2

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,96 +1,96 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "3.12.0";
+  version = "3.13.2";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.12.0-linux-x64.tar.gz";
-        sha256 = "19b8yndff9ziilrw1lrwjjcxl1lpn9q52z5swjc41rr0j751v8b0";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.13.2-linux-x64.tar.gz";
+        sha256 = "0xdxdyl9vlg5zgayqgx35gyhgqv31ljkf46qbarisyczj5vin7v5";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-linux-amd64.tar.gz";
-        sha256 = "0d88xfi7zzmpyrnvakwxsyavdx6d5hmfrcf4jhmd53mni0m0551l";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.7.3-linux-amd64.tar.gz";
+        sha256 = "0k599nlif46zf7l2mf3r8sr6fbdkx25gvkgm6ij36ysx8xr2nv5q";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.19.0-linux-amd64.tar.gz";
-        sha256 = "10hgsnab1472dzdb2qrx90mx1xaq8zifcnrsgqqvilzfjnfrd9ka";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v3.5.0-linux-amd64.tar.gz";
-        sha256 = "0rk1irqnmlxzdwx1jnls30xmsrkdn7qin561waqwxq9qrm5012i5";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.3.0-linux-amd64.tar.gz";
-        sha256 = "1f995sg2p1hpqagygsvyfq97gcmy4a925274p96vhy517568d5jg";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.1.0-linux-amd64.tar.gz";
-        sha256 = "1hz4w44c31wyi3vbr9sbph1007rj65vwwbhwrrzyhxy0i75r3igq";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.1-linux-amd64.tar.gz";
-        sha256 = "1divf2nga5kc60mf0cjmyzyghpkkbw44jakfwc7fjiq6j4j0g2ia";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.1.0-linux-amd64.tar.gz";
-        sha256 = "0ffqah4anhdacmfb8n3hdq17jhqq0qclc0l0cq77hvhvgn39yy4r";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v2.0.0-linux-amd64.tar.gz";
-        sha256 = "0yhdcjscdkvvai95z2v6xabvvsfvaqi38ngpqrb73ahlwqhz3nys";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.18.0-linux-amd64.tar.gz";
-        sha256 = "1vryq0ki5iimqwxpnvc53m15641p1a1cdbf1xzn0ps4xdsg4xz7j";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.3.0-linux-amd64.tar.gz";
-        sha256 = "1k7zd2cir6844awf1kpj7pifwvw74yfnrk78j0pall2jwmnf2zaa";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-linux-amd64.tar.gz";
-        sha256 = "1h5159y7xlslnijs8lpi4vqgvj2px6whxk9m17p9n7wiyqbmd5na";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.4.0-linux-amd64.tar.gz";
-        sha256 = "0g6h9j64aqj64slp8707kn6dwg32nyqy06xgwycz8ywcw5b2llqp";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.7.0-linux-amd64.tar.gz";
-        sha256 = "0n7vlja8s854nba209sq2pwkd8jnmnmzya65ncqpb0aa9kn9lc2j";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.3.2-linux-amd64.tar.gz";
-        sha256 = "07zmx5gdwqsrhzm50fj3y9q435ygwmb2j1r2pvpv0i1s66g92kij";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-linux-amd64.tar.gz";
-        sha256 = "0g392a6zyycdijjn0nswf2x5h31x1hcffgwwkmbjr304n2ycbb50";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-linux-amd64.tar.gz";
-        sha256 = "04gaimdzh04v7f11xw1b7p95rbb142kbnix1zqas68wd6vpw9kyp";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-linux-amd64.tar.gz";
-        sha256 = "0rpf48snjm5n1xn7s6lnda6ny1gjgmfsqmbibw6w7h7la0ff78jp";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-linux-amd64.tar.gz";
-        sha256 = "0glbjhgrb2hiyhd6kwmy7v384j8zw641pw9737g1fczv3x16a3s3";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.4.0-linux-amd64.tar.gz";
+        sha256 = "18mfln9iz838rqjhx39ncih7ndbbkj22w1m9gx1n2wszsgm3477b";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.2.0-linux-amd64.tar.gz";
         sha256 = "1lmy0dmpspzflc9z8p4w1cz47lbqnbkq8dng3v40lpbs75pnprvs";
       }
       {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.4.0-linux-amd64.tar.gz";
+        sha256 = "0jmbfy6y0l7zpzwndz6xj6jv20ax9rbg8nbqwcadjf96a3zglwhf";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-linux-amd64.tar.gz";
+        sha256 = "1p21963qr8rdl5jp7f05j02yq0ab3flybvzjn7xadcl7m85mkyxh";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-linux-amd64.tar.gz";
+        sha256 = "1h5159y7xlslnijs8lpi4vqgvj2px6whxk9m17p9n7wiyqbmd5na";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.22.1-linux-amd64.tar.gz";
+        sha256 = "14dk4m7963q9n1q4sq25zdjdnk4la5fxw7yhbw18krdy7ps0p6sr";
+      }
+      {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.2.0-linux-amd64.tar.gz";
         sha256 = "02g59jaifyjfcx185ir79d8lqic38dgaa9cb8dpi3xhvv32z0b0q";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.4.0-linux-amd64.tar.gz";
-        sha256 = "1lmhsvzhryj9sl3v51dgq6rby3q5m169mc3dg1jbx1fvgwglmhqb";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.3.0-linux-amd64.tar.gz";
+        sha256 = "1f995sg2p1hpqagygsvyfq97gcmy4a925274p96vhy517568d5jg";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-linux-amd64.tar.gz";
+        sha256 = "0g392a6zyycdijjn0nswf2x5h31x1hcffgwwkmbjr304n2ycbb50";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-linux-amd64.tar.gz";
+        sha256 = "0rpf48snjm5n1xn7s6lnda6ny1gjgmfsqmbibw6w7h7la0ff78jp";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.5.0-linux-amd64.tar.gz";
+        sha256 = "194kym832zfnf58z44y5n789xsvqp2dr3jy5sffqqhfrgcgabvr2";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.2.0-linux-amd64.tar.gz";
+        sha256 = "057h706kl0c1qq5x0iprikpglllcrb4bfixf5vv3jk8q9s44qbwj";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.1.0-linux-amd64.tar.gz";
+        sha256 = "0ffqah4anhdacmfb8n3hdq17jhqq0qclc0l0cq77hvhvgn39yy4r";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.1-linux-amd64.tar.gz";
+        sha256 = "1divf2nga5kc60mf0cjmyzyghpkkbw44jakfwc7fjiq6j4j0g2ia";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-linux-amd64.tar.gz";
+        sha256 = "0glbjhgrb2hiyhd6kwmy7v384j8zw641pw9737g1fczv3x16a3s3";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.0.0-linux-amd64.tar.gz";
+        sha256 = "0bp7ki3slszmy1vh4a5d4y4fhbvafrazj1cjf081xv91gi99xxz6";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.21.0-linux-amd64.tar.gz";
+        sha256 = "1r5cq4zmnp17n161n2npgxvy6y3bgq5b089mkm4yd7ck88sv2811";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-linux-amd64.tar.gz";
+        sha256 = "04gaimdzh04v7f11xw1b7p95rbb142kbnix1zqas68wd6vpw9kyp";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-linux-amd64.tar.gz";
+        sha256 = "0d88xfi7zzmpyrnvakwxsyavdx6d5hmfrcf4jhmd53mni0m0551l";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.0-linux-amd64.tar.gz";
+        sha256 = "06cgd7zd2cs88xych7rf0k0mfdh1f61mxj0194lbjs366lxi3bgj";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-linux-amd64.tar.gz";
@@ -99,92 +99,92 @@
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.12.0-darwin-x64.tar.gz";
-        sha256 = "1dlgcap861a5fljbadqikn0lm9gz6f1rdn0qhf1f9vyrj1jmwcqf";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.13.2-darwin-x64.tar.gz";
+        sha256 = "0hh5vq60klczgwahmi1yli3yliik1xf110cp9prxv9s4aqjzm2ga";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-amd64.tar.gz";
-        sha256 = "12mkr0xczdnp21k0k7qn4r3swkaq3pr6v2z853p1db7ksz5kds23";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.7.3-darwin-amd64.tar.gz";
+        sha256 = "1c42fi5sqj9hnlr20mv0dil6wl4qw4j7zdnr7sln21h5hxxj65wx";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.19.0-darwin-amd64.tar.gz";
-        sha256 = "18n729y5r827ahaybz01q61r3cv5grxpnfqb0m8fzh2bd41izg4s";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v3.5.0-darwin-amd64.tar.gz";
-        sha256 = "05z8zkbhpj0xsi7ffzd51j83sxx92k10r28gpznn43plnv1v5cjs";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.3.0-darwin-amd64.tar.gz";
-        sha256 = "12nba4xjcrh4g9iy3mqalk56bga4l3izqm9rj0fg3cyivr9fffvr";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.1.0-darwin-amd64.tar.gz";
-        sha256 = "0xknmx3d6083qvp3v2v8qwjlfihj35r8gzhmhbh759ccjf1d6h4h";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.1-darwin-amd64.tar.gz";
-        sha256 = "00m9nn0mrjdqg0ijkv86376df9kpfd9alk8h2ynk53s6nbz9ff4b";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.1.0-darwin-amd64.tar.gz";
-        sha256 = "0j8ysk4wh78xhk3nv6c1dvvyw5ihs7amwlyqicch52yc6jq3v5a6";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v2.0.0-darwin-amd64.tar.gz";
-        sha256 = "1dpsbq3b0fz86355jy7rz4kcsa1lnw4azn25vzlis89ay1ncbblc";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.18.0-darwin-amd64.tar.gz";
-        sha256 = "1cfxnshmc7b1ax819bvic4ih0gc1mi6rij1pp52nklzgby4zad6y";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.3.0-darwin-amd64.tar.gz";
-        sha256 = "0fabb3zi5p24xfgsc0jn8ynavd1g0qrlm1yqifxv12zr5id4vcvk";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-darwin-amd64.tar.gz";
-        sha256 = "0r2ykjwam5m2mfiibhq993s8n5pzmks837cwb57jwgwx8lc3ra4x";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.4.0-darwin-amd64.tar.gz";
-        sha256 = "03r5jxgjyrrpx082z785x2yxz3l4ja4al9yh2zhkvdcnjip88r35";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.7.0-darwin-amd64.tar.gz";
-        sha256 = "0l1wxnkik28y9y257jdxiq3m3njmfq1awxajp152k11izddxs05i";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.3.2-darwin-amd64.tar.gz";
-        sha256 = "0s8aaac55kdsid0ay2dm0if9irc55pslmy6lhf7v5bfpcb17i36w";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-darwin-amd64.tar.gz";
-        sha256 = "0awksrbsmvkgfszdsxfv8wfs1m16y1551jnz0rf51dq0cn9963hq";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-amd64.tar.gz";
-        sha256 = "18vrp0zzi92x4l5nkjszvd0zr7pk6nl6s3h5a3hvsz5qrj2830q3";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-darwin-amd64.tar.gz";
-        sha256 = "0jlvdnvcmml009a84lfa6745qwjsifa9zmdrv4gqy9p76iydfs1n";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-darwin-amd64.tar.gz";
-        sha256 = "0621njipng32x43lw8n49mapq10lnvibg8vlvgciqsfvrbpz1yp5";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.4.0-darwin-amd64.tar.gz";
+        sha256 = "0plqrh20mxl92achdmx7srg6rqrvzprlawy4q9f9xwn77618wx0b";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.2.0-darwin-amd64.tar.gz";
         sha256 = "1j7z5dbqzsdq1q8ks9g5pwzyc3ml6avhhp6xj94dzdhskl6pd8w5";
       }
       {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.4.0-darwin-amd64.tar.gz";
+        sha256 = "0vd527sx49shr3mpbm5bs4sspmm6vsjli6zlbl5w61y85jp2as1m";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-darwin-amd64.tar.gz";
+        sha256 = "1idvdcmbbia0cwkw5v7zp7695p1a6sfmrgsfmzn0r9p8lyg66k8w";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-darwin-amd64.tar.gz";
+        sha256 = "0r2ykjwam5m2mfiibhq993s8n5pzmks837cwb57jwgwx8lc3ra4x";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.22.1-darwin-amd64.tar.gz";
+        sha256 = "02irygvxhbisxyxaqhrd67rxp5dx3ralyjrgr16qz2v64mhmqxqx";
+      }
+      {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.2.0-darwin-amd64.tar.gz";
         sha256 = "0gd3xnl31892qp8ilz9lc1zdps77nf07jgvh0k37mink8f0ppy2z";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.4.0-darwin-amd64.tar.gz";
-        sha256 = "01rrmj95lhvwxi8f338f50l2zspnin41j8hi2j9pjsjwfayhpq93";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.3.0-darwin-amd64.tar.gz";
+        sha256 = "12nba4xjcrh4g9iy3mqalk56bga4l3izqm9rj0fg3cyivr9fffvr";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-darwin-amd64.tar.gz";
+        sha256 = "0awksrbsmvkgfszdsxfv8wfs1m16y1551jnz0rf51dq0cn9963hq";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-darwin-amd64.tar.gz";
+        sha256 = "0jlvdnvcmml009a84lfa6745qwjsifa9zmdrv4gqy9p76iydfs1n";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.5.0-darwin-amd64.tar.gz";
+        sha256 = "1gf83dv5wqvmx8ll7my3c8biklrddjrv069g97d3n510m0k7w85w";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.2.0-darwin-amd64.tar.gz";
+        sha256 = "0sss5mjjwwgvayqjvk7j4wpsrwmk8yzx3phnjxvq2mb7c4d25why";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.1.0-darwin-amd64.tar.gz";
+        sha256 = "0j8ysk4wh78xhk3nv6c1dvvyw5ihs7amwlyqicch52yc6jq3v5a6";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.1-darwin-amd64.tar.gz";
+        sha256 = "00m9nn0mrjdqg0ijkv86376df9kpfd9alk8h2ynk53s6nbz9ff4b";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-packet-v3.2.2-darwin-amd64.tar.gz";
+        sha256 = "0621njipng32x43lw8n49mapq10lnvibg8vlvgciqsfvrbpz1yp5";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.0.0-darwin-amd64.tar.gz";
+        sha256 = "1i73sxh6vf6adg6as1q1mab3fcjm7ma7gixj2b0y0d2a5d78lhpa";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.21.0-darwin-amd64.tar.gz";
+        sha256 = "0pdiiz0hqms1jaqnqzz33hzscn07imjv7p5akx1hars5kdbk3g8y";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-amd64.tar.gz";
+        sha256 = "18vrp0zzi92x4l5nkjszvd0zr7pk6nl6s3h5a3hvsz5qrj2830q3";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-amd64.tar.gz";
+        sha256 = "12mkr0xczdnp21k0k7qn4r3swkaq3pr6v2z853p1db7ksz5kds23";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.0-darwin-amd64.tar.gz";
+        sha256 = "112gyxfa5h4cchnzzxf6kzhr9wrs0xssm3ivaipimdh402mgib8g";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-darwin-amd64.tar.gz";
@@ -193,89 +193,89 @@
     ];
     aarch64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.12.0-linux-arm64.tar.gz";
-        sha256 = "1hzm80ajndaqchxrxdpg0fvc5rqqagbhd5zs8msw166xyanavl9p";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.13.2-linux-arm64.tar.gz";
+        sha256 = "1v93g2q5g5p4yvv4s4dhhx1lxxigdbnx5x3pd38cawzzbadvcqyg";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-linux-arm64.tar.gz";
-        sha256 = "1l7zpvacq6kyzj8n82drs9gdfa16k4j945w8nsd0z33byrswxr3w";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.7.3-linux-arm64.tar.gz";
+        sha256 = "1x73f24jwajj4c3plphbx2ia4i082w5m72z8annpcm11cx1k5130";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.19.0-linux-arm64.tar.gz";
-        sha256 = "1d67npimg49lx1g9adds32gfpwwv0ikk52qz1kyzfbz10hz62xyx";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.4.0-linux-arm64.tar.gz";
+        sha256 = "168zsb14ndvj2f66xwsbrjf5bn9fz8d70lzyqym1yblmqa2k7b6f";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v3.5.0-linux-arm64.tar.gz";
-        sha256 = "0fh4zrpmgg16jhzdmqihwq8k39bjlchd54mbkd50fphw1w2xw2jz";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.2.0-linux-arm64.tar.gz";
+        sha256 = "0mddv37k87wiygh6x9bnxpcr721qbmbqf6l5zk3xl61n56j8qyb1";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.3.0-linux-arm64.tar.gz";
-        sha256 = "1pjvrhmci1fbakx74yndjhkvxxy4yfnwrwbk12dyb3mxc07iycfj";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.4.0-linux-arm64.tar.gz";
+        sha256 = "0ybw5cbiw64zmaqjwlfk5b73h5sy0pk40f15hq41d9rdkc0sypxi";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.1.0-linux-arm64.tar.gz";
-        sha256 = "07c34x3g31f0bvwfwgxnnikqp5wzyn97hxzwlidvr6g1w7srj0qn";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.1-linux-arm64.tar.gz";
-        sha256 = "1l1p5gqnxd3rb9107m9wi76k8d57ak9w86dniiwys3dqbwxjn1ix";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.1.0-linux-arm64.tar.gz";
-        sha256 = "1lh1g90ab4blqmvx0yfp516hfsd6n1y751ab7fzhv7hcajf3klvi";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v2.0.0-linux-arm64.tar.gz";
-        sha256 = "0xibm242vjv1jr2c2v5a1ndlafybq66iqfdmdghys3fa4csb5d4s";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.18.0-linux-arm64.tar.gz";
-        sha256 = "18as1qkqz0b4cminqf9czd5lx04nr8da7w3g0dbp6bpr7biakra0";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.3.0-linux-arm64.tar.gz";
-        sha256 = "0pwcn2hlfj5nh5fyql8nk4rzfpsrp6ph5kd3r62872z6kz4fr1f8";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-linux-arm64.tar.gz";
+        sha256 = "0k4yi9xqrmd5m99lr27h672ycwyh138d9jhh3wvgpmnjpdxy28jm";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-linux-arm64.tar.gz";
         sha256 = "1sc8rf930cz6nkyhqn6p0h7450iqzdsrlw2smhp8yyjjvcjmsksf";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.4.0-linux-arm64.tar.gz";
-        sha256 = "0bz4i7bga2vy4pki9k93f7q6zfcy9yg17xz0j4wfyqmlaanfz8r0";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.7.0-linux-arm64.tar.gz";
-        sha256 = "1vkfrgk6lk3v7fgs10ygaw3x3srp3mncr0wna1xdzf7s1gsz8m09";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.3.2-linux-arm64.tar.gz";
-        sha256 = "1nyy1is8i9jx9ig1v01l5sbhp4xal1vklmfjnqhr8v8h5kjwkm4v";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-linux-arm64.tar.gz";
-        sha256 = "1hicy131pj6z4ni074f34qhvjyycjxl0024iir5021g1scm3hp7w";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-linux-arm64.tar.gz";
-        sha256 = "1slrl020xl092hjfr92zjf8i2ys8vzr3nxqh65fhnl0fzfsllvn0";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-linux-arm64.tar.gz";
-        sha256 = "1cpr53shxap4s25pw3xd9vnbwh4jbmp1x0qfqz46i9af0isa10i8";
-      }
-      # pulumi-resource-packet skipped (does not exist on remote)
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.2.0-linux-arm64.tar.gz";
-        sha256 = "0mddv37k87wiygh6x9bnxpcr721qbmbqf6l5zk3xl61n56j8qyb1";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.22.1-linux-arm64.tar.gz";
+        sha256 = "0l3infk8mj77dqazj7f2k6rshnmd8kcdxqvy9l23imvi75nqb6ws";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.2.0-linux-arm64.tar.gz";
         sha256 = "0y7wysd4j1dp73hrbydzj2bfvpgv8vxiza5m6dbg7nl66w9ng0rc";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.4.0-linux-arm64.tar.gz";
-        sha256 = "0fa295br09w7392mb62qw31ia2116dqs15f4r634zcachb0ad93g";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.3.0-linux-arm64.tar.gz";
+        sha256 = "1pjvrhmci1fbakx74yndjhkvxxy4yfnwrwbk12dyb3mxc07iycfj";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-linux-arm64.tar.gz";
+        sha256 = "1hicy131pj6z4ni074f34qhvjyycjxl0024iir5021g1scm3hp7w";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-linux-arm64.tar.gz";
+        sha256 = "1cpr53shxap4s25pw3xd9vnbwh4jbmp1x0qfqz46i9af0isa10i8";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.5.0-linux-arm64.tar.gz";
+        sha256 = "0ap4izb3507rw965qvww1nd2h9jz7ilav92fjdhhvf33g44r6r8y";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.2.0-linux-arm64.tar.gz";
+        sha256 = "06xdcm0cg3sh92fvwy8l4c0k91fah7hdxjb6mjchas2wk4q32vhq";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.1.0-linux-arm64.tar.gz";
+        sha256 = "1lh1g90ab4blqmvx0yfp516hfsd6n1y751ab7fzhv7hcajf3klvi";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.1-linux-arm64.tar.gz";
+        sha256 = "1l1p5gqnxd3rb9107m9wi76k8d57ak9w86dniiwys3dqbwxjn1ix";
+      }
+      # pulumi-resource-packet skipped (does not exist on remote)
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.0.0-linux-arm64.tar.gz";
+        sha256 = "0mwpbvv62k8fg07447wwfigs4li4n78fswpzwi4alsjrkqlmw9dj";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.21.0-linux-arm64.tar.gz";
+        sha256 = "1jsbn967x73z0hhh5kfq791xs3zsrccg8ci3s3607jd8gzv98n9w";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-linux-arm64.tar.gz";
+        sha256 = "1slrl020xl092hjfr92zjf8i2ys8vzr3nxqh65fhnl0fzfsllvn0";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-linux-arm64.tar.gz";
+        sha256 = "1l7zpvacq6kyzj8n82drs9gdfa16k4j945w8nsd0z33byrswxr3w";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.0-linux-arm64.tar.gz";
+        sha256 = "1zxrab7vz910v5p8rmi9ycmw36a77p46pkv415kzyy1vbwx3was1";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-linux-arm64.tar.gz";
@@ -284,89 +284,89 @@
     ];
     aarch64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.12.0-darwin-arm64.tar.gz";
-        sha256 = "1sasxi57ga7gazjmni4sksyih5dw1qx0bhcmh5f5xyznsb9flk4v";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.13.2-darwin-arm64.tar.gz";
+        sha256 = "0zhznqbm3bq8v0j9xbakryc02iybzdaic6pca2r842nbaj7ffcg9";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-arm64.tar.gz";
-        sha256 = "1rmvc2kgjmb978sfmlga6xy4i0f629lk1l95i30wg0rmj1hx3dag";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.7.3-darwin-arm64.tar.gz";
+        sha256 = "1zwlygvrglsna6y7wv61zb663vqzjcgvmm1ni4x4jk1xxmqd75yx";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.19.0-darwin-arm64.tar.gz";
-        sha256 = "0hw0x8bxj0rdkxchlsa30phkglgcln14xv2capx67vpdp9qg8iyi";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.4.0-darwin-arm64.tar.gz";
+        sha256 = "03m85545rl4m1rz9vvziibd60xc2za826zp4wpap9lf0y5glijv5";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v3.5.0-darwin-arm64.tar.gz";
-        sha256 = "125mb2qmxb5cwnvqwckiaih9gq84azfb0qbrw2vmz338967sfz2c";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.2.0-darwin-arm64.tar.gz";
+        sha256 = "0fj1ai1kv8xgmsvfbmy5gsinxag70rx9a9gkifqgcpn3r9mj48ks";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.3.0-darwin-arm64.tar.gz";
-        sha256 = "0p7hmdax7bzn93mv6l79g3g38fh1axnryyq8sg3h16wj8gcc8kq5";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.4.0-darwin-arm64.tar.gz";
+        sha256 = "1iyc67r551bi1h20lfb2qp5b2ds8kf09gklbaz73k90hcrf0g9la";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.1.0-darwin-arm64.tar.gz";
-        sha256 = "1aijk67byw9nwlsdvmw7fiks6ih6wlcbvqpmijchzn86qxikppcq";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.1-darwin-arm64.tar.gz";
-        sha256 = "1smg4r1aijl42hv28v2gjvbmlrhmcs5p4w4pzngv7wsgsm5y6lzm";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.1.0-darwin-arm64.tar.gz";
-        sha256 = "1z0gd0fagv55dl3ki340h0ljw7dqj8818w4072pc5xxy5id90gb0";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v2.0.0-darwin-arm64.tar.gz";
-        sha256 = "1170s85p6d850czb0amzk06d3bcyzyp14p49sgqvpa099jyvs4mm";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.18.0-darwin-arm64.tar.gz";
-        sha256 = "0hvsprzznj0incv60lhxxh4jsx67h7l49v65288ic0x0nsgibn4x";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v4.3.0-darwin-arm64.tar.gz";
-        sha256 = "0qjpay735gff28xdvippm11lh8gk2xsvh2mcil679ybgpk6kypw2";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v4.0.0-darwin-arm64.tar.gz";
+        sha256 = "0fsmmgq0hvzyrw6vrdf3pppxjcj94fxxp52dl73r4f5wjkays33c";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v4.2.0-darwin-arm64.tar.gz";
         sha256 = "1c3pchbnk6dsnxsl02ypq7s4mmkxdgxszdhql1klpx5js7i1lv8k";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.4.0-darwin-arm64.tar.gz";
-        sha256 = "1fcxgbqw6fpn202hza4yyq370r9vbfy8pw220g7yihg8vy9wb1dk";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v3.7.0-darwin-arm64.tar.gz";
-        sha256 = "0h35d4j6s22sxgf579b6f0v14qp49z5rqzcb30pi4grsk8zkqrrr";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v3.3.2-darwin-arm64.tar.gz";
-        sha256 = "0sg73w6h94w0mj9q45av9k2sw251k2a7lnh52ndkbc2phqx3rshh";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-darwin-arm64.tar.gz";
-        sha256 = "118kszs5y3ajh702dyy4wivwdima30s3spbr3cdm9g7aabqhl5l6";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-arm64.tar.gz";
-        sha256 = "10a2f5kdgk3jcd1441zbfcfnrl5zj6ks832jjmbyym33by7scvgc";
-      }
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-darwin-arm64.tar.gz";
-        sha256 = "17imdik9gb3bhqh71b82h12sx6rn13iann9dlbdxy3zj3g59k3ri";
-      }
-      # pulumi-resource-packet skipped (does not exist on remote)
-      {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-postgresql-v3.2.0-darwin-arm64.tar.gz";
-        sha256 = "0fj1ai1kv8xgmsvfbmy5gsinxag70rx9a9gkifqgcpn3r9mj48ks";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v4.22.1-darwin-arm64.tar.gz";
+        sha256 = "01kq2bx0ps92wb61jh6g3nvdvl4ia0bnn4h971lb0rgka39cb39y";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.2.0-darwin-arm64.tar.gz";
         sha256 = "0waf4apw5bzn276s34yaxvm3xyk5333l3zcz2j52c56wkadzxvpg";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.4.0-darwin-arm64.tar.gz";
-        sha256 = "1ywy4zv96k5x85j0fw36q331p11ka1fpg9x18d9ijwl424c7669j";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-consul-v3.3.0-darwin-arm64.tar.gz";
+        sha256 = "0p7hmdax7bzn93mv6l79g3g38fh1axnryyq8sg3h16wj8gcc8kq5";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mailgun-v3.1.0-darwin-arm64.tar.gz";
+        sha256 = "118kszs5y3ajh702dyy4wivwdima30s3spbr3cdm9g7aabqhl5l6";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-openstack-v3.3.0-darwin-arm64.tar.gz";
+        sha256 = "17imdik9gb3bhqh71b82h12sx6rn13iann9dlbdxy3zj3g59k3ri";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.5.0-darwin-arm64.tar.gz";
+        sha256 = "1y0wc1279ka05ng7wq6skmwyrmp1sb2sc64wiqx52napxvzjpv9r";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-datadog-v4.2.0-darwin-arm64.tar.gz";
+        sha256 = "0sg5c85dd0gvy9977igj1b06pdy2my62208fcfy11xf6bf1wqqvi";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v3.1.0-darwin-arm64.tar.gz";
+        sha256 = "1z0gd0fagv55dl3ki340h0ljw7dqj8818w4072pc5xxy5id90gb0";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-digitalocean-v4.6.1-darwin-arm64.tar.gz";
+        sha256 = "1smg4r1aijl42hv28v2gjvbmlrhmcs5p4w4pzngv7wsgsm5y6lzm";
+      }
+      # pulumi-resource-packet skipped (does not exist on remote)
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.0.0-darwin-arm64.tar.gz";
+        sha256 = "1hzhlxbwji4p8apx4rnqllsgf1k11w49rplz0syzmzb2fxpkif75";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v5.21.0-darwin-arm64.tar.gz";
+        sha256 = "1nn7j9ig30dk8lhyfqjpjm3l9clk0d1ipa6iy2qxvz8dgh0yx6wd";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-mysql-v3.0.0-darwin-arm64.tar.gz";
+        sha256 = "10a2f5kdgk3jcd1441zbfcfnrl5zj6ks832jjmbyym33by7scvgc";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.2.0-darwin-arm64.tar.gz";
+        sha256 = "1rmvc2kgjmb978sfmlga6xy4i0f629lk1l95i30wg0rmj1hx3dag";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vault-v4.5.0-darwin-arm64.tar.gz";
+        sha256 = "1k794xxyz7q50yw5lmznb0v2jjdqfi0dsc208fk9lgwchkn72x44";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-vsphere-v4.0.1-darwin-arm64.tar.gz";

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,36 +1,52 @@
 #!/usr/bin/env bash
 # Bash 3 compatible for Darwin
 
+# For getting the latest version of plugins automatically
+API_URL="https://api.github.com/repos/pulumi"
+
 # Version of Pulumi from
 # https://www.pulumi.com/docs/get-started/install/versions/
-VERSION="3.12.0"
+VERSION="3.13.2"
 
-# Grab latest release ${VERSION} from
-# https://github.com/pulumi/pulumi-${NAME}/releases
-plugins=(
-    "auth0=2.2.0"
-    "aws=4.19.0"
-    "cloudflare=3.5.0"
-    "consul=3.3.0"
-    "datadog=4.1.0"
-    "digitalocean=4.6.1"
-    "docker=3.1.0"
-    "equinix-metal=2.0.0"
-    "gcp=5.18.0"
-    "github=4.3.0"
-    "gitlab=4.2.0"
-    "hcloud=1.4.0"
-    "kubernetes=3.7.0"
-    "linode=3.3.2"
-    "mailgun=3.1.0"
-    "mysql=3.0.0"
-    "openstack=3.3.0"
-    "packet=3.2.2"
-    "postgresql=3.2.0"
-    "random=4.2.0"
-    "vault=4.4.0"
-    "vsphere=4.0.1"
+# A hashmap containing a plugin's name and it's respective repository inside
+# Pulumi's Github organization
+
+declare -A pulumi_repos
+pulumi_repos=(
+    ["auth0"]="pulumi-auth0"
+    ["aws"]="pulumi-aws"
+    ["cloudflare"]="pulumi-cloudflare"
+    ["consul"]="pulumi-consul"
+    ["datadog"]="pulumi-datadog"
+    ["digitalocean"]="pulumi-digitalocean"
+    ["docker"]="pulumi-docker"
+    ["equinix-metal"]="pulumi-equinix-metal"
+    ["gcp"]="pulumi-gcp"
+    ["github"]="pulumi-github"
+    ["gitlab"]="pulumi-gitlab"
+    ["hcloud"]="pulumi-hcloud"
+    ["kubernetes"]="pulumi-kubernetes"
+    ["linode"]="pulumi-linode"
+    ["mailgun"]="pulumi-mailgun"
+    ["mysql"]="pulumi-mysql"
+    ["openstack"]="pulumi-openstack"
+    ["packet"]="pulumi-packet"
+    ["postgresql"]="pulumi-postgresql"
+    ["random"]="pulumi-random"
+    ["vault"]="pulumi-vault"
+    ["vsphere"]="pulumi-vsphere"
 )
+
+# Contains latest release ${VERSION} from
+# https://github.com/pulumi/pulumi-${NAME}/releases
+
+# Dynamically builds the plugin array, using the hashmap's key/values and the
+# API for getting the latest version.
+plugins=()
+for key in "${!pulumi_repos[@]}"; do
+    plugins+=("${key}=$(curl -s ${API_URL}/${pulumi_repos[${key}]}/releases/latest | jq -M -r .tag_name | sed 's/v//g')")
+    sleep 1
+done
 
 function genMainSrc() {
     local url="https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-${1}-${2}.tar.gz"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates `pulumi` to `3.13.2` and also adds some automation to the `update.sh` script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
