### PR TITLE
mceinject: init at unstable-2013-01-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -896,6 +896,12 @@
     githubId = 1296771;
     name = "Anders Riutta";
   };
+  arkivm = {
+    email = "vikram186@gmail.com";
+    github = "arkivm";
+    githubId = 1118815;
+    name = "Vikram Narayanan";
+  };
   armijnhemel = {
     email = "armijn@tjaldur.nl";
     github = "armijnhemel";

--- a/pkgs/os-specific/linux/mceinject/default.nix
+++ b/pkgs/os-specific/linux/mceinject/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, bison, flex }:
+
+stdenv.mkDerivation rec {
+  pname = "mceinject";
+  version = "unstable-2013-01-19";
+
+  src = fetchFromGitHub {
+    owner  = "andikleen";
+    repo   = "mce-inject";
+    rev    = "4cbe46321b4a81365ff3aafafe63967264dbfec5";
+    sha256 = "0gjapg2hrlxp8ssrnhvc19i3r1xpcnql7xv0zjgbv09zyha08g6z";
+  };
+
+  nativeBuildInputs = [ flex bison ];
+
+  NIX_CFLAGS_COMPILE = "-Os -g -Wall";
+
+  NIX_LDFLAGS = [ "-lpthread" ];
+
+  makeFlags = [ "prefix=" ];
+
+  enableParallelBuilding = true;
+
+  installFlags = [ "destdir=$(out)" "manprefix=/share" ];
+
+  meta = with lib; {
+    description = "A tool to inject machine checks into x86 kernel for testing";
+    longDescription = ''
+      mce-inject allows to inject machine check errors on the software level
+      into a running Linux kernel. This is intended for validation of the
+      kernel machine check handler.
+    '';
+    homepage = "https://github.com/andikleen/mce-inject/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ arkivm ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3518,6 +3518,8 @@ with pkgs;
 
   mslink = callPackage ../tools/misc/mslink { };
 
+  mceinject = callPackage ../os-specific/linux/mceinject { };
+
   mcelog = callPackage ../os-specific/linux/mcelog {
     util-linux = util-linuxMinimal;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`mce-inject` allows one to inject machine checks on the x86 kernel. This is useful for testing Error detection and Correction (EDAC) [drivers](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/edac) in the Linux kernel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
