### PR TITLE
wgpu: init at 0.10.0

### DIFF
--- a/pkgs/tools/graphics/wgpu/default.nix
+++ b/pkgs/tools/graphics/wgpu/default.nix
@@ -1,0 +1,36 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, makeWrapper, vulkan-loader }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wgpu";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "gfx-rs";
+    repo = pname;
+    rev = "9da5c1d3a026c275feb57606b8c8d61f82b43386";
+    sha256 = "sha256-DcIMP06tlMxI16jqpKqei32FY8h7z41Nvygap2MQC8A=";
+  };
+
+  cargoSha256 = "sha256-3gtIx337IP5t4nYGysOaU7SZRJrvVjYXN7mAqGbVlo8=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  # Tests fail, as the Nix sandbox doesn't provide an appropriate adapter (e.g. Vulkan).
+  doCheck = false;
+
+  postInstall = ''
+    wrapProgram $out/bin/wgpu-info \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+  '';
+
+  meta = with lib; {
+    description = "Safe and portable GPU abstraction in Rust, implementing WebGPU API.";
+    homepage = "https://wgpu.rs/";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ erictapen ];
+    mainProgram = "wgpu-info";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10481,6 +10481,8 @@ with pkgs;
     });
   };
 
+  wgpu = callPackage ../tools/graphics/wgpu { };
+
   wg-bond = callPackage ../applications/networking/wg-bond { };
 
   which = callPackage ../tools/system/which { };


### PR DESCRIPTION

###### Motivation for this change

`wgpu` is a Rust library, but it also contains `wgpu-info` which I would like to package here.

Unfortunately upstream doesn't use git tags, so we need to use the commit id here. I already [asked them to tag their releases](https://github.com/gfx-rs/wgpu/issues/1638#issuecomment-933026031).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
