### PR TITLE
ocamlPackages.curses: 1.0.4 -> 1.0.8

### DIFF
--- a/pkgs/development/ocaml-modules/curses/default.nix
+++ b/pkgs/development/ocaml-modules/curses/default.nix
@@ -1,17 +1,19 @@
-{ lib, stdenv, fetchurl, ocaml, findlib, ncurses }:
+{ lib, stdenv, fetchFromGitHub, ocaml, findlib, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "ocaml-curses";
-  version = "1.0.4";
+  version = "1.0.8";
 
-  src = fetchurl {
-    url = "http://ocaml.phauna.org/distfiles/ocaml-curses-${version}.ogunden1.tar.gz";
-    sha256 = "08wq1r93lincdfzlriyc5nl2p4q7ca4h6ygzgp1nhkgd93pgk9v2";
+  src = fetchFromGitHub {
+    owner = "mbacarella";
+    repo = "curses";
+    rev = version;
+    sha256 = "0yy3wf8i7jgvzdc40bni7mvpkvclq97cgb5fw265mrjj0iqpkqpd";
   };
 
   propagatedBuildInputs = [ ncurses ];
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
 
   # Fix build for recent ncurses versions
   NIX_CFLAGS_COMPILE = "-DNCURSES_INTERNALS=1";
@@ -26,8 +28,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "OCaml Bindings to curses/ncurses";
-    homepage = "https://opam.ocaml.org/packages/curses/curses.1.0.4/";
-    license = licenses.gpl2;
+    homepage = "https://github.com/mbacarella/curses";
+    license = licenses.lgpl21Plus;
+    changelog = "https://github.com/mbacarella/curses/raw/${version}/CHANGES";
     maintainers = [ maintainers.volth ];
     platforms = ocaml.meta.platforms or [];
   };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/mbacarella/curses/raw/1.0.8/CHANGES

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
