### PR TITLE
rewritefs: add `unstable` prefix

### DIFF
--- a/pkgs/os-specific/linux/rewritefs/default.nix
+++ b/pkgs/os-specific/linux/rewritefs/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "rewritefs";
-  version = "2021-10-03";
+  version = "unstable-2021-10-03";
 
   src = fetchFromGitHub {
     owner  = "sloonz";


### PR DESCRIPTION
###### Motivation for this change

Add `unstable` to the version since it's using a git hash to fetch the source.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
