### PR TITLE
lib: add list of supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,15 +11,7 @@
 
       lib = import ./lib;
 
-      systems = [
-        "x86_64-linux"
-        "i686-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "armv6l-linux"
-        "armv7l-linux"
-        "aarch64-darwin"
-      ];
+      systems = lib.systems.supported.hydra;
 
       forAllSystems = f: lib.genAttrs systems (system: f system);
 

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -8,6 +8,7 @@ rec {
   platforms = import ./platforms.nix { inherit lib; };
   examples = import ./examples.nix { inherit lib; };
   architectures = import ./architectures.nix { inherit lib; };
+  supported = import ./supported.nix { inherit lib; };
 
   # Elaborate a `localSystem` or `crossSystem` so that it contains everything
   # necessary.

--- a/lib/systems/supported.nix
+++ b/lib/systems/supported.nix
@@ -1,0 +1,24 @@
+# Supported systems according to RFC0046's definition.
+#
+# https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md
+{ lib }:
+rec {
+  # List of systems that are built by Hydra.
+  hydra = tier1 ++ tier2 ++ tier3;
+
+  tier1 = [
+    "x86_64-linux"
+  ];
+
+  tier2 = [
+    "aarch64-linux"
+    "x86_64-darwin"
+  ];
+
+  tier3 = [
+    "armv6l-linux"
+    "armv7l-linux"
+    "i686-linux"
+    "mipsel-linux"
+  ];
+}


### PR DESCRIPTION
Adds the first 3 tiers of RFC0046 that are being used in flake.nix.

###### Motivation for this change

Let's integrate the list of supported systems. This is just the minimum.

/cc @7c6f434c @Ericson2314 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
