### PR TITLE
pantheon.switchboard-plug-parental-controls: init at 8.0.1

### DIFF
--- a/nixos/modules/services/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/desktop-managers/pantheon.nix
@@ -43,6 +43,8 @@ in
         enable = mkEnableOption "contractor, a desktop-wide extension service used by Pantheon";
       };
 
+      parental-controls.enable = mkEnableOption "Pantheon parental controls daemon";
+
       apps.enable = mkEnableOption "Pantheon default applications";
 
     };
@@ -162,6 +164,7 @@ in
       ];
       services.pantheon.apps.enable = mkDefault true;
       services.pantheon.contractor.enable = mkDefault true;
+      services.pantheon.parental-controls.enable = mkDefault true;
       services.gnome.at-spi2-core.enable = true;
       services.gnome.evolution-data-server.enable = true;
       services.gnome.glib-networking.enable = true;
@@ -360,5 +363,14 @@ in
       ];
     })
 
+    (mkIf serviceCfg.parental-controls.enable {
+      services.malcontent.enable = mkDefault true;
+
+      environment.systemPackages = [ pkgs.pantheon.switchboard-plug-parental-controls ];
+
+      services.dbus.packages = [ pkgs.pantheon.switchboard-plug-parental-controls ];
+
+      systemd.packages = [ pkgs.pantheon.switchboard-plug-parental-controls ];
+    })
   ];
 }

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -282,6 +282,11 @@ in
       account   include       login
       password  substack      login
       session   include       login
+    ''
+    # https://github.com/elementary/switchboard-plug-parental-controls/blob/8.0.1/src/daemon/Server.vala#L325
+    # Must specify conffile since pam_time defaults to ${linux-pam}/etc/security/time.conf.
+    + lib.optionalString config.services.pantheon.parental-controls.enable ''
+      account   required      pam_time.so conffile=/etc/security/time.conf
     '';
 
     security.pam.services.lightdm-greeter.text = ''

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/parental-controls/create-pam-time-conf.patch
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/parental-controls/create-pam-time-conf.patch
@@ -1,0 +1,21 @@
+diff --git a/src/common/PAM/Writer.vala b/src/common/PAM/Writer.vala
+index 6b80269..063f3b0 100644
+--- a/src/common/PAM/Writer.vala
++++ b/src/common/PAM/Writer.vala
+@@ -25,6 +25,17 @@ namespace PC.PAM {
+         private string filename;
+ 
+         public static Writer new_for_time () {
++            var time_file = File.new_for_path (Constants.PAM_TIME_CONF_PATH);
++            if (!time_file.query_exists ()) {
++                var security_dir = time_file.get_parent ();
++                try {
++                    security_dir.make_directory_with_parents ();
++                    time_file.create (FileCreateFlags.NONE);
++                } catch (Error err) {
++                    critical ("Could not create \"%s\": %s", Constants.PAM_TIME_CONF_PATH, err.message);
++                }
++            }
++
+             return new Writer (Constants.PAM_TIME_CONF_PATH);
+         }

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/parental-controls/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/parental-controls/default.nix
@@ -1,0 +1,106 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  gettext,
+  gtk4,
+  meson,
+  ninja,
+  pkg-config,
+  vala,
+  wrapGAppsHook4,
+  accountsservice,
+  dbus,
+  flatpak,
+  glib,
+  granite7,
+  libadwaita,
+  libgee,
+  malcontent,
+  polkit,
+  switchboard,
+  systemd,
+  iptables,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "switchboard-plug-parental-controls";
+  version = "8.0.1";
+
+  src = fetchFromGitHub {
+    owner = "elementary";
+    repo = "switchboard-plug-parental-controls";
+    tag = finalAttrs.version;
+    hash = "sha256-yxQZSbbtWP0+gMu4cZt4bKZC7z8iZILAILYnn9ExnJY=";
+  };
+
+  patches = [
+    # Change default config file path and separate default and run-time config file
+    # https://github.com/elementary/switchboard-plug-parental-controls/pull/206
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-parental-controls/commit/1e5a08c1c3b0a5503e9d3f6858047d53ed8188f7.patch";
+      hash = "sha256-daP/nBmrUw8b3UytIZz3bKdM+lIgAIQ/DJP0h9sdXmc=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-parental-controls/commit/51f027657616a5d4a6bd24478a5b94fad12edb95.patch";
+      hash = "sha256-JOogF1ychF7MAJdrKT4eiUgM8+Y7CN9nxnRNidRoMOk=";
+    })
+
+    # See the nixos/lightdm module for corresponding PAM files.
+    # Since we override conffile path we need to create time.conf ourselves.
+    ./create-pam-time-conf.patch
+
+    # We cannot really setfacl on read-only desktop files.
+    ./disable-applications-tab.patch
+  ];
+
+  nativeBuildInputs = [
+    gettext
+    gtk4 # gtk4-update-icon-cache
+    meson
+    ninja
+    pkg-config
+    vala
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    accountsservice
+    dbus
+    flatpak
+    glib
+    granite7
+    gtk4
+    libadwaita
+    libgee
+    malcontent
+    polkit
+    switchboard
+    systemd
+  ];
+
+  mesonFlags = [
+    # For /var/lib/pantheon-parental-controls/daemon.conf
+    "-Dsharedstatedir=/var/lib"
+    "-Dsystemdunitdir=${placeholder "out"}/etc/systemd/system"
+  ];
+
+  preFixup = ''
+    # For WebRestriction.
+    gappsWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ iptables ]})
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Switchboard Screen Time & Limits Plug";
+    homepage = "https://github.com/elementary/switchboard-plug-parental-controls";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.pantheon ];
+  };
+})

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/parental-controls/disable-applications-tab.patch
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/parental-controls/disable-applications-tab.patch
@@ -1,0 +1,12 @@
+diff --git a/src/plug/Widgets/ControlPage.vala b/src/plug/Widgets/ControlPage.vala
+index 7d1a17d..0d37da2 100644
+--- a/src/plug/Widgets/ControlPage.vala
++++ b/src/plug/Widgets/ControlPage.vala
+@@ -36,7 +36,6 @@ public class PC.Widgets.ControlPage : Switchboard.SettingsPage {
+         stack = new Gtk.Stack ();
+         stack.add_titled (time_limit_view, "general", _("Screen Time"));
+         stack.add_titled (internet_box, "internet", _("Internet"));
+-        stack.add_titled (apps_box, "apps", _("Applications"));
+ 
+         var switcher = new Gtk.StackSwitcher () {
+             halign = CENTER,

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -20,6 +20,7 @@ lib.makeScope pkgs.newScope (
       switchboard-plug-notifications
       switchboard-plug-onlineaccounts
       switchboard-plug-pantheon-shell
+      switchboard-plug-parental-controls
       switchboard-plug-power
       switchboard-plug-printers
       switchboard-plug-security-privacy
@@ -200,6 +201,8 @@ lib.makeScope pkgs.newScope (
     switchboard-plug-onlineaccounts = callPackage ./apps/switchboard-plugs/onlineaccounts { };
 
     switchboard-plug-pantheon-shell = callPackage ./apps/switchboard-plugs/pantheon-shell { };
+
+    switchboard-plug-parental-controls = callPackage ./apps/switchboard-plugs/parental-controls { };
 
     switchboard-plug-power = callPackage ./apps/switchboard-plugs/power { };
 


### PR DESCRIPTION
###### Motivation for this change

Close #138422 

![Screenshot from 2021-10-04 08-04-50](https://user-images.githubusercontent.com/91113/135801649-4cfaa6ed-572e-4d48-abd8-dabe2ff53161.png)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
