### PR TITLE
rancher: init at 2.4.13

### DIFF
--- a/pkgs/applications/networking/cluster/rancher/default.nix
+++ b/pkgs/applications/networking/cluster/rancher/default.nix
@@ -1,0 +1,41 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "rancher-cli";
+  version = "2.4.13";
+
+  src = fetchFromGitHub {
+    owner  = "rancher";
+    repo   = "cli";
+    rev    = "v${version}";
+    sha256 = "sha256-tkAnbQP35P+ZEE/WTpjgjdmvt0eJ0esKJ+I21cWraEI=";
+  };
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X main.VERSION=${version}"
+    "-extldflags"
+    "-static"
+  ];
+
+  vendorSha256 = "sha256-agXztvvrMEoa6bo/bQr3qhinOSj7bFnZ4kzTx4F0VxQ=";
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/rancher
+  '';
+
+  doCheck = true;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/rancher | grep ${version} > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "The Rancher Command Line Interface (CLI) is a unified tool for interacting with your Rancher Server";
+    homepage = "https://github.com/rancher/cli";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32116,6 +32116,8 @@ with pkgs;
 
   rargs = callPackage ../tools/misc/rargs { };
 
+  rancher = callPackage ../applications/networking/cluster/rancher { };
+
   rauc = callPackage ../tools/misc/rauc { };
 
   redprl = callPackage ../applications/science/logic/redprl { };


### PR DESCRIPTION
###### Motivation for this change

Init rancher CLI tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
