### PR TITLE
vscode-extensions.chenglou92.rescript-vscode: init at 1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2832,6 +2832,12 @@
     githubId = 28980797;
     name = "David Leslie";
   };
+  dlip = {
+    email = "dane@lipscombe.com.au";
+    github = "dlip";
+    githubId = 283316;
+    name = "Dane Lipscombe";
+  };
   dmalikov = {
     email = "malikov.d.y@gmail.com";
     github = "dmalikov";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -316,6 +316,8 @@ let
         };
       };
 
+      chenglou92.rescript-vscode = callPackage ./rescript { };
+
       cmschuetz12.wal = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "wal";

--- a/pkgs/misc/vscode-extensions/rescript/default.nix
+++ b/pkgs/misc/vscode-extensions/rescript/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, vscode-utils, callPackage }:
+let
+  rescript-editor-analysis = (callPackage ./rescript-editor-analysis.nix { });
+  arch =
+    if stdenv.isLinux then "linux"
+    else if stdenv.isDarwin then "darwin"
+    else throw "Unsupported platform";
+  analysisDir = "server/analysis_binaries/${arch}";
+in
+vscode-utils.buildVscodeMarketplaceExtension rec {
+  mktplcRef = {
+    name = "rescript-vscode";
+    publisher = "chenglou92";
+    version = "1.1.3";
+    sha256 = "1c1ipxgm0f0a3vlnhr0v85jr5l3rwpjzh9w8nv2jn5vgvpas0b2a";
+  };
+  postPatch = ''
+    rm -r ${analysisDir}
+    ln -s ${rescript-editor-analysis}/bin ${analysisDir}
+  '';
+
+  meta = with lib; {
+    description = "The official VSCode plugin for ReScript";
+    homepage = "https://github.com/rescript-lang/rescript-vscode";
+    maintainers = with maintainers; [ dlip ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/misc/vscode-extensions/rescript/rescript-editor-analysis.nix
+++ b/pkgs/misc/vscode-extensions/rescript/rescript-editor-analysis.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, bash, ocaml }:
+
+stdenv.mkDerivation {
+  pname = "rescript-editor-analysis";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "rescript-lang";
+    repo = "rescript-vscode";
+    rev = "8d0412a72307b220b7f5774e2612760a2d429059";
+    sha256 = "rHQtfuIiEWlSPuZvNpEafsvlXCj2Uv1YRR1IfvKfC2s=";
+  };
+
+  nativeBuildInputs = [ ocaml ];
+
+  postPatch = ''
+    cd analysis
+    substituteInPlace Makefile --replace "/bin/bash" "${bash}/bin/bash"
+  '';
+
+  installPhase = ''
+    install -D -m0555 rescript-editor-analysis.exe $out/bin/rescript-editor-analysis.exe
+  '';
+
+  meta = with lib; {
+    description = "Analysis binary for the ReScript VSCode plugin";
+    homepage = "https://github.com/rescript-lang/rescript-vscode";
+    maintainers = with maintainers; [ dlip ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This vscode plugin had an error running it's analysis binaries on nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
