### PR TITLE
duckstation: unstable-2020-12-29 -> unstable-2021-10-01

### DIFF
--- a/pkgs/misc/emulators/duckstation/default.nix
+++ b/pkgs/misc/emulators/duckstation/default.nix
@@ -1,33 +1,88 @@
-{ lib, mkDerivation, fetchFromGitHub, cmake, pkg-config, SDL2, qtbase
-, wrapQtAppsHook, qttools, ninja, gtk3 }:
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, pkg-config
+, SDL2
+, qtbase
+, wrapQtAppsHook
+, qttools
+, ninja
+, gtk3
+, libevdev
+, curl
+, libpulseaudio
+, sndio
+, mesa
+}:
 mkDerivation rec {
   pname = "duckstation";
-  version = "unstable-2020-12-29";
+  version = "unstable-2021-10-01";
 
   src = fetchFromGitHub {
     owner = "stenzek";
     repo = pname;
-    rev = "f8dcfabc44ff8391b2d41eab2e883dc8f21a88b7";
-    sha256 = "0v6w4di4yj1hbxpqqrcw8rbfjg18g9kla8mnb3b5zgv7i4dyzykw";
+    rev = "a7096f033ecca48827fa55825fc0d0221265f1c2";
+    sha256 = "sha256-e/Y1TJBuY76q3/0MCAqu9AJzLxIoJ8FJUV5vc/AgcjA=";
   };
 
-  nativeBuildInputs = [ cmake wrapQtAppsHook qttools ];
+  nativeBuildInputs = [ cmake ninja pkg-config extra-cmake-modules wrapQtAppsHook qttools ];
 
-  buildInputs = [ SDL2 qtbase gtk3 pkg-config ];
+  buildInputs = [
+    SDL2
+    qtbase
+    gtk3
+    libevdev
+    sndio
+    mesa
+    curl
+    libpulseaudio
+  ];
+
+  cmakeFlags = [
+    "-DUSE_DRMKMS=ON"
+    "-DUSE_EGL=ON"
+  ];
+
+  postPatch = ''
+    substituteInPlace extras/linux-desktop-files/duckstation-qt.desktop \
+      --replace "duckstation-qt" "duckstation" \
+      --replace "TryExec=duckstation" "tryExec=duckstation-qt" \
+      --replace "Exec=duckstation" "Exec=duckstation-qt"
+    substituteInPlace extras/linux-desktop-files/duckstation-nogui.desktop \
+      --replace "duckstation-nogui" "duckstation" \
+      --replace "TryExec=duckstation" "tryExec=duckstation-nogui" \
+      --replace "Exec=duckstation" "Exec=duckstation-nogui"
+  '';
 
   installPhase = ''
-    mkdir -p $out/
-    mv bin $out/
+    runHook preInstall
+    mkdir -p $out/bin $out/share $out/share/pixmaps $out/share/applications
+    rm bin/common-tests
+
+    cp -r bin $out/share/duckstation
+    ln -s $out/share/duckstation/duckstation-{qt,nogui} $out/bin/
+
+    cp ../extras/icons/icon-256px.png $out/share/pixmaps/duckstation.png
+    cp ../extras/linux-desktop-files/* $out/share/applications/
+    runHook postInstall
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    ./bin/common-tests
+    runHook postCheck
   '';
 
   # TODO:
   # - vulkan graphics backend (OpenGL works).
   # - default sound backend (cubeb) does not work, but SDL does.
   meta = with lib; {
-    description =
-      "PlayStation 1 emulator focusing on playability, speed and long-term maintainability";
+    description = "PlayStation 1 emulator focusing on playability, speed and long-term maintainability";
     homepage = "https://github.com/stenzek/duckstation";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = [ maintainers.guibou ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #140424

###### Things done

idk about those todos as i dont use this program
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
