### PR TITLE
cmake-language-server: 0.1.2 → 0.1.3

### DIFF
--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -2,6 +2,9 @@
 , buildPythonPackage
 , isPy3k
 , fetchFromGitHub
+, setuptools-scm
+, pydantic
+, typeguard
 , mock
 , pytest-asyncio
 , pytestCheckHook
@@ -9,17 +12,31 @@
 
 buildPythonPackage rec {
   pname = "pygls";
-  version = "0.9.1";
+  version = "0.11.2";
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner = "openlawlibrary";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1v7x5598d6jg8ya0spqjma56y062rznwimsrp8nq6fkskqgfm0ds";
+    sha256 = "sha256-zgQ5m198HMyFFrASSYCzn0EDLLeVy2j4LD0rEyEgahQ=";
   };
 
-  checkInputs = [ mock pytest-asyncio pytestCheckHook ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [
+    pydantic
+    typeguard
+  ];
+
+  checkInputs = [
+    mock
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pygls" ];
 
   meta = with lib; {
     description = "Pythonic generic implementation of the Language Server Protocol";

--- a/pkgs/development/tools/cmake-language-server/default.nix
+++ b/pkgs/development/tools/cmake-language-server/default.nix
@@ -1,46 +1,41 @@
-{ lib, stdenv, buildPythonApplication, fetchFromGitHub
-, poetry, pygls, pyparsing
-, cmake, pytest, pytest-datadir
-, fetchpatch
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, poetry
+, pygls
+, pyparsing
+, cmake
+, pytest-datadir
+, pytestCheckHook
 }:
 
 buildPythonApplication rec {
   pname = "cmake-language-server";
-  version = "0.1.2";
+  version = "0.1.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "regen100";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0vz7bjxkk0phjhz3h9kj6yr7wnk3g7lqmkqraa0kw12mzcfck837";
+    sha256 = "sha256-eZBnygEYjLzk29tvLGg1JdhCECc5x2MewHRSChMuCjo=";
   };
 
   patches = [
+    # Test timeouts occasionally cause the build to fail
     ./disable-test-timeouts.patch
-  ] ++ lib.optionals stdenv.isDarwin [
-    # can be removed after v0.1.2
-    (fetchpatch {
-      url = "https://github.com/regen100/cmake-language-server/commit/0ec120f39127f25898ab110b43819e3e9becb8a3.patch";
-      sha256 = "1xbmarvsvzd61fnlap4qscnijli2rw2iqr7cyyvar2jd87z6sfp0";
-    })
   ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'pygls = "^0.8.1"' 'pygls = "^0.9.0"'
-  '';
 
   nativeBuildInputs = [ poetry ];
   propagatedBuildInputs = [ pygls pyparsing ];
 
-  checkInputs = [ cmake pytest pytest-datadir ];
+  checkInputs = [ cmake pytest-datadir pytestCheckHook ];
   dontUseCmakeConfigure = true;
-  checkPhase = "pytest";
+  pythonImportsCheck = [ "cmake_language_server" ];
 
   meta = with lib; {
-    homepage = "https://github.com/regen100/cmake-language-server";
     description = "CMake LSP Implementation";
+    homepage = "https://github.com/regen100/cmake-language-server";
     license = licenses.mit;
     maintainers = with maintainers; [ kira-bruneau ];
   };


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/regen100/cmake-language-server/releases/tag/v0.1.3 and also update pygls as a requirement: https://github.com/openlawlibrary/pygls/releases/tag/v0.11.2.

This change also fixes the test failure introduced when python3 was updated to v3.9: https://hydra.nixos.org/build/154473169.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).