### PR TITLE
exploitdb: clean up bin directory

### DIFF
--- a/pkgs/tools/security/exploitdb/default.nix
+++ b/pkgs/tools/security/exploitdb/default.nix
@@ -1,4 +1,4 @@
-{stdenv, lib, fetchFromGitHub }:
+{ stdenv, lib, fetchFromGitHub, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
@@ -11,11 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-gUjFFxzkHHhNMDAgFmmIAuEACSCn1YXuauvjGAkrK6k=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin
-    cp --recursive ./* $out/bin
-    cp ./.searchsploit_rc $out/bin
+    mkdir -p $out/bin $out/share
+    cp --recursive . $out/share/exploitdb
+    makeWrapper $out/share/exploitdb/searchsploit $out/bin/searchsploit
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Motivation for this change
This package currently puts the entire exploitdb repo in the output bin directory.
This change reduces the bin directory to contain only the "searchsploit" script that is actually needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
