### PR TITLE
sad: 0.4.14 -> 0.4.17

### DIFF
--- a/pkgs/tools/text/sad/default.nix
+++ b/pkgs/tools/text/sad/default.nix
@@ -5,16 +5,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sad";
-  version = "0.4.14";
+  version = "0.4.17";
 
   src = fetchFromGitHub {
     owner = "ms-jpq";
     repo = pname;
     rev = "v${version}";
-    sha256 = "03b6qxkn8sqv06gs4p6wg02arz0n9llc3z92zhfd5ipz8han83fd";
+    sha256 = "sha256-dclnsncql3TFOZ4z6SyIAWe4bgAFK3Us3xJ0AeX/wNA=";
   };
 
-  cargoSha256 = "13nkd4354siy8pr2032bxz2z5x8b378mccq6pnm71cpl9dl6w4ad";
+  cargoSha256 = "sha256-jej7JKSllBpb13Zq0WrcDPLdMtnjau8I0a4ghstHVqk=";
 
   meta = with lib; {
     description = "CLI tool to search and replace";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.4.17

Change log:
- https://github.com/ms-jpq/sad/releases/tag/v0.4.17
- https://github.com/ms-jpq/sad/releases/tag/v0.4.16
- https://github.com/ms-jpq/sad/releases/tag/v0.4.15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
