### PR TITLE
cudatext: 1.143.0 → 1.146.0

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.143.0";
+  version = "1.146.0";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "sha256-j8J4OA4J43XIJKBMx8hQy7h1BcKfEhWvpgmpNmi/yrw=";
+    sha256 = "sha256-YK4nLQvRdgS7hq5a9uVfVjUAgkM/sYXiKjbt0QNzcok=";
   };
 
   postPatch = ''

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -11,23 +11,23 @@
   },
   "ATFlatControls": {
     "owner": "Alexey-T",
-    "rev": "2021.08.28",
-    "sha256": "sha256-nFRlSeU2ScPQrLXcd4dt8l9Ct7ceJyKMi97gtxz+S8I="
+    "rev": "2021.09.14",
+    "sha256": "sha256-j69UkRNdVdzMITBHMT1QwAsYX9S0fts5/0PCroCGtL8="
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2021.09.03",
-    "sha256": "sha256-2y1E+52MPkimmozo1Qwpg7Qyhjct3cs76nHlOf/Cs0M="
+    "rev": "2021.10.03",
+    "sha256": "sha256-JGw/GbQNLAgHhDm/EgCGvzPpd8rqQo2FhmAL51XIekw="
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
-    "rev": "2021.09.03",
-    "sha256": "sha256-pZo+wKnqN2HfDjPeC/WqaE5sdNnpjRN2VKSP8p4Q6Ek="
+    "rev": "2021.09.14",
+    "sha256": "sha256-6eC75zAtWbM1XEI9OM3iqy/a8Vj1l5WU7HGJBpmoQsA="
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2021.09.02",
-    "sha256": "sha256-i8laXF9IIhVkGZ2rzv7RlZeMxUza5LAXlTOxDj9CzJo="
+    "rev": "2021.10.03",
+    "sha256": "sha256-Kbjzn4Rp+/oTNgFMlzlkQEeob0Z4VidqJ/+wuNHS580="
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://cudatext.github.io/history.txt)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
