### PR TITLE
crow-translate: 2.8.4 → 2.8.7

### DIFF
--- a/pkgs/applications/misc/crow-translate/default.nix
+++ b/pkgs/applications/misc/crow-translate/default.nix
@@ -34,37 +34,37 @@ let
   qonlinetranslator = fetchFromGitHub {
     owner = "crow-translate";
     repo = "QOnlineTranslator";
-    rev = "1.4.4";
-    sha256 = "sha256-ogO6ovkQmyvTUPCYAQ4U3AxOju9r3zHB9COnAAfKSKA=";
+    rev = "df89083d2f680a8f856b1df00b8846f995cf1fae";
+    sha256 = "sha256-I64KGInnYd/QdI5kANJERsF95wMvRlr8kgQhUqXXN/0=";
   };
   circleflags = fetchFromGitHub {
     owner = "HatScripts";
     repo = "circle-flags";
-    rev = "v2.1.0";
-    sha256 = "sha256-E0iTDjicfdGqK4r+anUZanEII9SBafeEUcMLf7BGdp0=";
+    rev = "v2.3.0";
+    sha256 = "sha256-KabmewF1Xf/1JQuzolrlRyLJR8O5j+/iT+29/QtOQVE=";
   };
-  we10x = fetchFromGitHub {
-    owner = "yeyushengfan258";
-    repo = "We10X-icon-theme";
-    rev = "bd2c68482a06d38b2641503af1ca127b9e6540db";
-    sha256 = "sha256-T1oPstmjLffnVrIIlmTTpHv38nJHBBGJ070ilRwAjk8=";
+  fluent = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = "Fluent-icon-theme";
+    rev = "2021-08-15";
+    sha256 = "sha256-uBu0vbKfhhnPKGwrnSBjPwS9ncH1iAlmeefAcpckOm4=";
   };
 in
 mkDerivation rec {
   pname = "crow-translate";
-  version = "2.8.4";
+  version = "2.8.7";
 
   src = fetchFromGitHub {
     owner = "crow-translate";
     repo = pname;
     rev = version;
-    sha256 = "sha256-TPJgKTZqsh18BQGFWgp0wsw1ehtI8ydQ7ZCvYNX6pH8=";
+    sha256 = "sha256-0bq9itbFyzdOhdNuUtdCYLTCIhc91MM+YRhJgXC5PPw=";
   };
 
   patches = [
     (substituteAll {
       src = ./dont-fetch-external-libs.patch;
-      inherit singleapplication qtaskbarcontrol qhotkey qonlinetranslator circleflags we10x;
+      inherit singleapplication qtaskbarcontrol qhotkey qonlinetranslator circleflags fluent;
     })
     (substituteAll {
       # See https://github.com/NixOS/nixpkgs/issues/86054
@@ -75,7 +75,7 @@ mkDerivation rec {
 
   postPatch = ''
     cp -r ${circleflags}/flags/* data/icons
-    cp -r ${we10x}/src/* data/icons
+    cp -r ${fluent}/src/* data/icons
   '';
 
   nativeBuildInputs = [ cmake extra-cmake-modules qttools ];

--- a/pkgs/applications/misc/crow-translate/dont-fetch-external-libs.patch
+++ b/pkgs/applications/misc/crow-translate/dont-fetch-external-libs.patch
@@ -1,25 +1,25 @@
 diff --git i/CMakeLists.txt w/CMakeLists.txt
-index 0cd2140..16e3190 100644
+index faa9417..059b899 100644
 --- i/CMakeLists.txt
 +++ w/CMakeLists.txt
-@@ -97,13 +97,11 @@ qt5_add_translation(QM_FILES
+@@ -101,13 +101,11 @@ qt5_add_translation(QM_FILES
  )
  
  configure_file(src/cmake.h.in cmake.h)
 -configure_file(data/icons/flags.qrc ${CircleFlags_SOURCE_DIR}/flags/flags.qrc COPYONLY)
--configure_file(data/icons/we10x.qrc ${We10X_SOURCE_DIR}/src/we10x.qrc COPYONLY)
+-configure_file(data/icons/fluent-icon-theme.qrc ${FluentIconTheme_SOURCE_DIR}/src/fluent-icon-theme.qrc COPYONLY)
  
  add_executable(${PROJECT_NAME}
 -    ${CircleFlags_SOURCE_DIR}/flags/flags.qrc
 +    data/icons/flags.qrc
      ${QM_FILES}
--    ${We10X_SOURCE_DIR}/src/we10x.qrc
-+    data/icons/we10x.qrc
+-    ${FluentIconTheme_SOURCE_DIR}/src/fluent-icon-theme.qrc
++    data/icons/fluent-icon-theme.qrc
      data/icons/engines/engines.qrc
      src/addlanguagedialog.cpp
      src/addlanguagedialog.ui
 diff --git i/cmake/ExternalLibraries.cmake w/cmake/ExternalLibraries.cmake
-index d738716..fb01f3d 100644
+index e2501e1..e15ce6c 100644
 --- i/cmake/ExternalLibraries.cmake
 +++ w/cmake/ExternalLibraries.cmake
 @@ -2,34 +2,28 @@ include(FetchContent)
@@ -46,20 +46,20 @@ index d738716..fb01f3d 100644
  
  FetchContent_Declare(QOnlineTranslator
 -    GIT_REPOSITORY https://github.com/crow-translate/QOnlineTranslator
--    GIT_TAG 1.4.4
+-    GIT_TAG df89083d2f680a8f856b1df00b8846f995cf1fae
 +    SOURCE_DIR @qonlinetranslator@
  )
  
  FetchContent_Declare(CircleFlags
 -    GIT_REPOSITORY https://github.com/HatScripts/circle-flags
--    GIT_TAG v2.1.0
+-    GIT_TAG v2.3.0
 +    SOURCE_DIR @circleflags@
  )
  
- FetchContent_Declare(We10X
--    GIT_REPOSITORY https://github.com/yeyushengfan258/We10X-icon-theme
--    GIT_TAG bd2c68482a06d38b2641503af1ca127b9e6540db
-+    SOURCE_DIR @we10x@
+ FetchContent_Declare(FluentIconTheme
+-    GIT_REPOSITORY https://github.com/vinceliuice/Fluent-icon-theme
+-    GIT_TAG 2021-08-15
++    SOURCE_DIR @fluent@
  )
  
- FetchContent_MakeAvailable(SingleApplication QTaskbarControl QHotkey QOnlineTranslator CircleFlags We10X)
+ FetchContent_MakeAvailable(SingleApplication QTaskbarControl QHotkey QOnlineTranslator CircleFlags FluentIconTheme)

--- a/pkgs/applications/misc/crow-translate/fix-qttranslations-path.patch
+++ b/pkgs/applications/misc/crow-translate/fix-qttranslations-path.patch
@@ -1,8 +1,8 @@
-diff --git c/src/settings/appsettings.cpp i/src/settings/appsettings.cpp
-index ff99f64..fa929ae 100644
---- c/src/settings/appsettings.cpp
-+++ i/src/settings/appsettings.cpp
-@@ -80,7 +80,7 @@ void AppSettings::applyLanguage(QLocale::Language lang)
+diff --git i/src/settings/appsettings.cpp w/src/settings/appsettings.cpp
+index aa8b357..15e4f74 100644
+--- i/src/settings/appsettings.cpp
++++ w/src/settings/appsettings.cpp
+@@ -81,7 +81,7 @@ void AppSettings::applyLanguage(QLocale::Language lang)
      QLocale::setDefault(locale);
  
      s_appTranslator.load(locale, QStringLiteral(PROJECT_NAME), QStringLiteral("_"), QStandardPaths::locate(QStandardPaths::AppDataLocation, QStringLiteral("translations"), QStandardPaths::LocateDirectory));


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/crow-translate/crow-translate/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
