### PR TITLE
dismap: init at 0.2

### DIFF
--- a/pkgs/tools/security/dismap/default.nix
+++ b/pkgs/tools/security/dismap/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "dismap";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "zhzyker";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0d5r6n92ndlr48f4z6lxwrx7bdh5mmibdjcyab4j2h49lf37c1qd";
+  };
+
+  vendorSha256 = "00hwhc86rj806arvqfhfarmxs1drcdp91xkr12whqhsi9ddc254d";
+
+  meta = with lib; {
+    description = "Asset discovery and identification tools";
+    homepage = "https://github.com/zhzyker/dismap";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4390,6 +4390,8 @@ with pkgs;
 
   dirmngr = callPackage ../tools/security/dirmngr { };
 
+  dismap = callPackage ../tools/security/dismap { };
+
   dirvish  = callPackage ../tools/backup/dirvish { };
 
   disper = callPackage ../tools/misc/disper { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Asset discovery and identification tools

https://github.com/zhzyker/dismap

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
