### PR TITLE
terraform-providers.netlify: 0.4.0 -> 0.6.12

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -664,11 +664,13 @@
     "version": "1.2.0"
   },
   "netlify": {
-    "owner": "terraform-providers",
+    "owner": "AegirHealth",
+    "provider-source-address": "registry.terraform.io/AegirHealth/netlify",
     "repo": "terraform-provider-netlify",
-    "rev": "v0.4.0",
-    "sha256": "07xds84k2vgpvn2cy3id7hmzg57sz2603zs4msn3ysxmi28lmqyg",
-    "version": "0.4.0"
+    "rev": "v0.6.12",
+    "sha256": "0h3ff1ligjvvlmhghx9g92an79b26nyyq5sq4cdsf6psvwfa2kzd",
+    "vendorSha256": null,
+    "version": "0.6.12"
   },
   "newrelic": {
     "owner": "terraform-providers",


### PR DESCRIPTION
###### Motivation for this change

Switch base, https://github.com/hashicorp/terraform-provider-netlify has
been archived. AegirHealth is the freshest one and supports DNS
records that are needed for NixOS/nixos-org-configurations#163

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
