### PR TITLE
latte-dock: fix autostart file

### DIFF
--- a/pkgs/applications/misc/latte-dock/0001-close-user-autostart.patch
+++ b/pkgs/applications/misc/latte-dock/0001-close-user-autostart.patch
@@ -1,0 +1,25 @@
+From a162c54ed1fcc39434edf8666c72c305d05e79e6 Mon Sep 17 00:00:00 2001
+From: diffumist <git@diffumist.me>
+Date: Mon, 4 Oct 2021 16:58:37 +0800
+Subject: [PATCH] close user config autostart
+
+---
+ app/settings/universalsettings.cpp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/app/settings/universalsettings.cpp b/app/settings/universalsettings.cpp
+index e0010542..82b9e785 100644
+--- a/app/settings/universalsettings.cpp
++++ b/app/settings/universalsettings.cpp
+@@ -77,9 +77,6 @@ void UniversalSettings::load()
+     //! check if user has set the autostart option
+     bool autostartUserSet = m_universalGroup.readEntry("userConfiguredAutostart", false);
+
+-    if (!autostartUserSet && !autostart()) {
+-        setAutostart(true);
+-    }
+
+     //! init screen scales
+     m_screenScalesGroup = m_universalGroup.group("ScreenScales");
+--
+2.33.0

--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -16,7 +16,13 @@ mkDerivation rec {
   nativeBuildInputs = [ extra-cmake-modules cmake karchive kwindowsystem
     qtx11extras kcrash knewstuff ];
 
-
+  patches = [
+    ./0001-close-user-autostart.patch
+  ];
+  fixupPhase = ''
+    mkdir -p $out/etc/xdg/autostart
+    cp $out/share/applications/org.kde.latte-dock.desktop $out/etc/xdg/autostart
+  '';
 
   meta = with lib; {
     description = "Dock-style app launcher based on Plasma frameworks";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Latte-dock's user autostart file does not automatically replace the execution path, so replace it with the system autostart file. 

_Possible related issues_
https://github.com/NixOS/nixpkgs/issues/80653 https://github.com/NixOS/nixpkgs/issues/107318
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
