### PR TITLE
python3Packages.distorm3: 3.3.4 -> 3.5.2

### DIFF
--- a/pkgs/development/python-modules/distorm3/default.nix
+++ b/pkgs/development/python-modules/distorm3/default.nix
@@ -1,21 +1,29 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "distorm3";
-  version = "3.3.4";
+  version = "3.5.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "1bh9xdiz9mkf9lfffimfn3hgd0mh60y7wl1micgkxzpl7hnxrpd4";
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "gdabah";
+    repo = "distorm";
+    rev = version;
+    sha256 = "012bh1l2w7i9q8rcnznj3x0lra09d5yxd3r42cbrqdwl1mmg26qn";
   };
 
   # no tests included
   doCheck = false;
 
   meta = with lib; {
-    description = "Powerful Disassembler Library For x86/AMD64";
+    description = "Disassembler library for x86/AMD64";
     homepage = "https://github.com/gdabah/distorm";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/distorm3/default.nix
+++ b/pkgs/development/python-modules/distorm3/default.nix
@@ -2,6 +2,8 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
+, pytestCheckHook
+, yasm
 }:
 
 buildPythonPackage rec {
@@ -17,8 +19,17 @@ buildPythonPackage rec {
     sha256 = "012bh1l2w7i9q8rcnznj3x0lra09d5yxd3r42cbrqdwl1mmg26qn";
   };
 
-  # no tests included
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+    yasm
+  ];
+
+  disabledTests = [
+    # TypeError: __init__() missing 3 required positional...
+    "test_dummy"
+  ];
+
+  pythonImportsCheck = [ "distorm3" ];
 
   meta = with lib; {
     description = "Disassembler library for x86/AMD64";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.5.2

Change log:
- https://github.com/gdabah/distorm/releases/tag/3.5.2
- https://github.com/gdabah/distorm/releases/tag/v3.5
- https://github.com/gdabah/distorm/releases/tag/v3.4.4

Other changes:
- Use source from GitHub
- Enable tests
- Add `pythonImportsCheck`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
