### PR TITLE
terraform-providers.mkProvider: init

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -39,25 +39,28 @@ let
       passthru = data;
     };
 
-  # These providers are managed with the ./update-all script
-  automated-providers = lib.mapAttrs (_: attrs:
+  # Our generic constructor to build new providers
+  mkProvider = attrs:
     (if (lib.hasAttr "vendorSha256" attrs) then buildWithGoModule else buildWithGoPackage)
-      attrs) list;
+      attrs;
+
+  # These providers are managed with the ./update-all script
+  automated-providers = lib.mapAttrs (_: attrs: mkProvider attrs) list;
 
   # These are the providers that don't fall in line with the default model
   special-providers = {
     # Packages that don't fit the default model
-    ansible = callPackage ./ansible {};
-    cloudfoundry = callPackage ./cloudfoundry {};
-    gandi = callPackage ./gandi {};
-    hcloud = callPackage ./hcloud {};
-    libvirt = callPackage ./libvirt {};
-    linuxbox = callPackage ./linuxbox {};
-    lxd = callPackage ./lxd {};
-    vpsadmin = callPackage ./vpsadmin {};
-    vercel = callPackage ./vercel {};
+    ansible = callPackage ./ansible { };
+    cloudfoundry = callPackage ./cloudfoundry { };
+    gandi = callPackage ./gandi { };
+    hcloud = callPackage ./hcloud { };
+    libvirt = callPackage ./libvirt { };
+    linuxbox = callPackage ./linuxbox { };
+    lxd = callPackage ./lxd { };
+    vpsadmin = callPackage ./vpsadmin { };
+    vercel = callPackage ./vercel { };
   } // (lib.optionalAttrs (config.allowAliases or false) {
     kubernetes-alpha = throw "This has been merged as beta into the kubernetes provider. See https://www.hashicorp.com/blog/beta-support-for-crds-in-the-terraform-provider-for-kubernetes for details";
   });
 in
-  automated-providers // special-providers
+automated-providers // special-providers // { inherit mkProvider; }

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -114,7 +114,7 @@ let
           passthru = {
             withPlugins = newplugins:
               withPlugins (x: newplugins x ++ actualPlugins);
-            full = withPlugins lib.attrValues;
+            full = withPlugins (p: lib.filter lib.isDerivation (lib.attrValues p));
 
             # Ouch
             overrideDerivation = f:


### PR DESCRIPTION
Expose how the providers are being created. That way, users can more
easily extend or override the list of providers that they want to use.

For example, you need a new AWS provider version:

```nix
terraform.withPlugins (p: [
  (p.mkProvider rec {
    owner = "hashicorp";
    provider-source-address = "registry.terraform.io/hashicorp/aws";
    repo = "terraform-provider-aws";
    rev = "v${version}";
    sha256 = "0fa61i172maanxmxz28mj7mkgrs9a5bs61mlvb0d5y97lv6pm2xg";
    vendorSha256 ="1s22k4b2zq5n0pz6iqbqsf6f7chsbvkpdn432rvyshcryxlklfvl";
    version = "3.56.0";
  })
])
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
