### PR TITLE
datree: init at 0.13.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5283,6 +5283,12 @@
     githubId = 221929;
     name = "Jean-Baptiste Giraudeau";
   };
+  jceb = {
+    name = "jceb";
+    email = "jceb@e-jc.de";
+    github = "jceb";
+    githubId = 101593;
+  };
   jchw = {
     email = "johnwchadwick@gmail.com";
     github = "jchv";

--- a/pkgs/development/tools/datree/default.nix
+++ b/pkgs/development/tools/datree/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "datree";
+  version = "0.14.49";
+
+  src = fetchFromGitHub {
+    owner = "datreeio";
+    repo = "datree";
+    rev = version;
+    sha256 = "0m126jjklkwiwzg44xkii9gx0pmhqm7xdj0hblsrp09jnym7rjns";
+  };
+
+  vendorSha256 = "0msgq7bmy424bcyx23srjs7w2bck4b7zad8mi8l3j20ajya3amaa";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/datreeio/datree/cmd.CliVersion=${version}"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "CLI tool to ensure K8s manifests and Helm charts follow best practices as well as your organization’s policies";
+    homepage = "https://datree.io/";
+    license = [ licenses.asl20 ];
+    maintainers = [ maintainers.jceb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14450,6 +14450,8 @@ with pkgs;
 
   cli11 = callPackage ../development/tools/misc/cli11 { };
 
+  datree = callPackage ../development/tools/datree { };
+
   dcadec = callPackage ../development/tools/dcadec { };
 
   dejagnu = callPackage ../development/tools/misc/dejagnu { };


### PR DESCRIPTION
###### Motivation for this change

Add `datree` packages.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
