### PR TITLE
sabnzbd: add guessit and puremagic to python env

### DIFF
--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -13,9 +13,11 @@ let
     chardet
     cheetah3
     cherrypy
-    cryptography
     configobj
+    cryptography
     feedparser
+    guessit
+    puremagic
     sabyenc3
   ]);
   path = lib.makeBinPath [ par2cmdline unrar unzip p7zip ];


### PR DESCRIPTION
###### Motivation for this change

Currently, `sabnzbd` fails with the current backtrace:

```none
Traceback (most recent call last):
  File "/nix/store/44w52wjl1im0i6z6knvy3aqckgfdipnm-sabnzbd-3.4.0/SABnzbd.py", line 56, in <module>
    import sabnzbd
  File "/nix/store/44w52wjl1im0i6z6knvy3aqckgfdipnm-sabnzbd-3.4.0/sabnzbd/__init__.py", line 91, in <module>
    import sabnzbd.rss as rss
  File "/nix/store/44w52wjl1im0i6z6knvy3aqckgfdipnm-sabnzbd-3.4.0/sabnzbd/rss.py", line 35, in <module>
    import sabnzbd.emailer as emailer
  File "/nix/store/44w52wjl1im0i6z6knvy3aqckgfdipnm-sabnzbd-3.4.0/sabnzbd/emailer.py", line 36, in <module>
    from sabnzbd.notifier import check_cat
  File "/nix/store/44w52wjl1im0i6z6knvy3aqckgfdipnm-sabnzbd-3.4.0/sabnzbd/notifier.py", line 36, in <module>
    from sabnzbd.newsunpack import create_env
  File "/nix/store/44w52wjl1im0i6z6knvy3aqckgfdipnm-sabnzbd-3.4.0/sabnzbd/newsunpack.py", line 60, in <module>
    from sabnzbd.nzbstuff import NzbObject, NzbFile
  File "/nix/store/44w52wjl1im0i6z6knvy3aqckgfdipnm-sabnzbd-3.4.0/sabnzbd/nzbstuff.py", line 89, in <module>
    from sabnzbd.deobfuscate_filenames import is_probably_obfuscated
  File "/nix/store/44w52wjl1im0i6z6knvy3aqckgfdipnm-sabnzbd-3.4.0/sabnzbd/deobfuscate_filenames.py", line 38, in <module>
    import sabnzbd.utils.file_extension as file_extension
  File "/nix/store/44w52wjl1im0i6z6knvy3aqckgfdipnm-sabnzbd-3.4.0/sabnzbd/utils/file_extension.py", line 8, in <module>
    import puremagic
ModuleNotFoundError: No module named 'puremagic'

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
