### PR TITLE
lua-packages: fix getLuaPath and getLuaCPath

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -46,8 +46,8 @@ in
   # helper functions for dealing with LUA_PATH and LUA_CPATH
   lib = luaLib;
 
-  getLuaPath = drv: getPath drv (luaLib.luaPathList lua.luaversion) ;
-  getLuaCPath = drv: getPath drv (luaLib.luaCPathList lua.luaversion) ;
+  getLuaPath = drv: getPath drv luaLib.luaPathList;
+  getLuaCPath = drv: getPath drv luaLib.luaCPathList;
 
   inherit (callPackage ../development/interpreters/lua-5/hooks { inherit (args) lib;})
     lua-setup-hook;


### PR DESCRIPTION
luaLib.luaPathList is a list and not a function anymore which results in
the following error:

error: attempt to call something which is not a function but a list

       at /nix/store/v94vpi9na0flcnhh9gbmzcvbgfzqm10g-source/pkgs/top-level/lua-packages.nix:50:35:

           49|   getLuaPath = drv: getPath drv (luaLib.luaPathList lua.luaversion) ;
           50|   getLuaCPath = drv: getPath drv (luaLib.luaCPathList lua.luaversion) ;
             |                                   ^
           51|

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This has been broken recently

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
