### PR TITLE
gonic: 0.13.1 -> 0.14.0

### DIFF
--- a/pkgs/servers/gonic/default.nix
+++ b/pkgs/servers/gonic/default.nix
@@ -12,19 +12,19 @@
 
 buildGoModule rec {
   pname = "gonic";
-  version = "0.13.1";
+  version = "0.14.0";
   src = fetchFromGitHub {
     owner = "sentriz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "08zr5cbmn25wfi1sjfsb311ycn1855x57ypyn5165zcz49pcfzxn";
+    sha256 = "sha256-wX97HtvHgHpKTDwZl/wHQRpiyDJ7U38CpdzWu/CYizQ=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ taglib zlib ]
     ++ lib.optionals stdenv.isLinux [ alsa-lib ]
     ++ lib.optionals stdenv.isDarwin [ AudioToolbox AppKit ];
-  vendorSha256 = "0inxlqxnkglz4j14jav8080718a80nqdcl866lkql8r6zcxb4fm9";
+  vendorSha256 = "sha256-oTuaA5ZsZ7zMcjzGh37zO/1XyOfj6xjfNr6A7ecrOiA=";
 
   # TODO(Profpatsch): write a test for transcoding support,
   # since it is prone to break


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/sentriz/gonic/releases/tag/v0.14.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
