### PR TITLE
bpfmon: init at 2.50

### DIFF
--- a/pkgs/os-specific/linux/bpfmon/default.nix
+++ b/pkgs/os-specific/linux/bpfmon/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, lib, libpcap, yascreen }:
+
+stdenv.mkDerivation rec {
+  pname = "bpfmon";
+  version = "2.50";
+
+  src = fetchFromGitHub {
+    owner = "bbonev";
+    repo = "bpfmon";
+    rev = "v${version}";
+    sha256 = "sha256-x4EuGZBtg45bD9q1B/6KwjDRXXeRsdFmRllREsech+E=";
+  };
+
+  buildInputs = [ libpcap yascreen ];
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "BPF based visual packet rate monitor";
+    homepage = "https://github.com/bbonev/bpfmon";
+    maintainers = with maintainers; [ arezvov ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21316,6 +21316,8 @@ with pkgs;
 
   bolt = callPackage ../os-specific/linux/bolt { };
 
+  bpfmon = callPackage ../os-specific/linux/bpfmon { };
+
   bridge-utils = callPackage ../os-specific/linux/bridge-utils { };
 
   busybox = callPackage ../os-specific/linux/busybox { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
