### PR TITLE
lilypond-with-fonts: fix lilypond not finding its libraries

### DIFF
--- a/pkgs/misc/lilypond/with-fonts.nix
+++ b/pkgs/misc/lilypond/with-fonts.nix
@@ -1,4 +1,4 @@
-{ lib, lndir, symlinkJoin, makeWrapper
+{ lib, symlinkJoin, makeWrapper
 , lilypond, openlilylib-fonts
 }:
 
@@ -8,11 +8,10 @@ lib.appendToName "with-fonts" (symlinkJoin {
   paths = [ lilypond ] ++ openlilylib-fonts.all;
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ lndir ];
 
   postBuild = ''
     for p in $out/bin/*; do
-        wrapProgram "$p" --set LILYPOND_DATADIR "$datadir"
+        wrapProgram "$p" --set LILYPOND_DATADIR "$out/share/lilypond/${lilypond.version}"
     done
   '';
 })


### PR DESCRIPTION
Fixes #140152. The fix is inspired by how lilypond-with-fonts was
packaged in v18.09.

###### Motivation for this change
As described in the issue, the `lilypond-with-fonts` package is broken at the moment.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
