### PR TITLE
fstar: 2021.09.11 -> 2021.09.30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8818,6 +8818,12 @@
     githubId = 11365056;
     name = "Kevin Liu";
   };
+  pnmadelaine = {
+    name = "Paul-Nicolas Madelaine";
+    email = "pnm@pnm.tf";
+    github = "pnmadelaine";
+    githubId = 21977014;
+  };
   pnotequalnp = {
     email = "kevin@pnotequalnp.com";
     github = "pnotequalnp";

--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -17,19 +17,20 @@ in
 
 stdenv.mkDerivation rec {
   pname = "fstar";
-  version = "2021.09.11";
+  version = "2021.09.30";
 
   src = fetchFromGitHub {
     owner = "FStarLang";
     repo = "FStar";
     rev = "v${version}";
-    sha256 = "1aqk6fx77zcb7mcm78dk4l4zzd323qiv7yc7hvc38494yf6gk8a0";
+    sha256 = "gqy9iaLZlTyv9ufHrUG87ta2xyc1OaZ/KRGhAzB+wsQ=";
   };
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   buildInputs = [
     z3
+    sedlex-2_3
   ] ++ (with ocamlPackages; [
     ocaml
     findlib
@@ -42,7 +43,6 @@ stdenv.mkDerivation rec {
     menhir
     menhirLib
     pprint
-    sedlex-2_3
     ppxlib
     ppx_deriving
     ppx_deriving_yojson
@@ -52,6 +52,8 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" ];
 
   buildFlags = [ "libs" ];
+
+  enableParallelBuilding = true;
 
   postPatch = ''
     patchShebangs ulib/gen_mllib.sh
@@ -74,6 +76,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     changelog = "https://github.com/FStarLang/FStar/raw/v${version}/CHANGES.md";
     platforms = with platforms; darwin ++ linux;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ gebner pnmadelaine ];
   };
 }


### PR DESCRIPTION
###### Things done

- update fstar
- move sedlex-2_3 out of the list of ocaml dependencies for clarity
- enable parallel buidling
----
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
