### PR TITLE
pamixer: unstable-2021-03-29 -> 1.5

### DIFF
--- a/pkgs/applications/audio/pamixer/default.nix
+++ b/pkgs/applications/audio/pamixer/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pamixer";
-  version = "unstable-2021-03-29";
+  version = "1.5";
 
   src = fetchFromGitHub {
     owner = "cdemoulins";
     repo = "pamixer";
-    rev = "4ea2594cb8c605dccd00a381ba19680eba368e94";
-    sha256 = "sha256-kV4wIxm1WZvqqyfmgQ2cSbRJwJR154OW0MMDg2ntf6g=";
+    rev = version;
+    sha256 = "sha256-7VNhHAQ1CecQPlqb8SMKK0U1SsFZxDuS+QkPqJfMqrQ=";
   };
 
   buildInputs = [ boost libpulseaudio ];

--- a/pkgs/applications/audio/pamixer/default.nix
+++ b/pkgs/applications/audio/pamixer/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, boost, libpulseaudio, installShellFiles }:
+{ lib, stdenv, fetchFromGitHub, boost, libpulseaudio }:
 
 stdenv.mkDerivation rec {
   pname = "pamixer";
@@ -13,19 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost libpulseaudio ];
 
-  nativeBuildInputs = [ installShellFiles ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 pamixer -t $out/bin
-
-    runHook postInstall
-  '';
-
-  postInstall = ''
-    installManPage pamixer.1
-  '';
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
     description = "Pulseaudio command line mixer";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New release: https://github.com/cdemoulins/pamixer/releases/tag/1.5

Also, `pamixer` includes a perfectly fine Makefile. So use it to install.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
