### PR TITLE
urbackup-client: init at 2.4.11

### DIFF
--- a/pkgs/applications/backup/urbackup-client/default.nix
+++ b/pkgs/applications/backup/urbackup-client/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ wxGTK30 zlib zstd ];
 
   meta = with lib; {
-    description = "An easy to setup Open Source client/server backup system, that through a combination of image and file backups accomplishes both data safety and a fast restoration time";
+    description = "An easy to setup Open Source client/server backup system";
     homepage = "https://www.urbackup.org/index.html";
     license = licenses.agpl3;
     platforms = platforms.linux;

--- a/pkgs/applications/backup/urbackup-client/default.nix
+++ b/pkgs/applications/backup/urbackup-client/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An easy to setup Open Source client/server backup system";
+    longDescription = "An easy to setup Open Source client/server backup system, that through a combination of image and file backups accomplishes both data safety and a fast restoration time";
     homepage = "https://www.urbackup.org/index.html";
     license = licenses.agpl3;
     platforms = platforms.linux;

--- a/pkgs/applications/backup/urbackup-client/default.nix
+++ b/pkgs/applications/backup/urbackup-client/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchzip, wxGTK30, zlib, zstd }:
+
+stdenv.mkDerivation rec {
+  pname = "urbackup-client";
+  version = "2.4.11";
+
+  src = fetchzip {
+    url = "https://hndl.urbackup.org/Client/${version}/urbackup-client-${version}.tar.gz";
+    sha256 = "0cciy9v1pxj9qaklpbhp2d5rdbkmfm74vhpqx6b4phww0f10wvzh";
+  };
+
+  configureFlags = [ "--enable-embedded-cryptopp" ];
+  buildInputs = [ wxGTK30 zlib zstd ];
+
+  meta = with lib; {
+    description = "An easy to setup Open Source client/server backup system, that through a combination of image and file backups accomplishes both data safety and a fast restoration time";
+    homepage = "https://www.urbackup.org/index.html";
+    license = licenses.agpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mgttlinger ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12748,6 +12748,8 @@ with pkgs;
     icu = icu67;
   };
 
+  urbackup-client = callPackage ../applications/backup/urbackup-client { };
+
   vlang = callPackage ../development/compilers/vlang { };
 
   vala-lint = callPackage ../development/tools/vala-lint { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

package the urbackup-client to use the urbackup software from nixos

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
