### PR TITLE
[backport release 21.05]: newlib: Add parameter for "nano" variant

### DIFF
--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, buildPackages }:
+{ stdenv, fetchurl, buildPackages
+, # "newlib-nano" is what the official ARM embedded toolchain calls this build
+  # configuration that prioritizes low space usage. We include it as a preset
+  # for embedded projects striving for a similar configuration.
+  nanoizeNewlib ? false
+}:
 
 let version = "3.3.0";
 in stdenv.mkDerivation {
@@ -22,10 +27,21 @@ in stdenv.mkDerivation {
 
     "--disable-newlib-supplied-syscalls"
     "--disable-nls"
+    "--enable-newlib-retargetable-locking"
+  ] ++ (if !nanoizeNewlib then [
     "--enable-newlib-io-long-long"
     "--enable-newlib-register-fini"
-    "--enable-newlib-retargetable-locking"
-  ];
+  ] else [
+    "--enable-newlib-reent-small"
+    "--disable-newlib-fvwrite-in-streamio"
+    "--disable-newlib-fseek-optimization"
+    "--disable-newlib-wide-orient"
+    "--enable-newlib-nano-malloc"
+    "--disable-newlib-unbuf-stream-opt"
+    "--enable-lite-exit"
+    "--enable-newlib-global-atexit"
+    "--enable-newlib-nano-formatted-io"
+  ]);
 
   dontDisableStatic = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15006,6 +15006,7 @@ in
     else if name == "newlib" && stdenv.targetPlatform.isVc4 then targetPackages.vc4-newlib or vc4-newlib
     else if name == "newlib" && stdenv.targetPlatform.isOr1k then targetPackages.or1k-newlib or or1k-newlib
     else if name == "newlib" then targetPackages.newlibCross or newlibCross
+    else if name == "newlib-nano" then targetPackages.newlib-nanoCross or newlib-nanoCross
     else if name == "musl" then targetPackages.muslCross or muslCross
     else if name == "msvcrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
     else if name == "libSystem" then
@@ -31635,7 +31636,15 @@ in
   newlib = callPackage ../development/misc/newlib { };
   newlibCross = callPackage ../development/misc/newlib {
     stdenv = crossLibcStdenv;
-    };
+  };
+
+  newlib-nano = callPackage ../development/misc/newlib {
+    nanoizeNewlib = true;
+  };
+  newlib-nanoCross = callPackage ../development/misc/newlib {
+    nanoizeNewlib = true;
+    stdenv = crossLibcStdenv;
+  };
 
   omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };
 


### PR DESCRIPTION
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/140055

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
