### PR TITLE
wgpu: rename to wgpu-utils, use upstream tag

### DIFF
--- a/pkgs/tools/graphics/wgpu-utils/default.nix
+++ b/pkgs/tools/graphics/wgpu-utils/default.nix
@@ -1,17 +1,17 @@
 { lib, rustPlatform, fetchFromGitHub, pkg-config, makeWrapper, vulkan-loader }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "wgpu";
+  pname = "wgpu-utils";
   version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "gfx-rs";
-    repo = pname;
-    rev = "9da5c1d3a026c275feb57606b8c8d61f82b43386";
-    sha256 = "sha256-DcIMP06tlMxI16jqpKqei32FY8h7z41Nvygap2MQC8A=";
+    repo = "wgpu";
+    rev = "utils-${version}";
+    sha256 = "sha256-bOUcLtT5iPZuUgor2d/pJQ4Y+I1LMzREgj1cwLAvd+s=";
   };
 
-  cargoSha256 = "sha256-3gtIx337IP5t4nYGysOaU7SZRJrvVjYXN7mAqGbVlo8=";
+  cargoSha256 = "sha256-SSEG8JApQrgP7RWlXqb+xuy482oQZ5frE2IaVMruuG0=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10500,7 +10500,7 @@ with pkgs;
     });
   };
 
-  wgpu = callPackage ../tools/graphics/wgpu { };
+  wgpu-utils = callPackage ../tools/graphics/wgpu-utils { };
 
   wg-bond = callPackage ../applications/networking/wg-bond { };
 


### PR DESCRIPTION
###### Motivation for this change

After discussion with one of the developers in https://github.com/gfx-rs/wgpu/issues/1638#issuecomment-933492316 we decided to rename the newly added package. Also we got a git tag now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
