### PR TITLE
python3Packages.MDP: reenable tests

### DIFF
--- a/pkgs/development/python-modules/mdp/default.nix
+++ b/pkgs/development/python-modules/mdp/default.nix
@@ -1,4 +1,10 @@
-{ lib, buildPythonPackage, fetchPypi, pytest, future, numpy }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, future
+, numpy
+, pytest
+}:
 
 buildPythonPackage rec {
   pname = "MDP";
@@ -9,11 +15,27 @@ buildPythonPackage rec {
     sha256 = "ac52a652ccbaed1857ff1209862f03bf9b06d093b12606fb410787da3aa65a0e";
   };
 
-  checkInputs = [ pytest ];
   propagatedBuildInputs = [ future numpy ];
 
-  # Tests disabled because of missing dependencies not in nix
-  doCheck = false;
+  checkInputs = [ pytest ];
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "mdp" "bimdp" ];
+
+  postPatch = ''
+    # https://github.com/mdp-toolkit/mdp-toolkit/issues/92
+    substituteInPlace mdp/utils/routines.py --replace numx.typeDict numx.sctypeDict
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    pytest --seed 7710873 mdp
+    pytest --seed 7710873 bimdp
+
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "Library for building complex data processing software by combining widely used machine learning algorithms";


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tests were disabled years ago by 140136ad956 (mdp: disable tests, 2017-09-14) because of missing dependencies that are not in nixpkgs, but current version 3.6 prints a warning and run the tests just fine.

    ============================= test session starts ==============================
    platform darwin -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
              python: 3.9.6.final.0
                 mdp: 3.6
     parallel python: NOT AVAILABLE: No module named 'pp'
              shogun: NOT AVAILABLE: No module named 'shogun'
              libsvm: NOT AVAILABLE: No module named 'libsvm'
              joblib: NOT AVAILABLE: No module named 'joblib'
             sklearn: NOT AVAILABLE: No module named 'scikits'
                numx: numpy 1.21.2
              symeig: symeig_fake
    Random Seed: 7710873

###### Things done

Add a custom `checkPhase` to run `pytest`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
