### PR TITLE
command-not-found: remove NIX_AUTO_INSTALL

### DIFF
--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -25,14 +25,7 @@ if (!defined $res || scalar @$res == 0) {
     print STDERR "$program: command not found\n";
 } elsif (scalar @$res == 1) {
     my $package = @$res[0]->{package};
-    if ($ENV{"NIX_AUTO_INSTALL"} // "") {
-        print STDERR <<EOF;
-The program '$program' is currently not installed. It is provided by
-the package '$package', which I will now install for you.
-EOF
-        ;
-        exit 126 if system("nix-env", "-iA", "nixos.$package") == 0;
-    } elsif ($ENV{"NIX_AUTO_RUN"} // "") {
+    if ($ENV{"NIX_AUTO_RUN"} // "") {
         exec("nix-shell", "-p", $package, "--run", shell_quote("exec", @ARGV));
     } else {
         print STDERR <<EOF;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I think at this point it's pretty much consensus within the community that
`nix-env` is a footgun, especially for beginners. Previously we modified
`command-not-found.pl` to suggest `nix-shell` instead of `nix-env`, to avoid
newcomers from stumbling upon `nix-env` and taking that imperative escape hatch
to hell.

This PR removes the `NIX_AUTO_INSTALL` functionality from `command-not-found.pl`
altogether. This would enable users to configure `command-not-found` to
automatically install the missing binary for any command they type with
`nix-env`. I cannot see how this is desirable, and I don't think we should have
this option available. It's essentially a guaranteed way to cause havoc in your
environment.

cc. @edolstra

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
