### PR TITLE
gpsd: patch dependent packages to be compatible with version in nixpkgs

### DIFF
--- a/pkgs/applications/kde/marble.nix
+++ b/pkgs/applications/kde/marble.nix
@@ -2,7 +2,7 @@
 , extra-cmake-modules, kdoctools
 , qtscript, qtsvg, qtquickcontrols, qtwebengine
 , krunner, shared-mime-info, kparts, knewstuff
-, gpsd, perl
+, gpsd, perl, fetchpatch
 }:
 
 mkDerivation {
@@ -17,6 +17,15 @@ mkDerivation {
   propagatedBuildInputs = [
     qtscript qtsvg qtquickcontrols qtwebengine shared-mime-info krunner kparts
     knewstuff gpsd
+  ];
+  patches = [
+    (fetchpatch {
+      # Backport fix to allow compilation with gpsd 3.23.1
+      # Remove when marble compiles without the patch.
+      # See: https://invent.kde.org/education/marble/-/merge_requests/57
+      url = "https://invent.kde.org/education/marble/-/commit/8aadc3eb8f9484a65d497d442cd8c61fe1462bef.diff";
+      sha256 = "sha256-ZkPXyunVItSRctv6SLGIonvyZwLDhCz+wfJrIXeHcDo=";
+    })
   ];
   preConfigure = ''
     cmakeFlags+=" -DINCLUDE_INSTALL_DIR=''${!outputDev}/include"

--- a/pkgs/applications/misc/foxtrotgps/default.nix
+++ b/pkgs/applications/misc/foxtrotgps/default.nix
@@ -6,8 +6,8 @@ let
   srcs = {
     foxtrot = fetchbzr {
       url = "lp:foxtrotgps";
-      rev = "329";
-      sha256 = "0fwgnsrah63h1xdgm5xdi5ancrz89shdp5sdzw1qc1m7i9a03rid";
+      rev = "331";
+      sha256 = "sha256-/kJv6a3MzAzzwIl98Mqi7jrUJC1kDvouigf9kGtv868=";
     };
     screenshots = fetchbzr {
       url = "lp:foxtrotgps/screenshots";
@@ -17,7 +17,7 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "foxtrotgps";
-  version = "1.2.2+329";
+  version = "1.2.2+331";
 
   # Pull directly from bzr because gpsd API version 9 is not supported on latest release
   src = srcs.foxtrot;
@@ -39,12 +39,20 @@ in stdenv.mkDerivation rec {
   ];
 
   postUnpack = ''
-  cp -R ${srcs.screenshots} $sourceRoot/doc/screenshots
-  chmod -R u+w $sourceRoot/doc/screenshots
+    cp -R ${srcs.screenshots} $sourceRoot/doc/screenshots
+    chmod -R u+w $sourceRoot/doc/screenshots
+  '';
+
+  # Remove when foxtrotgps supports gpsd 3.23.1
+  # Patch for compatibility with gpsd 3.23.1. This was added for foxtrotgps
+  # 1.2.2+331. The command can be removed if the build of a newer version
+  # succeeds without it.
+  postPatch = ''
+    substituteInPlace src/gps_functions.c --replace "STATUS_NO_FIX" "STATUS_UNK"
   '';
 
   preConfigure = ''
-  intltoolize --automake --copy --force
+    intltoolize --automake --copy --force
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
gpsd 3.23.1 update (#139794) broke compilation of packages by updating the names of c macros (particularly STATUS_NO_FIX -> STATUS_UNK). Auto-patching them with substituteInPlace until upstream supports the new macros solves the issue. The KDE packages that failed to build only transitively depend on GPSD via marble, so that fix should allow the rest of the kde packages (calligra, kreport etc) to build successfully. 

The only package that still seems to be broken is timedoctor, i'm not sure how to proceed on that one since its extracted from an appimage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
