### PR TITLE
vimPlugins.nvim-treesitter: prefer queries from grammar repo

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -56,11 +56,12 @@ let
   builtGrammars =
     let
       change = name: grammar:
+        let src = fetchGrammar grammar; in
         callPackage ./grammar.nix { } {
           language = name;
           inherit version;
-          source = fetchGrammar grammar;
-          location = if grammar ? location then grammar.location else null;
+          src = "${src}/${grammar.location or "."}";
+          queriesSrc = "${src}/queries";
         };
       grammars' = (import ./grammars);
       grammars = grammars' //

--- a/pkgs/development/tools/parsing/tree-sitter/grammar.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammar.nix
@@ -12,22 +12,15 @@
   # version of tree-sitter
 , version
   # source for the language grammar
-, source
-, location ? null
+, src
+  # queries directory of the language if exists
+, queriesSrc
 }:
 
 stdenv.mkDerivation {
 
   pname = "${language}-grammar";
-  inherit version;
-
-  src =
-    if location == null
-    then
-      source
-    else
-      "${source}/${location}"
-  ;
+  inherit version src queriesSrc;
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
   buildInputs = [ tree-sitter ];
@@ -52,6 +45,9 @@ stdenv.mkDerivation {
     runHook preInstall
     mkdir $out
     mv parser $out/
+    if [[ -d "$queriesSrc" ]]; then
+      cp -r "$queriesSrc" $out/queries
+    fi
     runHook postInstall
   '';
 }


### PR DESCRIPTION
This prevent outdated queries being used when the parser repo is newer than nvim-treesitter itself like tree-sitter-toml.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tested via neovim.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
