### PR TITLE
usbrip: init at unstable-2021-07-02

### DIFF
--- a/pkgs/tools/security/usbrip/default.nix
+++ b/pkgs/tools/security/usbrip/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "usbrip";
+  version = "unstable-2021-07-02";
+
+  disabled = python3.pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "snovvcrash";
+    repo = pname;
+    rev = "0f3701607ba13212ebefb4bbd9e68ec0e22d76ac";
+    sha256 = "1vws8ybhv7szpqvlbmv0hrkys2fhhaa5bj9dywv3q2y1xmljl0py";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    termcolor
+    terminaltables
+    tqdm
+  ];
+
+  postPatch = ''
+    # Remove install helpers which we don't need
+    substituteInPlace setup.py \
+      --replace "parse_requirements('requirements.txt')," "[]," \
+      --replace "resolve('wheel')" "" \
+      --replace "'install': LocalInstallCommand," ""
+  '';
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "usbrip" ];
+
+  meta = with lib; {
+    description = "Tool to track the history of USB events";
+    homepage = "https://github.com/snovvcrash/usbrip";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19406,6 +19406,8 @@ with pkgs;
 
   usbredir = callPackage ../development/libraries/usbredir { };
 
+  usbrip = callPackage ../tools/security/usbrip { };
+
   uthash = callPackage ../development/libraries/uthash { };
 
   uthenticode = callPackage ../development/libraries/uthenticode { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to track the history of USB events

https://github.com/snovvcrash/usbrip

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
