### PR TITLE
python39Packages.ansible-lint: 5.0.8 -> 5.2.0

### DIFF
--- a/pkgs/development/python-modules/ansible-lint/default.nix
+++ b/pkgs/development/python-modules/ansible-lint/default.nix
@@ -18,13 +18,13 @@
 
 buildPythonPackage rec {
   pname = "ansible-lint";
-  version = "5.0.8";
+  version = "5.2.0";
   disabled = isPy27;
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-tnuWKEB66bwVuwu3H3mHG99ZP+/msGhMDMRL5fyQgD8=";
+    sha256 = "sha256-eQIDVtk/UD0syGmnJw48BDFtUQ4ztiZO3AjH0NsOgGE=";
   };
 
   nativeBuildInputs = [
@@ -52,18 +52,6 @@ buildPythonPackage rec {
     "--numprocesses" "auto"
   ];
 
-  postPatch = ''
-    # Both patches are addressed in https://github.com/ansible-community/ansible-lint/pull/1549
-    # and should be removed once merged upstream
-
-    # fixes test_get_yaml_files_umlaut and test_run_inside_role_dir
-    substituteInPlace src/ansiblelint/file_utils.py \
-      --replace 'os.path.join(root, name)' 'os.path.normpath(os.path.join(root, name))'
-    # fixes test_custom_kinds
-    substituteInPlace src/ansiblelint/file_utils.py \
-      --replace "if name.endswith('.yaml') or name.endswith('.yml')" ""
-  '';
-
   preCheck = ''
     # ansible wants to write to $HOME and crashes if it can't
     export HOME=$(mktemp -d)
@@ -80,8 +68,18 @@ buildPythonPackage rec {
 
   disabledTests = [
     # requires network
+    "test_cli_auto_detect"
+    "test_install_collection"
     "test_prerun_reqs_v1"
     "test_prerun_reqs_v2"
+    "test_require_collection_wrong_version"
+    # re-execs ansible-lint which does not works correct
+    "test_custom_kinds"
+    "test_run_inside_role_dir"
+    "test_run_multiple_role_path_no_trailing_slash"
+    "test_runner_exclude_globs"
+
+    "test_discover_lintables_umlaut"
   ];
 
   makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ ansible-base ]}" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
