### PR TITLE
python310: 3.10.0rc1 -> 3.10.0

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -198,9 +198,9 @@ in {
       major = "3";
       minor = "10";
       patch = "0";
-      suffix = "rc1";
+      suffix = "";
     };
-    sha256 = "0f76q6rsvbvrzcnsp0k7sp555krrgvjpcd09l1rybl4249ln2w3r";
+    sha256 = "sha256-Wpn456ahGnuYtOdeDRMD04MsraVTQGj2nHtiIqexsAI=";
     inherit (darwin) configd;
     inherit passthruFun;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://blog.python.org/2021/10/python-3100-is-available.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Note that `nix-build -A python310.tests` shows some test failures. How should we address these?

<details>
<summary><code>nix-build -A python310.tests</code></summary>
    
    ______________ Tester.test_class_decorator_respects_staticmethod _______________

    self = <tests.test_datetimes.Tester object at 0x7ffff5bb92a0>

        def test_class_decorator_respects_staticmethod(self):
    >       assert self.helper() == datetime.date(2012, 1, 14)

    tests/test_datetimes.py:450: 
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    args = (<tests.test_datetimes.Tester object at 0x7ffff5bb92a0>,), kwargs = {}
    time_factory = <freezegun.api.FrozenDateTimeFactory object at 0x7ffff5bb9300>

        def wrapper(*args, **kwargs):
            with self as time_factory:
                if self.as_arg and self.as_kwarg:
                    assert False, "You can't specify both as_arg and as_kwarg at the same time. Pick one."
                elif self.as_arg:
                    result = func(time_factory, *args, **kwargs)
                elif self.as_kwarg:
                    kwargs[self.as_kwarg] = time_factory
                    result = func(*args, **kwargs)
                else:
    >               result = func(*args, **kwargs)
    E               TypeError: Tester.helper() takes 0 positional arguments but 1 was given

    freezegun/api.py:778: TypeError
    =============================== warnings summary ===============================
    tests/test_asyncio.py::test_time_freeze_coroutine
    /build/freezegun-1.1.0/tests/test_asyncio.py:17: DeprecationWarning: There is no current event loop
        asyncio.get_event_loop().run_until_complete(frozen_coroutine())

    tests/test_asyncio.py::test_time_freeze_async_def
    <string>:5: DeprecationWarning: There is no current event loop

    -- Docs: https://docs.pytest.org/en/stable/warnings.html
    =========================== short test summary info ============================
    FAILED tests/test_datetimes.py::Tester::test_class_decorator_respects_staticmethod
</details>
