### PR TITLE
uboot: 2021.04 -> 2021.10

### DIFF
--- a/pkgs/misc/uboot/0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
+++ b/pkgs/misc/uboot/0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
@@ -1,0 +1,92 @@
+From 65d90cd17ad7cd3f9aeeb805a08be780fc5bae1a Mon Sep 17 00:00:00 2001
+From: Sjoerd Simons <sjoerd@collabora.com>
+Date: Sun, 22 Aug 2021 16:36:55 +0200
+Subject: [PATCH] rpi: Copy properties from firmware dtb to the loaded dtb
+
+The RPI firmware adjusts several property values in the dtb it passes
+to u-boot depending on the board/SoC revision. Inherit some of these
+when u-boot loads a dtb itself. Specificaly copy:
+
+* /model: The firmware provides a more specific string
+* /memreserve: The firmware defines a reserved range, better keep it
+* emmc2bus and pcie0 dma-ranges: The C0T revision of the bcm2711 Soc (as
+  present on rpi 400 and some rpi 4B boards) has different values for
+  these then the B0T revision. So these need to be adjusted to boot on
+  these boards
+* blconfig: The firmware defines the memory area where the blconfig
+  stored. Copy those over so it can be enabled.
+* /chosen/kaslr-seed: The firmware generates a kaslr seed, take advantage
+  of that.
+
+Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>
+Origin: https://patchwork.ozlabs.org/project/uboot/patch/20210822143656.289891-1-sjoerd@collabora.com/
+---
+ board/raspberrypi/rpi/rpi.c | 48 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
+index 372b26b6f2..64b8684b68 100644
+--- a/board/raspberrypi/rpi/rpi.c
++++ b/board/raspberrypi/rpi/rpi.c
+@@ -495,10 +495,58 @@ void *board_fdt_blob_setup(void)
+ 	return (void *)fw_dtb_pointer;
+ }
+ 
++int copy_property(void *dst, void *src, char *path, char *property)
++{
++	int dst_offset, src_offset;
++	const fdt32_t *prop;
++	int len;
++
++	src_offset = fdt_path_offset(src, path);
++	dst_offset = fdt_path_offset(dst, path);
++
++	if (src_offset < 0 || dst_offset < 0)
++		return -1;
++
++	prop = fdt_getprop(src, src_offset, property, &len);
++	if (!prop)
++		return -1;
++
++	return fdt_setprop(dst, dst_offset, property, prop, len);
++}
++
++/* Copy tweaks from the firmware dtb to the loaded dtb */
++void  update_fdt_from_fw(void *fdt, void *fw_fdt)
++{
++	/* Using dtb from firmware directly; leave it alone */
++	if (fdt == fw_fdt)
++		return;
++
++	/* The firmware provides a more precie model; so copy that */
++	copy_property(fdt, fw_fdt, "/", "model");
++
++	/* memory reserve as suggested by the firmware */
++	copy_property(fdt, fw_fdt, "/", "memreserve");
++
++	/* Adjust dma-ranges for the SD card and PCI bus as they can depend on
++	 * the SoC revision
++	 */
++	copy_property(fdt, fw_fdt, "emmc2bus", "dma-ranges");
++	copy_property(fdt, fw_fdt, "pcie0", "dma-ranges");
++
++	/* Bootloader configuration template exposes as nvmem */
++	if (copy_property(fdt, fw_fdt, "blconfig", "reg") == 0)
++		copy_property(fdt, fw_fdt, "blconfig", "status");
++
++	/* kernel address randomisation seed as provided by the firmware */
++	copy_property(fdt, fw_fdt, "/chosen", "kaslr-seed");
++}
++
+ int ft_board_setup(void *blob, struct bd_info *bd)
+ {
+ 	int node;
+ 
++	update_fdt_from_fw(blob, (void *)fw_dtb_pointer);
++
+ 	node = fdt_node_offset_by_compatible(blob, -1, "simple-framebuffer");
+ 	if (node < 0)
+ 		lcd_dt_simplefb_add_node(blob);
+-- 
+2.32.0
+

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -42,6 +42,11 @@ let
 
     patches = [
       ./0001-configs-rpi-allow-for-bigger-kernels.patch
+
+      # Make U-Boot forward some important settings from the firmware-provided FDT. Fixes booting on BCM2711C0 boards.
+      # See also: https://github.com/NixOS/nixpkgs/issues/135828
+      # Source: https://patchwork.ozlabs.org/project/uboot/patch/20210822143656.289891-1-sjoerd@collabora.com/
+      ./0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
     ] ++ extraPatches;
 
     postPatch = ''
@@ -108,7 +113,6 @@ let
       maintainers = with maintainers; [ dezgeg samueldr lopsided98 ];
     } // extraMeta;
   } // removeAttrs args [ "extraMeta" ]);
-
 in {
   inherit buildUBoot;
 

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -332,6 +332,12 @@ in {
     filesToInstall = ["u-boot.bin"];
   };
 
+  ubootQemuRiscv64Smode = buildUBoot {
+    defconfig = "qemu-riscv64_smode_defconfig";
+    extraMeta.platforms = ["riscv64-linux"];
+    filesToInstall = ["u-boot.bin"];
+  };
+
   ubootRaspberryPi = buildUBoot {
     defconfig = "rpi_defconfig";
     extraMeta.platforms = ["armv6l-linux"];

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -18,10 +18,10 @@
 }:
 
 let
-  defaultVersion = "2021.04";
+  defaultVersion = "2021.10";
   defaultSrc = fetchurl {
     url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
-    sha256 = "06p1vymf0dl6jc2xy5w7p42mpgppa46lmpm2ishmgsycnldqnhqd";
+    sha256 = "1m0bvwv8r62s4wk4w3cmvs888dhv9gnfa98dczr4drk2jbhj7ryd";
   };
   buildUBoot = {
     version ? null

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22258,6 +22258,7 @@ with pkgs;
     ubootPinebookPro
     ubootQemuAarch64
     ubootQemuArm
+    ubootQemuRiscv64Smode
     ubootRaspberryPi
     ubootRaspberryPi2
     ubootRaspberryPi3_32bit


### PR DESCRIPTION
###### Motivation for this change

Update U-Boot.

This includes changes from #139865, but ported forward to 2021.10.

@K900 I'll need a test to validate it actually works on a C0 variant.

This also includes changes from #125448, but ported forward to 2021.10.

@zhaofengli, it would be nice of you to test, but I guess that's not needed as your instructions on the PR were followed and it started just fine under QEMU.

I have not yet tested the build on any hardware.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
 $ nix-build --keep-going --no-out-link \<nixpkgs\> -A pkgsCross.armv7l-hf-multiplatform.ubootA20OlinuxinoLime -A pkgsCross.armv7l-hf-multiplatform.ubootAmx335xEVM -A pkgsCross.armv7l-hf-multiplatform.ubootBananaPi -A pkgsCross.armv7l-hf-multiplatform.ubootBananaPim3 -A pkgsCross.armv7l-hf-multiplatform.ubootBeagleboneBlack -A pkgsCross.armv7l-hf-multiplatform.ubootClearfog -A pkgsCross.armv7l-hf-multiplatform.ubootJetsonTK1 -A pkgsCross.armv7l-hf-multiplatform.ubootNovena -A pkgsCross.armv7l-hf-multiplatform.ubootOdroidXU3 -A pkgsCross.armv7l-hf-multiplatform.ubootOrangePiPc -A pkgsCross.armv7l-hf-multiplatform.ubootOrangePiZero -A pkgsCross.armv7l-hf-multiplatform.ubootPcduino3Nano -A pkgsCross.armv7l-hf-multiplatform.ubootQemuArm -A pkgsCross.armv7l-hf-multiplatform.ubootRaspberryPi2 -A pkgsCross.armv7l-hf-multiplatform.ubootRaspberryPi3_32bit -A pkgsCross.armv7l-hf-multiplatform.ubootRaspberryPi4_32bit -A pkgsCross.armv7l-hf-multiplatform.ubootUtilite -A pkgsCross.armv7l-hf-multiplatform.ubootWandboard

 $ nix-build --keep-going --no-out-link \<nixpkgs\> -A pkgsCross.aarch64-multiplatform.ubootBananaPim64 -A pkgsCross.aarch64-multiplatform.ubootNanoPCT4 -A pkgsCross.aarch64-multiplatform.ubootOdroidC2 -A pkgsCross.aarch64-multiplatform.ubootOrangePiZeroPlus2H5 -A pkgsCross.aarch64-multiplatform.ubootPine64 -A pkgsCross.aarch64-multiplatform.ubootPine64LTS -A pkgsCross.aarch64-multiplatform.ubootPinebook -A pkgsCross.aarch64-multiplatform.ubootPinebookPro -A pkgsCross.aarch64-multiplatform.ubootQemuAarch64 -A pkgsCross.aarch64-multiplatform.ubootROCPCRK3399 -A pkgsCross.aarch64-multiplatform.ubootRaspberryPi3_64bit -A pkgsCross.aarch64-multiplatform.ubootRaspberryPi4_64bit -A pkgsCross.aarch64-multiplatform.ubootRock64 -A pkgsCross.aarch64-multiplatform.ubootRockPi4 -A pkgsCross.aarch64-multiplatform.ubootRockPro64 -A pkgsCross.aarch64-multiplatform.ubootSopine
```