### PR TITLE
ms-dotnettools.csharp: 1.23.2 -> 1.23.15

### DIFF
--- a/pkgs/misc/vscode-extensions/_maintainers/update-bin-srcs-lib.sh
+++ b/pkgs/misc/vscode-extensions/_maintainers/update-bin-srcs-lib.sh
@@ -107,11 +107,13 @@ formatExtRuntimeDeps() {
 
   declare jqQuery
   jqQuery=$(cat <<'EOF'
-.runtimeDependencies \
-| map(select(.platforms[] | in({"linux": null}))) \
-| map(select(.architectures[] | in({"x86_64": null}))) \
-| .[] | {(.id + "-" + (.architectures[0]) + "-" + (.platforms[0])): \
-{installPath, binaries, urls: [.url, .fallbackUrl]}}
+.runtimeDependencies
+| map(select(.platforms[] | in({"linux": null})))
+| map(select(.architectures[] | in({"x86_64": null})))
+| .[] | {
+  (.id + "__" + (.architectures[0]) + "-" + (.platforms[0])):
+    {installPath, binaries, urls: [.url, .fallbackUrl] | map(select(. != null))}
+}
 EOF
 )
 

--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/default.nix
@@ -18,13 +18,12 @@ let
   rtDepsBinSrcs = builtins.mapAttrs (k: v:
       let
         # E.g: "OmniSharp-x86_64-linux"
-        kSplit = builtins.split "(-)" k;
+        kSplit = builtins.split "(__)" k;
         name = builtins.elemAt kSplit 0;
-        arch = builtins.elemAt kSplit 2;
-        platform = builtins.elemAt kSplit 4;
+        system = builtins.elemAt kSplit 2;
       in
       {
-        inherit name arch platform;
+        inherit name system;
         installPath = v.installPath;
         binaries = v.binaries;
         bin-src = fetchurl {
@@ -35,11 +34,8 @@ let
     )
     rtDepsSrcsFromJson;
 
-  arch = "x86_64";
-  platform = "linux";
-
   rtDepBinSrcByName = bSrcName:
-    rtDepsBinSrcs."${bSrcName}-${arch}-${platform}";
+    rtDepsBinSrcs."${bSrcName}__${stdenv.targetPlatform.system}";
 
   omnisharp = rtDepBinSrcByName "OmniSharp";
   vsdbg = rtDepBinSrcByName "Debugger";
@@ -50,8 +46,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "csharp";
     publisher = "ms-dotnettools";
-    version = "1.23.2";
-    sha256 = "0ydaiy8jfd1bj50bqiaz5wbl7r6qwmbz9b29bydimq0rdjgapaar";
+    version = "1.23.15";
+    sha256 = "0b74jr45zl7lzirjgj8s2lbf3viy9pbwlgjh055rcwmy77wcml1x";
   };
 
   nativeBuildInputs = [

--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/rt-deps-bin-srcs.json
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/rt-deps-bin-srcs.json
@@ -1,37 +1,36 @@
 {
-  "OmniSharp-x86_64-linux": {
-    "installPath": ".omnisharp/1.37.1",
+  "OmniSharp__x86_64-linux": {
+    "installPath": ".omnisharp/1.37.15",
     "binaries": [
       "./mono.linux-x86_64",
       "./run"
     ],
     "urls": [
-      "https://download.visualstudio.microsoft.com/download/pr/46933d64-075c-4f9f-b205-da4a839e2e3c/4bba2c3f40106056b53721c164ff86fa/omnisharp-linux-x64-1.37.1.zip",
-      "https://roslynomnisharp.blob.core.windows.net/releases/1.37.1/omnisharp-linux-x64-1.37.1.zip"
+      "https://download.visualstudio.microsoft.com/download/pr/4fbf71ce-5375-4ca9-b70d-8024ba1b9e0a/b96375395e639233d546a4937be3bd32/omnisharp-linux-x64-1.37.15.zip",
+      "https://roslynomnisharp.blob.core.windows.net/releases/1.37.15/omnisharp-linux-x64-1.37.15.zip"
     ],
-    "sha256": "0yzxkbq0fyq2bv0s7qmycxl0w54lla0vykg1a5lpv9j38k062vvz"
+    "sha256": "0pchywkxy8niq0i6gq2r43cmf58blfhhj8w8zyibf0m9h09h165s"
   },
-  "Debugger-x86_64-linux": {
+  "Debugger__x86_64-linux": {
     "installPath": ".debugger",
     "binaries": [
       "./vsdbg-ui",
       "./vsdbg"
     ],
     "urls": [
-      "https://download.visualstudio.microsoft.com/download/pr/292d2e01-fb93-455f-a6b3-76cddad4f1ef/2e9b8bc5431d8f6c56025e76eaabbdff/coreclr-debug-linux-x64.zip",
-      "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-22-2/coreclr-debug-linux-x64.zip"
+      "https://download.visualstudio.microsoft.com/download/pr/49f44239-bd47-4fb5-91be-4c91d7638fff/dd019b4c839f458596e26bfcfe6a3e7f/coreclr-debug-linux-x64.zip",
+      "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-23-14/coreclr-debug-linux-x64.zip"
     ],
-    "sha256": "1lhyjq6g6lc1b4n4z57g0ssr5msqgsmrl8yli8j9ah5s3jq1lrda"
+    "sha256": "0c5y0035sa07bl3m3iiqccqd92xjwpcfjrqhmi5xligk40q2i2gk"
   },
-  "Razor-x86_64-linux": {
+  "Razor__x86_64-linux": {
     "installPath": ".razor",
     "binaries": [
       "./rzls"
     ],
     "urls": [
-      "https://download.visualstudio.microsoft.com/download/pr/757f5246-2b09-43fe-9a8d-840cfd15092b/2b6d8eee0470acf725c1c7a09f8b6475/razorlanguageserver-linux-x64-6.0.0-alpha.1.20418.9.zip",
-      "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-6.0.0-alpha.1.20418.9.zip"
+      "https://download.visualstudio.microsoft.com/download/pr/b8678010-2cd7-4201-a5e7-ba57920607d5/b846e9c7d7afdba54a72fae1dcb6c42c/razorlanguageserver-linux-x64-6.0.0-preview.5.21358.6.zip"
     ],
-    "sha256": "1hksxq867anb9h040497phszq64f6krg4a46w0xqrm6crj8znqr5"
+    "sha256": "0gb36nlb7fgcv03a0awna1qyrsky6ys5gkpsmvxc5j35f1yq337b"
   }
 }

--- a/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/update-bin-srcs
+++ b/pkgs/misc/vscode-extensions/ms-dotnettools-csharp/update-bin-srcs
@@ -6,11 +6,11 @@ declare scriptDir
 scriptDir=$(cd "$(dirname "$0")"; pwd)
 1>&2 echo "scriptDir='$scriptDir'"
 
-. "$scriptDir/update-bin-srcs-lib.sh"
+. "$scriptDir/../_maintainers/update-bin-srcs-lib.sh"
 
 declare extPublisher="ms-dotnettools"
 declare extName="csharp"
-declare defaultExtVersion="1.23.2"
+declare defaultExtVersion="1.23.15"
 declare extVersion="${1:-$defaultExtVersion}"
 
 formatExtRuntimeDeps \
@@ -19,7 +19,3 @@ formatExtRuntimeDeps \
   | jqStreamToJson \
   | tee "$scriptDir/rt-deps-bin-srcs.json" \
   | jq '.'
-
-# TODO: Unfortunatly no simple json to nix implementation available.
-# This would allow us to dump to './rt-deps-bin-srcs.nix' instead.
-# jsonToNix


### PR DESCRIPTION

###### Motivation for this change

 -  Updating the package to latest.
 -  Minor refactor to allow reuse of maintainer tools from other extension packages.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Test run of the extension in isolation on an actual C# project. Syntax highlight seemed fine. Successfully hit breakpoints using the debugger.

Used the following shell to launch `code`:

```bash
$ nix-shell -I nixpkgs=. -p 'with import <nixpkgs> {}; vscode-with-extensions.override{ vscodeExtensions = with vscode-extensions; [ ms-dotnettools.csharp ]; }'
```