### PR TITLE
orpie: fix build

### DIFF
--- a/pkgs/applications/misc/orpie/default.nix
+++ b/pkgs/applications/misc/orpie/default.nix
@@ -13,12 +13,10 @@ ocamlPackages.buildDunePackage rec {
     sha256 = "1rx2nl6cdv609pfymnbq53pi3ql5fr4kda8x10ycd9xq2gc4f21g";
   };
 
+  patches = [ ./prefix.patch ];
+
   preConfigure = ''
-    patchShebangs scripts
-    substituteInPlace scripts/compute_prefix \
-      --replace '"topfind"' \
-      '"${ocamlPackages.findlib}/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib/topfind"'
-    export PREFIX=$out
+    substituteInPlace src/orpie/install.ml.in --replace '@prefix@' $out
   '';
 
   buildInputs = with ocamlPackages; [ curses camlp5 num gsl ];

--- a/pkgs/applications/misc/orpie/prefix.patch
+++ b/pkgs/applications/misc/orpie/prefix.patch
@@ -1,0 +1,11 @@
+--- a/src/orpie/dune	2021-10-05 06:09:09.040120000 +0200
++++ b/src/orpie/dune	2021-10-05 06:10:06.568418512 +0200
+@@ -18,7 +18,7 @@
+ ; Support $PREFIX for overriding installation location
+ (rule
+   (targets install.ml)
+-  (action (run %{project_root}/scripts/compute_prefix subst %{deps} %{targets}))
++  (action (copy# %{deps} %{targets}))
+   (deps (file install.ml.in)))
+ 
+ 


### PR DESCRIPTION
###### Motivation for this change

Build currently fails on darwin

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
