### PR TITLE
ms-python.python: fix #139813 and #137314 (lttng-ust and libstdc++ errors)

### DIFF
--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, vscode-utils, extractNuGet
-, icu, curl, openssl, lttng-ust, autoPatchelfHook
+, icu, curl, openssl, liburcu, lttng-ust, autoPatchelfHook
 , python3, musl
 , pythonUseFixed ? false       # When `true`, the python default setting will be fixed to specified.
                                # Use version from `PATH` for default setting otherwise.
@@ -12,6 +12,24 @@
 assert ctagsUseFixed -> null != ctags;
 
 let
+  liburcu-0-12 = liburcu.overrideAttrs (oldAttrs: rec {
+    version = "0.12.2";
+    src = fetchurl {
+      url = "https://lttng.org/files/urcu/userspace-rcu-${version}.tar.bz2";
+      sha256 = "0yx69kbx9zd6ayjzvwvglilhdnirq4f1x1sdv33jy8bc9wgc3vsf";
+    };
+  });
+
+  lttng-ust-2-10 = (lttng-ust.override {
+    liburcu = liburcu-0-12;
+  }).overrideAttrs (oldAttrs: rec {
+    version = "2.10.5";
+    src = fetchurl {
+      url = "https://lttng.org/files/lttng-ust/lttng-ust-${version}.tar.bz2";
+      sha256 = "0ddwk0nl28bkv2xb78gz16a2bvlpfbjmzwfbgwf5p1cq46dyvy86";
+    };
+  });
+
   pythonDefaultsTo = if pythonUseFixed then "${python3}/bin/python" else "python";
   ctagsDefaultsTo = if ctagsUseFixed then "${ctags}/bin/ctags" else "ctags";
 
@@ -54,7 +72,7 @@ in vscode-utils.buildVscodeMarketplaceExtension rec {
     icu
     curl
     openssl
-    lttng-ust
+    lttng-ust-2-10
     musl
   ];
 

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -94,7 +94,6 @@ in vscode-utils.buildVscodeMarketplaceExtension rec {
     substituteInPlace "./package.json" \
       --replace "\"default\": \"ctags\"" "\"default\": \"${ctagsDefaultsTo}\""
 
-
     # Similar cleanup to what's done in the `debugpy` python package.
     # This prevent our autopatchelf logic to bark on unsupported binaries (`attach_x86.so`
     # was problematic) but also should make our derivation less heavy.


### PR DESCRIPTION
###### Motivation for this change

 -  Fix #139813
 -  Fix #137314

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested the extension on an actual python project launching `code` from the following environment:

```bash
$ nix-shell -I nixpkgs=. -p 'with import <nixpkgs> {}; vscode-with-extensions.override{ vscodeExtensions = with vscode-extensions; [ ms-python.python ms-toolsai.jupyter ]; }'
```

Was able to debug, lint, type-check and use auto completion successfully. Seems to work fine.