### PR TITLE
vscode-utils: fix configure and build phase

### DIFF
--- a/pkgs/misc/vscode-extensions/vscode-utils.nix
+++ b/pkgs/misc/vscode-extensions/vscode-utils.nix
@@ -6,8 +6,14 @@ let
     # Same as "Unique Identifier" on the extension's web page.
     # For the moment, only serve as unique extension dir.
     vscodeExtUniqueId,
-    configurePhase ? ":",
-    buildPhase ? ":",
+    configurePhase ? ''
+      runHook preConfigure
+      runHook postConfigure
+    '',
+    buildPhase ?''
+      runHook preBuild
+      runHook postBuild
+    '',
     dontPatchELF ? true,
     dontStrip ? true,
     buildInputs ? [],


### PR DESCRIPTION
###### Motivation for this change

Fix problematic nix code that bit me while I was experimenting. 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
