### PR TITLE
tree-sitter: update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "c9e1952d311cf87762a42a79cb801c7bef1af815",
-  "date": "2021-09-09T23:38:47+01:00",
-  "path": "/nix/store/cl05d3zpbbkhms5fmd6wc4jhasjhg12l-tree-sitter-c-sharp",
-  "sha256": "0kn7p203ij8vz1cdxmxvn85mf3hpmz08l5psza96xxif2lcz8li8",
+  "rev": "52ad1d506debcd4623d641339f8f452e6ea8f10c",
+  "date": "2021-09-23T08:24:24+01:00",
+  "path": "/nix/store/ag2r3d659gj14hgfgdf0nv5dwcihxy3w-tree-sitter-c-sharp",
+  "sha256": "1n8jnw2yp966svkcyh68wwwbqjhrvhykzxilj6k8rn5yx9lpymz5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "f71e80b9f20c3968c131518ae8d272a3cf81a60b",
-  "date": "2021-09-18T14:26:00-05:00",
-  "path": "/nix/store/22iw8rdpmvxmyrsmxxbyx8yi44jq05qd-tree-sitter-c",
-  "sha256": "13qr8ms8w7y92a33p0wisg4kzj4q3dzi2bn7wd6x815j8hfz627q",
+  "rev": "e348e8ec5efd3aac020020e4af53d2ff18f393a9",
+  "date": "2021-09-20T10:21:48-07:00",
+  "path": "/nix/store/bnc2zml2igbpprx4i0h053inv023z6nj-tree-sitter-c",
+  "sha256": "0fmh8b94ra5fi0j9by9yqbc1pf9sh9pjwc3symrslg855w8a0yx7",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-comment",
-  "rev": "8d480c0a86e3b95812252d29292b2686eb92418d",
-  "date": "2021-08-13T15:03:50-05:00",
-  "path": "/nix/store/4aqsac34f0pzpa889067dqci743axrmx-tree-sitter-comment",
-  "sha256": "0fqhgvpd391nxrpyhxcp674h8qph280ax6rm6dz1pj3lqs3grdka",
+  "rev": "5dd3c62f1bbe378b220fe16b317b85247898639e",
+  "date": "2021-10-01T17:13:56-05:00",
+  "path": "/nix/store/isrc5wlyxvcawfj35yi4nmblshy69b1j-tree-sitter-comment",
+  "sha256": "1wk6lxzndaikbrn72pa54y59qs0xnfaffc8mxmm6c5v5x16l8vb3",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "8b112a131b910ec009853fc9dd1c27eae267a7a6",
-  "date": "2021-09-18T10:53:12-05:00",
-  "path": "/nix/store/bpfw6wckk0yfpr99nrv473g3r3b84vbv-tree-sitter-cpp",
-  "sha256": "0rskvx5krakfkkcmiv9qd0zf8rf63iaigv76x3dq7v00sj8m0xsn",
+  "rev": "a7652fce5943c9d5d9c49dd8e3256a699aa33bf5",
+  "date": "2021-09-24T15:54:22-05:00",
+  "path": "/nix/store/9q4xnklmv1220yjgwdz96qf0l8swx2j6-tree-sitter-cpp",
+  "sha256": "10dbif87axvban83mglvh81gjckbp7qya0rf525s10h8ihy7rbpm",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/rydesun/tree-sitter-dot",
-  "rev": "e6f55c43b87b81cc982e38d414f0147fefa2515c",
-  "date": "2021-09-01T14:36:57+08:00",
-  "path": "/nix/store/n5a6bzh8rf35865wvcr3cis9r0fn2047-tree-sitter-dot",
-  "sha256": "1s3fpd0lnbm3gk9nbskdkdjlmdm7kz0l0g2zipv1m7qkc05nnkfy",
+  "rev": "3a32e207e126a7f1cdd17de2473db1f03e6a3dac",
+  "date": "2021-10-05T10:30:04+08:00",
+  "path": "/nix/store/zz4sj2r6jyl7k4l7g8qggr0gv4wh5nx7-tree-sitter-dot",
+  "sha256": "17j8spga68y40fy2yizpkx7bmxp7h5p9l334w2b0685w2mnvrlgg",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elisp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elisp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/wilfred/tree-sitter-elisp",
-  "rev": "166777abacfe5821d3b7b6873e6d2fd70a99f348",
-  "date": "2021-09-05T23:34:46-07:00",
-  "path": "/nix/store/gfyr8hl9pj2i0dj0qqpwh53jphff2bcd-tree-sitter-elisp",
-  "sha256": "18798jb3cisrvhkmzhq2qxly19hxvznf9k1n5pzl8l1dhw1yvl2a",
+  "rev": "4b0e4a3891337514126ec72c7af394c0ff2cf48c",
+  "date": "2021-10-02T12:14:40-07:00",
+  "path": "/nix/store/1g3q3xzv5n9wzi84awrlbxwm6q3zh8qz-tree-sitter-elisp",
+  "sha256": "1g6qmpxn1y9hzk2kkpp9gpkphaq9j7vvm4nl5zv8a4wzy3w8p1wv",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/travonted/tree-sitter-fennel",
-  "rev": "42823442a18dd2aa7b0b22dc719abb54abb3fe2e",
-  "date": "2021-09-08T19:22:08-04:00",
-  "path": "/nix/store/2v174r3fc3cqsy8yanq2kdcjqvzl1jx9-tree-sitter-fennel",
-  "sha256": "0a59hgx7mmdicw9fq2q8dcd2ffmcgjdkk3rpwj84ya1qiyvs5x5s",
+  "rev": "fce4331731a960077ff5f98939bc675179f1908a",
+  "date": "2021-09-30T09:09:52-04:00",
+  "path": "/nix/store/mhpkw4gl6lzi306q21kckafqcdc0a715-tree-sitter-fennel",
+  "sha256": "1k8acyav26248liz0psk2r9dl7472mqgdyrjwg3pfxx94jgqjcik",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "42b1e657c3a394c01df51dd3eadc8b214274a73c",
-  "date": "2021-08-16T18:29:17+02:00",
-  "path": "/nix/store/a1crqhfrd8v9g9w0565aca7nc9k2x7a0-tree-sitter-go",
-  "sha256": "1khsl8qz6r4dqw7h43m3jw3iqhh79sgpnsps0jy95f165iy496z3",
+  "rev": "7f6bfd0161b2fe97f03564edad3287ebea0494a3",
+  "date": "2021-10-04T13:10:27-04:00",
+  "path": "/nix/store/64xzxzc8z4fmwhfb7wbdkcxlk7r3bia2-tree-sitter-go",
+  "sha256": "12naks95vzb0sf219i39myvfpkycr2dh3lv7i7i6kwddmlhqsjnl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "435db852fbeff8fe298e25ad967c634d9698eec0",
-  "date": "2021-09-13T13:32:20-07:00",
-  "path": "/nix/store/idvb37g3nqpidw0jviiw4b71sqpihhs0-tree-sitter-javascript",
-  "sha256": "0plc5jxxh1bm1dig6gsk1ma7gp29ad3p0169jd9xlagc4vysfgc3",
+  "rev": "fdeb68ac8d2bd5a78b943528bb68ceda3aade2eb",
+  "date": "2021-10-04T13:07:24-04:00",
+  "path": "/nix/store/psmsgqhg4di7mkkd6sgyvcs41jvvq2c3-tree-sitter-javascript",
+  "sha256": "175yrk382n2di0c2xn4gpv8y4n83x1lg4hqn04vabf0yqynlkq67",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "d1bdb1e535d39d4f93f7373f406e1837c8a7bb25",
-  "date": "2021-09-10T08:16:50+02:00",
-  "path": "/nix/store/4zzs4f1hz5il35pqyf355aps6k4a83i8-tree-sitter-php",
-  "sha256": "0ymkwlh1japlwsajxd06254qadzq9bvm5db02cg4n3zv0pkvyrzz",
+  "rev": "31550c1506b2033c5631cd18886edd600b67861e",
+  "date": "2021-09-27T11:44:23-07:00",
+  "path": "/nix/store/bls6gpbwqacgz7hr900khlfhbal29y27-tree-sitter-php",
+  "sha256": "1qykyziapwmw5qhd5svawzksp4w9hjdql84d7lqs3w0dfa60bjax",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "9b84b7fd9da1aa74c8a8afae58b7dcc4c109cda4",
-  "date": "2021-09-16T13:02:06+02:00",
-  "path": "/nix/store/vxh1bdkdqj3n6knlz6bbdyl5l4qj2a2v-tree-sitter-python",
-  "sha256": "0r5daw3pbqcaf08gnhghjr15n7vv43njvh4ky6vz985sjzdnjz02",
+  "rev": "8600d7fadf5a51b9396eacbc6d105d0649b4c6f6",
+  "date": "2021-09-30T09:07:59-07:00",
+  "path": "/nix/store/0m86a8y8p8cxq616gacd5wydhayl8g70-tree-sitter-python",
+  "sha256": "0ydiizy1jhmfv0kr7xw9k57jgfpkda95nc1rawzqmsxd7nixnrkp",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-rst",
-  "rev": "a9281c2250e0d32750de159413cdd87120407389",
-  "date": "2021-09-17T19:21:59-05:00",
-  "path": "/nix/store/3cnj1q9xfl0yh096pahqvlrf66azyhsr-tree-sitter-rst",
-  "sha256": "1fxknsmkn3pz1km77mii3w917fdl6h57h4mnw20b0syn4v1ag07d",
+  "rev": "632596b1fe5816315cafa90cdf8f8000e30c93e4",
+  "date": "2021-10-01T17:00:56-05:00",
+  "path": "/nix/store/pnbw1j9ynj4zgjqxjnhq9hgqp3nxm77j-tree-sitter-rst",
+  "sha256": "1l831aw4a080qin7dkq04b28nnyxs1r8zqrbp92d7j4y2lz31dla",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "3383cebec9c9546587d9fe00c2e565d91163014a",
-  "date": "2021-09-16T13:01:51-07:00",
-  "path": "/nix/store/ml188xckf51g1r6gw380svxsg639kjgc-tree-sitter-typescript",
-  "sha256": "0vgkhn36cyg134ygx5wzld3ic9rd4lq9s2rp2dkxh0zg610ilcms",
+  "rev": "ef6ee5b39d6c4660809a61c1c8556fb547283864",
+  "date": "2021-10-04T11:58:33-05:00",
+  "path": "/nix/store/ny8gc7l6hpa4snhccyw3149f7s92071l-tree-sitter-typescript",
+  "sha256": "1gyim8yackz9pq6s62wrywr3gsgwa68jwvd0s6i28xxvln2r7wlb",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-verilog",
-  "rev": "1b624ab8b3f8d54ecc37847aa04512844f0226ac",
-  "date": "2021-03-31T21:27:26-07:00",
-  "path": "/nix/store/4j6hrf8bc8zjd7r9xnna9njpw0i4z817-tree-sitter-verilog",
-  "sha256": "0ygm6bdxqzpl3qn5l58mnqyj730db0mbasj373bbsx81qmmzkgzz",
+  "rev": "6fae7414fa854b5052bee9111b200e9137797f3d",
+  "date": "2021-10-04T10:25:49-07:00",
+  "path": "/nix/store/aklrgpy0si72r8vac5fqjbzvcpqiy5lk-tree-sitter-verilog",
+  "sha256": "0yjhb2rp7drwkwfp35fgwnp6d7qf6k1k6zlf0dfxygjywnjy0bfs",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "59595443fb486449f42db839934117221358a85f",
-  "date": "2021-08-31T08:57:29+02:00",
-  "path": "/nix/store/9sixkkk37c2bl09aik32cd1jd322ywri-tree-sitter-viml",
-  "sha256": "1kh3il5vwlz5qxi9553ks7a0dpwx1n7wnqkv5v8jhslhn7w1c1l1",
+  "rev": "fd7bc35927ab44670e02d5ad035e0363f4ffde2b",
+  "date": "2021-09-27T15:41:51+02:00",
+  "path": "/nix/store/q2z07daw81cgn15z79qsfdqc2jc8ib9l-tree-sitter-viml",
+  "sha256": "0s1bp1c8p2ify67x49fv9wh0brn98lix3742zlds892985xl9zrj",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/maxxnino/tree-sitter-zig",
-  "rev": "5ca53bb7bd649069a6af48f4dfd32f3187491db1",
-  "date": "2021-09-06T21:30:14+09:00",
-  "path": "/nix/store/x2dfgc97jmvyq5fnbyg9w7rsjz8cknj6-tree-sitter-zig",
-  "sha256": "1c50pvza6l4snmvgj3by053j4z7asy828i9pi1zwm6121sl7ffpd",
+  "rev": "1f27fd1dfe7f352408f01b4894c7825f3a1d6c47",
+  "date": "2021-09-20T17:51:34+09:00",
+  "path": "/nix/store/c4slv3kpl9dxi2fn6nbhar098ikpfivf-tree-sitter-zig",
+  "sha256": "1sbxvn400wizwwgjw7qcxb0z9gazvzcp3z2986lblff2xw8759vw",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
