### PR TITLE
telepresence: 0.108 -> 0.109

### DIFF
--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -4,8 +4,8 @@
 
 let
   sshuttle-telepresence = lib.overrideDerivation sshuttle (p: {
-        postInstall = "mv $out/bin/sshuttle $out/bin/sshuttle-telepresence";
-      });
+    postInstall = "mv $out/bin/sshuttle $out/bin/sshuttle-telepresence";
+  });
 in pythonPackages.buildPythonPackage rec {
   pname = "telepresence";
   version = "0.109";

--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -3,32 +3,18 @@
 , iptables, bash }:
 
 let
-  sshuttle-telepresence =
-    let
-      sshuttleTelepresenceRev = "32226ff14d98d58ccad2a699e10cdfa5d86d6269";
-    in
-      lib.overrideDerivation sshuttle (p: {
-        src = fetchFromGitHub {
-          owner = "datawire";
-          repo = "sshuttle";
-          rev = sshuttleTelepresenceRev;
-          sha256 = "1lp5b0h9v59igf8wybjn42w6ajw08blhiqmjwp4r7qnvmvmyaxhh";
-        };
-
-        SETUPTOOLS_SCM_PRETEND_VERSION="${sshuttleTelepresenceRev}";
-
-        postPatch = "rm sshuttle/tests/client/test_methods_nat.py";
+  sshuttle-telepresence = lib.overrideDerivation sshuttle (p: {
         postInstall = "mv $out/bin/sshuttle $out/bin/sshuttle-telepresence";
       });
 in pythonPackages.buildPythonPackage rec {
   pname = "telepresence";
-  version = "0.108";
+  version = "0.109";
 
   src = fetchFromGitHub {
     owner = "telepresenceio";
     repo = "telepresence";
     rev = version;
-    sha256 = "6V0sM0Z+2xNDgL0wIzJOdaUp2Ol4ejNTk9K/pllVa7g=";
+    sha256 = "1ccc8bzcdxp6rh6llk7grcnmyc05fq7dz5w0mifdzjv3a473hsky";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Version bump and remove dependency on old sshuttle version.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
