### PR TITLE
s6-rc: fix source hash

### DIFF
--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -5,7 +5,7 @@ with skawarePackages;
 buildPackage {
   pname = "s6-rc";
   version = "0.5.2.3";
-  sha256 = "1f92dxw1n8r8avamixi9k0gqbnkpm0r3fmwzz7jd82g6bb2vsg5z";
+  sha256 = "1xyaplwzvqnb53mg59a7jklakzwsiqivp6qggsry3sbaw4hf3d5j";
 
   description = "A service manager for s6-based systems";
   platforms = lib.platforms.unix;


### PR DESCRIPTION
The tarball appears to have been re-uploaded, because both
Profpatsch[1] and r-rmcgibbo[2] got the previous hash, but by the time
it got to Hydra, the hash had changed[3].

By getting Profpatsch to send me his cached tarball, and comparing
each to the s6-rc git repo, I've determined that the difference
between them is a fast-forward of 7cadbf1..3d1af07 (summarised below).

So I think we're fine to bump the hash — it looks like some commits
were just mistakenly excluded the first time round.

Laurent Bercot (2):
      Add lock-fd support
      version: 0.5.2.3

 NEWS                                   | 1 +
 src/libs6rc/s6rc_servicedir_internal.c | 1 +
 src/s6-rc/s6-rc-compile.c              | 9 +++++++++
 3 files changed, 11 insertions(+)

<details>
<summary>Diffoscope output</summary>
<article>

# Comparing s6-rc-0.5.2.3.tar.gz & /nix/store/mrkxlfvj10z4aklrp1i2z0v7r5myqf9v-s6-rc-0.5.2.3.tar.gz

## Comparing s6-rc-0.5.2.3.tar & mrkxlfvj10z4aklrp1i2z0v7r5myqf9v-s6-rc-0.5.2.3.tar

### file list

    @@ -1,8 +1,8 @@
    -drwxr-sr-x   0        0        0        0 2021-09-26 11:25:49.000000 s6-rc-0.5.2.3/
    +drwxr-sr-x   0        0        0        0 2021-09-26 17:16:20.000000 s6-rc-0.5.2.3/
     drwxr-sr-x   0        0        0        0 2017-05-21 10:48:35.000000 s6-rc-0.5.2.3/examples/
     -rw-r--r--   0        0        0      508 2015-07-12 05:31:53.000000 s6-rc-0.5.2.3/examples/README
     drwxr-xr-x   0        0        0        0 2018-08-21 05:33:33.000000 s6-rc-0.5.2.3/examples/source/
     drwxr-xr-t   0        0        0        0 2018-08-21 05:37:42.000000 s6-rc-0.5.2.3/examples/source/taiclockd-4/
     -rwxr-xr-x   0        0        0      114 2017-09-13 16:13:17.000000 s6-rc-0.5.2.3/examples/source/taiclockd-4/run
     -rw-r--r--   0        0        0        9 2015-07-08 18:02:14.000000 s6-rc-0.5.2.3/examples/source/taiclockd-4/dependencies
     -rw-r--r--   0        0        0        8 2015-07-08 18:02:23.000000 s6-rc-0.5.2.3/examples/source/taiclockd-4/type
    @@ -366,44 +366,44 @@
     -rw-r--r--   0        0        0      171 2017-11-27 19:23:27.000000 s6-rc-0.5.2.3/README.macos
     -rw-r--r--   0        0        0      427 2014-08-24 14:25:42.000000 s6-rc-0.5.2.3/README.solaris
     -rw-r--r--   0        0        0      654 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/AUTHORS
     -rw-r--r--   0        0        0     6663 2021-08-10 18:14:57.000000 s6-rc-0.5.2.3/INSTALL
     -rwxr-xr-x   0        0        0      489 2014-12-16 02:35:39.000000 s6-rc-0.5.2.3/patch-for-solaris
     -rw-r--r--   0        0        0      890 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/README
     drwxr-xr-x   0        0        0        0 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/src/
    -drwxr-xr-x   0        0        0        0 2021-09-26 11:25:49.000000 s6-rc-0.5.2.3/src/libs6rc/
    +drwxr-xr-x   0        0        0        0 2021-09-26 17:15:06.000000 s6-rc-0.5.2.3/src/libs6rc/
     -rw-r--r--   0        0        0     1197 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_graph_closure.c
     -rw-r--r--   0        0        0      594 2021-09-02 13:56:30.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_servicedir_block.c
     -rw-r--r--   0        0        0      288 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_db_read_uint32.c
     -rw-r--r--   0        0        0     1071 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_db_read_sizes.c
     -rw-r--r--   0        0        0     5433 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_db_read.c
     -rw-r--r--   0        0        0      471 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_read_uint.c
     -rw-r--r--   0        0        0      794 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc-servicedir-internal.h
     -rw-r--r--   0        0        0     1746 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_livedir_create.c
     -rw-r--r--   0        0        0      492 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_livedir_prefix.c
     drwxr-xr-x   0        0        0        0 2021-07-24 16:30:53.000000 s6-rc-0.5.2.3/src/libs6rc/deps-exe/
     -rw-r--r--   0        0        0      477 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_servicedir_copy_offline.c
    --rw-r--r--   0        0        0     2913 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_servicedir_internal.c
    +-rw-r--r--   0        0        0     2975 2021-09-26 17:06:12.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_servicedir_internal.c
     -rw-r--r--   0        0        0      624 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_sanitize_dir.c
     -rw-r--r--   0        0        0     1322 2021-09-02 13:56:09.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_servicedir_manage.c
     -rw-r--r--   0        0        0      584 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_livedir_prefixsize.c
     -rw-r--r--   0        0        0     1256 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_lock.c
     -rw-r--r--   0        0        0     1433 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_db_check_depcycles.c
     -rw-r--r--   0        0        0     1597 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_db_check_pipelines.c
     -rw-r--r--   0        0        0      739 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_db_check_revdeps.c
     -rw-r--r--   0        0        0      488 2021-09-02 13:56:02.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_servicedir_unblock.c
     -rw-r--r--   0        0        0      604 2021-09-02 13:55:48.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_servicedir_unsupervise.c
     -rw-r--r--   0        0        0     2134 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/libs6rc/s6rc_servicedir_copy_online.c
     drwxr-xr-x   0        0        0        0 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/src/libs6rc/deps-lib/
     -rw-r--r--   0        0        0      482 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/src/libs6rc/deps-lib/s6rc
     drwxr-xr-x   0        0        0        0 2021-07-21 11:21:38.000000 s6-rc-0.5.2.3/src/include-local/
    -drwxr-xr-x   0        0        0        0 2021-09-26 11:25:49.000000 s6-rc-0.5.2.3/src/s6-rc/
    +drwxr-xr-x   0        0        0        0 2021-09-26 17:15:06.000000 s6-rc-0.5.2.3/src/s6-rc/
     -rw-r--r--   0        0        0     2004 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-format-upgrade.c
     -rw-r--r--   0        0        0    28495 2021-09-02 13:56:56.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-update.c
    --rw-r--r--   0        0        0    52581 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-compile.c
    +-rw-r--r--   0        0        0    52929 2021-09-26 17:14:40.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-compile.c
     -rw-r--r--   0        0        0     1296 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-dryrun.c
     -rw-r--r--   0        0        0     3205 2021-09-02 13:57:16.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-fdholder-filler.c
     drwxr-xr-x   0        0        0        0 2019-09-19 16:01:24.000000 s6-rc-0.5.2.3/src/s6-rc/deps-exe/
     -rw-r--r--   0        0        0       80 2019-09-19 16:01:24.000000 s6-rc-0.5.2.3/src/s6-rc/deps-exe/s6-rc-update
     -rw-r--r--   0        0        0       26 2019-09-19 16:01:24.000000 s6-rc-0.5.2.3/src/s6-rc/deps-exe/s6-rc-dryrun
     -rw-r--r--   0        0        0       32 2016-01-12 16:18:46.000000 s6-rc-0.5.2.3/src/s6-rc/deps-exe/s6-rc-bundle
     -rw-r--r--   0        0        0       69 2019-09-19 16:01:24.000000 s6-rc-0.5.2.3/src/s6-rc/deps-exe/s6-rc-init
    @@ -416,15 +416,15 @@
     -rw-r--r--   0        0        0    18710 2021-09-02 13:56:44.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc.c
     -rw-r--r--   0        0        0    10110 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-bundle.c
     -rw-r--r--   0        0        0     2937 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-oneshot-run.c
     -rw-r--r--   0        0        0    14869 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-db.c
     -rw-r--r--   0        0        0     3758 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/s6-rc/s6-rc-init.c
     drwxr-xr-x   0        0        0        0 2015-02-22 15:57:43.000000 s6-rc-0.5.2.3/src/s6-rc/deps-lib/
     drwxr-xr-x   0        0        0        0 2021-07-24 11:12:37.000000 s6-rc-0.5.2.3/src/include/
    -drwxr-xr-x   0        0        0        0 2021-09-26 11:25:49.000000 s6-rc-0.5.2.3/src/include/s6-rc/
    +drwxr-xr-x   0        0        0        0 2021-09-26 17:16:20.000000 s6-rc-0.5.2.3/src/include/s6-rc/
     -rw-r--r--   0        0        0      776 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/include/s6-rc/s6rc-servicedir.h
     -rw-r--r--   0        0        0      743 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/include/s6-rc/s6rc-utils.h
     -rw-r--r--   0        0        0     1787 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/include/s6-rc/s6rc-db.h
     -rw-r--r--   0        0        0      336 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/include/s6-rc/s6rc-constants.h
     -rw-r--r--   0        0        0      185 2021-08-09 23:32:25.000000 s6-rc-0.5.2.3/src/include/s6-rc/s6rc.h
     drwxr-sr-x   0        0        0        0 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/package/
     -rw-r--r--   0        0        0     7872 2021-07-24 16:31:04.000000 s6-rc-0.5.2.3/package/deps.mak
    @@ -435,15 +435,15 @@
     -rw-r--r--   0        0        0      760 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/COPYING
     -rwxr-xr-x   0        0        0    14019 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/configure
     -rw-r--r--   0        0        0     1421 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/DCO
     drwxr-sr-x   0        0        0        0 2019-10-21 17:15:33.000000 s6-rc-0.5.2.3/tools/
     -rwxr-xr-x   0        0        0      957 2014-07-27 14:36:43.000000 s6-rc-0.5.2.3/tools/install.sh
     -rwxr-xr-x   0        0        0     2531 2019-10-21 17:15:33.000000 s6-rc-0.5.2.3/tools/gen-deps.sh
     -rw-r--r--   0        0        0      287 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/CONTRIBUTING
    --rw-r--r--   0        0        0     3813 2021-08-10 18:15:33.000000 s6-rc-0.5.2.3/NEWS
    +-rw-r--r--   0        0        0     3843 2021-09-26 17:15:46.000000 s6-rc-0.5.2.3/NEWS
     -rw-r--r--   0        0        0     4732 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/Makefile
     drwxr-sr-x   0        0        0        0 2021-07-29 12:17:25.000000 s6-rc-0.5.2.3/doc/
     -rw-r--r--   0        0        0     4750 2017-05-23 11:01:02.000000 s6-rc-0.5.2.3/doc/s6-rc-bundle.html
     -rw-r--r--   0        0        0    16761 2020-08-20 14:06:21.000000 s6-rc-0.5.2.3/doc/s6-rc.html
     -rw-r--r--   0        0        0     4819 2021-08-10 18:15:17.000000 s6-rc-0.5.2.3/doc/index.html
     -rw-r--r--   0        0        0     2202 2017-05-23 11:01:02.000000 s6-rc-0.5.2.3/doc/s6-rc-dryrun.html
     -rw-r--r--   0        0        0    16527 2020-10-04 17:17:21.000000 s6-rc-0.5.2.3/doc/faq.html

### s6-rc-0.5.2.3/src/libs6rc/s6rc_servicedir_internal.c

    @@ -14,14 +14,15 @@
     static s6rc_servicedir_desc_t const svdir_file_list[] =
     {
       { .name = "finish", .type = FILETYPE_NORMAL, .options = SVFILE_EXECUTABLE | SVFILE_ATOMIC },
       { .name = "finish.user", .type = FILETYPE_NORMAL, .options = SVFILE_EXECUTABLE },
       { .name = "run", .type = FILETYPE_NORMAL, .options = SVFILE_EXECUTABLE | SVFILE_MANDATORY | SVFILE_ATOMIC },
       { .name = "run.user", .type = FILETYPE_NORMAL, .options = SVFILE_EXECUTABLE },
       { .name = "notification-fd", .type = FILETYPE_UINT, .options = 0 },
    +  { .name = "lock-fd", .type = FILETYPE_UINT, .options = 0 },
       { .name = "timeout-kill", .type = FILETYPE_UINT, .options = 0 },
       { .name = "timeout-finish", .type = FILETYPE_UINT, .options = 0 },
       { .name = "max-death-tally", .type = FILETYPE_UINT, .options = 0 },
       { .name = "down-signal", .type = FILETYPE_NORMAL, .options = 0 },
       { .name = "data", .type = FILETYPE_DIR, .options = 0 },
       { .name = "env", .type = FILETYPE_DIR, .options = 0 },
       { .name = 0, .options = 0 }

### s6-rc-0.5.2.3/src/s6-rc/s6-rc-compile.c

    @@ -1306,14 +1306,23 @@
         if (copy_uint(compiled, srcfn, dstfn, &u) && u < 3 && verbosity)
         {
           char fmt[UINT_FMT] ;
           fmt[uint_fmt(fmt, u)] = 0 ;
           strerr_warnw4x("longrun ", db->string + db->services[i].name, " has a notification-fd of ", fmt) ;
         }

    +    memcpy(srcfn + srcdirlen + len + 2, "lock-fd", 8) ;
    +    memcpy(dstfn + clen + 14 + len, "lock-fd", 8) ;
    +    if (copy_uint(compiled, srcfn, dstfn, &u) && u < 3 && verbosity)
    +    {
    +      char fmt[UINT_FMT] ;
    +      fmt[uint_fmt(fmt, u)] = 0 ;
    +      strerr_warnw4x("longrun ", db->string + db->services[i].name, " has a lock-fd of ", fmt) ;
    +    }
    +
         memcpy(srcfn + srcdirlen + len + 2, "timeout-kill", 13) ;
         memcpy(dstfn + clen + 14 + len, "timeout-kill", 13) ;
         copy_uint(compiled, srcfn, dstfn, &u) ;

         memcpy(srcfn + srcdirlen + len + 2, "timeout-finish", 15) ;
         memcpy(dstfn + clen + 14 + len, "timeout-finish", 15) ;
         copy_uint(compiled, srcfn, dstfn, &u) ;

### s6-rc-0.5.2.3/NEWS

    @@ -1,13 +1,14 @@
     Changelog for s6-rc.

     In 0.5.2.3
     ----------

      - Adaptation to skalibs-2.11.0.0.
    + - Adaptation to s6-2.11.0.0.
      - Bugfixes.


     In 0.5.2.2
     ----------

      - Bugfixes.

</article>
</details>

[1]: https://github.com/NixOS/nixpkgs/pull/139544
[2]: https://github.com/NixOS/nixpkgs/pull/139544#issuecomment-927332319
[3]: https://hydra.nixos.org/build/154845872

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
