### PR TITLE
nixos: fixes after #136909

### DIFF
--- a/nixos/modules/services/monitoring/alerta.nix
+++ b/nixos/modules/services/monitoring/alerta.nix
@@ -56,7 +56,7 @@ in
     corsOrigins = mkOption {
       type = types.listOf types.str;
       description = "List of URLs that can access the API for Cross-Origin Resource Sharing (CORS)";
-      example = [ "http://localhost" "http://localhost:5000" ];
+      default = [ "http://localhost" "http://localhost:5000" ];
     };
 
     authenticationRequired = mkOption {

--- a/nixos/modules/services/monitoring/kapacitor.nix
+++ b/nixos/modules/services/monitoring/kapacitor.nix
@@ -61,7 +61,7 @@ in
 
     dataDir = mkOption {
       type = types.path;
-      example = "/var/lib/kapacitor";
+      default = "/var/lib/kapacitor";
       description = "Location where Kapacitor stores its state";
     };
 


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/commit/0c6d8787d4b3d545932278593c86eff608834c71 I accidentally removed some defaults instead of examples.
