### PR TITLE
dbqn, dbqn-native: 2021-10-02 -> 2021-10-05 

### DIFF
--- a/pkgs/development/interpreters/bqn/dzaima-bqn/default.nix
+++ b/pkgs/development/interpreters/bqn/dzaima-bqn/default.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ AndersonTorres sternenseemann ];
     inherit (jdk.meta) platforms;
-    priority = if buildNativeImage then 10 else 0;
   };
 }
 # TODO: Processing app

--- a/pkgs/development/interpreters/bqn/dzaima-bqn/default.nix
+++ b/pkgs/development/interpreters/bqn/dzaima-bqn/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dbqn" + lib.optionalString buildNativeImage "-native";
-  version = "0.0.0+unstable=2021-10-02";
+  version = "0.0.0+unstable=2021-10-05";
 
   src = fetchFromGitHub {
     owner = "dzaima";
     repo = "BQN";
-    rev = "d6bd66d26a89b8e9f956ec4f6b6bc5dcb5861a09";
-    hash = "sha256-BLRep7OGHfDFowIAsBS19PTzgIhrdKMnO2JSjKuwGYo=";
+    rev = "c31ceef52bbf380e747723f5ffd09c5f006b21c5";
+    sha256 = "1nzqgwpjawcky85mfrz5izs9lfb3aqlm96dc8syrxhgg20xrziwx";
   };
 
   buildInputs = lib.optional (!buildNativeImage) jdk;
@@ -28,10 +28,8 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     runHook preBuild
 
-    mkdir -p output
-    javac --release 8 -encoding UTF-8 -d ./output $(find src -name '*.java')
-    (cd output; jar cvfe ../BQN.jar BQN.Main *)
-    rm -fr output
+    patchShebangs --build ./build8
+    ./build8
   '' + lib.optionalString buildNativeImage ''
     native-image --report-unsupported-elements-at-runtime \
       -J-Dfile.encoding=UTF-8 -jar BQN.jar dbqn

--- a/pkgs/development/interpreters/bqn/dzaima-bqn/default.nix
+++ b/pkgs/development/interpreters/bqn/dzaima-bqn/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     ./build8
   '' + lib.optionalString buildNativeImage ''
     native-image --report-unsupported-elements-at-runtime \
+      -H:CLibraryPath=${lib.getLib jdk}/lib \
       -J-Dfile.encoding=UTF-8 -jar BQN.jar dbqn
   '' + ''
     runHook postBuild

--- a/pkgs/development/interpreters/bqn/dzaima-bqn/default.nix
+++ b/pkgs/development/interpreters/bqn/dzaima-bqn/default.nix
@@ -17,11 +17,10 @@ stdenv.mkDerivation rec {
     sha256 = "1nzqgwpjawcky85mfrz5izs9lfb3aqlm96dc8syrxhgg20xrziwx";
   };
 
-  buildInputs = lib.optional (!buildNativeImage) jdk;
-
   nativeBuildInputs = [
     makeWrapper
-  ] ++ lib.optional buildNativeImage jdk;
+    jdk
+  ];
 
   dontConfigure = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
