### PR TITLE
texlive.combine: avoid sorting on store paths (fix CA stability)

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -33,10 +33,11 @@ let
       ++ lib.optional (lib.any pkgNeedsRuby splitBin.wrong) ruby;
   };
 
-  uniqueStrings = list: lib.sort (a: b: a < b) (lib.unique list);
+  sortedByPN = pkgs: lib.sort (a: b: a.pname < b.pname) pkgs;
+  sortedUniqueStrings = list: lib.sort (a: b: a < b) (lib.unique list);
 
-  mkUniqueOutPaths = pkgs: uniqueStrings
-    (map (p: p.outPath) (builtins.filter lib.isDerivation pkgs));
+  mkUniqueOutPaths = pkgs: lib.unique
+    (map (p: p.outPath) (sortedByPN (builtins.filter lib.isDerivation pkgs)));
 
 in (buildEnv {
   name = "texlive-${extraName}-${bin.texliveYear}${extraVersion}";
@@ -124,9 +125,9 @@ in (buildEnv {
     # now filter hyphenation patterns and formats
   (let
     hyphens = lib.filter (p: p.hasHyphens or false && p.tlType == "run") pkgList.splitBin.wrong;
-    hyphenPNames = uniqueStrings (map (p: p.pname) hyphens);
+    hyphenPNames = sortedUniqueStrings (map (p: p.pname) hyphens);
     formats = lib.filter (p: p.hasFormats or false && p.tlType == "run") pkgList.splitBin.wrong;
-    formatPNames = uniqueStrings (map (p: p.pname) formats);
+    formatPNames = sortedUniqueStrings (map (p: p.pname) formats);
     # sed expression that prints the lines in /start/,/end/ except for /end/
     section = start: end: "/${start}/,/${end}/{ /${start}/p; /${end}/!p; };\n";
     script =

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -33,11 +33,10 @@ let
       ++ lib.optional (lib.any pkgNeedsRuby splitBin.wrong) ruby;
   };
 
-  sortedByPN = pkgs: lib.sort (a: b: a.pname < b.pname) pkgs;
   sortedUniqueStrings = list: lib.sort (a: b: a < b) (lib.unique list);
 
   mkUniqueOutPaths = pkgs: lib.unique
-    (map (p: p.outPath) (sortedByPN (builtins.filter lib.isDerivation pkgs)));
+    (map (p: p.outPath) (builtins.filter lib.isDerivation pkgs));
 
 in (buildEnv {
   name = "texlive-${extraName}-${bin.texliveYear}${extraVersion}";


### PR DESCRIPTION
In https://github.com/NixOS/nix/issues/5333 I noticed that adding
a minor change to `bash` derivation triggers rebuilds in CA for
`bash` (expected) and `texlive.combine` (unexpected).

regnat debugged derivation instability down to sort on outPath.

The change avoid sorting on outPaths and uses pname of the derivations.

Tested on `R` derivation.

Closes: https://github.com/NixOS/nix/issues/5333
