### PR TITLE
emacs2nix: Bump version

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/emacs2nix.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/emacs2nix.nix
@@ -4,8 +4,8 @@ let
   src = pkgs.fetchgit {
     url = "https://github.com/nix-community/emacs2nix.git";
     fetchSubmodules = true;
-    rev = "703b144eeb490e87133c777f82e198b4e515c312";
-    sha256 = "sha256-YBbRh/Cb8u9+Pn6/Bc0atI6knKVjr8jiTGgFkD2FNGI=";
+    rev = "8612e136199b29201703e3e28eba26ddc53f297e";
+    sha256 = "sha256-p15KuXS18j8nqy69LPnHcj6ciHLxa/nibshts0HMZ0A=";
   };
 in
 pkgs.mkShell {


### PR DESCRIPTION
###### Motivation for this change
Currently updates are failing because of a very old pinned version of `cacert`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
