### PR TITLE
hpx: 1.6.0 -> 1.7.1

### DIFF
--- a/pkgs/development/libraries/hpx/default.nix
+++ b/pkgs/development/libraries/hpx/default.nix
@@ -1,17 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, boost, cmake, hwloc, gperftools, pkg-config, python3 }:
+{ lib, stdenv, fetchFromGitHub, asio, boost, cmake, hwloc, gperftools, ninja
+, pkg-config, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "hpx";
-  version = "1.6.0";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "STEllAR-GROUP";
     repo = "hpx";
     rev = version;
-    sha256 = "sha256-Fkntfk5AaWtS1x0fXfLSWW/9tvKcCBi1COqgNxurPmk=";
+    sha256 = "1knx7kr8iw4b7nh116ygd00y68y84jjb4fj58jkay7n5qlrxh604";
   };
 
-  buildInputs = [ boost hwloc gperftools ];
+  buildInputs = [ asio boost hwloc gperftools ];
   nativeBuildInputs = [ cmake pkg-config python3 ];
 
   strictDeps = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16499,7 +16499,10 @@ with pkgs;
 
   hound = callPackage ../development/tools/misc/hound { };
 
-  hpx = callPackage ../development/libraries/hpx { };
+  hpx = callPackage ../development/libraries/hpx {
+    boost = boost17x;
+    asio = asio.override { boost = boost17x; };
+  };
 
   hspell = callPackage ../development/libraries/hspell { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update HPX from 1.6.0 to 1.7.1. Adds dependency on Asio (new for 1.7.0) and uses fixed Boost version (1.71.0 is the minimum required by HPX).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
