### PR TITLE
giada: 0.16.4 -> unstable-2021-09-24

### DIFF
--- a/pkgs/applications/audio/giada/default.nix
+++ b/pkgs/applications/audio/giada/default.nix
@@ -1,8 +1,9 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
-, autoreconfHook
+, cmake
+, pkg-config
 , fltk
-, jansson
 , rtmidi
 , libsamplerate
 , libsndfile
@@ -10,51 +11,65 @@
 , alsa-lib
 , libpulseaudio
 , libXpm
-, libXinerama
-, libXcursor
-, catch2
-, nlohmann_json
+, flac
+, libogg
+, libvorbis
+, libopus
 }:
 
 stdenv.mkDerivation rec {
   pname = "giada";
-  version = "0.16.4";
+  version = "unstable-2021-09-24";
 
   src = fetchFromGitHub {
     owner = "monocasual";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0qyx0bvivlvly0vj5nnnbiks22xh13sqlw4mfgplq2lbbpgisigp";
+    # Using master with https://github.com/monocasual/giada/pull/509 till a new release is done.
+    rev = "f117a8b8eef08d904ef1ab22c45f0e1fad6b8a56";
+    sha256 = "01hb981lrsyk870zs8xph5fm0z7bbffpkxgw04hq487r804mkx9j";
+    fetchSubmodules = true;
   };
 
-  configureFlags = [
-    "--target=linux"
-    "--enable-system-catch"
+  NIX_CFLAGS_COMPILE = [
+    "-w"
+    "-Wno-error"
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_BUILD_TYPE=Release"
   ];
 
   nativeBuildInputs = [
-    autoreconfHook
+    cmake
+    pkg-config
   ];
 
   buildInputs = [
+    rtmidi
     fltk
     libsndfile
     libsamplerate
-    jansson
-    rtmidi
-    libXpm
-    jack2
     alsa-lib
+    libXpm
     libpulseaudio
-    libXinerama
-    libXcursor
-    catch2
-    nlohmann_json
+    jack2
+    flac
+    libogg
+    libvorbis
+    libopus
   ];
 
   postPatch = ''
-    sed -i 's:"deps/json/single_include/nlohmann/json\.hpp":<nlohmann/json.hpp>:' \
-        src/core/{conf,init,midiMapConf,patch}.cpp
+    local fixup_list=(
+      src/core/kernelMidi.cpp
+      src/gui/elems/config/tabMidi.cpp
+      src/utils/ver.cpp
+    )
+    for f in "''${fixup_list[@]}"; do
+      substituteInPlace "$f" \
+        --replace "<RtMidi.h>" "<${rtmidi.src}/RtMidi.h>"
+    done
   '';
 
   meta = with lib; {
@@ -63,6 +78,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ petabyteboy ];
     platforms = platforms.all;
-    broken = stdenv.hostPlatform.isAarch64; # produces build failure on aarch64-linux
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to [0.18.2](https://github.com/monocasual/giada/releases/tag/v0.18.2) incorporating these [changes](https://github.com/monocasual/giada/compare/v0.16.4...v0.18.2).

- [ ] Waiting for a release with https://github.com/monocasual/giada/pull/509

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
