### PR TITLE
python3Packages.foxdot: enable darwin build

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -35,6 +35,6 @@ mkDerivation rec {
     homepage = "https://supercollider.github.io";
     maintainers = with maintainers; [ mrmebelman ];
     license = licenses.gpl3Plus;
-    platforms = [ "x686-linux" "x86_64-linux" ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/foxdot/default.nix
+++ b/pkgs/development/python-modules/foxdot/default.nix
@@ -1,4 +1,10 @@
-{ lib, buildPythonPackage, fetchPypi, tkinter, supercollider }:
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, tkinter
+, supercollider
+}:
 
 buildPythonPackage rec {
   pname = "FoxDot";
@@ -9,7 +15,10 @@ buildPythonPackage rec {
     sha256 = "528999da55ad630e540a39c0eaeacd19c58c36f49d65d24ea9704d0781e18c90";
   };
 
-  propagatedBuildInputs = [ tkinter supercollider ];
+  propagatedBuildInputs = [ tkinter ]
+    # we currently build SuperCollider only on Linux
+    # but FoxDot is totally usable on macOS with the official SuperCollider binary
+    ++ lib.optionals stdenv.isLinux [ supercollider ];
 
   # Requires a running SuperCollider instance
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

- enable darwin build by not requiring SuperCollider.
  - User can install the official binary of SuperCollider and use that.
- enable supercollider build on aarch64-linux

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
