### PR TITLE
annotator: init at 1.0.0

### DIFF
--- a/pkgs/applications/graphics/annotator/default.nix
+++ b/pkgs/applications/graphics/annotator/default.nix
@@ -1,0 +1,91 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  vala,
+  meson,
+  ninja,
+  pkg-config,
+  pantheon,
+  gettext,
+  wrapGAppsHook,
+  python3,
+  shared-mime-info,
+  gtk3,
+  glib,
+  libgee,
+  libhandy,
+  libxml2,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "Annotator";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "phase1geo";
+    repo = pname;
+    rev = version;
+    sha256 = "zJRnr0Gb4GGfMKExvu6pvMNmM1VVO7brl3bcCU+ldqY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    gettext
+    wrapGAppsHook
+    python3
+    glib # for glib-compile-schemas
+    shared-mime-info # for update-mime-database
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    pantheon.granite
+    libhandy
+    libgee
+    libxml2
+  ];
+
+  postPatch = ''
+    patchShebangs meson/post_install.py
+
+    # https://github.com/phase1geo/Annotator/pull/20
+    substituteInPlace data/com.github.phase1geo.annotator.gresource.xml \
+      --replace "sticker_images/icons8_cup" "sticker_icons8_cup"
+  '';
+
+  postInstall = ''
+    # These icons are not defined in icon-naming-spec so they are not widely available.
+    # Let’s include those from Pantheon as a fallback.
+    nonStandardIcons=(
+      actions/24/document-export.svg
+      actions/24/format-text-highlight.svg
+      actions/symbolic/image-crop-symbolic.svg
+    )
+    for icon in "''${nonStandardIcons[@]}"; do
+      # elementary has a different layout from hicolor icon theme.
+      targetIcon=$(echo "$icon" | sed -E "s#^actions/24/#24x24/actions/#;s#^actions/symbolic/#16x16/actions/#")
+      mkdir -p "$(dirname "$out/share/icons/hicolor/$targetIcon")"
+      ln -s "${pantheon.elementary-icon-theme}/share/icons/elementary/$icon" "$out/share/icons/hicolor/$targetIcon"
+    done
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with lib; {
+    description = "Image annotation for Elementary OS";
+    homepage = "https://github.com/phase1geo/Annotator";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23420,6 +23420,8 @@ with pkgs;
 
   animbar = callPackage ../applications/graphics/animbar { };
 
+  annotator = callPackage ../applications/graphics/annotator { };
+
   antfs-cli = callPackage ../applications/misc/antfs-cli {};
 
   antimony = libsForQt514.callPackage ../applications/graphics/antimony {};


### PR DESCRIPTION
###### Motivation for this change

Thanks OMGUbuntu for the [recommendation](https://www.omgubuntu.co.uk/2021/10/best-annotation-tool-for-linux-desktop), this is much more convenient than Shutter.

I tried to fix the elementary specific icons by linking them to elementary theme as a fallback. In the future, we should probably help with adding those to [icon-naming-spec](https://gitlab.freedesktop.org/xdg/default-icon-theme) so that other themes implement them too.

cc @NixOS/pantheon @NixOS/gnome 

Closes #157510

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
