### PR TITLE
util-linux: replace "minimal" opt with more outputs

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
   # somewhat risky because we have to consider that mount can setuid
   # root...
   configureFlags = [
+    "--localstatedir=/var"
     "--enable-write"
     "--enable-last"
     "--enable-mesg"

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -1,5 +1,8 @@
 { lib, stdenv, fetchurl, pkg-config, zlib, shadow, libcap_ng
-, ncurses ? null, pam, systemd ? null, minimal ? false }:
+, ncurses ? null, pam, systemd ? null
+, minimal ? false
+, nlsSupport ? !minimal
+}:
 
 stdenv.mkDerivation rec {
   pname = "util-linux";
@@ -38,6 +41,7 @@ stdenv.mkDerivation rec {
     "--enable-fs-paths-default=/run/wrappers/bin:/run/current-system/sw/bin:/sbin"
     "--disable-makeinstall-setuid" "--disable-makeinstall-chown"
     "--disable-su" # provided by shadow
+    (lib.enableFeature nlsSupport "nls")
     (lib.withFeature (ncurses != null) "ncursesw")
     (lib.withFeature (systemd != null) "systemd")
     (lib.withFeatureAs (systemd != null)
@@ -59,7 +63,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # "For development purpose only. Don't execute on production system!"
 
   postInstall = lib.optionalString minimal ''
-    rm -rf $out/share/{locale,doc,bash-completion}
+    rm -rf $out/share/{doc,bash-completion}
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22328,7 +22328,7 @@ with pkgs;
   util-linuxCurses = util-linux;
 
   util-linuxMinimal = if stdenv.isLinux then appendToName "minimal" (util-linux.override {
-    minimal = true;
+    nlsSupport = false;
     ncurses = null;
     systemd = null;
   }) else util-linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See commit messages for more details, but broadly:

The "minimal" argument just removed some files to reduce package
size.  Now that we have multiple output derivations in Nixpkgs (we
didn't when "minimal" was added), we can just throw more outputs at
this problem and get the same effect, with the advantage that those
files are actually there, available for download without a rebuild, if
they're ever needed.

I've tested that with this change, there's no difference in the
closure size of util-linuxMinimal.bin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
