### PR TITLE
fonttools: 4.21.1 -> 4.26.2;  psautohint: 2.3.0 -> 2.3.1;  afdko: 3.5.1 -> 3.7.1; nototools: 0.2.13 -> 0.2.16

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -124,11 +124,6 @@ in
       sha256 = "1d6zzk0ii43iqfnjbldwp8sasyx99lbjp1nfgqjla7ixld6yp98l";
     };
 
-    makeFlags = [
-      # TODO(@sternenseemann): remove if afdko is new enough to know about Unicode 14.0
-      "BYPASS_SEQUENCE_CHECK=True"
-    ];
-
     nativeBuildInputs = [
       cairo
       imagemagick

--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -1,38 +1,45 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, fetchpatch, pythonOlder
+{ lib, stdenv, buildPythonPackage, fetchPypi, pythonOlder
 , fonttools, defcon, lxml, fs, unicodedata2, zopfli, brotlipy, fontpens
 , brotli, fontmath, mutatormath, booleanoperations
 , ufoprocessor, ufonormalizer, psautohint, tqdm
-, setuptools-scm
+, setuptools-scm, scikit-build
+, cmake
+, antlr4_9
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "afdko";
-  version = "3.5.1";
+  version = "3.7.1";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1qg7dgl81yq0sp50pkhgvmf8az1svx20zmpkfa68ka9d0ssh1wjw";
+    sha256 = "05hj2mw3ppfjaig5zdk5db9vfrbbq5gmv5rzggmvvrj0yyfpr0pd";
   };
 
-  patches = [
-    # Skip date-dependent test. See
-    # https://github.com/adobe-type-tools/afdko/pull/1232
-    # https://github.com/NixOS/nixpkgs/pull/98158#issuecomment-704321117
-    (fetchpatch {
-      url = "https://github.com/adobe-type-tools/afdko/commit/2c36ad10f9d964759f643e8ed7b0972a27aa26bd.patch";
-      sha256 = "0p6a485mmzrbfldfbhgfghsypfiad3cabcw7qlw2rh993ivpnibf";
-    })
-    # fix tests for fonttools 4.21.1
-    (fetchpatch {
-      url = "https://github.com/adobe-type-tools/afdko/commit/0919e7454a0a05a1b141c23bf8134c67e6b688fc.patch";
-      sha256 = "0glly85swyl1kcc0mi8i0w4bm148bb001jz1winz5drfrw3a63jp";
-    })
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    setuptools-scm
+    scikit-build
+    cmake
   ];
 
-  nativeBuildInputs = [ setuptools-scm ];
+  buildInputs = [
+    antlr4_9.runtime.cpp
+  ];
+
+  patches = [
+    # Don't try to install cmake and ninja using pip
+    ./no-pypi-build-tools.patch
+    # Use antlr4 runtime from nixpkgs and link it dynamically
+    ./use-dynamic-system-antlr4-runtime.patch
+  ];
+
+  # setup.py will always (re-)execute cmake in buildPhase
+  dontConfigure = true;
 
   propagatedBuildInputs = [
     booleanoperations
@@ -53,10 +60,6 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  # tests are broken on non x86_64
-  # https://github.com/adobe-type-tools/afdko/issues/1163
-  # https://github.com/adobe-type-tools/afdko/issues/1216
-  doCheck = stdenv.isx86_64;
   checkInputs = [ pytestCheckHook ];
   preCheck = ''
     export PATH=$PATH:$out/bin

--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -6,6 +6,9 @@
 , cmake
 , antlr4_9
 , pytestCheckHook
+# Enables some expensive tests, useful for verifying an update
+, runAllTests ? false
+, afdko
 }:
 
 buildPythonPackage rec {
@@ -68,7 +71,7 @@ buildPythonPackage rec {
     #   https://github.com/adobe-type-tools/afdko/issues/1418
     find tests -name layerinfo.plist -delete
   '';
-  disabledTests = [
+  disabledTests = lib.optionals (!runAllTests) [
     # Disable slow tests, reduces test time ~25 %
     "test_report"
     "test_post_overflow"
@@ -78,6 +81,10 @@ buildPythonPackage rec {
     "test_overwrite"
     "test_options"
   ];
+
+  passthru.tests = {
+    fullTestsuite = afdko.override { runAllTests = true; };
+  };
 
   meta = with lib; {
     description = "Adobe Font Development Kit for OpenType";

--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -80,6 +80,10 @@ buildPythonPackage rec {
     "test_filename_without_dir"
     "test_overwrite"
     "test_options"
+  ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+    # aarch64-only (?) failure, unknown reason so far
+    # https://github.com/adobe-type-tools/afdko/issues/1425
+    "test_spec"
   ];
 
   passthru.tests = {

--- a/pkgs/development/python-modules/afdko/no-pypi-build-tools.patch
+++ b/pkgs/development/python-modules/afdko/no-pypi-build-tools.patch
@@ -1,0 +1,24 @@
+commit 72b0ab672d1080049431eeee07ae6d2556ae9e4a
+Author: sternenseemann <sternenseemann@systemli.org>
+Date:   Tue Oct 5 18:17:20 2021 +0200
+
+    Don't use pypi distributions of build tools
+    
+    We want to use regular cmake and ninja and not the pypi projects which
+    somehow wrap and vendor a version of the proper tool.
+
+diff --git a/setup.py b/setup.py
+index 50deb781..81417971 100644
+--- a/setup.py
++++ b/setup.py
+@@ -196,9 +196,7 @@ def main():
+           setup_requires=[
+               'wheel',
+               'setuptools_scm',
+-              'scikit-build',
+-              'cmake',
+-              'ninja'
++              'scikit-build'
+           ],
+           tests_require=[
+               'pytest',

--- a/pkgs/development/python-modules/afdko/use-dynamic-system-antlr4-runtime.patch
+++ b/pkgs/development/python-modules/afdko/use-dynamic-system-antlr4-runtime.patch
@@ -1,0 +1,43 @@
+commit 105daa26f09034af58eb13ac7c5c4ff5420c1724
+Author: sternenseemann <sternenseemann@systemli.org>
+Date:   Tue Oct 5 18:16:10 2021 +0200
+
+    Link against system antlr4 runtime, dynamically
+    
+    Instead of cloning a antlr4 version from git, use the system one. Also
+    don't link it statically, but dynamically by default (the library is
+    called antlr4-runtime, not antlr4_static).
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d7f86fb6..c43c4456 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,13 +36,13 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ # https://www.antlr.org/download/antlr4-cpp-runtime-4.9.2-source.zip
+ # set(ANTLR4_ZIP_REPOSITORY "/path_to_antlr4_archive/a4.zip")
+ 
+-add_definitions(-DANTLR4CPP_STATIC)
+ set(ANTLR4_WITH_STATIC_CRT OFF)
+ # Use slightly more recent commit than 4.9.2 to deal with utfcpp test
+ # compilation problems
+ # set(ANTLR4_TAG tags/4.9.2)
+ set(ANTLR4_TAG 916f03366edf15bf8b50010b11d479c189bf9f96)
+-include(ExternalAntlr4Cpp)
++find_path(ANTLR4_HEADER antlr4-runtime.h PATH_SUFFIXES antlr4-runtime)
++set(ANTLR4_INCLUDE_DIRS ${ANTLR4_HEADER})
+ 
+ # sanitizer support
+ # work around https://github.com/pypa/setuptools/issues/1928 with environment
+diff --git a/c/makeotf/lib/hotconv/CMakeLists.txt b/c/makeotf/lib/hotconv/CMakeLists.txt
+index 82257bf2..02eb2e30 100644
+--- a/c/makeotf/lib/hotconv/CMakeLists.txt
++++ b/c/makeotf/lib/hotconv/CMakeLists.txt
+@@ -69,7 +69,7 @@ add_library(hotconv STATIC
+ 
+ set_property(TARGET hotconv PROPERTY C_STANDARD 99)
+ target_include_directories(hotconv PRIVATE AFTER $<$<COMPILE_LANGUAGE:CXX>:${ANTLR4_INCLUDE_DIRS}>)
+-target_link_libraries(hotconv PUBLIC antlr4_static)
++target_link_libraries(hotconv PUBLIC antlr4-runtime)
+ 
+ if ( CMAKE_COMPILER_IS_GNUCC )
+     target_compile_options(hotconv PRIVATE -Wall -Wno-attributes)

--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -13,29 +13,30 @@
 , matplotlib
 , reportlab
 , sphinx
-, pytest
+, pytestCheckHook
 , pytest-randomly
 , glibcLocales
 }:
 
 buildPythonPackage rec {
   pname = "fonttools";
-  version = "4.21.1";
+  version = "4.26.2";
+
+  # Bump to 3.7 when https://github.com/fonttools/fonttools/pull/2417 is merged
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
     rev    = version;
-    sha256 = "1x9qrg6ppqhm5214ymwvn0r34qdz8pqvyxd0sj7rkp06wa757z2i";
+    sha256 = "1zp9idjkn4bn1a4pn8x64vi8j1ijdsd4qvgf1f70dfwqvw6ak1i6";
   };
 
   # all dependencies are optional, but
   # we run the checks with them
   checkInputs = [
-    pytest
+    pytestCheckHook
     pytest-randomly
-    glibcLocales
     # etree extra
     lxml
     # ufo extra
@@ -43,8 +44,6 @@ buildPythonPackage rec {
     # woff extra
     brotlipy
     zopfli
-    # unicode extra
-    unicodedata2
     # interpolatable extra
     scipy
     munkres
@@ -55,17 +54,23 @@ buildPythonPackage rec {
     # pens
     reportlab
     sphinx
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    # unicode extra
+    unicodedata2
   ];
 
   preCheck = ''
-    export LC_ALL="en_US.UTF-8"
+    # tests want to execute the "fonttools" executable from $PATH
+    export PATH="$out/bin:$PATH"
   '';
 
-  # avoid timing issues with timestamps in subset_test.py and ttx_test.py
-  checkPhase = ''
-    pytest Tests fontTools \
-      -k 'not ttcompile_timestamp_calcs and not recalc_timestamp'
-  '';
+  # Timestamp tests have timing issues probably related
+  # to our file timestamp normalization
+  disabledTests = [
+    "test_recalc_timestamp_ttf"
+    "test_recalc_timestamp_otf"
+    "test_ttcompile_timestamp_calcs"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/fonttools/fonttools";

--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "psautohint";
-  version = "2.3.0";
+  version = "2.3.1";
 
   disabled = pythonOlder "3.6";
 
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     owner = "adobe-type-tools";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1y7mqc2myn1gfzg4h018f8xza0q535shnqg6snnaqynz20i8jcfh";
+    sha256 = "1knh428af0lvzijvd72i30jcvx9n6ga0hai69kxg8386jdpmmvkg";
     fetchSubmodules = true; # data dir for tests
   };
 

--- a/pkgs/development/tools/parsing/antlr/4.9.nix
+++ b/pkgs/development/tools/parsing/antlr/4.9.nix
@@ -1,0 +1,95 @@
+{ lib, stdenv, fetchurl, jre
+, fetchpatch, fetchFromGitHub, cmake, ninja, pkg-config, libuuid, utf8cpp, darwin }:
+
+let
+  version = "4.9.2";
+  source = fetchFromGitHub {
+    owner = "antlr";
+    repo = "antlr4";
+    rev = version;
+    sha256 = "0rpqgl2y22iiyg42y8jyiy2g7x421yf0q16cf17j76iai6y0bm5p";
+  };
+
+  runtime = {
+    cpp = stdenv.mkDerivation {
+      pname = "antlr-runtime-cpp";
+      inherit version;
+      src = source;
+
+      outputs = [ "out" "dev" "doc" ];
+
+      patches = [
+        (fetchpatch {
+          name = "use-utfcpp-from-system.patch";
+          url = "https://github.com/antlr/antlr4/commit/5a808b470e1314b63b0a921178040ccabb357945.patch";
+          sha256 = "0nq7iajy9inllcspyqpxskfg3k5s1fwm7ph75i8lfc25rl35k1w7";
+        })
+      ];
+
+      patchFlags = [ "-p3" ];
+
+      nativeBuildInputs = [ cmake ninja pkg-config ];
+      buildInputs = [ utf8cpp ]
+        ++ lib.optional stdenv.isLinux libuuid
+        ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.CoreFoundation;
+
+      postUnpack = ''
+        export sourceRoot=$sourceRoot/runtime/Cpp
+      '';
+
+      meta = with lib; {
+        description = "C++ target for ANTLR 4";
+        homepage = "https://www.antlr.org/";
+        license = licenses.bsd3;
+        platforms = platforms.unix;
+      };
+    };
+  };
+
+  antlr = stdenv.mkDerivation {
+    pname = "antlr";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://www.antlr.org/download/antlr-${version}-complete.jar";
+      sha256 = "1k9pw5gv2zhh06n1vys76kchlz4mz0vgv3iiba8w47b9fqa7n4dv";
+    };
+
+    dontUnpack = true;
+
+    installPhase = ''
+      mkdir -p "$out"/{share/java,bin}
+      cp "$src" "$out/share/java/antlr-${version}-complete.jar"
+
+      echo "#! ${stdenv.shell}" >> "$out/bin/antlr"
+      echo "'${jre}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' -Xmx500M org.antlr.v4.Tool \"\$@\"" >> "$out/bin/antlr"
+
+      echo "#! ${stdenv.shell}" >> "$out/bin/grun"
+      echo "'${jre}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' org.antlr.v4.gui.TestRig \"\$@\"" >> "$out/bin/grun"
+
+      chmod a+x "$out/bin/antlr" "$out/bin/grun"
+      ln -s "$out/bin/antlr"{,4}
+    '';
+
+    inherit jre;
+
+    passthru = {
+      inherit runtime;
+      jarLocation = "${antlr}/share/java/antlr-${version}-complete.jar";
+    };
+
+    meta = with lib; {
+      description = "Powerful parser generator";
+      longDescription = ''
+        ANTLR (ANother Tool for Language Recognition) is a powerful parser
+        generator for reading, processing, executing, or translating structured
+        text or binary files. It's widely used to build languages, tools, and
+        frameworks. From a grammar, ANTLR generates a parser that can build and
+        walk parse trees.
+      '';
+      homepage = "https://www.antlr.org/";
+      license = licenses.bsd3;
+      platforms = platforms.unix;
+    };
+  };
+in antlr

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13894,6 +13894,8 @@ with pkgs;
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
 
+  antlr4_9 = callPackage ../development/tools/parsing/antlr/4.9.nix { };
+
   antlr4 = antlr4_8;
 
   antlr = antlr4;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update a bunch of packages in the nototools font toolchain now that afdko 3.7.1 has been released for a bit (they took forever to release it and in between we were stuck with 3.5.x (holding other packages back) because it was broken on darwin).

Still outdated:

* fonttools (4.27.x isn't supported by afdko)
* ~~ufonormalizer (afdko's test suite doesn't like the behavior of 0.6.1)~~ (in `master` with workaround for the test suite)
* tqdm
* more?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
