### PR TITLE
firefox-bin: HTTPS for homepage and updateScript

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -190,12 +190,12 @@ stdenv.mkDerivation {
     inherit pname channel writeScript xidel coreutils gnused gnugrep gnupg curl runtimeShell;
     baseUrl =
       if channel == "devedition"
-        then "http://archive.mozilla.org/pub/devedition/releases/"
-        else "http://archive.mozilla.org/pub/firefox/releases/";
+        then "https://archive.mozilla.org/pub/devedition/releases/"
+        else "https://archive.mozilla.org/pub/firefox/releases/";
   };
   meta = with lib; {
     description = "Mozilla Firefox, free web browser (binary package)";
-    homepage = "http://www.mozilla.org/firefox/";
+    homepage = "https://www.mozilla.org/firefox/";
     license = licenses.mpl20;
     platforms = builtins.attrNames mozillaPlatforms;
     hydraPlatforms = [];

--- a/pkgs/tools/text/xidel/default.nix
+++ b/pkgs/tools/text/xidel/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchsvn, fetchFromGitHub, fpc }:
+{ lib, stdenv, fetchsvn, fetchFromGitHub, fpc, openssl }:
 
 let
   flreSrc = fetchFromGitHub {
@@ -36,6 +36,9 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ fpc ];
+  buildInputs = [ openssl ];
+
+  NIX_LDFLAGS = [ "-lcrypto" ];
 
   patchPhase = ''
     patchShebangs \


### PR DESCRIPTION
Using HTTPS for the updateScript requires HTTPS support in xidel, a tool used in the updateScript, so I've also included the fix for that here.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
