### PR TITLE
[21.05] onionshare: 2.3.1 -> 2.4

### DIFF
--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -4,6 +4,7 @@
   substituteAll,
   fetchFromGitHub,
   isPy3k,
+  colorama,
   flask,
   flask-httpauth,
   flask-socketio,
@@ -22,12 +23,12 @@
 }:
 
 let
-  version = "2.3.1";
+  version = "2.3.2";
   src = fetchFromGitHub {
     owner = "micahflee";
     repo = "onionshare";
     rev = "v${version}";
-    sha256 = "sha256-H09x3OF6l1HLHukGPvV2rZUjW9fxeKKMZkKbY9a2m9I=";
+    sha256 = "sha256-mzLDvvpO82iGDnzY42wx1KCNmAxUgVhpaDVprtb+YOI=";
   };
   meta = with lib; {
     description = "Securely and anonymously send and receive files";
@@ -69,6 +70,7 @@ in rec {
     ];
     disable = !isPy3k;
     propagatedBuildInputs = [
+      colorama
       flask
       flask-httpauth
       flask-socketio

--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -23,12 +23,12 @@
 }:
 
 let
-  version = "2.3.2";
+  version = "2.3.3";
   src = fetchFromGitHub {
     owner = "micahflee";
     repo = "onionshare";
     rev = "v${version}";
-    sha256 = "sha256-mzLDvvpO82iGDnzY42wx1KCNmAxUgVhpaDVprtb+YOI=";
+    sha256 = "sha256-wU2020RNXlwJ2y9uzcLxIX4EECev1Z9YvNyiBalLj/Y=";
   };
   meta = with lib; {
     description = "Securely and anonymously send and receive files";
@@ -94,6 +94,11 @@ in rec {
       # Tests use the home directory
       export HOME="$(mktemp -d)"
     '';
+
+    disabledTests = [
+      "test_firefox_like_behavior"
+      "test_if_unmodified_since"
+    ];
   };
 
   onionshare-gui = buildPythonApplication {

--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -1,52 +1,52 @@
-{
-  lib,
-  buildPythonApplication,
-  substituteAll,
-  fetchFromGitHub,
-  isPy3k,
-  colorama,
-  flask,
-  flask-httpauth,
-  flask-socketio,
-  stem,
-  psutil,
-  pyqt5,
-  pycrypto,
-  pyside2,
-  pytestCheckHook,
-  qrcode,
-  qt5,
-  requests,
-  unidecode,
-  tor,
-  obfs4,
+{ lib
+, buildPythonApplication
+, substituteAll
+, fetchFromGitHub
+, isPy3k
+, colorama
+, flask
+, flask-httpauth
+, flask-socketio
+, stem
+, psutil
+, pyqt5
+, pycrypto
+, pynacl
+, pyside2
+, pytestCheckHook
+, qrcode
+, qt5
+, requests
+, unidecode
+, tor
+, obfs4
 }:
 
 let
-  version = "2.3.3";
+  version = "2.4";
   src = fetchFromGitHub {
-    owner = "micahflee";
+    owner = "onionshare";
     repo = "onionshare";
     rev = "v${version}";
-    sha256 = "sha256-wU2020RNXlwJ2y9uzcLxIX4EECev1Z9YvNyiBalLj/Y=";
+    sha256 = "sha256-Lclm7mIkaAkQpWcNILTRJtLA43dpiyHtWAeHS2r3+ZQ=";
   };
   meta = with lib; {
     description = "Securely and anonymously send and receive files";
     longDescription = ''
-    OnionShare is an open source tool for securely and anonymously sending
-    and receiving files using Tor onion services. It works by starting a web
-    server directly on your computer and making it accessible as an
-    unguessable Tor web address that others can load in Tor Browser to
-    download files from you, or upload files to you. It doesn't require
-    setting up a separate server, using a third party file-sharing service,
-    or even logging into an account.
+      OnionShare is an open source tool for securely and anonymously sending
+      and receiving files using Tor onion services. It works by starting a web
+      server directly on your computer and making it accessible as an
+      unguessable Tor web address that others can load in Tor Browser to
+      download files from you, or upload files to you. It doesn't require
+      setting up a separate server, using a third party file-sharing service,
+      or even logging into an account.
 
-    Unlike services like email, Google Drive, DropBox, WeTransfer, or nearly
-    any other way people typically send files to each other, when you use
-    OnionShare you don't give any companies access to the files that you're
-    sharing. So long as you share the unguessable web address in a secure way
-    (like pasting it in an encrypted messaging app), no one but you and the
-    person you're sharing with can access the files.
+      Unlike services like email, Google Drive, DropBox, WeTransfer, or nearly
+      any other way people typically send files to each other, when you use
+      OnionShare you don't give any companies access to the files that you're
+      sharing. So long as you share the unguessable web address in a secure way
+      (like pasting it in an encrypted messaging app), no one but you and the
+      person you're sharing with can access the files.
     '';
 
     homepage = "https://onionshare.org/";
@@ -54,8 +54,19 @@ let
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ lourkeur ];
   };
+  stem' = stem.overrideAttrs (_: rec {
+    version = "1.8.1";
 
-in rec {
+    src = fetchFromGitHub {
+      owner = "onionshare";
+      repo = "stem";
+      rev = version;
+      sha256 = "Dzpvx7CgAr5OtGmfubWAYDLqq5LkGqcwjr3bxpfL/3A=";
+    };
+  });
+
+in
+rec {
   onionshare = buildPythonApplication {
     pname = "onionshare-cli";
     inherit version meta;
@@ -74,9 +85,10 @@ in rec {
       flask
       flask-httpauth
       flask-socketio
-      stem
+      stem'
       psutil
       pycrypto
+      pynacl
       requests
       unidecode
     ];
@@ -98,6 +110,7 @@ in rec {
     disabledTests = [
       "test_firefox_like_behavior"
       "test_if_unmodified_since"
+      "test_get_tor_paths_linux"  # expects /usr instead of /nix/store
     ];
   };
 

--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonApplication
 , substituteAll
 , fetchFromGitHub
@@ -111,6 +112,11 @@ rec {
       "test_firefox_like_behavior"
       "test_if_unmodified_since"
       "test_get_tor_paths_linux"  # expects /usr instead of /nix/store
+    ] ++ lib.optionals stdenv.isDarwin [
+      # on darwin (and only on darwin) onionshare attempts to discover
+      # user's *real* homedir via /etc/passwd, making it more painful
+      # to fake
+      "test_receive_mode_webhook"
     ];
   };
 

--- a/pkgs/applications/networking/onionshare/fix-paths-gui.patch
+++ b/pkgs/applications/networking/onionshare/fix-paths-gui.patch
@@ -1,7 +1,6 @@
-
 --- a/onionshare/gui_common.py
 +++ b/onionshare/gui_common.py
-@@ -376,29 +376,10 @@ class GuiCommon:
+@@ -391,29 +391,10 @@ class GuiCommon:
          }
  
      def get_tor_paths(self):
@@ -20,7 +19,7 @@
 -        elif self.common.platform == "Darwin":
 -            base_path = self.get_resource_path("tor")
 -            tor_path = os.path.join(base_path, "tor")
--            obfs4proxy_file_path = os.path.join(base_path, "obfs4proxy.exe")
+-            obfs4proxy_file_path = os.path.join(base_path, "obfs4proxy")
 -            tor_geo_ip_file_path = os.path.join(base_path, "geoip")
 -            tor_geo_ipv6_file_path = os.path.join(base_path, "geoip6")
 -        elif self.common.platform == "BSD":

--- a/pkgs/applications/networking/onionshare/fix-paths.patch
+++ b/pkgs/applications/networking/onionshare/fix-paths.patch
@@ -1,8 +1,8 @@
 --- a/onionshare_cli/common.py
 +++ b/onionshare_cli/common.py
-@@ -86,33 +86,10 @@ class Common:
+@@ -308,33 +308,10 @@ class Common:
          return path
- 
+
      def get_tor_paths(self):
 -        if self.platform == "Linux":
 -            tor_path = shutil.which("tor")
@@ -35,6 +35,7 @@
 +        tor_geo_ip_file_path = "@geoip@/share/tor/geoip"
 +        tor_geo_ipv6_file_path = "@geoip@/share/tor/geoip6"
 +        obfs4proxy_file_path = "@obfs4@/bin/obfs4proxy"
- 
+
          return (
              tor_path,
+


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-41868
https://nvd.nist.gov/vuln/detail/CVE-2021-41867

**Cannot** merge this yet, because the tests fail on macos. Will need to fix those in master first, then will cherry-pick that on top of this.

Update: see #140670

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
