### PR TITLE
quark-engine: init at 21.8.1

### DIFF
--- a/pkgs/development/python-modules/androguard/default.nix
+++ b/pkgs/development/python-modules/androguard/default.nix
@@ -21,8 +21,8 @@
 , codecov
 , coverage
 , qt5
-# This is usually used as a library, and it'd be a shame to force the gui
-# libraries to the closure if gui is not desired.
+# This is usually used as a library, and it'd be a shame to force the GUI
+# libraries to the closure if GUI is not desired.
 , withGui ? false
 # Tests take a very long time, and currently fail, but next release' tests
 # shouldn't fail
@@ -30,53 +30,52 @@
 }:
 
 buildPythonPackage rec {
-  version = "3.3.5";
   pname = "androguard";
+  version = "3.4.0a1";
 
-  # No tests in pypi tarball
   src = fetchFromGitHub {
     repo = pname;
     owner = pname;
     rev = "v${version}";
-    sha256 = "0zc8m1xnkmhz2v12ddn47q0c01p3sbna2v5npfxhcp88szswlr9y";
+    sha256 = "1aparxiq11y0hbvkayp92w684nyxyyx7mi0n1x6x51g5z6c58vmy";
   };
 
   propagatedBuildInputs = [
-    future
-    networkx
-    pygments
-    lxml
-    colorama
-    matplotlib
     asn1crypto
     click
-    pydot
+    colorama
+    future
     ipython
+    lxml
+    matplotlib
+    networkx
+    pydot
+    pygments
   ] ++ lib.optionals withGui [
     pyqt5
     pyperclip
   ];
 
   checkInputs = [
-    pyqt5
-    pyperclip
-    nose
-    nose-timer
     codecov
     coverage
     mock
+    nose
+    nose-timer
+    pyperclip
+    pyqt5
     python_magic
   ];
   inherit doCheck;
 
-  nativeBuildInputs = lib.optionals withGui [ qt5.wrapQtAppsHook ];
+  nativeBuildInputs = lib.optionals withGui [
+    qt5.wrapQtAppsHook
+  ];
 
   # If it won't be verbose, you'll see nothing going on for a long time.
   checkPhase = ''
     runHook preCheck
-
     nosetests --verbosity=3
-
     runHook postCheck
   '';
 
@@ -84,10 +83,10 @@ buildPythonPackage rec {
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
-  meta = {
-    description = "Tool and python library to interact with Android Files";
+  meta = with lib; {
+    description = "Tool and Python library to interact with Android Files";
     homepage = "https://github.com/androguard/androguard";
-    license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.pmiddend ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pmiddend ];
   };
 }

--- a/pkgs/development/python-modules/rzpipe/default.nix
+++ b/pkgs/development/python-modules/rzpipe/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "rzpipe";
+  version = "0.1.1";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13z88c4zjy10a1sc98ba25sz200v6w2wprbq4iknm4sy2fmrsydh";
+  };
+
+  # No native rz_core library
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "rzpipe"
+  ];
+
+  meta = with lib; {
+    description = "Python interface for rizin";
+    homepage = "https://rizin.re";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/quark-engine/default.nix
+++ b/pkgs/tools/security/quark-engine/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchFromGitHub
+, gitMinimal
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "quark-engine";
+  version = "21.8.1";
+
+  disabled = python3.pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ksmzwji4c98pnqns780n5rdm5r1zx7sc40w8qipk2nf6jncwv6p";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    androguard
+    click
+    colorama
+    gitMinimal
+    graphviz
+    pandas
+    plotly
+    prettytable
+    prompt-toolkit
+    rzpipe
+    tqdm
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "quark" ];
+
+  meta = with lib; {
+    description = "Android malware (analysis and scoring) system";
+    homepage = "https://quark-engine.readthedocs.io/";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18771,6 +18771,8 @@ with pkgs;
 
   qtscriptgenerator = callPackage ../development/libraries/qtscriptgenerator { };
 
+  quark-engine = callPackage ../tools/security/quark-engine { };
+
   quesoglc = callPackage ../development/libraries/quesoglc { };
 
   quickder = callPackage ../development/libraries/quickder {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8086,6 +8086,8 @@ in {
 
   rxv = callPackage ../development/python-modules/rxv { };
 
+  rzpipe = callPackage ../development/python-modules/rzpipe { };
+
   s2clientprotocol = callPackage ../development/python-modules/s2clientprotocol { };
 
   s3fs = callPackage ../development/python-modules/s3fs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Android malware (analysis and scoring) system

https://quark-engine.readthedocs.io/

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
