### PR TITLE
vmware-horizon-client: 2103 -> 2106.1

### DIFF
--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -39,7 +39,7 @@
 , zlib
 }:
 let
-  version = "2103";
+  version = "2106.1";
 
   sysArch =
     if stdenv.hostPlatform.system == "x86_64-linux" then "x64"
@@ -50,8 +50,8 @@ let
     name = "vmwareHorizonClientFiles";
     inherit version;
     src = fetchurl {
-      url = "https://download3.vmware.com/software/view/viewclients/CART22FQ1/VMware-Horizon-Client-Linux-2103-8.2.0-17742757.tar.gz";
-      sha256 = "62f95bb802b058a98f5ee6c2296b89bd7e15884a24dc8a8ba7ce89de7e0798e4";
+      url = "https://download3.vmware.com/software/view/viewclients/CART22FQ2/VMware-Horizon-Client-Linux-2106.1-8.3.1-18435609.tar.gz";
+      sha256 = "b42ddb9d7e9c8d0f8b86b69344fcfca45251c5a5f1e06a18a3334d5a04e18c39";
     };
     nativeBuildInputs = [ makeWrapper ];
     installPhase = ''

--- a/pkgs/applications/networking/remote/vmware-horizon-client/update.sh
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/update.sh
@@ -2,13 +2,13 @@
 #!nix-shell -p curl -p jq -p common-updater-scripts -i bash
 set -e
 
-entryPointURL='https://my.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY'
+entryPointURL='https://customerconnect.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY'
 
 function getTarballMetaUrl {
     curl "$entryPointURL" | jq -r '
         .dlgEditionsLists | .[] | select(.name | contains("Client for Linux")) |
         .dlgList | .[] | select(.name | contains("tarball version")) |
-        @uri "https://my.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&downloadGroup=\(.code)&productId=\(.productId)&rPId=\(.releasePackageId)"
+        @uri "https://customerconnect.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&downloadGroup=\(.code)&productId=\(.productId)&rPId=\(.releasePackageId)"
     '
 }
 


### PR DESCRIPTION
Update vmware horizon client to the latest version.
Update URLs in `update.sh` due to API changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
