### PR TITLE
nixos/networkmanager: make basePackages configurable, rename packages…

### DIFF
--- a/pkgs/tools/networking/networkmanager/fortisslvpn/default.nix
+++ b/pkgs/tools/networking/networkmanager/fortisslvpn/default.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation rec {
       attrPath = "networkmanager-fortisslvpn";
       versionPolicy = "odd-unstable";
     };
+    networkManagerPlugin = "VPN/nm-fortisslvpn-service.name";
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/networkmanager/iodine/default.nix
+++ b/pkgs/tools/networking/networkmanager/iodine/default.nix
@@ -48,6 +48,7 @@ in stdenv.mkDerivation {
       packageName = pname;
       attrPath = "networkmanager-iodine";
     };
+    networkManagerPlugin = "VPN/nm-iodine-service.name";
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/networkmanager/l2tp/default.nix
+++ b/pkgs/tools/networking/networkmanager/l2tp/default.nix
@@ -41,6 +41,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  passthru = {
+    networkManagerPlugin = "VPN/nm-l2tp-service.name";
+  };
+
   meta = with lib; {
     description = "L2TP plugin for NetworkManager";
     inherit (networkmanager.meta) platforms;

--- a/pkgs/tools/networking/networkmanager/openconnect/default.nix
+++ b/pkgs/tools/networking/networkmanager/openconnect/default.nix
@@ -71,6 +71,7 @@ in stdenv.mkDerivation {
       attrPath = "networkmanager-openconnect";
       versionPolicy = "odd-unstable";
     };
+    networkManagerPlugin = "VPN/nm-openconnect-service.name";
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/networkmanager/openvpn/default.nix
+++ b/pkgs/tools/networking/networkmanager/openvpn/default.nix
@@ -36,6 +36,7 @@ in stdenv.mkDerivation {
       attrPath = "networkmanager-openvpn";
       versionPolicy = "odd-unstable";
     };
+    networkManagerPlugin = "VPN/nm-openvpn-service.name";
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/networkmanager/sstp/default.nix
+++ b/pkgs/tools/networking/networkmanager/sstp/default.nix
@@ -54,6 +54,7 @@ in stdenv.mkDerivation {
       packageName = pname;
       attrPath = "networkmanager-sstp";
     };
+    networkManagerPlugin = "VPN/nm-sstp-service.name";
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/networkmanager/strongswan/default.nix
+++ b/pkgs/tools/networking/networkmanager/strongswan/default.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation rec {
     "--with-nm-plugindir=$(out)/lib/NetworkManager"
   ];
 
+  passthru = {
+    networkManagerPlugin = "VPN/nm-strongswan-service.name";
+  };
+
   PKG_CONFIG_LIBNM_VPNSERVICEDIR = "$(out)/lib/NetworkManager/VPN";
 
   meta = with lib; {

--- a/pkgs/tools/networking/networkmanager/vpnc/default.nix
+++ b/pkgs/tools/networking/networkmanager/vpnc/default.nix
@@ -40,6 +40,7 @@ in stdenv.mkDerivation {
       attrPath = "networkmanager-vpnc";
       versionPolicy = "odd-unstable";
     };
+    networkManagerPlugin = "VPN/nm-vpnc-service.name";
   };
 
   meta = with lib; {


### PR DESCRIPTION
… to extraPackages

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

alternate implementation of https://github.com/NixOS/nixpkgs/pull/84433

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
