### PR TITLE
onionshare: disable test_receive_mode_webhook on darwin

### DIFF
--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonApplication
 , substituteAll
 , fetchFromGitHub
@@ -111,6 +112,11 @@ rec {
       "test_firefox_like_behavior"
       "test_if_unmodified_since"
       "test_get_tor_paths_linux"  # expects /usr instead of /nix/store
+    ] ++ lib.optionals stdenv.isDarwin [
+      # on darwin (and only on darwin) onionshare attempts to discover
+      # user's *real* homedir via /etc/passwd, making it more painful
+      # to fake
+      "test_receive_mode_webhook"
     ];
   };
 


### PR DESCRIPTION
###### Motivation for this change
Onionshare is currently broken on darwin because of a single test failure. Tracked this down to https://github.com/onionshare/onionshare/blob/d08d5f0f32f755f504494d80794886f346fbafdb/cli/onionshare_cli/mode_settings.py#L101 which, on darwin, attempts to discover the users *real* homedir via `/etc/passwd`, which of course bypasses our attempt at `export HOME=...` fakery.

In theory we could use `libredirect` to point it at a fake `/etc/passwd` on darwin but that seems a little much.

*As trivial as this fix is, it's actually blocking #140661, which is security-level severity.*

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
