### PR TITLE
firefox: 92.0.1 -> 93.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -156,23 +156,6 @@ buildStdenv.mkDerivation ({
       sha256 = "0qc62di5823r7ly2lxkclzj9rhg2z7ms81igz44nv0fzv3dszdab";
     })
 
-  # These fix Firefox on sway and other non-Gnome wayland WMs. They should be
-  # removed whenever the following two patches make it onto a release:
-  # 1. https://hg.mozilla.org/mozilla-central/rev/51c13987d1b8
-  # 2. https://hg.mozilla.org/integration/autoland/rev/3b856ecc00e4
-  # This will probably happen in the next point release, but let's be careful
-  # and double check whether it's working on sway on the next v bump.
-  ++ lib.optionals (lib.versionAtLeast version "92") [
-      (fetchpatch {
-        url = "https://hg.mozilla.org/integration/autoland/raw-rev/3b856ecc00e4";
-        sha256 = "sha256-d8IRJD6ELC3ZgEs1ES/gy2kTNu/ivoUkUNGMEUoq8r8=";
-      })
-      (fetchpatch {
-        url = "https://hg.mozilla.org/mozilla-central/raw-rev/51c13987d1b8";
-        sha256 = "sha256-C2jcoWLuxW0Ic+Mbh3UpEzxTKZInljqVdcuA9WjspoA=";
-      })
-  ]
-
   ++ patches;
 
 
@@ -215,6 +198,7 @@ buildStdenv.mkDerivation ({
   '';
 
   MACH_USE_SYSTEM_PYTHON = "1";
+  MOZBUILD_STATE_PATH = "/build/mozbuild";
 
   postPatch = ''
     rm -rf obj-x86_64-pc-linux-gnu

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    version = "92.0.1";
+    version = "93.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "53361c231a4ac93a1808c9ccb29893d85b5e516fe939a770aac7f178abb4f43cbe3571097e5c5bf91b11fd95fc62b61f2aa215a45048357bfc9dad9eabdee9ef";
+      sha512 = "b29890e331819d47201b599b9feaaa7eaa0b02088fcbf980efc4f289d43da4f73970bf35ba2f763a2a892fd5318deb68cb9a66e71e9bc0c603642434c7e32e91";
     };
 
     meta = {


### PR DESCRIPTION
We now have to set MOZBUILD_STATE_PATH or the build system will get a
permission error trying to create the default directory.

> Mach and the build system store shared state in a common directory
> on the filesystem. The following directory will be created:
>
>   /homeless-shelter/.mozbuild
>
> If you would like to use a different directory, hit CTRL+c, set the
> MOZBUILD_STATE_PATH environment variable to the directory you'd like to
> use, and run Mach again.
>
> Press ENTER/RETURN to continue or CTRL+c to abort.

Tested that my menus are still working with firefox-wayland on Sway. :)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
