### PR TITLE
catgirl: fix path to openssl utility after configuring

### DIFF
--- a/pkgs/applications/networking/irc/catgirl/default.nix
+++ b/pkgs/applications/networking/irc/catgirl/default.nix
@@ -9,6 +9,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-MEm5mrrWfNp+mBHFjGSOGvvfvBJ+Ho/K+mPUxzJDkV0=";
   };
 
+  # catgirl's configure script uses pkg-config --variable exec_prefix openssl
+  # to discover the install location of the openssl(1) utility. exec_prefix
+  # is the "out" output of libressl in our case (where the libraries are
+  # installed), so we need to fix this up.
+  postConfigure = ''
+    substituteInPlace config.mk --replace \
+      "$($PKG_CONFIG --variable exec_prefix openssl)" \
+      "${lib.getBin libressl}"
+  '';
+
   nativeBuildInputs = [ ctags pkg-config ];
   buildInputs = [ libressl ncurses ];
   strictDeps = true;


### PR DESCRIPTION
catgirl wants to invoke the openssl utility at runtime and tries to
obtain a path to the binary as OPENSSL_BIN. This uses pkg-config's
exec_prefix which is not where binaries are installed in nixpkgs,
sadly. There is (at least as far as I know) no more appropriate
pkg-config variable unfortunately.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
