### PR TITLE
font-config-info: init at 1.0.0

### DIFF
--- a/pkgs/tools/misc/font-config-info/default.nix
+++ b/pkgs/tools/misc/font-config-info/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, gtk3
+, xsettingsd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "font-config-info";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "derat";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "14z7hg9c7q8wliyqv68kp080mmk2rh6kpww6pn87hy7lwq20l2b7";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    xsettingsd
+  ];
+
+  postPatch = ''
+    substituteInPlace font-config-info.c --replace "dump_xsettings |" "${xsettingsd}/bin/dump_xsettings |"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -t $out/bin font-config-info
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Prints a Linux system's font configuration";
+    homepage = "https://github.com/derat/font-config-info";
+    license = with licenses; [ bsd3 ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1621,6 +1621,8 @@ with pkgs;
 
   flood = nodePackages.flood;
 
+  font-config-info = callPackage ../tools/misc/font-config-info { };
+
   fxlinuxprintutil = callPackage ../tools/misc/fxlinuxprintutil { };
 
   genann = callPackage ../development/libraries/genann { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

> font-config-info is a tiny program that queries and prints a Linux system's font configuration. It is intended to produce brief reports that users can send to developers to aid in debugging font rendering issues.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
