### PR TITLE
hushboard: init at 2021-03-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10122,6 +10122,12 @@
     githubId = 307899;
     name = "Gurkan Gur";
   };
+  sersorrel = {
+    email = "ash@sorrel.sh";
+    github = "sersorrel";
+    githubId = 9433472;
+    name = "ash";
+  };
   servalcatty = {
     email = "servalcat@pm.me";
     github = "servalcatty";

--- a/pkgs/applications/audio/hushboard/default.nix
+++ b/pkgs/applications/audio/hushboard/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, gobject-introspection
+, gtk3
+, libappindicator
+, libpulseaudio
+, librsvg
+, pycairo
+, pygobject3
+, six
+, wrapGAppsHook
+, xlib
+}:
+
+buildPythonApplication {
+  pname = "hushboard";
+  version = "unstable-2021-03-17";
+
+  src = fetchFromGitHub {
+    owner = "stuartlangridge";
+    repo = "hushboard";
+    rev = "c16611c539be111891116a737b02c5fb359ad1fc";
+    sha256 = "06jav6j0bsxhawrq31cnls8zpf80fpwk0cak5s82js6wl4vw2582";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gobject-introspection
+    gtk3
+    libappindicator
+    libpulseaudio
+  ];
+
+  propagatedBuildInputs = [
+    pycairo
+    pygobject3
+    six
+    xlib
+  ];
+
+  postPatch = ''
+    substituteInPlace hushboard/_pulsectl.py \
+      --replace "ctypes.util.find_library('libpulse') or 'libpulse.so.0'" "'${libpulseaudio}/lib/libpulse.so.0'"
+    substituteInPlace snap/gui/hushboard.desktop \
+      --replace "\''${SNAP}/hushboard/icons/hushboard.svg" "hushboard"
+  '';
+
+  postInstall = ''
+    # Fix tray icon, see e.g. https://github.com/NixOS/nixpkgs/pull/43421
+    wrapProgram $out/bin/hushboard \
+      --set GDK_PIXBUF_MODULE_FILE "${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+
+    mkdir -p $out/share/applications $out/share/icons/hicolor/{scalable,512x512}/apps
+    cp snap/gui/hushboard.desktop $out/share/applications
+    cp hushboard/icons/hushboard.svg $out/share/icons/hicolor/scalable/apps
+    cp hushboard-512.png $out/share/icons/hicolor/512x512/apps/hushboard.png
+  '';
+
+  # There are no tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://kryogenix.org/code/hushboard/";
+    license = licenses.mit;
+    description = "Mute your microphone while typing";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sersorrel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25207,6 +25207,8 @@ with pkgs;
 
   go-org = callPackage ../applications/misc/go-org { };
 
+  hushboard = python3.pkgs.callPackage ../applications/audio/hushboard { };
+
   hydrogen = qt5.callPackage ../applications/audio/hydrogen { };
   hydrogen_0 = callPackage ../applications/audio/hydrogen/0.nix { }; # Old stable, has GMKit.
 


### PR DESCRIPTION
###### Motivation for this change
[Hushboard](https://kryogenix.org/code/hushboard/) mutes your microphone automatically while typing.

This is the first derivation I'm contributing to Nixpkgs, it could undoubtedly be better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
