### PR TITLE
init: libbde at 20210605

### DIFF
--- a/pkgs/development/libraries/libbde/default.nix
+++ b/pkgs/development/libraries/libbde/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, stdenv
+, fetchurl
+, fuse
+, ncurses
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libbde";
+  version = "20210605";
+
+  src = fetchurl {
+    url = "https://github.com/libyal/libbde/releases/download/${version}/${pname}-alpha-${version}.tar.gz";
+    sha256 = "0dk5h7gvp2fgg21n7k600mnayg4g4pc0lm7317k43j1q0p4hkfng";
+  };
+
+  buildInputs = [ fuse ncurses python3 ];
+
+  configureFlags = [ "--enable-python" ];
+
+  meta = with lib; {
+    description = "Library to access the BitLocker Drive Encryption (BDE) format";
+    homepage = "https://github.com/libyal/libbde/";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ eliasp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16975,6 +16975,8 @@ with pkgs;
   libbass = (callPackage ../development/libraries/audio/libbass { }).bass;
   libbass_fx = (callPackage ../development/libraries/audio/libbass { }).bass_fx;
 
+  libbde = callPackage ../development/libraries/libbde { };
+
   libbencodetools = callPackage ../development/libraries/libbencodetools { };
 
   libbluedevil = callPackage ../development/libraries/libbluedevil { };


### PR DESCRIPTION
###### Motivation for this change
Add an early alpha of libbde, which is a library to deal with the
BitLocker Drive Encryption (BDE) format.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
