### PR TITLE
jd-diff-patch: init at 1.4.0

### DIFF
--- a/pkgs/development/tools/jd-diff-patch/default.nix
+++ b/pkgs/development/tools/jd-diff-patch/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "jd-diff-patch";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner  = "josephburnett";
+    repo   = "jd";
+    rev    = "v${version}";
+    sha256 = "sha256-OAy4IS2JZYYPeJITNHZKiYEapzGqqYPDBCLflLYetzg=";
+  };
+
+  # not including web ui
+  excludedPackages = [ "gae" "pack" ];
+
+  vendorSha256 = "sha256-w3mFra7Je+8qIDQMSyUYucoLZ6GtrZmr56O6xmihIYc=";
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Commandline utility and Go library for diffing and patching JSON values";
+    homepage = "https://github.com/josephburnett/jd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bryanasdev000 blaggacao ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6366,6 +6366,8 @@ with pkgs;
 
   jd = callPackage ../development/tools/jd { };
 
+  jd-diff-patch = callPackage ../development/tools/jd-diff-patch { };
+
   jd-gui = callPackage ../tools/security/jd-gui { };
 
   jdiskreport = callPackage ../tools/misc/jdiskreport { };


### PR DESCRIPTION
###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/140311 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
