### PR TITLE
python3Packages.dateparser: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -2,12 +2,15 @@
 , buildPythonPackage
 , isPy3k
 , fetchFromGitHub
+, fetchpatch
 , python-dateutil
 , pytz
 , regex
 , tzlocal
 , hijri-converter
 , convertdate
+, fasttext
+, langdetect
 , parameterized
 , pytestCheckHook
 , GitPython
@@ -16,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "dateparser";
-  version = "1.0.0";
+  version = "1.1.0";
 
   disabled = !isPy3k;
 
@@ -24,14 +27,14 @@ buildPythonPackage rec {
     owner = "scrapinghub";
     repo = "dateparser";
     rev = "v${version}";
-    sha256 = "0i6ci14lqfsqrmaif57dyilrjbxzmbl98hps1b565gkiy1xqmjhl";
+    sha256 = "sha256-RpQWDsj7vGtfu6wf4yETdswfXDfoTkburTl6aOA03Ww=";
   };
 
   propagatedBuildInputs = [
     # install_requires
     python-dateutil pytz regex tzlocal
     # extra_requires
-    hijri-converter convertdate
+    hijri-converter convertdate fasttext langdetect
   ];
 
   checkInputs = [
@@ -41,8 +44,18 @@ buildPythonPackage rec {
     ruamel_yaml
   ];
 
+  preCheck = ''
+    export HOME="$TEMPDIR"
+  '';
+
   # Upstream only runs the tests in tests/ in CI, others use git clone
   pytestFlagsArray = [ "tests" ];
+
+  disabledTests = [
+    # access network
+    "test_custom_language_detect_fast_text_0"
+    "test_custom_language_detect_fast_text_1"
+  ];
 
   pythonImportsCheck = [ "dateparser" ];
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/scrapinghub/dateparser/releases/tag/v1.1.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
