### PR TITLE
llvmPackages_rocm.compiler-rt: replace dead patch with clone

### DIFF
--- a/pkgs/development/compilers/llvm/rocm/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/compiler-rt/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
     (fetchpatch {
       name = "libsanitizer-no-cyclades-rocm.patch";
-      url = "https://reviews.llvm.org/file/data/nrhbpc5axblqwx2xyyzv/PHID-FILE-wwcpjvquusomoddmqcwo/file";
+      url = "https://gist.github.com/lovesegfault/b255dcf2fa4e202411a6a04b61e6cc04/raw";
       sha256 = "sha256-PMMSLr2zHuNDn1OWqumqHwB74ktJSHxhJWkqEKB7Z64=";
       stripLen = 1;
      })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes the borked build of `llvmPackages_rocm.compiler-rt` due to a patch's URL
changing. I cached the patch permanently so this shouldn't happen again.

This should unbreak Steam.

cf. #139812
cc. @Princemachiavelli
cc. @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
