### PR TITLE
beekeeper-studio: init at 2.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7269,6 +7269,12 @@
     githubId = 7610974;
     name = "Jason Miller";
   };
+  milogert = {
+    email = "milo@milogert.com";
+    github = "milogert";
+    githubId = 5378535;
+    name = "Milo Gertjejansen";
+  };
   miltador = {
     email = "miltador@yandex.ua";
     name = "Vasiliy Solovey";

--- a/pkgs/development/tools/database/beekeeper-studio/default.nix
+++ b/pkgs/development/tools/database/beekeeper-studio/default.nix
@@ -1,0 +1,40 @@
+{ lib, fetchurl, appimageTools, pkgs }:
+
+let
+  pname = "beekeeper-studio";
+  version = "2.1.4";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v${version}/Beekeeper-Studio-${version}.AppImage";
+    name="${pname}-${version}.AppImage";
+    sha512 = "1aik88wi9axv66axjmmjmlna1sp0pz92z8i2x6pq3bs0gcs4i1q3qxxbrfc14ynbpa65knimfhwzrrshchnijgdazx3qjzh8jwzfiwl";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  multiPkgs = null; # no 32bit needed
+  extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
+
+  extraInstallCommands = ''
+    ln -s $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
+    install -m 444 -D ${appimageContents}/${pname}.png \
+      $out/share/icons/hicolor/512x512/apps/${pname}.png
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with lib; {
+    description = "Modern and easy to use SQL client for MySQL, Postgres, SQLite, SQL Server, and more. Linux, MacOS, and Windows";
+    homepage = "https://www.beekeeperstudio.io";
+    changelog = "https://github.com/beekeeper-studio/beekeeper-studio/releases/tag/v2.1.4";
+    license = licenses.mit;
+    maintainers = with maintainers; [ milogert ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11023,6 +11023,8 @@ with pkgs;
 
   avra = callPackage ../development/compilers/avra { };
 
+  beekeeper-studio = callPackage ../development/tools/database/beekeeper-studio { };
+
   bigloo = callPackage ../development/compilers/bigloo { };
 
   binaryen = callPackage ../development/compilers/binaryen { };


### PR DESCRIPTION
Adds [Beekeeper Studio](https://www.beekeeperstudio.io) at version 2.1.4 using the AppImage.

Addresses #139899

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I wanted this piece of software and found that others wanted it too.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
