### PR TITLE
vpn-slice: 0.14 -> 0.15, add update-script

### DIFF
--- a/pkgs/tools/networking/vpn-slice/default.nix
+++ b/pkgs/tools/networking/vpn-slice/default.nix
@@ -1,19 +1,25 @@
-{ lib, buildPythonApplication, python3Packages, fetchFromGitHub }:
+{ lib, buildPythonApplication, nix-update-script, python3Packages, fetchFromGitHub }:
 
 buildPythonApplication rec {
   pname = "vpn-slice";
-  version = "0.14";
+  version = "0.15";
 
   src = fetchFromGitHub {
     owner = "dlenski";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1z2mdl3arzl95zrj4ir57f762gcimmmq5nk91j679cshxz4snxyr";
+    sha256 = "sha256-9JnRuJkpcgW1cEgJPiqFDYotNSCl7XcmbHS6D4E13gM=";
   };
 
   propagatedBuildInputs = with python3Packages; [ setproctitle dnspython ];
 
   doCheck = false;
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/dlenski/vpn-slice";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To make the latest version of [vpn-slice](https://github.com/dlenski/vpn-slice) available via nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
