### PR TITLE
ocamlPackages.uunf: 13.0.0 → 14.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -1,50 +1,24 @@
-{ lib, stdenv, fetchurl, unzip, ocaml, findlib, ocamlbuild, topkg, uchar, uutf, cmdliner, uucd }:
+{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, uchar, uutf, cmdliner }:
 let
   pname = "uunf";
   webpage = "https://erratique.ch/software/${pname}";
-  version = "13.0.0";
-  ucdxml = fetchurl {
-    url = "http://www.unicode.org/Public/${version}/ucdxml/ucd.all.grouped.zip";
-    sha256 = "04gpl09ggb6fb0kmk6298rd8184dv6vcscn28l1gpdv1yjlw1a8q";
-  };
-  gen = fetchurl {
-    url = "https://raw.githubusercontent.com/dbuenzli/uunf/v12.0.0/support/gen.ml";
-    sha256 = "08j2mpi7j6q3rqc6bcdwspqn1s7pkkphznxfdycqjv4h9yaqsymj";
-  };
-  gen_norm = fetchurl {
-    url = "https://raw.githubusercontent.com/dbuenzli/uunf/v12.0.0/support/gen_norm.ml";
-    sha256 = "11vx5l5bag6bja7qj8jv4s2x9fknj3557n0mj87k2apq5gs5f4m5";
-  };
-  gen_props = fetchurl {
-    url = "https://raw.githubusercontent.com/dbuenzli/uunf/v12.0.0/support/gen_props.ml";
-    sha256 = "0a6lhja498kp9lxql0pbfvkgvajs10wx88wkqc7y5m3lrvw46268";
-  };
+  version = "14.0.0";
 in
 
-assert lib.versionAtLeast ocaml.version "4.03";
+if !lib.versionAtLeast ocaml.version "4.03"
+then throw "${pname} is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation {
-  name = "ocaml-${pname}-${version}";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
   inherit version;
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "1qci04nkp24kdls1z4s8kz5dzgky4nwd5r8345nwdrgwmxhw7ksm";
+    sha256 = "sha256:17wv0nm3vvwcbzb1b09akw8jblmigyhbfmh1sy9lkb5756ni94a2";
   };
 
-  postConfigure = ''
-    rm -f src/uunf_data.ml
-    mkdir -p support/
-    cp ${gen} support/gen.ml
-    cp ${gen_norm} support/gen_norm.ml
-    cp ${gen_props} support/gen_props.ml
-    funzip ${ucdxml} > support/ucd.xml
-    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ pkg/build_support.ml
-  '';
-
-  nativeBuildInputs = [ unzip ];
-
-  buildInputs = [ ocaml findlib ocamlbuild topkg uutf cmdliner uucd ];
+  buildInputs = [ ocaml findlib ocamlbuild topkg uutf cmdliner ];
 
   propagatedBuildInputs = [ uchar ];
 
@@ -53,11 +27,8 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "An OCaml module for normalizing Unicode text";
     homepage = webpage;
-    platforms = ocaml.meta.platforms or [];
+    inherit (ocaml.meta) platforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
-    # See https://github.com/dbuenzli/uunf/issues/15#issuecomment-903151264
-    broken = lib.versions.majorMinor ocaml.version == "4.08"
-      && stdenv.hostPlatform.isAarch64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Support for Unicode 14.0.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
