### PR TITLE
davix: 0.7.6 -> 0.8.0 and add build options

### DIFF
--- a/pkgs/tools/networking/davix/default.nix
+++ b/pkgs/tools/networking/davix/default.nix
@@ -1,19 +1,24 @@
 { lib, stdenv, fetchurl, cmake, pkg-config, openssl, libxml2, boost, python3, libuuid }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.6";
+  version = "0.8.0";
   pname = "davix";
   nativeBuildInputs = [ cmake pkg-config python3 ];
   buildInputs = [ openssl libxml2 boost libuuid ];
 
   # using the url below since the github release page states
   # "please ignore the GitHub-generated tarballs, as they are incomplete"
-  # https://github.com/cern-fts/davix/releases/tag/R_0_7_6
+  # https://github.com/cern-fts/davix/releases/tag/R_0_8_0
   src = fetchurl {
     url = "https://github.com/cern-fts/${pname}/releases/download/R_${lib.replaceStrings ["."] ["_"] version}/${pname}-${version}.tar.gz";
-    sha256 = "0wq66spnr616cns72f9dvr2xfvkdvfqqmc6d7dx29fpp57zzvrx2";
+    sha256 = "LxCNoECKg/tbnwxoFQ02C6cz5LOg/imNRbDTLSircSQ=";
   };
 
+  preConfigure = ''
+    find . -mindepth 1 -maxdepth 1 -type f -name "patch*.sh" -print0 | while IFS= read -r -d ''' file; do
+      patchShebangs "$file"
+    done
+  '';
 
   meta = with lib; {
     description = "Toolkit for Http-based file management";
@@ -22,10 +27,10 @@ stdenv.mkDerivation rec {
     operations with Http based protocols (WebDav, Amazon S3, ...).
     Davix provides an API and a set of command line tools";
 
-    license     = licenses.lgpl2Plus;
-    homepage    = "http://dmc.web.cern.ch/projects/davix/home";
-    maintainers = [ maintainers.adev ];
-    platforms   = platforms.all;
+    license = licenses.lgpl2Plus;
+    homepage = "http://dmc.web.cern.ch/projects/davix/home";
+    changelog = "https://github.com/cern-fts/davix/blob/devel/RELEASE-NOTES.md";
+    maintainers = with maintainers; [ adev ];
+    platforms = platforms.all;
   };
 }
-

--- a/pkgs/tools/networking/davix/default.nix
+++ b/pkgs/tools/networking/davix/default.nix
@@ -1,10 +1,44 @@
-{ lib, stdenv, fetchurl, cmake, pkg-config, openssl, libxml2, boost, python3, libuuid }:
+{ lib
+, stdenv
+, fetchurl
+, cmake
+, pkg-config
+, openssl
+, libxml2
+, boost
+, python3
+, libuuid
+, curl
+, gsoap
+, enableTools ? true
+  # Build the bundled libcurl
+  # and, if defaultToLibCurl,
+  # use instead of an external one
+, useEmbeddedLibcurl ? true
+  # Use libcurl instead of libneon
+  # Note that the libneon used is bundled in the project
+  # See https://github.com/cern-fts/davix/issues/23
+, defaultToLibcurl ? false
+, enableIpv6 ? true
+, enableTcpNodelay ? true
+  # Build davix_copy.so
+, enableThirdPartyCopy ? false
+}:
 
+let
+  boolToUpper = b: lib.toUpper (lib.boolToString b);
+in
 stdenv.mkDerivation rec {
   version = "0.8.0";
   pname = "davix";
   nativeBuildInputs = [ cmake pkg-config python3 ];
-  buildInputs = [ openssl libxml2 boost libuuid ];
+  buildInputs = [
+    openssl
+    libxml2
+    boost
+    libuuid
+  ] ++ lib.optional (defaultToLibcurl && !useEmbeddedLibcurl) curl
+  ++ lib.optional (enableThirdPartyCopy) gsoap;
 
   # using the url below since the github release page states
   # "please ignore the GitHub-generated tarballs, as they are incomplete"
@@ -19,6 +53,15 @@ stdenv.mkDerivation rec {
       patchShebangs "$file"
     done
   '';
+
+  cmakeFlags = [
+    "-DENABLE_TOOLS=${boolToUpper enableTools}"
+    "-DEMBEDDED_LIBCURL=${boolToUpper useEmbeddedLibcurl}"
+    "-DLIBCURL_BACKEND_BY_DEFAULT=${boolToUpper defaultToLibcurl}"
+    "-DENABLE_IPV6=${boolToUpper enableIpv6}"
+    "-DENABLE_TCP_NODELAY=${boolToUpper enableTcpNodelay}"
+    "-DENABLE_THIRD_PARTY_COPY=${boolToUpper enableThirdPartyCopy}"
+  ];
 
   meta = with lib; {
     description = "Toolkit for Http-based file management";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3720,6 +3720,8 @@ with pkgs;
 
   davix = callPackage ../tools/networking/davix { };
 
+  davix-copy = appendToName "copy" (davix.override { enableThirdPartyCopy = true; });
+
   cantata = libsForQt5.callPackage ../applications/audio/cantata { };
 
   cantoolz = python3Packages.callPackage ../tools/networking/cantoolz { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

1.  Upgrade to a new version
2.  Make it easier to override build options, preparing for the shift of the backend
3.  Make davix_copy available (as a build option and another derivaton) (closes #140590 )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
