### PR TITLE
foot: 1.9.0 -> 1.9.2

### DIFF
--- a/pkgs/applications/terminal-emulators/foot/default.nix
+++ b/pkgs/applications/terminal-emulators/foot/default.nix
@@ -27,7 +27,7 @@
 }:
 
 let
-  version = "1.9.0";
+  version = "1.9.2";
 
   # build stimuli file for PGO build and the script to generate it
   # independently of the foot's build, so we can cache the result
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
     owner = "dnkl";
     repo = pname;
     rev = version;
-    sha256 = "0mkzq5lbgl5qp5nj8sk5gyg9hrrklmbjdqzlcr2a6rlmilkxlhwm";
+    sha256 = "15h01ijx87i60bdgjjap1ymwlxggsxc6iziykh3bahj8432s1836";
   };
 
   depsBuildBuild = [
@@ -144,16 +144,15 @@ stdenv.mkDerivation rec {
 
   mesonBuildType = "release";
 
+  # See https://codeberg.org/dnkl/foot/src/tag/1.9.2/INSTALL.md#options
   mesonFlags = [
+    # Use lto
     "-Db_lto=true"
-    # Prevent foot from installing its terminfo file into a custom location,
-    # we need to do this manually in postInstall.
-    # See https://codeberg.org/dnkl/foot/pulls/673,
-    # https://codeberg.org/dnkl/foot/src/tag/1.9.0/INSTALL.md#options
-    "-Dterminfo=disabled"
+    # “Build” and install terminfo db
+    "-Dterminfo=enabled"
     # Ensure TERM=foot is used
     "-Ddefault-terminfo=foot"
-    # Tell foot what to set TERMINFO to
+    # Tell foot to set TERMINFO and where to install the terminfo files
     "-Dcustom-terminfo-install-location=${terminfoDir}"
   ];
 
@@ -173,13 +172,6 @@ stdenv.mkDerivation rec {
   '';
 
   outputs = [ "out" "terminfo" ];
-
-  postInstall = ''
-    # build and install foot's terminfo to the standard location
-    # instead of its custom location
-    mkdir -p "${terminfoDir}"
-    tic -o "${terminfoDir}" -x -e foot,foot-direct "$NIX_BUILD_TOP/$sourceRoot/foot.info"
-  '';
 
   passthru.tests = {
     clang-default-compilation = foot.override {

--- a/pkgs/applications/terminal-emulators/foot/default.nix
+++ b/pkgs/applications/terminal-emulators/foot/default.nix
@@ -36,8 +36,7 @@ let
   #
   # For every bump, make sure that the hash is still accurate.
   stimulusGenerator = stdenv.mkDerivation {
-    pname = "foot-generate-alt-random-writes";
-    inherit version;
+    name = "foot-generate-alt-random-writes";
 
     src = fetchurl {
       url = "https://codeberg.org/dnkl/foot/raw/tag/${version}/scripts/generate-alt-random-writes.py";
@@ -185,6 +184,13 @@ stdenv.mkDerivation rec {
     noPgo = foot.override {
       allowPgo = false;
     };
+
+    # By changing name, this will get rebuilt everytime we change version,
+    # even if the hash stays the same. Consequently it'll fail if we introduce
+    # a hash mismatch when updating.
+    stimulus-script-is-current = stimulusGenerator.src.overrideAttrs (_: {
+      name = "generate-alt-random-writes-${version}.py";
+    });
   };
 
   meta = with lib; {


### PR DESCRIPTION
foot's upstream has abandoned the approach of using a custom terminfo
install location and setting TERMINFO, but still supports it. For us
this has eliminated the need to build the foot terminfo files manually,
somehow which is appreciated.

We preserve our current approach: Install terminfo files to the terminfo
output and set TERMINFO to that store path instead of propagating the
output for user env insatllations.

Change logs:

* https://codeberg.org/dnkl/foot/releases/tag/1.9.1

* https://codeberg.org/dnkl/foot/releases/tag/1.9.2

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
