### PR TITLE
opendht: support proxy

### DIFF
--- a/pkgs/development/libraries/opendht/default.nix
+++ b/pkgs/development/libraries/opendht/default.nix
@@ -1,6 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, darwin
-, cmake, pkg-config
-, asio, nettle, gnutls, msgpack, readline, libargon2
+{ lib
+, stdenv
+, fetchFromGitHub
+, Security
+, cmake
+, pkg-config
+, asio
+, nettle
+, gnutls
+, msgpack
+, readline
+, libargon2
+, jsoncpp
+, restinio
+, http-parser
+, openssl
+, fmt
+, enableProxyServerAndClient ? false
+, enablePushNotifications ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -14,29 +30,42 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Os5PRYTZMVekQrbwNODWsHANTx6RSC5vzGJ5JoYtvtE=";
   };
 
-  nativeBuildInputs =
-    [ cmake
-      pkg-config
-    ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
-  buildInputs =
-    [ asio
-      nettle
-      gnutls
-      msgpack
-      readline
-      libargon2
-    ] ++ lib.optionals stdenv.isDarwin [
-      darwin.apple_sdk.frameworks.Security
-    ];
+  buildInputs = [
+    asio
+    nettle
+    gnutls
+    msgpack
+    readline
+    libargon2
+  ] ++ lib.optionals enableProxyServerAndClient [
+    jsoncpp
+    restinio
+    http-parser
+    openssl
+    fmt
+  ] ++ lib.optionals stdenv.isDarwin [
+    Security
+  ];
+
+  cmakeFlags = lib.optionals enableProxyServerAndClient [
+    "-DOPENDHT_PROXY_SERVER=ON"
+    "-DOPENDHT_PROXY_CLIENT=ON"
+  ] ++ lib.optionals enablePushNotifications [
+    "-DOPENDHT_PUSH_NOTIFICATIONS=ON"
+  ];
 
   outputs = [ "out" "lib" "dev" "man" ];
 
   meta = with lib; {
     description = "A C++11 Kademlia distributed hash table implementation";
-    homepage    = "https://github.com/savoirfairelinux/opendht";
-    license     = licenses.gpl3Plus;
+    homepage = "https://github.com/savoirfairelinux/opendht";
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ taeer olynch thoughtpolice ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7942,7 +7942,9 @@ with pkgs;
 
   opendbx = callPackage ../development/libraries/opendbx { };
 
-  opendht = callPackage ../development/libraries/opendht {};
+  opendht = callPackage ../development/libraries/opendht  {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   opendkim = callPackage ../development/libraries/opendkim { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
