### PR TITLE
top-level/release-r.nix: init Hydra job set for rPackages

### DIFF
--- a/pkgs/top-level/release-r.nix
+++ b/pkgs/top-level/release-r.nix
@@ -1,0 +1,13 @@
+/*
+  This is the Hydra jobset for the `r-updates` branch in Nixpkgs.
+  The jobset can be tested by:
+
+  $ hydra-eval-jobs -I . pkgs/top-level/release-r.nix
+*/
+{ supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ] }:
+
+with import ./release-lib.nix { inherit supportedSystems; };
+
+mapTestOn {
+  rPackages = packagePlatforms pkgs.rPackages;
+}


### PR DESCRIPTION
As suggested in #138210, this establishes a Hydra job set for the rPackages tree. Remaining todos:

1. create a branch nixpkgs/r-updates from master
2. reconfigure Hydra to use this jobset and point at nixpkgs/r-updates

Not sure who to ping for Hydra config?

@domenkozar @sternenseemann 