### PR TITLE
unifiedpush-common-proxies: init at 1.0.0

### DIFF
--- a/pkgs/servers/unifiedpush-common-proxies/default.nix
+++ b/pkgs/servers/unifiedpush-common-proxies/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+}:
+
+buildGoModule rec {
+  pname = "unifiedpush-common-proxies";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "unifiedpush";
+    repo = "common-proxies";
+    rev = "v${version}";
+    sha256 = "sha256-1Nl36Ldb0/DrQEKgPBsCgJk7oRCIq2m9Vb8D8wnS1g0=";
+  };
+
+  vendorSha256 = "sha256-7A2ErjqmgberMabayWEc3w53+YierfetzmT8DzHwbpE=";
+
+  meta = with lib; {
+    description = "A set of rewrite proxies and gateways for UnifiedPush";
+    homepage = "https://github.com/UnifiedPush/common-proxies";
+    license = licenses.mit;
+    maintainers = with maintainers; [ yuka ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20528,6 +20528,8 @@ with pkgs;
 
   networkaudiod = callPackage ../servers/networkaudiod { };
 
+  unifiedpush-common-proxies = callPackage ../servers/unifiedpush-common-proxies { };
+
   unit = callPackage ../servers/http/unit { };
 
   ncdns = callPackage ../servers/dns/ncdns { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
