### PR TITLE
pantheon.switchboard-plug-power: fix crash

### DIFF
--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
@@ -15,6 +15,7 @@
 , dbus
 , polkit
 , switchboard
+, wingpanel-indicator-power
 }:
 
 stdenv.mkDerivation rec {
@@ -51,6 +52,7 @@ stdenv.mkDerivation rec {
     libgee
     polkit
     switchboard
+    wingpanel-indicator-power # settings schema
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Similar to https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-884704684.

```
(.io.elementary.switchboard-wrapped_:3264): GLib-GIO-ERROR **: 20:51:52.806: Settings schema 'io.elementary.desktop.wingpanel.power' is not installed
[1]    3264 trace trap (core dumped)  io.elementary.switchboard
```

Haven't found similar issue from other switchboard plugins yet, but would like to fix once reported.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
