### PR TITLE
openethereum: mark as broken

### DIFF
--- a/pkgs/applications/blockchains/openethereum/default.nix
+++ b/pkgs/applications/blockchains/openethereum/default.nix
@@ -52,5 +52,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ akru xrelkd ];
     platforms = lib.platforms.unix;
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

When I try to `nix-shell -p openethereum` on my `21.11pre320334.82155ff501c (Porcupine)`, I got the `cargo build` error:

```
error[E0061]: this function takes 1 argument but 2 arguments were supplied
    --> /build/openethereum-3.2.6-vendor.tar.gz/logos-derive/src/lib.rs:55:20
     |
55   |             extras.insert(util::ident(&ext), |_| panic!("Only one #[extras] attribute can be declared."));
     |                    ^^^^^^ -----------------  ----------------------------------------------------------- supplied 2 arguments
     |                    |
     |                    expected 1 argument
     |
note: associated function defined here

error[E0061]: this function takes 1 argument but 2 arguments were supplied
    --> /build/openethereum-3.2.6-vendor.tar.gz/logos-derive/src/lib.rs:89:23
     |
89   |                 error.insert(variant, |_| panic!("Only one #[error] variant can be declared."));
     |                       ^^^^^^ -------  -------------------------------------------------------- supplied 2 arguments
     |                       |
     |                       expected 1 argument
     |
note: associated function defined here

error[E0061]: this function takes 1 argument but 2 arguments were supplied
    --> /build/openethereum-3.2.6-vendor.tar.gz/logos-derive/src/lib.rs:93:21
     |
93   |                 end.insert(variant, |_| panic!("Only one #[end] variant can be declared."));
     |                     ^^^^^^ -------  ------------------------------------------------------ supplied 2 arguments
     |                     |
     |                     expected 1 argument
     |
note: associated function defined here
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
