### PR TITLE
open-policy-agent: 0.32.1 -> 0.33.1

### DIFF
--- a/pkgs/development/tools/open-policy-agent/default.nix
+++ b/pkgs/development/tools/open-policy-agent/default.nix
@@ -1,26 +1,67 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+
+, enableWasmEval ? false
+}:
 
 buildGoModule rec {
   pname = "open-policy-agent";
-  version = "0.32.1";
+  version = "0.33.1";
 
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "opa";
     rev = "v${version}";
-    sha256 = "sha256-pd0bOE0cSi+93B0U46KpeC7AHgsV3oBJcT/wg8XED5Y=";
+    sha256 = "sha256-n0VuzYlgn9IGiaxzDeuVjMqFbDwTe3UjExk7BT2DNZc=";
   };
   vendorSha256 = null;
+
+  nativeBuildInputs = [ installShellFiles ];
 
   subPackages = [ "." ];
 
   ldflags = [ "-s" "-w" "-X github.com/open-policy-agent/opa/version.Version=${version}" ];
 
+  tags = lib.optional enableWasmEval (
+    builtins.trace
+      ("Warning: enableWasmEval breaks reproducability, "
+        + "ensure you need wasm evaluation. "
+        + "`opa build` does not need this feature.")
+      "opa_wasm");
+
+  preCheck = ''
+    # Feed in all but the e2e tests for testing
+    # This is because subPackages above limits what is built to just what we
+    # want but also limits the tests
+    getGoDirs() {
+      go list ./... | grep -v e2e
+    }
+
+    # Remove test case that fails on < go1.17
+    rm test/cases/testdata/cryptox509parsecertificates/test-cryptox509parsecertificates-0123.yaml
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd opa \
+      --bash <($out/bin/opa completion bash) \
+      --fish <($out/bin/opa completion fish) \
+      --zsh <($out/bin/opa completion zsh)
+  '';
+
   doInstallCheck = true;
   installCheckPhase = ''
     runHook preInstallCheck
+
     $out/bin/opa --help
     $out/bin/opa version | grep "Version: ${version}"
+
+    ${lib.optionalString enableWasmEval ''
+      # If wasm is enabled verify it works
+      $out/bin/opa eval -t wasm 'trace("hello from wasm")'
+    ''}
+
     runHook postInstallCheck
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump open-policy-agent to `0.33.1`

Also enabled the wasm feature and/or the ability to change go tags

Validate wasm works with `./result/bin/opa eval -t wasm 'trace("hello from wasm")`

Added the tests

Times:

* no wasm + no tests (original)
  * `0.53s user 0.12s system 2% cpu 28.378 total`
* wasm + no tests
  * `0.55s user 0.13s system 1% cpu 35.521 total` Δ+7.143s
* no wasm + tests
  * `0.81s user 0.79s system 1% cpu 2:34.90 total` Δ+125.522s
* wasm + tests
  * `0.81s user 0.82s system 0% cpu 3:24.85 total` Δ+176.472s

@nlewo

---

Edit: ok the wasm feature breaks reproducibility. Should we have it off by default?, There might also be concerns with WASM on aarch64 linux and both darwin versions

without wasm eval it's 17 MB, with wasm eval it's 33 MB

Added shell completions too

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
