### PR TITLE
Update liquidsoap to 2.0.5

### DIFF
--- a/pkgs/development/ocaml-modules/cry/default.nix
+++ b/pkgs/development/ocaml-modules/cry/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, fetchFromGitHub }:
+
+buildDunePackage rec {
+  pname = "cry";
+  version = "0.6.5";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-cry";
+    rev = version;
+    sha256 = "1g4smccj27sv8pb9az5hbzxi99swg3d55mp7j25lz30xyabvksc3";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-cry";
+    description = "OCaml client for the various icecast & shoutcast source protocols";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/faad/default.nix
+++ b/pkgs/development/ocaml-modules/faad/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, faad2, pkg-config }:
+
+buildDunePackage rec {
+  pname = "faad";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-faad";
+    rev = "v${version}";
+    sha256 = "sha256-3ayKZhgJAgsoOqn0InSrM5f3TImRHOQMtWETICo4t3o=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ faad2 ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-faad";
+    description = "Bindings for the faad library which provides functions for decoding AAC audio files";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/frei0r/default.nix
+++ b/pkgs/development/ocaml-modules/frei0r/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, pkg-config, frei0r }:
+
+buildDunePackage rec {
+  pname = "frei0r";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-frei0r";
+    rev = "v${version}";
+    sha256 = "sha256-eh/ymZO/3a1z6uvZdnXgma/7AU2NBVs2lddA+R/kuQA=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ frei0r ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-frei0r";
+    description = "Bindings for the frei0r API which provides video effects";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/lame/default.nix
+++ b/pkgs/development/ocaml-modules/lame/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildDunePackage, fetchFromGitHub, pkg-config, dune-configurator, lame }:
+
+buildDunePackage rec {
+  pname = "lame";
+  version = "0.3.6";
+
+  minimalOCamlVersion = "4.03";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-lame";
+    rev = "v${version}";
+    sha256 = "sha256-oRxP1OM0pGdz8CB+ou7kbbrNaB1x9z9KTfciLsivFnI=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ lame ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-lame";
+    description = "Bindings for the lame library which provides functions for encoding mp3 files";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/lilv/default.nix
+++ b/pkgs/development/ocaml-modules/lilv/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, ctypes, lilv }:
+
+buildDunePackage rec {
+  pname = "lilv";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-lilv";
+    rev = "v${version}";
+    sha256 = "080ja8c4sxprk5qnldpfzxriag57m9603vny3b4bnwh5xm1id08c";
+  };
+
+  minimalOCamlVersion = "4.03.0";
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ctypes lilv ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-lilv";
+    description = "OCaml bindings for lilv";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ocurl/default.nix
+++ b/pkgs/development/ocaml-modules/ocurl/default.nix
@@ -1,21 +1,18 @@
-{ stdenv, lib, pkg-config, ocaml, findlib, fetchurl, curl, ncurses, lwt }:
-
-if lib.versionOlder ocaml.version "4.02"
+{ lib, stdenv, fetchurl, pkg-config, ocaml, findlib, curl, lwt, lwt_ppx }:
+if lib.versionOlder ocaml.version "4.04"
 then throw "ocurl is not available for OCaml ${ocaml.version}"
 else
-
 stdenv.mkDerivation rec {
   pname = "ocurl";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchurl {
-    url = "http://ygrek.org.ua/p/release/ocurl/ocurl-${version}.tar.gz";
-    sha256 = "0n621cxb9012pj280c7821qqsdhypj8qy9qgrah79dkh6a8h2py6";
+    url = "https://github.com/ygrek/ocurl/releases/download/${version}/ocurl-${version}.tar.gz";
+    sha256 = "sha256-4DWXGMh02s1VwLWW5d7h0jtMOUubWmBPGm1hghfWd2M=";
   };
 
   nativeBuildInputs = [ pkg-config ocaml findlib ];
-  buildInputs = [ ncurses ];
-  propagatedBuildInputs = [ curl lwt ];
+  propagatedBuildInputs = [ curl lwt lwt_ppx ];
 
   strictDeps = true;
 
@@ -24,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "OCaml bindings to libcurl";
     license = lib.licenses.mit;
     homepage = "http://ygrek.org.ua/p/ocurl/";
-    maintainers = with lib.maintainers; [ bennofs ];
+    maintainers = with lib.maintainers; [ dandellion bennofs ];
     platforms = ocaml.meta.platforms or [ ];
   };
 }

--- a/pkgs/development/ocaml-modules/soundtouch/default.nix
+++ b/pkgs/development/ocaml-modules/soundtouch/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, soundtouch }:
+
+buildDunePackage rec {
+  pname = "soundtouch";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-soundtouch";
+    rev = "v${version}";
+    sha256 = "sha256-81Mhk4PZx4jGrVIevzMslvVbKzipzDzHWnbtOjeZCI8=";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ soundtouch ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-soundtouch";
+    description = "Bindings for the soundtouch library which provides functions for changing pitch and timestretching audio data";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/taglib/default.nix
+++ b/pkgs/development/ocaml-modules/taglib/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, pkg-config, taglib, zlib }:
+
+buildDunePackage rec {
+  pname = "taglib";
+  version = "0.3.9";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-taglib";
+    rev = "v${version}";
+    sha256 = "sha256-n8Vv8Vepvhx7anZdWIdBfw+HSQShKWjNe6l0gqRRsSs=";
+  };
+
+  minimalOCamlVersion = "4.05.0"; # Documented version 4.02.0. 4.05.0 actually required.
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ taglib zlib ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-taglib";
+    description = "Bindings for the taglib library which provides functions for reading tags in headers of audio files";
+    license = with licenses; [ lgpl21Plus "link-exception" ]; # GNU Library Public License 2 Linking Exception
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -464,6 +464,10 @@ let
 
     fpath = callPackage ../development/ocaml-modules/fpath { };
 
+    frei0r = callPackage ../development/ocaml-modules/frei0r {
+      inherit (pkgs) frei0r;
+    };
+
     functoria = callPackage ../development/ocaml-modules/functoria { };
 
     functoria-runtime = callPackage ../development/ocaml-modules/functoria/runtime.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1191,6 +1191,10 @@ let
 
     sosa = callPackage ../development/ocaml-modules/sosa { };
 
+    soundtouch = callPackage ../development/ocaml-modules/soundtouch {
+      inherit (pkgs) soundtouch;
+    };
+
     spacetime_lib = callPackage ../development/ocaml-modules/spacetime_lib { };
 
     speex = callPackage ../development/ocaml-modules/speex {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -239,6 +239,8 @@ let
 
     crunch = callPackage ../development/tools/ocaml/crunch { };
 
+    cry = callPackage ../development/ocaml-modules/cry { };
+
     cryptokit = callPackage ../development/ocaml-modules/cryptokit { };
 
     csexp = callPackage ../development/ocaml-modules/csexp { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -688,6 +688,10 @@ let
 
     lambda-term = callPackage ../development/ocaml-modules/lambda-term { };
 
+    lame = callPackage ../development/ocaml-modules/lame {
+      inherit (pkgs) lame;
+    };
+
     lastfm = callPackage ../development/ocaml-modules/lastfm { };
 
     lens = callPackage ../development/ocaml-modules/lens { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -706,6 +706,10 @@ let
 
     letsencrypt-dns = callPackage ../development/ocaml-modules/letsencrypt/dns.nix { };
 
+    lilv = callPackage ../development/ocaml-modules/lilv {
+      inherit (pkgs) lilv;
+    };
+
     linenoise = callPackage ../development/ocaml-modules/linenoise { };
 
     llvm = callPackage ../development/ocaml-modules/llvm {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1393,6 +1393,10 @@ let
 
     stringext = callPackage ../development/ocaml-modules/stringext { };
 
+    taglib = callPackage ../development/ocaml-modules/taglib {
+      inherit (pkgs) taglib;
+    };
+
     tcslib = callPackage ../development/ocaml-modules/tcslib { };
 
     telegraml = callPackage ../development/ocaml-modules/telegraml { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -399,6 +399,8 @@ let
 
     ezxmlm = callPackage ../development/ocaml-modules/ezxmlm { };
 
+    faad = callPackage ../development/ocaml-modules/faad { };
+
     facile = callPackage ../development/ocaml-modules/facile { };
 
     faraday = callPackage ../development/ocaml-modules/faraday { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Liquidsoap no longer provides liquidsoap-full source, so all the savonet libraries must be packaged properly as libraries now.

Camomile's META file did not include a version, which is required for liquidsoap's configure step, so I added it.  
Feel free to suggest a better way to accomplish this

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
