### PR TITLE
[21.05] onionshare: mark as vulnerable to CVE-2021-41867, CVE-2021-41868

### DIFF
--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -52,6 +52,8 @@ let
 
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ lourkeur ];
+
+    knownVulnerabilities = [ "CVE-2021-41867" "CVE-2021-41868" ];
   };
 
 in rec {


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-41868
https://nvd.nist.gov/vuln/detail/CVE-2021-41867

See discussion in #140661.

Bumping to a fixed version would require bumping tor, and patching doesn't appear simple.

Of course the other alternative would be to embed a copy of tor 0.4.6.x from master just for this package ;)
