### PR TITLE
k3s: updateScript updated

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -47,7 +47,7 @@ let
   k3sCommit = "3e250fdbab72d88f7e6aae57446023a0567ffc97"; # k3s git commit at the above version
   k3sRepoSha256 = "1w7drvk0bmlmqrxh1y6dxjy7dk6bdrl72pkd25lc1ir6wbzb05h9";
 
-  traefikChartVersion = "9.18.2"; # taken from ./scripts/download at TRAEFIK_VERSION
+  traefikChartVersion = "9.18.2"; # taken from ./manifests/traefik.yaml at spec.version
   traefikChartSha256 = "sha256-9d7p0ngyMN27u4OPgz7yI14Zj9y36t9o/HMX5wyDpUI=";
 
   k3sRootVersion = "0.9.1";       # taken from ./scripts/download at ROOT_VERSION

--- a/pkgs/applications/networking/cluster/k3s/update.sh
+++ b/pkgs/applications/networking/cluster/k3s/update.sh
@@ -10,19 +10,16 @@ cd $(dirname "${BASH_SOURCE[0]}")
 
 LATEST_TAG_RAWFILE=${WORKDIR}/latest_tag.json
 curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
-    https://api.github.com/repos/k3s-io/k3s/releases/latest > ${LATEST_TAG_RAWFILE}
+    https://api.github.com/repos/k3s-io/k3s/releases > ${LATEST_TAG_RAWFILE}
 
-LATEST_TAG_NAME=$(jq -r '.tag_name' ${LATEST_TAG_RAWFILE})
-
+LATEST_TAG_NAME=$(jq 'map(.tag_name)' ${LATEST_TAG_RAWFILE} | grep -v -e rc -e engine | sed 's/["|,| ]//g' | sort -r | head -n1)
 K3S_VERSION=$(echo ${LATEST_TAG_NAME} | sed 's/^v//')
-
-LATEST_TAG_TARBALL_URL=$(jq -r '.tarball_url' ${LATEST_TAG_RAWFILE})
 
 K3S_COMMIT=$(curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
     https://api.github.com/repos/k3s-io/k3s/tags \
     | jq -r "map(select(.name == \"${LATEST_TAG_NAME}\")) | .[0] | .commit.sha")
 
-K3S_REPO_SHA256=$(nix-prefetch-url --quiet --unpack ${LATEST_TAG_TARBALL_URL})
+K3S_REPO_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/k3s-io/k3s/archive/refs/tags/${LATEST_TAG_NAME}.tar.gz)
 
 FILE_SCRIPTS_DOWNLOAD=${WORKDIR}/scripts-download
 curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts/download > $FILE_SCRIPTS_DOWNLOAD
@@ -30,16 +27,19 @@ curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts
 FILE_SCRIPTS_VERSION=${WORKDIR}/scripts-version.sh
 curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts/version.sh > $FILE_SCRIPTS_VERSION
 
-TRAEFIK_CHART_VERSION=$(grep TRAEFIK_VERSION= $FILE_SCRIPTS_DOWNLOAD \
-    | cut -d'=' -f2 | cut -d' ' -f1)
+FILE_MANIFESTS_TRAEFIK=${WORKDIR}/manifests-traefik.yaml
+curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/manifests/traefik.yaml > $FILE_MANIFESTS_TRAEFIK
+
+TRAEFIK_CHART_VERSION=$(awk -F/ '/traefik-([[:digit:]]+\.)/ {sub(/traefik-/, "", $6) ; sub(/\.tgz/, "", $6); print $6}' $FILE_MANIFESTS_TRAEFIK)
+
 TRAEFIK_CHART_SHA256=$(nix-prefetch-url --quiet "https://helm.traefik.io/traefik/traefik-${TRAEFIK_CHART_VERSION}.tgz")
 
-K3S_ROOT_VERSION=$(grep ROOT_VERSION= $FILE_SCRIPTS_DOWNLOAD \
+K3S_ROOT_VERSION=$(grep 'ROOT_VERSION=' ${FILE_SCRIPTS_DOWNLOAD} \
     | cut -d'=' -f2 | cut -d' ' -f1 | sed 's/^v//')
 K3S_ROOT_SHA256=$(nix-prefetch-url --quiet --unpack \
     "https://github.com/k3s-io/k3s-root/releases/download/v${K3S_ROOT_VERSION}/k3s-root-amd64.tar")
 
-CNIPLUGINS_VERSION=$(grep VERSION_CNIPLUGINS= $FILE_SCRIPTS_VERSION \
+CNIPLUGINS_VERSION=$(grep 'VERSION_CNIPLUGINS=' ${FILE_SCRIPTS_VERSION} \
     | cut -d'=' -f2 | cut -d' ' -f1 | sed -e 's/"//g' -e 's/^v//')
 CNIPLUGINS_SHA256=$(nix-prefetch-url --quiet --unpack \
     "https://github.com/rancher/plugins/archive/refs/tags/v${CNIPLUGINS_VERSION}.tar.gz")


### PR DESCRIPTION
* k3s: updateScript updated

@JesusMtnez Update script is working for me. Feel free to test it. 
On nixpkgs root, run: `pkgs/applications/networking/cluster/k3s/update.sh`
It should properly update `pkgs/applications/networking/cluster/k3s/default.nix`.

Once PR is merged, the bot will update overnight (runs once a day), logs here:
https://r.ryantm.com/log/updatescript/k3s/

On any problem, feel free to fix the script (that is the real solution).

Look forward to more contributions from you. :-)