### PR TITLE
nixos/qemu-vm: Allow building a Nix store image instead of relying on 9p + more

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1176,6 +1176,13 @@ Superuser created successfully.
           dropped because it was EOLed by upstream in 2021-10.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>virtualisation.pathsInNixDB</literal> option was
+          renamed
+          <link xlink:href="options.html#opt-virtualisation.additionalPaths"><literal>virtualisation.additionalPaths</literal></link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-notable-changes">
@@ -1199,25 +1206,31 @@ Superuser created successfully.
         <para>
           In NixOS virtual machines (QEMU), the
           <literal>virtualisation</literal> module has been updated with
-          new options to configure:
+          new options:
         </para>
         <itemizedlist spacing="compact">
           <listitem>
             <para>
-              IPv4 port forwarding
-              (<link xlink:href="options.html#opt-virtualisation.forwardPorts"><literal>virtualisation.forwardPorts</literal></link>),
+              <link xlink:href="options.html#opt-virtualisation.forwardPorts"><literal>forwardPorts</literal></link>
+              to configure IPv4 port forwarding,
             </para>
           </listitem>
           <listitem>
             <para>
-              shared host directories
-              (<link xlink:href="options.html#opt-virtualisation.sharedDirectories"><literal>virtualisation.sharedDirectories</literal></link>),
+              <link xlink:href="options.html#opt-virtualisation.sharedDirectories"><literal>sharedDirectories</literal></link>
+              to set up shared host directories,
             </para>
           </listitem>
           <listitem>
             <para>
-              screen resolution
-              (<link xlink:href="options.html#opt-virtualisation.resolution"><literal>virtualisation.resolution</literal></link>).
+              <link xlink:href="options.html#opt-virtualisation.resolution"><literal>resolution</literal></link>
+              to set the screen resolution,
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <link xlink:href="options.html#opt-virtualisation.useNixStoreImage"><literal>useNixStoreImage</literal></link>
+              to use a disk image for the Nix store instead of 9P.
             </para>
           </listitem>
         </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -362,16 +362,20 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - Nextcloud 20 (`pkgs.nextcloud20`) has been dropped because it was EOLed by upstream in 2021-10.
 
+- The `virtualisation.pathsInNixDB` option was renamed
+  [`virtualisation.additionalPaths`](options.html#opt-virtualisation.additionalPaths).
+
 ## Other Notable Changes {#sec-release-21.11-notable-changes}
 
 
 - The linux kernel package infrastructure was moved out of `all-packages.nix`, and restructured. Linux related functions and attributes now live under the `pkgs.linuxKernel` attribute set.
   In particular the versioned `linuxPackages_*` package sets (such as `linuxPackages_5_4`) and kernels from `pkgs` were moved there and now live under `pkgs.linuxKernel.packages.*`. The unversioned ones (such as `linuxPackages_latest`) remain untouched.
 
-- In NixOS virtual machines (QEMU), the `virtualisation` module has been updated with new options to configure:
-    - IPv4 port forwarding ([`virtualisation.forwardPorts`](options.html#opt-virtualisation.forwardPorts)),
-    - shared host directories ([`virtualisation.sharedDirectories`](options.html#opt-virtualisation.sharedDirectories)),
-    - screen resolution ([`virtualisation.resolution`](options.html#opt-virtualisation.resolution)).
+- In NixOS virtual machines (QEMU), the `virtualisation` module has been updated with new options:
+    - [`forwardPorts`](options.html#opt-virtualisation.forwardPorts) to configure IPv4 port forwarding,
+    - [`sharedDirectories`](options.html#opt-virtualisation.sharedDirectories) to set up shared host directories,
+    - [`resolution`](options.html#opt-virtualisation.resolution) to set the screen resolution,
+    - [`useNixStoreImage`](options.html#opt-virtualisation.useNixStoreImage) to use a disk image for the Nix store instead of 9P.
 
   In addition, the default [`msize`](options.html#opt-virtualisation.msize) parameter in 9P filesystems (including /nix/store and all shared directories) has been increased to 16K for improved performance.
 

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -44,6 +44,9 @@
   #   most likely fails as GRUB will probably refuse to install.
   partitionTableType ? "legacy"
 
+, # Whether to invoke `switch-to-configuration boot` during image creation
+  installBootLoader ? true
+
 , # The root file system type.
   fsType ? "ext4"
 
@@ -368,11 +371,13 @@ in pkgs.vmTools.runInLinuxVM (
         cp ${configFile} /mnt/etc/nixos/configuration.nix
       ''}
 
-      # Set up core system link, GRUB, etc.
-      NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+      ${lib.optionalString installBootLoader ''
+        # Set up core system link, GRUB, etc.
+        NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 
-      # The above scripts will generate a random machine-id and we don't want to bake a single ID into all our images
-      rm -f $mountPoint/etc/machine-id
+        # The above scripts will generate a random machine-id and we don't want to bake a single ID into all our images
+        rm -f $mountPoint/etc/machine-id
+      ''}
 
       # Set the ownerships of the contents. The modes are set in preVM.
       # No globbing on targets, so no need to set -f

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -209,11 +209,30 @@ rec {
     let
       nodes = qemu_pkg:
         let
+          testScript' =
+            # Call the test script with the computed nodes.
+            if lib.isFunction testScript
+            then testScript { nodes = nodes qemu_pkg; }
+            else testScript;
+
           build-vms = import ./build-vms.nix {
             inherit system lib pkgs minimal specialArgs;
             extraConfigurations = extraConfigurations ++ [(
               {
                 virtualisation.qemu.package = qemu_pkg;
+
+                # Make sure all derivations referenced by the test
+                # script are available on the nodes. When the store is
+                # accessed through 9p, this isn't important, since
+                # everything in the store is available to the guest,
+                # but when building a root image it is, as all paths
+                # that should be available to the guest has to be
+                # copied to the image.
+                virtualisation.additionalPaths =
+                  lib.optional
+                    (builtins.hasContext testScript')
+                    (pkgs.writeStringReferencesToFile testScript');
+
                 # Ensure we do not use aliases. Ideally this is only set
                 # when the test framework is used by Nixpkgs NixOS tests.
                 nixpkgs.config.allowAliases = false;

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -56,7 +56,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
         };
 
 
-      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+      virtualisation.additionalPaths = [ pkgs.stdenv ];
     };
 
   testScript = ''

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -45,7 +45,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
             };
         };
 
-      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+      virtualisation.additionalPaths = [ pkgs.stdenv ];
     };
 
   testScript =

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -17,7 +17,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       virtualisation.memorySize = 1024;
       # Make sure we always have all the required dependencies for creating a
       # container available within the VM, because we don't have network access.
-      virtualisation.pathsInNixDB = let
+      virtualisation.additionalPaths = let
         emptyContainer = import ../lib/eval-config.nix {
           inherit (config.nixpkgs.localSystem) system;
           modules = lib.singleton {

--- a/nixos/tests/containers-ip.nix
+++ b/nixos/tests/containers-ip.nix
@@ -27,7 +27,7 @@ in import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
       containers.webserver4 = webserverFor "10.231.136.1" "10.231.136.2";
       containers.webserver6 = webserverFor "fc00::2" "fc00::1";
-      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+      virtualisation.additionalPaths = [ pkgs.stdenv ];
     };
 
   testScript = { nodes, ... }: ''

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -29,7 +29,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
             };
         };
 
-      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+      virtualisation.additionalPaths = [ pkgs.stdenv ];
     };
 
   testScript =

--- a/nixos/tests/containers-tmpfs.nix
+++ b/nixos/tests/containers-tmpfs.nix
@@ -26,7 +26,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
           config = { };
         };
 
-      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+      virtualisation.additionalPaths = [ pkgs.stdenv ];
     };
 
   testScript = ''

--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -28,6 +28,8 @@ import ./make-test-python.nix (
       { nodes, ... }:
       {
         virtualisation.memorySize = 2048;
+        virtualisation.cores = 4;
+        virtualisation.useNixStoreImage = true;
 
         imports = [ common/user-account.nix ];
 

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -14,6 +14,8 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : with lib; {
       imports = [ common/user-account.nix ];
 
       virtualisation.memorySize = if pkgs.stdenv.is64bit then 4096 else 2047;
+      virtualisation.cores = 4;
+      virtualisation.useNixStoreImage = true;
       systemd.services.gitlab.serviceConfig.Restart = mkForce "no";
       systemd.services.gitlab-workhorse.serviceConfig.Restart = mkForce "no";
       systemd.services.gitaly.serviceConfig.Restart = mkForce "no";

--- a/pkgs/build-support/trivial-builders/test/sample.nix
+++ b/pkgs/build-support/trivial-builders/test/sample.nix
@@ -2,6 +2,7 @@
 let
   inherit (pkgs)
     figlet
+    zlib
     hello
     writeText
     ;
@@ -9,8 +10,13 @@ in
 {
   hello = hello;
   figlet = figlet;
+  zlib = zlib;
+  zlib-dev = zlib.dev;
   norefs = writeText "hi" "hello";
+  norefsDup = writeText "hi" "hello";
   helloRef = writeText "hi" "hello ${hello}";
+  helloRefDup = writeText "hi" "hello ${hello}";
+  path = ./invoke-writeReferencesToFile.nix;
   helloFigletRef = writeText "hi" "hello ${hello} ${figlet}";
   inherit (pkgs)
     emptyFile


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The goal of this PR is to speed up some IO heavy tests by building a Nix store disk image instead of using 9p to access the host store. 

To this end, the following things are done:
- In `make-disk-image.nix`:
  - Add the `onlyNixStore` argument, which allows building an image containing only the Nix store
  - Reintroduce the `installBootLoader` argument, which seemed to have been accidentally removed
  - Add the `copyChannel` argument, to control whether a default nix channel is copied to the image
  - Add the `additionalPaths` argument to allow additional paths to be copied to the image's nix store
- In `qemu-vm.nix`:
  - Add the `useNixStoreImage` option, which controls whether an image is used rather than 9p
  - Rename the `pathsInNixDB` option to the more general `additionalPaths`, since its purpose is different when building an image
- In `trivial-builders.nix`:
  - Add `writeStringReferencesToFile`, a builder which extracts a string's references to derivations and paths and writes them to a text file, removing the input string itself from the dependency graph
- In `testing-python.nix`:
  - Make sure all derivations referenced by the test script are added to `additionalPaths`, since they need to be explicitly made available when building an image

These changes are then put to use in the `discourse` and `gitlab` tests. With my laptop (AMD Ryzen 7 PRO 2700U) as the reference system, I see the following test run times:

- Discourse
  - No change:
    25 mins, 49 secs

  - Building a Nix store image:
    4 mins, 44 secs

  - Building a Nix store image and bumping the core count to `4`:
    3 mins, 6 secs

- GitLab
  - No change:
    Times out after 28 mins

  - Building a Nix store image:
    7 mins, 48 secs

  - Building a Nix store image and bumping the core count to `4`:
    7 mins, 17 secs

The times include the time it takes to build the image (~40 secs for `discourse` and ~1 min, 20 secs for `gitlab`).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
