### PR TITLE
cbqn: 2021-10-01 -> 2021-10-05

### DIFF
--- a/pkgs/development/interpreters/bqn/cbqn/default.nix
+++ b/pkgs/development/interpreters/bqn/cbqn/default.nix
@@ -11,20 +11,20 @@ let
     name = "cbqn-bytecode-files";
     owner = "dzaima";
     repo = "CBQN";
-    rev = "94bb312d20919f942eabed3dca33c514de3c3227";
-    hash = "sha256-aFw5/F7/sYkYmxAnGeK8EwkoVrbEcjuJAD9YT+iW9Rw=";
+    rev = "4d23479cdbd5ac6eb512c376ade58077b814b2b7";
+    sha256 = "1il6pxbllf4rs0wf2s6q6h72m3p1d6ymgsllpkmadnw1agif0fri";
   };
 in
 assert genBytecode -> ((bqn-path != null) && (mbqn-source != null));
 stdenv.mkDerivation rec {
   pname = "cbqn" + lib.optionalString (!genBytecode) "-standalone";
-  version = "0.0.0+unstable=2021-10-01";
+  version = "0.0.0+unstable=2021-10-05";
 
   src = fetchFromGitHub {
     owner = "dzaima";
     repo = "CBQN";
-    rev = "3725bd58c758a749653080319766a33169551536";
-    hash = "sha256-xWp64inFZRqGGTrH6Hqbj7aA0vYPyd+FdetowTMTjPs=";
+    rev = "e23dab20daff9c0dacc2561c616174af72029a3e";
+    sha256 = "17h8fb9a0hjindbxgkljajl1hjr8rdqrb85s5lz903v17wl4lrba";
   };
 
   dontConfigure = true;
@@ -34,6 +34,9 @@ stdenv.mkDerivation rec {
   '';
 
   preBuild = ''
+    # otherwise cbqn defaults to clang
+    makeFlagsArray+=("CC=$CC")
+
     # inform make we are providing the runtime ourselves
     touch src/gen/customRuntime
   '' + (if genBytecode then ''
@@ -41,10 +44,6 @@ stdenv.mkDerivation rec {
   '' else ''
     cp ${cbqn-bytecode-files}/src/gen/{compiler,formatter,runtime0,runtime1,src} src/gen/
   '');
-
-  makeFlags = [
-    "CC=${stdenv.cc.targetPrefix}cc"
-  ];
 
   installPhase = ''
      runHook preInstall


### PR DESCRIPTION
By setting CC to include the proper compilers
name (i. e. ${targetPrefix}gcc or ${targetPrefix}clang), a lot of the
annoying warnings for gcc will be silenced as the makefile has a check
for it. Should make cross-compiled cbqn less obnoxious.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
