### PR TITLE
linux-libre: fix build and unmark as broken

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -14,9 +14,14 @@ let
   minor = lib.versions.minor linux.modDirVersion;
   patch = lib.versions.patch linux.modDirVersion;
 
+  # See http://linux-libre.fsfla.org/pub/linux-libre/releases
+  versionPrefix = if linux.kernelOlder "5.14" then
+    "gnu1"
+  else
+    "gnu";
 in linux.override {
   argsOverride = {
-    modDirVersion = "${linux.modDirVersion}-gnu";
+    modDirVersion = "${linux.modDirVersion}-${versionPrefix}";
     isLibre = true;
 
     src = stdenv.mkDerivation {
@@ -35,10 +40,8 @@ in linux.override {
       '';
     };
 
-    extraMeta.broken = true;
-
     passthru.updateScript = ./update-libre.sh;
 
-    maintainers = [ lib.maintainers.qyliss ];
+    maintainers = with lib.maintainers; [ qyliss ivar ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This was disabled because some patch failed to apply, but that issue seems to have been fixed with more recent nixpkgs revisions. Without setting the `gnu{,1}` prefixes, you get the following (extremely handy) error message on versions < 5.14:
```
Error: modDirVersion 5.10.70-gnu specified in the Nix expression is wrong, it should be: 5.10.70-gnu1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>9 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_libre.anbox</li>
    <li>linuxKernel.packages.linux_libre.ixgbevf</li>
    <li>linuxKernel.packages.linux_libre.mxu11x0</li>
    <li>linuxKernel.packages.linux_libre.ndiswrapper</li>
    <li>linuxKernel.packages.linux_libre.phc-intel</li>
    <li>linuxKernel.packages.linux_libre.r8125</li>
    <li>linuxKernel.packages.linux_libre.rtl8723bs</li>
    <li>linuxKernel.packages.linux_libre.sch_cake</li>
    <li>linuxKernel.packages.linux_libre.tbs</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_libre.amdgpu-pro # I'm not entirely sure why, needs some investigating.</li>
    <li>linuxKernel.packages.linux_libre.nvidia_x11_legacy340</li>
  </ul>
</details>
<details>
  <summary>70 packages built:</summary>
  <ul>
    <li>linux-libre</li>
    <li>linuxKernel.packages.linux_libre.acpi_call</li>
    <li>linuxKernel.packages.linux_libre.akvcam</li>
    <li>linuxKernel.packages.linux_libre.apfs</li>
    <li>linuxKernel.packages.linux_libre.asus-wmi-sensors</li>
    <li>linuxKernel.packages.linux_libre.batman_adv</li>
    <li>linuxKernel.packages.linux_libre.bbswitch</li>
    <li>linuxKernel.packages.linux_libre.bcc</li>
    <li>linuxKernel.packages.linux_libre.bpftrace</li>
    <li>linuxKernel.packages.linux_libre.broadcom_sta</li>
    <li>linuxKernel.packages.linux_libre.can-isotp</li>
    <li>linuxKernel.packages.linux_libre.chipsec</li>
    <li>linuxKernel.packages.linux_libre.cryptodev</li>
    <li>linuxKernel.packages.linux_libre.ddcci-driver</li>
    <li>linuxKernel.packages.linux_libre.digimend</li>
    <li>linuxKernel.packages.linux_libre.dpdk-kmods</li>
    <li>linuxKernel.packages.linux_libre.ena</li>
    <li>linuxKernel.packages.linux_libre.evdi</li>
    <li>linuxKernel.packages.linux_libre.facetimehd</li>
    <li>linuxKernel.packages.linux_libre.fwts-efi-runtime</li>
    <li>linuxKernel.packages.linux_libre.gcadapter-oc-kmod</li>
    <li>linuxKernel.packages.linux_libre.hid-nintendo</li>
    <li>linuxKernel.packages.linux_libre.isgx</li>
    <li>linuxKernel.packages.linux_libre.it87</li>
    <li>linuxKernel.packages.linux_libre.jool</li>
    <li>linuxKernel.packages.linux_libre.kvmfr</li>
    <li>linuxKernel.packages.linux_libre.lttng-modules</li>
    <li>linuxKernel.packages.linux_libre.mba6x_bl</li>
    <li>linuxKernel.packages.linux_libre.mbp2018-bridge-drv</li>
    <li>linuxKernel.packages.linux_libre.mwprocapture</li>
    <li>linuxKernel.packages.linux_libre.netatop</li>
    <li>linuxKernel.packages.linux_libre.nvidia_x11</li>
    <li>linuxKernel.packages.linux_libre.nvidia_x11_beta</li>
    <li>linuxKernel.packages.linux_libre.nvidia_x11_legacy390</li>
    <li>linuxKernel.packages.linux_libre.nvidia_x11_vulkan_beta</li>
    <li>linuxKernel.packages.linux_libre.nvidiabl</li>
    <li>linuxKernel.packages.linux_libre.oci-seccomp-bpf-hook</li>
    <li>linuxKernel.packages.linux_libre.openafs</li>
    <li>linuxKernel.packages.linux_libre.openafs_1_9</li>
    <li>linuxKernel.packages.linux_libre.openrazer</li>
    <li>linuxKernel.packages.linux_libre.r8168</li>
    <li>linuxKernel.packages.linux_libre.rtl8188eus-aircrack</li>
    <li>linuxKernel.packages.linux_libre.rtl8192eu</li>
    <li>linuxKernel.packages.linux_libre.rtl8812au</li>
    <li>linuxKernel.packages.linux_libre.rtl8814au</li>
    <li>linuxKernel.packages.linux_libre.rtl8821au</li>
    <li>linuxKernel.packages.linux_libre.rtl8821ce</li>
    <li>linuxKernel.packages.linux_libre.rtl8821cu</li>
    <li>linuxKernel.packages.linux_libre.rtl88x2bu</li>
    <li>linuxKernel.packages.linux_libre.rtl88xxau-aircrack</li>
    <li>linuxKernel.packages.linux_libre.rtlwifi_new</li>
    <li>linuxKernel.packages.linux_libre.rtw89</li>
    <li>linuxKernel.packages.linux_libre.sysdig</li>
    <li>linuxKernel.packages.linux_libre.system76</li>
    <li>linuxKernel.packages.linux_libre.system76-acpi</li>
    <li>linuxKernel.packages.linux_libre.system76-io</li>
    <li>linuxKernel.packages.linux_libre.systemtap</li>
    <li>linuxKernel.packages.linux_libre.tp_smapi</li>
    <li>linuxKernel.packages.linux_libre.tuxedo-keyboard</li>
    <li>linuxKernel.packages.linux_libre.v4l2loopback</li>
    <li>linuxKernel.packages.linux_libre.v86d</li>
    <li>linuxKernel.packages.linux_libre.veikk-linux-driver</li>
    <li>linuxKernel.packages.linux_libre.vendor-reset</li>
    <li>linuxKernel.packages.linux_libre.vhba</li>
    <li>linuxKernel.packages.linux_libre.virtualbox</li>
    <li>linuxKernel.packages.linux_libre.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_libre.xmm7360-pci</li>
    <li>linuxKernel.packages.linux_libre.xpadneo</li>
    <li>linuxKernel.packages.linux_libre.zenpower</li>
    <li>linuxKernel.packages.linux_libre.zfs (linuxKernel.packages.linux_libre.zfsUnstable)</li>
  </ul>
</details>
