### PR TITLE
coq2html: 1.2 → 1.3

### DIFF
--- a/pkgs/tools/typesetting/coq2html/default.nix
+++ b/pkgs/tools/typesetting/coq2html/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation  rec {
   pname = "coq2html";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "xavierleroy";
     repo = "coq2html";
     rev = "v${version}";
-    sha256 = "sha256-ty/6A3wivjDCrmlZAcZyaIwQQ+vPBJm9MhtW6nZcV3s=";
+    sha256 = "sha256:1ad825yifn518wk1c2y2ji10q3m468r8ajjgw2nzzy7d608nx7yq";
   };
 
   nativeBuildInputs = [ ocaml ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30961,7 +30961,7 @@ with pkgs;
     coqPackages      coq
   ;
 
-  coq2html = callPackage ../applications/science/logic/coq2html { };
+  coq2html = callPackage ../tools/typesetting/coq2html { };
 
   cryptoverif = callPackage ../applications/science/logic/cryptoverif { };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/xavierleroy/coq2html/releases/tag/v1.3

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
