### PR TITLE
luarocks-nix: bumped to pass args too

### DIFF
--- a/maintainers/scripts/update-luarocks-packages
+++ b/maintainers/scripts/update-luarocks-packages
@@ -33,8 +33,7 @@ TMP_FILE="$(mktemp)"
 GENERATED_NIXFILE="pkgs/development/lua-modules/generated-packages.nix"
 LUAROCKS_CONFIG="$NIXPKGS_PATH/maintainers/scripts/luarocks-config.lua"
 
-HEADER = """
-/* {GENERATED_NIXFILE} is an auto-generated file -- DO NOT EDIT!
+HEADER = """/* {GENERATED_NIXFILE} is an auto-generated file -- DO NOT EDIT!
 Regenerate it with:
 nixpkgs$ ./maintainers/scripts/update-luarocks-packages
 
@@ -99,9 +98,8 @@ class LuaEditor(Editor):
             header2 = textwrap.dedent(
             # header2 = inspect.cleandoc(
             """
-                { self, stdenv, lib, fetchurl, fetchgit, ... } @ args:
-                self: super:
-                with self;
+                { self, stdenv, lib, fetchurl, fetchgit, callPackage, ... } @ args:
+                final: prev:
                 {
             """)
             f.write(header2)
@@ -199,6 +197,7 @@ def generate_pkg_nix(plug: LuaPlugin):
 
     log.debug("running %s", ' '.join(cmd))
     output = subprocess.check_output(cmd, text=True)
+    output = "callPackage(" + output.strip() + ") {};\n\n"
     return (plug, output)
 
 def main():

--- a/pkgs/development/lua-modules/default.nix
+++ b/pkgs/development/lua-modules/default.nix
@@ -15,7 +15,7 @@ let
   overridenPackages = import ./overrides.nix { inherit pkgs; };
 
   generatedPackages = if (builtins.pathExists ./generated-packages.nix) then
-        pkgs.callPackage ./generated-packages.nix { } else (final: prev: {});
+    (final: prev: pkgs.callPackage ./generated-packages.nix { inherit (final) callPackage; } final prev) else (final: prev: {});
 
   extensible-self = lib.makeExtensible
     (extends overrides

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1,4 +1,3 @@
-
 /* pkgs/development/lua-modules/generated-packages.nix is an auto-generated file -- DO NOT EDIT!
 Regenerate it with:
 nixpkgs$ ./maintainers/scripts/update-luarocks-packages
@@ -6,11 +5,13 @@ nixpkgs$ ./maintainers/scripts/update-luarocks-packages
 You can customize the generated packages in pkgs/development/lua-modules/overrides.nix
 */
 
-{ self, stdenv, lib, fetchurl, fetchgit, ... } @ args:
-self: super:
-with self;
+{ self, stdenv, lib, fetchurl, fetchgit, callPackage, ... } @ args:
+final: prev:
 {
-alt-getopt = buildLuarocksPackage {
+alt-getopt = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "alt-getopt";
   version = "0.8.0-1";
   knownRockspec = (fetchurl {
@@ -30,7 +31,7 @@ alt-getopt = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -39,9 +40,12 @@ alt-getopt = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ arobyn ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-argparse = buildLuarocksPackage {
+argparse = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "argparse";
   version = "scm-2";
 
@@ -58,7 +62,7 @@ argparse = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -66,9 +70,12 @@ argparse = buildLuarocksPackage {
     description = "A feature-rich command-line argument parser";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-basexx = buildLuarocksPackage {
+basexx = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "basexx";
   version = "scm-0";
   rockspecDir = "dist";
@@ -78,7 +85,7 @@ basexx = buildLuarocksPackage {
     sha256 = "1x0d24aaj4zld4ifr7mi8zwrym5shsfphmwx5jzw2zg22r6xzlz1";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -86,9 +93,12 @@ basexx = buildLuarocksPackage {
     description = "A base2, base16, base32, base64 and base85 library for Lua";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-binaryheap = buildLuarocksPackage {
+binaryheap = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "binaryheap";
   version = "0.4-1";
 
@@ -97,7 +107,7 @@ binaryheap = buildLuarocksPackage {
     sha256 = "0f5l4nb5s7dycbkgh3rrl7pf0npcf9k6m2gr2bsn09fjyb3bdc8h";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -106,9 +116,12 @@ binaryheap = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ vcunat ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-bit32 = buildLuarocksPackage {
+bit32 = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "bit32";
   version = "5.3.0-1";
   knownRockspec = (fetchurl {
@@ -128,7 +141,7 @@ bit32 = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -137,9 +150,12 @@ bit32 = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ lblasc ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-busted = buildLuarocksPackage {
+busted = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua, lua_cliargs, luafilesystem, luasystem, dkjson, say, luassert, lua-term, penlight, mediator_lua
+}:
+buildLuarocksPackage {
   pname = "busted";
   version = "2.0.0-1";
   knownRockspec = (fetchurl {
@@ -151,7 +167,7 @@ busted = buildLuarocksPackage {
     sha256 = "1ps7b3f4diawfj637mibznaw4x08gn567pyni0m2s50hrnw4v8zx";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua lua_cliargs luafilesystem luasystem dkjson say luassert lua-term penlight mediator_lua ];
 
   meta = {
@@ -159,13 +175,16 @@ busted = buildLuarocksPackage {
     description = "Elegant Lua unit testing.";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
-};
+}) {};
 
-cassowary = buildLuarocksPackage {
+cassowary = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, penlight
+}:
+buildLuarocksPackage {
   pname = "cassowary";
   version = "2.3.1-2";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/cassowary-2.3.1-2.rockspec";
+    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/cassowary-2.3.1-2.rockspec";
     sha256 = "04y882f9ai1jhk0zwla2g0fvl56a75rwnxhsl9r3m0qa5i0ia1i5";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
@@ -181,7 +200,7 @@ cassowary = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua penlight ];
 
   meta = {
@@ -190,9 +209,12 @@ cassowary = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ marsam alerque ];
     license.fullName = "Apache 2";
   };
-};
+}) {};
 
-compat53 = buildLuarocksPackage {
+compat53 = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "compat53";
   version = "0.7-1";
   knownRockspec = (fetchurl {
@@ -204,7 +226,7 @@ compat53 = buildLuarocksPackage {
     sha256 = "1x3wv1qx7b2zlf3fh4q9pmi2xxkcdm024g7bf11rpv0yacnhran3";
   };
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -213,9 +235,12 @@ compat53 = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ vcunat ];
     license.fullName = "MIT";
   };
-};
+}) {};
 
-cosmo = buildLuarocksPackage {
+cosmo = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lpeg
+}:
+buildLuarocksPackage {
   pname = "cosmo";
   version = "16.06.04-1";
   knownRockspec = (fetchurl {
@@ -243,9 +268,11 @@ cosmo = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ marsam ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-coxpcall = buildLuarocksPackage {
+coxpcall = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit}:
+buildLuarocksPackage {
   pname = "coxpcall";
   version = "1.17.0-1";
   knownRockspec = (fetchurl {
@@ -271,9 +298,12 @@ coxpcall = buildLuarocksPackage {
     description = "Coroutine safe xpcall and pcall";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-cqueues = buildLuarocksPackage {
+cqueues = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "cqueues";
   version = "20200726.52-0";
   knownRockspec = (fetchurl {
@@ -285,7 +315,7 @@ cqueues = buildLuarocksPackage {
     sha256 = "0lhd02ag3r1sxr2hx847rdjkddm04l1vf5234v5cz9bd4kfjw4cy";
   };
 
-  disabled = (lua.luaversion != "5.2");
+  disabled = with lua; (luaversion != "5.2");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -294,9 +324,12 @@ cqueues = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ vcunat ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-cyrussasl = buildLuarocksPackage {
+cyrussasl = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "cyrussasl";
   version = "1.1.0-1";
 
@@ -313,7 +346,7 @@ cyrussasl = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -321,18 +354,21 @@ cyrussasl = buildLuarocksPackage {
     description = "Cyrus SASL library for Lua 5.1+";
     license.fullName = "BSD";
   };
-};
+}) {};
 
-digestif = buildLuarocksPackage {
+digestif = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, lpeg
+}:
+buildLuarocksPackage {
   pname = "digestif";
   version = "dev-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/astoff/digestif",
-  "rev": "9f8f299cf7094d72edbd32a455869751246028b7",
-  "date": "2021-09-25T14:32:42+02:00",
-  "path": "/nix/store/ln1zx9cw2b7q4x5vzd6hv5nd01c1gsy3-digestif",
-  "sha256": "1cf14m03jvfs1mwaywfgv759jh0ha3pxrnyj7jxjxlsj6cim89v0",
+  "rev": "505ca88a54012be5534654238baaa457f8446fed",
+  "date": "2021-10-06T21:27:45+02:00",
+  "path": "/nix/store/6wvpy0nsr5yf78by3dg8m2m0h0kf9xk4-digestif",
+  "sha256": "1prv5nqskvilyyx3z9b2jiz72lwpz2xcas57qjpbv6qq5l2si1xm",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
@@ -340,7 +376,7 @@ digestif = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.3");
+  disabled = with lua; (luaOlder "5.3");
   propagatedBuildInputs = [ lua lpeg ];
 
   meta = {
@@ -348,13 +384,16 @@ digestif = buildLuarocksPackage {
     description = "A code analyzer for TeX";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-dkjson = buildLuarocksPackage {
+dkjson = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "dkjson";
   version = "2.5-3";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/dkjson-2.5-3.rockspec";
+    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/dkjson-2.5-3.rockspec";
     sha256 = "18xngdzl2q207cil64aj81qi6qvj1g269pf07j5x4pbvamd6a1l3";
   }).outPath;
   src = fetchurl {
@@ -362,7 +401,7 @@ dkjson = buildLuarocksPackage {
     sha256 = "14wanday1l7wj2lnpabbxw8rcsa0zbvcdi1w88rdr5gbsq3xwasm";
   };
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -370,13 +409,16 @@ dkjson = buildLuarocksPackage {
     description = "David Kolf's JSON module for Lua";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-fifo = buildLuarocksPackage {
+fifo = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "fifo";
   version = "0.2-0";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/fifo-0.2-0.rockspec";
+    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/fifo-0.2-0.rockspec";
     sha256 = "0vr9apmai2cyra2n573nr3dyk929gzcs4nm1096jdxcixmvh2ymq";
   }).outPath;
   src = fetchurl {
@@ -391,18 +433,21 @@ fifo = buildLuarocksPackage {
     description = "A lua library/'class' that implements a FIFO";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-gitsigns-nvim = buildLuarocksPackage {
+gitsigns-nvim = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, plenary-nvim
+}:
+buildLuarocksPackage {
   pname = "gitsigns.nvim";
   version = "scm-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/lewis6991/gitsigns.nvim",
-  "rev": "7e5c1a831f555dc398dd1564489e2b8a5c867754",
-  "date": "2021-09-25T16:49:34+01:00",
-  "path": "/nix/store/a1h8xxb9w4kvvmq7q30m1ny2pq3zbmin-gitsigns.nvim",
-  "sha256": "02kssw0lpprf9k3il6gfd00gj9fbjbksipa4f6xqkgfdq5c9l9fr",
+  "rev": "552f114caeaec4ce97822cb55dfa7c7e5368136b",
+  "date": "2021-10-15T13:31:44+01:00",
+  "path": "/nix/store/40vkv3sc4h6gh9ac88k7pilszxmy38yv-gitsigns.nvim",
+  "sha256": "0qdafm3arjf8bcqpvv085dwzbikad3sr3xzvrn3gfa0dsls8pg6q",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
@@ -410,7 +455,7 @@ gitsigns-nvim = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (lua.luaversion != "5.1");
+  disabled = with lua; (luaversion != "5.1");
   propagatedBuildInputs = [ lua plenary-nvim ];
 
   meta = {
@@ -418,9 +463,12 @@ gitsigns-nvim = buildLuarocksPackage {
     description = "Git signs written in pure lua";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-http = buildLuarocksPackage {
+http = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua, compat53, bit32, cqueues, luaossl, basexx, lpeg, lpeg_patterns, binaryheap, fifo
+}:
+buildLuarocksPackage {
   pname = "http";
   version = "0.3-0";
   knownRockspec = (fetchurl {
@@ -432,7 +480,7 @@ http = buildLuarocksPackage {
     sha256 = "13xyj8qx42mzn1z4lwwdfd7ha06a720q4b7d04ir6vvp2fwp3s4q";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua compat53 bit32 cqueues luaossl basexx lpeg lpeg_patterns binaryheap fifo ];
 
   meta = {
@@ -441,9 +489,12 @@ http = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ vcunat ];
     license.fullName = "MIT";
   };
-};
+}) {};
 
-inspect = buildLuarocksPackage {
+inspect = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "inspect";
   version = "3.1.1-0";
   knownRockspec = (fetchurl {
@@ -455,7 +506,7 @@ inspect = buildLuarocksPackage {
     sha256 = "1nz0yqhkd0nkymghrj99gb2id40g50drh4a96g3v5k7h1sbg94h2";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -463,9 +514,12 @@ inspect = buildLuarocksPackage {
     description = "Lua table visualizer, ideal for debugging";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
-};
+}) {};
 
-ldbus = buildLuarocksPackage {
+ldbus = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "ldbus";
   version = "scm-0";
   knownRockspec = (fetchurl {
@@ -485,7 +539,7 @@ ldbus = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -493,9 +547,12 @@ ldbus = buildLuarocksPackage {
     description = "A Lua library to access dbus.";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-ldoc = buildLuarocksPackage {
+ldoc = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, penlight, markdown
+}:
+buildLuarocksPackage {
   pname = "ldoc";
   version = "scm-3";
 
@@ -519,9 +576,12 @@ ldoc = buildLuarocksPackage {
     description = "A Lua Documentation Tool";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lgi = buildLuarocksPackage {
+lgi = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lgi";
   version = "0.9.2-1";
   knownRockspec = (fetchurl {
@@ -541,7 +601,7 @@ lgi = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -549,9 +609,12 @@ lgi = buildLuarocksPackage {
     description = "Lua bindings to GObject libraries";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-linenoise = buildLuarocksPackage {
+linenoise = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "linenoise";
   version = "0.9-1";
 
@@ -560,7 +623,7 @@ linenoise = buildLuarocksPackage {
     sha256 = "177h6gbq89arwiwxah9943i8hl5gvd9wivnd1nhmdl7d8x0dn76c";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -568,9 +631,12 @@ linenoise = buildLuarocksPackage {
     description = "A binding for the linenoise command line library";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-ljsyscall = buildLuarocksPackage {
+ljsyscall = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "ljsyscall";
   version = "0.12-1";
   knownRockspec = (fetchurl {
@@ -582,7 +648,7 @@ ljsyscall = buildLuarocksPackage {
     sha256 = "1w9g36nhxv92cypjia7igg1xpfrn3dbs3hfy6gnnz5mx14v50abf";
   };
 
-  disabled = (lua.luaversion != "5.1");
+  disabled = with lua; (luaversion != "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -591,13 +657,16 @@ ljsyscall = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ lblasc ];
     license.fullName = "MIT";
   };
-};
+}) {};
 
-lpeg = buildLuarocksPackage {
+lpeg = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "lpeg";
   version = "1.0.2-1";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/lpeg-1.0.2-1.rockspec";
+    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lpeg-1.0.2-1.rockspec";
     sha256 = "08a8p5cwlwpjawk8sczb7bq2whdsng4mmhphahyklf1bkvl2li89";
   }).outPath;
   src = fetchurl {
@@ -605,7 +674,7 @@ lpeg = buildLuarocksPackage {
     sha256 = "1zjzl7acvcdavmcg5l7wi12jd4rh95q9pl5aiww7hv0v0mv6bmj8";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -614,9 +683,12 @@ lpeg = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ vyp ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lpeg_patterns = buildLuarocksPackage {
+lpeg_patterns = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua, lpeg
+}:
+buildLuarocksPackage {
   pname = "lpeg_patterns";
   version = "0.5-0";
   knownRockspec = (fetchurl {
@@ -635,9 +707,12 @@ lpeg_patterns = buildLuarocksPackage {
     description = "a collection of LPEG patterns";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-lpeglabel = buildLuarocksPackage {
+lpeglabel = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "lpeglabel";
   version = "1.6.0-1";
   knownRockspec = (fetchurl {
@@ -649,7 +724,7 @@ lpeglabel = buildLuarocksPackage {
     sha256 = "1i02lsxj20iygqm8fy6dih1gh21lqk5qj1mv14wlrkaywnv35wcv";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -657,13 +732,16 @@ lpeglabel = buildLuarocksPackage {
     description = "Parsing Expression Grammars For Lua with Labeled Failures";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lpty = buildLuarocksPackage {
+lpty = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "lpty";
   version = "1.2.2-1";
   knownRockspec = (fetchurl {
-    url    = "https://luafr.org/luarocks/lpty-1.2.2-1.rockspec";
+    url    = "https://luarocks.org/lpty-1.2.2-1.rockspec";
     sha256 = "04af4mhiqrw3br4qzz7yznw9zy2m50wddwzgvzkvhd99ng71fkzg";
   }).outPath;
   src = fetchurl {
@@ -671,7 +749,7 @@ lpty = buildLuarocksPackage {
     sha256 = "071mvz79wi9vr6hvrnb1rv19lqp1bh2fi742zkpv2sm1r9gy5rav";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -679,9 +757,12 @@ lpty = buildLuarocksPackage {
     description = "A simple facility for lua to control other programs via PTYs.";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-lrexlib-gnu = buildLuarocksPackage {
+lrexlib-gnu = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lrexlib-gnu";
   version = "2.9.1-1";
   knownRockspec = (fetchurl {
@@ -701,7 +782,7 @@ lrexlib-gnu = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -709,9 +790,12 @@ lrexlib-gnu = buildLuarocksPackage {
     description = "Regular expression library binding (GNU flavour).";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lrexlib-pcre = buildLuarocksPackage {
+lrexlib-pcre = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lrexlib-pcre";
   version = "2.9.1-1";
   knownRockspec = (fetchurl {
@@ -731,7 +815,7 @@ lrexlib-pcre = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -740,9 +824,12 @@ lrexlib-pcre = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ vyp ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lrexlib-posix = buildLuarocksPackage {
+lrexlib-posix = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lrexlib-posix";
   version = "2.9.1-1";
   knownRockspec = (fetchurl {
@@ -762,7 +849,7 @@ lrexlib-posix = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -770,9 +857,12 @@ lrexlib-posix = buildLuarocksPackage {
     description = "Regular expression library binding (POSIX flavour).";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lua-cjson = buildLuarocksPackage {
+lua-cjson = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lua-cjson";
   version = "2.1.0.6-1";
   knownRockspec = (fetchurl {
@@ -792,7 +882,7 @@ lua-cjson = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -800,9 +890,12 @@ lua-cjson = buildLuarocksPackage {
     description = "A fast JSON encoding/parsing module";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-lua-cmsgpack = buildLuarocksPackage {
+lua-cmsgpack = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lua-cmsgpack";
   version = "0.4.0-0";
   knownRockspec = (fetchurl {
@@ -822,7 +915,7 @@ lua-cmsgpack = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -830,9 +923,12 @@ lua-cmsgpack = buildLuarocksPackage {
     description = "MessagePack C implementation and bindings for Lua 5.1/5.2/5.3";
     license.fullName = "Two-clause BSD";
   };
-};
+}) {};
 
-lua-iconv = buildLuarocksPackage {
+lua-iconv = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "lua-iconv";
   version = "7-3";
   knownRockspec = (fetchurl {
@@ -844,7 +940,7 @@ lua-iconv = buildLuarocksPackage {
     sha256 = "02dg5x79fg5mwsycr0fj6w04zykdpiki9xjswkkwzdalqwaikny1";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -852,9 +948,12 @@ lua-iconv = buildLuarocksPackage {
     description = "Lua binding to the iconv";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lua-lsp = buildLuarocksPackage {
+lua-lsp = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, dkjson, lpeglabel, inspect
+}:
+buildLuarocksPackage {
   pname = "lua-lsp";
   version = "0.1.0-2";
   knownRockspec = (fetchurl {
@@ -874,7 +973,7 @@ lua-lsp = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua dkjson lpeglabel inspect ];
 
   meta = {
@@ -882,9 +981,12 @@ lua-lsp = buildLuarocksPackage {
     description = "A Language Server implementation for lua, the language";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-lua-messagepack = buildLuarocksPackage {
+lua-messagepack = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "lua-messagepack";
   version = "0.5.2-1";
   knownRockspec = (fetchurl {
@@ -896,7 +998,7 @@ lua-messagepack = buildLuarocksPackage {
     sha256 = "1jgi944d0vx4zs9lrphys9pw0wrsibip93sh141qjwymrjyjg1nc";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -904,9 +1006,12 @@ lua-messagepack = buildLuarocksPackage {
     description = "a pure Lua implementation of the MessagePack serialization format";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lua-resty-http = buildLuarocksPackage {
+lua-resty-http = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lua-resty-http";
   version = "0.16.1-0";
   knownRockspec = (fetchurl {
@@ -926,7 +1031,7 @@ lua-resty-http = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -934,9 +1039,12 @@ lua-resty-http = buildLuarocksPackage {
     description = "Lua HTTP client cosocket driver for OpenResty / ngx_lua.";
     license.fullName = "2-clause BSD";
   };
-};
+}) {};
 
-lua-resty-jwt = buildLuarocksPackage {
+lua-resty-jwt = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, lua-resty-openssl
+}:
+buildLuarocksPackage {
   pname = "lua-resty-jwt";
   version = "0.2.3-0";
   knownRockspec = (fetchurl {
@@ -956,7 +1064,7 @@ lua-resty-jwt = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua lua-resty-openssl ];
 
   meta = {
@@ -964,9 +1072,12 @@ lua-resty-jwt = buildLuarocksPackage {
     description = "JWT for ngx_lua and LuaJIT.";
     license.fullName = "Apache License Version 2";
   };
-};
+}) {};
 
-lua-resty-openidc = buildLuarocksPackage {
+lua-resty-openidc = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, lua-resty-http, lua-resty-session, lua-resty-jwt
+}:
+buildLuarocksPackage {
   pname = "lua-resty-openidc";
   version = "1.7.4-1";
   knownRockspec = (fetchurl {
@@ -986,7 +1097,7 @@ lua-resty-openidc = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua lua-resty-http lua-resty-session lua-resty-jwt ];
 
   meta = {
@@ -994,13 +1105,15 @@ lua-resty-openidc = buildLuarocksPackage {
     description = "A library for NGINX implementing the OpenID Connect Relying Party (RP) and the OAuth 2.0 Resource Server (RS) functionality";
     license.fullName = "Apache 2.0";
   };
-};
+}) {};
 
-lua-resty-openssl = buildLuarocksPackage {
+lua-resty-openssl = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit}:
+buildLuarocksPackage {
   pname = "lua-resty-openssl";
   version = "0.7.5-1";
   knownRockspec = (fetchurl {
-    url    = "https://luafr.org/luarocks/lua-resty-openssl-0.7.5-1.rockspec";
+    url    = "https://luarocks.org/lua-resty-openssl-0.7.5-1.rockspec";
     sha256 = "13v14in9cgmjgarmy6br9629ns1qlhw7a30c061y6gncjannnv6y";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
@@ -1022,9 +1135,12 @@ lua-resty-openssl = buildLuarocksPackage {
     description = "No summary";
     license.fullName = "BSD";
   };
-};
+}) {};
 
-lua-resty-session = buildLuarocksPackage {
+lua-resty-session = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lua-resty-session";
   version = "3.8-1";
   knownRockspec = (fetchurl {
@@ -1044,7 +1160,7 @@ lua-resty-session = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1052,13 +1168,15 @@ lua-resty-session = buildLuarocksPackage {
     description = "Session Library for OpenResty – Flexible and Secure";
     license.fullName = "BSD";
   };
-};
+}) {};
 
-lua-term = buildLuarocksPackage {
+lua-term = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl}:
+buildLuarocksPackage {
   pname = "lua-term";
   version = "0.7-1";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/lua-term-0.7-1.rockspec";
+    url    = "https://luafr.org/luarocks/lua-term-0.7-1.rockspec";
     sha256 = "0r9g5jw7pqr1dyj6w58dqlr7y7l0jp077n8nnji4phf10biyrvg2";
   }).outPath;
   src = fetchurl {
@@ -1072,9 +1190,12 @@ lua-term = buildLuarocksPackage {
     description = "Terminal functions for Lua";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lua-toml = buildLuarocksPackage {
+lua-toml = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lua-toml";
   version = "2.0-1";
   knownRockspec = (fetchurl {
@@ -1094,7 +1215,7 @@ lua-toml = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1102,13 +1223,16 @@ lua-toml = buildLuarocksPackage {
     description = "toml decoder/encoder for Lua";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-lua-yajl = buildLuarocksPackage {
+lua-yajl = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lua-yajl";
   version = "2.0-1";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/lua-yajl-2.0-1.rockspec";
+    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lua-yajl-2.0-1.rockspec";
     sha256 = "0h600zgq5qc9z3cid1kr35q3qb98alg0m3qf0a3mfj33hya6pcxp";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
@@ -1124,7 +1248,7 @@ lua-yajl = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1133,9 +1257,12 @@ lua-yajl = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ pstn ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lua-zlib = buildLuarocksPackage {
+lua-zlib = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "lua-zlib";
   version = "1.2-1";
   knownRockspec = (fetchurl {
@@ -1155,7 +1282,7 @@ lua-zlib = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1164,9 +1291,12 @@ lua-zlib = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ koral ];
     license.fullName = "MIT";
   };
-};
+}) {};
 
-lua_cliargs = buildLuarocksPackage {
+lua_cliargs = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "lua_cliargs";
   version = "3.0-2";
 
@@ -1175,7 +1305,7 @@ lua_cliargs = buildLuarocksPackage {
     sha256 = "0vhpgmy9a8wlxp8a15pnfqfk0aj7pyyb5m41nnfxynx580a6y7cp";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1183,9 +1313,12 @@ lua_cliargs = buildLuarocksPackage {
     description = "A command-line argument parser.";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
-};
+}) {};
 
-luabitop = buildLuarocksPackage {
+luabitop = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "luabitop";
   version = "1.0.2-3";
 
@@ -1202,7 +1335,7 @@ luabitop = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.3");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.3");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1210,21 +1343,24 @@ luabitop = buildLuarocksPackage {
     description = "Lua Bit Operations Module";
     license.fullName = "MIT/X license";
   };
-};
+}) {};
 
-luacheck = buildLuarocksPackage {
+luacheck = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, argparse, luafilesystem
+}:
+buildLuarocksPackage {
   pname = "luacheck";
-  version = "0.24.0-2";
+  version = "0.25.0-1";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/luacheck-0.24.0-2.rockspec";
-    sha256 = "1x8n7w1mdr1bmmbw38syzi2612yyd7bbv4j2hnlk2k76qfcvkhf3";
+    url    = "https://luarocks.org/luacheck-0.25.0-1.rockspec";
+    sha256 = "11mvbpnykibg0dx9sdh5x9gpvrhkmvrw76qvjz337x83f8gmvy91";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/luarocks/luacheck.git",
-  "rev": "6651c20d8495c380a49ca81662fcfd1ade6b2411",
-  "date": "2020-08-20T19:21:52-03:00",
-  "path": "/nix/store/8r4x8snxp0kjabn9bsxwh62pfczd8wma-luacheck",
-  "sha256": "08jsqibksdvpl6mvf8d6rlh5pii78hqm3fkhbkgzrs6k8kk5a7lf",
+  "rev": "abf7386a892df4ce566fef9e4640ddbf9af78411",
+  "date": "2021-08-10T12:19:20-03:00",
+  "path": "/nix/store/9cdlf6c3y0087qwh48ky8ysxxx3lirlj-luacheck",
+  "sha256": "1ymfkr0qmg6idrrxf9x6mfq14skag8h09kl2qlalwiykicrdljs1",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
@@ -1232,7 +1368,7 @@ luacheck = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua argparse luafilesystem ];
 
   meta = {
@@ -1240,13 +1376,16 @@ luacheck = buildLuarocksPackage {
     description = "A static analyzer and a linter for Lua";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-luacov = buildLuarocksPackage {
+luacov = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "luacov";
   version = "0.15.0-1";
   knownRockspec = (fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luacov-0.15.0-1.rockspec";
+    url    = "https://luafr.org/luarocks/luacov-0.15.0-1.rockspec";
     sha256 = "18byfl23c73pazi60hsx0vd74hqq80mzixab76j36cyn8k4ni9db";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
@@ -1262,7 +1401,7 @@ luacov = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1270,9 +1409,12 @@ luacov = buildLuarocksPackage {
     description = "Coverage analysis tool for Lua scripts";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-luadbi = buildLuarocksPackage {
+luadbi = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "luadbi";
   version = "0.7.2-1";
   knownRockspec = (fetchurl {
@@ -1292,7 +1434,7 @@ luadbi = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1300,13 +1442,16 @@ luadbi = buildLuarocksPackage {
     description = "Database abstraction layer";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luadbi-mysql = buildLuarocksPackage {
+luadbi-mysql = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, luadbi
+}:
+buildLuarocksPackage {
   pname = "luadbi-mysql";
   version = "0.7.2-1";
   knownRockspec = (fetchurl {
-    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luadbi-mysql-0.7.2-1.rockspec";
+    url    = "https://luarocks.org/luadbi-mysql-0.7.2-1.rockspec";
     sha256 = "0gnyqnvcfif06rzzrdw6w6hchp4jrjiwm0rmfx2r8ljchj2bvml5";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
@@ -1322,7 +1467,7 @@ luadbi-mysql = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua luadbi ];
 
   meta = {
@@ -1330,13 +1475,16 @@ luadbi-mysql = buildLuarocksPackage {
     description = "Database abstraction layer";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luadbi-postgresql = buildLuarocksPackage {
+luadbi-postgresql = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, luadbi
+}:
+buildLuarocksPackage {
   pname = "luadbi-postgresql";
   version = "0.7.2-1";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/luadbi-postgresql-0.7.2-1.rockspec";
+    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luadbi-postgresql-0.7.2-1.rockspec";
     sha256 = "07rx4agw4hjyzf8157apdwfqh9s26nqndmkr3wm7v09ygjvdjiix";
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
@@ -1352,7 +1500,7 @@ luadbi-postgresql = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua luadbi ];
 
   meta = {
@@ -1360,9 +1508,12 @@ luadbi-postgresql = buildLuarocksPackage {
     description = "Database abstraction layer";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luadbi-sqlite3 = buildLuarocksPackage {
+luadbi-sqlite3 = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, luadbi
+}:
+buildLuarocksPackage {
   pname = "luadbi-sqlite3";
   version = "0.7.2-1";
   knownRockspec = (fetchurl {
@@ -1382,7 +1533,7 @@ luadbi-sqlite3 = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua luadbi ];
 
   meta = {
@@ -1390,9 +1541,12 @@ luadbi-sqlite3 = buildLuarocksPackage {
     description = "Database abstraction layer";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luaepnf = buildLuarocksPackage {
+luaepnf = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, lpeg
+}:
+buildLuarocksPackage {
   pname = "luaepnf";
   version = "0.3-2";
   knownRockspec = (fetchurl {
@@ -1412,7 +1566,7 @@ luaepnf = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua lpeg ];
 
   meta = {
@@ -1420,9 +1574,12 @@ luaepnf = buildLuarocksPackage {
     description = "Extended PEG Notation Format (easy grammars for LPeg)";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-luaevent = buildLuarocksPackage {
+luaevent = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "luaevent";
   version = "0.4.6-1";
   knownRockspec = (fetchurl {
@@ -1434,7 +1591,7 @@ luaevent = buildLuarocksPackage {
     sha256 = "0pbh315d3p7hxgzmbhphkcldxv2dadbka96131b8j5914nxvl4nx";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1442,9 +1599,12 @@ luaevent = buildLuarocksPackage {
     description = "libevent binding for Lua";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-luaexpat = buildLuarocksPackage {
+luaexpat = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "luaexpat";
   version = "1.3.0-1";
   knownRockspec = (fetchurl {
@@ -1456,7 +1616,7 @@ luaexpat = buildLuarocksPackage {
     sha256 = "1hvxqngn0wf5642i5p3vcyhg3pmp102k63s9ry4jqyyqc1wkjq6h";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1465,9 +1625,12 @@ luaexpat = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ arobyn flosse ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luaffi = buildLuarocksPackage {
+luaffi = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "luaffi";
   version = "scm-1";
   knownRockspec = (fetchurl {
@@ -1487,7 +1650,7 @@ luaffi = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1495,9 +1658,12 @@ luaffi = buildLuarocksPackage {
     description = "FFI library for calling C functions from lua";
     license.fullName = "BSD";
   };
-};
+}) {};
 
-luafilesystem = buildLuarocksPackage {
+luafilesystem = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "luafilesystem";
   version = "1.7.0-2";
   knownRockspec = (fetchurl {
@@ -1517,7 +1683,7 @@ luafilesystem = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1526,9 +1692,12 @@ luafilesystem = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ flosse ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-lualogging = buildLuarocksPackage {
+lualogging = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, luasocket
+}:
+buildLuarocksPackage {
   pname = "lualogging";
   version = "1.5.2-1";
   knownRockspec = (fetchurl {
@@ -1555,9 +1724,12 @@ lualogging = buildLuarocksPackage {
     description = "A simple API to use logging features";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luaossl = buildLuarocksPackage {
+luaossl = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "luaossl";
   version = "20200709-0";
   knownRockspec = (fetchurl {
@@ -1576,9 +1748,12 @@ luaossl = buildLuarocksPackage {
     description = "Most comprehensive OpenSSL module in the Lua universe.";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luaposix = buildLuarocksPackage {
+luaposix = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, bit32, lua
+}:
+buildLuarocksPackage {
   pname = "luaposix";
   version = "34.1.1-1";
   knownRockspec = (fetchurl {
@@ -1590,7 +1765,7 @@ luaposix = buildLuarocksPackage {
     sha256 = "1xqx764ji054jphxdhkynsmwzqzkfgxqfizxkf70za6qfrvnl3yh";
   };
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ bit32 lua ];
 
   meta = {
@@ -1599,9 +1774,12 @@ luaposix = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ vyp lblasc ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luarepl = buildLuarocksPackage {
+luarepl = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "luarepl";
   version = "0.9-1";
   knownRockspec = (fetchurl {
@@ -1613,7 +1791,7 @@ luarepl = buildLuarocksPackage {
     sha256 = "04xka7b84d9mrz3gyf8ywhw08xp65v8jrnzs8ry8k9540aqs721w";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1621,9 +1799,12 @@ luarepl = buildLuarocksPackage {
     description = "A reusable REPL component for Lua, written in Lua";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luasec = buildLuarocksPackage {
+luasec = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, luasocket
+}:
+buildLuarocksPackage {
   pname = "luasec";
   version = "1.0.2-1";
   knownRockspec = (fetchurl {
@@ -1643,7 +1824,7 @@ luasec = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua luasocket ];
 
   meta = {
@@ -1652,13 +1833,16 @@ luasec = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ flosse ];
     license.fullName = "MIT";
   };
-};
+}) {};
 
-luasocket = buildLuarocksPackage {
+luasocket = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "luasocket";
   version = "3.0rc1-2";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/luasocket-3.0rc1-2.rockspec";
+    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/luasocket-3.0rc1-2.rockspec";
     sha256 = "17fbkihp4zypv5wwgxz8dnghj37pf5bhpi2llg4gbljp1bl2f42c";
   }).outPath;
   src = fetchurl {
@@ -1666,7 +1850,7 @@ luasocket = buildLuarocksPackage {
     sha256 = "0x0fg07cg08ybgkpzif7zmzaaq5ga979rxwd9rj95kfws9bbrl0y";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1674,9 +1858,12 @@ luasocket = buildLuarocksPackage {
     description = "Network support for the Lua language";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-luasql-sqlite3 = buildLuarocksPackage {
+luasql-sqlite3 = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "luasql-sqlite3";
   version = "2.6.0-1";
   knownRockspec = (fetchurl {
@@ -1685,10 +1872,10 @@ luasql-sqlite3 = buildLuarocksPackage {
   }).outPath;
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/keplerproject/luasql.git",
-  "rev": "69f68a858134d6adbe9b65a902dcd3f60cd6a7ce",
-  "date": "2021-08-27T15:17:22-03:00",
-  "path": "/nix/store/2374agarn72cnlnk2vripfy1zz2y50la-luasql",
-  "sha256": "13xs1g67d2p69x4wzxk1h97xh25388h0kkh9bjgw3l1yss9zlxhx",
+  "rev": "ce22164f63783afac9c644fd37c231e56fc097cb",
+  "date": "2021-10-14T09:38:24-03:00",
+  "path": "/nix/store/h8r8axcc76x7y6gwc2jzsmr7h2lqgbxa-luasql",
+  "sha256": "10gq3x7vqkafvfk9fs4039rl1xhnqpl2v60z4qpd96wbcy205gnk",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
@@ -1696,7 +1883,7 @@ luasql-sqlite3 = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1705,9 +1892,12 @@ luasql-sqlite3 = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ vyp ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-luassert = buildLuarocksPackage {
+luassert = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua, say
+}:
+buildLuarocksPackage {
   pname = "luassert";
   version = "1.8.0-0";
   knownRockspec = (fetchurl {
@@ -1719,7 +1909,7 @@ luassert = buildLuarocksPackage {
     sha256 = "0xlwlb32215524bg33svp1ci8mdvh9wykchl8dkhihpxcd526mar";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua say ];
 
   meta = {
@@ -1727,9 +1917,12 @@ luassert = buildLuarocksPackage {
     description = "Lua Assertions Extension";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
-};
+}) {};
 
-luasystem = buildLuarocksPackage {
+luasystem = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "luasystem";
   version = "0.2.1-0";
   knownRockspec = (fetchurl {
@@ -1741,7 +1934,7 @@ luasystem = buildLuarocksPackage {
     sha256 = "150bbklchh02gsvpngv56xrrlxxvwpqwrh0yy6z95fnvks7gd0qb";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1749,9 +1942,12 @@ luasystem = buildLuarocksPackage {
     description = "Platform independent system calls for Lua.";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
-};
+}) {};
 
-luautf8 = buildLuarocksPackage {
+luautf8 = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "luautf8";
   version = "0.1.3-1";
   knownRockspec = (fetchurl {
@@ -1763,7 +1959,7 @@ luautf8 = buildLuarocksPackage {
     sha256 = "02rf8jmazmi8rp3i5v4jsz0d7mrf1747qszsl8i2hv1sl0ik92r0";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1772,9 +1968,12 @@ luautf8 = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ pstn ];
     license.fullName = "MIT";
   };
-};
+}) {};
 
-luazip = buildLuarocksPackage {
+luazip = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "luazip";
   version = "1.2.7-1";
   knownRockspec = (fetchurl {
@@ -1794,7 +1993,7 @@ luazip = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1802,9 +2001,12 @@ luazip = buildLuarocksPackage {
     description = "Library for reading files inside zip files";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-luuid = buildLuarocksPackage {
+luuid = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "luuid";
   version = "20120509-2";
   knownRockspec = (fetchurl {
@@ -1816,7 +2018,7 @@ luuid = buildLuarocksPackage {
     sha256 = "1bfkj613d05yps3fivmz0j1bxf2zkg9g1yl0ifffgw0vy00hpnvm";
   };
 
-  disabled = (luaOlder "5.2") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.2") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1824,9 +2026,12 @@ luuid = buildLuarocksPackage {
     description = "A library for UUID generation";
     license.fullName = "Public domain";
   };
-};
+}) {};
 
-luv = buildLuarocksPackage {
+luv = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "luv";
   version = "1.42.0-0";
   knownRockspec = (fetchurl {
@@ -1838,7 +2043,7 @@ luv = buildLuarocksPackage {
     sha256 = "0dkzjkkm0h516ag6sfz5iji761y9slrcfw325f39zkda1sfql8mm";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1846,13 +2051,16 @@ luv = buildLuarocksPackage {
     description = "Bare libuv bindings for lua";
     license.fullName = "Apache 2.0";
   };
-};
+}) {};
 
-lyaml = buildLuarocksPackage {
+lyaml = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "lyaml";
   version = "6.2.7-1";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/lyaml-6.2.7-1.rockspec";
+    url    = "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/lyaml-6.2.7-1.rockspec";
     sha256 = "0m5bnzg24nyk35gcn4rydgzk0ysk1f6rslxwxd0w3drl1bg64zja";
   }).outPath;
   src = fetchurl {
@@ -1860,7 +2068,7 @@ lyaml = buildLuarocksPackage {
     sha256 = "165mr3krf8g8070j4ax9z0j2plfbdwb8x2zk2hydpqaqa0kcdb0c";
   };
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1869,9 +2077,12 @@ lyaml = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ lblasc ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-markdown = buildLuarocksPackage {
+markdown = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "markdown";
   version = "0.33-1";
   knownRockspec = (fetchurl {
@@ -1891,7 +2102,7 @@ markdown = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1899,9 +2110,12 @@ markdown = buildLuarocksPackage {
     description = "Markdown text-to-html markup system.";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-mediator_lua = buildLuarocksPackage {
+mediator_lua = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "mediator_lua";
   version = "1.1.2-0";
   knownRockspec = (fetchurl {
@@ -1913,7 +2127,7 @@ mediator_lua = buildLuarocksPackage {
     sha256 = "16zzzhiy3y35v8advmlkzpryzxv5vji7727vwkly86q8sagqbxgs";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -1921,9 +2135,12 @@ mediator_lua = buildLuarocksPackage {
     description = "Event handling through channels";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
-};
+}) {};
 
-moonscript = buildLuarocksPackage {
+moonscript = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, lpeg, alt-getopt, luafilesystem
+}:
+buildLuarocksPackage {
   pname = "moonscript";
   version = "0.5.0-1";
   knownRockspec = (fetchurl {
@@ -1943,7 +2160,7 @@ moonscript = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua lpeg alt-getopt luafilesystem ];
 
   meta = {
@@ -1952,29 +2169,34 @@ moonscript = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ arobyn ];
     license.fullName = "MIT";
   };
-};
+}) {};
 
-mpack = buildLuarocksPackage {
+mpack = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl}:
+buildLuarocksPackage {
   pname = "mpack";
-  version = "1.0.8-0";
+  version = "1.0.9-0";
   knownRockspec = (fetchurl {
-    url    = "https://luarocks.org/mpack-1.0.8-0.rockspec";
-    sha256 = "0hhpamw2bydnfrild274faaan6v48918nhslnw3kvi9y36b4i5ha";
+    url    = "https://luarocks.org/mpack-1.0.9-0.rockspec";
+    sha256 = "1v10kmw3qw559bbm142z40ib26bwvcyi64qjrk0vf8v6n1mx8wcn";
   }).outPath;
   src = fetchurl {
-    url    = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.8/libmpack-lua-1.0.8.tar.gz";
-    sha256 = "1sf93ffx7a3y1waknc4994l2yrxilrlf3hcp2cj2cvxmpm5inszd";
+    url    = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.9/libmpack-lua-1.0.9.tar.gz";
+    sha256 = "17lyjmnbychacwahqgs128nb00xky777g7zw5wf20vrzkiq7xl0g";
   };
 
 
   meta = {
-    homepage = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.8/libmpack-lua-1.0.8.tar.gz";
+    homepage = "https://github.com/libmpack/libmpack-lua";
     description = "Lua binding to libmpack";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-nvim-client = buildLuarocksPackage {
+nvim-client = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua, mpack, luv, coxpcall
+}:
+buildLuarocksPackage {
   pname = "nvim-client";
   version = "0.2.2-1";
 
@@ -1983,7 +2205,7 @@ nvim-client = buildLuarocksPackage {
     sha256 = "1h736im524lq0vwlpihv9b317jarpkf3j13a25xl5qq8y8asm8mr";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua mpack luv coxpcall ];
 
   meta = {
@@ -1991,9 +2213,12 @@ nvim-client = buildLuarocksPackage {
     description = "Lua client to Nvim";
     license.fullName = "Apache";
   };
-};
+}) {};
 
-penlight = buildLuarocksPackage {
+penlight = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, luafilesystem
+}:
+buildLuarocksPackage {
   pname = "penlight";
   version = "dev-1";
 
@@ -2010,10 +2235,8 @@ penlight = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua luafilesystem ];
-  checkInputs = [ busted busted ];
-  doCheck = false;
 
   meta = {
     homepage = "https://lunarmodules.github.io/penlight";
@@ -2021,18 +2244,21 @@ penlight = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ alerque ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-plenary-nvim = buildLuarocksPackage {
+plenary-nvim = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, luassert
+}:
+buildLuarocksPackage {
   pname = "plenary.nvim";
   version = "scm-1";
 
   src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "https://github.com/nvim-lua/plenary.nvim",
-  "rev": "8c6cc07a68b65eb707be44598f0084647d495978",
-  "date": "2021-09-26T16:13:25+02:00",
-  "path": "/nix/store/j8hmr48blm4brq8rqv7b9m08vmalg8sp-plenary.nvim",
-  "sha256": "05h5n7jj33y9vs6gc8hqlfd628j6i33s3c8fmfl6ahxwfygx2wpd",
+  "rev": "80bb2b9bb74bdca38a46480b6f2e15af990406e4",
+  "date": "2021-10-06T19:20:08+02:00",
+  "path": "/nix/store/mw4r562qxr7giy1n43iylp3qb8ch0jqs-plenary.nvim",
+  "sha256": "11akcpxcp4m997a2y76ajknnmsifac2hj4nq9i4a8b1j08bxinim",
   "fetchLFS": false,
   "fetchSubmodules": true,
   "deepClone": false,
@@ -2040,7 +2266,7 @@ plenary-nvim = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ lua luassert ];
 
   meta = {
@@ -2048,9 +2274,12 @@ plenary-nvim = buildLuarocksPackage {
     description = "lua functions you don't want to write ";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-rapidjson = buildLuarocksPackage {
+rapidjson = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "rapidjson";
   version = "0.7.1-1";
 
@@ -2067,7 +2296,7 @@ rapidjson = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -2075,9 +2304,12 @@ rapidjson = buildLuarocksPackage {
     description = "Json module based on the very fast RapidJSON.";
     license.fullName = "MIT";
   };
-};
+}) {};
 
-readline = buildLuarocksPackage {
+readline = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua, luaposix
+}:
+buildLuarocksPackage {
   pname = "readline";
   version = "3.0-0";
   knownRockspec = (fetchurl {
@@ -2089,7 +2321,7 @@ readline = buildLuarocksPackage {
     sha256 = "1rr2b7q8w3i4bm1i634sd6kzhw6v1fpnh53mj09af6xdq1rfhr5n";
   };
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua luaposix ];
 
   meta = {
@@ -2097,9 +2329,12 @@ readline = buildLuarocksPackage {
     description = "Interface to the readline library";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-say = buildLuarocksPackage {
+say = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "say";
   version = "1.3-1";
 
@@ -2108,7 +2343,7 @@ say = buildLuarocksPackage {
     sha256 = "1jh76mxq9dcmv7kps2spwcc6895jmj2sf04i4y9idaxlicvwvs13";
   };
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -2116,9 +2351,12 @@ say = buildLuarocksPackage {
     description = "Lua String Hashing/Indexing Library";
     license.fullName = "MIT <http://opensource.org/licenses/MIT>";
   };
-};
+}) {};
 
-std-_debug = buildLuarocksPackage {
+std-_debug = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "std._debug";
   version = "git-1";
 
@@ -2135,7 +2373,7 @@ std-_debug = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -2143,9 +2381,12 @@ std-_debug = buildLuarocksPackage {
     description = "Debug Hints Library";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-std-normalize = buildLuarocksPackage {
+std-normalize = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua, std-_debug
+}:
+buildLuarocksPackage {
   pname = "std.normalize";
   version = "git-1";
 
@@ -2162,7 +2403,7 @@ std-normalize = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua std-_debug ];
 
   meta = {
@@ -2170,9 +2411,12 @@ std-normalize = buildLuarocksPackage {
     description = "Normalized Lua Functions";
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-stdlib = buildLuarocksPackage {
+stdlib = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchurl, lua
+}:
+buildLuarocksPackage {
   pname = "stdlib";
   version = "41.2.2-1";
   knownRockspec = (fetchurl {
@@ -2184,7 +2428,7 @@ stdlib = buildLuarocksPackage {
     sha256 = "0is8i8lk4qq4afnan0vj1bwr8brialyrva7cjy43alzgwdphwynx";
   };
 
-  disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+  disabled = with lua; (luaOlder "5.1") || (luaAtLeast "5.5");
   propagatedBuildInputs = [ lua ];
 
   meta = {
@@ -2193,9 +2437,12 @@ stdlib = buildLuarocksPackage {
     maintainers = with lib.maintainers; [ vyp ];
     license.fullName = "MIT/X11";
   };
-};
+}) {};
 
-vstruct = buildLuarocksPackage {
+vstruct = callPackage({ buildLuarocksPackage, luaOlder, luaAtLeast
+, fetchgit, lua
+}:
+buildLuarocksPackage {
   pname = "vstruct";
   version = "2.1.1-1";
 
@@ -2212,14 +2459,14 @@ vstruct = buildLuarocksPackage {
 }
  '') ["date" "path"]) ;
 
-  disabled = (luaOlder "5.1");
+  disabled = with lua; (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = {
     homepage = "https://github.com/ToxicFrog/vstruct";
     description = "Lua library to manipulate binary data";
   };
-};
+}) {};
 
 
 }

--- a/pkgs/development/lua-modules/lib.nix
+++ b/pkgs/development/lua-modules/lib.nix
@@ -5,8 +5,20 @@ let
   in unique ([lua] ++ modules ++ concatLists (catAttrs "requiredLuaModules" modules));
   # Check whether a derivation provides a lua module.
   hasLuaModule = drv: drv ? luaModule;
+
+
+  /*
+  Use this to override the arguments passed to buildLuarocksPackage
+  */
+  overrideLuarocks = drv: f: (drv.override (args: args // {
+    buildLuarocksPackage = drv: (args.buildLuarocksPackage drv).override f;
+  })) // {
+    overrideScope = scope: overrideLuarocks (drv.overrideScope scope) f;
+  };
+
 in
 rec {
+  inherit overrideLuarocks;
   inherit hasLuaModule requiredLuaModules;
 
   luaPathList = [

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -5,8 +5,8 @@ luarocks.overrideAttrs(old: {
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "luarocks-nix";
-    rev = "test-speedup";
-    sha256 = "sha256-WfzLSpIp0V7Ib4sjYvoJHF+/vHaieccvfVAr5W47QsQ=";
+    rev = "standalone";
+    sha256 = "sha256-53Zi+GTayO9EQTCIVrzPeRRHeIkHLqy0mHyBDzbcQQk=";
   };
   patches = [];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Motivations are:
- https://github.com/nix-community/luarocks-nix/issues/9
- https://github.com/nix-community/luarocks-nix/issues/4
- also I hope it makes it easier to retreive the lua dependencies of vimPlugins (parsing their rockspec, generate a lua derivation and just copy their buildInpuits as vim plugins dependencies)

I am not that comfortable with fixed point in nix so not sure what I did with the newScope callPackage stuff is correct.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
