### PR TITLE
superTuxKart: 1.2 -> 1.3

### DIFF
--- a/pkgs/development/interpreters/angelscript/default.nix
+++ b/pkgs/development/interpreters/angelscript/default.nix
@@ -1,20 +1,17 @@
-{ lib, stdenv, fetchurl, unzip, cmake }:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="angelscript";
-    version = "2.35.0";
-    name="${baseName}-${version}";
-    url="http://www.angelcode.com/angelscript/sdk/files/angelscript_${version}.zip";
-    sha256 = "sha256-AQ3UXiPnNNRvWJHXDiaGB6EsuasSUD3aQvhC2dt+iFc=";
-  };
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, cmake
+}:
 
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
+stdenv.mkDerivation rec {
+  pname = "angelscript";
+  version = "2.35.1";
 
   src = fetchurl {
-    inherit (s) url sha256;
+    url = "https://www.angelcode.com/angelscript/sdk/files/angelscript_${version}.zip";
+    sha256 = "12x12fs2bjkbh73n2w84wnqhg6xn6mnp6g79gbkwfl6gssv9c42w";
   };
 
   nativeBuildInputs = [ unzip cmake ];
@@ -32,7 +29,6 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    inherit (s) version;
     description = "Light-weight scripting library";
     license = licenses.zlib;
     maintainers = with maintainers; [ raskin ];

--- a/pkgs/development/interpreters/angelscript/default.upstream
+++ b/pkgs/development/interpreters/angelscript/default.upstream
@@ -1,4 +1,0 @@
-url http://www.angelcode.com/angelscript/downloads.html
-version_link '[.]zip$'
-version '.*_([0-9.]+)[.].*' '\1'
-do_overwrite () { do_overwrite_just_version ; }

--- a/pkgs/development/libraries/libopenglrecorder/default.nix
+++ b/pkgs/development/libraries/libopenglrecorder/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libjpeg
+, libvpx
+, openh264
+, withPulse ? stdenv.hostPlatform.isLinux
+, libpulseaudio
+, libvorbis
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libopenglrecorder";
+  version = "unstable-2020-08-13";
+
+  src = fetchFromGitHub {
+    owner = "Benau";
+    repo = "libopenglrecorder";
+    rev = "c1b81ce26e62fae1aaa086b5cd337cb12361ea3d";
+    sha256 = "13s2d7qs8z4w0gb3hx03n97xmwl07d4s473m4gw90qcvmz217kiz";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libjpeg
+    libvpx
+    openh264
+  ] ++ lib.optionals withPulse [
+    libpulseaudio
+    libvorbis
+  ];
+
+  meta = with lib; {
+    description = "Library allowing Optional async readback OpenGL frame buffer with optional audio recording";
+    homepage = "https://github.com/Benau/libopenglrecorder";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = with platforms; windows ++ linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17693,6 +17693,8 @@ with pkgs;
 
   libopenaptx = callPackage ../development/libraries/libopenaptx { };
 
+  libopenglrecorder = callPackage ../development/libraries/libopenglrecorder { };
+
   libopus = callPackage ../development/libraries/libopus { };
 
   libopusenc = callPackage ../development/libraries/libopusenc { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/supertuxkart/stk-code/releases/tag/1.3
https://github.com/supertuxkart/stk-code/blob/1.3/CHANGELOG.md#supertuxkart-13-28-september-2021
:partying_face: 

Will test building on x86_64-darwin & aarch64-linux in abit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
