### PR TITLE
nixUnstable: pre20211001 -> pre20211006

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -234,13 +234,13 @@ in rec {
   nixUnstable = lib.lowPrio (callPackage common rec {
     pname = "nix";
     version = "2.4${suffix}";
-    suffix = "pre20211001_${lib.substring 0 7 src.rev}";
+    suffix = "pre20211006_${lib.substring 0 7 src.rev}";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "4f496150eb4e0012914c11f0a3ff4df2412b1d09";
-      sha256 = "00hxxk66f068588ymv60ygib6vgk7c97s9yia3qd561679rq3nsj";
+      rev = "53e479428958b39a126ce15de85d7397fdcfe2e1";
+      sha256 = "18mm3f0n964msj5bha6wpnwckg5lwjwdm6r7frrwdj75v10jiyb7";
     };
 
     boehmgc = boehmgc_nixUnstable;


### PR DESCRIPTION
The specific reason to update is to pull in logging fix:
  c6718a9d950214 "Don't reset the logger in a vfork"

Otherwise 'nix build' does not report build progress correctly.
