### PR TITLE
utf8cpp: 3.1.2 -> 3.2.1

### DIFF
--- a/pkgs/development/libraries/utf8cpp/default.nix
+++ b/pkgs/development/libraries/utf8cpp/default.nix
@@ -2,20 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "utf8cpp";
-  version = "3.1.2";
+  version = "3.2.1";
 
   src = fetchFromGitHub {
     owner = "nemtrif";
     repo = "utfcpp";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-l5sneFsuvPDIRni2x+aR9fmQ9bzXNnIiP9EzZ63sNtg=";
+    sha256 = "0gsbwif97i025bxgyax4fbf6v9z44zrca4s6wwd8x36ac8qzjppf";
   };
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=None"
     "-DCMAKE_INSTALL_LIBDIR=lib"
-    "-DINSTALL_GTEST=OFF"
   ];
 
   nativeBuildInputs = [ cmake ];
@@ -25,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/nemtrif/utfcpp";
     description = "UTF-8 with C++ in a Portable Way";
-    license = licenses.free;
+    license = licenses.boost;
     maintainers = with maintainers; [ jobojeha ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
Bump Package Version. Specify correct upstream license. Remove Cmake flags that are not required anymore.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
