### PR TITLE
leocad: 21.03 -> 21.06 + library update + povray functionality

### DIFF
--- a/pkgs/applications/graphics/leocad/default.nix
+++ b/pkgs/applications/graphics/leocad/default.nix
@@ -14,20 +14,20 @@ set the variable LEOCAD_LIB=/path/to/libs/ or use option -l /path/to/libs/
 
 let
   parts = fetchurl {
-    url = "https://web.archive.org/web/20190715142541/https://www.ldraw.org/library/updates/complete.zip";
+    url = "https://web.archive.org/web/20210705153544/https://www.ldraw.org/library/updates/complete.zip";
     sha256 = "sha256-PW3XCbFwRaNkx4EgCnl2rXH7QgmpNgjTi17kZ5bladA=";
   };
 
 in
 mkDerivation rec {
   pname = "leocad";
-  version = "21.03";
+  version = "21.06";
 
   src = fetchFromGitHub {
     owner = "leozide";
     repo = "leocad";
     rev = "v${version}";
-    sha256 = "sha256-69Ocfk5dBXwcRqAZWEP9Xg41o/tAQo76dIOk9oYhCUE=";
+    sha256 = "1ifbxngkbmg6d8vv08amxbnfvlyjdwzykrjp98lbwvgb0b843ygq";
   };
 
   nativeBuildInputs = [ qmake qttools ];

--- a/pkgs/applications/graphics/leocad/default.nix
+++ b/pkgs/applications/graphics/leocad/default.nix
@@ -2,8 +2,10 @@
 , mkDerivation
 , fetchFromGitHub
 , fetchurl
+, povray
 , qmake
 , qttools
+, substituteAll
 , zlib
 }:
 
@@ -33,6 +35,15 @@ mkDerivation rec {
   nativeBuildInputs = [ qmake qttools ];
 
   buildInputs = [ zlib ];
+
+  propagatedBuildInputs = [ povray ];
+
+  patches = [
+    (substituteAll {
+      src = ./povray.patch;
+      inherit povray;
+    })
+  ];
 
   qmakeFlags = [
     "INSTALL_PREFIX=${placeholder "out"}"

--- a/pkgs/applications/graphics/leocad/povray.patch
+++ b/pkgs/applications/graphics/leocad/povray.patch
@@ -1,0 +1,72 @@
+From 6e7dd2c763e2cc79db4cd7173921a4e72ce9b95e Mon Sep 17 00:00:00 2001
+From: Elias Probst <mail@eliasprobst.eu>
+Date: Tue, 5 Oct 2021 02:55:18 +0200
+Subject: [PATCH] Don't use configurable POV-ray path.
+
+Once the POV-ray path is configurable, it'll be written to the LeoCAD
+profile, which will break upon the next update of POV-ray which will
+have a different Nix store path.
+
+Signed-off-by: Elias Probst <mail@eliasprobst.eu>
+---
+ common/lc_application.cpp    | 1 -
+ common/lc_profile.cpp        | 2 +-
+ qt/lc_qpreferencesdialog.cpp | 3 ++-
+ qt/lc_renderdialog.cpp       | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/common/lc_application.cpp b/common/lc_application.cpp
+index cbdec82e..21974510 100644
+--- a/common/lc_application.cpp
++++ b/common/lc_application.cpp
+@@ -1267,7 +1267,6 @@ void lcApplication::ShowPreferencesDialog()
+ 	lcSetProfileString(LC_PROFILE_DEFAULT_AUTHOR_NAME, Options.DefaultAuthor);
+ 	lcSetProfileString(LC_PROFILE_PARTS_LIBRARY, Options.LibraryPath);
+ 	lcSetProfileString(LC_PROFILE_MINIFIG_SETTINGS, Options.MinifigSettingsPath);
+-	lcSetProfileString(LC_PROFILE_POVRAY_PATH, Options.POVRayPath);
+ 	lcSetProfileString(LC_PROFILE_POVRAY_LGEO_PATH, Options.LGEOPath);
+ 	lcSetProfileString(LC_PROFILE_LANGUAGE, Options.Language);
+ 	lcSetProfileInt(LC_PROFILE_CHECK_UPDATES, Options.CheckForUpdates);
+diff --git a/common/lc_profile.cpp b/common/lc_profile.cpp
+index 1975b586..911c4fb0 100644
+--- a/common/lc_profile.cpp
++++ b/common/lc_profile.cpp
+@@ -132,7 +132,7 @@ static lcProfileEntry gProfileEntries[LC_NUM_PROFILE_KEYS] =
+ 	lcProfileEntry("HTML", "ImageWidth", 640),                                                 // LC_PROFILE_HTML_IMAGE_WIDTH
+ 	lcProfileEntry("HTML", "ImageHeight", 480),                                                // LC_PROFILE_HTML_IMAGE_HEIGHT
+ 
+-	lcProfileEntry("POVRay", "Path", "/usr/bin/povray"),                                       // LC_PROFILE_POVRAY_PATH
++	lcProfileEntry("POVRay", "Path", "@povray@/bin/povray"),                                   // LC_PROFILE_POVRAY_PATH
+ 	lcProfileEntry("POVRay", "LGEOPath", ""),                                                  // LC_PROFILE_POVRAY_LGEO_PATH
+ 	lcProfileEntry("POVRay", "Width", 1280),                                                   // LC_PROFILE_POVRAY_WIDTH
+ 	lcProfileEntry("POVRay", "Height", 720),                                                   // LC_PROFILE_POVRAY_HEIGHT
+diff --git a/qt/lc_qpreferencesdialog.cpp b/qt/lc_qpreferencesdialog.cpp
+index 89f86aad..c239763f 100644
+--- a/qt/lc_qpreferencesdialog.cpp
++++ b/qt/lc_qpreferencesdialog.cpp
+@@ -55,7 +55,8 @@ lcQPreferencesDialog::lcQPreferencesDialog(QWidget* Parent, lcPreferencesDialogO
+ 	ui->partsLibrary->setText(mOptions->LibraryPath);
+ 	ui->ColorConfigEdit->setText(mOptions->ColorConfigPath);
+ 	ui->MinifigSettingsEdit->setText(mOptions->MinifigSettingsPath);
+-	ui->povrayExecutable->setText(mOptions->POVRayPath);
++	ui->povrayExecutable->hide();
++	ui->povrayExecutableBrowse->hide();
+ 	ui->lgeoPath->setText(mOptions->LGEOPath);
+ 	ui->authorName->setText(mOptions->DefaultAuthor);
+ 	ui->mouseSensitivity->setValue(mOptions->Preferences.mMouseSensitivity);
+diff --git a/qt/lc_renderdialog.cpp b/qt/lc_renderdialog.cpp
+index bd8a9102..96794738 100644
+--- a/qt/lc_renderdialog.cpp
++++ b/qt/lc_renderdialog.cpp
+@@ -184,7 +184,7 @@ void lcRenderDialog::on_RenderButton_clicked()
+ #endif
+ 
+ #ifdef Q_OS_LINUX
+-	POVRayPath = lcGetProfileString(LC_PROFILE_POVRAY_PATH);
++	POVRayPath = QDir::cleanPath(QLatin1String("@povray@/bin/povray"));
+ 	Arguments.append("+FN");
+ 	Arguments.append("-D");
+ #endif
+-- 
+2.33.0
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- bump leocad to its latest release
- update the parts library
- enable the povray rendering functionality

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
