### PR TITLE
hilbish: fix paths

### DIFF
--- a/pkgs/shells/hilbish/default.nix
+++ b/pkgs/shells/hilbish/default.nix
@@ -8,12 +8,29 @@ buildGoModule rec {
     owner = "Rosettea";
     repo = "Hilbish";
     rev = "v${version}";
-    sha256 = "sha256-xqGesBNN9lZTYx0kTZfFARq1a/dEC+c3Fo0xLxZuZP4=";
+    sha256 = "sha256-557Je9KeBpkZxVAxcjWAhybIJJYlzhtbnIyZh0rCRUc=";
+    fetchSubmodules = true;
   };
 
   vendorSha256 = "sha256-8l+Kb1ADMLwv0Hf/ikok8eUcEEST07rhk8BjHxJI0lc=";
 
   buildInputs = [ readline ];
+
+  ldflags = [ "-s" "-w" ];
+
+  postPatch = ''
+    # in master vars.go is called vars_linux.go
+    substituteInPlace vars.go \
+      --replace "/usr/share" "${placeholder "out"}/share/"
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/share/hilbish"
+
+    cp .hilbishrc.lua $out/share/hilbish/
+    cp -r libs -t $out/share/hilbish/
+    cp preload.lua $out/share/hilbish/
+  '';
 
   meta = with lib; {
     description = "An interactive Unix-like shell written in Go";


### PR DESCRIPTION
###### Motivation for this change
Program expects paths in /usr/share

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
