### PR TITLE
Patch gtk-mac-integration to disable building Carbon components

### DIFF
--- a/pkgs/development/libraries/gtk-mac-integration/default.nix
+++ b/pkgs/development/libraries/gtk-mac-integration/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gtk-mac-integration";
-  version = "2.1.3";
+  version = "3.0.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "1w0agv4r0daklv5d2f3l0c10krravjq8bj9hsdsrpka48dbnqmap";
+    sha256 = "0sc0m3p8r5xfh5i4d7dg72kfixx9yi4f800y43bszyr88y52jkga";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config gtk-doc gobject-introspection ];

--- a/pkgs/development/libraries/gtk-mac-integration/default.nix
+++ b/pkgs/development/libraries/gtk-mac-integration/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0sc0m3p8r5xfh5i4d7dg72kfixx9yi4f800y43bszyr88y52jkga";
   };
 
+  patches = [ ./disable-carbon-components.patch ];
+
   nativeBuildInputs = [ autoreconfHook pkg-config gtk-doc gobject-introspection ];
   buildInputs = [ glib ];
   propagatedBuildInputs = [ gtk ];

--- a/pkgs/development/libraries/gtk-mac-integration/disable-carbon-components.patch
+++ b/pkgs/development/libraries/gtk-mac-integration/disable-carbon-components.patch
@@ -1,0 +1,58 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 3180e5e..2915df5 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -13,11 +13,7 @@ SOURCES = \
+ 	cocoa_menu_item.c				\
+ 	gtkosxapplication_quartz.c		\
+ 	gtkosxapplication.c				\
+-	gtkosx-image.c					\
+-	gtk-mac-dock.c					\
+-	gtk-mac-bundle.c				\
+-	gtk-mac-menu.c					\
+-	gtk-mac-image-utils.c
++	gtkosx-image.c
+
+ HEADER = \
+ 	cocoa_menu.h              \
+@@ -26,12 +22,6 @@ HEADER = \
+ 	GNSMenuBar.h              \
+ 	GNSMenuDelegate.h         \
+ 	GNSMenuItem.h             \
+-	gtk-mac-bundle.h          \
+-	gtk-mac-dock.h            \
+-	gtk-mac-image-utils.h     \
+-	gtk-mac-integration.h     \
+-	gtk-mac-menu.h            \
+-	gtk-mac-private.h         \
+ 	GtkApplicationDelegate.h  \
+ 	GtkApplicationNotify.h    \
+ 	gtkosx-image.h            \
+@@ -45,7 +35,7 @@ libgtkmacintegration_gtk3_la_SOURCES = $(SOURCES)
+ libgtkmacintegration_gtk3_la_CFLAGS = $(GTK3_CFLAGS) -xobjective-c
+ libgtkmacintegration_gtk3_la_OBJCFLAGS = $(GTK3_CFLAGS)
+ libgtkmacintegration_gtk3_la_LIBADD =  $(GTK3_LIBS) -lobjc
+-libgtkmacintegration_gtk3_la_LDFLAGS = -framework Carbon -framework ApplicationServices -version-info $(GTK_MAC_INTEGRATION_LT_VERSION)
++libgtkmacintegration_gtk3_la_LDFLAGS = -framework ApplicationServices -version-info $(GTK_MAC_INTEGRATION_LT_VERSION)
+ endif
+ if WITH_GTK2
+ lib_LTLIBRARIES += libgtkmacintegration-gtk2.la
+@@ -53,16 +43,12 @@ libgtkmacintegration_gtk2_la_SOURCES = $(SOURCES)
+ libgtkmacintegration_gtk2_la_CFLAGS = $(GTK2_CFLAGS) -xobjective-c
+ libgtkmacintegration_gtk2_la_OBJCFLAGS = $(GTK2_CFLAGS)
+ libgtkmacintegration_gtk2_la_LIBADD = $(GTK2_LIBS) -lobjc
+-libgtkmacintegration_gtk2_la_LDFLAGS = -framework Carbon -framework ApplicationServices -version-info $(GTK_MAC_INTEGRATION_LT_VERSION)
++libgtkmacintegration_gtk2_la_LDFLAGS = -framework ApplicationServices -version-info $(GTK_MAC_INTEGRATION_LT_VERSION)
+ endif
+
+ integration_includedir = $(includedir)/gtkmacintegration
+ integration_include_HEADERS =				\
+-	gtk-mac-integration.h				\
+-	gtkosxapplication.h				\
+-	gtk-mac-menu.h					\
+-	gtk-mac-dock.h					\
+-	gtk-mac-bundle.h
++	gtkosxapplication.h
+
+ noinst_PROGRAMS =
+ test_integration_gtk3_CFLAGS =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

gtk-mac-integration no longer builds if Carbon components are enabled
Also upgrade to v3.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
