### PR TITLE
home-assistant: 2021.9.7 -> 2021.10.0

### DIFF
--- a/pkgs/development/python-modules/aiodiscover/default.nix
+++ b/pkgs/development/python-modules/aiodiscover/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "aiodiscover";
-  version = "1.4.2";
+  version = "1.4.4";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "bdraco";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-xiIN/YLIOdPuqenyxybu0iUpYEy3MyBssXswza5InU0=";
+    sha256 = "sha256-DobTx6oUr25J8bolo84V4yTT0b0jBsOIzPn93uAmDl0=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiohomekit/default.nix
+++ b/pkgs/development/python-modules/aiohomekit/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "aiohomekit";
-  version = "0.6.2";
+  version = "0.6.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "Jc2k";
     repo = pname;
     rev = version;
-    sha256 = "16lfav83g12vzs3ssfva7chcqqb7xdx54djwfwyn9xcwfaa7cwhw";
+    sha256 = "sha256-XBinbhYUB9BuQxxmWfZUw276uNam4DgBpiCAjT7KDlg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/aiohue/default.nix
+++ b/pkgs/development/python-modules/aiohue/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "aiohue";
-  version = "2.6.1";
+  version = "2.6.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0101bw2n6vd3c0p323qqr61wwraja48xbrwcw5sn7i5sa3ygfx0k";
+    sha256 = "sha256-qLs5k4hKdF0zCpgvYAi5V1VXT8rAwzxzlFpS2WYcpHk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiohue/default.nix
+++ b/pkgs/development/python-modules/aiohue/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "aiohue";
-  version = "2.6.2";
+  version = "2.6.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-qLs5k4hKdF0zCpgvYAi5V1VXT8rAwzxzlFpS2WYcpHk=";
+    sha256 = "sha256-zpwkDKPrE5TFZQO0A1ifTQ7n+TRFpXi3jai3h5plyGM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aioshelly/default.nix
+++ b/pkgs/development/python-modules/aioshelly/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "aioshelly";
-  version = "0.6.4";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-QRCqkaKhPQQjNt9mw8nlTB5YKLmIZbXfrxarb3Ksr5k=";
+    sha256 = "sha256-tHGay/esk97oJJhBUD4QOi5IkUBrrQe5koVVdR5NQGw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aioshelly/default.nix
+++ b/pkgs/development/python-modules/aioshelly/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "aioshelly";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-tHGay/esk97oJJhBUD4QOi5IkUBrrQe5koVVdR5NQGw=";
+    sha256 = "sha256-STJ9BDVbvlIMvKMiGwkGZ9Z32NvlE+3cyYduYlwTbx4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/airthings/default.nix
+++ b/pkgs/development/python-modules/airthings/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, aiohttp
+, async-timeout
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "airthings";
+  version = "0.0.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "Danielhiversen";
+    repo = "pyAirthings";
+    rev = version;
+    sha256 = "08cbysx5p9k8hzr6sdykx91j0gx8x15b8807338dsl3qx8nhfb8j";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "airthings" ];
+
+  meta = with lib; {
+    description = "Python module for Airthings";
+    homepage = "https://github.com/Danielhiversen/pyAirthings";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/bellows/default.nix
+++ b/pkgs/development/python-modules/bellows/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "bellows";
-  version = "0.27.0";
+  version = "0.28.0";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "bellows";
     rev = version;
-    sha256 = "sha256-lsGpCd4XgwP91JmRpV6ohXefd1Hm9C51Jk4shU6Irkw=";
+    sha256 = "sha256-j1vS6PDvvuJapECn0lKGuBkYwWsyzJaTZDRQPjMsuLk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/ciso8601/default.nix
+++ b/pkgs/development/python-modules/ciso8601/default.nix
@@ -8,23 +8,27 @@
 
 buildPythonPackage rec {
   pname = "ciso8601";
-  version = "2.1.3";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "closeio";
     repo = "ciso8601";
     rev = "v${version}";
-    sha256 = "0g1aiyc1ayh0rnibyy416m5mmck38ksgdm3jsy0z3rxgmgb24951";
+    sha256 = "sha256-TqB1tQDgCkXu+QuzP6yBEH/xHxhhD/kGR2S0I8Osc5E=";
   };
 
   checkInputs = [
     pytz
-  ] ++ lib.optional (isPy27) unittest2;
+  ] ++ lib.optional (isPy27) [
+    unittest2
+  ];
+
+  pythonImportsCheck = [ "ciso8601" ];
 
   meta = with lib; {
     description = "Fast ISO8601 date time parser for Python written in C";
     homepage = "https://github.com/closeio/ciso8601";
     license = licenses.mit;
-    maintainers = [ maintainers.mic92 ];
+    maintainers = with maintainers; [ mic92 ];
   };
 }

--- a/pkgs/development/python-modules/demjson3/default.nix
+++ b/pkgs/development/python-modules/demjson3/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, python
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "demjson3";
+  version = "3.0.5";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "103dc4pzwg8791q3zll1vv4gcc17d9v3jvr9zj23cpv9hpfsp6mb";
+  };
+
+  checkPhase = ''
+    ${python.interpreter} test/test_demjson3.py
+  '';
+
+  pythonImportsCheck = [ "demjson3" ];
+
+  meta = with lib; {
+    description = "Encoder/decoder and lint/validator for JSON (JavaScript Object Notation)";
+    homepage = "https://github.com/nielstron/demjson3/";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.46.0";
+  version = "0.47.1";
 
   src = fetchFromGitHub {
     owner = "nabucasa";
     repo = pname;
     rev = version;
-    sha256 = "109ma1qlhifj5hs530zfnvc6mqv5grfmcq3s57wawq9nzq0gpfy8";
+    sha256 = "sha256-VlNmW4SM+qyrC2T+/41zwRTYKDq/wyty7UUPC7Egf7g=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.47.1";
+  version = "0.50.0";
 
   src = fetchFromGitHub {
     owner = "nabucasa";
     repo = pname;
     rev = version;
-    sha256 = "sha256-VlNmW4SM+qyrC2T+/41zwRTYKDq/wyty7UUPC7Egf7g=";
+    sha256 = "sha256-0E8eiHzqbxHbtAd97MbvFMRDWTu25E9x/44oNGC4mUM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/netdisco/default.nix
+++ b/pkgs/development/python-modules/netdisco/default.nix
@@ -2,18 +2,23 @@
 
 buildPythonPackage rec {
   pname = "netdisco";
-  version = "2.9.0";
+  version = "3.0.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-OpLFM+0ZmhggJ1SuLoSO+qWLcKcpS65sd7u2zkzPys4=";
+    sha256 = "sha256-TbtZBILzd8zEYeAXQnB8y+jx0tGyhXivkdybf+vNy9I=";
   };
 
   propagatedBuildInputs = [ requests zeroconf ];
 
   checkInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # Broken due to removed discoverables in https://github.com/home-assistant-libs/netdisco/commit/477db5a1dc93919a6c5bd61b4b1d3c80e75785bd
+    "tests/test_xboxone.py"
+  ];
 
   pythonImportsCheck = [
     "netdisco"

--- a/pkgs/development/python-modules/pyatmo/default.nix
+++ b/pkgs/development/python-modules/pyatmo/default.nix
@@ -1,35 +1,37 @@
 { lib
-, buildPythonPackage
-, pythonOlder
-, fetchFromGitHub
 , aiohttp
-, oauthlib
-, requests
-, requests_oauthlib
+, buildPythonPackage
+, fetchFromGitHub
 , freezegun
+, oauthlib
 , pytest-asyncio
 , pytest-mock
 , pytestCheckHook
+, pythonOlder
+, requests
+, requests_oauthlib
 , requests-mock
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "pyatmo";
-  version = "5.2.3";
-  disabled = pythonOlder "3.7";
+  version = "6.0.0";
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "jabesq";
     repo = "pyatmo";
     rev = "v${version}";
-    sha256 = "1w9rhh85z9m3c4rbz6zxlrxglsm5sk5d6796dsj1p1l3b3ad476z";
+    sha256 = "sha256-PFVa2koLaoiaZ9uqSeFwLy/nVHCQBOlRXNsRmgXrWIo=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "oauthlib~=3.1" "oauthlib" \
-      --replace "requests~=2.24" "requests"
-  '';
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
   propagatedBuildInputs = [
     aiohttp
@@ -46,12 +48,18 @@ buildPythonPackage rec {
     requests-mock
   ];
 
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "oauthlib~=3.1" "oauthlib" \
+      --replace "requests~=2.24" "requests"
+  '';
+
   pythonImportsCheck = [ "pyatmo" ];
 
   meta = with lib; {
     description = "Simple API to access Netatmo weather station data";
+    homepage = "https://github.com/jabesq/pyatmo";
     license = licenses.mit;
-    homepage = "https://github.com/jabesq/netatmo-api-python";
     maintainers = with maintainers; [ delroth ];
   };
 }

--- a/pkgs/development/python-modules/pyatmo/default.nix
+++ b/pkgs/development/python-modules/pyatmo/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "pyatmo";
-  version = "6.0.0";
+  version = "6.1.0";
 
   disabled = pythonOlder "3.8";
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "jabesq";
     repo = "pyatmo";
     rev = "v${version}";
-    sha256 = "sha256-PFVa2koLaoiaZ9uqSeFwLy/nVHCQBOlRXNsRmgXrWIo=";
+    sha256 = "sha256-Iscnv3hfYa8QFiXMUN334Muo0oGqnnK11RPNxQJggG0=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/pycarwings2/default.nix
+++ b/pkgs/development/python-modules/pycarwings2/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "pycarwings2";
-  version = "2.11";
+  version = "2.12";
   format = "setuptools";
 
   disabled = pythonOlder "3.5";
@@ -19,8 +19,9 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "filcole";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0daqxnic7kphspqqq8a0bjp009l5a7d1k72q6cz43g7ca6wfq4b1";
+    # release not tagged: https://github.com/filcole/pycarwings2/issues/33
+    rev = "0dc9e7e74cb119614c72c7f955801a366f303c56";
+    sha256 = "sha256-3lyAgLuaNrCDvRT2yYkgaDiLPKW9Hbg05cQlMIBUs6o=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pydeconz/default.nix
+++ b/pkgs/development/python-modules/pydeconz/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pydeconz";
-  version = "83";
+  version = "84";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Kane610";
     repo = "deconz";
     rev = "v${version}";
-    sha256 = "0azpdgmfby8plsp22hy1ip9vzbnmvf9brmah7hcwkpypg31rb61y";
+    sha256 = "sha256-SVWz6r5UiAS7gCpkgN2Swy8dAon26XY9JZucV/eE0t8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pypoint/default.nix
+++ b/pkgs/development/python-modules/pypoint/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "pypoint";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "fredrike";
     repo = "pypoint";
     rev = "v${version}";
-    sha256 = "13p68d2qxfj31lfjv94wzpigjfgjw03yjpl2h16zgxbka2k8zf3x";
+    sha256 = "sha256-2PKZtn+l93de4/gPPM2Wdt04Zw+ekDadwNgL6ZKTqhY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pysyncthru/default.nix
+++ b/pkgs/development/python-modules/pysyncthru/default.nix
@@ -3,13 +3,13 @@
 , buildPythonPackage
 , fetchFromGitHub
 , aiohttp
-, demjson
+, demjson3
 , python
 }:
 
 buildPythonPackage rec {
   pname = "pysyncthru";
-  version = "0.7.8";
+  version = "0.7.10";
 
   disabled = isPy27;
 
@@ -17,12 +17,12 @@ buildPythonPackage rec {
     owner = "nielstron";
     repo = "pysyncthru";
     rev = "release-${version}";
-    sha256 = "17k9dhnya4304gqmkyvvf94jvikmnkf2lqairl3rfrl7w68jm3vp";
+    sha256 = "1c29w2ldrnq0vxr9cfa2pjhwdvrpw393c84khgg2y56jrkbidq53";
   };
 
   propagatedBuildInputs = [
     aiohttp
-    demjson
+    demjson3
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/python-smarttub/default.nix
+++ b/pkgs/development/python-modules/python-smarttub/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "python-smarttub";
-  version = "0.0.25";
+  version = "0.0.27";
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "mdz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "13yf75vmn15g2hrbiv78mws96qbk40p5pz7vc6ljyp41y2lc9wpm";
+    sha256 = "sha256-EoZn5yxj18hi4oEMuUcB5UN2xQFkLbSG/awp+Qh029E=";
   };
 
   propagatedBuildInputs = [
@@ -43,6 +43,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/mdz/python-smarttub";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
-    broken = pyjwt.version != "1.7.1";
   };
 }

--- a/pkgs/development/python-modules/python-tado/default.nix
+++ b/pkgs/development/python-modules/python-tado/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "python-tado";
-  version = "0.11.0";
+  version = "0.12.0";
 
   disabled = pythonOlder "3.5";
 
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "wmalgadey";
     repo = "PyTado";
     rev = version;
-    sha256 = "0fw4f9gqnhxwpxyb34qi8bl5pmzz13h4x3mdk903hhjyccanqncr";
+    sha256 = "sha256-n+H6H2ORLizv9cn1P5Cd8wHDWMNonPrs+x+XMQbEzZQ=";
   };
 
   propagatedBuildInputs = [ requests ];

--- a/pkgs/development/python-modules/pyvicare/default.nix
+++ b/pkgs/development/python-modules/pyvicare/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyvicare";
-  version = "2.8.1";
+  version = "2.9.1";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "somm15";
     repo = "PyViCare";
     rev = version;
-    sha256 = "sha256-SmbsEN6vZ28ihgUggtcF2AjbmUVaqLLweh7cKipr6u4=";
+    sha256 = "sha256-Uzz2mWBT5BaMxYeR6YFIP1BqTWye1Hz9CTTg/bg4kSU=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;

--- a/pkgs/development/python-modules/streamlabswater/default.nix
+++ b/pkgs/development/python-modules/streamlabswater/default.nix
@@ -1,22 +1,20 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , pythonOlder
 , requests
 }:
 
 buildPythonPackage rec {
   pname = "streamlabswater";
-  version = "0.3.2";
+  version = "1.0.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
-  src = fetchFromGitHub {
-    owner = pname;
-    repo = "stream-python";
-    rev = "v${version}";
-    sha256 = "1lh1i1ksic9yhxnwc7mqm5qla98x85dfwj846kwldwam0vcrqlk7";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-kXG0Wg3PVryMBQ9RMMtEzudMiwVQq7Ikw2OK7JcBojA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/surepy/default.nix
+++ b/pkgs/development/python-modules/surepy/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "surepy";
-  version = "0.7.1";
+  version = "0.7.2";
   format = "pyproject";
   disabled = pythonOlder "3.8";
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "benleb";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-h2PEzS3R7NXIUWYOiTpe5ZEU1RopaRj1phudmvcklug=";
+    sha256 = "sha256-yc+jXA4ndFhRZmFPz11HbVs9qaPFNa6WdwXj6hRyjw4=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/twilio/default.nix
+++ b/pkgs/development/python-modules/twilio/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "twilio";
-  version = "6.56.0";
+  version = "7.1.0";
 
 
   src = fetchFromGitHub {
     owner = "twilio";
     repo = "twilio-python";
     rev = version;
-    sha256 = "sha256-vVJuuPxVyOqnplPYrjCjIm5IyIFZvsCMoDLrrHpHK+4=";
+    sha256 = "sha256-pagqetDQ8/1xDCxZJVTZc9T0dmFA1opd7tMDR11wlVs=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.61";
+  version = "0.0.62";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zha-device-handlers";
     rev = version;
-    sha256 = "sha256-uDQAXH0p8Ly0ZbwNlkVo1b7fAXSu77U7v3BHd0B1YQk=";
+    sha256 = "sha256-wXXdxE69EABrvJA8utrhLW4+8ixcyCraWHx2M3uE8mw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.37.1";
+  version = "0.38.0";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy";
     rev = version;
-    sha256 = "sha256-tDpu6tv8qwIPB3G5GKURtDi6QOYxF5jEVbzmJ2Px5W4=";
+    sha256 = "sha256-3iS2VMaicbgtsiKUPe6GjFJQV8xKjs+dC8+IeprMa9I=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zwave-js-server-python/default.nix
+++ b/pkgs/development/python-modules/zwave-js-server-python/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "zwave-js-server-python";
-  version = "0.30.0";
+  version = "0.31.1";
   disabled = pythonOlder "3.8";
 
 
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-KYMq0qDVLHzgaYljwYeK58aggD5kBAI1J/RsirGcVvs=";
+    sha256 = "sha256-lGsG4Q1VcJlj1cZn3j6ZnuZ30SmlBcds3ROZkZEVPCU=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zwave-js-server-python/default.nix
+++ b/pkgs/development/python-modules/zwave-js-server-python/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "zwave-js-server-python";
-  version = "0.31.1";
+  version = "0.31.3";
   disabled = pythonOlder "3.8";
 
 
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-lGsG4Q1VcJlj1cZn3j6ZnuZ30SmlBcds3ROZkZEVPCU=";
+    sha256 = "sha256-mOcaxt8pc+d7qBoDtwCsDWoVs3Hw17v5WDKgzIW1WzY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.9.7";
+  version = "2021.10.0";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];
@@ -19,6 +19,7 @@
     "air_quality" = ps: with ps; [ ];
     "airly" = ps: with ps; [ airly ];
     "airnow" = ps: with ps; [ pyairnow ];
+    "airthings" = ps: with ps; [ ]; # missing inputs: airthings_cloud
     "airtouch4" = ps: with ps; [ ]; # missing inputs: airtouch4pyapi
     "airvisual" = ps: with ps; [ pyairvisual ];
     "aladdin_connect" = ps: with ps; [ aladdin-connect ];
@@ -30,6 +31,7 @@
     "alpha_vantage" = ps: with ps; [ alpha-vantage ];
     "amazon_polly" = ps: with ps; [ boto3 ];
     "ambee" = ps: with ps; [ ambee ];
+    "amberelectric" = ps: with ps; [ amberelectric ];
     "ambiclimate" = ps: with ps; [ aiohttp-cors ambiclimate ];
     "ambient_station" = ps: with ps; [ aioambient ];
     "amcrest" = ps: with ps; [ amcrest ha-ffmpeg ];
@@ -43,7 +45,7 @@
     "apcupsd" = ps: with ps; [ ]; # missing inputs: apcaccess
     "api" = ps: with ps; [ aiohttp-cors ];
     "apns" = ps: with ps; [ ]; # missing inputs: apns2
-    "apple_tv" = ps: with ps; [ aiohttp-cors ifaddr netdisco pyatv zeroconf ];
+    "apple_tv" = ps: with ps; [ pyatv ];
     "apprise" = ps: with ps; [ apprise ];
     "aprs" = ps: with ps; [ aprslib geopy ];
     "aqualogic" = ps: with ps; [ aqualogic ];
@@ -149,6 +151,7 @@
     "cover" = ps: with ps; [ ];
     "cppm_tracker" = ps: with ps; [ ]; # missing inputs: clearpasspy
     "cpuspeed" = ps: with ps; [ py-cpuinfo ];
+    "crownstone" = ps: with ps; [ aiohttp-cors pyserial pyudev ]; # missing inputs: crownstone-cloud crownstone-sse crownstone-uart
     "cups" = ps: with ps; [ pycups ];
     "currencylayer" = ps: with ps; [ ];
     "daikin" = ps: with ps; [ pydaikin ];
@@ -160,7 +163,7 @@
     "deconz" = ps: with ps; [ pydeconz ];
     "decora" = ps: with ps; [ bluepy ]; # missing inputs: decora
     "decora_wifi" = ps: with ps; [ ]; # missing inputs: decora_wifi
-    "default_config" = ps: with ps; [ pynacl pyturbojpeg aiodiscover aiohttp-cors async-upnp-client defusedxml emoji hass-nabucasa home-assistant-frontend ifaddr pillow pyserial pyudev scapy sqlalchemy zeroconf ];
+    "default_config" = ps: with ps; [ pynacl pyturbojpeg aiodiscover aiohttp-cors async-upnp-client emoji hass-nabucasa home-assistant-frontend ifaddr pillow pyserial pyudev scapy sqlalchemy zeroconf ];
     "delijn" = ps: with ps; [ pydelijn ];
     "deluge" = ps: with ps; [ deluge-client ];
     "demo" = ps: with ps; [ aiohttp-cors ];
@@ -185,7 +188,7 @@
     "dlib_face_detect" = ps: with ps; [ face_recognition ];
     "dlib_face_identify" = ps: with ps; [ face_recognition ];
     "dlink" = ps: with ps; [ ]; # missing inputs: pyW215
-    "dlna_dmr" = ps: with ps; [ aiohttp-cors async-upnp-client ifaddr ];
+    "dlna_dmr" = ps: with ps; [ aiohttp-cors async-upnp-client ifaddr zeroconf ];
     "dnsip" = ps: with ps; [ aiodns ];
     "dominos" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pizzapi
     "doods" = ps: with ps; [ pillow pydoods ];
@@ -213,7 +216,7 @@
     "edimax" = ps: with ps; [ pyedimax ];
     "edl21" = ps: with ps; [ pysml ];
     "ee_brightbox" = ps: with ps; [ eebrightbox ];
-    "efergy" = ps: with ps; [ ];
+    "efergy" = ps: with ps; [ ]; # missing inputs: pyefergy
     "egardia" = ps: with ps; [ pythonegardia ];
     "eight_sleep" = ps: with ps; [ pyeight ];
     "elgato" = ps: with ps; [ elgato ];
@@ -224,7 +227,7 @@
     "emoncms" = ps: with ps; [ ];
     "emoncms_history" = ps: with ps; [ ];
     "emonitor" = ps: with ps; [ aioemonitor ];
-    "emulated_hue" = ps: with ps; [ aiohttp-cors ];
+    "emulated_hue" = ps: with ps; [ aiohttp-cors ifaddr ];
     "emulated_kasa" = ps: with ps; [ sense-energy ];
     "emulated_roku" = ps: with ps; [ aiohttp-cors emulated-roku ifaddr ];
     "energy" = ps: with ps; [ aiohttp-cors sqlalchemy ];
@@ -527,7 +530,7 @@
     "mobile_app" = ps: with ps; [ pynacl pyturbojpeg aiohttp-cors emoji hass-nabucasa pillow ];
     "mochad" = ps: with ps; [ ]; # missing inputs: pymochad
     "modbus" = ps: with ps; [ pymodbus ];
-    "modem_callerid" = ps: with ps; [ ]; # missing inputs: basicmodem
+    "modem_callerid" = ps: with ps; [ aiohttp-cors phone-modem pyserial pyudev ];
     "modern_forms" = ps: with ps; [ aiomodernforms ];
     "mold_indicator" = ps: with ps; [ ];
     "monoprice" = ps: with ps; [ ]; # missing inputs: pymonoprice
@@ -555,7 +558,7 @@
     "nad" = ps: with ps; [ nad-receiver ];
     "nam" = ps: with ps; [ nettigo-air-monitor ];
     "namecheapdns" = ps: with ps; [ defusedxml ];
-    "nanoleaf" = ps: with ps; [ pynanoleaf ];
+    "nanoleaf" = ps: with ps; [ aionanoleaf ];
     "neato" = ps: with ps; [ aiohttp-cors pybotvac ];
     "nederlandse_spoorwegen" = ps: with ps; [ nsapi ];
     "nello" = ps: with ps; [ pynello ];
@@ -802,7 +805,7 @@
     "somfy_mylink" = ps: with ps; [ somfy-mylink-synergy ];
     "sonarr" = ps: with ps; [ sonarr ];
     "songpal" = ps: with ps; [ python-songpal ];
-    "sonos" = ps: with ps; [ aiohttp-cors async-upnp-client defusedxml ifaddr plexapi plexauth plexwebsocket soco zeroconf ];
+    "sonos" = ps: with ps; [ aiohttp-cors async-upnp-client ifaddr plexapi plexauth plexwebsocket soco zeroconf ];
     "sony_projector" = ps: with ps; [ pysdcp ];
     "soundtouch" = ps: with ps; [ aiohttp-cors ifaddr libsoundtouch zeroconf ];
     "spaceapi" = ps: with ps; [ aiohttp-cors ];
@@ -814,7 +817,7 @@
     "sql" = ps: with ps; [ sqlalchemy ];
     "squeezebox" = ps: with ps; [ pysqueezebox ];
     "srp_energy" = ps: with ps; [ srpenergy ];
-    "ssdp" = ps: with ps; [ aiohttp-cors async-upnp-client defusedxml ifaddr zeroconf ];
+    "ssdp" = ps: with ps; [ aiohttp-cors async-upnp-client ifaddr zeroconf ];
     "starline" = ps: with ps; [ starline ];
     "starlingbank" = ps: with ps; [ ]; # missing inputs: starlingbank
     "startca" = ps: with ps; [ xmltodict ];
@@ -867,7 +870,6 @@
     "temper" = ps: with ps; [ ]; # missing inputs: temperusb
     "template" = ps: with ps; [ ];
     "tensorflow" = ps: with ps; [ numpy pillow pycocotools tensorflow ]; # missing inputs: tf-models-official
-    "tesla" = ps: with ps; [ teslajsonpy ];
     "tfiac" = ps: with ps; [ ]; # missing inputs: pytfiac
     "thermoworks_smoke" = ps: with ps; [ stringcase ]; # missing inputs: thermoworks_smoke
     "thethingsnetwork" = ps: with ps; [ ];
@@ -889,11 +891,10 @@
     "torque" = ps: with ps; [ aiohttp-cors ];
     "totalconnect" = ps: with ps; [ total-connect-client ];
     "touchline" = ps: with ps; [ ]; # missing inputs: pytouchline
-    "tplink" = ps: with ps; [ pyhs100 ];
+    "tplink" = ps: with ps; [ aiohttp-cors ifaddr python-kasa ];
     "tplink_lte" = ps: with ps; [ ]; # missing inputs: tp-connected
     "traccar" = ps: with ps; [ aiohttp-cors stringcase ]; # missing inputs: pytraccar
     "trace" = ps: with ps; [ ];
-    "trackr" = ps: with ps; [ ]; # missing inputs: pytrackr
     "tractive" = ps: with ps; [ aiotractive ];
     "tradfri" = ps: with ps; [ pytradfri ];
     "trafikverket_train" = ps: with ps; [ pytrafikverket ];
@@ -903,7 +904,7 @@
     "travisci" = ps: with ps; [ ]; # missing inputs: TravisPy
     "trend" = ps: with ps; [ numpy ];
     "tts" = ps: with ps; [ aiohttp-cors mutagen ];
-    "tuya" = ps: with ps; [ tuyaha ];
+    "tuya" = ps: with ps; [ tuya-iot-py-sdk ];
     "twentemilieu" = ps: with ps; [ twentemilieu ];
     "twilio" = ps: with ps; [ aiohttp-cors twilio ];
     "twilio_call" = ps: with ps; [ aiohttp-cors twilio ];
@@ -922,7 +923,7 @@
     "upc_connect" = ps: with ps; [ connect-box ];
     "upcloud" = ps: with ps; [ upcloud-api ];
     "updater" = ps: with ps; [ ];
-    "upnp" = ps: with ps; [ aiohttp-cors async-upnp-client defusedxml ifaddr zeroconf ];
+    "upnp" = ps: with ps; [ aiohttp-cors async-upnp-client ifaddr zeroconf ];
     "uptime" = ps: with ps; [ ];
     "uptimerobot" = ps: with ps; [ ]; # missing inputs: pyuptimerobot
     "usb" = ps: with ps; [ aiohttp-cors pyserial pyudev ];
@@ -933,7 +934,7 @@
     "vacuum" = ps: with ps; [ ];
     "vallox" = ps: with ps; [ ]; # missing inputs: vallox-websocket-api
     "vasttrafik" = ps: with ps; [ ]; # missing inputs: vtjp
-    "velbus" = ps: with ps; [ python-velbus ];
+    "velbus" = ps: with ps; [ velbus-aio ];
     "velux" = ps: with ps; [ pyvlx ];
     "venstar" = ps: with ps; [ venstarcolortouch ];
     "vera" = ps: with ps; [ pyvera ];
@@ -961,12 +962,14 @@
     "waterfurnace" = ps: with ps; [ waterfurnace ];
     "watson_iot" = ps: with ps; [ ]; # missing inputs: ibmiotf
     "watson_tts" = ps: with ps; [ ibm-watson ];
+    "watttime" = ps: with ps; [ aiowatttime ];
     "waze_travel_time" = ps: with ps; [ wazeroutecalculator ];
     "weather" = ps: with ps; [ ];
     "webhook" = ps: with ps; [ aiohttp-cors ];
     "webostv" = ps: with ps; [ aiopylgtv ];
     "websocket_api" = ps: with ps; [ aiohttp-cors ];
     "wemo" = ps: with ps; [ pywemo ];
+    "whirlpool" = ps: with ps; [ whirlpool-sixth-sense ];
     "whois" = ps: with ps; [ python-whois ];
     "wiffi" = ps: with ps; [ wiffi ];
     "wilight" = ps: with ps; [ pywilight ];
@@ -993,7 +996,7 @@
     "xs1" = ps: with ps; [ ]; # missing inputs: xs1-api-client
     "yale_smart_alarm" = ps: with ps; [ yalesmartalarmclient ];
     "yamaha" = ps: with ps; [ rxv ];
-    "yamaha_musiccast" = ps: with ps; [ aiohttp-cors aiomusiccast async-upnp-client defusedxml ifaddr zeroconf ];
+    "yamaha_musiccast" = ps: with ps; [ aiohttp-cors aiomusiccast async-upnp-client ifaddr zeroconf ];
     "yandex_transport" = ps: with ps; [ aioymaps ];
     "yandextts" = ps: with ps; [ ];
     "yeelight" = ps: with ps; [ aiohttp-cors async-upnp-client ifaddr yeelight ];
@@ -1006,13 +1009,13 @@
     "zeroconf" = ps: with ps; [ aiohttp-cors ifaddr zeroconf ];
     "zerproc" = ps: with ps; [ pyzerproc ];
     "zestimate" = ps: with ps; [ xmltodict ];
-    "zha" = ps: with ps; [ aiohttp-cors bellows ifaddr pyserial-asyncio pyserial pyudev zeroconf zha-quirks zigpy-cc zigpy-deconz zigpy-xbee zigpy-zigate zigpy-znp zigpy ];
+    "zha" = ps: with ps; [ aiohttp-cors bellows ifaddr pyserial-asyncio pyserial pyudev zeroconf zha-quirks zigpy-deconz zigpy-xbee zigpy-zigate zigpy-znp zigpy ];
     "zhong_hong" = ps: with ps; [ ]; # missing inputs: zhong_hong_hvac
     "ziggo_mediabox_xl" = ps: with ps; [ ]; # missing inputs: ziggo-mediabox-xl
     "zodiac" = ps: with ps; [ ];
     "zone" = ps: with ps; [ ];
     "zoneminder" = ps: with ps; [ zm-py ];
-    "zwave" = ps: with ps; [ aiohttp-cors homeassistant-pyozw paho-mqtt pydispatcher python-openzwave-mqtt ];
+    "zwave" = ps: with ps; [ homeassistant-pyozw pydispatcher ];
     "zwave_js" = ps: with ps; [ aiohttp-cors pyserial pyudev zwave-js-server-python ];
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -39,20 +39,6 @@ let
       });
     })
 
-    # Pinned due to API changes in pyjwt>=2.0
-    (self: super: {
-      pyjwt = super.pyjwt.overridePythonAttrs (oldAttrs: rec {
-        version = "1.7.1";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "15hflax5qkw1v6nssk1r0wkj83jgghskcmn875m3wgvpzdvajncd";
-        };
-        disabledTests = [
-          "test_ec_verify_should_return_false_if_signature_invalid"
-        ];
-      });
-    })
-
     # Pinned due to API changes in pyruckus>0.12
     (self: super: {
       pyruckus = super.pyruckus.overridePythonAttrs (oldAttrs: rec {

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -53,10 +53,6 @@ let
       });
     })
 
-    # Pinned due to API changes in pylast 4.2.1
-    (mkOverride "pylast" "4.2.0"
-      "0zd0dn2l738ndz62vpa751z0ldnm91dcz9zzbvxv53r08l0s9yf3")
-
     # Pinned due to API changes in pyruckus>0.12
     (self: super: {
       pyruckus = super.pyruckus.overridePythonAttrs (oldAttrs: rec {

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -21,19 +21,6 @@
 
 let
   defaultOverrides = [
-    # Pinned due to API changes in async-upnp-client>=0.20.0, remove after
-    (self: super: {
-      async-upnp-client = super.async-upnp-client.overridePythonAttrs (oldAttrs: rec {
-        version = "0.20.0";
-        src = fetchFromGitHub {
-          owner = "StevenLooman";
-          repo = "async_upnp_client";
-          rev = "v${version}";
-          sha256 = "sha256-jxYGOljV7tcsiAgpOhbXj7g7AwyP1kDDC83PiHG6ZFg=";
-        };
-      });
-    })
-
     # Override the version of some packages pinned in Home Assistant's setup.py and requirements_all.txt
     (mkOverride "python-slugify" "4.0.1" "69a517766e00c1268e5bbfc0d010a0a8508de0b18d30ad5a1ff357f8ae724270")
 

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -114,7 +114,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.9.7";
+  hassVersion = "2021.10.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -131,7 +131,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "1vcdnxh671iqhlbf6811j537by2i03fhryp9r9x77477y2y0xd6k";
+    sha256 = "0m54ynx0i4a6wljg6d9i6xa79c15cqah5cgaswgrbaxhjw5q78iv";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling
@@ -306,7 +306,6 @@ in with py.pkgs; buildPythonApplication rec {
     "ecobee"
     "econet"
     "ee_brightbox"
-    "efergy"
     "elgato"
     "elkm1"
     "emonitor"
@@ -769,7 +768,7 @@ in with py.pkgs; buildPythonApplication rec {
     "--deselect tests/components/wemo/test_sensor.py::TestInsightTodayEnergy::test_state_unavailable"
     "--deselect tests/components/wemo/test_sensor.py::TestInsightCurrentPower::test_state_unavailable"
     # tado/test_climate.py: Tries to connect to my.tado.com
-    "--deselect tests/components/tado/test_climate.py::test_air_con["
+    "--deselect tests/components/tado/test_climate.py::test_air_con"
     # helpers/test_system_info.py: AssertionError: assert 'Unknown' == 'Home Assistant Container'
     "--deselect tests/helpers/test_system_info.py::test_container_installationtype"
     # tests are located in tests/
@@ -782,6 +781,9 @@ in with py.pkgs; buildPythonApplication rec {
     "tests/components"
     # pyotp since v2.4.0 complains about the short mock keys, hass pins v2.3.0
     "tests/auth/mfa_modules/test_notify.py"
+    # emulated_hue/test_upnp.py: Tries to establish the public ipv4 address
+    "tests/components/emulated_hue/test_upnp.py"
+
   ];
 
   disabledTests = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20210830.0";
+  version = "20211006.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-4sNCnYFQ4IjmMPj7axgienZUMDo+GwTJ38cEf0iZzJI=";
+    sha256 = "sha256-rlscTHqa1TMsIVW7kWFGR/feak0XewDRkybpo8dPXj0=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -403,6 +403,8 @@ in {
 
   airly = callPackage ../development/python-modules/airly { };
 
+  airthings = callPackage ../development/python-modules/airthings { };
+
   ajpy = callPackage ../development/python-modules/ajpy { };
 
   ajsonrpc = callPackage ../development/python-modules/ajsonrpc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1956,6 +1956,8 @@ in {
 
   demjson = callPackage ../development/python-modules/demjson { };
 
+  demjson3 = callPackage ../development/python-modules/demjson3 { };
+
   dendropy = callPackage ../development/python-modules/dendropy { };
 
   denonavr = callPackage ../development/python-modules/denonavr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://www.home-assistant.io/blog/2021/10/06/release-202110/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
