### PR TITLE
time-ghc-modules: init at 1.0.0

### DIFF
--- a/pkgs/development/tools/time-ghc-modules/default.nix
+++ b/pkgs/development/tools/time-ghc-modules/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, sqlite
+, python3
+, coreutils
+, findutils
+, gnused
+}:
+
+stdenv.mkDerivation rec {
+  pname = "time-ghc-modules";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "codedownio";
+    repo = "time-ghc-modules";
+    rev = version;
+    sha256 = "sha256:1fa1lz0r8s8q664z4303y3b9jqa6d7wv53bnh7pifj0fm45xqznp";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [makeWrapper];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+    cp ./time-ghc-modules $out/bin/time-ghc-modules
+    wrapProgram $out/bin/time-ghc-modules --prefix PATH : ${lib.makeBinPath [ sqlite python3 coreutils findutils gnused ]}
+
+    mkdir -p $out/bin/scripts
+    cp ./scripts/process $out/bin/scripts/process
+
+    mkdir -p $out/bin/dist
+    cp ./dist/index.html $out/bin/dist/index.html
+  '';
+
+  dontInstall = true;
+
+  meta = with lib; {
+    description = "Analyze GHC .dump-timings files";
+    homepage = "https://github.com/codedownio/time-ghc-modules";
+    license = licenses.mit;
+    maintainers = [ maintainers.thomasjm ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/time-ghc-modules/default.nix
+++ b/pkgs/development/tools/time-ghc-modules/default.nix
@@ -28,19 +28,19 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp ./time-ghc-modules $out/bin/time-ghc-modules
     wrapProgram $out/bin/time-ghc-modules --prefix PATH : ${lib.makeBinPath [ sqlite python3 coreutils findutils gnused ]} \
-                                          --set PROCESS_SCRIPT $out/lib/scripts/process \
-                                          --set HTML_FILE $out/lib/dist/index.html
-
-    mkdir -p $out/lib/scripts
-    cp ./scripts/process $out/lib/scripts/process
-
-    mkdir -p $out/lib/dist
-    cp ./dist/index.html $out/lib/dist/index.html
-
-    runHook postBuild
+                                          --set PROCESS_SCRIPT $out/lib/process \
+                                          --set HTML_FILE $out/lib/index.html
   '';
 
-  dontInstall = true;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    install -m 444 ./dist/index.html $out/lib
+    install ./scripts/process $out/lib
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Analyze GHC .dump-timings files";

--- a/pkgs/development/tools/time-ghc-modules/default.nix
+++ b/pkgs/development/tools/time-ghc-modules/default.nix
@@ -21,9 +21,11 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [makeWrapper];
+  nativeBuildInputs = [makeWrapper];
 
   buildPhase = ''
+    runHook preBuild
+
     mkdir -p $out/bin
     cp ./time-ghc-modules $out/bin/time-ghc-modules
     wrapProgram $out/bin/time-ghc-modules --prefix PATH : ${lib.makeBinPath [ sqlite python3 coreutils findutils gnused ]}
@@ -33,6 +35,8 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin/dist
     cp ./dist/index.html $out/bin/dist/index.html
+
+    runHook postBuild
   '';
 
   dontInstall = true;

--- a/pkgs/development/tools/time-ghc-modules/default.nix
+++ b/pkgs/development/tools/time-ghc-modules/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/time-ghc-modules --prefix PATH : ${lib.makeBinPath [ sqlite python3 coreutils findutils gnused ]} \
                                           --set PROCESS_SCRIPT $out/lib/process \
                                           --set HTML_FILE $out/lib/index.html
+
+    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/development/tools/time-ghc-modules/default.nix
+++ b/pkgs/development/tools/time-ghc-modules/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "time-ghc-modules";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "codedownio";
     repo = "time-ghc-modules";
     rev = version;
-    sha256 = "1fa1lz0r8s8q664z4303y3b9jqa6d7wv53bnh7pifj0fm45xqznp";
+    sha256 = "0s6540gllhjn7366inhwa70rdnngnhbi07jn1h6x8a0pi71wdfm9";
   };
 
   nativeBuildInputs = [makeWrapper];
@@ -27,13 +27,15 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     cp ./time-ghc-modules $out/bin/time-ghc-modules
-    wrapProgram $out/bin/time-ghc-modules --prefix PATH : ${lib.makeBinPath [ sqlite python3 coreutils findutils gnused ]}
+    wrapProgram $out/bin/time-ghc-modules --prefix PATH : ${lib.makeBinPath [ sqlite python3 coreutils findutils gnused ]} \
+                                          --set PROCESS_SCRIPT $out/lib/scripts/process \
+                                          --set HTML_FILE $out/lib/dist/index.html
 
-    mkdir -p $out/bin/scripts
-    cp ./scripts/process $out/bin/scripts/process
+    mkdir -p $out/lib/scripts
+    cp ./scripts/process $out/lib/scripts/process
 
-    mkdir -p $out/bin/dist
-    cp ./dist/index.html $out/bin/dist/index.html
+    mkdir -p $out/lib/dist
+    cp ./dist/index.html $out/lib/dist/index.html
 
     runHook postBuild
   '';

--- a/pkgs/development/tools/time-ghc-modules/default.nix
+++ b/pkgs/development/tools/time-ghc-modules/default.nix
@@ -17,8 +17,7 @@ stdenv.mkDerivation rec {
     owner = "codedownio";
     repo = "time-ghc-modules";
     rev = version;
-    sha256 = "sha256:1fa1lz0r8s8q664z4303y3b9jqa6d7wv53bnh7pifj0fm45xqznp";
-    fetchSubmodules = true;
+    sha256 = "1fa1lz0r8s8q664z4303y3b9jqa6d7wv53bnh7pifj0fm45xqznp";
   };
 
   nativeBuildInputs = [makeWrapper];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15045,6 +15045,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security CoreServices;
   };
 
+  time-ghc-modules = callPackage ../development/tools/time-ghc-modules { };
+
   tflint = callPackage ../development/tools/analysis/tflint { };
 
   tfsec = callPackage ../development/tools/analysis/tfsec { };


### PR DESCRIPTION
Closes https://github.com/codedownio/time-ghc-modules/issues/7, CC @teto.

###### Motivation for this change

Package the `time-ghc-modules` tool in Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
