### PR TITLE
libcanberra: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/libcanberra/default.nix
+++ b/pkgs/development/libraries/libcanberra/default.nix
@@ -13,9 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "0wps39h8rx2b00vyvkia5j40fkak3dpipp1kzilqla0cgvk73dn2";
   };
 
-  nativeBuildInputs = [ pkg-config libtool ];
+  strictDeps = true;
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     libpulseaudio libvorbis
+    libtool # in buildInputs rather than nativeBuildInputs since libltdl is used (not libtool itself)
   ] ++ (with gst_all_1; [ gstreamer gst-plugins-base ])
     ++ lib.optional (gtkSupport == "gtk2") gtk2-x11
     ++ lib.optional (gtkSupport == "gtk3") gtk3-x11


### PR DESCRIPTION
###### Motivation for this change

Shuffling around dependencies to make cross-compilation work.

Content-addressed outputs for native are the same, so should be good like this for the native case.

Tested building with `nix build .#pkgsCross-aarch64-multiplatform.libcanberra`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
