### PR TITLE
libgrss: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/libgrss/default.nix
+++ b/pkgs/development/libraries/libgrss/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, vala, gobject-introspection, gtk-doc, docbook_xsl, docbook_xml_dtd_412, glib, libxml2, libsoup, gnome }:
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, vala, gobject-introspection, gtk-doc
+, docbook_xsl, docbook_xml_dtd_412, glib, libxml2, libsoup, gnome, buildPackages
+}:
 
 stdenv.mkDerivation rec {
   pname = "libgrss";
@@ -20,10 +22,24 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ pkg-config vala gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_412 ];
-  buildInputs = [ glib libxml2 libsoup ];
+  nativeBuildInputs = [
+    pkg-config
+    vala
+    gobject-introspection
+    gtk-doc
+    docbook_xsl
+    docbook_xml_dtd_412
+  ];
+
+  buildInputs = [
+    glib
+    libxml2
+    libsoup
+  ];
 
   configureFlags = [
+    "PKG_CONFIG=${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config"
+  ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
     "--enable-gtk-doc"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Support cross-compilation to `pkgsCross.aarch64-multiplatform`.

I've tested that the native output hash stays the same
(with ca-derivations), so for native this should be fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
