### PR TITLE
pkgsLLVM.grpc: fix build

### DIFF
--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -68,7 +68,12 @@ stdenv.mkDerivation rec {
     rm -vf BUILD
   '';
 
-  preBuild = ''
+  # When natively compiling, grpc_cpp_plugin is executed from the build directory,
+  # needing to load dynamic libraries from the build directory, so we set
+  # LD_LIBRARY_PATH to enable this. When cross compiling we need to avoid this,
+  # since it can cause the grpc_cpp_plugin executable from buildPackages to
+  # crash if build and host architecture are compatible (e. g. pkgsLLVM).
+  preBuild = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     export LD_LIBRARY_PATH=$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
   '';
 

--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -57,7 +57,12 @@ stdenv.mkDerivation rec {
     "-DgRPC_ABSL_PROVIDER=package"
     "-DBUILD_SHARED_LIBS=ON"
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
-    "-DCMAKE_CXX_STANDARD=17"
+    # Needs to be compiled with -std=c++11 for clang < 11. Interestingly this is
+    # only an issue with the useLLVM stdenv, not the darwin stdenv…
+    # https://github.com/grpc/grpc/issues/26473#issuecomment-860885484
+    (if (stdenv.hostPlatform.useLLVM or false) && lib.versionOlder stdenv.cc.cc.version "11.0"
+     then "-DCMAKE_CXX_STANDARD=11"
+     else "-DCMAKE_CXX_STANDARD=17")
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-D_gRPC_PROTOBUF_PROTOC_EXECUTABLE=${buildPackages.protobuf}/bin/protoc"
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tested:

* [x] grpc
* [x] pkgsLLVM.grpc
* [x] pkgsLLVM.grpc with overlay `self: super: { llvmPackages = self.llvmPackages_11; }`
* [x] pkgsCross.aarch64-multiplatform.grpc
* [x] grpc with `crossSystem = { config = "aarch64-unknown-linux-gnu"; linker = "lld"; useLLVM = true; }`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
