### PR TITLE
starsector: generate desktop file

### DIFF
--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -6,6 +6,8 @@
 , openjdk
 , stdenv
 , xorg
+, copyDesktopItems
+, makeDesktopItem
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +19,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-/5ij/079aOad7otXSFFcmVmiYQnMX/0RXGOr1j0rkGY=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
   buildInputs = with xorg; [
     alsa-lib
     libXxf86vm
@@ -25,18 +30,37 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "starsector";
+      exec = "starsector";
+      icon = "starsector";
+      comment = meta.description;
+      genericName = "starsector";
+      desktopName = "Starsector";
+      categories = "Game;";
+    })
+  ];
+
   # need to cd into $out in order for classpath to pick up correct jar files
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     rm -r jre_linux # remove jre7
     rm starfarer.api.zip
     cp -r ./* $out
 
+    mkdir -p $out/share/icons/hicolor/64x64/apps
+    ln -s $out/graphics/ui/s_icon64.png $out/share/icons/hicolor/64x64/apps/starsector.png
+
     wrapProgram $out/starsector.sh \
       --prefix PATH : ${lib.makeBinPath [ openjdk ]} \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
-      --run "mkdir -p \$XDG_DATA_HOME/starsector; cd $out"
+      --run 'mkdir -p ''${XDG_DATA_HOME:-~/.local/share}/starsector; cd '"$out"
     ln -s $out/starsector.sh $out/bin/starsector
+
+    runHook postInstall
   '';
 
   # it tries to run everything with relative paths, which makes it CWD dependent
@@ -44,8 +68,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace starsector.sh \
       --replace "./jre_linux/bin/java" "${openjdk}/bin/java" \
-      --replace "./native/linux" "$out/native/linux" \
-      --replace "./" "\$XDG_DATA_HOME/starsector/"
+      --replace "./native/linux" "$out/native/linux"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
