### PR TITLE
hamlib: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/hamlib/default.nix
+++ b/pkgs/development/libraries/hamlib/default.nix
@@ -15,7 +15,8 @@
 , perlPackages
 , pythonBindings ? true
 , tclBindings ? true
-, perlBindings ? true
+, perlBindings ? stdenv.buildPlatform == stdenv.hostPlatform
+, buildPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -27,11 +28,15 @@ stdenv.mkDerivation rec {
     sha256 = "10788mgrhbc57zpzakcxv5aqnr2819pcshml6fbh8zvnkja562y9";
   };
 
+  strictDeps = true;
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [
     swig
     pkg-config
     libtool
-  ];
+  ] ++ lib.optionals pythonBindings [ python3 ]
+    ++ lib.optionals tclBindings [ tcl ]
+    ++ lib.optionals perlBindings [ perl ];
 
   buildInputs = [
     gd
@@ -39,10 +44,12 @@ stdenv.mkDerivation rec {
     libusb-compat-0_1
     boost
   ] ++ lib.optionals pythonBindings [ python3 ncurses ]
-    ++ lib.optionals tclBindings [ tcl ]
-    ++ lib.optionals perlBindings [ perl perlPackages.ExtUtilsMakeMaker ];
+    ++ lib.optionals tclBindings [ tcl ];
 
-  configureFlags = lib.optionals perlBindings [ "--with-perl-binding" ]
+
+  configureFlags = [
+    "CC_FOR_BUILD=${stdenv.cc.targetPrefix}cc"
+  ] ++ lib.optionals perlBindings [ "--with-perl-binding" ]
     ++ lib.optionals tclBindings [ "--with-tcl-binding" "--with-tcl=${tcl}/lib/" ]
     ++ lib.optionals pythonBindings [ "--with-python-binding" ];
 


### PR DESCRIPTION
###### Motivation for this change

Stepping stone for rtl_433 cross-compilation.

Unfortunately, this disables perl bindings, but at least it compiles now. Perl binding might need some extra love if someone requires them in the future.

Also tested building `pkgsCross.aarch64-multiplatform.soapyaudio`, which depends on this package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compilated using `pkgsCross.aarch64-multiplatform`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
