### PR TITLE
Allow overriding Erlang package in Elixir

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -12,6 +12,7 @@
 
 { baseName ? "elixir"
 , version
+, erlangPackage ? erlang
 , minimumOTPVersion
 , sha256 ? null
 , rev ? "v${version}"
@@ -22,7 +23,7 @@ let
   inherit (lib) getVersion versionAtLeast optional;
 
 in
-assert versionAtLeast (getVersion erlang) minimumOTPVersion;
+assert versionAtLeast (getVersion erlangPackage) minimumOTPVersion;
 
 stdenv.mkDerivation ({
   name = "${baseName}-${version}";
@@ -30,7 +31,7 @@ stdenv.mkDerivation ({
   inherit src version debugInfo;
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ erlang ];
+  buildInputs = [ erlangPackage ];
 
   LANG = "C.UTF-8";
   LC_TYPE = "C.UTF-8";


### PR DESCRIPTION
###### Motivation for this change

Sometimes it is needed to override Erlang version in Elixir, for example to use custom flags (for example to support DTrace/SystemTap) or to use alternative derivation like `erlang_nox` or `erlang_odbc`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
