### PR TITLE
camlboot: init unstable-2021-09-08

### DIFF
--- a/pkgs/development/compilers/ocaml/camlboot.nix
+++ b/pkgs/development/compilers/ocaml/camlboot.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, guile
+}:
+
+stdenv.mkDerivation rec {
+  pname = "camlboot";
+  version = "unstable-2021-09-08";
+
+  src = fetchFromGitHub {
+    owner = "ekdohibs";
+    repo = "camlboot";
+    rev = "b103dc52411d94c8df69bc8b7915dd43aa40f8e8";
+    sha256 = "JFj9C1HqHpUgbq6cFvIfd6mOPy67s2C9ZPWMqsrB4d0=";
+    fetchSubmodules = true;
+  };
+
+  depsBuildBuild = [ guile ];
+
+  patchPhase = ''
+    runHook prePatch
+    patchShebangs \
+      compile_ocamlc.sh \
+      compile_stdlib.sh \
+      miniml/interp/cvt_emit.sh \
+      miniml/interp/depend.sh \
+      miniml/interp/genfileopt.sh \
+      miniml/interp/interp \
+      miniml/interp/interp.opt \
+      miniml/interp/lex.sh \
+      miniml/interp/make_opcodes.sh \
+      timed.sh
+    runHook postPatch
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make -j$NIX_BUILD_CORES _boot/ocamlc
+    make -j$NIX_BUILD_CORES fullboot
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r . $out
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Bootstrap of the OCaml compiler.";
+    homepage = "https://github.com/Ekdohibs/camlboot";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pnmadelaine r-burns ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12362,6 +12362,8 @@ with pkgs;
   ocaml-ng = callPackage ./ocaml-packages.nix { };
   ocaml = ocamlPackages.ocaml;
 
+  camlboot = callPackage ../development/compilers/ocaml/camlboot.nix { };
+
   ocamlPackages = recurseIntoAttrs ocaml-ng.ocamlPackages;
 
   ocaml-crunch = ocamlPackages.crunch.bin;


### PR DESCRIPTION
###### Motivation for this change

Bootstrap ocaml with https://github.com/Ekdohibs/camlboot.
Replaces #138519.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
