### PR TITLE
libjaylink: Init at 0.2.0

### DIFF
--- a/pkgs/development/libraries/libjaylink/default.nix
+++ b/pkgs/development/libraries/libjaylink/default.nix
@@ -1,0 +1,36 @@
+{ fetchFromGitLab, lib, stdenv
+, autoreconfHook, pkg-config
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libjaylink";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.zapb.de";
+    owner = "libjaylink";
+    repo = "libjaylink";
+    rev = version;
+    sha256 = "0ndyfh51hiqyv2yscpj6qd091w7myxxjid3a6rx8f6k233vy826q";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ libusb1 ];
+
+  postPatch = ''
+    patchShebangs autogen.sh
+  '';
+
+  postInstall = ''
+    install -Dm644 contrib/99-libjaylink.rules $out/lib/udev/rules.d/libjaylink.rules
+  '';
+
+  meta = with lib; {
+    homepage = "https://gitlab.zapb.de/libjaylink/libjaylink";
+    description = "libjaylink is a shared library written in C to access SEGGER J-Link and compatible devices.";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ felixsinger ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17956,6 +17956,8 @@ with pkgs;
 
   liburcu = callPackage ../development/libraries/liburcu { };
 
+  libjaylink = callPackage ../development/libraries/libjaylink { };
+
   libusb-compat-0_1 = callPackage ../development/libraries/libusb-compat/0.1.nix {};
 
   libusb1 = callPackage ../development/libraries/libusb1 {


### PR DESCRIPTION
###### Motivation for this change
Add package for libjaylink. libjaylink is a shared library written in C to access SEGGER J-Link and compatible devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
