### PR TITLE
Discourse: add plugins: assign, chat-integration, docs, prometheus, saved-searches

### DIFF
--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -9,6 +9,7 @@ in
   discourse-chat-integration = callPackage ./discourse-chat-integration {};
   discourse-checklist = callPackage ./discourse-checklist {};
   discourse-data-explorer = callPackage ./discourse-data-explorer {};
+  discourse-docs = callPackage ./discourse-docs {};
   discourse-github = callPackage ./discourse-github {};
   discourse-ldap-auth = callPackage ./discourse-ldap-auth {};
   discourse-math = callPackage ./discourse-math {};

--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -15,6 +15,7 @@ in
   discourse-math = callPackage ./discourse-math {};
   discourse-migratepassword = callPackage ./discourse-migratepassword {};
   discourse-openid-connect = callPackage ./discourse-openid-connect {};
+  discourse-prometheus = callPackage ./discourse-prometheus {};
   discourse-solved = callPackage ./discourse-solved {};
   discourse-spoiler-alert = callPackage ./discourse-spoiler-alert {};
   discourse-yearly-review = callPackage ./discourse-yearly-review {};

--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -3,6 +3,7 @@ let
   callPackage = newScope args;
 in
 {
+  discourse-assign = callPackage ./discourse-assign {};
   discourse-calendar = callPackage ./discourse-calendar {};
   discourse-canned-replies = callPackage ./discourse-canned-replies {};
   discourse-checklist = callPackage ./discourse-checklist {};

--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -19,5 +19,6 @@ in
   discourse-saved-searches = callPackage ./discourse-saved-searches {};
   discourse-solved = callPackage ./discourse-solved {};
   discourse-spoiler-alert = callPackage ./discourse-spoiler-alert {};
+  discourse-voting = callPackage ./discourse-voting {};
   discourse-yearly-review = callPackage ./discourse-yearly-review {};
 }

--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -16,6 +16,7 @@ in
   discourse-migratepassword = callPackage ./discourse-migratepassword {};
   discourse-openid-connect = callPackage ./discourse-openid-connect {};
   discourse-prometheus = callPackage ./discourse-prometheus {};
+  discourse-saved-searches = callPackage ./discourse-saved-searches {};
   discourse-solved = callPackage ./discourse-solved {};
   discourse-spoiler-alert = callPackage ./discourse-spoiler-alert {};
   discourse-yearly-review = callPackage ./discourse-yearly-review {};

--- a/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/all-plugins.nix
@@ -6,6 +6,7 @@ in
   discourse-assign = callPackage ./discourse-assign {};
   discourse-calendar = callPackage ./discourse-calendar {};
   discourse-canned-replies = callPackage ./discourse-canned-replies {};
+  discourse-chat-integration = callPackage ./discourse-chat-integration {};
   discourse-checklist = callPackage ./discourse-checklist {};
   discourse-data-explorer = callPackage ./discourse-data-explorer {};
   discourse-github = callPackage ./discourse-github {};

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-assign/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-assign/default.nix
@@ -1,0 +1,17 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-assign";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-assign";
+    rev = "5124ba0f67e26a075f0a0fc8993273f1211d1c28";
+    sha256 = "1zd2irp5siza0vd5rlwzmjfvcdfw785988jc526xc741flazk1lr";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/discourse/discourse-docs";
+    maintainers = with maintainers; [ dpausp ];
+    license = licenses.mit;
+    description = "Discourse Plugin for assigning users to a topic";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-chat-integration/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-chat-integration/default.nix
@@ -1,0 +1,17 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-chat-integration";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-chat-integration";
+    rev = "8ade892b387f0ce843d5e78ef4a271b0d35847ff";
+    sha256 = "1qn1bm09i9gzmh74ws32zgc89hrqzyhmh63qvmv0h00r52rmgxvx";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/discourse/discourse-chat-integration";
+    maintainers = with maintainers; [ dpausp ];
+    license = licenses.mit;
+    description = "This plugin integrates Discourse with a number of external chatroom systems";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-docs/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-docs/default.nix
@@ -1,0 +1,17 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-docs";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-docs";
+    rev = "72cdd8d415ae3f797c0d5e2c857370714a42c54a";
+    sha256 = "07hvw8lpg8873vhwh8rrbml3s5hq606b7sw93r2xv38gxfhmx5lq";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/discourse/discourse-docs";
+    maintainers = with maintainers; [ dpausp ];
+    license = licenses.mit;
+    description = "Find and filter knowledge base topics";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/Gemfile
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# gem "rails"
+gem 'prometheus_exporter', '0.5.0'

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    prometheus_exporter (0.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  prometheus_exporter (= 0.5.0)
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, mkDiscoursePlugin, fetchFromGitHub }:
+
+ mkDiscoursePlugin {
+  bundlerEnvArgs.gemdir = ./.;
+  name = "discourse-prometheus";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-prometheus";
+    rev = "46260710e8770344af438f86b47409d864a1c499";
+    sha256 = "0nmpi0nysp59x4hyn1c3niypvxw1jkz86acb6m8acacw0c6682k2";
+  };
+
+  patches = [
+    # The metrics collector tries to run git to get the commit id but fails
+    # because we don't run Discourse from a Git repository.
+    ./no-git-version.patch
+    ./spec-import-fix-abi-version.patch
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/discourse/discourse-prometheus";
+    maintainers = with maintainers; [ dpausp ];
+    license = licenses.mit;
+    description = "Official Discourse Plugin for Prometheus Monitoring";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/gemset.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/gemset.nix
@@ -1,0 +1,12 @@
+{
+  prometheus_exporter = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1kmabnxz466zqnyqlzc693ny4l7i0rxvmc0znswvizc0zg4pri80";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/no-git-version.patch
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/no-git-version.patch
@@ -1,0 +1,36 @@
+diff --git a/lib/internal_metric/global.rb b/lib/internal_metric/global.rb
+index 682571b..7bdd431 100644
+--- a/lib/internal_metric/global.rb
++++ b/lib/internal_metric/global.rb
+@@ -30,30 +30,7 @@ module DiscoursePrometheus::InternalMetric
+       @active_app_reqs = 0
+       @queued_app_reqs = 0
+       @fault_logged = {}
+-
+-      begin
+-        @@version = nil
+-
+-        out, error, status = Open3.capture3('git rev-parse HEAD')
+-
+-        if status.success?
+-          @@version ||= out.chomp
+-        else
+-          raise error
+-        end
+-      rescue => e
+-        if defined?(::Discourse)
+-          Discourse.warn_exception(e, message: "Failed to calculate discourse_version_info metric")
+-        else
+-          STDERR.puts "Failed to calculate discourse_version_info metric: #{e}\n#{e.backtrace.join("\n")}"
+-        end
+-
+-        @@retries ||= 10
+-        @@retries -= 1
+-        if @@retries < 0
+-          @@version = -1
+-        end
+-      end
++      @@version = -1
+     end
+ 
+     def collect

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/spec-import-fix-abi-version.patch
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-prometheus/spec-import-fix-abi-version.patch
@@ -1,0 +1,16 @@
+diff --git a/bin/collector b/bin/collector
+index 4fec65e..e59eac7 100755
+--- a/bin/collector
++++ b/bin/collector
+@@ -3,8 +3,10 @@
+ 
+ Process.setproctitle("discourse prometheus-collector")
+ 
++# We need the ABI version {MAJOR}.{MINOR}.0 here.
++abi_version = ENV['GEM_PATH'].split("/")[-1]
+ version = File.read(File.expand_path("../../prometheus_exporter_version", __FILE__)).strip
+-spec_file = File.expand_path("../../gems/#{RUBY_VERSION}/specifications/prometheus_exporter-#{version}.gemspec", __FILE__)
++spec_file = File.expand_path("../../gems/#{abi_version}/specifications/prometheus_exporter-#{version}.gemspec", __FILE__)
+ 
+ spec = Gem::Specification.load spec_file
+ spec.activate

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-saved-searches/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-saved-searches/default.nix
@@ -1,0 +1,17 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-saved-searches";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-saved-searches";
+    rev = "b59e0b60afdd5133e60c5cc6169f42f1edd746be";
+    sha256 = "0yhr7gx35q2nshvfxkplplkq73l7sgqlm8r3g1apniqicpk5flqy";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/discourse/discourse-saved-searches";
+    maintainers = with maintainers; [ dpausp ];
+    license = licenses.mit;
+    description = "Allow users to save searches and be notified of new results";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/plugins/discourse-voting/default.nix
+++ b/pkgs/servers/web-apps/discourse/plugins/discourse-voting/default.nix
@@ -1,0 +1,17 @@
+{ lib, mkDiscoursePlugin, fetchFromGitHub }:
+
+mkDiscoursePlugin {
+  name = "discourse-voting";
+  src = fetchFromGitHub {
+    owner = "discourse";
+    repo = "discourse-voting";
+    rev = "fc4d23174eba1a57ddcba93eaf4a4e75d469d4a4";
+    sha256 = "07mj667qn387kaafg475f36pgnannsrb2bdqi0zj487av43252qb";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/discourse/discourse-voting";
+    maintainers = with maintainers; [ dpausp ];
+    license = licenses.gpl2Only;
+    description = "Adds the ability for voting on a topic within a specified category in Discourse";
+  };
+}

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -212,6 +212,9 @@ def update_plugins():
         {'name': 'discourse-ldap-auth', 'owner': 'jonmbake'},
         {'name': 'discourse-math'},
         {'name': 'discourse-migratepassword', 'owner': 'discoursehosting'},
+        # We can't update this automatically at the moment because the plugin.rb
+        # tries to load a version number which breaks bundler called by this script.
+        # {'name': 'discourse-prometheus'},
         {'name': 'discourse-solved'},
         {'name': 'discourse-spoiler-alert'},
         {'name': 'discourse-yearly-review'},

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -204,6 +204,7 @@ def update_plugins():
         {'name': 'discourse-assign'},
         {'name': 'discourse-calendar'},
         {'name': 'discourse-canned-replies'},
+        {'name': 'discourse-chat-integration'},
         {'name': 'discourse-checklist'},
         {'name': 'discourse-data-explorer'},
         {'name': 'discourse-github'},

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -218,6 +218,7 @@ def update_plugins():
         {'name': 'discourse-saved-searches'},
         {'name': 'discourse-solved'},
         {'name': 'discourse-spoiler-alert'},
+        {'name': 'discourse-voting'},
         {'name': 'discourse-yearly-review'},
     ]
 

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -201,6 +201,7 @@ def update_plugins():
 
     """
     plugins = [
+        {'name': 'discourse-assign'},
         {'name': 'discourse-calendar'},
         {'name': 'discourse-canned-replies'},
         {'name': 'discourse-checklist'},

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -215,6 +215,7 @@ def update_plugins():
         # We can't update this automatically at the moment because the plugin.rb
         # tries to load a version number which breaks bundler called by this script.
         # {'name': 'discourse-prometheus'},
+        {'name': 'discourse-saved-searches'},
         {'name': 'discourse-solved'},
         {'name': 'discourse-spoiler-alert'},
         {'name': 'discourse-yearly-review'},

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -207,6 +207,7 @@ def update_plugins():
         {'name': 'discourse-chat-integration'},
         {'name': 'discourse-checklist'},
         {'name': 'discourse-data-explorer'},
+        {'name': 'discourse-docs'},
         {'name': 'discourse-github'},
         {'name': 'discourse-ldap-auth', 'owner': 'jonmbake'},
         {'name': 'discourse-math'},


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package various official feature plugins and the discourse-prometheus for metrics.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested all plugins with Discourse 2.7.8 from unstable and 2.8.0.beta6.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
