### PR TITLE
copyDesktopItems: fix handling of plain paths

### DIFF
--- a/pkgs/build-support/setup-hooks/copy-desktop-items.sh
+++ b/pkgs/build-support/setup-hooks/copy-desktop-items.sh
@@ -30,8 +30,8 @@ copyDesktopItems() {
 
     for desktopItem in $desktopItems; do
         if [[ -f "$desktopItem" ]]; then
-            echo "Copying '$f' into '$out/share/applications'"
-            install -D -m 444 -t "$out"/share/applications "$f"
+            echo "Copying '$desktopItem' into '$out/share/applications'"
+            install -D -m 444 -t "$out"/share/applications "$desktopItem"
         else
             for f in "$desktopItem"/share/applications/*.desktop; do
                 echo "Copying '$f' into '$out/share/applications'"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
copyDesktopItems is broken (and seems to have always been broken) for the usecase of "passing a path" rather than "passing the output of makeDesktopItem", despite that being documented as working:

```
# This hook will copy files which are either given by full path
# or all '*.desktop' files placed inside the 'share/applications'
# folder of each `desktopItems` argument.
```

As far as I can tell, no existing package ever tried to depend on this behaviour anyway, but it would be useful to have it working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
