### PR TITLE
dapl: init at 0.2.0+unstable=2021-06-30

### DIFF
--- a/pkgs/development/interpreters/dzaima-apl/default.nix
+++ b/pkgs/development/interpreters/dzaima-apl/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, jdk
+, makeWrapper
+, buildNativeImage ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dapl" + lib.optionalString buildNativeImage "-native";
+  version = "0.2.0+unstable=2021-06-30";
+
+  src = fetchFromGitHub {
+    owner = "dzaima";
+    repo = "APL";
+    rev = "28b3667beb23c6472266bb2b6eb701708fa421c6";
+    hash = "sha256-2kM9XDMclxJNOZngwLvoDQG23UZQQ6ePK/j215UumCg=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    jdk
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    patchShebangs --build ./build
+    ./build
+  '' + lib.optionalString buildNativeImage ''
+    native-image --report-unsupported-elements-at-runtime \
+      -H:CLibraryPath=${lib.getLib jdk}/lib -jar APL.jar dapl
+  '' + ''
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+  '' + (if buildNativeImage then ''
+    mv dapl $out/bin
+  '' else ''
+    mkdir -p $out/share/${pname}
+    mv APL.jar $out/share/${pname}/
+
+    makeWrapper "${lib.getBin jdk}/bin/java" "$out/bin/dapl" \
+      --add-flags "-jar $out/share/${pname}/APL.jar"
+  '') + ''
+    ln -s $out/bin/dapl $out/bin/apl
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/dzaima/APL";
+    description = "An APL implementation in Java" + lib.optionalString buildNativeImage ", compiled as a native image";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+    inherit (jdk.meta) platforms;
+  };
+}
+# TODO: Processing app
+# TODO: minimalistic JDK

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5621,6 +5621,16 @@ with pkgs;
 
   gnuapl = callPackage ../development/interpreters/gnu-apl { };
 
+  dapl = callPackage ../development/interpreters/dzaima-apl {
+    buildNativeImage = false;
+    stdenv = stdenvNoCC;
+    jdk = jre;
+  };
+  dapl-native = callPackage ../development/interpreters/dzaima-apl {
+    buildNativeImage = true;
+    jdk = graalvm11-ce;
+  };
+
   gnucap = callPackage ../applications/science/electronics/gnucap { };
 
   gnu-cobol = callPackage ../development/compilers/gnu-cobol { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
