### PR TITLE
Fix compilation against `<bpf/btf.h>` on pre-5.13 kernels (including bpftrace)

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -6,7 +6,7 @@
 
 python.pkgs.buildPythonApplication rec {
   pname = "bcc";
-  version = "0.20.0";
+  version = "0.22.0";
 
   disabled = !stdenv.isLinux;
 
@@ -14,8 +14,9 @@ python.pkgs.buildPythonApplication rec {
     owner = "iovisor";
     repo = "bcc";
     rev = "v${version}";
-    sha256 = "1xnpz2zv445dp5h0160drv6xlvrnwfj23ngc4dp3clcd59jh1baq";
+    sha256 = "1rlz3h0zm5y395wdwdhvlxzxgki6422n5qcm8xib4qqmpcdskfr2";
   };
+
   format = "other";
 
   buildInputs = with llvmPackages; [

--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -1,19 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config
+{ lib, stdenv, fetchFromGitHub
+, pkg-config
 , libelf, zlib
-, fetchpatch
 }:
-
-with builtins;
 
 stdenv.mkDerivation rec {
   pname = "libbpf";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner  = "libbpf";
     repo   = "libbpf";
     rev    = "v${version}";
-    sha256 = "1by5w7g3i2fc10bi6f0j8jqi2nq0x8r973j2qx7qlfryjxr7b2v3";
+    sha256 = "08mg5agd40qaz1hz5rqqhf0wgfna06f7l01z5v06y995xdmw2v9g";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
     sha256 = "08mg5agd40qaz1hz5rqqhf0wgfna06f7l01z5v06y995xdmw2v9g";
   };
 
+  patches = [
+    # Adds a compatibility definition for BTF_KIND_FLOAT to allow files
+    # that pull in <bpf/btf.h> to compile with pre-5.13 kernel headers
+    ./libbpf-Add-BTF_KIND_FLOAT-compatibility-definition.patch
+  ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libelf zlib ];
 

--- a/pkgs/os-specific/linux/libbpf/libbpf-Add-BTF_KIND_FLOAT-compatibility-definition.patch
+++ b/pkgs/os-specific/linux/libbpf/libbpf-Add-BTF_KIND_FLOAT-compatibility-definition.patch
@@ -1,0 +1,35 @@
+From caf46eef59f5607bdd72df9de4c0f089f0a0d435 Mon Sep 17 00:00:00 2001
+From: V <v@anomalous.eu>
+Date: Thu, 7 Oct 2021 15:47:35 +0200
+Subject: [PATCH] libbpf: Add BTF_KIND_FLOAT compatibility definition
+
+While libbpf is built against vendored kernel headers, packages
+depending on it use kernel headers provided by the system. Unless
+the system's kernel headers are sufficiently recent (5.13 or newer),
+BTF_KIND_FLOAT will not be defined, which breaks compilation when
+including <bpf/btf.h> due to the reference in btf_is_float(3).
+---
+ btf.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/btf.h b/btf.h
+index 4a711f9..315b907 100644
+--- a/btf.h
++++ b/btf.h
+@@ -9,6 +9,13 @@
+ #include <linux/btf.h>
+ #include <linux/types.h>
+ 
++/* Required when compiling against kernel headers predating this definition */
++#ifndef BTF_KIND_FLOAT
++# define BTF_KIND_FLOAT 16
++# define BTF_KIND_MAX BTF_KIND_FLOAT
++# define BTF_INFO_KIND(info) (((info) >> 24) & 0x1f)
++#endif
++
+ #include "libbpf_common.h"
+ 
+ #ifdef __cplusplus
+-- 
+2.33.0
+


### PR DESCRIPTION
This adds a compatibility definition for `BTF_KIND_FLOAT` to `libbpf`'s `btf.h`. Since `BTF_KIND_FLOAT` is referenced in `btf_is_float(3)`, should the kernel headers not define it (as turns out to be the case, on all but the most recent of kernel versions), compilation of any file that pulls in `<bpf/btf.h>` will break.

###### Motivation for this change

Making `bpftrace` build again, and allowing us to use our own versions of `libbpf` with `bcc` instead of vendoring it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
