### PR TITLE
jrsonnet: install shell completions

### DIFF
--- a/pkgs/development/compilers/jrsonnet/default.nix
+++ b/pkgs/development/compilers/jrsonnet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, rustPlatform }:
+{ stdenv, lib, fetchFromGitHub, rustPlatform, installShellFiles }:
 
 rustPlatform.buildRustPackage rec {
   pname = "jrsonnet";
@@ -11,8 +11,17 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-OX+iJJ3vdCsWWr8x31psV9Vne6xWDZnJc83NbJqMK1A=";
   };
 
+  nativeBuildInputs = [ installShellFiles ];
+
   postInstall = ''
     ln -s $out/bin/jrsonnet $out/bin/jsonnet
+
+    for shell in bash zsh fish; do
+      installShellCompletion --cmd jrsonnet \
+        --$shell <($out/bin/jrsonnet --generate $shell /dev/null)
+      installShellCompletion --cmd jsonnet \
+        --$shell <($out/bin/jrsonnet --generate $shell /dev/null | sed s/jrsonnet/jsonnet/g)
+    done
   '';
 
   cargoSha256 = "sha256-eFfAU9Q3nYAJK+kKP1Y6ONjOIfkuYTlelrFrEW9IJ8c=";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Have shell completions installed.

###### Things done

Added the completions for bash, zsh and fish to postInstall, both for jrsonnet and the jsonnet symlink.

Verified the output:

```
$ ls -l /nix/store/nhn8hsg67rvraz04wyn9m5gimknsd015-jrsonnet-0.4.2/share/*/* 
/nix/store/nhn8hsg67rvraz04wyn9m5gimknsd015-jrsonnet-0.4.2/share/bash-completion/completions:
total 16
-r--r--r-- 4 root root 5202 Jan  1  1970 jrsonnet.bash
-r--r--r-- 4 root root 5196 Jan  1  1970 jsonnet.bash

/nix/store/nhn8hsg67rvraz04wyn9m5gimknsd015-jrsonnet-0.4.2/share/fish/vendor_completions.d:
total 16
-r--r--r-- 2 root root 4243 Jan  1  1970 jrsonnet.fish
-r--r--r-- 2 root root 4212 Jan  1  1970 jsonnet.fish

/nix/store/nhn8hsg67rvraz04wyn9m5gimknsd015-jrsonnet-0.4.2/share/zsh/site-functions:
total 16
-r--r--r-- 2 root root 5810 Jan  1  1970 _jrsonnet
-r--r--r-- 2 root root 5803 Jan  1  1970 _jsonnet
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
