### PR TITLE
avogadro2: 1.94.0 -> 1.95.1

### DIFF
--- a/pkgs/applications/science/chemistry/avogadro2/default.nix
+++ b/pkgs/applications/science/chemistry/avogadro2/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "avogadro2";
-  version = "1.94.0";
+  version = "1.95.1";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "avogadroapp";
     rev = version;
-    sha256 = "6RaiX23YUMfTYAuSighcLGGlJtqeydNgi3PWGF77Jp8=";
+    sha256 = "9GnsxQsMuik6CPDmJbJPF0/+LXbZHf/JLevpSsMEoP0=";
   };
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];

--- a/pkgs/applications/science/chemistry/avogadro2/default.nix
+++ b/pkgs/applications/science/chemistry/avogadro2/default.nix
@@ -2,7 +2,15 @@
 , openbabel, qttools, wrapQtAppsHook
 }:
 
-stdenv.mkDerivation rec {
+let
+  avogadroI18N = fetchFromGitHub {
+    owner = "OpenChemistry";
+    repo = "avogadro-i18n";
+    rev = "3b8a86cc37e988b043d1503d2f11068389b0aca3";
+    sha256 = "9wLY7/EJyIZYnlUAMsViCwD5kGc1vCNbk8vUhb90LMQ=";
+  };
+
+in stdenv.mkDerivation rec {
   pname = "avogadro2";
   version = "1.95.1";
 
@@ -12,6 +20,10 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "9GnsxQsMuik6CPDmJbJPF0/+LXbZHf/JLevpSsMEoP0=";
   };
+
+  postUnpack = ''
+    cp -r ${avogadroI18N} avogadro-i18n
+  '';
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];
 

--- a/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
+++ b/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
@@ -21,13 +21,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "avogadrolibs";
-  version = "1.94.0";
+  version = "1.95.1";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = pname;
     rev = version;
-    sha256 = "6bChJhqrjOxeEWZBNToq3JExHPu7DUMsEHWBDe75zAo=";
+    sha256 = "0zzVg8xNqFwDrK8gRkDm3tRgBt7fD4K3Uy/ajUBc+eQ=";
   };
 
   postUnpack = ''

--- a/pkgs/development/libraries/science/chemistry/libmsym/default.nix
+++ b/pkgs/development/libraries/science/chemistry/libmsym/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = " molecular point group symmetry lib";
-    homepage = "https://github.com/rcsb/mmtf-cpp";
+    homepage = "https://github.com/mcodev31/libmsym";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [ maintainers.sheepforce ];


### PR DESCRIPTION
###### Motivation for this change
Updates of the Avogadro2 family of packages to the latest versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
