### PR TITLE
nixos/matrix-synapse: minor improvements to implement worker-support

### DIFF
--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -122,6 +122,14 @@ in {
   options = {
     services.matrix-synapse = {
       enable = mkEnableOption "matrix.org synapse";
+      configFile = mkOption {
+        type = types.str;
+        readOnly = true;
+        description = ''
+          Path to the configuration file on the target system. Useful to configure e.g. workers
+          that also need this.
+        '';
+      };
       package = mkOption {
         type = types.package;
         default = pkgs.matrix-synapse;
@@ -705,6 +713,8 @@ in {
         '';
       }
     ];
+
+    services.matrix-synapse.configFile = "${configFile}";
 
     users.users.matrix-synapse = {
       group = "matrix-synapse";

--- a/pkgs/servers/matrix-synapse/0001-setup-add-homeserver-as-console-script.patch
+++ b/pkgs/servers/matrix-synapse/0001-setup-add-homeserver-as-console-script.patch
@@ -1,7 +1,7 @@
 From 36ffbb7ad2c535180cae473b470a43f9db4fbdcd Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
 Date: Mon, 16 Aug 2021 13:27:28 +0200
-Subject: [PATCH] setup: add homeserver as console script
+Subject: [PATCH 1/2] setup: add homeserver as console script
 
 With this change, it will be added to `$out/bin` in `nixpkgs` directly.
 This became necessary since our old workaround, calling it as script,

--- a/pkgs/servers/matrix-synapse/0002-Expose-generic-worker-as-binary-under-NixOS.patch
+++ b/pkgs/servers/matrix-synapse/0002-Expose-generic-worker-as-binary-under-NixOS.patch
@@ -1,0 +1,43 @@
+From 3089758015c64cc1e6788793c4fe40a0e1783457 Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Tue, 5 Oct 2021 22:33:12 +0200
+Subject: [PATCH 2/2] Expose generic worker as binary under NixOS
+
+---
+ setup.py                      | 3 ++-
+ synapse/app/generic_worker.py | 6 +++++-
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 27f1d842c..6383aed6f 100755
+--- a/setup.py
++++ b/setup.py
+@@ -135,7 +135,8 @@ setup(
+     python_requires="~=3.6",
+     entry_points={
+         'console_scripts': [
+-            'homeserver = synapse.app.homeserver:main'
++            'homeserver = synapse.app.homeserver:main',
++            'worker = synapse.app.generic_worker:main'
+         ]
+     },
+     classifiers=[
+diff --git a/synapse/app/generic_worker.py b/synapse/app/generic_worker.py
+index 3b7131af8..c77a6a95c 100644
+--- a/synapse/app/generic_worker.py
++++ b/synapse/app/generic_worker.py
+@@ -491,6 +491,10 @@ def start(config_options):
+     _base.start_worker_reactor("synapse-generic-worker", config)
+ 
+ 
+-if __name__ == "__main__":
++def main():
+     with LoggingContext("main"):
+         start(sys.argv[1:])
++
++
++if __name__ == "__main__":
++    main()
+-- 
+2.31.1
+

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -36,6 +36,7 @@ buildPythonApplication rec {
 
   patches = [
     ./0001-setup-add-homeserver-as-console-script.patch
+    ./0002-Expose-generic-worker-as-binary-under-NixOS.patch
   ];
 
   buildInputs = [ openssl ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This doesn't contain changes for actual worker-support as I haven't figured out (yet) how to properly implement this in this module.

However, there are two changes that I needed to implement it in my personal Matrix configuration:

* Expose config file for matrix-synapse as read-only option to make sure that custom worker services can access it.
* Expose `synapse.app.generic_worker` as executable in `pkgs.matrix-synapse`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
