### PR TITLE
tdesktop: 3.1.1 -> 3.1.8

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -46,6 +46,7 @@
 , libpsl
 , brotli
 , microsoft_gsl
+, rlottie
 }:
 
 # Main reference:
@@ -60,7 +61,7 @@ let
 in
 mkDerivation rec {
   pname = "telegram-desktop";
-  version = "3.1.1";
+  version = "3.1.8";
   # Note: Update via pkgs/applications/networking/instant-messengers/telegram/tdesktop/update.py
 
   # Telegram-Desktop with submodules
@@ -69,7 +70,7 @@ mkDerivation rec {
     repo = "tdesktop";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0h4g8lw9hf9pwmdljavflyn9g9jvjvany7y4vji0qcc1kd99vsnp";
+    sha256 = "129x733a5h6d5xdf3zdz5j5lz8mv6gas5jcnyhwzyk79df138whq";
   };
 
   postPatch = ''
@@ -138,6 +139,7 @@ mkDerivation rec {
     libpsl
     brotli
     microsoft_gsl
+    rlottie
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
