### PR TITLE
Netfilter packages/updates

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11000,6 +11000,12 @@
     githubId = 1634990;
     name = "Tom McLaughlin";
   };
+  thomassdk = {
+    email = "thomassdk@pm.me";
+    github = "thomassdk";
+    githubId = 32598350;
+    name = "Thomas Kelly";
+  };
   thoughtpolice = {
     email = "aseipp@pobox.com";
     github = "thoughtpolice";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -300,6 +300,7 @@ in
   # TODO: Test nfsv3 + Kerberos
   nfs3 = handleTest ./nfs { version = 3; };
   nfs4 = handleTest ./nfs { version = 4; };
+  nftables = handleTest ./nftables.nix {};
   nghttpx = handleTest ./nghttpx.nix {};
   nginx = handleTest ./nginx.nix {};
   nginx-auth = handleTest ./nginx-auth.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -200,6 +200,7 @@ in
   installer = handleTest ./installer.nix {};
   iodine = handleTest ./iodine.nix {};
   ipfs = handleTest ./ipfs.nix {};
+  iptables = handleTest ./iptables.nix {};
   ipv6 = handleTest ./ipv6.nix {};
   iscsi-root = handleTest ./iscsi-root.nix {};
   jackett = handleTest ./jackett.nix {};

--- a/nixos/tests/iptables.nix
+++ b/nixos/tests/iptables.nix
@@ -1,0 +1,14 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+let
+  inherit (pkgs) iptables python3;
+in
+{
+  name = "iptables";
+
+  machine = { ... }: { };
+
+  testScript = ''
+    machine.succeed("cp -r ${iptables.src} ~/src")
+    machine.succeed("cd ~/src && ${python3}/bin/python ~/src/iptables-test.py")
+  '';
+})

--- a/nixos/tests/nftables.nix
+++ b/nixos/tests/nftables.nix
@@ -1,0 +1,52 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+  let
+    inherit (pkgs) nftables runCommand writeShellScriptBin;
+
+    patchBash = writeShellScriptBin "patchBash" ''
+      sed -i '1s|.*|#!/usr/bin/env bash|' $1
+    '';
+    tests = runCommand "patched tests" { } ''
+      cp -r ${nftables.src}/tests/shell ./tests
+
+      find tests -not -name "*.*" \
+        -exec chmod a+w '{}' \; \
+        -exec ${patchBash}/bin/patchBash '{}' \;
+
+      find tests -name "*.sh" \
+        -exec chmod a+w '{}' \; \
+        -exec ${patchBash}/bin/patchBash '{}' \;
+
+      mkdir -p $out/
+      cp -R tests/. $out
+    '';
+  in {
+    name = "nftables";
+
+    machine = { config, ... }: {
+
+      /* 6 tests fail with the current kernel
+         vm-test-run-nftables> machine # W: [FAILED]     ././testcases/maps/0011vmap_0: got 1
+         vm-test-run-nftables> machine # W: [DUMP FAIL]  ././testcases/nft-f/0025empty_dynset_0: dump diff detected
+         vm-test-run-nftables> machine # W: [FAILED]     ././testcases/sets/0059set_update_multistmt_0: got 1
+         vm-test-run-nftables> machine # W: [FAILED]     ././testcases/sets/0060set_multistmt_0: got 1
+         vm-test-run-nftables> machine # W: [FAILED]     ././testcases/sets/0063set_catchall_0: got 1
+         vm-test-run-nftables> machine # W: [FAILED]     ././testcases/sets/0064map_catchall_0: got 1
+      */
+      boot.kernelPackages = pkgs.linuxPackages_latest;
+
+      networking.firewall.enable = false;
+      networking.nftables.enable = true;
+
+      # This cannot be empty when enabling nftables but it has no effect on the tests
+      networking.nftables.ruleset = "";
+
+      environment.variables = { NFT = "${nftables}/bin/nft"; };
+
+      boot.kernelModules = [ "br_netfilter" ];
+    };
+
+    testScript = ''
+      machine.succeed("cp -r ${tests} ~/tests")
+      machine.succeed("cd ~/tests && ./run-tests.sh -v")
+    '';
+  })

--- a/pkgs/development/libraries/libnetfilter_queue/default.nix
+++ b/pkgs/development/libraries/libnetfilter_queue/default.nix
@@ -17,5 +17,11 @@ stdenv.mkDerivation rec {
     description = "Userspace API to packets queued by the kernel packet filter";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    longDescription = ''
+       libnetfilter_queue is a userspace library providing an API to packets that have been queued by the kernel packet filter
+       It is is part of a system that deprecates the old ip_queue / libipq mechanism.
+
+       libnetfilter_queue has been previously known as libnfnetlink_queue.
+    '';
   };
 }

--- a/pkgs/os-specific/linux/arptables/default.nix
+++ b/pkgs/os-specific/linux/arptables/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  pname = "arptables";
+  version = "0.0.5";
+
+  src = fetchzip {
+    url = "http://ftp.netfilter.org/pub/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "MWyU8I+rRpUHKsk7qEF0c6otJcx4jKY0AGz3ZmFFPPY=";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Administration tool for arp packet filtering";
+    homepage = "https://git.netfilter.org/arptables/";
+    downloadPage = "http://ftp.netfilter.org/pub/arptables";
+    mainProgram = "arptables-legacy";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    longDescription = ''
+      arptables is a user space tool, it is used to set up and maintain the tables of ARP rules in the Linux kernel.
+      These rules inspect the ARP frames which they see.
+      arptables is analogous to the iptables user space tool,
+      but arptables is less complicated.
+    '';
+  };
+}

--- a/pkgs/os-specific/linux/conntrack-tools/default.nix
+++ b/pkgs/os-specific/linux/conntrack-tools/default.nix
@@ -25,5 +25,17 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ fpletz ];
+    mainProgram = "conntrack";
+    longDescription = ''
+       The conntrack-tools are a set of tools targeted at system administrators.
+       They are conntrack, the userspace command line interface, and conntrackd, the userspace daemon.
+       The tool conntrack provides a full featured interface that is intended to replace the old /proc/net/ip_conntrack interface.
+       Using conntrack, you can view and manage the in-kernel connection tracking state table from userspace.
+       On the other hand, conntrackd covers the specific aspects of stateful firewalls to enable highly available scenarios, and can be used as statistics collector as well.
+
+       Since 1.2.0, the conntrack-tools includes the nfct command line utility.
+       This utility only supports the nfnetlink_cttimeout by now.
+       In the long run, we expect that it will replace conntrack by providing a syntax similar to nftables.
+    '';
   };
 }

--- a/pkgs/os-specific/linux/ipset/default.nix
+++ b/pkgs/os-specific/linux/ipset/default.nix
@@ -19,5 +19,12 @@ stdenv.mkDerivation rec {
     description = "Administration tool for IP sets";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    longDescription = ''
+      IP sets are a framework inside the Linux 2.4.x and later kernel,
+      which can be administered by the ipset utility.
+      Depending on the type, currently an IP set may store IP addresses,
+      (TCP/UDP) port numbers or IP addresses with MAC addresses in a way,
+      which ensures lightning speed when matching an entry against a set.
+    '';
   };
 }

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, pkg-config, pruneLibtoolFiles, flex, bison
+{ lib, stdenv, pkg-config, pruneLibtoolFiles, flex, bison
 , libmnl, libnetfilter_conntrack, libnfnetlink, libnftnl, libpcap
-, nftablesCompat ? false
+, fetchzip, nixosTests, nftablesCompat ? false
 }:
 
 with lib;
@@ -9,9 +9,9 @@ stdenv.mkDerivation rec {
   version = "1.8.7";
   pname = "iptables";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://www.netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
-    sha256 = "1w6qx3sxzkv80shk21f63rq41c84irpx68k62m2cv629n1mwj2f1";
+    sha256 = "hH7fDPyFAICI1LUNhB9H4di5S/7n+u8vLKb/aMb/5BA=";
   };
 
   nativeBuildInputs = [ pkg-config pruneLibtoolFiles flex bison ];
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
     ln -sv xtables-nft-multi $out/bin/ip6tables-save
   '';
 
+  passthru.tests = nixosTests.iptables;
+
   meta = {
     description = "A program to configure the Linux IP packet filtering ruleset";
     homepage = "https://www.netfilter.org/projects/iptables/index.html";
@@ -50,5 +52,15 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     downloadPage = "https://www.netfilter.org/projects/iptables/files/";
     updateWalker = true;
+    longDescription = ''
+      iptables is the userspace command line program used to configure the Linux 2.4.x and later packet filtering ruleset.
+      It is targeted towards system administrators.
+
+      Since Network Address Translation is also configured from the packet filter ruleset,
+      iptables is used for this, too.
+
+      The iptables package also includes ip6tables.
+      ip6tables is used for configuring the IPv6 packet filter.
+    '';
   };
 }

--- a/pkgs/os-specific/linux/nfacct/default.nix
+++ b/pkgs/os-specific/linux/nfacct/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchurl, pkg-config, libnetfilter_acct, libmnl }:
+
+stdenv.mkDerivation rec {
+  pname = "nfacct";
+  version = "1.0.2";
+
+  src = fetchurl {
+    url = "https://netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
+    sha256 = "sha256-7P8iGHVL4xi848Ol0Xdbq5O/QWiyxKrEZXhd5WVfvWk=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libnetfilter_acct libmnl ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/nfacct help > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "A command line tool to create/retrieve/delete accounting objects";
+    homepage = "https://www.netfilter.org/projects/nfacct/index.html";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ thomassdk ];
+    license = licenses.gpl2;
+    downloadPage = "https://www.netfilter.org/projects/nfacct/files/";
+  };
+}

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -1,7 +1,8 @@
-{ lib, stdenv, fetchurl, pkg-config, bison, file, flex
+{ lib, stdenv, pkg-config, bison, file, flex
 , asciidoc, libxslt, findXMLCatalogs, docbook_xml_dtd_45, docbook_xsl
 , libmnl, libnftnl, libpcap
 , gmp, jansson, readline
+, fetchzip, nixosTests
 , withDebugSymbols ? false
 , withPython ? false , python3
 , withXtables ? false , iptables
@@ -13,9 +14,9 @@ stdenv.mkDerivation rec {
   version = "1.0.0";
   pname = "nftables";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://netfilter.org/projects/nftables/files/${pname}-${version}.tar.bz2";
-    sha256 = "1x25zs2czmn14mmq1nqi4zibsvh04vqjbx5lxj42nylnmxym9gsq";
+    sha256 = "0h696szcgwzxlvwim5m5wi32jxi8fs20636yz01pmi175mpf6vsq";
   };
 
   nativeBuildInputs = [
@@ -40,11 +41,7 @@ stdenv.mkDerivation rec {
     ++ optional withPython "--enable-python"
     ++ optional withXtables "--with-xtables";
 
-  doInstallCheck = true;
-
-  installCheckPhase = ''
-    $out/bin/${meta.mainProgram} --help > /dev/null
-  '';
+  passthru.tests = nixosTests.nftables;
 
   meta = {
     description = "The project that aims to replace the existing {ip,ip6,arp,eb}tables framework";

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -40,11 +40,25 @@ stdenv.mkDerivation rec {
     ++ optional withPython "--enable-python"
     ++ optional withXtables "--with-xtables";
 
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/${meta.mainProgram} --help > /dev/null
+  '';
+
   meta = {
     description = "The project that aims to replace the existing {ip,ip6,arp,eb}tables framework";
     homepage = "https://netfilter.org/projects/nftables/";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ izorkin ];
+    mainProgram = "nft";
+    longDescription = ''
+      nftables replaces the popular {ip,ip6,arp,eb}tables.
+      This software provides a new in-kernel packet classification framework that is based
+      on a network-specific Virtual Machine (VM) and a new nft userspace command line tool.
+      nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure,
+      the connection tracking system, NAT, userspace queueing and logging subsystem.
+    '';
   };
 }

--- a/pkgs/os-specific/linux/ulogd/default.nix
+++ b/pkgs/os-specific/linux/ulogd/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchurl, pkg-config, libnfnetlink,
+  libnetfilter_log, libnetfilter_conntrack, libnetfilter_acct,
+  libmnl }:
+
+stdenv.mkDerivation rec {
+  pname = "ulogd";
+  version = "2.0.7";
+
+  src = fetchurl {
+    url = "https://netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
+    sha256 = "sha256-mQoFSU2cFgKboKg/O3KU/AXHVlRrjWDRwVctwlJJqSs=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    libnfnetlink libnetfilter_log libnetfilter_conntrack libnetfilter_acct libmnl
+  ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/ulogd -h > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "A userspace logging daemon for netfilter/iptables related logging";
+    homepage = "https://www.netfilter.org/projects/ulogd/index.html";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ thomassdk ];
+    license = licenses.gpl2;
+    downloadPage = "https://www.netfilter.org/projects/ulogd/files/";
+    longDescription = ''
+      ulogd is a userspace logging daemon for netfilter/iptables related logging.
+      This includes per-packet logging of security violations,
+      per-packet logging for accounting, per-flow logging and flexible user-defined accounting.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22160,6 +22160,8 @@ with pkgs;
 
   ugtrain = callPackage ../tools/misc/ugtrain { };
 
+  ulogd = callPackage ../os-specific/linux/ulogd { };
+
   untie = callPackage ../os-specific/linux/untie { };
 
   upower = callPackage ../os-specific/linux/upower { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21364,6 +21364,8 @@ with pkgs;
     stdenv = gcc11Stdenv;
   };
 
+  nfacct = callPackage ../os-specific/linux/nfacct {  };
+
   nmon = callPackage ../os-specific/linux/nmon { };
 
   hwdata = callPackage ../os-specific/linux/hwdata { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -181,6 +181,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
 
+  arptables = arptables-legacy;
+  arptables-legacy = callPackage ../os-specific/linux/arptables { };
+
   fiche = callPackage ../servers/fiche { };
 
   fishnet = callPackage ../servers/fishnet { };


### PR DESCRIPTION
###### Motivation for this change
Updating these packages as part of Summer of Nix https://github.com/ngi-nix/ngi/issues/164#issuecomment-929051137

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
