### PR TITLE
phpExtensions.amqp: init at 1.11.0beta

### DIFF
--- a/pkgs/development/php-packages/amqp/default.nix
+++ b/pkgs/development/php-packages/amqp/default.nix
@@ -1,0 +1,19 @@
+{ buildPecl, lib, rabbitmq-c }:
+
+buildPecl {
+  pname = "amqp";
+
+  version = "1.11.0beta";
+  sha256 = "sha256-HbVLN6fg2htYZgAFw+IhYHP+XN8j7cTLG6S0YHHOC14=";
+
+  buildInputs = [ rabbitmq-c ];
+
+  AMQP_DIR = rabbitmq-c;
+
+  meta = with lib; {
+    description = "PHP extension to communicate with any AMQP compliant server";
+    license = licenses.php301;
+    homepage = "https://github.com/php-amqp/php-amqp";
+    maintainers = teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -159,6 +159,8 @@ lib.makeScope pkgs.newScope (self: with self; {
   # or php.withExtensions to extend the functionality of the PHP
   # interpreter.
   extensions = {
+    amqp = callPackage ../development/php-packages/amqp { };
+
     apcu = callPackage ../development/php-packages/apcu { };
 
     apcu_bc = callPackage ../development/php-packages/apcu_bc { };


### PR DESCRIPTION
###### Motivation for this change

The extension gives PHP an AMQP client library.
I am using the beta version, because there is no stable PHP 8 support yet, see [here](https://github.com/php-amqp/php-amqp/issues/386).


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)… sort of, I connected to a local RabbitMQ server in the resulting PHP environment.
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).