### PR TITLE
qcengine: 0.20.0 -> 0.20.1

### DIFF
--- a/pkgs/development/python-modules/qcengine/default.nix
+++ b/pkgs/development/python-modules/qcengine/default.nix
@@ -4,7 +4,7 @@
 
 buildPythonPackage rec {
   pname = "qcengine";
-  version = "0.20.0";
+  version = "0.20.1";
 
   checkInputs = [
     pytest-runner
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5b405efb4b6ebe81e7f991b360126a4f61c2768ceed6027346e2b8ef3f57ef39";
+    sha256 = "hZxE7b0bOx/B8Kz4cgBC7wV23OikRxwrdZ4UQ8G/yhg=";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change
Bug fix release, that repairs the Turbomole harness, that was broken as of 0.20.0.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
