### PR TITLE
yarn2nix: workaround for NixOS/nix#5128

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
@@ -45,11 +45,13 @@ function fetchgit(fileName, url, rev, branch, builtinFetchGit) {
     name = "${fileName}";
     path =
       let${builtinFetchGit ? `
-        repo = builtins.fetchGit {
+        repo = builtins.fetchGit ({
           url = "${url}";
           ref = "${branch}";
           rev = "${rev}";
-        };
+        } // (if builtins.substring 0 3 builtins.nixVersion == "2.4" then {
+          allRefs = true;
+        } else {}));
       ` : `
         repo = fetchgit {
           url = "${url}";


### PR DESCRIPTION
###### Motivation for this change
NixOS/nix#5128

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
