### PR TITLE
zoneminder: 1.34.22 -> 1.36.8

### DIFF
--- a/pkgs/servers/zoneminder/0001-Don-t-use-file-timestamp-in-cache-filename.patch
+++ b/pkgs/servers/zoneminder/0001-Don-t-use-file-timestamp-in-cache-filename.patch
@@ -1,4 +1,4 @@
-From db38a11228eceea10dc97ecc87023b4919caa918 Mon Sep 17 00:00:00 2001
+From 8823e48b055b7e574c08069048ba21ffa4393699 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Fri, 21 Feb 2020 21:52:00 -0500
 Subject: [PATCH] Don't use file timestamp in cache filename
@@ -14,13 +14,13 @@ unique.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/web/includes/functions.php b/web/includes/functions.php
-index 19567a5c1..0242c09bc 100644
+index 89d2cc8ad..52cbb6f38 100644
 --- a/web/includes/functions.php
 +++ b/web/includes/functions.php
-@@ -2223,7 +2223,8 @@ function cache_bust($file) {
+@@ -1941,7 +1941,8 @@ function cache_bust($file) {
    $parts = pathinfo($file);
    global $css;
-   $dirname = preg_replace('/\//', '_', $parts['dirname']);
+   $dirname = str_replace('/', '_', $parts['dirname']);
 -  $cacheFile = $dirname.'_'.$parts['filename'].'-'.$css.'-'.filemtime($file).'.'.$parts['extension'];
 +  $srcHash = '@srcHash@';
 +  $cacheFile = $dirname.'_'.$parts['filename'].'-'.$css.'-'.$srcHash.'.'.$parts['extension'];
@@ -28,5 +28,4 @@ index 19567a5c1..0242c09bc 100644
      return 'cache/'.$cacheFile;
    } else {
 -- 
-2.25.1
-
+2.32.0

--- a/pkgs/servers/zoneminder/default.nix
+++ b/pkgs/servers/zoneminder/default.nix
@@ -78,13 +78,14 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "zoneminder";
-  version = "1.34.22";
+  version = "1.36.8";
 
   src = fetchFromGitHub {
     owner  = "ZoneMinder";
     repo   = "zoneminder";
     rev    = version;
-    sha256 = "1144j9crm0q5pwxnkmy3ahw1vbkddpbk2ys2m2pxxxiqifdhll83";
+    sha256 = "sha256-UUpq4CCZq+EwVNGsLCQuVWdY3yoGw977AaMk1iJ6a5U=";
+    fetchSubmodules = true;
   };
 
   patches = [
@@ -130,7 +131,7 @@ in stdenv.mkDerivation rec {
 
     for f in scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in \
              scripts/zmupdate.pl.in \
-             src/zm_config.h.in \
+             src/zm_config_data.h.in \
              web/api/app/Config/bootstrap.php.in \
              web/includes/config.php.in ; do
       substituteInPlace $f --replace @ZM_CONFIG_SUBDIR@ /etc/zoneminder


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The [zoneminder blog](https://zoneminder.com/blog/) has a big warning about using older versions
> We DO NOT RECOMMEND running any prior version of ZoneMinder

I have never used ZoneMinder before, and the derivation is complex, so I don't know if this properly upgrades it. It does build on my machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
