### PR TITLE
hdl-dump: 20202808 -> unstable-2021-08-20, change upstream

### DIFF
--- a/pkgs/tools/misc/hdl-dump/default.nix
+++ b/pkgs/tools/misc/hdl-dump/default.nix
@@ -1,22 +1,18 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, upx
 }:
 
 stdenv.mkDerivation rec {
   pname = "hdl-dump";
-  version = "20202807";
+  version = "unstable-2021-08-20";
 
-  # Using AkuHAK's repo because playstation2's repo is outdated
   src = fetchFromGitHub {
-    owner = "AKuHAK";
+    owner = "ps2homebrew";
     repo = pname;
-    rev = "0c98b235c83c0fca1da93648f05ea5f940a4aee0";
-    sha256 = "1s3wflqjjlcslpa9n5chr8dbamhmfk88885dzw68apz4vf6g27iq";
+    rev = "1e760d7672dc12a36c09690b8c9b20d6642a2926";
+    sha256 = "sha256-NMExi2pUyj8vRn9beT2YvnEogRw/xzgqE+roaZ/vNZs=";
   };
-
-  buildInputs = [ upx ];
 
   makeFlags = [ "RELEASE=yes" ];
 
@@ -25,10 +21,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/AKuHAK/hdl-dump";
+    homepage = "https://github.com/ps2homebrew/hdl-dump";
     description = "PlayStation 2 HDLoader image dump/install utility";
     platforms = platforms.linux;
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ makefu ];
+    mainProgram = "hdl_dump";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Most of the AKuHAK commits were upstreamed to ps2homebrew, that has even further commits.

Also, removes `upx`. Not necessary anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
