### PR TITLE
[21.05] tix: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/tix/default.nix
+++ b/pkgs/development/libraries/tix/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchurl, tcl, tk, fetchpatch } :
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, tcl
+, tk
+}:
 
 stdenv.mkDerivation {
   version = "8.4.3";
@@ -13,6 +19,8 @@ stdenv.mkDerivation {
     url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-tcltk/tix/files/tix-8.4.3-tcl8.5.patch?id=56bd759df1d0c750a065b8c845e93d5dfa6b549d";
     sha256 = "0wzqmcxxq0rqpnjgxz10spw92yhfygnlwv0h8pcx2ycnqiljz6vj";
     })
+    # Remove duplicated definition of XLowerWindow
+    ./duplicated-xlowerwindow.patch
   ] ++ lib.optional (tcl.release == "8.6")
   (fetchpatch {
     name = "tix-8.4.3-tcl8.6.patch";

--- a/pkgs/development/libraries/tix/duplicated-xlowerwindow.patch
+++ b/pkgs/development/libraries/tix/duplicated-xlowerwindow.patch
@@ -1,0 +1,49 @@
+This is duplicated code from Tk.
+It causes errors during build since XLowerWindow is not only a function but also "defined" in tkIntXlibDecls.h.
+
+See
+https://github.com/tcltk/tk/blob/71dcaddc69769cbd3e2c4b5edb5810f974579527/generic/tkIntXlibDecls.h#L396
+and
+https://github.com/tcltk/tk/blob/71dcaddc69769cbd3e2c4b5edb5810f974579527/generic/tkIntXlibDecls.h#L1487
+
+--- a/unix/tixUnixWm.c	2005-03-25 13:15:53.000000000 -0700
++++ b/unix/tixUnixWm.c	2021-03-20 07:31:52.000000000 -0700
+@@ -24,38 +24,3 @@
+ {
+     return TCL_OK;
+ }
+-
+-#ifdef MAC_OSX_TK
+-#include "tkInt.h"
+-/*
+- *----------------------------------------------------------------------
+- *
+- * XLowerWindow --
+- *
+- *	Change the stacking order of a window.
+- *
+- * Results:
+- *	None.
+- *
+- * Side effects:
+- *	Changes the stacking order of the specified window.
+- *
+- *----------------------------------------------------------------------
+- */
+-
+-int 
+-XLowerWindow(
+-    Display* display,		/* Display. */
+-    Window window)		/* Window. */
+-{
+-    TkWindow *winPtr = *((TkWindow **) window);
+-    
+-    display->request++;
+-    if (Tk_IsTopLevel(winPtr) && !Tk_IsEmbedded(winPtr)) {
+-	TkWmRestackToplevel(winPtr, Below, NULL);
+-    } else {
+-    	/* TODO: this should generate damage */
+-    }
+-    return 0;
+-}
+-#endif

--- a/pkgs/development/libraries/tk/8.5.nix
+++ b/pkgs/development/libraries/tk/8.5.nix
@@ -1,4 +1,11 @@
-{ callPackage, fetchurl, tcl, ... } @ args:
+{ lib
+, stdenv
+, callPackage
+, fetchurl
+, fetchpatch
+, tcl
+, ...
+} @ args:
 
 callPackage ./generic.nix (args // {
 
@@ -6,5 +13,16 @@ callPackage ./generic.nix (args // {
     url = "mirror://sourceforge/tcl/tk${tcl.version}-src.tar.gz";
     sha256 = "0an3wqkjzlyyq6l9l3nawz76axsrsppbyylx0zk9lkv7llrala03";
   };
+
+  patches = lib.optionals stdenv.isDarwin [
+    # Define MODULE_SCOPE before including tkPort.h
+    # https://core.tcl-lang.org/tk/info/dba9f5ce3b
+    (fetchpatch {
+      name = "module_scope.patch";
+      url = "https://core.tcl-lang.org/tk/vpatch?from=ef6c6960c53ea30c&to=9b8aa74eebed509a";
+      extraPrefix = "";
+      sha256 = "0crhf4zrzdpc1jdgyv6l6mxqgmny12r3i39y1i0j8q3pbqkd04bv";
+    })
+  ];
 
 })

--- a/pkgs/development/libraries/tk/8.6.nix
+++ b/pkgs/development/libraries/tk/8.6.nix
@@ -1,4 +1,11 @@
-{ callPackage, fetchurl, tcl, lib, stdenv, ... } @ args:
+{ lib
+, stdenv
+, callPackage
+, fetchurl
+, fetchpatch
+, tcl
+, ...
+} @ args:
 
 callPackage ./generic.nix (args // {
 
@@ -7,6 +14,16 @@ callPackage ./generic.nix (args // {
     sha256 = "1gh9k7l76qg9l0sb78ijw9xz4xl1af47aqbdifb6mjpf3cbsnv00";
   };
 
-  patches = [ ./different-prefix-with-tcl.patch ] ++ lib.optionals stdenv.isDarwin [ ./Fix-bad-install_name-for-libtk8.6.dylib.patch ];
+  patches = [ ./different-prefix-with-tcl.patch ] ++ lib.optionals stdenv.isDarwin [
+    ./Fix-bad-install_name-for-libtk8.6.dylib.patch
+    # Define MODULE_SCOPE before including tkPort.h
+    # https://core.tcl-lang.org/tk/info/dba9f5ce3b
+    (fetchpatch {
+      name = "module_scope.patch";
+      url = "https://core.tcl-lang.org/tk/vpatch?from=ef6c6960c53ea30c&to=9b8aa74eebed509a";
+      extraPrefix = "";
+      sha256 = "0crhf4zrzdpc1jdgyv6l6mxqgmny12r3i39y1i0j8q3pbqkd04bv";
+    })
+  ];
 
 })


### PR DESCRIPTION
###### Motivation for this change
This is a backport of  #139114 to fix the build of `tix` on darwin which has been broken on 21.05 since #135738

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
