### PR TITLE
update nextcloud.nix to change log type

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -89,6 +89,11 @@ in {
       default = "syslog";
       description = "Log driver used for nextcloud logging. Possible options: errorlog, file, syslog or systemd (see https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/logging_configuration.html).";
     };
+    logFile = mkOption {
+      type = types.str;
+      default = "nextcloud.log";
+      description = "When logType is file, the file or path where the logfile should be stored. Default is nextcloud.log stored in the datadirectory.";
+    };
     https = mkOption {
       type = types.bool;
       default = false;
@@ -611,7 +616,8 @@ in {
               'skeletondirectory' => '${cfg.skeletonDirectory}',
               ${optionalString cfg.caching.apcu "'memcache.local' => '\\OC\\Memcache\\APCu',"}
               'log_type' => '${cfg.logType}',
-              'log_level' => '${builtins.toString cfg.logLevel}',
+              'logfile' => '${cfg.logFile}',
+              'loglevel' => '${builtins.toString cfg.logLevel}',
               ${optionalString (c.overwriteProtocol != null) "'overwriteprotocol' => '${c.overwriteProtocol}',"}
               ${optionalString (c.dbname != null) "'dbname' => '${c.dbname}',"}
               ${optionalString (c.dbhost != null) "'dbhost' => '${c.dbhost}',"}

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -90,9 +90,9 @@ in {
       description = "Log driver used for nextcloud logging. Possible options: errorlog, file, syslog or systemd (see https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/logging_configuration.html).";
     };
     logFile = mkOption {
-      type = types.str;
-      default = "nextcloud.log";
-      description = "When logType is file, the file or path where the logfile should be stored. Default is nextcloud.log stored in the datadirectory.";
+      type = types.nullOr types.str;
+      default = null;
+      description = "When logType is file, the file or path where the logfile should be stored.";
     };
     https = mkOption {
       type = types.bool;
@@ -616,7 +616,7 @@ in {
               'skeletondirectory' => '${cfg.skeletonDirectory}',
               ${optionalString cfg.caching.apcu "'memcache.local' => '\\OC\\Memcache\\APCu',"}
               'log_type' => '${cfg.logType}',
-              'logfile' => '${cfg.logFile}',
+              ${optionalString cfg.logFile "'logfile' => '${cfg.logFile}',"}
               'loglevel' => '${builtins.toString cfg.logLevel}',
               ${optionalString (c.overwriteProtocol != null) "'overwriteprotocol' => '${c.overwriteProtocol}',"}
               ${optionalString (c.dbname != null) "'dbname' => '${c.dbname}',"}

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -85,9 +85,9 @@ in {
       description = "Log level value between 0 (DEBUG) and 4 (FATAL).";
     };
     logType = mkOption {
-      type = types.str;
+      type = types.enum [ "syslog" "file" "systemd" "errorlog" ];
       default = "syslog";
-      description = "log driver used, could be errorlog, file, syslog or systemd";
+      description = "Log driver used for nextcloud logging. Possible options: errorlog, file, syslog or systemd (see https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/logging_configuration.html).";
     };
     https = mkOption {
       type = types.bool;

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -84,6 +84,11 @@ in {
       default = 2;
       description = "Log level value between 0 (DEBUG) and 4 (FATAL).";
     };
+    logType = mkOption {
+      type = types.str;
+      default = "syslog";
+      description = "log driver used, could be errorlog, file, syslog or systemd";
+    };
     https = mkOption {
       type = types.bool;
       default = false;
@@ -605,7 +610,7 @@ in {
               'datadirectory' => '${cfg.home}/data',
               'skeletondirectory' => '${cfg.skeletonDirectory}',
               ${optionalString cfg.caching.apcu "'memcache.local' => '\\OC\\Memcache\\APCu',"}
-              'log_type' => 'syslog',
+              'log_type' => '${cfg.logType}',
               'log_level' => '${builtins.toString cfg.logLevel}',
               ${optionalString (c.overwriteProtocol != null) "'overwriteprotocol' => '${c.overwriteProtocol}',"}
               ${optionalString (c.dbname != null) "'dbname' => '${c.dbname}',"}


### PR DESCRIPTION
enable ability to change logtype for nextcloud

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
