### PR TITLE
[21.05] python3Packages.vyper: 0.2.11 -> 0.3.0

### DIFF
--- a/pkgs/development/compilers/vyper/default.nix
+++ b/pkgs/development/compilers/vyper/default.nix
@@ -14,11 +14,11 @@ in
 
 buildPythonPackage rec {
   pname = "vyper";
-  version = "0.2.16";
+  version = "0.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6cf347440716964012d46686faefc9c689f01872f19736287a63aa8652ac3ddd";
+    sha256 = "3e50cd802696ea3f5e6ab1bf4c9a90a39c332591d416c99f3d2fa93d7d7ba394";
   };
 
   nativeBuildInputs = [ pytestrunner ];

--- a/pkgs/development/compilers/vyper/default.nix
+++ b/pkgs/development/compilers/vyper/default.nix
@@ -14,11 +14,11 @@ in
 
 buildPythonPackage rec {
   pname = "vyper";
-  version = "0.2.15";
+  version = "0.2.16";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-cNnKHVKwIx0miC2VhGYBzcSckTnyWYmjNzW0bEzP4bU=";
+    sha256 = "6cf347440716964012d46686faefc9c689f01872f19736287a63aa8652ac3ddd";
   };
 
   nativeBuildInputs = [ pytestrunner ];

--- a/pkgs/development/compilers/vyper/default.nix
+++ b/pkgs/development/compilers/vyper/default.nix
@@ -14,20 +14,21 @@ in
 
 buildPythonPackage rec {
   pname = "vyper";
-  version = "0.2.11";
+  version = "0.2.15";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e763561a161c35c03b92a0c176096dd9b4c78ab003c2f08324d443f459b3de84";
+    sha256 = "sha256-cNnKHVKwIx0miC2VhGYBzcSckTnyWYmjNzW0bEzP4bU=";
   };
 
   nativeBuildInputs = [ pytestrunner ];
 
+  # Replace the dynamic commit hash lookup with the hash from the tag
   postPatch = ''
     substituteInPlace setup.py \
       --replace 'asttokens==' 'asttokens>=' \
       --replace 'subprocess.check_output("git rev-parse HEAD".split())' "' '" \
-      --replace 'commithash.decode("utf-8").strip()' "'069936fa3fee8646ff362145593128d7ef07da38'"
+      --replace 'commithash.decode("utf-8").strip()' "'6e7dba7a8b5f29762d3470da4f44634b819c808d'"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-41122

Fix is pretty extensive, don't see a patch being realistic. So this is a backport of #131823, #136086, #140691.

`python39Packages.astroid` already broken on 21.05.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
