### PR TITLE
kexec-tools: 2.0.20 -> 2.0.22

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -220,6 +220,7 @@ in
   kerberos = handleTest ./kerberos/default.nix {};
   kernel-generic = handleTest ./kernel-generic.nix {};
   kernel-latest-ath-user-regd = handleTest ./kernel-latest-ath-user-regd.nix {};
+  kexec = handleTest ./kexec.nix {};
   keycloak = discoverTests (import ./keycloak.nix);
   keymap = handleTest ./keymap.nix {};
   knot = handleTest ./knot.nix {};

--- a/nixos/tests/kexec.nix
+++ b/nixos/tests/kexec.nix
@@ -4,12 +4,6 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
   name = "kexec";
   meta = with lib.maintainers; {
     maintainers = [ eelco ];
-    # Currently hangs forever; last output is:
-    #     machine # [   10.239914] dhcpcd[707]: eth0: adding default route via fe80::2
-    #     machine: waiting for the VM to finish booting
-    #     machine # Cannot find the ESP partition mount point.
-    #     machine # [   28.681197] nscd[692]: 692 checking for monitored file `/etc/netgroup': No such file or directory
-    broken = true;
   };
 
   machine = { ... }:
@@ -18,8 +12,11 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
   testScript =
     ''
       machine.wait_for_unit("multi-user.target")
-      machine.execute("systemctl kexec &")
+      machine.succeed('kexec --load /run/current-system/kernel --initrd /run/current-system/initrd --command-line "$(</proc/cmdline)"')
+      machine.succeed("systemctl kexec &")
       machine.connected = False
+      machine.connect()
       machine.wait_for_unit("multi-user.target")
+      machine.shutdown()
     '';
 })

--- a/pkgs/os-specific/linux/kexec-tools/default.nix
+++ b/pkgs/os-specific/linux/kexec-tools/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, buildPackages, fetchurl, zlib, fetchpatch }:
+{ lib, stdenv, buildPackages, fetchurl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "kexec-tools";
-  version = "2.0.20";
+  version = "2.0.22";
 
   src = fetchurl {
     urls = [
@@ -20,23 +20,6 @@ stdenv.mkDerivation rec {
   configureFlags = [ "BUILD_CC=${buildPackages.stdenv.cc.targetPrefix}cc" ];
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   buildInputs = [ zlib ];
-
-  patches = [
-    # fix build on i686
-    # See: https://src.fedoraproject.org/rpms/kexec-tools/c/cb1e5463b5298b064e9b6c86ad6fe3505fec9298
-    (fetchpatch {
-      name = "kexec-tools-2.0.20-fix-broken-multiboot2-buliding-for-i386.patch";
-      url = "https://src.fedoraproject.org/rpms/kexec-tools/raw/cb1e5463b5298b064e9b6c86ad6fe3505fec9298/f/kexec-tools-2.0.20-fix-broken-multiboot2-buliding-for-i386.patch";
-      sha256 = "1kzmcsbhwfdgxlc5s88ir0n494phww1j16yk0z42x09qlkxxkg0l";
-    })
-
-    (fetchpatch {
-      # upstream build fix against -fno-common compilers like >=gcc-10
-      name = "fno-common.patch";
-      url = "https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git/patch/?id=cc087b11462af9f971a2c090d07e8d780a867b50";
-      sha256 = "043hcsy6m14h64p6b9w25c7a3y0f487322dj81l6mbm6sws6s9lv";
-    })
-  ];
 
   meta = with lib; {
     homepage = "http://horms.net/projects/kexec/kexec-tools";


### PR DESCRIPTION
###### Motivation for this change
Update to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
