### PR TITLE
chromium: Drop Python 2

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -6,7 +6,7 @@
 
 # Native build inputs:
 , ninja, pkg-config
-, python2, python3, perl
+, python3, perl
 , gnutar, which
 , llvmPackages
 # postPatch:
@@ -56,6 +56,10 @@ let
   python3WithPackages = python3.withPackages(ps: with ps; [
     ply jinja2 setuptools
   ]);
+  clangFormatPython3 = fetchurl {
+    url = "https://chromium.googlesource.com/chromium/tools/build/+/e77882e0dde52c2ccf33c5570929b75b4a2a2522/recipes/recipe_modules/chromium/resources/clang-format?format=TEXT";
+    sha256 = "0ic3hn65dimgfhakli1cyf9j3cxcqsf1qib706ihfhmlzxf7256l";
+  };
 
   # The additional attributes for creating derivations based on the chromium
   # source tree.
@@ -122,7 +126,7 @@ let
 
     nativeBuildInputs = [
       ninja pkg-config
-      python2 python3WithPackages perl
+      python3WithPackages perl
       gnutar which
       llvmPackages.bintools
     ];
@@ -208,6 +212,9 @@ let
 
       # Allow to put extensions into the system-path.
       sed -i -e 's,/usr,/run/current-system/sw,' chrome/common/chrome_paths.cc
+
+      # We need the fix for https://bugs.chromium.org/p/chromium/issues/detail?id=1254408:
+      base64 --decode ${clangFormatPython3} > buildtools/linux64/clang-format
 
       patchShebangs .
       # Link to our own Node.js and Java (required during the build):


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

~~The build doesn't succeed yet but this should be fixable. I currently lack time but I'll try to get it to work within a few weeks (I should have some time during the weekends).
Feel free to help if you have time (you can also replace my PR and reuse my work).~~

Relevant upstream issue: [Get chromium/src/ compiling with Python 3](https://bugs.chromium.org/p/chromium/issues/detail?id=1112471)
- Related issues:
  - [Make our code work with Python 3](https://bugs.chromium.org/p/chromium/issues/detail?id=942720)
  - [Support Python 3 for Chromium development (in src.git)](https://bugs.chromium.org/p/chromium/issues/detail?id=941669)

(https://app.element.io/#/room/#dev:nixos.org/$nRxBuaBwE-00H9XdIMGUmlhuWsb9JHK55aakd_nuTig)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
