### PR TITLE
lesspipe: fix cross-compile

### DIFF
--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -1,16 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, substituteAll, perl, file, ncurses, runtimeShell }:
+{ lib, stdenv, fetchFromGitHub, substituteAll, perl, file, ncurses, bash }:
 
 stdenv.mkDerivation rec {
   pname = "lesspipe";
   version = "1.85";
 
   nativeBuildInputs = [ perl ];
-  buildInputs = [ perl ];
-  configurePhase = ''
-    patchShebangs --build configure
-    ./configure --prefix=$out --shell=${runtimeShell} --yes
-  '';
-  buildPhase = "patchShebangs --host .";
+  buildInputs = [ perl bash ];
+  strictDeps = true;
+  preConfigure = "patchShebangs --build configure";
+  configureFlags = [ "--shell=${bash}/bin/bash" "--yes" ];
+  configurePlatforms = [];
+  dontBuild = true;
 
   src = fetchFromGitHub {
     owner = "wofr06";

--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -1,11 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, substituteAll, perl, file, ncurses }:
+{ lib, stdenv, fetchFromGitHub, substituteAll, perl, file, ncurses, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "lesspipe";
   version = "1.85";
 
+  nativeBuildInputs = [ perl ];
   buildInputs = [ perl ];
-  preConfigure = "patchShebangs .";
+  configurePhase = ''
+    patchShebangs --build configure
+    ./configure --prefix=$out --shell=${runtimeShell} --yes
+  '';
+  buildPhase = "patchShebangs --host .";
 
   src = fetchFromGitHub {
     owner = "wofr06";
@@ -20,6 +25,7 @@ stdenv.mkDerivation rec {
       file = "${file}/bin/file";
       tput = "${ncurses}/bin/tput";
     })
+    ./override-shell-detection.patch
   ];
 
   meta = with lib; {

--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -7,7 +7,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl ];
   buildInputs = [ perl bash ];
   strictDeps = true;
-  preConfigure = "patchShebangs --build configure";
+  preConfigure = ''
+    patchShebangs --build configure
+  '';
   configureFlags = [ "--shell=${bash}/bin/bash" "--yes" ];
   configurePlatforms = [];
   dontBuild = true;

--- a/pkgs/tools/misc/lesspipe/override-shell-detection.patch
+++ b/pkgs/tools/misc/lesspipe/override-shell-detection.patch
@@ -1,0 +1,12 @@
+--- a/configure
++++ b/configure
+@@ -101,7 +101,8 @@
+ open OUT, ">lesspipe.sh.tmp";
+ my $in = 1;
+ my $anyin;
+-my $shell = check_shell_vers();
++my $shell = $opt_shell;
++print OUT "#!$shell\n";
+ # ask if syntax highlighting should be included
+ $ifsyntax = '';
+ if ($opt_yes) {


### PR DESCRIPTION
###### Motivation for this change
Lesspipe was blocking cross-compilation. After this fix, I can cross-compile the aarch64 version on my x86_64 machine. I'm not able to test on aarch64 right now, but all the shebangs in ${lesspipe}/bin now look correct, and lesspipe still seems to be working on x86_64 native.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
