### PR TITLE
wiretrustee: init at 0.3.3

### DIFF
--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "wiretrustee";
-  version = "0.1.0-beta.3";
+  version = "0.2.0-beta.1";
 
   src = fetchFromGitHub {
     owner = "wiretrustee";
     repo = "wiretrustee";
     rev = "v${version}";
-    sha256 = "1i52zm660561mbhibwd3adgh8g4ql3m7hrgjndv23j2vn2vz12bp";
+    sha256 = "13zn8544vj9ag2nws02zm4bm5f2mkargc3i0p0d3n9q2zlpc3q4c";
   };
 
-  vendorSha256 = "014nkhy3kf2aq14k68h8fgcpvzn5bvd3jvsf26ix61nykc24laga";
+  vendorSha256 = "1sz5lbw0cvzspg19n45x8kx5xhs26hf2a726ls1byc6r5cg52hcw";
 
   doCheck = false;
 

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -5,13 +5,13 @@
 
 buildGoModule rec {
   pname = "wiretrustee";
-  version = "0.2.0-beta.2";
+  version = "0.2.0-beta.3";
 
   src = fetchFromGitHub {
     owner = "wiretrustee";
     repo = "wiretrustee";
     rev = "v${version}";
-    sha256 = "1d69gr71achbbcdlzy96s6f50cyfpw3a42094yyfvqjipb2jbazl";
+    sha256 = "15hf7and6gvhsmhxcx22xd0bdyqk7p914cyljs18ipbma0iiihi9";
   };
 
   vendorSha256 = "1sz5lbw0cvzspg19n45x8kx5xhs26hf2a726ls1byc6r5cg52hcw";

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -1,24 +1,34 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, wiretrustee
+, testVersion
 }:
 
 buildGoModule rec {
   pname = "wiretrustee";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "wiretrustee";
     repo = "wiretrustee";
     rev = "v${version}";
-    sha256 = "11crspy55kgsqnh64xa4dbmagyiy871q7klzassgpiqlcpbsfz88";
+    sha256 = "0wyi8n29q8gsza6cwwp8qqri8wfp1rlfhizw4y65r0dq3xc7g1wm";
   };
 
   vendorSha256 = "13yfh3ylm9pyqjrhwdkl8hk5rr7d2bgi6n2xcy1aw1b674fk5713";
 
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
   # Fails with:
   # - Failed to write to log, can't make directories for new logfile: mkdir /var: permission denied
   doCheck = false;
+
+  passthru.tests.version = testVersion { package = wiretrustee; command = "client version"; };
 
   meta = with lib; {
     description = "Connect your devices into a single secure private WireGuard-based mesh network";

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -5,13 +5,13 @@
 
 buildGoModule rec {
   pname = "wiretrustee";
-  version = "0.2.0-beta.3";
+  version = "0.2.0-beta.4";
 
   src = fetchFromGitHub {
     owner = "wiretrustee";
     repo = "wiretrustee";
     rev = "v${version}";
-    sha256 = "15hf7and6gvhsmhxcx22xd0bdyqk7p914cyljs18ipbma0iiihi9";
+    sha256 = "0p53y1dwa9ppifiv1wg29vqkln44cqv1mg758a356shl742q9f5n";
   };
 
   vendorSha256 = "1sz5lbw0cvzspg19n45x8kx5xhs26hf2a726ls1byc6r5cg52hcw";

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -17,7 +17,10 @@ buildGoModule rec {
   };
 
   vendorSha256 = "sha256-BLiunzoUr7FcwfGlwoWXaK1D9NKytinWrV2+bZd+YK8=";
+
   patches = [
+    # Fails with:
+    # - Failed to write to log, can't make directories for new logfile: mkdir /var: permission denied
     ./log-path.patch
   ];
 
@@ -27,10 +30,31 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  # Fails with:
-  # - Failed to write to log, can't make directories for new logfile: mkdir /var: permission denied
-  doCheck = false;
+  #doCheck = false;
+  checkPhase = ''
+    runHook preCheck
 
+    # Failing tests:
+    #
+    # client/cmd:
+    # up_test.go:80: expected wireguard interface wt0 to be created
+    # "TestUp"
+    # "TestUp_Start"
+    #
+    # client/internal:
+    # === RUN   TestEngine_MultiplePeers
+    # level=error msg="failed creating interface wt3: [CreateTUN(\"wt3\") failed; /dev/net/tun does not exist]"
+    #
+    # iface:
+    # iface_test.go:186: CreateTUN("utun1003") failed; /dev/net/tun does not exist
+    # TestUp
+
+    for pkg in $(getGoDirs test | grep -Ev 'client\/cmd|client\/internal|iface'); do
+      buildGoDir test $checkFlags "$pkg"
+    done
+
+    runHook postCheck
+  '';
   passthru.tests.version = testVersion { package = wiretrustee; command = "client version"; };
 
   meta = with lib; {

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "wiretrustee";
+  version = "0.1.0-beta.3";
+
+  src = fetchFromGitHub {
+    owner = "wiretrustee";
+    repo = "wiretrustee";
+    rev = "v${version}";
+    sha256 = "1i52zm660561mbhibwd3adgh8g4ql3m7hrgjndv23j2vn2vz12bp";
+  };
+
+  vendorSha256 = "014nkhy3kf2aq14k68h8fgcpvzn5bvd3jvsf26ix61nykc24laga";
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Connect your devices into a single secure private WireGuard-based mesh network";
+    homepage = "https://github.com/wiretrustee/wiretrustee";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ _0x4A6F ];
+  };
+}

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -5,13 +5,13 @@
 
 buildGoModule rec {
   pname = "wiretrustee";
-  version = "0.2.0-beta.1";
+  version = "0.2.0-beta.2";
 
   src = fetchFromGitHub {
     owner = "wiretrustee";
     repo = "wiretrustee";
     rev = "v${version}";
-    sha256 = "13zn8544vj9ag2nws02zm4bm5f2mkargc3i0p0d3n9q2zlpc3q4c";
+    sha256 = "1d69gr71achbbcdlzy96s6f50cyfpw3a42094yyfvqjipb2jbazl";
   };
 
   vendorSha256 = "1sz5lbw0cvzspg19n45x8kx5xhs26hf2a726ls1byc6r5cg52hcw";

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "wiretrustee";
-  version = "0.2.3";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "wiretrustee";
     repo = "wiretrustee";
     rev = "v${version}";
-    sha256 = "051c234rvjjkadjhwxs7x3lph40pidvkx7si1cvsrlcnyjrcddcy";
+    sha256 = "11crspy55kgsqnh64xa4dbmagyiy871q7klzassgpiqlcpbsfz88";
   };
 
-  vendorSha256 = "1sz5lbw0cvzspg19n45x8kx5xhs26hf2a726ls1byc6r5cg52hcw";
+  vendorSha256 = "13yfh3ylm9pyqjrhwdkl8hk5rr7d2bgi6n2xcy1aw1b674fk5713";
 
   # Fails with:
   # - Failed to write to log, can't make directories for new logfile: mkdir /var: permission denied

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -5,13 +5,13 @@
 
 buildGoModule rec {
   pname = "wiretrustee";
-  version = "0.2.0-beta.4";
+  version = "0.2.2-beta.1";
 
   src = fetchFromGitHub {
     owner = "wiretrustee";
     repo = "wiretrustee";
     rev = "v${version}";
-    sha256 = "0p53y1dwa9ppifiv1wg29vqkln44cqv1mg758a356shl742q9f5n";
+    sha256 = "1n2hy91f7y32nw7m32vbm9sxh3c0qg4f3pzfd2w7dzk7vl6zrvk7";
   };
 
   vendorSha256 = "1sz5lbw0cvzspg19n45x8kx5xhs26hf2a726ls1byc6r5cg52hcw";

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -5,17 +5,19 @@
 
 buildGoModule rec {
   pname = "wiretrustee";
-  version = "0.2.2-beta.1";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "wiretrustee";
     repo = "wiretrustee";
     rev = "v${version}";
-    sha256 = "1n2hy91f7y32nw7m32vbm9sxh3c0qg4f3pzfd2w7dzk7vl6zrvk7";
+    sha256 = "051c234rvjjkadjhwxs7x3lph40pidvkx7si1cvsrlcnyjrcddcy";
   };
 
   vendorSha256 = "1sz5lbw0cvzspg19n45x8kx5xhs26hf2a726ls1byc6r5cg52hcw";
 
+  # Fails with:
+  # - Failed to write to log, can't make directories for new logfile: mkdir /var: permission denied
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/tools/networking/wiretrustee/default.nix
+++ b/pkgs/tools/networking/wiretrustee/default.nix
@@ -7,16 +7,19 @@
 
 buildGoModule rec {
   pname = "wiretrustee";
-  version = "0.3.1";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "wiretrustee";
     repo = "wiretrustee";
     rev = "v${version}";
-    sha256 = "0wyi8n29q8gsza6cwwp8qqri8wfp1rlfhizw4y65r0dq3xc7g1wm";
+    sha256 = "sha256-3vBx1QNTgV67Yo0Wn6GKy3QWa9IIEW/9DaHuJ2BEN3M=";
   };
 
-  vendorSha256 = "13yfh3ylm9pyqjrhwdkl8hk5rr7d2bgi6n2xcy1aw1b674fk5713";
+  vendorSha256 = "sha256-BLiunzoUr7FcwfGlwoWXaK1D9NKytinWrV2+bZd+YK8=";
+  patches = [
+    ./log-path.patch
+  ];
 
   ldflags = [
     "-s"

--- a/pkgs/tools/networking/wiretrustee/log-path.patch
+++ b/pkgs/tools/networking/wiretrustee/log-path.patch
@@ -1,0 +1,43 @@
+diff --git a/client/cmd/root.go b/client/cmd/root.go
+index dc5a87a..c1f0b4a 100644
+--- a/client/cmd/root.go
++++ b/client/cmd/root.go
+@@ -42,8 +42,8 @@ func init() {
+ 	stopCh = make(chan int)
+ 	cleanupCh = make(chan struct{})
+ 
+-	defaultConfigPath = "/etc/wiretrustee/config.json"
+-	defaultLogFile = "/var/log/wiretrustee/client.log"
++	defaultConfigPath = "wiretrustee-config.json"
++	defaultLogFile = "wiretrustee-client.log"
+ 	if runtime.GOOS == "windows" {
+ 		defaultConfigPath = os.Getenv("PROGRAMDATA") + "\\Wiretrustee\\" + "config.json"
+ 		defaultLogFile = os.Getenv("PROGRAMDATA") + "\\Wiretrustee\\" + "client.log"
+diff --git a/management/cmd/root.go b/management/cmd/root.go
+index b576106..20ece59 100644
+--- a/management/cmd/root.go
++++ b/management/cmd/root.go
+@@ -38,8 +38,8 @@ func init() {
+ 
+ 	stopCh = make(chan int)
+ 
+-	defaultConfigPath = "/etc/wiretrustee/management.json"
+-	defaultLogFile = "/var/log/wiretrustee/management.log"
++	defaultConfigPath = "wiretrustee-management.json"
++	defaultLogFile = "wiretrustee-management.log"
+ 	if runtime.GOOS == "windows" {
+ 		defaultConfigPath = os.Getenv("PROGRAMDATA") + "\\Wiretrustee\\" + "management.json"
+ 		defaultLogFile = os.Getenv("PROGRAMDATA") + "\\Wiretrustee\\" + "management.log"
+diff --git a/signal/cmd/root.go b/signal/cmd/root.go
+index 0a364a1..5c6f996 100644
+--- a/signal/cmd/root.go
++++ b/signal/cmd/root.go
+@@ -35,7 +35,7 @@ func Execute() error {
+ func init() {
+ 
+ 	stopCh = make(chan int)
+-	defaultLogFile = "/var/log/wiretrustee/signal.log"
++	defaultLogFile = "wiretrustee-signal.log"
+ 	if runtime.GOOS == "windows" {
+ 		defaultLogFile = os.Getenv("PROGRAMDATA") + "\\Wiretrustee\\" + "signal.log"
+ 	}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10762,6 +10762,8 @@ with pkgs;
 
   wireguard-tools = callPackage ../tools/networking/wireguard-tools { };
 
+  wiretrustee = callPackage ../tools/networking/wiretrustee { };
+
   wg-friendly-peer-names = callPackage ../tools/networking/wg-friendly-peer-names { };
 
   woff2 = callPackage ../development/web/woff2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [wiretrustee](https://github.com/wiretrustee/wiretrustee) to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
