### PR TITLE
_3270font: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/data/fonts/3270font/default.nix
+++ b/pkgs/data/fonts/3270font/default.nix
@@ -1,13 +1,13 @@
 { lib, fetchzip }:
 let
-  version = "2.3.0";
+  version = "2.3.1";
 in
 fetchzip {
   name = "3270font-${version}";
 
-  url = "https://github.com/rbanffy/3270font/releases/download/v${version}/3270_fonts_fd00815.zip";
+  url = "https://github.com/rbanffy/3270font/releases/download/v${version}/3270_fonts_3b8f2fb.zip";
 
-  sha256 = "0ny2jcsfa1kfzkm979dfzqv756ijm5xirm02ln7a4kwhxxsm5xr1";
+  sha256 = "06n87ydn2ayfhpg8318chmnwmdk3d4mmy65fcgf8frbiv2kpqncs";
 
   postFetch = ''
     mkdir -p $out/share/fonts/


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/rbanffy/3270font/releases/tag/v2.3.1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
