### PR TITLE
znapzend: 0.20.0 -> 0.21.0

### DIFF
--- a/pkgs/tools/backup/znapzend/default.nix
+++ b/pkgs/tools/backup/znapzend/default.nix
@@ -2,13 +2,13 @@
 
 let
   # when upgrade znapzend, check versions of Perl libs here: https://github.com/oetiker/znapzend/blob/master/cpanfile
-  # pinned versions are listed at https://github.com/oetiker/znapzend/blob/master/thirdparty/cpanfile-5.26.1.snapshot
-  Mojolicious-8-35 = perlPackages.buildPerlPackage rec {
+  # pinned versions are listed at https://github.com/oetiker/znapzend/blob/master/thirdparty/cpanfile-5.30.snapshot
+  Mojolicious-8-73 = perlPackages.buildPerlPackage rec {
     pname = "Mojolicious";
-    version = "8.35";
+    version = "8.73";
     src = fetchurl {
       url = "mirror://cpan/authors/id/S/SR/SRI/${pname}-${version}.tar.gz";
-      sha256 = "1bll0ahh5v1y3x0ql29klwsa68cj46wzqc385srsnn2m8kh2ak8h";
+      sha256 = "118y2264f89bbp5ly2dh36xjq25jk85s2ssxa3y4gsgsk6sjzzk1";
     };
   };
   MojoIOLoopForkCall-0-20 = perlPackages.buildPerlModule rec {
@@ -18,7 +18,7 @@ let
       url = "mirror://cpan/authors/id/J/JB/JBERGER/${pname}-${version}.tar.gz";
       sha256 = "19pih5x0ayxs2m8j29qwdpi6ky3w4ghv6vrmax3ix9r59hj6569b";
     };
-    propagatedBuildInputs = [ perlPackages.IOPipely Mojolicious-8-35 ];
+    propagatedBuildInputs = [ perlPackages.IOPipely Mojolicious-8-73 ];
   };
 
   perl' = perl.withPackages (p:
@@ -26,8 +26,8 @@ let
       p.TAPParserSourceHandlerpgTAP
     ]);
 
-  version = "0.20.0";
-  checksum = "15lb5qwksa508m9bj6d3n4rrjpakfaas9qxspg408bcqfp7pqjw3";
+  version = "0.21.0";
+  checksum = "1lg46rf2ahlclan29zx8ag5k4fjp28sc9l02z76f0pvdlj4qnihl";
 in
 stdenv.mkDerivation {
   pname = "znapzend";

--- a/pkgs/tools/backup/znapzend/default.nix
+++ b/pkgs/tools/backup/znapzend/default.nix
@@ -3,7 +3,7 @@
 let
   # when upgrade znapzend, check versions of Perl libs here: https://github.com/oetiker/znapzend/blob/master/cpanfile
   # pinned versions are listed at https://github.com/oetiker/znapzend/blob/master/thirdparty/cpanfile-5.30.snapshot
-  Mojolicious-8-73 = perlPackages.buildPerlPackage rec {
+  Mojolicious' = perlPackages.buildPerlPackage rec {
     pname = "Mojolicious";
     version = "8.73";
     src = fetchurl {
@@ -11,23 +11,23 @@ let
       sha256 = "118y2264f89bbp5ly2dh36xjq25jk85s2ssxa3y4gsgsk6sjzzk1";
     };
   };
-  MojoIOLoopForkCall-0-20 = perlPackages.buildPerlModule rec {
+  MojoIOLoopForkCall' = perlPackages.buildPerlModule rec {
     pname = "Mojo-IOLoop-ForkCall";
     version = "0.20";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JB/JBERGER/${pname}-${version}.tar.gz";
       sha256 = "19pih5x0ayxs2m8j29qwdpi6ky3w4ghv6vrmax3ix9r59hj6569b";
     };
-    propagatedBuildInputs = [ perlPackages.IOPipely Mojolicious-8-73 ];
+    propagatedBuildInputs = [ perlPackages.IOPipely Mojolicious' ];
   };
 
   perl' = perl.withPackages (p:
-    [ MojoIOLoopForkCall-0-20
+    [ MojoIOLoopForkCall'
       p.TAPParserSourceHandlerpgTAP
     ]);
 
   version = "0.21.0";
-  checksum = "1lg46rf2ahlclan29zx8ag5k4fjp28sc9l02z76f0pvdlj4qnihl";
+  sha256 = "1lg46rf2ahlclan29zx8ag5k4fjp28sc9l02z76f0pvdlj4qnihl";
 in
 stdenv.mkDerivation {
   pname = "znapzend";
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
     owner = "oetiker";
     repo = "znapzend";
     rev = "v${version}";
-    sha256 = checksum;
+    inherit sha256;
   };
 
   buildInputs = [ wget perl' ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

znapzend 0.21.0 has been available for several months, and includes important bugfixes such as oetiker/znapzend#496 which makes it much easier to send raw encrypted snapshots.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
I've built and deployed this on my own system using the `services.znapzend` configuration options, and confirmed that it's generating snapshots and sending them to my remote backup destination.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
