### PR TITLE
fishPlugins.replay: init at 1.2.0

### DIFF
--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -23,4 +23,5 @@ lib.makeScope newScope (self: with self; {
 
   pure = callPackage ./pure.nix { };
 
+  replay = callPackage ./replay.nix { };
 })

--- a/pkgs/shells/fish/plugins/replay.nix
+++ b/pkgs/shells/fish/plugins/replay.nix
@@ -1,0 +1,24 @@
+{ lib, buildFishPlugin, fetchFromGitHub, fishtape }:
+
+buildFishPlugin rec {
+  pname = "replay";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "jorgebucaran";
+    repo = "replay.fish";
+    rev = version;
+    sha256 = "sha256-Q/9YVdiRSJw1SdcfQv2h7Lj6EyFustRk+kmh1eRRQ6k=";
+  };
+
+  checkPlugins = [ fishtape ];
+  checkFunctionDirs = [ "functions" ];
+  checkPhase = "fishtape tests/*.fish";
+
+  meta = with lib; {
+    description = "Run Bash commands replaying changes in Fish";
+    homepage = "https://github.com/jorgebucaran/replay.fish";
+    license = licenses.mit;
+    maintainers = with maintainers; [ vanilla ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
https://github.com/jorgebucaran/replay.fish

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
