### PR TITLE
p7zip: fix determinism of compressed manpages

### DIFF
--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation rec {
   # Default makefile is full of impurities on Darwin. The patch doesn't hurt Linux so I'm leaving it unconditional
   postPatch = ''
     sed -i '/CC=\/usr/d' makefile.macosx_llvm_64bits
+    # Avoid writing timestamps into compressed manpages
+    # to maintain determinism.
+    substituteInPlace install.sh --replace 'gzip' 'gzip -n'
     chmod +x install.sh
 
     # I think this is a typo and should be CXX? Either way let's kill it


### PR DESCRIPTION
diffoscope shown non-determinism in embedded gzip timestamp:

  --- p7zip-17.04/share/man/man1/7z.1.gz
  +++ p7zip-17.04.check/share/man/man1/7z.1.gz
  ─ filetype from file(1)
  @@ -1 +1 @@
  -gzip compressed data, was "7z.1", last modified: Fri Oct  1 14:14:55 2021, from Unix
  +gzip compressed data, was "7z.1", last modified: Sat Oct  9 08:15:33 2021, from Unix

Fix it by using `gzip -n`.