### PR TITLE
perl-modules: set PERL_HASH_SEED=0

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -17,6 +17,10 @@ toPerlModule(stdenv.mkDerivation (
 
     checkTarget = "test";
 
+    # Avoid non-deterministic output of associative arrays
+    # (example is libnet package).
+    PERL_HASH_SEED = "0";
+
     # Prevent CPAN downloads.
     PERL_AUTOINSTALL = "--skipdeps";
 


### PR DESCRIPTION
Noticed non-determinism in perl534Packages.libnet:

  -perl5.34.0-libnet-3.12/lib/perl5/site_perl/5.34.0/Net/libnet.cfg
  +perl5.34.0-libnet-3.12.check/lib/perl5/site_perl/5.34.0/Net/libnet.cfg
   Ordering differences only
   {
  -   'ph_hosts' => [],
      'daytime_hosts' => [],
  +   'ph_hosts' => [],
  ...

It's caused by a raw dump of perl's dictionaries governed
by PERL_HASH_SEED=0. Let's stabilize it's output with and
while at it stabilize execution during build as well.