### PR TITLE
xorg.xf86inputlibinput: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1977,11 +1977,11 @@ lib.makeScope newScope (self: with self; {
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xf86inputlibinput = callPackage ({ stdenv, pkg-config, fetchurl, xorgproto, libinput, xorgserver }: stdenv.mkDerivation {
     pname = "xf86-input-libinput";
-    version = "1.1.0";
+    version = "1.2.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/driver/xf86-input-libinput-1.1.0.tar.bz2";
-      sha256 = "05ldqr10f2rrnshyk3lc773rz0gp3ccdzwa8n7lsc94i850jl7g1";
+      url = "mirror://xorg/individual/driver/xf86-input-libinput-1.2.0.tar.bz2";
+      sha256 = "1xk9b05csndcgcj8kbb6fkwa3c7njzzxc6qvz9bvy77y2k2s63gq";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -81,7 +81,7 @@ mirror://xorg/individual/doc/xorg-sgml-doctools-1.11.tar.bz2
 mirror://xorg/individual/driver/xf86-input-evdev-2.10.6.tar.bz2
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.3.tar.bz2
 mirror://xorg/individual/driver/xf86-input-keyboard-1.9.0.tar.bz2
-mirror://xorg/individual/driver/xf86-input-libinput-1.1.0.tar.bz2
+mirror://xorg/individual/driver/xf86-input-libinput-1.2.0.tar.bz2
 mirror://xorg/individual/driver/xf86-input-mouse-1.9.3.tar.bz2
 mirror://xorg/individual/driver/xf86-input-synaptics-1.9.1.tar.bz2
 mirror://xorg/individual/driver/xf86-input-vmmouse-13.1.0.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-September/003110.html

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).