### PR TITLE
python3Packages.scancode-toolkit: 21.8.4 -> 30.1.0

### DIFF
--- a/pkgs/development/python-modules/commoncode/default.nix
+++ b/pkgs/development/python-modules/commoncode/default.nix
@@ -1,24 +1,29 @@
 { lib
-, fetchPypi
-, buildPythonPackage
-, setuptools-scm
-, click
-, requests
 , attrs
-, intbitset
-, saneyaml
-, text-unidecode
 , beautifulsoup4
-, pytestCheckHook
+, buildPythonPackage
+, click
+, fetchPypi
+, intbitset
 , pytest-xdist
+, pytestCheckHook
+, pythonOlder
+, requests
+, saneyaml
+, setuptools-scm
+, text-unidecode
+, typing
 }:
+
 buildPythonPackage rec {
   pname = "commoncode";
-  version = "21.8.31";
+  version = "30.0.0";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0e74c61226834393801e921ab125eae3b52361340278fb9a468c5c691d286c32";
+    sha256 = "sha256-6SeU4u6pfDuGCgCYAO5fdbWBxW9XN3WvM8j6DwUlFwM=";
   };
 
   dontConfigure = true;
@@ -28,13 +33,15 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    click
-    requests
     attrs
+    beautifulsoup4
+    click
     intbitset
+    requests
     saneyaml
     text-unidecode
-    beautifulsoup4
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    typing
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/debian-inspector/default.nix
+++ b/pkgs/development/python-modules/debian-inspector/default.nix
@@ -11,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "debian-inspector";
-  version = "21.5.25";
+  version = "30.0.0";
 
   src = fetchPypi {
     pname = "debian_inspector";
     inherit version;
-    sha256 = "1d3xaqw00kav85nk29qm2yqb73bkyqf185fs1q0vgd7bnap9wqaw";
+    sha256 = "sha256-0PT5sT6adaqgYQtWjks12ys0z1C3n116aeJaEKR/Wxg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/extractcode/default.nix
+++ b/pkgs/development/python-modules/extractcode/default.nix
@@ -9,6 +9,7 @@
 , pytestCheckHook
 , pytest-xdist
 }:
+
 buildPythonPackage rec {
   pname = "extractcode";
   version = "21.7.23";
@@ -36,7 +37,7 @@ buildPythonPackage rec {
     pytest-xdist
   ];
 
-  # cli test tests the cli which we can't do until after install
+  # CLI test tests the cli which we can't do until after install
   disabledTestPaths = [
     "tests/test_extractcode_cli.py"
   ];
@@ -45,6 +46,7 @@ buildPythonPackage rec {
   disabledTests = [
     "test_uncompress_lz4_basic"
     "test_extract_tarlz4_basic"
+    "test_extract_rar_with_trailing_data"
     # tries to parse /boot/vmlinuz-*, which is not available in the nix sandbox
     "test_can_extract_qcow2_vm_image_as_tarball"
     "test_can_extract_qcow2_vm_image_not_as_tarball"
@@ -56,7 +58,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "A mostly universal archive extractor using z7zip, libarchve, other libraries and the Python standard library for reliable archive extraction";
+    description = "Universal archive extractor using z7zip, libarchve, other libraries and the Python standard library";
     homepage = "https://github.com/nexB/extractcode";
     license = licenses.asl20;
     maintainers = teams.determinatesystems.members;

--- a/pkgs/development/python-modules/license-expression/default.nix
+++ b/pkgs/development/python-modules/license-expression/default.nix
@@ -1,25 +1,45 @@
-{ lib, buildPythonPackage, fetchFromGitHub
+{ lib
 , boolean-py
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "license-expression";
-  version = "1.2";
+  version = "21.6.14";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "nexB";
     repo = "license-expression";
     rev = "v${version}";
-    sha256 = "0bbd7d90z58p9sd01b00g0vfd9bmwzksjb7pc8833s2jpja9mxz1";
+    sha256 = "sha256-hwfYKKalo8WYFwPCsRRXNz+/F8/42PXA8jxbIQjJH/g=";
   };
-  postPatch = "patchShebangs ./configure";
 
-  propagatedBuildInputs = [ boolean-py ];
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    boolean-py
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "license_expression" ];
 
   meta = with lib; {
+    description = "Utility library to parse, normalize and compare License expressions for Python";
     homepage = "https://github.com/nexB/license-expression";
-    description = "Utility library to parse, normalize and compare License expressions for Python using a boolean logic engine";
     license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
   };
-
 }

--- a/pkgs/development/python-modules/parameter-expansion-patched/default.nix
+++ b/pkgs/development/python-modules/parameter-expansion-patched/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "parameter-expansion-patched";
+  version = "0.2.1b4";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vhshscjifi78qapzwn29gln6p8jhyc7cccszl8ai2jamhcph5zs";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "parameter_expansion"
+  ];
+
+  meta = with lib; {
+    description = "POSIX parameter expansion in Python";
+    homepage = "https://github.com/nexB/commoncode";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pygmars/default.nix
+++ b/pkgs/development/python-modules/pygmars/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, setuptools-scm
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pygmars";
+  version = "0.7.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "nexB";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0wghk4nzplpl26iwrgvm0n9x88nyxlcxz4ywss4nwdr4hfccl28l";
+  };
+
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pygmars"
+  ];
+
+  meta = with lib; {
+    description = "Python lexing and parsing library";
+    homepage = "https://github.com/nexB/pygmars";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/scancode-toolkit/default.nix
+++ b/pkgs/development/python-modules/scancode-toolkit/default.nix
@@ -1,104 +1,140 @@
 { lib
-, fetchPypi
-, buildPythonPackage
-, isPy3k
-, markupsafe
-, click
-, typecode
-, gemfileparser
-, pefile
-, fingerprints
-, spdx-tools
-, fasteners
-, pycryptodome
-, urlpy
-, dparse
-, jaraco_functools
-, pkginfo
-, debian-inspector
-, extractcode
-, ftfy
-, pyahocorasick
-, colorama
-, jsonstreams
-, packageurl-python
-, pymaven-patch
-, nltk
-, pygments
+, attrs
+, beautifulsoup4
 , bitarray
-, jinja2
-, javaproperties
 , boolean-py
-, license-expression
+, buildPythonPackage
+, chardet
+, click
+, colorama
+, commoncode
+, debian-inspector
+, dparse
+, extractcode
 , extractcode-7z
 , extractcode-libarchive
-, typecode-libmagic
+, fasteners
+, fetchPypi
+, fingerprints
+, ftfy
+, gemfileparser
+, html5lib
+, importlib-metadata
+, intbitset
+, jaraco_functools
+, javaproperties
+, jinja2
+, jsonstreams
+, license-expression
+, lxml
+, markupsafe
+, packageurl-python
+, packaging
+, parameter-expansion-patched
+, pefile
+, pkginfo
+, pluggy
+, plugincode
+, publicsuffix2
+, pyahocorasick
+, pycryptodome
+, pygmars
+, pygments
+, pymaven-patch
 , pytestCheckHook
+, pythonOlder
+, requests
+, saneyaml
+, spdx-tools
+, text-unidecode
+, toml
+, typecode
+, typecode-libmagic
+, typing
+, urlpy
+, xmltodict
+, zipp
 }:
+
 buildPythonPackage rec {
   pname = "scancode-toolkit";
-  version = "21.8.4";
-  disabled = !isPy3k;
+  version = "30.1.0";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c18340067244274c67e166f701c60e747e1d0bccb17efc99f277a4bc0a5a13c6";
+    sha256 = "sha256-UYQf+cBi2FmyZxIbQJo7vLjPuoePIMC8FugvoG1Ebj0=";
   };
 
   dontConfigure = true;
 
-  # https://github.com/nexB/scancode-toolkit/issues/2501
-  # * dparse2 is a "Temp fork for Python 2 support", but pdfminer requires
-  # Python 3, so it's "fine" to leave dparse2 unpackaged and use the "normal"
-  # version
-  # * ftfy was pinned for similar reasons (to support Python 2), but rather than
-  # packaging an older version, I figured it would be better to remove the
-  # erroneous (at least for our usage) version bound
-  # * bitarray's version bound appears to be unnecessary for similar reasons
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "dparse2" "dparse" \
-      --replace "ftfy <  5.0.0" "ftfy" \
-      --replace "bitarray >= 0.8.1, < 1.0.0" "bitarray"
-  '';
-
   propagatedBuildInputs = [
-    markupsafe
-    click
-    typecode
-    gemfileparser
-    pefile
-    fingerprints
-    spdx-tools
-    fasteners
-    pycryptodome
-    urlpy
-    dparse
-    jaraco_functools
-    pkginfo
-    debian-inspector
-    extractcode
-    ftfy
-    pyahocorasick
-    colorama
-    jsonstreams
-    packageurl-python
-    pymaven-patch
-    nltk
-    pygments
+    attrs
+    beautifulsoup4
     bitarray
-    jinja2
-    javaproperties
     boolean-py
-    license-expression
+    chardet
+    click
+    colorama
+    commoncode
+    debian-inspector
+    dparse
+    extractcode
     extractcode-7z
     extractcode-libarchive
+    fasteners
+    fingerprints
+    ftfy
+    gemfileparser
+    html5lib
+    intbitset
+    jaraco_functools
+    javaproperties
+    jinja2
+    jsonstreams
+    license-expression
+    lxml
+    markupsafe
+    packageurl-python
+    packaging
+    parameter-expansion-patched
+    pefile
+    pkginfo
+    pluggy
+    plugincode
+    publicsuffix2
+    pyahocorasick
+    pycryptodome
+    pygmars
+    pygments
+    pymaven-patch
+    requests
+    saneyaml
+    spdx-tools
+    text-unidecode
+    toml
+    typecode
     typecode-libmagic
+    urlpy
+    xmltodict
+    zipp
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    importlib-metadata
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    typing
   ];
 
   checkInputs = [
     pytestCheckHook
   ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "pluggy >= 0.12.0, < 1.0" "pluggy" \
+      --replace "pygmars >= 0.7.0" "pygmars" \
+      --replace "license_expression >= 21.6.14" "license_expression"
+  '';
 
   # Importing scancode needs a writeable home, and preCheck happens in between
   # pythonImportsCheckPhase and pytestCheckPhase.
@@ -114,7 +150,7 @@ buildPythonPackage rec {
   dontStrip = true;
 
   meta = with lib; {
-    description = "A tool to scan code for license, copyright, package and their documented dependencies and other interesting facts";
+    description = "Tool to scan code for license, copyright, package and their documented dependencies and other interesting facts";
     homepage = "https://github.com/nexB/scancode-toolkit";
     license = with licenses; [ asl20 cc-by-40 ];
     maintainers = teams.determinatesystems.members;

--- a/pkgs/development/python-modules/spdx-tools/default.nix
+++ b/pkgs/development/python-modules/spdx-tools/default.nix
@@ -1,39 +1,31 @@
 { lib
 , buildPythonPackage
+, click
 , fetchPypi
-, fetchpatch
-, six
 , pyyaml
 , rdflib
 , ply
 , xmltodict
 , pytestCheckHook
-, pythonAtLeast
+, pythonOlder
 }:
+
 buildPythonPackage rec {
   pname = "spdx-tools";
-  version = "0.6.1";
+  version = "0.7.0a3";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9a1aaae051771e865705dd2fd374c3f73d0ad595c1056548466997551cbd7a81";
+    sha256 = "sha256-afV1W1n5ubHhqfLFpPO5fxaIy5TaZdw9eDy3JYOJ1oE=";
   };
 
-  patches = lib.optionals (pythonAtLeast "3.9") [
-    # https://github.com/spdx/tools-python/pull/159
-    # fixes tests on Python 3.9
-    (fetchpatch {
-      name = "drop-encoding-argument.patch";
-      url = "https://github.com/spdx/tools-python/commit/6c8b9a852f8a787122c0e2492126ee8aa52acff0.patch";
-      sha256 = "RhvLhexsQRjqYqJg10SAM53RsOW+R93G+mns8C9g5E8=";
-    })
-  ];
-
   propagatedBuildInputs = [
-    six
+    click
+    ply
     pyyaml
     rdflib
-    ply
     xmltodict
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6310,6 +6310,8 @@ in {
 
   pygls = callPackage ../development/python-modules/pygls { };
 
+  pygmars = callPackage ../development/python-modules/pygmars { };
+
   pygments-better-html = callPackage ../development/python-modules/pygments-better-html { };
 
   pygments = callPackage ../development/python-modules/Pygments { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5332,6 +5332,8 @@ in {
 
   param = callPackage ../development/python-modules/param { };
 
+  parameter-expansion-patched = callPackage ../development/python-modules/parameter-expansion-patched { };
+
   parameterized = callPackage ../development/python-modules/parameterized { };
 
   paramiko = callPackage ../development/python-modules/paramiko { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Started with fixing a build failure (https://hydra.nixos.org/build/155345031) and ended with a `scancode-toolkit` update to 30.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
