### PR TITLE
configuration-ghc-9.2.x.nix: overrides

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -43,54 +43,129 @@ self: super: {
   unix = null;
   xhtml = null;
 
+  aeson = appendPatch (doJailbreak super.aeson) (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/aeson-1.5.6.0.patch";
+    sha256 = "07rk7f0lhgilxvbg2grpl1p5x25wjf9m7a0wqmi2jr0q61p9a0nl";
+    # The revision information is newer than that included in the patch
+    excludes = ["*.cabal"];
+  });
+
+  attoparsec = appendPatch (doJailbreak super.attoparsec_0_14_1) (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/attoparsec-0.14.1.patch";
+    sha256 = "0nprywmi3i9ih8mcc8afyimrfjr8pbcjxr2ywz9gwdlwdplk21da";
+  });
+
   # 0.12.0 introduces support for 9.2
   base-compat = self.base-compat_0_12_0;
+  base-compat-batteries = self.base-compat-batteries_0_12_0;
+
+  basement = overrideCabal (appendPatch super.basement (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/basement-0.0.12.patch";
+    sha256 = "0c8n2krz827cv87p3vb1vpl3v0k255aysjx9lq44gz3z1dhxd64z";
+  })) (drv: {
+    # This is inside a conditional block so `doJailbreak` doesn't work
+    postPatch = "sed -i -e 's,<4.16,<4.17,' basement.cabal";
+  });
+
+  # Duplicate Show instances in tests and library cause compiling tests to fail
+  blaze-builder = appendPatch (dontCheck super.blaze-builder) (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/blaze-builder-0.4.2.1.patch";
+    sha256 = "1h5ny3mlng69vwaabl3af8hlv4qi24wfw8s14lw2ksw1yjbgi0j8";
+  });
+
+  cereal = appendPatch super.cereal (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/cereal-0.5.8.1.patch";
+    sha256 = "03v4nxwz9y6viaa8anxcmp4zdf2clczv4pf9fqq6lnpplpz5i128";
+  });
+
+  # Tests fail because of typechecking changes
+  conduit = dontCheck super.conduit;
+
+  constraints = appendPatch super.constraints (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/constraints-0.13.patch";
+    sha256 = "0cr4qzw0fbwy97f3wx0v3mv8yc642ahpfa80kaqrq191232fzzf3";
+  });
+
+  cryptonite = appendPatch super.cryptonite (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/cryptonite-0.29.patch";
+    sha256 = "1g48lrmqgd88hqvfq3klz7lsrpwrir2v1931myrhh6dy0d9pqj09";
+  });
 
   # cabal-install needs more recent versions of Cabal and base16-bytestring.
   cabal-install = (doJailbreak super.cabal-install).overrideScope (self: super: {
     Cabal = null;
   });
 
+  doctest = appendPatch (dontCheck (doJailbreak super.doctest_0_18_1)) (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/doctest-0.18.1.patch";
+    sha256 = "030kdsk0fg08cgdcjpyv6z8ym1vkkrbd34aacs91y5hqzc9g79y1";
+  });
+
+  entropy = appendPatch super.entropy (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/entropy-0.4.1.6.patch";
+    sha256 = "0pbbl6m8b3snf9cz6rs0ljmacpsavayfn0s3p67hdcmndy3ndawi";
+  });
+
+  # Tests fail in GHC 9.2
+  extra = dontCheck super.extra;
+
   # Jailbreaks & Version Updates
+  assoc = doJailbreak super.assoc;
   async = doJailbreak super.async;
   base64-bytestring = doJailbreak super.base64-bytestring;
   ChasingBottoms = doJailbreak super.ChasingBottoms;
+  cpphs = overrideCabal super.cpphs (drv: { postPatch = "sed -i -e 's,time >=1.5 && <1.11,time >=1.5 \\&\\& <1.12,' cpphs.cabal";});
+  cryptohash-md5 = doJailbreak super.cryptohash-md5;
+  cryptohash-sha1 = doJailbreak super.cryptohash-sha1;
   data-fix = doJailbreak super.data-fix;
   dec = doJailbreak super.dec;
   ed25519 = doJailbreak super.ed25519;
+  ghc-byteorder = doJailbreak super.ghc-byteorder;
   hackage-security = doJailbreak super.hackage-security;
   hashable-time = doJailbreak super.hashable-time;
   HTTP = overrideCabal (doJailbreak super.HTTP) (drv: { postPatch = "sed -i -e 's,! Socket,!Socket,' Network/TCP.hs"; });
-  integer-logarithms = overrideCabal (doJailbreak super.integer-logarithms) (drv: { postPatch = "sed -i -e 's,integer-gmp <1.1,integer-gmp < 2,' integer-logarithms.cabal"; });
+  integer-logarithms = overrideCabal (doJailbreak super.integer-logarithms) (drv: { postPatch = "sed -i -e 's, <1.1, <1.3,' integer-logarithms.cabal"; });
+  indexed-traversable = doJailbreak super.indexed-traversable;
+  lifted-async = doJailbreak super.lifted-async;
   lukko = doJailbreak super.lukko;
   network = super.network_3_1_2_5;
   parallel = doJailbreak super.parallel;
+  polyparse = overrideCabal (doJailbreak super.polyparse) (drv: { postPatch = "sed -i -e 's, <0.11, <0.12,' polyparse.cabal"; });
   primitive = doJailbreak super.primitive;
   regex-posix = doJailbreak super.regex-posix;
   resolv = doJailbreak super.resolv;
   singleton-bool = doJailbreak super.singleton-bool;
+  scientific = doJailbreak super.scientific;
+  shelly = doJailbreak super.shelly;
   split = doJailbreak super.split;
   splitmix = doJailbreak super.splitmix;
   tar = doJailbreak super.tar;
+  these = doJailbreak super.these;
   time-compat = doJailbreak super.time-compat;
+  type-equality = doJailbreak super.type-equality;
   vector = doJailbreak (dontCheck super.vector);
   vector-binary-instances = doJailbreak super.vector-binary-instances;
   vector-th-unbox = doJailbreak super.vector-th-unbox;
   zlib = doJailbreak super.zlib;
 
+  # Syntax error in tests fixed in https://github.com/simonmar/alex/commit/84b29475e057ef744f32a94bc0d3954b84160760
+  alex = dontCheck super.alex;
+
   # Apply patches from head.hackage.
-  alex = appendPatch (dontCheck super.alex) (pkgs.fetchpatch {
-    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/fe192e12b88b09499d4aff0e562713e820544bd6/patches/alex-3.2.6.patch";
-    sha256 = "1rzs764a0nhx002v4fadbys98s6qblw4kx4g46galzjf5f7n2dn4";
-  });
-  doctest = dontCheck (doJailbreak super.doctest_0_18_1);
   language-haskell-extract = appendPatch (doJailbreak super.language-haskell-extract) (pkgs.fetchpatch {
     url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/language-haskell-extract-0.2.4.patch";
     sha256 = "0w4y3v69nd3yafpml4gr23l94bdhbmx8xky48a59lckmz5x9fgxv";
   });
 
-  # 1.3.0 (on stackage) defines instances for the Option-type, which has been removed from base in GHC 9.2.x
-  hashable = super.hashable_1_3_3_0;
+  hashable = super.hashable_1_3_4_1;
+
+  haskell-src-meta = appendPatch (doJailbreak super.haskell-src-meta) (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/haskell-src-meta-0.8.7.patch";
+    sha256 = "013k8hpxac226j47cdzgdf9a1j91kmm0cvv7n8zwlajbj3y9bzjp";
+  });
+
+  # Tests depend on `parseTime` which is no longer available
+  hourglass = dontCheck super.hourglass;
 
   # 1.2.1 introduced support for GHC 9.2.1, stackage has 1.2.0
   # The test suite indirectly depends on random, which leads to infinite recursion
@@ -100,15 +175,30 @@ self: super: {
   lens = super.lens_5_0_1;
 
   # 0.16.0 introduced support for GHC 9.0.x, stackage has 0.15.0
-  memory = super.memory_0_16_0;
+  memory = appendPatch super.memory_0_16_0 (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/memory-0.16.0.patch";
+    sha256 = "1kjganx729a6xfgfnrb3z7q6mvnidl042zrsd9n5n5a3i76nl5nl";
+  });
 
   # GHC 9.0.x doesn't like `import Spec (main)` in Main.hs
   # https://github.com/snoyberg/mono-traversable/issues/192
   mono-traversable = dontCheck super.mono-traversable;
 
+  quickcheck-instances = appendPatch (doJailbreak super.quickcheck-instances) (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/quickcheck-instances-0.3.25.2.patch";
+    sha256 = "0ndnb6wbnhxxwy69jjdpmd7gmmv6asmx1jczwz1hsn921mn1ilnp";
+    # `.cabal` revision information has been included in the patch
+    excludes = ["*.cabal"];
+  });
+
   # Disable tests pending resolution of
   # https://github.com/Soostone/retry/issues/71
   retry = dontCheck super.retry;
+
+  streaming-commons = appendPatch super.streaming-commons (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/streaming-commons-0.2.2.1.patch";
+    sha256 = "04wi1jskr3j8ayh88kkx4irvhhgz0i7aj6fblzijy0fygikvidpy";
+  });
 
   # hlint 3.3 needs a ghc-lib-parser newer than the one from stackage
   hlint = super.hlint_3_3_4.overrideScope (self: super: {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Various updates for GHC 9.2 that I am finding in the process of working on https://github.com/gibiansky/IHaskell/pull/1283.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
