### PR TITLE
python3Packages.astroid: 2.7.3 -> 2.8.2

### DIFF
--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -7,13 +7,13 @@
 , wrapt
 , typed-ast
 , pytestCheckHook
-, setuptools-scm
 , pylint
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "astroid";
-  version = "2.7.3"; # Check whether the version is compatible with pylint
+  version = "2.8.2"; # Check whether the version is compatible with pylint
 
   disabled = pythonOlder "3.6";
 
@@ -21,24 +21,23 @@ buildPythonPackage rec {
     owner = "PyCQA";
     repo = pname;
     rev = "v${version}";
-    sha256 = "08qxw58cdyglkni6ahyil4cmnb48zz0wr4v05gzqk4r5ifs4gl2m";
+    sha256 = "0140h4l7licwdw0scnfzsbi5b2ncxi7fxhdab7c1i3sk01r4asp6";
   };
 
-  SETUPTOOLS_SCM_PRETEND_VERSION=version;
-
-  nativeBuildInputs = [
-    setuptools-scm
-  ];
+  PBR_VERSION=version;
 
   # From astroid/__pkginfo__.py
   propagatedBuildInputs = [
     lazy-object-proxy
     wrapt
+    typing-extensions
   ] ++ lib.optional (!isPyPy && pythonOlder "3.8") typed-ast;
 
   checkInputs = [
     pytestCheckHook
   ];
+
+  pythonImportsCheck = [ "astroid" ];
 
   passthru.tests = {
     inherit pylint;


### PR DESCRIPTION
python3Packages.astroid: 2.7.3 -> 2.8.2

`astroid` is a dependency of `pylint`.
PR #140627 is being broken down.

Feel free to review/merge this!