### PR TITLE
cozydrive: fix maintainers

### DIFF
--- a/pkgs/applications/networking/cozy-drive/default.nix
+++ b/pkgs/applications/networking/cozy-drive/default.nix
@@ -29,7 +29,7 @@ appimageTools.wrapType2 {
     description = "Cozy Drive is a synchronization tool for your files and folders with Cozy Cloud.";
     homepage = "https://cozy.io";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ "Simarra" ];
+    maintainers = with maintainers; [ simarra ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
Having a string instead of a maintainer entry is causing the nixos-search import to [fail](https://github.com/NixOS/nixos-search/runs/3846627702?check_suite_focus=true#step:8:13)