### PR TITLE
python3Packages.pylint: 2.10.2 -> 2.11.1

### DIFF
--- a/pkgs/development/python-modules/astroid/default.nix
+++ b/pkgs/development/python-modules/astroid/default.nix
@@ -7,13 +7,13 @@
 , wrapt
 , typed-ast
 , pytestCheckHook
-, setuptools-scm
 , pylint
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "astroid";
-  version = "2.7.3"; # Check whether the version is compatible with pylint
+  version = "2.8.2"; # Check whether the version is compatible with pylint
 
   disabled = pythonOlder "3.6";
 
@@ -21,24 +21,23 @@ buildPythonPackage rec {
     owner = "PyCQA";
     repo = pname;
     rev = "v${version}";
-    sha256 = "08qxw58cdyglkni6ahyil4cmnb48zz0wr4v05gzqk4r5ifs4gl2m";
+    sha256 = "0140h4l7licwdw0scnfzsbi5b2ncxi7fxhdab7c1i3sk01r4asp6";
   };
 
-  SETUPTOOLS_SCM_PRETEND_VERSION=version;
-
-  nativeBuildInputs = [
-    setuptools-scm
-  ];
+  PBR_VERSION = version;
 
   # From astroid/__pkginfo__.py
   propagatedBuildInputs = [
     lazy-object-proxy
     wrapt
+    typing-extensions
   ] ++ lib.optional (!isPyPy && pythonOlder "3.8") typed-ast;
 
   checkInputs = [
     pytestCheckHook
   ];
+
+  pythonImportsCheck = [ "astroid" ];
 
   passthru.tests = {
     inherit pylint;

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "pylint";
-  version = "2.10.2";
+  version = "2.11.1";
 
   disabled = pythonOlder "3.6";
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "PyCQA";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-hkrkgUdC5LO1oSPFL6gvIk0zFpMw45gCmnoRbdPZuRs=";
+    sha256 = "08kc9139v1sd0vhna0rqikyds0xq8hxv0j9707n2i1nbv2z6xhsv";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -49,6 +49,9 @@ buildPythonPackage rec {
     substituteInPlace setup.cfg \
       --replace "--cov-report html --cov-report term --junitxml=pytest.xml" "" \
       --replace "--cov pylsp --cov test" ""
+
+    substituteInPlace setup.py \
+      --replace "pylint>=2.5.0,<2.10.0" "pylint"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
* python3Packages.pylint: 2.10.2 -> 2.11.1
  - python3Packages.astroid: 2.7.3 -> 2.8.2
  - python3Packages.python-lsp-server: unlock pylint

`pylint` upgrade came up as a dependency of fixing `spyder` for Python38. As this seems a change with large effects. I'll try to avoid this. [Back to drawing board.]