### PR TITLE
libsForQt5.dxflib: 3.17.0 -> 3.26.4

### DIFF
--- a/pkgs/development/libraries/dxflib/default.nix
+++ b/pkgs/development/libraries/dxflib/default.nix
@@ -4,11 +4,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.17.0";
+  version = "3.26.4";
   pname = "dxflib";
   src = fetchurl {
-    url = "http://www.qcad.org/archives/dxflib/${pname}-${version}-src.tar.gz";
-    sha256 = "09yjgzh8677pzkkr7a59pql5d11451c22pxksk2my30mapxsri96";
+    url = "https://qcad.org/archives/dxflib/${pname}-${version}-src.tar.gz";
+    sha256 = "0pwic33mj6bp4axai5jiyn4xqf31y0xmb1i0pcf55b2h9fav8zah";
   };
   nativeBuildInputs = [
     qmake
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
+    homepage = "https://qcad.org/en/90-dxflib";
     maintainers = with lib.maintainers; [raskin];
     platforms = lib.platforms.linux;
     description = "DXF file format library";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-21897.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>rapcad</li>
  </ul>
</details>
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>cloudcompare</li>
    <li>libsForQt5.dxflib</li>
    <li>libsForQt512.dxflib</li>
    <li>libsForQt514.dxflib</li>
    <li>saga</li>
  </ul>
</details>
