### PR TITLE
nixos/doc/md-to-db.sh: handle path to nixpkgs with spaces

### DIFF
--- a/nixos/doc/manual/md-to-db.sh
+++ b/nixos/doc/manual/md-to-db.sh
@@ -6,7 +6,7 @@
 # into DocBook files in the from_md folder.
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-pushd $DIR
+pushd "$DIR"
 
 # NOTE: Keep in sync with Nixpkgs manual (/doc/Makefile).
 # TODO: Remove raw-attribute when we can get rid of DocBook altogether.
@@ -29,7 +29,7 @@ mapfile -t MD_FILES < <(find . -type f -regex '.*\.md$')
 
 for mf in ${MD_FILES[*]}; do
   if [ "${mf: -11}" == ".section.md" ]; then
-    mkdir -p $(dirname "$OUT/$mf")
+    mkdir -p "$(dirname "$OUT/$mf")"
     OUTFILE="$OUT/${mf%".section.md"}.section.xml"
     pandoc "$mf" "${pandoc_flags[@]}" \
       -o "$OUTFILE"
@@ -37,7 +37,7 @@ for mf in ${MD_FILES[*]}; do
   fi
 
   if [ "${mf: -11}" == ".chapter.md" ]; then
-    mkdir -p $(dirname "$OUT/$mf")
+    mkdir -p "$(dirname "$OUT/$mf")"
     OUTFILE="$OUT/${mf%".chapter.md"}.chapter.xml"
     pandoc "$mf" "${pandoc_flags[@]}" \
       --top-level-division=chapter \


### PR DESCRIPTION
###### Motivation for this change
Without this change, the script will fail if the path to nixpkgs contains a space.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).