### PR TITLE
kde-gear: 21.08.1 -> 21.08.2

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/release-service/21.08.1/src -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/release-service/21.08.2/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1811 +4,1811 @@
 
 {
   akonadi = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akonadi-21.08.1.tar.xz";
-      sha256 = "02abs3mxwna30rgidlndj4jq0swy3id236ckw726vp3r8m9qimd6";
-      name = "akonadi-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-21.08.2.tar.xz";
+      sha256 = "0jwhjdqha82hbyg2wmzjl5qi2rgmyd2sghdw85s77y63bxm9f0s2";
+      name = "akonadi-21.08.2.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akonadi-calendar-21.08.1.tar.xz";
-      sha256 = "1p8myayr6kfgp805wdpy39f9bjxw1fafv6kn35h1zsl1fgyc4812";
-      name = "akonadi-calendar-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-calendar-21.08.2.tar.xz";
+      sha256 = "0k4cbcr6cw9rcrzidlbjbpshmsfh0p2m8bd9inkgzxi08drwizsa";
+      name = "akonadi-calendar-21.08.2.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akonadi-calendar-tools-21.08.1.tar.xz";
-      sha256 = "0j8cc0x2bx64crgvprksnmng4yi7fk71s5pfyjrnw8d9xnj7vvvg";
-      name = "akonadi-calendar-tools-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-calendar-tools-21.08.2.tar.xz";
+      sha256 = "1hxah75grydlaz6hzd3ng91dsap860111alph7vnrqcakhcfm0yc";
+      name = "akonadi-calendar-tools-21.08.2.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akonadi-contacts-21.08.1.tar.xz";
-      sha256 = "13sjy2jg4bbg7dm182apppmcpkhmiwhkpnkjhh13dhz8v7488vnc";
-      name = "akonadi-contacts-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-contacts-21.08.2.tar.xz";
+      sha256 = "1ap2c16c0z4m7f3zsp5w5wqwcdr3fn1n2kvb6d647c3knszgibvg";
+      name = "akonadi-contacts-21.08.2.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akonadi-import-wizard-21.08.1.tar.xz";
-      sha256 = "1v0nzaijy6nahjx4j1wsvi8s6s3zk79b8h01n3r6gwilbxklqnqs";
-      name = "akonadi-import-wizard-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-import-wizard-21.08.2.tar.xz";
+      sha256 = "0hgbjdkl4nva9dy9ljn8f5g4v9bw1rl84x2m0x94msf6bih20nr3";
+      name = "akonadi-import-wizard-21.08.2.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akonadi-mime-21.08.1.tar.xz";
-      sha256 = "15lm1248diqhnv1qldcyyfi1v7w8h13jvwhp80py93hijq07iwz5";
-      name = "akonadi-mime-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-mime-21.08.2.tar.xz";
+      sha256 = "0fkv26zl92xijkibpxvbqcmip24qrq58lan3w9s642gqh972a6x3";
+      name = "akonadi-mime-21.08.2.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akonadi-notes-21.08.1.tar.xz";
-      sha256 = "1r43pvxpk3f183qaiydxg83xc1y5zss7xgxq5p1vnwgqyifibh3h";
-      name = "akonadi-notes-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-notes-21.08.2.tar.xz";
+      sha256 = "0r19g9a0asqlw1qsh9vidbwpgbslfwqc8g577hdkhahfvg7hplmq";
+      name = "akonadi-notes-21.08.2.tar.xz";
     };
   };
   akonadi-search = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akonadi-search-21.08.1.tar.xz";
-      sha256 = "1w5vps398kadl6p2jhsj18jqfn4lyysx09jzj6q9cvkvzmq4im6i";
-      name = "akonadi-search-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akonadi-search-21.08.2.tar.xz";
+      sha256 = "1a1pf9q93z0cv7v2fxksiw3vn5dylg0lgniv98z9p6zv0wijxhn5";
+      name = "akonadi-search-21.08.2.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akonadiconsole-21.08.1.tar.xz";
-      sha256 = "1dplpb6z3glps82bzlqhnx29k13m6b7q2wvdlcw9hfqrp2xgzyfk";
-      name = "akonadiconsole-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akonadiconsole-21.08.2.tar.xz";
+      sha256 = "07vr4nwjzz6y1babwnhhidpv8pldx7vk2mq98midqji87xxh7r10";
+      name = "akonadiconsole-21.08.2.tar.xz";
     };
   };
   akregator = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/akregator-21.08.1.tar.xz";
-      sha256 = "03rv9m3f7vrn80jfdmnbzxsl226s82liyfam1cysxl2skkmvpimm";
-      name = "akregator-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/akregator-21.08.2.tar.xz";
+      sha256 = "15qkkfrxiwcd1gz5skqj8sb8fkr1mkc51wc2chqr4jv6aa0lbf5r";
+      name = "akregator-21.08.2.tar.xz";
     };
   };
   analitza = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/analitza-21.08.1.tar.xz";
-      sha256 = "0aagcj2dvm5aq24m6r5z79qsq2ra8xwzj7b1f64kcq8sabw7dbn4";
-      name = "analitza-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/analitza-21.08.2.tar.xz";
+      sha256 = "1y4amcl3sjpxhlqzyjmnpycgv3jfdn4458zch9qzakvjxamq6m9c";
+      name = "analitza-21.08.2.tar.xz";
     };
   };
   ark = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ark-21.08.1.tar.xz";
-      sha256 = "1ss33qizhg325k4hhf8339xg52iv4s32qjm048zhi2jaz54pdnv0";
-      name = "ark-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ark-21.08.2.tar.xz";
+      sha256 = "0hxzd0qr07wyz5v76nj4qj4db4lav53xapknmakif1fkghj1r51g";
+      name = "ark-21.08.2.tar.xz";
     };
   };
   artikulate = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/artikulate-21.08.1.tar.xz";
-      sha256 = "0x71m715iw1hv6xy36sd2gzd0cnsbn09wipp02nx2dc161lavnxk";
-      name = "artikulate-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/artikulate-21.08.2.tar.xz";
+      sha256 = "0b4fvxwrynnwr8mm87h60mhk293invaq8vw4y9dk6hv36l1z5fbf";
+      name = "artikulate-21.08.2.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/audiocd-kio-21.08.1.tar.xz";
-      sha256 = "1aqzgmpypzska5lgjwjpnbl6q2cbyiirph6h8ph5wnnb992lx8li";
-      name = "audiocd-kio-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/audiocd-kio-21.08.2.tar.xz";
+      sha256 = "1l0wym8gisgwv2mg2jsvpj8hb2yvmzd7dcximg540ljphv3hp1p2";
+      name = "audiocd-kio-21.08.2.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/baloo-widgets-21.08.1.tar.xz";
-      sha256 = "01f0hpgvlwxn3yms6yyi0ykryb78c9plp0q2z0ywk1p4lx4iywhd";
-      name = "baloo-widgets-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/baloo-widgets-21.08.2.tar.xz";
+      sha256 = "1fk8qvqh1xx6139wvyfk607vkb7w3d79gc3v3c8s96pkp5b228ax";
+      name = "baloo-widgets-21.08.2.tar.xz";
     };
   };
   blinken = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/blinken-21.08.1.tar.xz";
-      sha256 = "1bfkiwg2cwn4dizwcjb0ynzvvdxndf5172a8z0ch9b2wxlaljh87";
-      name = "blinken-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/blinken-21.08.2.tar.xz";
+      sha256 = "1ciq6fk9430p8sihc1q40djjw4994w1lghps9kr3415ryv08bfci";
+      name = "blinken-21.08.2.tar.xz";
     };
   };
   bomber = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/bomber-21.08.1.tar.xz";
-      sha256 = "1ppsnnbwsf1y9pavnpxr64k845gx1yn5p1mqswpcqgp9zd58f338";
-      name = "bomber-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/bomber-21.08.2.tar.xz";
+      sha256 = "0wk6j89m8lbp83yfz2xwy78x99cvph9p36jzscpp4i894j6fad61";
+      name = "bomber-21.08.2.tar.xz";
     };
   };
   bovo = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/bovo-21.08.1.tar.xz";
-      sha256 = "0qs96ds0clbvf7q487h9bq7l4haymdcyxzq8rlfd74qpki9cb9aa";
-      name = "bovo-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/bovo-21.08.2.tar.xz";
+      sha256 = "1k5ncxxx64yj2b71jlpz7ll935mrilhrhphwz1h8n8pdr6dn91mf";
+      name = "bovo-21.08.2.tar.xz";
     };
   };
   calendarsupport = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/calendarsupport-21.08.1.tar.xz";
-      sha256 = "0n9mbwdgyc4530g1rn9b393qq8pgpcclcpip9p72q8qc630jsvbw";
-      name = "calendarsupport-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/calendarsupport-21.08.2.tar.xz";
+      sha256 = "01plq4qzp94lxcc2gp04afnlvmni8993c8mf6kl256158z0y24ik";
+      name = "calendarsupport-21.08.2.tar.xz";
     };
   };
   cantor = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/cantor-21.08.1.tar.xz";
-      sha256 = "18gl6bw8mnn9sp4jws5b57k9w9scqg53ynw6yrabx2796k0hwfiw";
-      name = "cantor-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/cantor-21.08.2.tar.xz";
+      sha256 = "07xxwm3aa00v6cax7nyv326glapll01qh4libszhhn8pwpiyl00w";
+      name = "cantor-21.08.2.tar.xz";
     };
   };
   cervisia = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/cervisia-21.08.1.tar.xz";
-      sha256 = "0dah0lgzpdzxyvccqk2k2qbl5x4dl53qp23d0rxb5cg1ba5h7n2l";
-      name = "cervisia-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/cervisia-21.08.2.tar.xz";
+      sha256 = "0x4hisqfkizjxzl34s0yc6dn5r5fyh7f5yaadq5g47fdcah5cmmf";
+      name = "cervisia-21.08.2.tar.xz";
     };
   };
   dolphin = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/dolphin-21.08.1.tar.xz";
-      sha256 = "1vmk9iaylw427x203ccdjhlbah3dr5fz7l3lc113nczq54kcwpbf";
-      name = "dolphin-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/dolphin-21.08.2.tar.xz";
+      sha256 = "18aiqpf8qsig64gpcn6b1f0fs5mvzbdg8ncbhcjq0gy8gh3xamj2";
+      name = "dolphin-21.08.2.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/dolphin-plugins-21.08.1.tar.xz";
-      sha256 = "0gnmr73ly0djngp3imdi4zm72icj3gilqcshb4ks3rq3lwk408rr";
-      name = "dolphin-plugins-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/dolphin-plugins-21.08.2.tar.xz";
+      sha256 = "0278pmakd4xqc8ckyxkzvf1xj1jp7jdq3a86i0n0k691zfljnan7";
+      name = "dolphin-plugins-21.08.2.tar.xz";
     };
   };
   dragon = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/dragon-21.08.1.tar.xz";
-      sha256 = "050jrizyip362fanrbx3fwp4n69sr7d4y2w6n70aqv8hhi90xqjy";
-      name = "dragon-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/dragon-21.08.2.tar.xz";
+      sha256 = "0ddijz96z58582w298jp11vns9fx3rmzqd3x1qplxvp4sl0hp9l7";
+      name = "dragon-21.08.2.tar.xz";
     };
   };
   elisa = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/elisa-21.08.1.tar.xz";
-      sha256 = "12kr5aixw5gdmy2vj6id0wmznkwg6p1ysxcqayk8bwvv2qz2pygr";
-      name = "elisa-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/elisa-21.08.2.tar.xz";
+      sha256 = "14wi7dva0bfagxw49bs80qszqcv6k16s0569mh1c4m97gzlzgv35";
+      name = "elisa-21.08.2.tar.xz";
     };
   };
   eventviews = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/eventviews-21.08.1.tar.xz";
-      sha256 = "04z5cb4vhxcwxp8dwv7w4400zmj090gr7dm4d4h4x39312d25rhh";
-      name = "eventviews-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/eventviews-21.08.2.tar.xz";
+      sha256 = "0d1ahknazkjav9641i1wggj9f67cr3s3y176v1j6ljhr4dl3m3xj";
+      name = "eventviews-21.08.2.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ffmpegthumbs-21.08.1.tar.xz";
-      sha256 = "13v5y99fvj0p9f9hqafw652qzb7z267fjfsqykv7wb3pv274f11w";
-      name = "ffmpegthumbs-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ffmpegthumbs-21.08.2.tar.xz";
+      sha256 = "1gsxcm86aq3r485ivk532a949z5l4129kildbd752c2qy0hdy5z1";
+      name = "ffmpegthumbs-21.08.2.tar.xz";
     };
   };
   filelight = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/filelight-21.08.1.tar.xz";
-      sha256 = "0smvvh7g9p0vh4s3xd0pk6whszk8vmqv9ww1jp0y3dy6ai2cwixi";
-      name = "filelight-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/filelight-21.08.2.tar.xz";
+      sha256 = "0phisyrnxc6i19253fdayx8cn51y6vxd66gfdy08hi4r31ih57jd";
+      name = "filelight-21.08.2.tar.xz";
     };
   };
   granatier = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/granatier-21.08.1.tar.xz";
-      sha256 = "1n7bvkh118530hi0aka9wwz7kycljwawb5d0wxzjb74kqp5rp0lv";
-      name = "granatier-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/granatier-21.08.2.tar.xz";
+      sha256 = "1bly3jlmn9d2im05srr3v28mw8wmr3hnw180wi8lpfzianh589v7";
+      name = "granatier-21.08.2.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/grantlee-editor-21.08.1.tar.xz";
-      sha256 = "1nfqylrnkvhjiygah527i9q16987n99ry69nwd1000xvf7r1k2yd";
-      name = "grantlee-editor-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/grantlee-editor-21.08.2.tar.xz";
+      sha256 = "1sm35c4r5sawcrclv1sc6ij4gsll87zwmissahgf30km32vz0rbv";
+      name = "grantlee-editor-21.08.2.tar.xz";
     };
   };
   grantleetheme = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/grantleetheme-21.08.1.tar.xz";
-      sha256 = "0zscb0wb85g1r0zcqb50ylg1r0640mjk985ifffnjzxlx4ayqglm";
-      name = "grantleetheme-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/grantleetheme-21.08.2.tar.xz";
+      sha256 = "0xm19a21y8b4cqiqg6mhxip1xxk7hrz88z1sijhhgc8d14i7mkdk";
+      name = "grantleetheme-21.08.2.tar.xz";
     };
   };
   gwenview = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/gwenview-21.08.1.tar.xz";
-      sha256 = "187br8271z00v02vllpxqwk8x6y38gg43xixczd8x4j0p6rgv8a0";
-      name = "gwenview-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/gwenview-21.08.2.tar.xz";
+      sha256 = "0yignay0g4vz3zj9xpziinsqd8pwywd1cq43f0n5hmzxrrv0abcf";
+      name = "gwenview-21.08.2.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/incidenceeditor-21.08.1.tar.xz";
-      sha256 = "1xyb106ck64qq4z083g0qx9n3rax5ma41jsfwl8am8w5q4szxw31";
-      name = "incidenceeditor-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/incidenceeditor-21.08.2.tar.xz";
+      sha256 = "0xrz3kzf4mc37zgfbjgc23l7wxry9m6d5igvyf1qm33yxwr4w78q";
+      name = "incidenceeditor-21.08.2.tar.xz";
     };
   };
   itinerary = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/itinerary-21.08.1.tar.xz";
-      sha256 = "018871y48yd2z2qsrnjhymb72nn4by2l8lrz38gcd9fq2dwlh5fs";
-      name = "itinerary-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/itinerary-21.08.2.tar.xz";
+      sha256 = "059n7xy3gjbqxl9cn7nxng9y4662ggi2lh2zj3yv0knwy78ccwjk";
+      name = "itinerary-21.08.2.tar.xz";
     };
   };
   juk = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/juk-21.08.1.tar.xz";
-      sha256 = "0q2q31r72d28hhabrnwglhcz6h3ay70i4fg7gyn658njvx8gl26b";
-      name = "juk-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/juk-21.08.2.tar.xz";
+      sha256 = "0c74s9ylx1xh1y581ygm6zyafwv3l5d7297wfg50f64nyr5npxm2";
+      name = "juk-21.08.2.tar.xz";
     };
   };
   k3b = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/k3b-21.08.1.tar.xz";
-      sha256 = "1gs4api78ngyb03sgknhc1cil6rx7rd1y66674lmi3sssyhi6bkz";
-      name = "k3b-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/k3b-21.08.2.tar.xz";
+      sha256 = "1g9xgzklsyard3ghcmr9irixcilga6kcj46jav884y8w7zxb4mrd";
+      name = "k3b-21.08.2.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kaccounts-integration-21.08.1.tar.xz";
-      sha256 = "1860njydckpdz34y7g94pa4xz0229j1szj8ihvql05kgysdm11qp";
-      name = "kaccounts-integration-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kaccounts-integration-21.08.2.tar.xz";
+      sha256 = "1ckwm2kwb83kl89491wrmpd748zhkwd1vyaffwiyaqkp4rkrjph0";
+      name = "kaccounts-integration-21.08.2.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kaccounts-providers-21.08.1.tar.xz";
-      sha256 = "1w5k7y8xakp1lf4ca3wip7af3f9avd04i6zixv7kq9w3fh1mndp0";
-      name = "kaccounts-providers-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kaccounts-providers-21.08.2.tar.xz";
+      sha256 = "15q1ibhxwxcvsjn6b2whyynhipq5b571d98bz20dn25fff88xllg";
+      name = "kaccounts-providers-21.08.2.tar.xz";
     };
   };
   kaddressbook = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kaddressbook-21.08.1.tar.xz";
-      sha256 = "05lrxban904szlqhri71qqfykyygsxwgsx9w406s213vwkakirxb";
-      name = "kaddressbook-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kaddressbook-21.08.2.tar.xz";
+      sha256 = "1pvd31zpam13jv0mhxzaagdlvnav60znd68l24y1dw5i98wk7n72";
+      name = "kaddressbook-21.08.2.tar.xz";
     };
   };
   kajongg = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kajongg-21.08.1.tar.xz";
-      sha256 = "1izm0n2nsvxh9zvws53q4hkpzjihjwwccspas7k10ryasgp4nwsb";
-      name = "kajongg-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kajongg-21.08.2.tar.xz";
+      sha256 = "0c8kxh6kbk7ml16df4gmr142rjllc7v0v7m3kw4ksngk93f7vz2s";
+      name = "kajongg-21.08.2.tar.xz";
     };
   };
   kalarm = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kalarm-21.08.1.tar.xz";
-      sha256 = "088461j6piwas0g4chpj579r3bhyncmyajsfh2hz4679ir5lf6yh";
-      name = "kalarm-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kalarm-21.08.2.tar.xz";
+      sha256 = "06cww023m4ng4g3v344lci0rvapk4zyzf1vi5jlajfs5d8bfkgf5";
+      name = "kalarm-21.08.2.tar.xz";
     };
   };
   kalarmcal = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kalarmcal-21.08.1.tar.xz";
-      sha256 = "1s0yrh0y54rjp4d6y8vcixxrlsdra1xr8j3lxswl2h866p87v7fa";
-      name = "kalarmcal-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kalarmcal-21.08.2.tar.xz";
+      sha256 = "0xdcazbbkm2z0r2g1avwh9bvdkvv0fy6qhhddlmfzj4cwh4c9vih";
+      name = "kalarmcal-21.08.2.tar.xz";
     };
   };
   kalgebra = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kalgebra-21.08.1.tar.xz";
-      sha256 = "0a8hmzdslr92v9a8pjf7rnmpf040l9cizzlx8xrxqk2bdb7qls5w";
-      name = "kalgebra-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kalgebra-21.08.2.tar.xz";
+      sha256 = "07fw8ab8gy9mam5dij6i9nl1zv4fp13vari6nzdk337klhsdbsjr";
+      name = "kalgebra-21.08.2.tar.xz";
     };
   };
   kalzium = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kalzium-21.08.1.tar.xz";
-      sha256 = "0ijxyzryry1j9gfdmk56dlzyb4iz0v4vmjzjnqkv6sq2lm47lhyp";
-      name = "kalzium-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kalzium-21.08.2.tar.xz";
+      sha256 = "0hjkpgclm67nyninywdmcpi7vn3jmf7ikbd4afg4bhj5mcz2a4vg";
+      name = "kalzium-21.08.2.tar.xz";
     };
   };
   kamera = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kamera-21.08.1.tar.xz";
-      sha256 = "0cmppa8bc9iqbdk0pbnzrj1qqryqmrdgs7hliay3hsl7gjlz9zgy";
-      name = "kamera-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kamera-21.08.2.tar.xz";
+      sha256 = "1arb93sa730ha8bgbcvp6bng8s4fp9yvcv0qvkhk2nl4db4m5rng";
+      name = "kamera-21.08.2.tar.xz";
     };
   };
   kamoso = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kamoso-21.08.1.tar.xz";
-      sha256 = "15nqy97m913f0sdjs15bjivs7hvxghlhlw5579fsnfahg5iz5qp6";
-      name = "kamoso-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kamoso-21.08.2.tar.xz";
+      sha256 = "0rkd9mk7rgha40j19rwpyqmn8lchqahakn4p3sbab7h3p3cq2b7p";
+      name = "kamoso-21.08.2.tar.xz";
     };
   };
   kanagram = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kanagram-21.08.1.tar.xz";
-      sha256 = "1jqrmgyd2ijqb1sq17r7mijvcix6syys02kyasyilwgibbnlzjz1";
-      name = "kanagram-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kanagram-21.08.2.tar.xz";
+      sha256 = "12iq58jc36rp664c92s7442gnxq6k1fi4017a4hwqq67b9ismgzl";
+      name = "kanagram-21.08.2.tar.xz";
     };
   };
   kapman = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kapman-21.08.1.tar.xz";
-      sha256 = "072376xqm4a8fwvslf9grsklvzb50d9f098z4qba1lh3y3ivp7wm";
-      name = "kapman-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kapman-21.08.2.tar.xz";
+      sha256 = "04yv6j2bjlgclp916k2gibhhv5d64sxk181cqw7sh5j4aq555a3r";
+      name = "kapman-21.08.2.tar.xz";
     };
   };
   kapptemplate = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kapptemplate-21.08.1.tar.xz";
-      sha256 = "1crll3dr299qpigh2w9psvpi0r4jmb8y0b0facfcfcs6j9ldfbw5";
-      name = "kapptemplate-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kapptemplate-21.08.2.tar.xz";
+      sha256 = "0vgfz4pz9yjns4dpks8mrp8zzipka4chw257l1db25khibksgh48";
+      name = "kapptemplate-21.08.2.tar.xz";
     };
   };
   kate = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kate-21.08.1.tar.xz";
-      sha256 = "0k9kf8x5gbj5vbnr6lfhizi8122p76xixw480a3zsqi57i4bxk0z";
-      name = "kate-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kate-21.08.2.tar.xz";
+      sha256 = "1cm6iq3cqmp0kvsxhv0vlqy1dyzmis9fb0a6298q0lyjkmsri26n";
+      name = "kate-21.08.2.tar.xz";
     };
   };
   katomic = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/katomic-21.08.1.tar.xz";
-      sha256 = "1595swszpw2ia9dh5c6wgrz04qlcvw84l474imkms4gv1cz583pb";
-      name = "katomic-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/katomic-21.08.2.tar.xz";
+      sha256 = "0lng3fpc1b255n8hayla3lpb77rmgvx8bkzi1s152kq7bf2mnxj7";
+      name = "katomic-21.08.2.tar.xz";
     };
   };
   kbackup = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kbackup-21.08.1.tar.xz";
-      sha256 = "04795m0r4icfpv6166ingb82mfai0g6q48f9qvcqn029z0f347ya";
-      name = "kbackup-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kbackup-21.08.2.tar.xz";
+      sha256 = "06xvw94m6zr7zj0i54if9vanbflnj88b0c16751br6ibp2m9zvlp";
+      name = "kbackup-21.08.2.tar.xz";
     };
   };
   kblackbox = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kblackbox-21.08.1.tar.xz";
-      sha256 = "019nd86wmm1m8yz0lsayx37mqyzhx1pa5kbddajf5032dscncymd";
-      name = "kblackbox-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kblackbox-21.08.2.tar.xz";
+      sha256 = "093k42259lwbhmq6pm5hv1iqm4maqd63qic80p748wmh88bsh8yg";
+      name = "kblackbox-21.08.2.tar.xz";
     };
   };
   kblocks = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kblocks-21.08.1.tar.xz";
-      sha256 = "1grgkikl7zcs58y86kaw6slq7wvqa51g85kvwrysniv6l3yzhvxj";
-      name = "kblocks-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kblocks-21.08.2.tar.xz";
+      sha256 = "0p4k3wr8756qfxr09daqp7z3461ljnd3yv34h893j5dini1lfy3d";
+      name = "kblocks-21.08.2.tar.xz";
     };
   };
   kbounce = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kbounce-21.08.1.tar.xz";
-      sha256 = "18sd3yzz0mj9j666pnkm49ngfzh7aw125a5zyf1k947z6ayv5zix";
-      name = "kbounce-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kbounce-21.08.2.tar.xz";
+      sha256 = "06zd4p8glpzp7q4a8qcmnj1lszgfdircfkgc8ay5abmfx2rr9hcw";
+      name = "kbounce-21.08.2.tar.xz";
     };
   };
   kbreakout = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kbreakout-21.08.1.tar.xz";
-      sha256 = "0264w926ldfhdx22z1iqk41w5a9gnycff4vdjf0i6rzyws2qsb0g";
-      name = "kbreakout-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kbreakout-21.08.2.tar.xz";
+      sha256 = "1gj37ryhak1czv95ksigssmbmicdpirzi1l5zsv1w7jdh4nqcz54";
+      name = "kbreakout-21.08.2.tar.xz";
     };
   };
   kbruch = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kbruch-21.08.1.tar.xz";
-      sha256 = "1rbkwzca3m93p3z294cwkiyycg0w87r6j37v0zyiq802pwkkpm34";
-      name = "kbruch-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kbruch-21.08.2.tar.xz";
+      sha256 = "1syy188f3sg3r22f7dklzman0h8fz6r1n4r5z986240q0r316rbn";
+      name = "kbruch-21.08.2.tar.xz";
     };
   };
   kcachegrind = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kcachegrind-21.08.1.tar.xz";
-      sha256 = "09zgilcya7asj2si747snli6h0s7wzgjzkns9f53rwvq06xbp2zv";
-      name = "kcachegrind-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kcachegrind-21.08.2.tar.xz";
+      sha256 = "126qa061bwz2d4s721vbv2099mz07vw3i1yw7vm0b3ih43h95149";
+      name = "kcachegrind-21.08.2.tar.xz";
     };
   };
   kcalc = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kcalc-21.08.1.tar.xz";
-      sha256 = "0si3mp1xbk6gps5fhc9fv1vskx37pgwx72i2x1kcm7azif26nzsk";
-      name = "kcalc-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kcalc-21.08.2.tar.xz";
+      sha256 = "01923w7zav2iia5pffs33vhblzh26lr1zpf2274cgplsbb5lcc9p";
+      name = "kcalc-21.08.2.tar.xz";
     };
   };
   kcalutils = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kcalutils-21.08.1.tar.xz";
-      sha256 = "1xrggb8vv8lrjyhdb9yf2fzs36q766if78hlymgfndj1z37s0m6m";
-      name = "kcalutils-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kcalutils-21.08.2.tar.xz";
+      sha256 = "0kvfpsz6zxdbgl4qvk3q55fjgjql1chx844cys26anhza0ld9afz";
+      name = "kcalutils-21.08.2.tar.xz";
     };
   };
   kcharselect = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kcharselect-21.08.1.tar.xz";
-      sha256 = "0qbhmyczc13kmbls06732i91s8n6w396dfj1z50z28wrkyqls8zr";
-      name = "kcharselect-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kcharselect-21.08.2.tar.xz";
+      sha256 = "08x060xmnyzqyadimwdqz767q29rmd48m8aqr3dsrzvb969ijnha";
+      name = "kcharselect-21.08.2.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kcolorchooser-21.08.1.tar.xz";
-      sha256 = "13zdyksijxflvjb3zaszl6q7wzwz0pxsq8hyi5pb2gb7gryz65h7";
-      name = "kcolorchooser-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kcolorchooser-21.08.2.tar.xz";
+      sha256 = "00vn2001crd0in3zd016xkhm38qgl7m03k1n90fiashjlnfd0928";
+      name = "kcolorchooser-21.08.2.tar.xz";
     };
   };
   kcron = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kcron-21.08.1.tar.xz";
-      sha256 = "0c9d3rlml2adk11bp541l1zpbgp3q6mfhb7bpq4alrwlrbd4fxan";
-      name = "kcron-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kcron-21.08.2.tar.xz";
+      sha256 = "1ryfa084cfp7v11lbr58j4rx3n4m70ynpzbyavin31x1zzbw7bh8";
+      name = "kcron-21.08.2.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kde-dev-scripts-21.08.1.tar.xz";
-      sha256 = "1pv0qj7xpvxqgcrjbr9989cax0aan64cbipia4kmlg7kriz5wz6c";
-      name = "kde-dev-scripts-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kde-dev-scripts-21.08.2.tar.xz";
+      sha256 = "093i4k4qqmjlffjyz7wqfv4lpsq6x9rc4svldbq5iszk8a7ldal5";
+      name = "kde-dev-scripts-21.08.2.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kde-dev-utils-21.08.1.tar.xz";
-      sha256 = "02ksa35xh8vw08pqik7q8v3wax1fcvx2inicm1b2z2c4gq5k766l";
-      name = "kde-dev-utils-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kde-dev-utils-21.08.2.tar.xz";
+      sha256 = "1gidcxnixymzvdqjyzwdc9bfphvrbq7xx1miabn221gjc42bkggs";
+      name = "kde-dev-utils-21.08.2.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdebugsettings-21.08.1.tar.xz";
-      sha256 = "1fmnmvyzlhczbsxdpnm3bi50pdh2659raizaqbal2yjxcp6rlb90";
-      name = "kdebugsettings-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdebugsettings-21.08.2.tar.xz";
+      sha256 = "1wpj1hldrpbi538fd69i36zr3q3dg04i5bcmy41i1brzbddxl6sv";
+      name = "kdebugsettings-21.08.2.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdeconnect-kde-21.08.1.tar.xz";
-      sha256 = "01nwzsryxg7kkxb6g4h0lwn6g5zx4k64vizqk4gsvkif8d5zfc33";
-      name = "kdeconnect-kde-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdeconnect-kde-21.08.2.tar.xz";
+      sha256 = "09dv3l5g0wjilpga11mkxbyy3d8xk46pb2i35yvjbgi9yzp0xzfv";
+      name = "kdeconnect-kde-21.08.2.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdeedu-data-21.08.1.tar.xz";
-      sha256 = "19hc9mykw8q0krcxmrjq4mhn5dljfrv9pzv38dm80w3yfflj8y65";
-      name = "kdeedu-data-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdeedu-data-21.08.2.tar.xz";
+      sha256 = "0zm7gl4nz1b6m9m8hw5zklf5nbfh6qms7qbrrdxzcn6kj50zx6m2";
+      name = "kdeedu-data-21.08.2.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdegraphics-mobipocket-21.08.1.tar.xz";
-      sha256 = "06zpm5d58q10dalm2lm7v7lcjmainn3lmagra6a1f007yshm3i32";
-      name = "kdegraphics-mobipocket-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdegraphics-mobipocket-21.08.2.tar.xz";
+      sha256 = "15wd7sfwfz3n1a0m0l2ymyhsdxjajw3kkl4piv9956amcg1bxlcp";
+      name = "kdegraphics-mobipocket-21.08.2.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdegraphics-thumbnailers-21.08.1.tar.xz";
-      sha256 = "0hqdxsnv6xgvy2knnhq733hbfgzhr6f4fi63l80saysqvpjyrxly";
-      name = "kdegraphics-thumbnailers-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdegraphics-thumbnailers-21.08.2.tar.xz";
+      sha256 = "1261kn4fa2lrissqc9cb5s7rd94pzfzq79kjw3gagbhrjfs91872";
+      name = "kdegraphics-thumbnailers-21.08.2.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdenetwork-filesharing-21.08.1.tar.xz";
-      sha256 = "1q5wisy6gz94lbf3dnmxp3rq0c5b1laajph8lnlm9dhfxxmrkacf";
-      name = "kdenetwork-filesharing-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdenetwork-filesharing-21.08.2.tar.xz";
+      sha256 = "0xyph51w7ba0jrp9dds0v97k7av2h5a3098h7wpwd0sclj2hbnwc";
+      name = "kdenetwork-filesharing-21.08.2.tar.xz";
     };
   };
   kdenlive = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdenlive-21.08.1.tar.xz";
-      sha256 = "0gjv1fm07f1qckpmlvia58myg9si9z46nwxiz1lcca5mx5k7rpcz";
-      name = "kdenlive-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdenlive-21.08.2.tar.xz";
+      sha256 = "10x160sdj7dk27aa7iyvfmpgfidc8pisfmx6a50z0b23y54kg77m";
+      name = "kdenlive-21.08.2.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdepim-addons-21.08.1.tar.xz";
-      sha256 = "08vpjcqnjh99bbmwp3h64anp53zafifblqy2f7bqkvwifmlrqvz8";
-      name = "kdepim-addons-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdepim-addons-21.08.2.tar.xz";
+      sha256 = "050kbxh89drd0yd9gzjjipmz1cvxkk5riivr5fcccqayyvskvyh2";
+      name = "kdepim-addons-21.08.2.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdepim-runtime-21.08.1.tar.xz";
-      sha256 = "0ai6v5sysh5pzwpvbhjzi1fvfp608abpndh9nhnm7b87hca73vm9";
-      name = "kdepim-runtime-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdepim-runtime-21.08.2.tar.xz";
+      sha256 = "0vzly768f2g0zhprl1970k16kza128izhrby2mm1wdskrmdrvflq";
+      name = "kdepim-runtime-21.08.2.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdesdk-kioslaves-21.08.1.tar.xz";
-      sha256 = "0cz2cmcgksfkgl2nh0nnyz38q3rp1dfwhnajgcif5q0ka528v33w";
-      name = "kdesdk-kioslaves-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdesdk-kioslaves-21.08.2.tar.xz";
+      sha256 = "1g4i7sc30m7sjmmgjf12b83yhcwpdnvb7gzdjs1da5np5nq96j4y";
+      name = "kdesdk-kioslaves-21.08.2.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdesdk-thumbnailers-21.08.1.tar.xz";
-      sha256 = "1cvh2p3vfzbqbr9cfa1bchgflmp9mi12qx1j6j1jdaqqwhz43kj6";
-      name = "kdesdk-thumbnailers-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdesdk-thumbnailers-21.08.2.tar.xz";
+      sha256 = "1bdwdpvdqx19j714fnxfhi3b647ynm1cgrkny7i27pkqlyw72hjg";
+      name = "kdesdk-thumbnailers-21.08.2.tar.xz";
     };
   };
   kdf = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdf-21.08.1.tar.xz";
-      sha256 = "1xmn7dhbnj9bhaw545ry0qwayxh3jhpgx9xa2fjcc0dhn8yx1spv";
-      name = "kdf-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdf-21.08.2.tar.xz";
+      sha256 = "1z2m9a4rzjsjxv9pkassn3j7pxkqrpq04hw0j6q913q69a999rwg";
+      name = "kdf-21.08.2.tar.xz";
     };
   };
   kdialog = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdialog-21.08.1.tar.xz";
-      sha256 = "1mxmj5cm5h1dhqkblcqdc7ba9x04sqj6gp0b12gii7jsz3g0pa94";
-      name = "kdialog-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdialog-21.08.2.tar.xz";
+      sha256 = "08klapfcxwp3mf7jv7swsia4719fq6aqdv7lnxr16j8sd6h3z0yx";
+      name = "kdialog-21.08.2.tar.xz";
     };
   };
   kdiamond = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kdiamond-21.08.1.tar.xz";
-      sha256 = "0l8z71k0a300yp03mkpabi3a9xydky6x19sk7xhq727canrb3nwz";
-      name = "kdiamond-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kdiamond-21.08.2.tar.xz";
+      sha256 = "1k458rs0x82jf4sjzcry4xzazwfn9drg41736749nc5d26k6csz1";
+      name = "kdiamond-21.08.2.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/keditbookmarks-21.08.1.tar.xz";
-      sha256 = "0j9m5l3llb969ras4bvsswahqqpwrv1zscjpdscchk72vxi2ky4w";
-      name = "keditbookmarks-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/keditbookmarks-21.08.2.tar.xz";
+      sha256 = "07yscqr3zzjvb1snl1k0ilmpgv8wrxvjrjdcr1410llfwd80fpvi";
+      name = "keditbookmarks-21.08.2.tar.xz";
     };
   };
   kfind = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kfind-21.08.1.tar.xz";
-      sha256 = "0d3milbrznwls197a5bjrdwarpdly4pyask7j97ia7nx0z91k35f";
-      name = "kfind-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kfind-21.08.2.tar.xz";
+      sha256 = "1rqn77m8i3fvknkq4gdl4fyihxkc34537010d6i992pxcx9yxv4d";
+      name = "kfind-21.08.2.tar.xz";
     };
   };
   kfloppy = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kfloppy-21.08.1.tar.xz";
-      sha256 = "1nxkjaarvr7fq494hb4pk6nf9731f74zsxhfia3lzb2qf3rnxhvg";
-      name = "kfloppy-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kfloppy-21.08.2.tar.xz";
+      sha256 = "0g54qwrmqkd3jxi6nwprzd0jckzdq3iawibfsfblkchnd8hnlxiw";
+      name = "kfloppy-21.08.2.tar.xz";
     };
   };
   kfourinline = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kfourinline-21.08.1.tar.xz";
-      sha256 = "0niwvc1fxvxk5xi90n753y7gjhljrnm3jjzxgjxs9ca5y1c7jcac";
-      name = "kfourinline-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kfourinline-21.08.2.tar.xz";
+      sha256 = "0z28lzx9jqp2krgwf6cpwv4hhyl8q8azgw3ni24c8hjl81sxidvb";
+      name = "kfourinline-21.08.2.tar.xz";
     };
   };
   kgeography = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kgeography-21.08.1.tar.xz";
-      sha256 = "0wqblfs4h8pr0c3m9qv5xpz1sq1zxxbbgv42d0m12fhlbmhx0l64";
-      name = "kgeography-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kgeography-21.08.2.tar.xz";
+      sha256 = "16rqlh2n4xz5rcs0p9ppzsk7wh060zf1i5yfx4cjrswfn2wk5brv";
+      name = "kgeography-21.08.2.tar.xz";
     };
   };
   kget = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kget-21.08.1.tar.xz";
-      sha256 = "06lng1sr1l5a7qcbld7xn97vlaxnq4f98sai2llmjkyna3awzi6r";
-      name = "kget-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kget-21.08.2.tar.xz";
+      sha256 = "11h073nkk5axr263wz5wjq8pdad2wk3nmhixx12ilkqqinb0pi6h";
+      name = "kget-21.08.2.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kgoldrunner-21.08.1.tar.xz";
-      sha256 = "1dggs4fbfqc7q97j8fpi2v6q52165yikaps15mracn319c8mbx85";
-      name = "kgoldrunner-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kgoldrunner-21.08.2.tar.xz";
+      sha256 = "13y8a1zxfy16sbdf2c94wdx15ghmb436pzx7kvvsfv8d5yizlzdz";
+      name = "kgoldrunner-21.08.2.tar.xz";
     };
   };
   kgpg = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kgpg-21.08.1.tar.xz";
-      sha256 = "0q4k7ahh1qr4fnkw4na5kyp4kq922a45hjgz9qzh7whn6zqrhsxs";
-      name = "kgpg-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kgpg-21.08.2.tar.xz";
+      sha256 = "051z9h12zqmhgvr8pk17vsfzld25mpklk1z6nknlf3hydjnq6ns1";
+      name = "kgpg-21.08.2.tar.xz";
     };
   };
   khangman = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/khangman-21.08.1.tar.xz";
-      sha256 = "1jv7vbk4za17l73b10xx1ckv56qhsvlf2irlys917bk39jhxmwpp";
-      name = "khangman-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/khangman-21.08.2.tar.xz";
+      sha256 = "0xrwsg5pv1y5lh6d2na1gx8aiimpbl8y2i9a4qj3qg5l4nf0inal";
+      name = "khangman-21.08.2.tar.xz";
     };
   };
   khelpcenter = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/khelpcenter-21.08.1.tar.xz";
-      sha256 = "09ayg8kb4b4v30xjm8ca5csw1axipn1336mq2sfqra5qwkj8d93y";
-      name = "khelpcenter-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/khelpcenter-21.08.2.tar.xz";
+      sha256 = "0ivm1z7c6yy6dm9sb88ggiww9c2k526lhpipkgiwm6kslzallxsn";
+      name = "khelpcenter-21.08.2.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kidentitymanagement-21.08.1.tar.xz";
-      sha256 = "0xhkz33w0z9jlxlqb06w5fiyj1qz2mjssrbba2kdm55q67lj1b76";
-      name = "kidentitymanagement-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kidentitymanagement-21.08.2.tar.xz";
+      sha256 = "0kaws0w21sm0mb0fd5av7gid8gvyz0zxxjrbx0kf3c52dwkrmw5c";
+      name = "kidentitymanagement-21.08.2.tar.xz";
     };
   };
   kig = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kig-21.08.1.tar.xz";
-      sha256 = "0gvp07mnkpfamdq78bv2r1m84l4xp23qh2i6iscdhjdh05dzyl6s";
-      name = "kig-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kig-21.08.2.tar.xz";
+      sha256 = "1i5lszzj200mda7vbc8c6bzdlx8ycf2d8kk28pl2n17ajra33iim";
+      name = "kig-21.08.2.tar.xz";
     };
   };
   kigo = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kigo-21.08.1.tar.xz";
-      sha256 = "1y7fh9acng4a135bz7skg7hgmyisaxgwli4ddv7y5h3r1rlhfd47";
-      name = "kigo-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kigo-21.08.2.tar.xz";
+      sha256 = "0ss15k2qpmrf4xvsjpqpvf9pvw8wijmk4zqqhvsjrbd5xrk53bkf";
+      name = "kigo-21.08.2.tar.xz";
     };
   };
   killbots = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/killbots-21.08.1.tar.xz";
-      sha256 = "02rh60ww43r3zqv3v7zs42j7nl8b5373mykbql80amxnbj5965mn";
-      name = "killbots-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/killbots-21.08.2.tar.xz";
+      sha256 = "11cgkx5wpzgzx62frn90h35ga2scrvyxv7sasfsxldf3yiv15m30";
+      name = "killbots-21.08.2.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kimagemapeditor-21.08.1.tar.xz";
-      sha256 = "1mrf0k923gwy4cfh7g5yv0nnm4kx0j0yk9sz051sbvvbm4hbxqjg";
-      name = "kimagemapeditor-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kimagemapeditor-21.08.2.tar.xz";
+      sha256 = "0k1jl5d9qxdg9lrz19vzjbsnpnf236hmckvwy9c620sik0rzpj12";
+      name = "kimagemapeditor-21.08.2.tar.xz";
     };
   };
   kimap = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kimap-21.08.1.tar.xz";
-      sha256 = "19b8awcbrn61dwqli10v883i8s18sjz8w335c2sxlhzqgdijgxhl";
-      name = "kimap-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kimap-21.08.2.tar.xz";
+      sha256 = "0qdl94zqk0qvy5mcnbhskh7dskcx8g1bkv4qv8zjjj9rz1r2rm2x";
+      name = "kimap-21.08.2.tar.xz";
     };
   };
   kio-extras = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kio-extras-21.08.1.tar.xz";
-      sha256 = "0wlgd0cc56gzicgi16nx4592i6f6594d1mvz7d0266xrwmm8n688";
-      name = "kio-extras-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kio-extras-21.08.2.tar.xz";
+      sha256 = "0735c9n50qflkcl8j032m84wvb6alv8rr9yfhyzflzv56k8r4034";
+      name = "kio-extras-21.08.2.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kio-gdrive-21.08.1.tar.xz";
-      sha256 = "1vqm8b819hg1yfjlz1x3yis9qkbclahp7l00cpqbxnra0ph9b1vw";
-      name = "kio-gdrive-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kio-gdrive-21.08.2.tar.xz";
+      sha256 = "0mbh5ccw3iyfnhqkidds9kq8bm7dwpx5zrnbqi93fach7zmpidk2";
+      name = "kio-gdrive-21.08.2.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kipi-plugins-21.08.1.tar.xz";
-      sha256 = "1w6sw3wn0nj15jv6qp0yg7psg1m87b3izgn303z74vzkhqw04pid";
-      name = "kipi-plugins-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kipi-plugins-21.08.2.tar.xz";
+      sha256 = "0ygji1dm6bzyn6f455l1avbw12kl5vdhx1g8lwvgfc51vflv3vxp";
+      name = "kipi-plugins-21.08.2.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kirigami-gallery-21.08.1.tar.xz";
-      sha256 = "0db1a5czq0xg0dhhmphds5vrz2lq771zwmps7gq6ahpfj01vyavd";
-      name = "kirigami-gallery-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kirigami-gallery-21.08.2.tar.xz";
+      sha256 = "1i5aly7pwc39avarqmi8wwzv6bbza5pxaz5v8jm6b57d5mampkn8";
+      name = "kirigami-gallery-21.08.2.tar.xz";
     };
   };
   kiriki = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kiriki-21.08.1.tar.xz";
-      sha256 = "0x7iq3y2jc4wykgcyrgm8gmrkvlhs8gsxdl0495n1x1invsnmj00";
-      name = "kiriki-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kiriki-21.08.2.tar.xz";
+      sha256 = "1l3sc3fi4b8hc9dyrsi66src52wygckngiwqq8hf4mj2h0hf9s55";
+      name = "kiriki-21.08.2.tar.xz";
     };
   };
   kiten = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kiten-21.08.1.tar.xz";
-      sha256 = "1skyfw5bshy6z8xvhs5q9f3c8nwqbm4mc74jcs6yhzc3i4mp82n3";
-      name = "kiten-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kiten-21.08.2.tar.xz";
+      sha256 = "12jmsg26y4ldkh5qyz2bzyd14wk401p7kl48m5ngxv95qxw2ix9s";
+      name = "kiten-21.08.2.tar.xz";
     };
   };
   kitinerary = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kitinerary-21.08.1.tar.xz";
-      sha256 = "0r7mrcs7gh9ffscksvkh5v78dr2y1nh26p8r8ginafachg32p0mi";
-      name = "kitinerary-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kitinerary-21.08.2.tar.xz";
+      sha256 = "1l21q95rszdm1gp1msr9mzlj8ay115dl4cxchhm1mz7w7h53scg3";
+      name = "kitinerary-21.08.2.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kjumpingcube-21.08.1.tar.xz";
-      sha256 = "1kh3jqp3m96lal6salcrqhgzg1pbacx20xn41c1jy272ch57r2jj";
-      name = "kjumpingcube-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kjumpingcube-21.08.2.tar.xz";
+      sha256 = "1akg30mz8j6w6dzc43z56siiljblqpah80ghbashq3h2wq3q1lxz";
+      name = "kjumpingcube-21.08.2.tar.xz";
     };
   };
   kldap = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kldap-21.08.1.tar.xz";
-      sha256 = "1m92kd6mrz3dxap6rzw0r85wij030a60n10hkgkjkxb8npgvl14g";
-      name = "kldap-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kldap-21.08.2.tar.xz";
+      sha256 = "1vc94n9wq1422bp9ky2sapy8wra0gi5gfl6dz0h8wxnxflb28zvw";
+      name = "kldap-21.08.2.tar.xz";
     };
   };
   kleopatra = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kleopatra-21.08.1.tar.xz";
-      sha256 = "1j1jd8ivcw2r2nlzzhr24kxcvfp5q1206gpkchd5mvsl6q34fmzx";
-      name = "kleopatra-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kleopatra-21.08.2.tar.xz";
+      sha256 = "1ym40xxwl9qqz8sbsck606vzxys5qhkca8g23gqn3sxx3kk8zpn9";
+      name = "kleopatra-21.08.2.tar.xz";
     };
   };
   klettres = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/klettres-21.08.1.tar.xz";
-      sha256 = "0scgccwsma1hc1zp52h4rqddwizsqzwsh6gql5lf4qxhr8ihgj4m";
-      name = "klettres-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/klettres-21.08.2.tar.xz";
+      sha256 = "1n3qw190nznz0h4l68iy9azky57f8pflx10dihhl541jspgga5lg";
+      name = "klettres-21.08.2.tar.xz";
     };
   };
   klickety = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/klickety-21.08.1.tar.xz";
-      sha256 = "0r8dr4blwv1l6b8585qw7q258qr9pgk97pmrfmpssb90yxni2c1c";
-      name = "klickety-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/klickety-21.08.2.tar.xz";
+      sha256 = "1vi4xx4y7s225b3vgi2z8l1d5z4fgz3v5jfg4zq6v1pis46zpmwz";
+      name = "klickety-21.08.2.tar.xz";
     };
   };
   klines = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/klines-21.08.1.tar.xz";
-      sha256 = "1iyk91spsnfrkbjyf6jng6rgximcav2zf2xqkq1q2vvyhwwpchn6";
-      name = "klines-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/klines-21.08.2.tar.xz";
+      sha256 = "1gxaadl8gnbaliwbnr6ychp1da5dgppk58jgv5z0zngacwy80d97";
+      name = "klines-21.08.2.tar.xz";
     };
   };
   kmag = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmag-21.08.1.tar.xz";
-      sha256 = "1hdjcya1jv6adz0d9hp1sq7y8f6fvzpw30fchmjkdm9y2kf8il6c";
-      name = "kmag-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmag-21.08.2.tar.xz";
+      sha256 = "0y68vg95fjhfsjvvn2i214jrv06f6811j1asjxrgvwcmwdf0fnc0";
+      name = "kmag-21.08.2.tar.xz";
     };
   };
   kmahjongg = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmahjongg-21.08.1.tar.xz";
-      sha256 = "1wrzyiv07cffn5xiachqa8k9spcsi3iwvdj6prgbgdndbffw2gim";
-      name = "kmahjongg-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmahjongg-21.08.2.tar.xz";
+      sha256 = "1fx4almqcz8x3pzbrjv9yd9kfb7akrfy45z7idhyb31dkdaxi40w";
+      name = "kmahjongg-21.08.2.tar.xz";
     };
   };
   kmail = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmail-21.08.1.tar.xz";
-      sha256 = "08q7c8l2nfrvw5xgc2dzcmidcpsjfya3jjnssziy3hpznmf8jpjr";
-      name = "kmail-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmail-21.08.2.tar.xz";
+      sha256 = "0way147xqjhapswdfqnnvav8dk41lf2050jzmd6jz7qj0dina977";
+      name = "kmail-21.08.2.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmail-account-wizard-21.08.1.tar.xz";
-      sha256 = "1xqm4737p5l5cwqlnn7xladz4yna7aghl84hlbvzrfcc72v5xkal";
-      name = "kmail-account-wizard-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmail-account-wizard-21.08.2.tar.xz";
+      sha256 = "0ac4p9jy3n45i0aj0fn2151pdbjmvkzyr3qlzdidzf386y7m7y9b";
+      name = "kmail-account-wizard-21.08.2.tar.xz";
     };
   };
   kmailtransport = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmailtransport-21.08.1.tar.xz";
-      sha256 = "0zd03s4848n3g1w8fm0q3kq5sy91zhjw3hc2w6ncv6cgbb9s50dv";
-      name = "kmailtransport-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmailtransport-21.08.2.tar.xz";
+      sha256 = "0q76wanhby9gb9c07z8gpkmdqn6rv82bh6fz182m7bdzkqh4rbxx";
+      name = "kmailtransport-21.08.2.tar.xz";
     };
   };
   kmbox = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmbox-21.08.1.tar.xz";
-      sha256 = "027x76lrjssrhqpr651fyqqkdv6jmiad901cssv7w54r2dpzs6w3";
-      name = "kmbox-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmbox-21.08.2.tar.xz";
+      sha256 = "055vx2cr9zqab887grjans5cassh2g86r1lcn64jb61sh1cvzj7y";
+      name = "kmbox-21.08.2.tar.xz";
     };
   };
   kmime = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmime-21.08.1.tar.xz";
-      sha256 = "0prsmiv0g6icclhv7mkha66pddmdqz2mi69njz0xwz6m3ax068jw";
-      name = "kmime-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmime-21.08.2.tar.xz";
+      sha256 = "1dg0vm576gqvj7ia80zcdyf9cyg3fzvj7j3fkxx79mw17binlzg4";
+      name = "kmime-21.08.2.tar.xz";
     };
   };
   kmines = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmines-21.08.1.tar.xz";
-      sha256 = "0nx07cghq20rja8rncrayx87v357s036whdfyzc6qkhdmlmkh6qj";
-      name = "kmines-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmines-21.08.2.tar.xz";
+      sha256 = "0vzspy446pwbd04zyq7x0s7q6nrhmdnzq3jfvv6nnazhjmxpfafv";
+      name = "kmines-21.08.2.tar.xz";
     };
   };
   kmix = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmix-21.08.1.tar.xz";
-      sha256 = "0jc0b1j32gg7az0z7m1cvfdjrwss4q91hm1cfhrk5fq12620vivf";
-      name = "kmix-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmix-21.08.2.tar.xz";
+      sha256 = "1srv1alrq2w87rmv9jriz1y37rb0fp7w14291ky64gf23phwmfdq";
+      name = "kmix-21.08.2.tar.xz";
     };
   };
   kmousetool = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmousetool-21.08.1.tar.xz";
-      sha256 = "04a5zrxg48svrvdf8gf3qc7cj7cayzhw0q4l1v8nzs2ykc330xq1";
-      name = "kmousetool-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmousetool-21.08.2.tar.xz";
+      sha256 = "1b09z6793zjjspcrhz4f1vxk3zbs4qdrkdp59q61i7ganm49znma";
+      name = "kmousetool-21.08.2.tar.xz";
     };
   };
   kmouth = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmouth-21.08.1.tar.xz";
-      sha256 = "1rmqppmjjcrc7xp63csdgp440f003nia6hcnixxlya8pwn90bpwr";
-      name = "kmouth-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmouth-21.08.2.tar.xz";
+      sha256 = "1b9bc0vnqihaqa4wfa9sqcrq92q1kyw0w1ikkx3pb8rzdzkk4cv2";
+      name = "kmouth-21.08.2.tar.xz";
     };
   };
   kmplot = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kmplot-21.08.1.tar.xz";
-      sha256 = "0mkcrdg0v98hdy5lgkyfv4x019w4sm7yiyfpryhx1wiqcpibxwl1";
-      name = "kmplot-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kmplot-21.08.2.tar.xz";
+      sha256 = "0p81x7qlpj1b84wzqqb7sxmbmnxfys0clg1k07d2hw4rb8gisgic";
+      name = "kmplot-21.08.2.tar.xz";
     };
   };
   knavalbattle = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/knavalbattle-21.08.1.tar.xz";
-      sha256 = "1lvq223jspc5y0z6qaf648m85a58yp88b0jm8510p77ymxhyvgm7";
-      name = "knavalbattle-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/knavalbattle-21.08.2.tar.xz";
+      sha256 = "0zhp8zmnsjv1ainlc98waixv2p05w8jh91clb8747rc8x4k3phxk";
+      name = "knavalbattle-21.08.2.tar.xz";
     };
   };
   knetwalk = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/knetwalk-21.08.1.tar.xz";
-      sha256 = "1akv78yaym474b57d9qxqp3vivs405m1zm6x0plf2g1adp93myz2";
-      name = "knetwalk-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/knetwalk-21.08.2.tar.xz";
+      sha256 = "1jb6w790jfngifhgp4clgakiacw0lbn40jnj00zlzcg751vl6ajl";
+      name = "knetwalk-21.08.2.tar.xz";
     };
   };
   knights = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/knights-21.08.1.tar.xz";
-      sha256 = "1m00nryw69k4dyb0vvnjz3fwasf67ghkq78l7k8ck9vvzrihmwd1";
-      name = "knights-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/knights-21.08.2.tar.xz";
+      sha256 = "0v72niszn93671c4313f3cz2y8wq5nsww0c4irsbz9jpivcq080z";
+      name = "knights-21.08.2.tar.xz";
     };
   };
   knotes = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/knotes-21.08.1.tar.xz";
-      sha256 = "1av537f02zsz72mqkzlcrv977kf96nrdwsj4fx7kmdbhf5x9rvgv";
-      name = "knotes-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/knotes-21.08.2.tar.xz";
+      sha256 = "1g3rmkpwbicga09qwhxn47rhiv9rfaacpzapsrhddh63831bl999";
+      name = "knotes-21.08.2.tar.xz";
     };
   };
   kolf = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kolf-21.08.1.tar.xz";
-      sha256 = "15wk2c2pzpg39hv6s1b80mf5l7gkbxlprahjq6wh6f6a5hm3wkxb";
-      name = "kolf-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kolf-21.08.2.tar.xz";
+      sha256 = "1dziji28syv7rirm959ahcch6696sc4y6pnfp40v11j1pw58jm8p";
+      name = "kolf-21.08.2.tar.xz";
     };
   };
   kollision = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kollision-21.08.1.tar.xz";
-      sha256 = "15ddxccj29094lxrihchc17x2a2xnjk790dqhfja9d235vkg3lpb";
-      name = "kollision-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kollision-21.08.2.tar.xz";
+      sha256 = "04hb91gqy58lvhwy0hx27xcd1pvqm378lcavswh7b142f63mhmjf";
+      name = "kollision-21.08.2.tar.xz";
     };
   };
   kolourpaint = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kolourpaint-21.08.1.tar.xz";
-      sha256 = "0vjssni7c8dx1617gsnkp8dip92agys8n1ydzdly6jpwhvlr382a";
-      name = "kolourpaint-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kolourpaint-21.08.2.tar.xz";
+      sha256 = "0p64dp63m8ycy5qrgd6fdgf670y5iqdyw4gjbkwphg01qp8kpj6d";
+      name = "kolourpaint-21.08.2.tar.xz";
     };
   };
   kompare = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kompare-21.08.1.tar.xz";
-      sha256 = "0sigh2c91ff7r6yclx18lcwqbwh4gbj55n5fjpd1fw9rb7xf9j3n";
-      name = "kompare-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kompare-21.08.2.tar.xz";
+      sha256 = "14bbqxdzj67g2m6zmz28ax6v4bzz9nmyy45flqzm8jqvq9afqb1d";
+      name = "kompare-21.08.2.tar.xz";
     };
   };
   konqueror = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/konqueror-21.08.1.tar.xz";
-      sha256 = "155dc8nd3kgr25wpjisnp9z2jr1f31vcnm8ywa98p4i59kaaxh7h";
-      name = "konqueror-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/konqueror-21.08.2.tar.xz";
+      sha256 = "0v5l1nqa0fm4q17l0rncriwyvkgq0pdg2q4kjc92kvvdvrpm3jjp";
+      name = "konqueror-21.08.2.tar.xz";
     };
   };
   konquest = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/konquest-21.08.1.tar.xz";
-      sha256 = "0i0pm5zq2ipm1ipsam19c771v16bxlhilidny336rzwfa1vik0zl";
-      name = "konquest-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/konquest-21.08.2.tar.xz";
+      sha256 = "0shky9cys79prdgr6bcmi50gvfmqr0famdq6gqacv9krbja4pl20";
+      name = "konquest-21.08.2.tar.xz";
     };
   };
   konsole = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/konsole-21.08.1.tar.xz";
-      sha256 = "0v74yrblwakbmy0p4x5j9lhmqyavgsffahr51bh5r5qcgx0cafjv";
-      name = "konsole-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/konsole-21.08.2.tar.xz";
+      sha256 = "1lhpgags85y0s5p44dpa2k0b9vq46m7h19pha59w1wy72an884ig";
+      name = "konsole-21.08.2.tar.xz";
     };
   };
   kontact = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kontact-21.08.1.tar.xz";
-      sha256 = "1aqyrkmc7hnzja1spm75ybrb9c3yg37rklcgdr7myyyhjxmvnrzg";
-      name = "kontact-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kontact-21.08.2.tar.xz";
+      sha256 = "1a7d7xfby796kk9hbqqnnhjnn5yvk99hglm4270azlcgbjxf4s2j";
+      name = "kontact-21.08.2.tar.xz";
     };
   };
   kontactinterface = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kontactinterface-21.08.1.tar.xz";
-      sha256 = "1l251rw80c329sgrv25r8cn242v0kl7pvcfv9xkakql7dw707xs9";
-      name = "kontactinterface-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kontactinterface-21.08.2.tar.xz";
+      sha256 = "0wavclk0z55z8xmqiq6wjhlf2byiggmj9fr5kwdk8wsjfj30npwg";
+      name = "kontactinterface-21.08.2.tar.xz";
     };
   };
   kontrast = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kontrast-21.08.1.tar.xz";
-      sha256 = "05nw7z05maxpcr37andv60fn9s8kprz474bkza980ah05xzvkkvb";
-      name = "kontrast-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kontrast-21.08.2.tar.xz";
+      sha256 = "12pmkkgrj848whwfz523ciix2a4dm3wgw1vva30svyvlv6qyrgwa";
+      name = "kontrast-21.08.2.tar.xz";
     };
   };
   konversation = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/konversation-21.08.1.tar.xz";
-      sha256 = "0v3nvyjc13jav8x9krg9sd9p533j7ndan0fqb5p0virwk1dznvfy";
-      name = "konversation-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/konversation-21.08.2.tar.xz";
+      sha256 = "1blaxxpp0831frw2v4ylvq23ffyqabbq1zcqj0v4kq736acdl8pa";
+      name = "konversation-21.08.2.tar.xz";
     };
   };
   kopeninghours = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kopeninghours-21.08.1.tar.xz";
-      sha256 = "09yskjfkr190vkp8xgj2hicfyg1mx9mqm7pgn4133qfn08xh52vd";
-      name = "kopeninghours-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kopeninghours-21.08.2.tar.xz";
+      sha256 = "1g4g3hc0zpklnw8an49dk25zfw740w4slkm52191q2ajymp589l0";
+      name = "kopeninghours-21.08.2.tar.xz";
     };
   };
   kopete = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kopete-21.08.1.tar.xz";
-      sha256 = "131nic6w1bzc0l94b8jkzac2dckaz64y2fgplyiqjidicm0cyrd1";
-      name = "kopete-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kopete-21.08.2.tar.xz";
+      sha256 = "015pjfc5kxhm5nmjv8fx4jlczp0l3vhqrkxgfvq83a200nlvg2pm";
+      name = "kopete-21.08.2.tar.xz";
     };
   };
   korganizer = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/korganizer-21.08.1.tar.xz";
-      sha256 = "0x05i3c0nj46bnnd7msz1rpghbr2p6sywfsa15d6l1j72i2ay0vr";
-      name = "korganizer-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/korganizer-21.08.2.tar.xz";
+      sha256 = "0izrzg5xxqgz0wq0vkv1i1xcf0xnzgfwixy8f4gcvihpqxyvixb7";
+      name = "korganizer-21.08.2.tar.xz";
     };
   };
   kosmindoormap = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kosmindoormap-21.08.1.tar.xz";
-      sha256 = "1v31cik859b994xka37z0l86nd0crykbsnafyxpmqdzf942ixixb";
-      name = "kosmindoormap-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kosmindoormap-21.08.2.tar.xz";
+      sha256 = "0yf4n48x041wl07f575hzqdkn1qmx3idpxswinsk9r8zdr2dwch7";
+      name = "kosmindoormap-21.08.2.tar.xz";
     };
   };
   kpat = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kpat-21.08.1.tar.xz";
-      sha256 = "1dxihma5mad2kbg7wzfbnaq3gmgwav70rqrj5fpji42pvlqx4vyn";
-      name = "kpat-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kpat-21.08.2.tar.xz";
+      sha256 = "16cj3w4cibar1q12wam3i623kzddhl39ychvi3nphlni5cmr4x42";
+      name = "kpat-21.08.2.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kpimtextedit-21.08.1.tar.xz";
-      sha256 = "1zaavf0gpaibk22fz8ij0fqrlp18lj07hgdg6ynhdmhamw59sfr5";
-      name = "kpimtextedit-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kpimtextedit-21.08.2.tar.xz";
+      sha256 = "0v479g998amh822lxr0l2d9xhlrwbij9prlrn1z9y9al056cic7h";
+      name = "kpimtextedit-21.08.2.tar.xz";
     };
   };
   kpkpass = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kpkpass-21.08.1.tar.xz";
-      sha256 = "0z8dk548awy37iq8zz41x2wm2i9bhpfa2g0ghlwvhj7sy97ap1vk";
-      name = "kpkpass-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kpkpass-21.08.2.tar.xz";
+      sha256 = "003rmp8svnz74qfd3727l7p5wj56j9x8w3dwk19ysyklh2rbaj2p";
+      name = "kpkpass-21.08.2.tar.xz";
     };
   };
   kpmcore = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kpmcore-21.08.1.tar.xz";
-      sha256 = "1aw21x70kgm1dmhqr384k6rbsd1fx70zd94i0slq5zyf37zx6b9l";
-      name = "kpmcore-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kpmcore-21.08.2.tar.xz";
+      sha256 = "0rn8x0add1qflsbgppmhz1zbnjvy39d5wckxga0vmhdix2m3d60g";
+      name = "kpmcore-21.08.2.tar.xz";
     };
   };
   kpublictransport = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kpublictransport-21.08.1.tar.xz";
-      sha256 = "1dbbsdrzhqaiz6d4hlyy1f50m6hi0arafxrxr65gh9h4zs2ym4qs";
-      name = "kpublictransport-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kpublictransport-21.08.2.tar.xz";
+      sha256 = "1g4k1wxhvjya0k79ysr92kq37fbdfly5qdrmp11apvar4la4xmr8";
+      name = "kpublictransport-21.08.2.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kqtquickcharts-21.08.1.tar.xz";
-      sha256 = "0ghmxzy3jqzy3zdpp5zhjv3mcq6micnnk1jhnlq03v4z981rrs6h";
-      name = "kqtquickcharts-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kqtquickcharts-21.08.2.tar.xz";
+      sha256 = "04cxw88lv7mj74znzfl3m9jzks11z837y3bch40qdn8ysk9wqjhn";
+      name = "kqtquickcharts-21.08.2.tar.xz";
     };
   };
   krdc = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/krdc-21.08.1.tar.xz";
-      sha256 = "038m7wgpg33sqqqq7iy4rvficsi7x2012rimxb1gn2azg5kcwk6v";
-      name = "krdc-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/krdc-21.08.2.tar.xz";
+      sha256 = "0zrpfbs4r0d4wnficmhn0av7877hbrl4jvxpi0qiy2gdc7zksnbd";
+      name = "krdc-21.08.2.tar.xz";
     };
   };
   kreversi = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kreversi-21.08.1.tar.xz";
-      sha256 = "1gh7zhqzyh2m34v3gyb902c6cvw33rbib5g8p3dwsmm5v2bfgggj";
-      name = "kreversi-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kreversi-21.08.2.tar.xz";
+      sha256 = "18z2aclpd0xln1n442jg13n5j2yip6dldfvd5z56g7n23l9paywq";
+      name = "kreversi-21.08.2.tar.xz";
     };
   };
   krfb = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/krfb-21.08.1.tar.xz";
-      sha256 = "0l28l9wmfxf6vihxr86pwxj027fkz0k0pwkif8had0s4swc9jfnx";
-      name = "krfb-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/krfb-21.08.2.tar.xz";
+      sha256 = "1hn21d0cp2k6zair2wwf492y0ip69f1b5axaaz9fqgmgqn0l47qb";
+      name = "krfb-21.08.2.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kross-interpreters-21.08.1.tar.xz";
-      sha256 = "1fznrng6mz9s8ynzr48p05n6akkmzn3fifbgpxs98nhzlz2ay574";
-      name = "kross-interpreters-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kross-interpreters-21.08.2.tar.xz";
+      sha256 = "07f153ib1gmbfnkchzymvwlng3sgn28zspxkrx75g8xa5jszwwym";
+      name = "kross-interpreters-21.08.2.tar.xz";
     };
   };
   kruler = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kruler-21.08.1.tar.xz";
-      sha256 = "0l78hk7zjwjxba094gjvajh32v4avdc80h5r0rv94k2r3gckfjv4";
-      name = "kruler-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kruler-21.08.2.tar.xz";
+      sha256 = "082z14vcp1ww42jrlxl128gp6y5iqrz360cipvj4xph4q7lpgb0r";
+      name = "kruler-21.08.2.tar.xz";
     };
   };
   kshisen = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kshisen-21.08.1.tar.xz";
-      sha256 = "107y828nkdzza5hi68pxxk5gp017dy2yxdmmhmg6ylppk5gfp6dp";
-      name = "kshisen-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kshisen-21.08.2.tar.xz";
+      sha256 = "12mi59n8sm7wqf53wbi2nlh4d2i673x93rlqz6qxkaqznlpf7lrr";
+      name = "kshisen-21.08.2.tar.xz";
     };
   };
   ksirk = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ksirk-21.08.1.tar.xz";
-      sha256 = "0l6bfpima9whgfdkbghhfh36p6kjs8j26gz5zc7r8fcswv66ya21";
-      name = "ksirk-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ksirk-21.08.2.tar.xz";
+      sha256 = "1j6nzyl3ppi68d1y84yals0y90km5mxzz4x44frn3k3bb1n1imzc";
+      name = "ksirk-21.08.2.tar.xz";
     };
   };
   ksmtp = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ksmtp-21.08.1.tar.xz";
-      sha256 = "0pl167gjhpmdvhsjm6hcygxwjs8v1z4xfc7x0c69bac8rdrzrlb6";
-      name = "ksmtp-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ksmtp-21.08.2.tar.xz";
+      sha256 = "08bdi23qwvayl9w1nsfgpxpxmxrw820qcmvw03ivdk1h7m6sl3yh";
+      name = "ksmtp-21.08.2.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ksnakeduel-21.08.1.tar.xz";
-      sha256 = "1jk4mdxg2b1aa1686rimhjqh91ijaf8n7fahvswwbl473zfjf748";
-      name = "ksnakeduel-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ksnakeduel-21.08.2.tar.xz";
+      sha256 = "0n7digcymwrcg24y2libp0x67s1rj2qmps4yzp2bxpgasx9pf6ik";
+      name = "ksnakeduel-21.08.2.tar.xz";
     };
   };
   kspaceduel = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kspaceduel-21.08.1.tar.xz";
-      sha256 = "0q2mpidkhgjz3nm88j3m8wdb06y3m8ixr0540q0s9i9d997jdkch";
-      name = "kspaceduel-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kspaceduel-21.08.2.tar.xz";
+      sha256 = "1gjb23dw8fh61b7s23b2bfkgcfxqvndrv1x7lkk2bpi4i4g6sqz3";
+      name = "kspaceduel-21.08.2.tar.xz";
     };
   };
   ksquares = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ksquares-21.08.1.tar.xz";
-      sha256 = "0z7h5vig5zablvdlv7lanmsjjbqq931pqjyynm75mygrrbavgcfq";
-      name = "ksquares-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ksquares-21.08.2.tar.xz";
+      sha256 = "10sl49mjjlpqyh6f930iz1nncy2dqzm1b8hksn8zxz5kwi2gvfrc";
+      name = "ksquares-21.08.2.tar.xz";
     };
   };
   ksudoku = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ksudoku-21.08.1.tar.xz";
-      sha256 = "0aax14xwg42wr8g563nbpn7m55gs4k50kwk0zn79pf62i78g10lp";
-      name = "ksudoku-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ksudoku-21.08.2.tar.xz";
+      sha256 = "15svd1paf1hx5aqmdrh6bcdag7k8iq18fpjflk3vkkip6s76lrv6";
+      name = "ksudoku-21.08.2.tar.xz";
     };
   };
   ksystemlog = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ksystemlog-21.08.1.tar.xz";
-      sha256 = "1vv0wbb3npbq8r0mq8y5lc36qx1hxdjxygfcnw2h9hm4dwl8mc5v";
-      name = "ksystemlog-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ksystemlog-21.08.2.tar.xz";
+      sha256 = "1qnnhbi75glgvcvpmpy5zrq6x6hygl7r7v4h99lfm48jdfpyxilj";
+      name = "ksystemlog-21.08.2.tar.xz";
     };
   };
   kteatime = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kteatime-21.08.1.tar.xz";
-      sha256 = "0gjnvcvrnb3049ln64chnjgr7xm722ighjscxxhqz61i872dgb72";
-      name = "kteatime-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kteatime-21.08.2.tar.xz";
+      sha256 = "02vkh3dyacba9x0zl8j8g8isj50h8wz7mjnfqgxc67azcwwx41sp";
+      name = "kteatime-21.08.2.tar.xz";
     };
   };
   ktimer = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktimer-21.08.1.tar.xz";
-      sha256 = "1l79yrg6g78gf8av1h6yr4mxyd1n63g4r38qp4csvpnjpx7y8ijd";
-      name = "ktimer-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktimer-21.08.2.tar.xz";
+      sha256 = "0rfmrh7i8c23r6wdyh4w55980vlj2p127mbpiw5brj4dazdjll5x";
+      name = "ktimer-21.08.2.tar.xz";
     };
   };
   ktnef = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktnef-21.08.1.tar.xz";
-      sha256 = "08wk4ssasqqixwnp59smv64c8m4jf89vpcwc3zvz4h92sfk0pk33";
-      name = "ktnef-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktnef-21.08.2.tar.xz";
+      sha256 = "05l4g38f2m3qjl6q45j12zarpazsizjl2pyqh87vhaxgnf4fbqqp";
+      name = "ktnef-21.08.2.tar.xz";
     };
   };
   ktorrent = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktorrent-21.08.1.tar.xz";
-      sha256 = "1r7w43ns4zy94y82dbghrjgqv1sbdj01rni0iijirzjjikr5av9m";
-      name = "ktorrent-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktorrent-21.08.2.tar.xz";
+      sha256 = "1nd72jcvsc0kabd23ddy93dxp59ihg5npa8r3vbzvic89xlpkivi";
+      name = "ktorrent-21.08.2.tar.xz";
     };
   };
   ktouch = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktouch-21.08.1.tar.xz";
-      sha256 = "00pyrp00dqbanb2w0cxmxh8aahih714q85prjij6iy5sv0917zr7";
-      name = "ktouch-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktouch-21.08.2.tar.xz";
+      sha256 = "16r3hj160y1517dk1nzvikwkjlfbzmjpx54k9jc98csaplbv683l";
+      name = "ktouch-21.08.2.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-accounts-kcm-21.08.1.tar.xz";
-      sha256 = "0pn8g5w4p2synwfskw9m805nj2wk9g7yff423243qc3fxl572sv8";
-      name = "ktp-accounts-kcm-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-accounts-kcm-21.08.2.tar.xz";
+      sha256 = "0fxlkbx8kzlbfyfj7ac6m0y6vc80n3nlm5skrq106vbm1nnh565p";
+      name = "ktp-accounts-kcm-21.08.2.tar.xz";
     };
   };
   ktp-approver = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-approver-21.08.1.tar.xz";
-      sha256 = "1q2rsg9520ra7ap3ipvv0sdyc2mzbzap2ygzkwbm80fpspl6b973";
-      name = "ktp-approver-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-approver-21.08.2.tar.xz";
+      sha256 = "1pbc2f477xysv707j1xbcw799pxas31j5cmf26wrkbjmzxh5nhnd";
+      name = "ktp-approver-21.08.2.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-auth-handler-21.08.1.tar.xz";
-      sha256 = "0yzh2sqsyic3d979mj3m8d9m42y37w3h2s7gsyifw08gf5sna48p";
-      name = "ktp-auth-handler-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-auth-handler-21.08.2.tar.xz";
+      sha256 = "1fwzm15s8q8h47kfqw4jz2vfv81fc4azxg7c9r4vvlh23grlzbx8";
+      name = "ktp-auth-handler-21.08.2.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-call-ui-21.08.1.tar.xz";
-      sha256 = "0m8x3mfhy5rnv9wp15zrl5fiwdkm66pc8szkncqnjxw2nv721s3m";
-      name = "ktp-call-ui-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-call-ui-21.08.2.tar.xz";
+      sha256 = "0d4iaqpl67w3q7rrk2h9glq91ha03hvnrywi6271nc4892r4b2ys";
+      name = "ktp-call-ui-21.08.2.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-common-internals-21.08.1.tar.xz";
-      sha256 = "12jcfr3cvyhzn62jnlnfmp39wyxa06bih4qz8gxzv56nl434qzv0";
-      name = "ktp-common-internals-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-common-internals-21.08.2.tar.xz";
+      sha256 = "1jc8dv4563y4xlx13sz07lmkfnxraidqpxq08plapkliq56hv2xd";
+      name = "ktp-common-internals-21.08.2.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-contact-list-21.08.1.tar.xz";
-      sha256 = "1d4d0bvi9c813c3gyws3gc8zca1az2f3ych2r1cgpdhhbqjrf3wl";
-      name = "ktp-contact-list-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-contact-list-21.08.2.tar.xz";
+      sha256 = "1glh9np0q82x9z7pb3xzvq1mwmfggzq8lc5in1lhhjzhpnla2n21";
+      name = "ktp-contact-list-21.08.2.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-contact-runner-21.08.1.tar.xz";
-      sha256 = "0l2qimrpfnpmhvspgv62y8a7hsbw4abz92n1xry040qmkfqzv2l7";
-      name = "ktp-contact-runner-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-contact-runner-21.08.2.tar.xz";
+      sha256 = "15xvw84c4ygz1zz3qkjmxfjrkczwrdwdmls5a4bc4d4i78df8v4m";
+      name = "ktp-contact-runner-21.08.2.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-desktop-applets-21.08.1.tar.xz";
-      sha256 = "03si91agdjascs6ri0g5zrhicjzx24p6kh2ni1d96k5sc7alwxnl";
-      name = "ktp-desktop-applets-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-desktop-applets-21.08.2.tar.xz";
+      sha256 = "09bli0hhibwhia5zsprf1mv2li344lcqjq6pkirzz8h2dr1nr2s5";
+      name = "ktp-desktop-applets-21.08.2.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-filetransfer-handler-21.08.1.tar.xz";
-      sha256 = "08dklgklc31fvcdi3917lh77gr58y75f1di0xhjf6jq8vxplqjd8";
-      name = "ktp-filetransfer-handler-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-filetransfer-handler-21.08.2.tar.xz";
+      sha256 = "0g0w1ayj3m6lkmy71xqvfg829rk9y5z98h6rnim3ag9yx44namzw";
+      name = "ktp-filetransfer-handler-21.08.2.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-kded-module-21.08.1.tar.xz";
-      sha256 = "1135hh82ivvbpks9k39baisrq053570yq2x851j4vb2qrxg000yg";
-      name = "ktp-kded-module-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-kded-module-21.08.2.tar.xz";
+      sha256 = "1rx79zqqk2gl2qi28q429ss63kyndfzs24mdrn4491hsbln0sv1x";
+      name = "ktp-kded-module-21.08.2.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-send-file-21.08.1.tar.xz";
-      sha256 = "1fnn5m9spa0x8nw1rx94x85hy06qwkb1fl5l498rmhyzikhxmhqp";
-      name = "ktp-send-file-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-send-file-21.08.2.tar.xz";
+      sha256 = "1791zhp5rpwizx3y48hgamk7pgbx2yk650nczxbnza828m1lxzab";
+      name = "ktp-send-file-21.08.2.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktp-text-ui-21.08.1.tar.xz";
-      sha256 = "0cfnf688jz5953x7jxjrdlfs96rxjcfzvasrc881y1aprav1dmjq";
-      name = "ktp-text-ui-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktp-text-ui-21.08.2.tar.xz";
+      sha256 = "1pinn61dkb2jcyzms3kf70sxjbkd3pkn6cxvxs8zsj1m1bdkydym";
+      name = "ktp-text-ui-21.08.2.tar.xz";
     };
   };
   ktuberling = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/ktuberling-21.08.1.tar.xz";
-      sha256 = "1f3a74nfh4fhxibcfxgjdj6phy185iz6y9nfg3pag3jvqsn8nx49";
-      name = "ktuberling-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/ktuberling-21.08.2.tar.xz";
+      sha256 = "0h7vhvh03w11dr17zxdmb5j2vz8flwahvz70h9kw8a63sxpw0x6f";
+      name = "ktuberling-21.08.2.tar.xz";
     };
   };
   kturtle = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kturtle-21.08.1.tar.xz";
-      sha256 = "15ng6k6xfaj37dvycm29pj2pk73yfr66pp0wgj719c0kq7c9avdp";
-      name = "kturtle-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kturtle-21.08.2.tar.xz";
+      sha256 = "1f3iw3fk4l8q2jnnadaqjbj6jzmw86ibf0p515x4rrqz4l8m6plg";
+      name = "kturtle-21.08.2.tar.xz";
     };
   };
   kubrick = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kubrick-21.08.1.tar.xz";
-      sha256 = "03i0b24mmq3jqf7812a9sjr8lr82mq9mrq75z2a9h62jinvxvigj";
-      name = "kubrick-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kubrick-21.08.2.tar.xz";
+      sha256 = "0kvd8dsg9hdgid70jd5b1vngqpmi9rigkvxl2v4h2ps1ziqqxa78";
+      name = "kubrick-21.08.2.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kwalletmanager-21.08.1.tar.xz";
-      sha256 = "1a4aiajq04rlm566jwqwjq2b6sfamnabfrjfa80pld3qcmq0l1mz";
-      name = "kwalletmanager-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kwalletmanager-21.08.2.tar.xz";
+      sha256 = "134690b4bhkjczwxg8776163aggwrqmb84xkvb7612wgs5jygyib";
+      name = "kwalletmanager-21.08.2.tar.xz";
     };
   };
   kwave = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kwave-21.08.1.tar.xz";
-      sha256 = "1dl7kn67hp9y39xlnq989kg743295a23kbpjpvbjashgdqy3hqwl";
-      name = "kwave-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kwave-21.08.2.tar.xz";
+      sha256 = "0sivhgcypwpdi6g0mkdzf1k2hqkj1vj4b5cdcvn8chs2gk9pisgh";
+      name = "kwave-21.08.2.tar.xz";
     };
   };
   kwordquiz = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/kwordquiz-21.08.1.tar.xz";
-      sha256 = "1mzdmgls07bb6k2x6qb1xzp04jpfifdrka2k6kzwy9bq071gs7q5";
-      name = "kwordquiz-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/kwordquiz-21.08.2.tar.xz";
+      sha256 = "1prj7iz71z8zy2ynjad7yqkgswg96q4hmc76kg1lvahn2waikr0y";
+      name = "kwordquiz-21.08.2.tar.xz";
     };
   };
   libgravatar = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libgravatar-21.08.1.tar.xz";
-      sha256 = "08xl8nb0bn6zf9sh7sn4v7aa86ffqb16hixci4ymixyxy5c4gwbv";
-      name = "libgravatar-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libgravatar-21.08.2.tar.xz";
+      sha256 = "047fbdj02rnb7bn2vn9lava2mh4ypzlyd8iiri4mbpd686lmi0s1";
+      name = "libgravatar-21.08.2.tar.xz";
     };
   };
   libkcddb = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkcddb-21.08.1.tar.xz";
-      sha256 = "08841rssxcg9vi490qih8jxnalnbjd2wqsgcq22gkm1ahfj5dizq";
-      name = "libkcddb-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkcddb-21.08.2.tar.xz";
+      sha256 = "03az77p3p0c0shzi2y2n5721gppzgrq469afvpjppria1n3ks5d2";
+      name = "libkcddb-21.08.2.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkcompactdisc-21.08.1.tar.xz";
-      sha256 = "1q838md6kqvjmc61sy943lqgv5isll2px1s0izyvvxkf747hcpin";
-      name = "libkcompactdisc-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkcompactdisc-21.08.2.tar.xz";
+      sha256 = "0sjr8gdbqsjlggxax0l2bxn42l9znplrjiln15izj2zwfkah7d69";
+      name = "libkcompactdisc-21.08.2.tar.xz";
     };
   };
   libkdcraw = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkdcraw-21.08.1.tar.xz";
-      sha256 = "17ijpgljhrm851mdnd1znjpa7hidmv1d5d05q68r6lp1aclcgmwm";
-      name = "libkdcraw-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkdcraw-21.08.2.tar.xz";
+      sha256 = "0yhcrzl7piginz19vmyg63154j9rrqxfvfchn9k8g9jiddwnjfd8";
+      name = "libkdcraw-21.08.2.tar.xz";
     };
   };
   libkdegames = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkdegames-21.08.1.tar.xz";
-      sha256 = "0vfx3ksy6z5h4hjx0dl3fr3phfz3q590h86ksbp5q20lyylmdpji";
-      name = "libkdegames-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkdegames-21.08.2.tar.xz";
+      sha256 = "0jbb4h515c9h08r7dqaslqgrpmb6f08ai46phwgipd67jzgh6wh7";
+      name = "libkdegames-21.08.2.tar.xz";
     };
   };
   libkdepim = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkdepim-21.08.1.tar.xz";
-      sha256 = "10zb97zf1jidh9q6dkn8cjs9f4gqz2xn6yqylsbq0bjlycv991fh";
-      name = "libkdepim-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkdepim-21.08.2.tar.xz";
+      sha256 = "1j8nkfgzixpchz34p338mcm87f112ddy1linhaczg5fal1brangh";
+      name = "libkdepim-21.08.2.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkeduvocdocument-21.08.1.tar.xz";
-      sha256 = "0wnyx7h284g6wssnfdfz4m0hcb0rc6fnlryav8vnjcyzz7p5ni6l";
-      name = "libkeduvocdocument-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkeduvocdocument-21.08.2.tar.xz";
+      sha256 = "051mzwbrlpvjnqphf01nzzc76zbz9hasd57sn6y6x8cviflf7kmy";
+      name = "libkeduvocdocument-21.08.2.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkexiv2-21.08.1.tar.xz";
-      sha256 = "0wnpkzivb5f5z3d1dn5952cx07q8nw421xrs21r57cmbsss344xa";
-      name = "libkexiv2-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkexiv2-21.08.2.tar.xz";
+      sha256 = "0spa6pbr6rpnznvm2z0c410k5wssw4rw15rdc3f5ds9mbzbyxpva";
+      name = "libkexiv2-21.08.2.tar.xz";
     };
   };
   libkgapi = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkgapi-21.08.1.tar.xz";
-      sha256 = "14wzl40j5baw20628dqcpkg8vi6jsq5f9gw0sc1my8qhw91mj3vy";
-      name = "libkgapi-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkgapi-21.08.2.tar.xz";
+      sha256 = "13dna8iv3qzkc1jagjgji928g88wrgds47lcfj3dqkn8swamisa0";
+      name = "libkgapi-21.08.2.tar.xz";
     };
   };
   libkipi = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkipi-21.08.1.tar.xz";
-      sha256 = "13579gqxyj8dwmrmxylnw6mf56vr73vlbbv07rpi661kfrbjk2ms";
-      name = "libkipi-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkipi-21.08.2.tar.xz";
+      sha256 = "134iaagdn49y79aihi6k5pgx0cyk52wq38cdiinpcsxqc4xmzswh";
+      name = "libkipi-21.08.2.tar.xz";
     };
   };
   libkleo = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkleo-21.08.1.tar.xz";
-      sha256 = "1n1nacr1q0nw2jq8px6b3cmda6ff9mygggfrl3xh6qz042bg77xz";
-      name = "libkleo-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkleo-21.08.2.tar.xz";
+      sha256 = "14p3x2jq9sa5gkhcd7q3g5ras2sl62shrjm9kx4426mbnj10n0q2";
+      name = "libkleo-21.08.2.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkmahjongg-21.08.1.tar.xz";
-      sha256 = "0ry6wz0i9dccjn5w2qy2nin0rhbg30vlbcr4zrlx8bxsw0la2k94";
-      name = "libkmahjongg-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkmahjongg-21.08.2.tar.xz";
+      sha256 = "195c7bgn4jp2whqrg7l8g147kj92bvdcvcrh7n186kac9q0jqr3b";
+      name = "libkmahjongg-21.08.2.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libkomparediff2-21.08.1.tar.xz";
-      sha256 = "0n6xxam33k8j6c9wqdf0lhfpk6nyf9brhvdkivdamp0idhi3rcpx";
-      name = "libkomparediff2-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libkomparediff2-21.08.2.tar.xz";
+      sha256 = "08y9p3il0i5sayq42v9p1v9f6yynp7ljb5d4ls1hf5ww4xxvx10x";
+      name = "libkomparediff2-21.08.2.tar.xz";
     };
   };
   libksane = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libksane-21.08.1.tar.xz";
-      sha256 = "1x4wsdfczqnasr6ps8677m0ix1fqqd2316f6k2k3awn9qfgsqy3x";
-      name = "libksane-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libksane-21.08.2.tar.xz";
+      sha256 = "094k5f0qwcm74jn5jlzs0mr74myp4s217ah2pl1kny1fm5hv5pyj";
+      name = "libksane-21.08.2.tar.xz";
     };
   };
   libksieve = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libksieve-21.08.1.tar.xz";
-      sha256 = "1569xcjz575f8007z91zs9xn5wjklzkiy6l0cl7yzpzn880wc03p";
-      name = "libksieve-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libksieve-21.08.2.tar.xz";
+      sha256 = "1jxb0a18mf8yqxbi90jbgjh90x17qr6z7ga6zxdb8gk1hjsyb10y";
+      name = "libksieve-21.08.2.tar.xz";
     };
   };
   libktorrent = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/libktorrent-21.08.1.tar.xz";
-      sha256 = "0y5881v0g49rr8dspzaq4l1c62rchgfq4mjx64sn0ng2jjpnhv1x";
-      name = "libktorrent-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/libktorrent-21.08.2.tar.xz";
+      sha256 = "16rx0na7gy03c0qbwy07q7si35z62p0pq7fcvf3ggr594akwz4kl";
+      name = "libktorrent-21.08.2.tar.xz";
     };
   };
   lokalize = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/lokalize-21.08.1.tar.xz";
-      sha256 = "0ih7a1rkwn9jpgk3qld8anavr0g4wlf8figwikhvbc2dw79lxs7k";
-      name = "lokalize-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/lokalize-21.08.2.tar.xz";
+      sha256 = "01f48fsrv095vlgxfjfdlm70xwsw73x5zhqbm38szn6r404jcmjm";
+      name = "lokalize-21.08.2.tar.xz";
     };
   };
   lskat = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/lskat-21.08.1.tar.xz";
-      sha256 = "1d89yqfsc703pnvxljcsn33wpsv64s4nr2wlmlbl609m9x8b9g9b";
-      name = "lskat-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/lskat-21.08.2.tar.xz";
+      sha256 = "03www1ix31ifmn6hvzymvhg157rdhahjfwvc9arns23zxpn1sq9p";
+      name = "lskat-21.08.2.tar.xz";
     };
   };
   mailcommon = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/mailcommon-21.08.1.tar.xz";
-      sha256 = "1r0qyqasah4z8vx836fhvv1f4zm20az9qrw8122l3a986lazh1zw";
-      name = "mailcommon-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/mailcommon-21.08.2.tar.xz";
+      sha256 = "0d0czxrf3i796pyrlifv4psq3hl4z2abhsqj1ns30xng45pzyrvz";
+      name = "mailcommon-21.08.2.tar.xz";
     };
   };
   mailimporter = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/mailimporter-21.08.1.tar.xz";
-      sha256 = "05kiizbdnsl15ry2zb5sg94lcdwq9w4lnznd6zcq8n09s0zpz8nf";
-      name = "mailimporter-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/mailimporter-21.08.2.tar.xz";
+      sha256 = "0vd0bghszwr1wh4x2ygd7flg0kypb8m92gvh0q800gdgnqj87lw7";
+      name = "mailimporter-21.08.2.tar.xz";
     };
   };
   marble = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/marble-21.08.1.tar.xz";
-      sha256 = "01hf3wwz9zflkpgx1pbkxbnl1vs2yyafrwmldnil66nkxsxx7izw";
-      name = "marble-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/marble-21.08.2.tar.xz";
+      sha256 = "1l8dwj0kyq8r3cap2sjsr4blbz591l6cxhglkhxwds901igacmxa";
+      name = "marble-21.08.2.tar.xz";
     };
   };
   markdownpart = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/markdownpart-21.08.1.tar.xz";
-      sha256 = "0xgs2kxnbrn70mrzza2d4f7xpx9ks3dbl3yj1y1kds7bnidsf3f9";
-      name = "markdownpart-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/markdownpart-21.08.2.tar.xz";
+      sha256 = "0vx2d31d9c9ipwkbnlrjhzkaj97a7vz6vigbbkvw4cyaqhq6zkqp";
+      name = "markdownpart-21.08.2.tar.xz";
     };
   };
   mbox-importer = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/mbox-importer-21.08.1.tar.xz";
-      sha256 = "06mgz10ma8r0vi7ln9zxz2kipdp9rd0zw0sgm69h43rq9zyjnjkk";
-      name = "mbox-importer-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/mbox-importer-21.08.2.tar.xz";
+      sha256 = "1bf4awkrivx209rnwflxrqdxzvj8mzlgzis79hn9n654qy6ar2d5";
+      name = "mbox-importer-21.08.2.tar.xz";
     };
   };
   messagelib = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/messagelib-21.08.1.tar.xz";
-      sha256 = "1r3lqacixy5vy36jgy6glz08gp8k4559h1bdqyh7svmmflhs927i";
-      name = "messagelib-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/messagelib-21.08.2.tar.xz";
+      sha256 = "0gsxik4ib72xhw948h257m17w4k49sa3ymbg87n0q8nd6gykxyhr";
+      name = "messagelib-21.08.2.tar.xz";
     };
   };
   minuet = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/minuet-21.08.1.tar.xz";
-      sha256 = "0law0ram3xdf5ayc7j8as1xwj83k37mf7w6qkkp3hy3kj2r2dahx";
-      name = "minuet-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/minuet-21.08.2.tar.xz";
+      sha256 = "13i37xw2aarmqi25m1r68z9zjwqf9nx8bxlflb0wxghzf3pgrp4v";
+      name = "minuet-21.08.2.tar.xz";
     };
   };
   okular = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/okular-21.08.1.tar.xz";
-      sha256 = "1vk1mn40i80b5vkxq47i1qf2i734n5nfa1wgx3748jwc1fws631p";
-      name = "okular-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/okular-21.08.2.tar.xz";
+      sha256 = "0y3n340fbhsgmmrq4vz2p9682xzs7hsvvna8ffh4r15wgl1qdb9q";
+      name = "okular-21.08.2.tar.xz";
     };
   };
   palapeli = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/palapeli-21.08.1.tar.xz";
-      sha256 = "09mswv446s6vqlllhz727qpd7mdszdkgivfn9sazgmydmmmzrw53";
-      name = "palapeli-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/palapeli-21.08.2.tar.xz";
+      sha256 = "0pl6hi0c5fa6zs3gdicm1s7rmzzdjjvrm8s8ds6f4ghq6dmlknqj";
+      name = "palapeli-21.08.2.tar.xz";
     };
   };
   parley = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/parley-21.08.1.tar.xz";
-      sha256 = "02v9gfjdryf48m5iinsc9qg2qfmj1s96xga5b3ndd63g66b6gp9b";
-      name = "parley-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/parley-21.08.2.tar.xz";
+      sha256 = "0lykvjaxfj6blgjkmipvlw9531npz46d6jwq6w5wxvk6f1b2cgbh";
+      name = "parley-21.08.2.tar.xz";
     };
   };
   partitionmanager = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/partitionmanager-21.08.1.tar.xz";
-      sha256 = "16vc0g08rs6dz87zv4b1ygs198c6mbjwcp2j4994z6cf16bxfgz8";
-      name = "partitionmanager-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/partitionmanager-21.08.2.tar.xz";
+      sha256 = "1fa90mnby2kf5a85wjz7xvb999gh5c2yn0j3g562zndqznqhcpvx";
+      name = "partitionmanager-21.08.2.tar.xz";
     };
   };
   picmi = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/picmi-21.08.1.tar.xz";
-      sha256 = "1yshwfl8baw0cw8hnvzkb3y72r0bycyr19rwwns9sjc3fk9gnk6a";
-      name = "picmi-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/picmi-21.08.2.tar.xz";
+      sha256 = "0qvz4fl4jb256rwmaw0bszr3x2b5jd8priilc3jr33v393f3pd6q";
+      name = "picmi-21.08.2.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/pim-data-exporter-21.08.1.tar.xz";
-      sha256 = "1vx7h7900wq8icx7q4khkx9g5gm6j5c8dl38q08pwda4vl0pmxmd";
-      name = "pim-data-exporter-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/pim-data-exporter-21.08.2.tar.xz";
+      sha256 = "0li96fkwkdg4ziyv4n56vn49wav4kilf7lqb4s9xwj8h44kjpa5f";
+      name = "pim-data-exporter-21.08.2.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/pim-sieve-editor-21.08.1.tar.xz";
-      sha256 = "0ph62khl2k2gpfjf05p9sklihib0hbxgl3n1bv59l58awj9brs0r";
-      name = "pim-sieve-editor-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/pim-sieve-editor-21.08.2.tar.xz";
+      sha256 = "173c595djmz3wyzl9dl3br8m3k0940ncdyjf8rjfgrh79y86bh7m";
+      name = "pim-sieve-editor-21.08.2.tar.xz";
     };
   };
   pimcommon = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/pimcommon-21.08.1.tar.xz";
-      sha256 = "1379lhvin2vkikd3fzanhwfjszb4cc9f3h9bxf3md3h4gx1i6hb6";
-      name = "pimcommon-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/pimcommon-21.08.2.tar.xz";
+      sha256 = "074pbxprzx8hd6fikjvx8hn9g9135swzhj1f5zvfvhyvlpyj90wg";
+      name = "pimcommon-21.08.2.tar.xz";
     };
   };
   poxml = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/poxml-21.08.1.tar.xz";
-      sha256 = "10wwrbmhwbjk71m4ya1shb7mviil33fciykrzyqvvdnvx668aawm";
-      name = "poxml-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/poxml-21.08.2.tar.xz";
+      sha256 = "1h7y4y1n3xcpgrkabik21ilck5dmq6p3qxs3xm9vzq1jxpb9izyf";
+      name = "poxml-21.08.2.tar.xz";
     };
   };
   print-manager = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/print-manager-21.08.1.tar.xz";
-      sha256 = "1hzykjnymr0knh67h6s5214bjp5lk1klm6znh8q2asf49c6x2zgw";
-      name = "print-manager-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/print-manager-21.08.2.tar.xz";
+      sha256 = "0g2y2i7iysi6i397gd9fpqpk9cha7z4b2wz6shcqp0jyvvwl1pd3";
+      name = "print-manager-21.08.2.tar.xz";
     };
   };
   rocs = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/rocs-21.08.1.tar.xz";
-      sha256 = "1b527n0csk43sxafynqijiwf0bzj89viznpxnk2ayb9lik4q3djm";
-      name = "rocs-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/rocs-21.08.2.tar.xz";
+      sha256 = "0cvgi42w1a7zd6bzazly9w2azbyp9gzvkyx5wlff5z99nk6v3mp0";
+      name = "rocs-21.08.2.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/signon-kwallet-extension-21.08.1.tar.xz";
-      sha256 = "1x1q1vmqm9nq7sjhxc495x612jh39scxba0nbr8a4rval144268m";
-      name = "signon-kwallet-extension-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/signon-kwallet-extension-21.08.2.tar.xz";
+      sha256 = "19jp6h9xqhlyvddgyg9jz74by0pcxqm920c5h8vln5vkkcgsdwws";
+      name = "signon-kwallet-extension-21.08.2.tar.xz";
     };
   };
   skanlite = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/skanlite-21.08.1.tar.xz";
-      sha256 = "17lnazx1h4lk78037gvzscnm3p2yl6dhc4970bdq982ahwp63gg8";
-      name = "skanlite-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/skanlite-21.08.2.tar.xz";
+      sha256 = "1zwrb7j7x234vbb57p8gzbqz2mfr1n2i84yjf16jrsv1fm53z9md";
+      name = "skanlite-21.08.2.tar.xz";
     };
   };
   spectacle = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/spectacle-21.08.1.tar.xz";
-      sha256 = "0bs93gylw90wj3b9kw71xhqy60smggh38s5g4jcras1n6iqmb06x";
-      name = "spectacle-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/spectacle-21.08.2.tar.xz";
+      sha256 = "0m59cnfqkm379i6ayj1g5flszqs26dmnwl79324d1j6bxk24mjrh";
+      name = "spectacle-21.08.2.tar.xz";
     };
   };
   step = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/step-21.08.1.tar.xz";
-      sha256 = "0rg69j8r479vzyrajbdjgh5l2506w8f2dnlh1di545gzjk2ww448";
-      name = "step-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/step-21.08.2.tar.xz";
+      sha256 = "15l11s39hw847kd37fhq6kp3ajbsxidkfpp2ryb9dfh595lncg2r";
+      name = "step-21.08.2.tar.xz";
     };
   };
   svgpart = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/svgpart-21.08.1.tar.xz";
-      sha256 = "1silp6k0l9xb363h8whiv4dry6gf1mj4w53mksl1i2slhqn9q96v";
-      name = "svgpart-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/svgpart-21.08.2.tar.xz";
+      sha256 = "14xgwdvpcvgw0jj4gy3175ah38x9f8lhknqbw5bczvm9cy8j7qfw";
+      name = "svgpart-21.08.2.tar.xz";
     };
   };
   sweeper = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/sweeper-21.08.1.tar.xz";
-      sha256 = "0p25bkczxmx93igicyiasvjd4v9rc3sg7gm7b9ddgzz8rrnr0d9p";
-      name = "sweeper-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/sweeper-21.08.2.tar.xz";
+      sha256 = "1yvcfdhapml1vzqns67v6j2c39g752f8czxs7bnczi69fq1ksh0b";
+      name = "sweeper-21.08.2.tar.xz";
     };
   };
   umbrello = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/umbrello-21.08.1.tar.xz";
-      sha256 = "0x4f3hiydyprhzd56i8lijwfhzca041bmbbxp7x1dckv3shdangc";
-      name = "umbrello-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/umbrello-21.08.2.tar.xz";
+      sha256 = "1xiz006ppgss6rxg7lndgnrbcdbm0iq1hjly3rjn943ff11wq5yr";
+      name = "umbrello-21.08.2.tar.xz";
     };
   };
   yakuake = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/yakuake-21.08.1.tar.xz";
-      sha256 = "1x41jrkvlff8x5qcd12lcrv6zqzw7jqw02ikpmqv1v4gw7lz94w9";
-      name = "yakuake-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/yakuake-21.08.2.tar.xz";
+      sha256 = "1d8dh10jkpm4pm8fh1bmkdwvv59gk0fg6dr3gahlspnh4hhzy4hg";
+      name = "yakuake-21.08.2.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "21.08.1";
+    version = "21.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.08.1/src/zeroconf-ioslave-21.08.1.tar.xz";
-      sha256 = "113sp3lqzyxx7icww4sznc23kxarmxz0158kzl6nazxj4m6cnm4r";
-      name = "zeroconf-ioslave-21.08.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.08.2/src/zeroconf-ioslave-21.08.2.tar.xz";
+      sha256 = "0xgm4y29iklal5kd5z76jdw6wgw0mg9xn0f0d07zyshv5hjgllv6";
+      name = "zeroconf-ioslave-21.08.2.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update KDE Gear / Applications to [`21.08.2`, released in October 07 2021](https://kde.org/announcements/gear/21.08.2/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
