### PR TITLE
python3Packages.editdistance: 0.5.3 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/editdistance/default.nix
+++ b/pkgs/development/python-modules/editdistance/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "editdistance";
-  version = "0.5.3";
+  version = "0.6.0";
 
 
   src = fetchFromGitHub {
     owner = "roy-ht";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0vk8vz41p2cs7s7zbaw3cnw2jnvy5rhy525xral68dh14digpgsd";
+    sha256 = "sha256-JcvvfiACKxgAQ0deVwzvHtQ/ocXhFzG7syQ433izs58=";
   };
 
   nativeBuildInputs = [ cython ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.6.0

Change log: https://github.com/roy-ht/editdistance/releases/tag/v0.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
