### PR TITLE
depotdownloader: 2.4.1 -> 2.4.5

### DIFF
--- a/pkgs/tools/misc/depotdownloader/default.nix
+++ b/pkgs/tools/misc/depotdownloader/default.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "depotdownloader";
-  version = "2.4.1";
+  version = "2.4.5";
 
   src = fetchFromGitHub {
     owner = "SteamRE";
     repo = "DepotDownloader";
     rev = "DepotDownloader_${version}";
-    sha256 = "1ldwda7wyvzqvqv1wshvqvqaimlm0rcdzhy9yn5hvxyswc0jxirr";
+    sha256 = "0i5qgjnliji1g408ks1034r69vqdmfnzanb0qm7jmyzwww7vwpnh";
   };
 
   nativeBuildInputs = [ dotnet-sdk_5 dotnetPackages.Nuget makeWrapper ];

--- a/pkgs/tools/misc/depotdownloader/deps.nix
+++ b/pkgs/tools/misc/depotdownloader/deps.nix
@@ -7,8 +7,8 @@ fetchNuGet:
   })
   (fetchNuGet {
     name = "SteamKit2";
-    version = "2.4.0-Alpha.2";
-    sha256 = "1r6chqdp912pr8f8d7px2vp4y1ydx0kida7d5a1hbf6b7acnsg7d";
+    version = "2.4.0-Alpha.3";
+    sha256 = "0n48yjkyzj49kv89jbkwdq6nm9w9ng6cjhvdv0chpryx9zgasgvv";
   })
   (fetchNuGet {
     name = "protobuf-net.Core";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Recent steam api change seems to have broken depotdownloader but was just fixed in the newest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
