### PR TITLE
vscode-extensions.vadimcn.vscode-lldb: 1.6.7 -> 1.6.8

### DIFF
--- a/pkgs/misc/vscode-extensions/vscode-lldb/build-deps/package.json
+++ b/pkgs/misc/vscode-extensions/vscode-lldb/build-deps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-lldb",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "dependencies": {
     "string-argv": "^0.3.1",
     "yaml": "^1.10.0",

--- a/pkgs/misc/vscode-extensions/vscode-lldb/default.nix
+++ b/pkgs/misc/vscode-extensions/vscode-lldb/default.nix
@@ -5,7 +5,7 @@ assert lib.versionAtLeast python3.version "3.5";
 let
   publisher = "vadimcn";
   pname = "vscode-lldb";
-  version = "1.6.7";
+  version = "1.6.8";
 
   vscodeExtUniqueId = "${publisher}.${pname}";
 
@@ -13,7 +13,7 @@ let
     owner = "vadimcn";
     repo = "vscode-lldb";
     rev = "v${version}";
-    sha256 = "sha256-9rqdqpxUWcUV9RnZOTxg+zMW7wlTXZVkoKYHuv/lE7c=";
+    sha256 = "sha256-/2iyWJfNjvk5n7KwWIu2gc24/21KWibU6IAPN/tJ8Q4=";
   };
 
   lldb = callPackage ./lldb.nix {};
@@ -25,7 +25,7 @@ let
     # It will pollute the build environment of `buildRustPackage`.
     cargoPatches = [ ./reset-cargo-config.patch ];
 
-    cargoSha256 = "sha256-KeZpjMCBdOJTLj8pA5WWi3EMyhhWw/+aik4IJqIs/mk=";
+    cargoSha256 = "sha256-rG+Qw8ac9cCgCjfLFXLlohLk+zV5s1OaqzU0/nXiqgU=";
 
     nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/misc/vscode-extensions/vscode-lldb/update.sh
+++ b/pkgs/misc/vscode-extensions/vscode-lldb/update.sh
@@ -19,17 +19,26 @@ repo=vscode-lldb
 version="$1"
 
 sed -E 's/\bversion = ".*?"/version = "'$version'"/' --in-place "$nixFile"
-srcHash=$(nix-prefetch fetchFromGitHub --owner vadimcn --repo vscode-lldb --rev "v$version" --fetchSubmodules)
+srcHash=$(nix-prefetch fetchFromGitHub --owner vadimcn --repo vscode-lldb --rev "v$version")
 sed -E 's#\bsha256 = ".*?"#sha256 = "'$srcHash'"#' --in-place "$nixFile"
 cargoHash=$(nix-prefetch "{ sha256 }: (import $nixpkgs {}).vscode-extensions.vadimcn.vscode-lldb.adapter.cargoDeps.overrideAttrs (_: { outputHash = sha256; })")
 sed -E 's#\bcargoSha256 = ".*?"#cargoSha256 = "'$cargoHash'"#' --in-place "$nixFile"
 
 src="$(nix-build $nixpkgs -A vscode-extensions.vadimcn.vscode-lldb.src --no-out-link)"
+oldDeps="$(jq '.dependencies' build-deps/package.json)"
+newDeps="$(jq '.dependencies + .devDependencies' "$src/package.json")"
 jq '{ name, version: $version, dependencies: (.dependencies + .devDependencies) }' \
     --arg version "$version" \
     "$src/package.json" \
     > build-deps/package.json
 
-# Regenerate nodePackages.
-cd "$nixpkgs/pkgs/development/node-packages"
-exec ./generate.sh
+if [[ "$oldDeps" == "$newDeps" ]]; then
+    echo "Dependencies not changed"
+    sed '/"vscode-lldb-build-deps-/,+3 s/version = ".*"/version = "'"$version"'"/' \
+        --in-place "$nixpkgs/pkgs/development/node-packages/node-packages.nix"
+else
+    echo "Dependencies changed"
+    # Regenerate nodePackages.
+    cd "$nixpkgs/pkgs/development/node-packages"
+    exec ./generate.sh
+fi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump. Tested via vscodium.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
