### PR TITLE
python3Packages.furo: 2021.9.22 -> 2021.10.9

### DIFF
--- a/pkgs/development/python-modules/furo/default.nix
+++ b/pkgs/development/python-modules/furo/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "furo";
-  version = "2021.9.22";
+  version = "2021.10.9";
   format = "flit";
   disable = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-749l6cXyGbIarXXJmiCU0DsWQwrvH1dobOGePyT5VK8=";
+    sha256 = "sha256-K6pCoi7ePm6Vxhgqs2S6wuwVt5vH+cp/sJ/ZrsSzVAw=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://github.com/pradyunsg/furo/releases/tag/2021.10.09

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).