### PR TITLE
crabz: init at 0.7.2

### DIFF
--- a/pkgs/tools/compression/crabz/default.nix
+++ b/pkgs/tools/compression/crabz/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, cmake
+, stdenv
+, libiconv
+, CoreFoundation
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "crabz";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "sstadick";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ch9cqarsakihg9ymbdm0ka6wz77z84n4g6cdlcskczc5g3b9gp9";
+  };
+
+  cargoSha256 = "sha256-nrCYlhq/f8gk3NmltAg+xppRJ533ooEpetWvaF2vmP0=";
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    libiconv
+    CoreFoundation
+    Security
+  ];
+
+  meta = with lib; {
+    description = "A cross platform, fast, compression and decompression tool";
+    homepage = "https://github.com/sstadick/crabz";
+    changelog = "https://github.com/sstadick/crabz/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ unlicense /* or */ mit ];
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3912,6 +3912,10 @@ with pkgs;
 
   cpuminer-multi = callPackage ../tools/misc/cpuminer-multi { };
 
+  crabz = callPackage ../tools/compression/crabz {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+
   cryptpad = callPackage ../servers/web-apps/cryptpad {
     nodejs = nodejs-12_x;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

crabz is a cross platform, fast, compression and decompression tool

https://github.com/sstadick/crabz

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
