### PR TITLE
dialogbox: init at 1.0+unstable=2020-11-16

### DIFF
--- a/pkgs/tools/misc/dialogbox/default.nix
+++ b/pkgs/tools/misc/dialogbox/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, qmake
+, qtbase
+}:
+
+mkDerivation rec {
+  pname = "dialogbox";
+  version = "1.0+unstable=2020-11-16";
+
+  src = fetchFromGitHub {
+    owner = "martynets";
+    repo = pname;
+    rev = "6989740746f376becc989ab2698e77d14186a0f9";
+    hash = "sha256-paTas3KbV4yZ0ePnrOH1S3bLLHDddFml1h6b6azK4RQ=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  buildInputs = [
+    qtbase
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/{bin,share/doc/dialogbox}
+    install dist/dialogbox $out/bin
+    install README.md $out/share/doc/dialogbox/
+    cp -r demos $out/share/doc/dialogbox/demos
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/martynets/dialogbox/";
+    description = "Qt-based scriptable engine providing GUI dialog boxes";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2599,6 +2599,8 @@ with pkgs;
 
   dialog = callPackage ../tools/misc/dialog { };
 
+  dialogbox = libsForQt5.callPackage ../tools/misc/dialogbox { };
+
   dibbler = callPackage ../tools/networking/dibbler { };
 
   diesel-cli = callPackage ../development/tools/diesel-cli {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
