### PR TITLE
python3Packages.pytest-rerunfailures: 10.1 → 10.2

### DIFF
--- a/pkgs/development/python-modules/pytest-rerunfailures/default.nix
+++ b/pkgs/development/python-modules/pytest-rerunfailures/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "pytest-rerunfailures";
-  version = "10.1";
+  version = "10.2";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7617c06de13ee6dd2df9add7e275bfb2bcebbaaf3e450f5937cd0200df824273";
+    sha256 = "9e1e1bad51e07642c5bbab809fc1d4ec8eebcb7de86f90f1a26e6ef9de446697";
   };
 
   buildInputs = [ pytest ];

--- a/pkgs/development/python-modules/pytest-rerunfailures/default.nix
+++ b/pkgs/development/python-modules/pytest-rerunfailures/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "pytest plugin to re-run tests to eliminate flaky failures";
+    description = "Pytest plugin to re-run tests to eliminate flaky failures";
     homepage = "https://github.com/pytest-dev/pytest-rerunfailures";
     license = licenses.mpl20;
     maintainers = with maintainers; [ das-g ];


### PR DESCRIPTION
###### Motivation for this change

upstream release 10.2 ([on PyPI](https://pypi.org/project/pytest-rerunfailures/10.2/),  [on GitHub](https://github.com/pytest-dev/pytest-rerunfailures/releases/tag/10.2))
- [Changelog](https://github.com/pytest-dev/pytest-rerunfailures/blob/10.2/CHANGES.rst#102-2021-09-17)
- [all changes since 10.1](https://github.com/pytest-dev/pytest-rerunfailures/compare/10.1...10.2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix run nixpkgs.nixpkgs-review -c nixpkgs-review wip`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - (there are no executable ones, this is a library)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
    - not applicable, as the change is minor
  - [ ] (Module updates) Added a release notes entry if the change is significant
    - not applicable, as the change is not a module update
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
    - not applicable, as the change is not a module addition
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages marked as broken and skipped:</summary>
  <ul>
    <li>pepper</li>
    <li>python38Packages.dask-xgboost</li>
    <li>python38Packages.rl-coach</li>
    <li>python39Packages.dask-xgboost</li>
    <li>python39Packages.rl-coach</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>devpi-client</li>
  </ul>
</details>
<details>
  <summary>84 packages built:</summary>
  <ul>
    <li>home-assistant</li>
    <li>intensity-normalization (python39Packages.intensity-normalization)</li>
    <li>opsdroid</li>
    <li>python38Packages.aplpy</li>
    <li>python38Packages.asdf</li>
    <li>python38Packages.batchgenerators</li>
    <li>python38Packages.build</li>
    <li>python38Packages.caffe</li>
    <li>python38Packages.check-manifest</li>
    <li>python38Packages.clifford</li>
    <li>python38Packages.dask</li>
    <li>python38Packages.dask-gateway</li>
    <li>python38Packages.dask-glm</li>
    <li>python38Packages.dask-image</li>
    <li>python38Packages.dask-jobqueue</li>
    <li>python38Packages.dask-ml</li>
    <li>python38Packages.dask-mpi</li>
    <li>python38Packages.datashader</li>
    <li>python38Packages.distributed</li>
    <li>python38Packages.glymur</li>
    <li>python38Packages.ibm-watson</li>
    <li>python38Packages.image-match</li>
    <li>python38Packages.imagecorruptions</li>
    <li>python38Packages.imgaug</li>
    <li>python38Packages.intake</li>
    <li>python38Packages.intake-parquet</li>
    <li>python38Packages.intensity-normalization</li>
    <li>python38Packages.mask-rcnn</li>
    <li>python38Packages.pims</li>
    <li>python38Packages.pyfftw</li>
    <li>python38Packages.pyregion</li>
    <li>python38Packages.pytest-astropy</li>
    <li>python38Packages.pytest-astropy-header</li>
    <li>python38Packages.pytest-rerunfailures</li>
    <li>python38Packages.reproject</li>
    <li>python38Packages.scikitimage</li>
    <li>python38Packages.slicedimage</li>
    <li>python38Packages.sparse</li>
    <li>python38Packages.spectral-cube</li>
    <li>python38Packages.streamz</li>
    <li>python38Packages.stumpy</li>
    <li>python38Packages.stytra</li>
    <li>python38Packages.sunpy</li>
    <li>python38Packages.tensorly</li>
    <li>python39Packages.aplpy</li>
    <li>python39Packages.asdf</li>
    <li>python39Packages.batchgenerators</li>
    <li>python39Packages.build</li>
    <li>python39Packages.caffe</li>
    <li>python39Packages.check-manifest</li>
    <li>python39Packages.clifford</li>
    <li>python39Packages.dask</li>
    <li>python39Packages.dask-gateway</li>
    <li>python39Packages.dask-glm</li>
    <li>python39Packages.dask-image</li>
    <li>python39Packages.dask-jobqueue</li>
    <li>python39Packages.dask-ml</li>
    <li>python39Packages.dask-mpi</li>
    <li>python39Packages.datashader</li>
    <li>python39Packages.distributed</li>
    <li>python39Packages.glymur</li>
    <li>python39Packages.ibm-watson</li>
    <li>python39Packages.image-match</li>
    <li>python39Packages.imagecorruptions</li>
    <li>python39Packages.imgaug</li>
    <li>python39Packages.intake</li>
    <li>python39Packages.intake-parquet</li>
    <li>python39Packages.mask-rcnn</li>
    <li>python39Packages.pims</li>
    <li>python39Packages.pyfftw</li>
    <li>python39Packages.pyregion</li>
    <li>python39Packages.pytest-astropy</li>
    <li>python39Packages.pytest-astropy-header</li>
    <li>python39Packages.pytest-rerunfailures</li>
    <li>python39Packages.reproject</li>
    <li>python39Packages.scikitimage</li>
    <li>python39Packages.slicedimage</li>
    <li>python39Packages.sparse</li>
    <li>python39Packages.spectral-cube</li>
    <li>python39Packages.streamz</li>
    <li>python39Packages.stumpy</li>
    <li>python39Packages.stytra</li>
    <li>python39Packages.sunpy</li>
    <li>python39Packages.tensorly</li>
  </ul>
</details>

---

`devpi-client` fails to build with
```
ERROR: Could not find a version that satisfies the requirement pluggy<1.0,>=0.6.0 (from devpi-client) (from versions: none)
ERROR: No matching distribution found for pluggy<1.0,>=0.6.0
```
during `Executing pipInstallPhase`: [devpi-client.log](https://github.com/NixOS/nixpkgs/files/7317099/devpi-client.log)

`devpi-client` fails to build the same way on `master` (b7e7d35cccea936bc41d9f2602bda3effee97b0a), too.