### PR TITLE
nix-eval-jobs: init at 0.0.1

### DIFF
--- a/pkgs/tools/package-management/nix-eval-jobs/default.nix
+++ b/pkgs/tools/package-management/nix-eval-jobs/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, boost
+, cmake
+, fetchFromGitHub
+, meson
+, ninja
+, nixUnstable
+, nlohmann_json
+, pkg-config
+, stdenv
+}:
+stdenv.mkDerivation rec {
+  pname = "nix-eval-jobs";
+  version = "0.0.1";
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-LTMW4356f8pvIyfYdOyZbF9yzU8MH9mryQgB4LrwZMI=";
+  };
+  buildInputs = [
+    boost
+    nixUnstable
+    nlohmann_json
+  ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    # nlohmann_json can be only discovered via cmake files
+    cmake
+  ];
+
+  meta = {
+    description = "Hydra's builtin hydra-eval-jobs as a standalone";
+    homepage = "https://github.com/nix-community/nix-eval-jobs";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ adisbladis mic92 ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32040,6 +32040,8 @@ with pkgs;
 
   dnadd = callPackage ../tools/nix/dnadd { };
 
+  nix-eval-jobs = callPackage ../tools/package-management/nix-eval-jobs { };
+
   nix-doc = callPackage ../tools/package-management/nix-doc { };
 
   nix-bundle = callPackage ../tools/package-management/nix-bundle { };


### PR DESCRIPTION
###### Motivation for this change

nix-eval-jobs extracts the cool part of Hydra; the evaluator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
