### PR TITLE
playfair-display: initial at version 1.202

### DIFF
--- a/pkgs/data/fonts/playfair-display/default.nix
+++ b/pkgs/data/fonts/playfair-display/default.nix
@@ -1,0 +1,39 @@
+{ lib, fetchFromGitHub }:
+
+let
+  version = "unstable-2021-10-10";
+  pname = "playfair-display";
+in fetchFromGitHub rec {
+  rev = "7ae68c5da1c379fec062735cd702473fe3fb11f6";
+  name = "${pname}-${version}";
+  owner = "clauseggers";
+  repo = "Playfair-Display";
+  sha256 = "KYiC3TNV8361VNKvMtkGATf4X/uIVAp9MqyuLMWm0sI=";
+
+  postFetch = ''
+    tar -xf $downloadedFile
+    mkdir -p $out/share/fonts/truetype
+    cp */fonts/TTF/*.ttf $out/share/fonts/truetype
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/clauseggers/Playfair-Display";
+    description = "An Open Source typeface family for display and titling use";
+    longDescription = ''
+      Playfair is a transitional design. As the name indicates, Playfair
+      Display is well suited for titling and head­lines.
+
+      Playfair includes a full set of small-caps, common ligatures, and
+      discretionary ligatures. For Polish, a set of alternate diacritical
+      characters designed with ‘kreska’s are included. All European lan­guages using
+      the latin script are supported. A set of eight arrow devices are also
+      included.
+
+      Playfair Display also cover the cyrillic glyphs used in Bulgarian,
+      Belarusian, Russian, Bosnian/Serbian (including Serbian morphology for б),
+      and Ukrainian.
+    '';
+    license = licenses.ofl;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23125,6 +23125,8 @@ with pkgs;
     inherit (mate) marco;
   };
 
+  playfair-display = callPackage ../data/fonts/playfair-display { };
+
   poly = callPackage ../data/fonts/poly { };
 
   polytopes_db = callPackage ../data/misc/polytopes_db { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding package for the font that's not yet available in the nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
