### PR TITLE
emacs: resolve wrapper load-path at build time

### DIFF
--- a/pkgs/build-support/emacs/mk-wrapper-subdirs.el
+++ b/pkgs/build-support/emacs/mk-wrapper-subdirs.el
@@ -1,0 +1,6 @@
+(defmacro mk-subdirs-expr (path)
+  `(setq load-path
+         (delete-dups (append '(,path)
+                              ',(let ((default-directory path))
+                                  (normal-top-level-add-subdirs-to-load-path))
+                              load-path))))

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -165,8 +165,13 @@ runCommand
           (add-to-list 'native-comp-eln-load-path "$out/share/emacs/native-lisp/")
         ''}
         EOF
-        # Link subdirs.el from the emacs distribution
-        ln -s $emacs/share/emacs/site-lisp/subdirs.el -T $subdirs
+
+        # Generate a subdirs.el that statically adds all subdirectories to load-path.
+        $emacs/bin/emacs \
+          --batch \
+          --load ${./mk-wrapper-subdirs.el} \
+          --eval "(prin1 (macroexpand-1 '(mk-subdirs-expr \"$out/share/emacs/site-lisp\")))" \
+          > "$subdirs"
 
         # Byte-compiling improves start-up time only slightly, but costs nothing.
         $emacs/bin/emacs --batch -f batch-byte-compile "$siteStart" "$subdirs"


### PR DESCRIPTION
###### Motivation for this change

Since the included package set is determined at build time we can also generate the `subdirs.el` file at build time. This improves startup time somewhat since we don't have to traverse the directory to add to `load-path`.

For example,

``` sh-session
$ bench './emacs-old -Q --batch --kill' './emacs-new -Q --batch --kill'
benchmarking bench/./emacs-old -Q --batch --kill
time                 72.77 ms   (71.66 ms .. 73.65 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 72.49 ms   (72.06 ms .. 72.92 ms)
std dev              746.5 μs   (582.4 μs .. 1.008 ms)

benchmarking bench/./emacs-new -Q --batch --kill
time                 40.56 ms   (40.24 ms .. 40.86 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 40.30 ms   (40.12 ms .. 40.51 ms)
std dev              401.9 μs   (311.1 μs .. 555.8 μs)
```

The change does not actually affect the content of `load-path`:

``` sh-session
$ diff -s <(./emacs-old --batch --eval '(prin1 load-path)' | sed -E 's!/nix/store/[[:alnum:]]{32}-!!g') \
          <(./emacs-new --batch --eval '(prin1 load-path)' | sed -E 's!/nix/store/[[:alnum:]]{32}-!!g')
Files /dev/fd/63 and /dev/fd/62 are identical
```

So in principle the only observable effect should be the improved startup time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
