### PR TITLE
nixos/switch-to-configuration: Improve socket and timer handling, clean up, minor fixes, add test

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1554,6 +1554,15 @@ Superuser created successfully.
           encapsulation.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          Changing systemd <literal>.socket</literal> units now restarts
+          them and stops the service that is activated by them.
+          Additionally, services with
+          <literal>stopOnChange = false</literal> don’t break anymore
+          when they are socket-activated.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -449,3 +449,5 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The `networking` module has a new `networking.fooOverUDP` option to configure Foo-over-UDP encapsulations.
 
 - `networking.sits` now supports Foo-over-UDP encapsulation.
+
+- Changing systemd `.socket` units now restarts them and stops the service that is activated by them. Additionally, services with `stopOnChange = false` don't break anymore when they are socket-activated.

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -180,12 +180,13 @@ sub handleModifiedUnit {
                     @sockets = ("$baseName.socket");
                 }
                 foreach my $socket (@sockets) {
-                    if (defined $activePrev->{$socket}) {
-                        # Only restart sockets that actually
-                        # exist in new configuration
-                        if (-e "$out/etc/systemd/system/$socket") {
-                            $socketActivated = 1;
-                            $unitsToStop->{$unit} = 1;
+                    if (-e "$out/etc/systemd/system/$socket") {
+                        $socketActivated = 1;
+                        $unitsToStop->{$unit} = 1;
+                        # If the socket was not running previously,
+                        # start it now.
+                        if (not defined $activePrev->{$socket}) {
+                            $unitsToStart->{$socket} = 1;
                         }
                     }
                 }

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -25,7 +25,7 @@ my $reloadByActivationFile = "/run/nixos/activation-reload-list";
 my $dryRestartByActivationFile = "/run/nixos/dry-activation-restart-list";
 my $dryReloadByActivationFile = "/run/nixos/dry-activation-reload-list";
 
-make_path("/run/nixos", { mode => 0755 });
+make_path("/run/nixos", { mode => oct(755) });
 
 my $action = shift @ARGV;
 

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -430,18 +430,17 @@ if ($action eq "dry-activate") {
             if scalar @unitsToAlsoStopFiltered;
     }
 
-print STDERR "NOT restarting the following changed units as well: ", join(", ", sort(keys %unitsToAlsoSkip)), "\n"
-    if scalar(keys %unitsToAlsoSkip) > 0;
+    print STDERR "would NOT restart the following changed units as well: ", join(", ", sort(keys %unitsToAlsoSkip)), "\n"
+        if scalar(keys %unitsToAlsoSkip) > 0;
 
     print STDERR "would restart systemd\n" if $restartSystemd;
+    print STDERR "would reload the following units: ", join(", ", sort(keys %unitsToReload)), "\n"
+        if scalar(keys %unitsToReload) > 0;
     print STDERR "would restart the following units: ", join(", ", sort(keys %unitsToRestart)), "\n"
         if scalar(keys %unitsToRestart) > 0;
     my @unitsToStartFiltered = filterUnits(\%unitsToStart);
     print STDERR "would start the following units: ", join(", ", @unitsToStartFiltered), "\n"
         if scalar @unitsToStartFiltered;
-    print STDERR "would reload the following units: ", join(", ", sort(keys %unitsToReload)), "\n"
-        if scalar(keys %unitsToReload) > 0;
-    unlink($dryRestartByActivationFile);
     exit 0;
 }
 

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -152,7 +152,7 @@ sub fingerprintUnit {
 sub handleModifiedUnit {
     my ($unit, $baseName, $newUnitFile, $activePrev, $unitsToStop, $unitsToStart, $unitsToReload, $unitsToRestart, $unitsToSkip) = @_;
 
-    if ($unit eq "sysinit.target" || $unit eq "basic.target" || $unit eq "multi-user.target" || $unit eq "graphical.target") {
+    if ($unit eq "sysinit.target" || $unit eq "basic.target" || $unit eq "multi-user.target" || $unit eq "graphical.target" || $unit =~ /\.slice$/) {
         # Do nothing.  These cannot be restarted directly.
         # Slices and Paths don't have to be restarted since
         # properties (resource limits and inotify watches)
@@ -161,7 +161,7 @@ sub handleModifiedUnit {
         # Reload the changed mount unit to force a remount.
         $unitsToReload->{$unit} = 1;
         recordUnit($reloadListFile, $unit);
-    } elsif ($unit =~ /\.slice$/ || $unit =~ /\.path$/) {
+    } elsif ($unit =~ /\.path$/) {
         # FIXME: do something?
     } else {
         my $unitInfo = parseUnit($newUnitFile);

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -501,7 +501,9 @@ while (my ($unit, $state) = each %{$activeNew}) {
             push @failed, $unit;
         }
     }
-    elsif ($state->{state} ne "failed" && !defined $activePrev->{$unit}) {
+    # Ignore scopes since they are not managed by this script but rather
+    # created and managed by third-party services via the systemd dbus API.
+    elsif ($state->{state} ne "failed" && !defined $activePrev->{$unit} && $unit !~ /\.scope$/) {
         push @new, $unit;
     }
 }

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -210,7 +210,10 @@ sub handleModifiedUnit {
                     $unitsToRestart->{$unit} = 1;
                     recordUnit($restartListFile, $unit);
                 } else {
-                    if (!boolIsTrue($unitInfo->{'X-StopIfChanged'} // "yes")) {
+                    # Always restart non-services instead of stopping and starting them
+                    # because it doesn't make sense to stop them with a config from
+                    # the old evaluation.
+                    if (!boolIsTrue($unitInfo->{'X-StopIfChanged'} // "yes") || $unit !~ /\.service$/) {
                         # This unit should be restarted instead of
                         # stopped and started.
                         $unitsToRestart->{$unit} = 1;

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -485,7 +485,7 @@ unlink($startListFile);
 
 
 # Print failed and new units.
-my (@failed, @new, @restarting);
+my (@failed, @new);
 my $activeNew = getActiveUnits;
 while (my ($unit, $state) = each %{$activeNew}) {
     if ($state->{state} eq "failed") {

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -152,7 +152,7 @@ sub fingerprintUnit {
 sub handleModifiedUnit {
     my ($unit, $baseName, $newUnitFile, $activePrev, $unitsToStop, $unitsToStart, $unitsToReload, $unitsToRestart, $unitsToSkip) = @_;
 
-    if ($unit eq "sysinit.target" || $unit eq "basic.target" || $unit eq "multi-user.target" || $unit eq "graphical.target" || $unit =~ /\.slice$/) {
+    if ($unit eq "sysinit.target" || $unit eq "basic.target" || $unit eq "multi-user.target" || $unit eq "graphical.target" || $unit =~ /\.slice$/ || $unit =~ /\.path$/) {
         # Do nothing.  These cannot be restarted directly.
         # Slices and Paths don't have to be restarted since
         # properties (resource limits and inotify watches)
@@ -161,8 +161,6 @@ sub handleModifiedUnit {
         # Reload the changed mount unit to force a remount.
         $unitsToReload->{$unit} = 1;
         recordUnit($reloadListFile, $unit);
-    } elsif ($unit =~ /\.path$/) {
-        # FIXME: do something?
     } else {
         my $unitInfo = parseUnit($newUnitFile);
         if (boolIsTrue($unitInfo->{'X-ReloadIfChanged'} // "no")) {

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -11,7 +11,6 @@ use Cwd 'abs_path';
 
 my $out = "@out@";
 
-# FIXME: maybe we should use /proc/1/exe to get the current systemd.
 my $curSystemd = abs_path("/run/current-system/sw/bin");
 
 # To be robust against interruption, record what units need to be started etc.
@@ -448,7 +447,7 @@ if (scalar (keys %unitsToStop) > 0) {
     print STDERR "stopping the following units: ", join(", ", @unitsToStopFiltered), "\n"
         if scalar @unitsToStopFiltered;
     # Use current version of systemctl binary before daemon is reexeced.
-    system("$curSystemd/systemctl", "stop", "--", sort(keys %unitsToStop)); # FIXME: ignore errors?
+    system("$curSystemd/systemctl", "stop", "--", sort(keys %unitsToStop));
 }
 
 print STDERR "NOT restarting the following changed units: ", join(", ", sort(keys %unitsToSkip)), "\n"

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -84,6 +84,13 @@ let
       export localeArchive="${config.i18n.glibcLocales}/lib/locale/locale-archive"
       substituteAll ${./switch-to-configuration.pl} $out/bin/switch-to-configuration
       chmod +x $out/bin/switch-to-configuration
+      ${optionalString (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) ''
+        if ! output=$($perl/bin/perl -c $out/bin/switch-to-configuration 2>&1); then
+          echo "switch-to-configuration syntax is not valid:"
+          echo "$output"
+          exit 1
+        fi
+      ''}
 
       echo -n "${toString config.system.extraDependencies}" > $out/extra-dependencies
 

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -7,15 +7,135 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   };
 
   nodes = {
-    machine = { ... }: {
+    machine = { config, pkgs, lib, ... }: {
+      environment.systemPackages = [ pkgs.socat ]; # for the socket activation stuff
       users.mutableUsers = false;
+
+      specialisation = {
+        # A system with a simple socket-activated unit
+        simple-socket.configuration = {
+          systemd.services.socket-activated.serviceConfig = {
+            ExecStart = pkgs.writeScript "socket-test.py" /* python */ ''
+              #!${pkgs.python3}/bin/python3
+
+              from socketserver import TCPServer, StreamRequestHandler
+              import socket
+
+              class Handler(StreamRequestHandler):
+                  def handle(self):
+                      self.wfile.write("hello".encode("utf-8"))
+
+              class Server(TCPServer):
+                  def __init__(self, server_address, handler_cls):
+                      # Invoke base but omit bind/listen steps (performed by systemd activation!)
+                      TCPServer.__init__(
+                          self, server_address, handler_cls, bind_and_activate=False)
+                      # Override socket
+                      self.socket = socket.fromfd(3, self.address_family, self.socket_type)
+
+              if __name__ == "__main__":
+                  server = Server(("localhost", 1234), Handler)
+                  server.serve_forever()
+            '';
+          };
+          systemd.sockets.socket-activated = {
+            wantedBy = [ "sockets.target" ];
+            listenStreams = [ "/run/test.sock" ];
+            socketConfig.SocketMode = lib.mkDefault "0777";
+          };
+        };
+
+        # The same system but the socket is modified
+        modified-socket.configuration = {
+          imports = [ config.specialisation.simple-socket.configuration ];
+          systemd.sockets.socket-activated.socketConfig.SocketMode = "0666";
+        };
+
+        # The same system but the service is modified
+        modified-service.configuration = {
+          imports = [ config.specialisation.simple-socket.configuration ];
+          systemd.services.socket-activated.serviceConfig.X-Test = "test";
+        };
+
+        # The same system but both service and socket are modified
+        modified-service-and-socket.configuration = {
+          imports = [ config.specialisation.simple-socket.configuration ];
+          systemd.services.socket-activated.serviceConfig.X-Test = "some_value";
+          systemd.sockets.socket-activated.socketConfig.SocketMode = "0444";
+        };
+
+        # A system with a socket-activated service and some simple services
+        service-and-socket.configuration = {
+          imports = [ config.specialisation.simple-socket.configuration ];
+          systemd.services.simple-service = {
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = "${pkgs.coreutils}/bin/true";
+            };
+          };
+
+          systemd.services.simple-restart-service = {
+            stopIfChanged = false;
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = "${pkgs.coreutils}/bin/true";
+            };
+          };
+
+          systemd.services.simple-reload-service = {
+            reloadIfChanged = true;
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = "${pkgs.coreutils}/bin/true";
+              ExecReload = "${pkgs.coreutils}/bin/true";
+            };
+          };
+
+          systemd.services.no-restart-service = {
+            restartIfChanged = false;
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = "${pkgs.coreutils}/bin/true";
+            };
+          };
+        };
+        restart-and-reload-by-activation-script.configuration = {
+          imports = [ config.specialisation.service-and-socket.configuration ];
+          system.activationScripts.restart-and-reload-test = {
+            supportsDryActivation = true;
+            deps = [];
+            text = ''
+              if [ "$NIXOS_ACTION" = dry-activate ]; then
+                f=/run/nixos/dry-activation-restart-list
+              else
+                f=/run/nixos/activation-restart-list
+              fi
+              cat <<EOF >> "$f"
+              simple-service.service
+              simple-restart-service.service
+              simple-reload-service.service
+              no-restart-service.service
+              socket-activated.service
+              EOF
+            '';
+          };
+        };
+      };
     };
     other = { ... }: {
       users.mutableUsers = true;
     };
   };
 
-  testScript = {nodes, ...}: let
+  testScript = { nodes, ... }: let
     originalSystem = nodes.machine.config.system.build.toplevel;
     otherSystem = nodes.other.config.system.build.toplevel;
 
@@ -27,12 +147,121 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       set -o pipefail
       exec env -i "$@" | tee /dev/stderr
     '';
-  in ''
+  in /* python */ ''
+    def switch_to_specialisation(name, action="test"):
+        out = machine.succeed(f"${originalSystem}/specialisation/{name}/bin/switch-to-configuration {action} 2>&1")
+        assert_lacks(out, "switch-to-configuration line")  # Perl warnings
+        return out
+
+    def assert_contains(haystack, needle):
+        if needle not in haystack:
+            print("The haystack that will cause the following exception is:")
+            print("---")
+            print(haystack)
+            print("---")
+            raise Exception(f"Expected string '{needle}' was not found")
+
+    def assert_lacks(haystack, needle):
+        if needle in haystack:
+            print("The haystack that will cause the following exception is:")
+            print("---")
+            print(haystack, end="")
+            print("---")
+            raise Exception(f"Unexpected string '{needle}' was found")
+
+
     machine.succeed(
         "${stderrRunner} ${originalSystem}/bin/switch-to-configuration test"
     )
     machine.succeed(
         "${stderrRunner} ${otherSystem}/bin/switch-to-configuration test"
     )
+
+    with subtest("systemd sockets"):
+        machine.succeed("${originalSystem}/bin/switch-to-configuration test")
+
+        # Simple socket is created
+        out = switch_to_specialisation("simple-socket")
+        assert_lacks(out, "stopping the following units:")
+        # not checking for reload because dbus gets reloaded
+        assert_lacks(out, "restarting the following units:")
+        assert_lacks(out, "\nstarting the following units:")
+        assert_contains(out, "the following new units were started: socket-activated.socket\n")
+        assert_lacks(out, "as well:")
+        machine.succeed("[ $(stat -c%a /run/test.sock) = 777 ]")
+
+        # Changing the socket restarts it
+        out = switch_to_specialisation("modified-socket")
+        assert_lacks(out, "stopping the following units:")
+        #assert_lacks(out, "reloading the following units:")
+        assert_contains(out, "restarting the following units: socket-activated.socket\n")
+        assert_lacks(out, "\nstarting the following units:")
+        assert_lacks(out, "the following new units were started:")
+        assert_lacks(out, "as well:")
+        machine.succeed("[ $(stat -c%a /run/test.sock) = 666 ]")  # change was applied
+
+        # The unit is properly activated when the socket is accessed
+        if machine.succeed("socat - UNIX-CONNECT:/run/test.sock") != "hello":
+            raise Exception("Socket was not properly activated")
+
+        # Changing the socket restarts it and ignores the active service
+        out = switch_to_specialisation("simple-socket")
+        assert_contains(out, "stopping the following units: socket-activated.service\n")
+        assert_lacks(out, "reloading the following units:")
+        assert_contains(out, "restarting the following units: socket-activated.socket\n")
+        assert_lacks(out, "\nstarting the following units:")
+        assert_lacks(out, "the following new units were started:")
+        assert_lacks(out, "as well:")
+        machine.succeed("[ $(stat -c%a /run/test.sock) = 777 ]")  # change was applied
+
+        # Changing the service does nothing when the service is not active
+        out = switch_to_specialisation("modified-service")
+        assert_lacks(out, "stopping the following units:")
+        assert_lacks(out, "reloading the following units:")
+        assert_lacks(out, "restarting the following units:")
+        assert_lacks(out, "\nstarting the following units:")
+        assert_lacks(out, "the following new units were started:")
+        assert_lacks(out, "as well:")
+
+        # Activating the service and modifying it stops it but leaves the socket untouched
+        machine.succeed("socat - UNIX-CONNECT:/run/test.sock")
+        out = switch_to_specialisation("simple-socket")
+        assert_contains(out, "stopping the following units: socket-activated.service\n")
+        assert_lacks(out, "reloading the following units:")
+        assert_lacks(out, "restarting the following units:")
+        assert_lacks(out, "\nstarting the following units:")
+        assert_lacks(out, "the following new units were started:")
+        assert_lacks(out, "as well:")
+
+        # Activating the service and both the service and the socket stops the service and restarts the socket
+        machine.succeed("socat - UNIX-CONNECT:/run/test.sock")
+        out = switch_to_specialisation("modified-service-and-socket")
+        assert_contains(out, "stopping the following units: socket-activated.service\n")
+        assert_lacks(out, "reloading the following units:")
+        assert_contains(out, "restarting the following units: socket-activated.socket\n")
+        assert_lacks(out, "\nstarting the following units:")
+        assert_lacks(out, "the following new units were started:")
+        assert_lacks(out, "as well:")
+
+    with subtest("restart and reload by activation file"):
+        out = switch_to_specialisation("service-and-socket")
+        # Switch to a system where the example services get restarted
+        # by the activation script
+        out = switch_to_specialisation("restart-and-reload-by-activation-script")
+        assert_lacks(out, "stopping the following units:")
+        assert_contains(out, "stopping the following units as well: simple-service.service, socket-activated.service\n")
+        assert_contains(out, "reloading the following units: simple-reload-service.service\n")
+        assert_contains(out, "restarting the following units: simple-restart-service.service\n")
+        assert_contains(out, "\nstarting the following units: simple-service.service")
+
+        # The same, but in dry mode
+        switch_to_specialisation("service-and-socket")
+        out = switch_to_specialisation("restart-and-reload-by-activation-script", action="dry-activate")
+        assert_lacks(out, "would stop the following units:")
+        assert_contains(out, "would stop the following units as well: simple-service.service, socket-activated.service\n")
+        assert_contains(out, "would reload the following units: simple-reload-service.service\n")
+        assert_contains(out, "would restart the following units: simple-restart-service.service\n")
+        assert_contains(out, "\nwould start the following units: simple-service.service")
+
   '';
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is the second attempt to restart sockets properly.
The last time people were not completely happy so I kind of went over the top here.

cc @alyssais to make sure I don't break cross again
cc @grahamc maybe you could take a look at the Perl if you find time

Fixes #74899
Closes #33661

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) → `switch-test.nix`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
