### PR TITLE
Adds a notice that the service.wakeonlan module was moved

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -79,6 +79,7 @@ with lib;
         The hidepid module was removed, since the underlying machinery
         is broken when using cgroups-v2.
     '')
+    (mkRemovedOptionModule ["services" "wakeonlan"] "This module was removed in favor of enabling it with networking.interfaces.<name>.wakeOnLan")
 
     # Do NOT add any option renames here, see top of the file
   ];


### PR DESCRIPTION
###### Motivation for this change
Forgot/didn't know I should've done this 
As suggested by https://github.com/NixOS/nixpkgs/pull/140779#issuecomment-939306503

Works for me: 
```
error:
       Failed assertions:
       - The option definition `services.wakeonlan' in `/nix/store/hmgr1sr6qrj98wwgnzl8hcklb9z7d1ak-source/hosts/pain/configuration.nix' no longer has any effect; please remove it.
       This module was removed in favor of enabling it with networking.interfaces.<name>.wakeOnLan
```

@rnhmjoj please merge this as soon as possible 😄 
###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
