### PR TITLE
releaseTools.debBuild: fix invocation

### DIFF
--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -3,7 +3,7 @@
 
 { name ? "debian-build"
 , diskImage
-, src, stdenv, vmTools, checkinstall
+, src, lib, stdenv, vmTools, checkinstall
 , fsTranslation ? false
 , # Features provided by this package.
   debProvides ? []


### PR DESCRIPTION
Somewhere between #110628, which replaced `stdenv.lib` with just `lib`, and up to bug #134572, `lib` got removed from the argument list, breaking any invocations of `releaseTools.debBuild` with messages like the following:

```
error: undefined variable 'lib' at /nix/store/278hhh3sb9jc12x6f01c4f496ncyzklv-nixpkgs-21.11pre320922.ee084c02040/nixpkgs/pkgs/build-support/release/debian-build.nix:60:23
```

This adds it back. Notably, invoking this still requires invoking with `NIXPKGS_ALLOW_INSECURE=1` due to:

```
error: Package ‘checkinstall-1.6.2’ in /home/tdemin/Projects/librespot/nixpkgs/pkgs/tools/package-management/checkinstall/default.nix:70 is marked as insecure, refusing to evaluate.


Known issues:
 - CVE-2020-25031
```

Fixes #134572.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
