### PR TITLE
pywayland: init at v0.4.7

### DIFF
--- a/pkgs/development/python-modules/pywayland/default.nix
+++ b/pkgs/development/python-modules/pywayland/default.nix
@@ -1,0 +1,37 @@
+{ pytest
+, cffi
+, wayland
+, pkg-config
+, buildPythonApplication
+, fetchFromGitHub
+, setuptools
+}:
+buildPythonApplication rec {
+  name = "pywayland-${version}";
+  version = "0.4.7";
+  src = fetchFromGitHub {
+    owner = "flacjacket";
+    repo = "pywayland";
+    rev = "v${version}";
+    sha256 = "bFjw8sjB+Zo4F5i2Jo7srMa8po+URcLVvu1QoU9scvM=";
+  };
+  nativeBuildInputs = [
+    setuptools
+    cffi
+    wayland
+  ];
+  propagatedBuildInputs = nativeBuildInputs;
+  preBuild = ''
+        python ./pywayland/ffi_build.py
+        python -m pywayland.scanner
+  '';
+  checkInputs = [
+    pytest
+    pkg-config
+  ];
+  checkPhase = ''
+    export XDG_RUNTIME_DIR=/tmp
+    pytest
+  '';
+  doCheck = true;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8582,6 +8582,8 @@ with pkgs;
 
   pywal = with python3Packages; toPythonApplication pywal;
 
+  pywayland = with python39Packages; callPackage ../development/python-modules/pywayland { };
+
   pystring = callPackage ../development/libraries/pystring {};
 
   rbw = callPackage ../tools/security/rbw {


### PR DESCRIPTION
###### Motivation for this change
First step towards supporting qtile on wayland.

###### Things done

Added the pywayland package, a dependency for qtile's wayland backend.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
