### PR TITLE
sabnzbd: Add needed python modules puremagic and guessit

### DIFF
--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -17,6 +17,8 @@ let
     configobj
     feedparser
     sabyenc3
+    puremagic
+    guessit
   ]);
   path = lib.makeBinPath [ par2cmdline unrar unzip p7zip ];
 in stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change

Fixing the sabnzbd service. Without these, setting `services.sabnzbd.enable = true` fails to start the
sabnzbd service with:
```
okt 10 18:57:09 airtop sabnzbd[1625042]: Traceback (most recent call last):
okt 10 18:57:09 airtop sabnzbd[1625042]:   File "/nix/store/0z8z40h0197r6g91q3sal97zswbvfg5k-sabnzbd-3.4.0/SABnzbd.py", line 56, in <module>
okt 10 18:57:09 airtop sabnzbd[1625042]:     import sabnzbd
okt 10 18:57:09 airtop sabnzbd[1625042]:   File "/nix/store/0z8z40h0197r6g91q3sal97zswbvfg5k-sabnzbd-3.4.0/sabnzbd/__init__.py", line 91, in <module>
okt 10 18:57:09 airtop sabnzbd[1625042]:     import sabnzbd.rss as rss
okt 10 18:57:09 airtop sabnzbd[1625042]:   File "/nix/store/0z8z40h0197r6g91q3sal97zswbvfg5k-sabnzbd-3.4.0/sabnzbd/rss.py", line 35, in <module>
okt 10 18:57:09 airtop sabnzbd[1625042]:     import sabnzbd.emailer as emailer
okt 10 18:57:09 airtop sabnzbd[1625042]:   File "/nix/store/0z8z40h0197r6g91q3sal97zswbvfg5k-sabnzbd-3.4.0/sabnzbd/emailer.py", line 36, in <module>
okt 10 18:57:09 airtop sabnzbd[1625042]:     from sabnzbd.notifier import check_cat
okt 10 18:57:09 airtop sabnzbd[1625042]:   File "/nix/store/0z8z40h0197r6g91q3sal97zswbvfg5k-sabnzbd-3.4.0/sabnzbd/notifier.py", line 36, in <module>
okt 10 18:57:09 airtop sabnzbd[1625042]:     from sabnzbd.newsunpack import create_env
okt 10 18:57:09 airtop sabnzbd[1625042]:   File "/nix/store/0z8z40h0197r6g91q3sal97zswbvfg5k-sabnzbd-3.4.0/sabnzbd/newsunpack.py", line 60, in <module>
okt 10 18:57:09 airtop sabnzbd[1625042]:     from sabnzbd.nzbstuff import NzbObject, NzbFile
okt 10 18:57:09 airtop sabnzbd[1625042]:   File "/nix/store/0z8z40h0197r6g91q3sal97zswbvfg5k-sabnzbd-3.4.0/sabnzbd/nzbstuff.py", line 89, in <module>
okt 10 18:57:09 airtop sabnzbd[1625042]:     from sabnzbd.deobfuscate_filenames import is_probably_obfuscated
okt 10 18:57:09 airtop sabnzbd[1625042]:   File "/nix/store/0z8z40h0197r6g91q3sal97zswbvfg5k-sabnzbd-3.4.0/sabnzbd/deobfuscate_filenames.py", line 38, in <module>
okt 10 18:57:09 airtop sabnzbd[1625042]:     import sabnzbd.utils.file_extension as file_extension
okt 10 18:57:09 airtop sabnzbd[1625042]:   File "/nix/store/0z8z40h0197r6g91q3sal97zswbvfg5k-sabnzbd-3.4.0/sabnzbd/utils/file_extension.py", line 8, in <module>
okt 10 18:57:09 airtop sabnzbd[1625042]:     import puremagic
okt 10 18:57:09 airtop sabnzbd[1625042]: ModuleNotFoundError: No module named 'puremagic'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
