### PR TITLE
yarn2nix: fix "rev is not defined"

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
@@ -89,7 +89,7 @@ function fetchLockedDep(builtinFetchGit) {
 
       const [_, branch] = nameWithVersion.split('#')
 
-      return fetchgit(fileName, githubUrl, rev, branch || 'master', builtinFetchGit)
+      return fetchgit(fileName, githubUrl, githubRev, branch || 'master', builtinFetchGit)
     }
 
     if (url.startsWith('git+') || url.startsWith("git:")) {


### PR DESCRIPTION
###### Motivation for this change

```
ReferenceError: rev is not defined
    at /nix/store/fg0vcsh2qdiiy54mb4s7i7wylk7j73in-yarn2nix-1.0.0/libexec/yarn2nix/deps/yarn2nix/lib/generateNix.js:92:44
[...]
```


Must have slipped in when incorporating comments on #136922 

###### Things done

Tested that it can build schildichat-desktop with IFD (which previously resulted in the error above)