### PR TITLE
irrlicht: fix build on aarch64

### DIFF
--- a/pkgs/development/libraries/irrlicht/default.nix
+++ b/pkgs/development/libraries/irrlicht/default.nix
@@ -21,17 +21,20 @@ stdenv.mkDerivation rec {
     cd source/Irrlicht
   '';
 
-  buildPhase = ''
-    make sharedlib NDEBUG=1 "LDFLAGS=-lX11 -lGL -lXxf86vm"
+  preBuild = ''
+    makeFlagsArray+=(sharedlib NDEBUG=1 LDFLAGS="-lX11 -lGL -lXxf86vm")
   '';
+
+  enableParallelBuilding = true;
 
   preInstall = ''
     sed -i s,/usr/local/lib,$out/lib, Makefile
     mkdir -p $out/lib
   '';
 
-  buildInputs = [ libGLU libGL libXrandr libX11 libXxf86vm ]
-                ++ lib.optional stdenv.isAarch64 zlib;
+  buildInputs = [
+    libGLU libGL libXrandr libX11 libXxf86vm
+  ] ++ lib.optional stdenv.isAarch64 zlib;
 
   meta = {
     homepage = "http://irrlicht.sourceforge.net/";

--- a/pkgs/development/libraries/irrlicht/default.nix
+++ b/pkgs/development/libraries/irrlicht/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, libGLU, libGL, libXrandr, libX11, libXxf86vm }:
+{ lib, stdenv, fetchzip, libGLU, libGL, libXrandr, libX11, libXxf86vm, zlib }:
 
 let
   common = import ./common.nix { inherit fetchzip; };
@@ -12,6 +12,9 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     sed -ie '/sys\/sysctl.h/d' source/Irrlicht/COSOperator.cpp
+  '' + lib.optionalString stdenv.isAarch64 ''
+    substituteInPlace source/Irrlicht/Makefile \
+      --replace "-DIRRLICHT_EXPORTS=1" "-DIRRLICHT_EXPORTS=1 -DPNG_ARM_NEON_OPT=0"
   '';
 
   preConfigure = ''
@@ -27,7 +30,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib
   '';
 
-  buildInputs = [ libGLU libGL libXrandr libX11 libXxf86vm ];
+  buildInputs = [ libGLU libGL libXrandr libX11 libXxf86vm ]
+                ++ lib.optional stdenv.isAarch64 zlib;
 
   meta = {
     homepage = "http://irrlicht.sourceforge.net/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Building **minetest** on aarch64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
