### PR TITLE
steamPackages: make customisable

### DIFF
--- a/pkgs/games/steam/default.nix
+++ b/pkgs/games/steam/default.nix
@@ -1,26 +1,37 @@
-{ pkgs, newScope, buildFHSUserEnv }:
+{ lib, newScope, splicePackages, steamPackagesAttr ? "steamPackages"
+, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget, pkgsHostHost, pkgsTargetTarget
+, stdenv, buildFHSUserEnv, pkgsi686Linux
+}:
 
 let
-  callPackage = newScope self;
-
-  self = rec {
-    steamArch = if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then "amd64"
-                else if pkgs.stdenv.hostPlatform.system == "i686-linux" then "i386"
-                else throw "Unsupported platform: ${pkgs.stdenv.hostPlatform.system}";
+  steamPackagesFun = self: let
+    inherit (self) callPackage;
+  in {
+    steamArch = if stdenv.hostPlatform.system == "x86_64-linux" then "amd64"
+                else if stdenv.hostPlatform.system == "i686-linux" then "i386"
+                else throw "Unsupported platform: ${stdenv.hostPlatform.system}";
 
     steam-runtime = callPackage ./runtime.nix { };
     steam-runtime-wrapped = callPackage ./runtime-wrapped.nix { };
     steam = callPackage ./steam.nix { };
     steam-fonts = callPackage ./fonts.nix { };
     steam-fhsenv = callPackage ./fhsenv.nix {
-      glxinfo-i686 = pkgs.pkgsi686Linux.glxinfo;
+      glxinfo-i686 = pkgsi686Linux.glxinfo;
       steam-runtime-wrapped-i686 =
-        if steamArch == "amd64"
-        then pkgs.pkgsi686Linux.steamPackages.steam-runtime-wrapped
+        if self.steamArch == "amd64"
+        then pkgsi686Linux.${steamPackagesAttr}.steam-runtime-wrapped
         else null;
       inherit buildFHSUserEnv;
     };
     steamcmd = callPackage ./steamcmd.nix { };
   };
-
-in self
+  otherSplices = {
+    selfBuildBuild = pkgsBuildBuild.${steamPackagesAttr};
+    selfBuildHost = pkgsBuildHost.${steamPackagesAttr};
+    selfBuildTarget = pkgsBuildTarget.${steamPackagesAttr};
+    selfHostHost = pkgsHostHost.${steamPackagesAttr};
+    selfTargetTarget = pkgsTargetTarget.${steamPackagesAttr};
+  };
+  keep = self: { };
+  extra = spliced0: { };
+in lib.makeScopeWithSplicing splicePackages newScope otherSplices keep extra steamPackagesFun


### PR DESCRIPTION
###### Motivation for this change

I wanted to use `steamPackages.steam-runtime` with a newer `src` while using the rest of my current packages and without another local Nixpkgs checkout.

###### Things done

`steamPackages` is now a package scope via `lib.makeScopeWithSplicing`. The source was already rather in a customisable shape, so that made things easier.

Additionally, the argument `steamPackagesAttr` is now exposed and used as `.${steamPackagesAttr}` where `.steamPackages` was previously used hardcoded (in the value expression for `steam-runtime-wrapped-i386`).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
