### PR TITLE
r-documentation: discuss hydra builds

### DIFF
--- a/doc/languages-frameworks/r.section.md
+++ b/doc/languages-frameworks/r.section.md
@@ -125,3 +125,12 @@ patches and special requirements. These overrides are specified in the
 `pkgs/development/r-modules/default.nix` file. As the `*-packages.nix`
 contents are automatically generated it should not be edited and broken
 builds should be addressed using overrides.
+
+## Fixing packages {#fixing-packages}
+
+Hydra will attempt to build all the R packages in the branch
+`nixpkgs/r-updates`, and the results can be found at
+https://hydra.nixos.org/jobset/nixpkgs/r-updates
+
+Once the package set has been updated, push to `nixpkgs/r-updates`
+and fix any packages that are broken before submitting a PR to `master`.

--- a/doc/languages-frameworks/r.section.md
+++ b/doc/languages-frameworks/r.section.md
@@ -126,11 +126,18 @@ patches and special requirements. These overrides are specified in the
 contents are automatically generated it should not be edited and broken
 builds should be addressed using overrides.
 
-## Fixing packages {#fixing-packages}
+## Verify that core packages build {#verify-that-core-packages-build}
 
-Hydra will attempt to build all the R packages in the branch
-`nixpkgs/r-updates`, and the results can be found at
-https://hydra.nixos.org/jobset/nixpkgs/r-updates
+Once the package set has been updated, push to `nixpkgs/r-updates`.
 
-Once the package set has been updated, push to `nixpkgs/r-updates`
-and fix any packages that are broken before submitting a PR to `master`.
+Hydra will attempt to build all the R packages in the `nixpkgs` branch
+[r-updates](https://github.com/NixOS/nixpkgs/tree/r-updates), and the results
+can be found at https://hydra.nixos.org/jobset/nixpkgs/r-updates
+
+Check that the core packages used by `generate-r-packages.R` (listed below) are
+building. Fix any core packages that are broken before submitting a PR to
+`master`. Other broken packages can be fixed on demand.
+
+- data.table
+- parallel
+- BiocManager


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The Hydra build of R packages is extremely useful for finding broken packages. 

Currently it is only mentioned in some PRs and issues.

This PR puts the hydra build result URL into the language docs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
