### PR TITLE
[staging] Fix azure python packages

### DIFF
--- a/pkgs/development/python-modules/azure-core/default.nix
+++ b/pkgs/development/python-modules/azure-core/default.nix
@@ -44,6 +44,11 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
+  # test server needs to be available
+  preCheck = ''
+    export PYTHONPATH=tests/testserver_tests/coretestserver:$PYTHONPATH
+  '';
+
   pytestFlagsArray = [ "tests/" ];
   # disable tests which touch network
   disabledTests = [ "aiohttp" "multipart_send" "response" "request" "timeout" ];

--- a/pkgs/development/python-modules/google-cloud-storage/default.nix
+++ b/pkgs/development/python-modules/google-cloud-storage/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage rec {
     "tests/system/test_bucket.py"
     "tests/system/test_fileio.py"
     "tests/system/test_kms_integration.py"
+    "tests/conformance/test_conformance.py" # requires docker
   ];
 
   # prevent google directory from shadowing google imports

--- a/pkgs/development/python-modules/msal/default.nix
+++ b/pkgs/development/python-modules/msal/default.nix
@@ -21,6 +21,13 @@ buildPythonPackage rec {
     requests
   ];
 
+  # we already have cryptography included, version bounds are causing issues
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "PyJWT[crypto]>=1.0.0,<3" "PyJWT" \
+      --replace "cryptography>=0.6,<38" "cryptography"
+  '';
+
   # Tests assume Network Connectivity:
   # https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/e2958961e8ec16d0af4199f60c36c3f913497e48/tests/test_authority.py#L73
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Made the fixes on python-unstable, rebased them onto staging

cc @mweinelt 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
