### PR TITLE
nixos/openldap: refactor the openldap module to make it safer and more versatile

### DIFF
--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -279,6 +279,7 @@ in {
       attrs = {
         objectClass = "olcGlobal";
         cn = "config";
+        olcPidFile = "/run/openldap/slapd.pid";
       };
       children."cn=schema".attrs = {
         cn = "schema";
@@ -311,8 +312,9 @@ in {
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
+        Type = "forking";
         ExecStart = lib.escapeShellArgs ([
-          "${openldap}/libexec/slapd" "-d" "0" "-F" configDir
+          "${openldap}/libexec/slapd" "-F" configDir
           "-h" (lib.concatStringsSep " " cfg.urlList)
         ]);
         StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
@@ -320,6 +322,7 @@ in {
         RuntimeDirectory = "openldap";
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+        PIDFile = cfg.settings.attrs.olcPidFile;
       };
     };
 

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -111,7 +111,7 @@ in {
           olcDatabase = "{1}${database}";
           olcDbDirectory = lib.mkDefault (
             if versionAtLeast config.system.stateVersion "21.11"
-            then "/var/lib/openldap/slapd.d"
+            then "/var/lib/openldap/default"
             else "/var/db/openldap"
           );
         };

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -109,7 +109,11 @@ in {
           # objectClass is case-insensitive, so don't need to capitalize ${database}
           objectClass = [ "olcdatabaseconfig" "olc${database}config" ];
           olcDatabase = "{1}${database}";
-          olcDbDirectory = lib.mkDefault "/var/lib/openldap/slapd.d";
+          olcDbDirectory = lib.mkDefault (
+            if versionAtLeast config.system.stateVersion "21.11"
+            then "/var/lib/openldap/slapd.d"
+            else "/var/db/openldap"
+          );
         };
         "cn=schema".includes = lib.mkDefault (
           map (schema: "${openldap}/etc/schema/${schema}.ldif") [ "core" "cosine" "inetorgperson" "nis" ]

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -313,6 +313,8 @@ in {
         ]);
         StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
         StateDirectoryMode = "600";
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
       };
     };
 

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -312,7 +312,7 @@ in {
           "-h" (lib.concatStringsSep " " cfg.urlList)
         ]);
         StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
-        StateDirectoryMode = "600";
+        StateDirectoryMode = "700";
         RuntimeDirectory = "openldap";
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -208,8 +208,7 @@ in {
         default = null;
         description = ''
           Use this config directory instead of generating one from the
-          <literal>settings</literal> option. Overrides all NixOS settings. If
-          you use this option,ensure `olcPidFile` is set to `/run/slapd/slapd.conf`.
+          <literal>settings</literal> option. Overrides all NixOS settings.
         '';
         example = "/var/db/slapd.d";
       };
@@ -259,7 +258,6 @@ in {
       attrs = {
         objectClass = "olcGlobal";
         cn = "config";
-        olcPidFile = "/run/slapd/slapd.pid";
       };
       children."cn=schema".attrs = {
         cn = "schema";
@@ -286,9 +284,6 @@ in {
           chown -R "${cfg.user}:${cfg.group}" ${dataDir}
         '';
       in ''
-        mkdir -p /run/slapd
-        chown -R "${cfg.user}:${cfg.group}" /run/slapd
-
         mkdir -p ${lib.escapeShellArg configDir} ${lib.escapeShellArgs (lib.attrValues dataDirs)}
         chown "${cfg.user}:${cfg.group}" ${lib.escapeShellArg configDir} ${lib.escapeShellArgs (lib.attrValues dataDirs)}
 
@@ -303,11 +298,9 @@ in {
       '';
       serviceConfig = {
         ExecStart = lib.escapeShellArgs ([
-          "${openldap}/libexec/slapd" "-u" cfg.user "-g" cfg.group "-F" configDir
+          "${openldap}/libexec/slapd" "-d" "0" "-u" cfg.user "-g" cfg.group "-F" configDir
           "-h" (lib.concatStringsSep " " cfg.urlList)
         ]);
-        Type = "forking";
-        PIDFile = cfg.settings.attrs.olcPidFile;
       };
     };
 

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -262,7 +262,7 @@ in {
       assertion = ((getAttr opt cfg) != "_mkMergedOptionModule") -> (cfg.database != "_mkMergedOptionModule");
       message = "Legacy OpenLDAP option `services.openldap.${opt}` requires `services.openldap.database` (use value \"mdb\" if unsure)";
     }) legacyOptions ++ map (dn: {
-      assertion = dataDirsMap ? dn;
+      assertion = dataDirsMap ? "${dn}";
       message = ''
         declarative DB ${dn} does not exist in "servies.openldap.settings" or it exists but the "olcDbDirectory"
         is not prefixed by "/var/lib/openldap/"

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -313,6 +313,7 @@ in {
         ]);
         StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
         StateDirectoryMode = "600";
+        RuntimeDirectory = "openldap";
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
       };

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -290,7 +290,7 @@ in {
         settingsFile = pkgs.writeText "config.ldif" (lib.concatStringsSep "\n" (attrsToLdif "cn=config" cfg.settings));
         dataFiles = lib.mapAttrs (dn: contents: pkgs.writeText "${dn}.ldif" contents) cfg.declarativeContents;
         mkLoadScript = dn: let
-          dataDir = lib.escapeShellArg (getAttr dn dataDirsMap);
+          dataDir = lib.escapeShellArg ("/var/lib/openldap/" + getAttr dn dataDirsMap);
         in  ''
           rm -rf ${dataDir}/*
           ${openldap}/bin/slapadd -F ${lib.escapeShellArg configDir} -b ${dn} -l ${getAttr dn dataFiles}

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -60,25 +60,6 @@ in {
     };
   }) { inherit pkgs system; };
 
-  # Old-style configuration
-  oldOptions = import ./make-test-python.nix ({ pkgs, ... }: {
-    inherit testScript;
-    name = "openldap";
-
-    machine = { pkgs, ... }: {
-      services.openldap = {
-        enable = true;
-        logLevel = "stats acl";
-        defaultSchemas = true;
-        database = "mdb";
-        suffix = "dc=example";
-        rootdn = "cn=root,dc=example";
-        rootpw = "notapassword";
-        declarativeContents."dc=example" = dbContents;
-      };
-    };
-  }) { inherit system pkgs; };
-
   # Manually managed configDir, for example if dynamic config is essential
   manualConfigDir = import ./make-test-python.nix ({ pkgs, ... }: {
     name = "openldap";

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -42,7 +42,7 @@ in {
               attrs = {
                 objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
                 olcDatabase = "{1}mdb";
-                olcDbDirectory = "/var/db/openldap";
+                olcDbDirectory = "/var/lib/openldap/current";
                 olcSuffix = "dc=example";
                 olcRootDN = {
                   # cn=root,dc=example
@@ -97,7 +97,6 @@ in {
         cn: config
         objectClass: olcGlobal
         olcLogLevel: stats
-        olcPidFile: /run/slapd/slapd.pid
 
         dn: cn=schema,cn=config
         cn: schema

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -97,6 +97,7 @@ in {
         cn: config
         objectClass: olcGlobal
         olcLogLevel: stats
+        olcPidFile: /run/openldap/slapd.pid
 
         dn: cn=schema,cn=config
         cn: schema


### PR DESCRIPTION
###### Motivation for this change
Changes
- Run OpenLDAP in [foreground](https://www.openldap.net/lists/openldap-technical/201908/msg00040.html)
- Use systemd's `StateDirectory` to create configuration dir (if it is the default config dir), and database dirs (if they are located under `/var/lib/openldap`)
- Forbid setting declarativeContents for database whos directory is not under `/var/lib/openldap` to avoid accidentally `rm -rf` of the whole directory
- Run both the prestart script and slapd as unprivileged user instead of root
- Change the default config directory to `/var/lib/openldap/slapd.d`

cc @kwohlfahrt

Todos
- [x] Test on my machine
- [x] Fix tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
