### PR TITLE
yices: 2.6.1 -> 2.6.3

### DIFF
--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner  = "SRI-CSL";
     repo   = "yices2";
     rev    = "Yices-${version}";
-    sha256 = "0a7xmsk0d6fn2lff1kcpcnmbm4yy1bjfhvlawbkcbkm3zf8rk2dx";
+    sha256 = "01fi818lbkwilfcf1dz2dpxkcc1kh8ls0sl5aynyx9pwfn2v03zl";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs       = [ cudd gmp-static gperf libpoly ];
+  buildInputs = [ cudd gmp-static gperf libpoly ];
   configureFlags =
     [ "--with-static-gmp=${gmp-static.out}/lib/libgmp.a"
       "--with-static-gmp-include-dir=${gmp-static.dev}/include"

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -1,18 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, gmp-static, gperf, autoreconfHook, libpoly }:
+{ lib, stdenv, fetchFromGitHub, cudd, gmp-static, gperf, autoreconfHook, libpoly }:
 
 stdenv.mkDerivation rec {
   pname = "yices";
-  version = "2.6.1";
+  version = "2.6.3";
 
   src = fetchFromGitHub {
     owner  = "SRI-CSL";
     repo   = "yices2";
     rev    = "Yices-${version}";
-    sha256 = "04vf468spsh00jh7gj94cjnq8kjyfwy9l6r4z7l2pm0zgwkqgyhm";
+    sha256 = "0a7xmsk0d6fn2lff1kcpcnmbm4yy1bjfhvlawbkcbkm3zf8rk2dx";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs       = [ gmp-static gperf libpoly ];
+  buildInputs       = [ cudd gmp-static gperf libpoly ];
   configureFlags =
     [ "--with-static-gmp=${gmp-static.out}/lib/libgmp.a"
       "--with-static-gmp-include-dir=${gmp-static.dev}/include"


### PR DESCRIPTION
Among other things fixes build on clang-12:

    $ nix-build -E 'with import ./. {}; yices.override { stdenv = clang12Stdenv; }'
    ld: ../build/x86_64-pc-linux-gnu-release/lib/libyices.a(smt2_commands.o):(.bss+0x2b0):
      multiple definition of `smt2_opcodes_t';
        ../build/x86_64-pc-linux-gnu-release/obj/frontend/yices_smt2.o:(.bss+0x254):
          first defined here
