### PR TITLE
nixos/libvirtd: improved swtpm support

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -118,6 +118,13 @@ in {
         OVMF package to use.
       '';
     };
+    qemuSwtpm = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Allows libvirtd to use swtpm to create an emulated TPM.
+      '';
+    };
 
     extraOptions = mkOption {
       type = types.listOf types.str;
@@ -257,7 +264,8 @@ in {
         ] ++ cfg.extraOptions);
 
       path = [ cfg.qemuPackage ] # libvirtd requires qemu-img to manage disk images
-             ++ optional vswitch.enable vswitch.package;
+             ++ optional vswitch.enable vswitch.package
+             ++ optional cfg.qemuSwtpm pkgs.swtpm;
 
       serviceConfig = {
         Type = "notify";


### PR DESCRIPTION
###### Motivation for this change
As-is, libvirt will fail to initialize an emulated tpm. This patch provides a mechanism to fix that.
Related to #141224 

###### Things done
Added configuration option to virtualisation.libvirt for enabling software TPM.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
