### PR TITLE
bearssl: fix cross

### DIFF
--- a/pkgs/development/libraries/bearssl/default.nix
+++ b/pkgs/development/libraries/bearssl/default.nix
@@ -13,12 +13,18 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  makeFlags = [
+    "AR=${stdenv.cc.targetPrefix}ar"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "LD=${stdenv.cc.targetPrefix}cc"
+    "LDDLL=${stdenv.cc.targetPrefix}cc"
+  ] ++ lib.optional stdenv.hostPlatform.isStatic "DLL=no";
+
   installPhase = ''
     runHook preInstall
     install -D build/brssl $bin/brssl
     install -D build/testcrypto $bin/testcrypto
-    install -Dm644 build/libbearssl.so $lib/lib/libbearssl.so
-    install -Dm644 build/libbearssl.a $lib/lib/libbearssl.a
+    install -Dm644 -t $lib/lib build/libbearssl.*
     install -Dm644 -t $dev/include inc/*.h
     touch $out
     runHook postInstall


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
