### PR TITLE
haskell.packages.ghc921.cabal2nix: make dependencies build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -78,7 +78,7 @@ self: super: {
     sha256 = "1h5ny3mlng69vwaabl3af8hlv4qi24wfw8s14lw2ksw1yjbgi0j8";
   });
 
-  cereal = appendPatch super.cereal (pkgs.fetchpatch {
+  cereal = appendPatch (doJailbreak super.cereal) (pkgs.fetchpatch {
     url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/cereal-0.5.8.1.patch";
     sha256 = "03v4nxwz9y6viaa8anxcmp4zdf2clczv4pf9fqq6lnpplpz5i128";
   });

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -67,6 +67,11 @@ self: super: {
     postPatch = "sed -i -e 's,<4.16,<4.17,' basement.cabal";
   });
 
+  base16-bytestring = appendPatch super.base16-bytestring (pkgs.fetchpatch {
+    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/base16-bytestring-1.0.1.0.patch";
+    sha256 = "19ajai9y04981zfpcdj1nlz44b12gjj4m1ncciijv43mnz82plji";
+  });
+
   # Duplicate Show instances in tests and library cause compiling tests to fail
   blaze-builder = appendPatch (dontCheck super.blaze-builder) (pkgs.fetchpatch {
     url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/blaze-builder-0.4.2.1.patch";
@@ -91,9 +96,9 @@ self: super: {
     sha256 = "1g48lrmqgd88hqvfq3klz7lsrpwrir2v1931myrhh6dy0d9pqj09";
   });
 
-  # cabal-install needs more recent versions of Cabal and base16-bytestring.
+  # cabal-install needs more recent versions of Cabal
   cabal-install = (doJailbreak super.cabal-install).overrideScope (self: super: {
-    Cabal = null;
+    Cabal = self.Cabal_3_6_2_0;
   });
 
   doctest = appendPatch (dontCheck (doJailbreak super.doctest_0_18_1)) (pkgs.fetchpatch {

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -48,7 +48,7 @@ let
   compilerNames = lib.mapAttrs (name: _: name) pkgs.haskell.packages;
 
   # list of all compilers to test specific packages on
-  all = with compilerNames; [
+  released = with compilerNames; [
     ghc884
     ghc8107
     ghc901
@@ -304,18 +304,18 @@ let
       # and to confirm that critical packages for the
       # package sets (like Cabal, jailbreak-cabal) are
       # working as expected.
-      cabal-install = all;
-      Cabal_3_6_2_0 = with compilerNames; [ ghc884 ghc8107 ghc901 ghc921 ];
-      cabal2nix-unstable = all;
-      funcmp = all;
-      haskell-language-server = all;
-      hoogle = all;
-      hsdns = all;
-      jailbreak-cabal = all;
-      language-nix = all;
-      nix-paths = all;
-      titlecase = all;
-      ghc-api-compat = all;
+      cabal-install = released;
+      Cabal_3_6_2_0 = released ++ [ compilerNames.ghc921 ];
+      cabal2nix-unstable = released;
+      funcmp = released;
+      haskell-language-server = released;
+      hoogle = released;
+      hsdns = released;
+      jailbreak-cabal = released;
+      language-nix = released;
+      nix-paths = released;
+      titlecase = released;
+      ghc-api-compat = released;
     })
     {
       mergeable = pkgs.releaseTools.aggregate {

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -304,17 +304,18 @@ let
       # and to confirm that critical packages for the
       # package sets (like Cabal, jailbreak-cabal) are
       # working as expected.
-      cabal-install = released;
+      cabal-install = released ++ [ compilerNames.ghc921 ];
       Cabal_3_6_2_0 = released ++ [ compilerNames.ghc921 ];
-      cabal2nix-unstable = released;
-      funcmp = released;
+      cabal2nix = released ++ [ compilerNames.ghc921 ];
+      cabal2nix-unstable = released ++ [ compilerNames.ghc921 ];
+      funcmp = released ++ [ compilerNames.ghc921 ];
       haskell-language-server = released;
       hoogle = released;
-      hsdns = released;
-      jailbreak-cabal = released;
-      language-nix = released;
-      nix-paths = released;
-      titlecase = released;
+      hsdns = released ++ [ compilerNames.ghc921 ];
+      jailbreak-cabal = released ++ [ compilerNames.ghc921 ];
+      language-nix = released ++ [ compilerNames.ghc921 ];
+      nix-paths = released ++ [ compilerNames.ghc921 ];
+      titlecase = released ++ [ compilerNames.ghc921 ];
       ghc-api-compat = released;
     })
     {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

~~Especially the `distribution-nixpkgs` fix is a bit ugly, could be fixed by making a new 1.6.2 release.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
