### PR TITLE
cameradar: init at 5.0.1

### DIFF
--- a/pkgs/tools/security/cameradar/default.nix
+++ b/pkgs/tools/security/cameradar/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildGoModule
+, curl
+, fetchFromGitHub
+, pkg-config
+}:
+
+buildGoModule rec {
+  pname = "cameradar";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "Ullaakut";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "03nm03cqhq04ixw4rssfkgrin918pa0v7ai26v4h99gz7j8hs7ll";
+  };
+
+  vendorSha256 = "099np130dn51nb4lcyrrm46fihfipxrw0vpqs2jh5g4c6pnbk200";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+  ];
+
+  subPackages = [
+    "cmd/cameradar"
+  ];
+  # At least one test is outdated
+  #doCheck = false;
+
+  meta = with lib; {
+    description = "RTSP stream access tool";
+    homepage = "https://github.com/Ullaakut/cameradar";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2279,6 +2279,8 @@ with pkgs;
 
   calendar-cli = callPackage ../tools/networking/calendar-cli { };
 
+  cameradar = callPackage ../tools/security/cameradar { };
+
   candle = libsForQt5.callPackage ../applications/misc/candle { };
 
   capstone = callPackage ../development/libraries/capstone { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
RTSP stream access tool

https://github.com/Ullaakut/cameradar

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
