### PR TITLE
sumneko-lua-language-server: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/development/tools/sumneko-lua-language-server/default.nix
+++ b/pkgs/development/tools/sumneko-lua-language-server/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sumneko-lua-language-server";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "sumneko";
     repo = "lua-language-server";
     rev = version;
-    sha256 = "sha256-RhjH/phRVlNO9nPL+TtcrZYpwqNygpXjI/Pdyrxxv/4=";
+    sha256 = "sha256-PYlHjKMnqnhAJAvmHbH6Bb+qOyNzDH+ewOkXkj2u4CU=";
     fetchSubmodules = true;
   };
 
@@ -33,13 +33,14 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/extras
-    cp -r ./{locale,meta,script,*.lua} $out/extras/
-    cp ./bin/Linux/{bee.so,lpeglabel.so} $out/extras
-    cp ./bin/Linux/lua-language-server $out/extras/.lua-language-server-unwrapped
-    makeWrapper $out/extras/.lua-language-server-unwrapped \
+    install -Dt "$out"/share/lua-language-server/bin/Linux bin/Linux/lua-language-server
+    install -m644 -t "$out"/share/lua-language-server/bin/Linux bin/Linux/*.*
+    install -m644 -t "$out"/share/lua-language-server {debugger,main}.lua
+    cp -r locale meta script "$out"/share/lua-language-server
+
+    makeWrapper "$out"/share/lua-language-server/bin/Linux/lua-language-server \
       $out/bin/lua-language-server \
-      --add-flags "-E $out/extras/main.lua \
+      --add-flags "-E $out/share/lua-language-server/main.lua \
       --logpath='~/.cache/sumneko_lua/log' \
       --metapath='~/.cache/sumneko_lua/meta'"
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

After a few attempts I got the package finally working again. There are two main.lua files now and the first one sets up the `package.path`. The files need to be put into the correct directory hierarchy. I ended up translating the `package()` phase from the official Arch [PKGBUILD](https://github.com/archlinux/svntogit-community/tree/packages/lua-language-server/trunk
) which did the trick. This has the advantage that in the future we can simply diff our version against the Arch one if they happened to be faster than us.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
