### PR TITLE
nixos/ssh: take care not to create broken host key files

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -439,7 +439,7 @@ in
                 mkdir -m 0755 -p /etc/ssh
 
                 ${flip concatMapStrings cfg.hostKeys (k: ''
-                  if ! [ -f "${k.path}" ]; then
+                  if ! [ -s "${k.path}" ]; then
                       ssh-keygen \
                         -t "${k.type}" \
                         ${if k ? bits then "-b ${toString k.bits}" else ""} \


### PR DESCRIPTION
###### Motivation for this change

The old logic allowed to generate, depending on the
file system, empty host key files. This could happen
when the system is powered off shortly after first boot.

Because it is only checked if the file exists but not
if the file is actually usable, a new host key would
never be created again, preventing sshd from startup.

By initally writing the keys to a temp file, syncing
and finally renaming to the final name, it is now
guaranteed that the file is either there and readable
or completely missing, causing it to be generated
again.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
