### PR TITLE
coqPackages: filter packages depending on filtered packages

### DIFF
--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -16,6 +16,7 @@ in
   displayVersion ? {},
   release ? {},
   extraBuildInputs ? [],
+  propagatedBuildInputs ? [],
   namePrefix ? [ "coq" ],
   enableParallelBuilding ? true,
   extraInstallFlags ? [],
@@ -79,6 +80,8 @@ stdenv.mkDerivation (removeAttrs ({
         out = { homepage = "https://${domain}/${owner}/${repo}"; };
       }] {}) //
     optionalAttrs (fetched.broken or false) { coqFilter = true; broken = true; }) //
+    # Filter packages that depend on filtered packages
+    optionalAttrs (any (p: p.meta.coqFilter or false) propagatedBuildInputs) { coqFilter = true; } //
     (args.meta or {}) ;
 
 }


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This should avoid the issue of having packages that cannot evaluate because they depend on broken packages.

We decided to do this with @CohenCyril when I explained to him the problems I had encountered while packaging Coq 8.14 (#138274).

Unfortunately, the solution as currently implemented does not work yet. Any help is welcome (@CohenCyril @vbgl). The current issue is something like:

```
error: while evaluating the attribute 'coqPackages_8_14' at /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:145:3:
while evaluating 'mkCoqPackages' at /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:121:19, called from /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:145:22:
while evaluating 'filterPackages' at /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:95:24, called from /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:123:5:
while evaluating 'filterCoqPackages' at /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:98:23, called from /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:95:55:
while evaluating anonymous function at /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:100:22, called from /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:100:7:
while evaluating 'optional' at /home/theo/git/nixpkgs/lib/lists.nix:254:20, called from /home/theo/git/nixpkgs/pkgs/top-level/coq-packages.nix:101:11:
while evaluating the attribute 'meta.coqFilter' at /home/theo/git/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:405:13:
while evaluating the attribute 'meta' at /home/theo/git/nixpkgs/pkgs/build-support/coq/default.nix:76:3:
while evaluating 'optionalAttrs' at /home/theo/git/nixpkgs/lib/attrsets.nix:356:25, called from /home/theo/git/nixpkgs/pkgs/build-support/coq/default.nix:83:5:
while evaluating the attribute 'propagatedBuildInputs' at /home/theo/git/nixpkgs/pkgs/development/coq-modules/interval/default.nix:22:3:
while evaluating 'optionals' at /home/theo/git/nixpkgs/lib/lists.nix:270:5, called from /home/theo/git/nixpkgs/pkgs/development/coq-modules/interval/default.nix:23:8:
while evaluating 'opTruncate' at /home/theo/git/nixpkgs/pkgs/build-support/coq/extra-lib.nix:7:28, called from /home/theo/git/nixpkgs/pkgs/development/coq-modules/interval/default.nix:23:23:
while evaluating 'versionAtLeast' at /home/theo/git/nixpkgs/lib/strings.nix:516:24, called from /home/theo/git/nixpkgs/pkgs/build-support/coq/extra-lib.nix:8:10:
while evaluating 'versionOlder' at /home/theo/git/nixpkgs/lib/strings.nix:504:22, called from /home/theo/git/nixpkgs/lib/strings.nix:516:29:
while evaluating 'truncate' at /home/theo/git/nixpkgs/pkgs/build-support/coq/extra-lib.nix:6:21, called from /home/theo/git/nixpkgs/pkgs/build-support/coq/extra-lib.nix:8:14:
while evaluating 'sublist' at /home/theo/git/nixpkgs/lib/lists.nix:589:5, called from /home/theo/git/nixpkgs/pkgs/build-support/coq/extra-lib.nix:6:46:
value is null while a string was expected, at /home/theo/git/nixpkgs/pkgs/build-support/coq/extra-lib.nix:6:54
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
