### PR TITLE
home-assistant: 2021.10.2 -> 2021.10.4

### DIFF
--- a/pkgs/development/python-modules/aiomusiccast/default.nix
+++ b/pkgs/development/python-modules/aiomusiccast/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "aiomusiccast";
-  version = "0.9.2";
+  version = "0.10.0";
 
   format = "pyproject";
 
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "vigonotion";
     repo = "aiomusiccast";
     rev = version;
-    sha256 = "sha256-xZPNEynj0kbeika15ZDEIRUe519V6Asaw+CEiBu7VL4=";
+    sha256 = "sha256-UdWZLthpCuKLjASVwi4GTkrHY+K9c1xrNYVLezC/NGM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyhaversion/default.nix
+++ b/pkgs/development/python-modules/pyhaversion/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pyhaversion";
-  version = "21.10.1";
+  version = "21.10.0";
 
   # Only 3.8.0 and beyond are supported
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "ludeeus";
     repo = pname;
     rev = version;
-    sha256 = "sha256-7J7zzJlevNQb7TpFYuGvsk3EWBgwhmV32xPNSLA/LS4=";
+    sha256 = "sha256-EvVkewFgkfYL6BjmJ/IWeuCyR+0R0ZxI35i9sxKcqxo=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zeroconf/default.nix
+++ b/pkgs/development/python-modules/zeroconf/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "zeroconf";
-  version = "0.36.7";
+  version = "0.36.8";
   format = "setuptools";
   disabled = pythonOlder "3.6";
 
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "jstasiak";
     repo = "python-zeroconf";
     rev = version;
-    sha256 = "sha256-jGbYd56JCXYUE4N2He5Ds8vVcgfny1kUYbd1rL7upcM=";
+    sha256 = "sha256-lsvrttfyUtQneUkQlWFpmQ99BSJp/YiVYUKY7AWh0rs=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.10.2";
+  version = "2021.10.3";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.10.3";
+  version = "2021.10.4";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -114,7 +114,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.10.2";
+  hassVersion = "2021.10.3";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -131,7 +131,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "0nds4491v8wy4d8w842asjpjj7xhqghlq0h61i7z6wp8jln7m418";
+    sha256 = "039wi74hx6jy5hqj9cpp8kdifnfyipbzl31f4s1wg3g4fxjq6167";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -114,7 +114,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.10.3";
+  hassVersion = "2021.10.4";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -131,7 +131,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "039wi74hx6jy5hqj9cpp8kdifnfyipbzl31f4s1wg3g4fxjq6167";
+    sha256 = "1cl0h15285x7xba425d9anv882adi6bdqx4i3cicg3gf0nzcc8am";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling
@@ -768,9 +768,6 @@ in with py.pkgs; buildPythonApplication rec {
     # wemo/test_sensor.py: KeyError for various power attributes
     "--deselect tests/components/wemo/test_sensor.py::TestInsightTodayEnergy::test_state_unavailable"
     "--deselect tests/components/wemo/test_sensor.py::TestInsightCurrentPower::test_state_unavailable"
-    # tado/test_climate.py: Tries to connect to my.tado.com
-    "--deselect tests/components/tado/test_climate.py::test_air_con"
-    "--deselect tests/components/tado/test_climate.py::test_heater"
     # helpers/test_system_info.py: AssertionError: assert 'Unknown' == 'Home Assistant Container'
     "--deselect tests/helpers/test_system_info.py::test_container_installationtype"
     # tests are located in tests/
@@ -785,7 +782,8 @@ in with py.pkgs; buildPythonApplication rec {
     "tests/auth/mfa_modules/test_notify.py"
     # emulated_hue/test_upnp.py: Tries to establish the public ipv4 address
     "tests/components/emulated_hue/test_upnp.py"
-
+    # tado/test_climate.py: Tries to connect to my.tado.com
+    "tests/components/tado/test_climate.py"
   ];
 
   disabledTests = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20211007.0";
+  version = "20211007.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-GchSCqdVPk8RVe4iNEVvrsIgrV9/CHE5bQwyaT+ErvU=";
+    sha256 = "sha256-wsDNLwzhpwH5vwdHRWhZGlumjFM8/S+kXProbD+VpE8=";
   };
 
   # there is nothing to strip in this package


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
