### PR TITLE
lib/types: add attrsRec type

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -41,6 +41,7 @@ let
     mapAttrs
     optionalAttrs
     zipAttrsWith
+    recursiveUpdate
     ;
   inherit (lib.options)
     getFiles
@@ -341,6 +342,14 @@ rec {
       description = "attribute set";
       check = isAttrs;
       merge = loc: foldl' (res: def: res // def.value) {};
+      emptyValue = { value = {}; };
+    };
+
+    attrsRec = mkOptionType {
+      name = "attrs";
+      description = "attribute set (merged recursively)";
+      check = isAttrs;
+      merge = loc: foldl' (res: def: recursiveUpdate res def.value) {};
       emptyValue = { value = {}; };
     };
 

--- a/nixos/modules/programs/git.nix
+++ b/nixos/modules/programs/git.nix
@@ -20,7 +20,7 @@ in
       };
 
       config = mkOption {
-        type = types.attrs;
+        type = types.attrsRec;
         default = { };
         example = {
           init.defaultBranch = "main";


### PR DESCRIPTION

###### Motivation for this change

This depends on #141255

This extends types.nix with a new type, attrsRec, which intends to solve the problem of nested attrs being merged improperly by using something more advanced than just `//`

Before: `{ opt.a.b.z = true; }` and `{ opt.a.c.z = true; }` -> `{ opt.a.c.z = true; }`

After: `{ opt.a.b.z = true; }` and `{ opt.a.c.z = true; }` -> `{ opt.a = { c.z = true; b.z = true; } }`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
