### PR TITLE
avizo: init at unstable-2021-07-21

### DIFF
--- a/pkgs/applications/misc/avizo/default.nix
+++ b/pkgs/applications/misc/avizo/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub
+, meson, ninja, pkg-config, vala
+, gtk3, glib, gtk-layer-shell
+, dbus, dbus-glib, librsvg
+, gobject-introspection, gdk-pixbuf, wrapGAppsHook
+}:
+
+stdenv.mkDerivation {
+  pname = "avizo";
+  version = "unstable-2021-07-21";
+
+  src = fetchFromGitHub {
+    owner = "misterdanb";
+    repo = "avizo";
+    rev = "7b3874e5ee25c80800b3c61c8ea30612aaa6e8d1";
+    sha256 = "sha256-ixAdiAH22Nh19uK5GoAXtAZJeAfCGSWTcGbrvCczWYc=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config vala gobject-introspection wrapGAppsHook ];
+
+  buildInputs = [ dbus dbus-glib gdk-pixbuf glib gtk-layer-shell gtk3 librsvg ];
+
+  postInstall = ''
+    substituteInPlace "$out"/bin/volumectl \
+      --replace 'avizo-client' "$out/bin/avizo-client"
+    substituteInPlace "$out"/bin/lightctl \
+      --replace 'avizo-client' "$out/bin/avizo-client"
+  '';
+
+  meta = with lib; {
+    description = "A neat notification daemon for Wayland";
+    homepage = "https://github.com/misterdanb/avizo";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.berbiche ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23598,6 +23598,8 @@ with pkgs;
 
   av-98 = callPackage ../applications/networking/browsers/av-98 { };
 
+  avizo = callPackage ../applications/misc/avizo { };
+
   avocode = callPackage ../applications/graphics/avocode {};
 
   azpainter = callPackage ../applications/graphics/azpainter { };


### PR DESCRIPTION
###### Motivation for this change

Package [avizo](https://github.com/misterdanb/avizo), a notification daemon for Wayland.

This tool can be used in place of [volnoti](https://github.com/davidbrazdil/volnoti) on Wayland.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
