### PR TITLE
zesarux: init at 10.0

### DIFF
--- a/pkgs/misc/emulators/zesarux/default.nix
+++ b/pkgs/misc/emulators/zesarux/default.nix
@@ -1,0 +1,89 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, SDL2
+, aalib
+, alsa-lib
+, libXext
+, libXxf86vm
+, libcaca
+, libpulseaudio
+, libsndfile
+, ncurses
+, openssl
+, which
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zesarux";
+  version = "10.0";
+
+  src = fetchFromGitHub {
+    owner = "chernandezba";
+    repo = pname;
+    rev = version;
+    hash = "sha256-cxV2dAzGnIzJiCRdq8vN/Cl4AQeJqjmiCAahijIJQ9k=";
+  };
+
+  nativeBuildInputs = [
+    which
+  ];
+
+  buildInputs = [
+    SDL2
+    aalib
+    alsa-lib
+    libXxf86vm
+    libXext
+    libcaca
+    libpulseaudio
+    libsndfile
+    ncurses
+    openssl
+  ];
+
+  patches = [
+    # Patch the shell scripts; remove it when the next version arrives
+    (fetchpatch {
+      name = "000-fix-shebangs.patch";
+      url = "https://github.com/chernandezba/zesarux/commit/4493439b38f565c5be7c36239ecaf0cf80045627.diff";
+      sha256 = "sha256-f+21naPcPXdcVvqU8ymlGfl1WkYGOeOBe9B/WFUauTI=";
+    })
+  ];
+
+  postPatch = ''
+    cd src
+    patchShebangs ./configure *.sh
+  '';
+
+  configureFlags = [
+    "--prefix=${placeholder "out"}"
+    "--c-compiler ${stdenv.cc.targetPrefix}cc"
+    "--enable-cpustats"
+    "--enable-memptr"
+    "--enable-sdl2"
+    "--enable-ssl"
+    "--enable-undoc-scfccf"
+    "--enable-visualmem"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    ./generate_install_sh.sh
+    patchShebangs ./install.sh
+    ./install.sh
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/chernandezba/zesarux";
+    description = " ZX Second-Emulator And Released for UniX";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}
+# TODO: Darwin support

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33139,6 +33139,8 @@ with pkgs;
 
   xcfun = callPackage ../development/libraries/science/chemistry/xcfun { };
 
+  zesarux = callPackage ../misc/emulators/zesarux { };
+
   zthrottle = callPackage ../tools/misc/zthrottle { };
 
   zktree = callPackage ../applications/misc/zktree {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
