### PR TITLE
wlroots, sway: make xwayland optional

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -6,6 +6,8 @@
 , nixosTests
 # Used by the NixOS module:
 , isNixOS ? false
+
+, enableXWayland ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -40,13 +42,16 @@ stdenv.mkDerivation rec {
   buildInputs = [
     wayland libxkbcommon pcre json_c dbus libevdev
     pango cairo libinput libcap pam gdk-pixbuf librsvg
-    wlroots wayland-protocols libdrm
+    wayland-protocols libdrm
+    (wlroots.override { inherit enableXWayland; })
   ];
 
   mesonFlags = [
     "-Ddefault-wallpaper=false"
     "-Dsd-bus-provider=libsystemd"
-  ];
+  ]
+    ++ lib.optional (!enableXWayland) "-Dxwayland=disabled"
+  ;
 
   passthru.tests.basic = nixosTests.sway;
 

--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -6,6 +6,8 @@
 , extraOptions ? [] # E.g.: [ "--verbose" ]
 # Used by the NixOS module:
 , isNixOS ? false
+
+, enableXWayland ? true
 }:
 
 assert extraSessionCommands != "" -> withBaseWrapper;
@@ -13,7 +15,7 @@ assert extraSessionCommands != "" -> withBaseWrapper;
 with lib;
 
 let
-  sway = sway-unwrapped.override { inherit isNixOS; };
+  sway = sway-unwrapped.override { inherit isNixOS enableXWayland; };
   baseWrapper = writeShellScriptBin "sway" ''
      set -o errexit
      if [ ! "$_SWAY_WRAPPER_ALREADY_EXECUTED" ]; then

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -1,7 +1,9 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland-scanner
 , libGL, wayland, wayland-protocols, libinput, libxkbcommon, pixman
 , xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
-, libpng, ffmpeg, xcbutilrenderutil, xwayland, seatd
+, libpng, ffmpeg, xcbutilrenderutil, seatd
+
+, enableXWayland ? true, xwayland ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -25,8 +27,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libGL wayland wayland-protocols libinput libxkbcommon pixman
     xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
-    libpng ffmpeg xcbutilrenderutil xwayland seatd
-  ];
+    libpng ffmpeg xcbutilrenderutil seatd
+  ]
+    ++ lib.optional enableXWayland xwayland
+  ;
+
+  mesonFlags =
+    lib.optional (!enableXWayland) "-Dxwayland=disabled"
+  ;
 
   postFixup = ''
     # Install ALL example programs to $examples:


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
