### PR TITLE
python3Packages.qualysclient: init at 0.0.4.8.1

### DIFF
--- a/pkgs/development/python-modules/qualysclient/default.nix
+++ b/pkgs/development/python-modules/qualysclient/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, certifi
+, charset-normalizer
+, fetchFromGitHub
+, idna
+, lxml
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, requests
+, responses
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "qualysclient";
+  version = "0.0.4.8.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "woodtechie1428";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1fdcmspjm1cy53x9gm7frfq175saskcwn565zqprgxzfcigip1n3";
+  };
+
+  propagatedBuildInputs = [
+    certifi
+    charset-normalizer
+    idna
+    lxml
+    requests
+    urllib3
+  ];
+
+  checkInputs = [
+    pytest-mock
+    pytestCheckHook
+    responses
+  ];
+
+  pythonImportsCheck = [
+    "qualysclient"
+  ];
+
+  meta = with lib; {
+    description = "Python SDK for interacting with the Qualys API";
+    homepage = "https://qualysclient.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7784,6 +7784,8 @@ in {
 
   qtpy = callPackage ../development/python-modules/qtpy { };
 
+  qualysclient = callPackage ../development/python-modules/qualysclient { };
+
   quamash = callPackage ../development/python-modules/quamash { };
 
   quandl = callPackage ../development/python-modules/quandl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python SDK for interacting with the Qualys API

https://github.com/woodtechie1428/qualysclient

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
