### PR TITLE
cagebreak: 1.7.1 -> 1.8.0

### DIFF
--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -4,6 +4,8 @@
 , fetchpatch
 , cairo
 , fontconfig
+, libevdev
+, libinput
 , libxkbcommon
 , makeWrapper
 , mesa
@@ -23,23 +25,14 @@
 
 stdenv.mkDerivation rec {
   pname = "cagebreak";
-  version = "1.7.1";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "project-repo";
     repo = pname;
     rev = version;
-    hash = "sha256-1IztedN5/I/4TDKHLJ26fSrDsvJ5QAr+cbzS2PQITDE=";
+    hash = "sha256-tWfHJajAOYZJ73GckZWWTdVz75YmHA7t/qDhM7+tJgk=";
   };
-
-  patches = [
-    # To fix the build with wlroots 0.14.0:
-    (fetchpatch {
-      # Add fixes for wlroots 0.14.0
-      url = "https://github.com/project-repo/cagebreak/commit/d57869d43add58331386fc8e89c14bb2b74afe17.patch";
-      sha256 = "0g6sl8y4kk0bm5x6pxqbxw2j0gyg3ybr2v9m70q2pxp70kms4lqg";
-    })
-  ];
 
   nativeBuildInputs = [
     makeWrapper
@@ -53,6 +46,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     cairo
     fontconfig
+    libevdev
+    libinput
     libxkbcommon
     mesa # for libEGL headers
     pango

--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cairo
 , fontconfig
 , libevdev


### PR DESCRIPTION
###### Motivation for this change

Update [cagebreak](https://github.com/project-repo/cagebreak) (a manual tiling window manager for Wayland, successor to ratpoison) to 1.8.0.

Changelog:
> - Add libinput configuration
> - Add virtual keyboard and pointer support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
