### PR TITLE
gtkwave: 3.3.110 -> 3.3.111

### DIFF
--- a/pkgs/applications/science/electronics/gtkwave/default.nix
+++ b/pkgs/applications/science/electronics/gtkwave/default.nix
@@ -1,16 +1,29 @@
-{ lib, stdenv, fetchurl, glib, gtk3, gperf, pkg-config, bzip2, tcl, tk, wrapGAppsHook, judy, xz }:
+{ bzip2
+, fetchurl
+, glib
+, gperf
+, gtk3
+, judy
+, lib
+, pkg-config
+, stdenv
+, tcl
+, tk
+, wrapGAppsHook
+, xz
+}:
 
 stdenv.mkDerivation rec {
   pname = "gtkwave";
-  version = "3.3.110";
+  version = "3.3.111";
 
   src = fetchurl {
-    url    = "mirror://sourceforge/gtkwave/${pname}-gtk3-${version}.tar.gz";
-    sha256 = "sha256-Ku25IVa8ot3SWxODeMrOaxBY5X022TnvD3l2kAa3Wao=";
+    url = "mirror://sourceforge/gtkwave/${pname}-gtk3-${version}.tar.gz";
+    sha256 = "0cv222qhgldfniz6zys52zhrynfsp5v0h8ia857lng7v33vw5qdl";
   };
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook ];
-  buildInputs = [ glib gtk3 gperf bzip2 tcl tk judy xz ];
+  buildInputs = [ bzip2 glib gperf gtk3 judy tcl tk xz ];
 
   configureFlags = [
     "--with-tcl=${tcl}/lib"
@@ -21,9 +34,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "VCD/Waveform viewer for Unix and Win32";
-    homepage    = "http://gtkwave.sourceforge.net";
-    license     = lib.licenses.gpl2Plus;
+    homepage = "http://gtkwave.sourceforge.net";
+    license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ thoughtpolice ];
-    platforms   = lib.platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update GTKWave to latest release. Also, reformat default.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
