### PR TITLE
sphinxcontrib-ditaa: Init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-ditaa/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-ditaa/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage
+, fetchPypi
+, docutils
+, ditaa
+, lib
+, sphinx
+, substituteAll
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-ditaa";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0kpqqf7cn66i3zpmwb3rda847shlfdspcxngnjzhk2jwpn5k2ykm";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ ditaa docutils sphinx ];
+
+  # no tests in package
+
+  meta = with lib; {
+    description = "ditaa extension for Sphinx";
+    homepage = "https://pypi.org/project/sphinxcontrib-ditaa";
+    maintainers = with maintainers; [ felixsinger ];
+    license = licenses.bsd0;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8601,6 +8601,8 @@ in {
 
   sphinxcontrib-devhelp = callPackage ../development/python-modules/sphinxcontrib-devhelp { };
 
+  sphinxcontrib-ditaa = callPackage ../development/python-modules/sphinxcontrib-ditaa { };
+
   sphinxcontrib-excel-table = callPackage ../development/python-modules/sphinxcontrib-excel-table { };
 
   sphinxcontrib-fulltoc = callPackage ../development/python-modules/sphinxcontrib-fulltoc { };


### PR DESCRIPTION
###### Motivation for this change
WIP

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
