### PR TITLE
nixos/cloudflared: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1,53 +1,53 @@
 /* List of NixOS maintainers.
-    ```nix
-    handle = {
-      # Required
-      name = "Your name";
-      email = "address@example.org";
+  ```nix
+  handle = {
+  # Required
+  name = "Your name";
+  email = "address@example.org";
 
-      # Optional
-      matrix = "@user:example.org";
-      github = "GithubUsername";
-      githubId = your-github-id;
-      keys = [{
-        longkeyid = "rsa2048/0x0123456789ABCDEF";
-        fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
-      }];
-    };
-    ```
+  # Optional
+  matrix = "@user:example.org";
+  github = "GithubUsername";
+  githubId = your-github-id;
+  keys = [{
+  longkeyid = "rsa2048/0x0123456789ABCDEF";
+  fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
+  }];
+  };
+  ```
 
-    where
+  where
 
-    - `handle` is the handle you are going to use in nixpkgs expressions,
-    - `name` is your, preferably real, name,
-    - `email` is your maintainer email address,
-    - `matrix` is your Matrix user ID,
-    - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
-    - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
-    - `keys` is a list of your PGP/GPG key IDs and fingerprints.
+  - `handle` is the handle you are going to use in nixpkgs expressions,
+  - `name` is your, preferably real, name,
+  - `email` is your maintainer email address,
+  - `matrix` is your Matrix user ID,
+  - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
+  - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
+  - `keys` is a list of your PGP/GPG key IDs and fingerprints.
 
-    `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
+  `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
 
-    If `github` begins with a numeral, `handle` should be prefixed with an underscore.
-    ```nix
-    _1example = {
-      github = "1example";
-    };
-    ```
+  If `github` begins with a numeral, `handle` should be prefixed with an underscore.
+  ```nix
+  _1example = {
+  github = "1example";
+  };
+  ```
 
-    Add PGP/GPG keys only if you actually use them to sign commits and/or mail.
+  Add PGP/GPG keys only if you actually use them to sign commits and/or mail.
 
-    To get the required PGP/GPG values for a key run
-    ```shell
-    gpg --keyid-format 0xlong --fingerprint <email> | head -n 2
-    ```
+  To get the required PGP/GPG values for a key run
+  ```shell
+  gpg --keyid-format 0xlong --fingerprint <email> | head -n 2
+  ```
 
-    !!! Note that PGP/GPG values stored here are for informational purposes only, don't use this file as a source of truth.
+  !!! Note that PGP/GPG values stored here are for informational purposes only, don't use this file as a source of truth.
 
-    More fields may be added in the future, however, in order to comply with GDPR this file should stay as minimal as possible.
+  More fields may be added in the future, however, in order to comply with GDPR this file should stay as minimal as possible.
 
-    Please keep the list alphabetically sorted.
-    See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
+  Please keep the list alphabetically sorted.
+  See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
 */
 {
   _0qq = {
@@ -5945,7 +5945,7 @@
     keys = [{
       longkeyid = "rsa4096/0x7248991EFA8EFBEE";
       fingerprint = "01F5 0A29 D4AA 9117 5A11  BDB1 7248 991E FA8E FBEE";
-     }];
+    }];
   };
   kiwi = {
     email = "envy1988@gmail.com";
@@ -8898,6 +8898,13 @@
     githubId = 103822;
     name = "Patrick Mahoney";
   };
+  pmc = {
+    name = "Piper McCorkle";
+    email = "contact@piperswe.me";
+    matrix = "@piper:lutris.engineering";
+    github = "piperswe";
+    githubId = 1830959;
+  };
   pmenke = {
     email = "nixos@pmenke.de";
     github = "pmenke-de";
@@ -10743,10 +10750,10 @@
     name = "Justus K";
   };
   SubhrajyotiSen = {
-      email = "subhrajyoti12@gmail.com";
-      github = "SubhrajyotiSen";
-      githubId = 12984845;
-      name = "Subhrajyoti Sen";
+    email = "subhrajyoti12@gmail.com";
+    github = "SubhrajyotiSen";
+    githubId = 12984845;
+    name = "Subhrajyoti Sen";
   };
   suhr = {
     email = "suhr@i2pmail.org";

--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -344,6 +344,14 @@
           controller support.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/cloudflare/cloudflared">cloudflared</link>,
+          the Cloudflare Argo Tunnel client, which allows exposing local
+          services over the Cloudflare network. Available as
+          <link linkend="opt-services.cloudflared.enable">services.cloudflared</link>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -105,6 +105,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [joycond](https://github.com/DanielOgorchock/joycond), a service that uses `hid-nintendo` to provide nintendo joycond pairing and better nintendo switch pro controller support.
 
+- [cloudflared](https://github.com/cloudflare/cloudflared), the Cloudflare Argo Tunnel client, which allows exposing local services over the Cloudflare network. Available as [services.cloudflared](#opt-services.cloudflared.enable).
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 - The `services.wakeonlan` option was removed, and replaced with `networking.interfaces.<name>.wakeOnLan`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -696,6 +696,7 @@
   ./services/networking/blockbook-frontend.nix
   ./services/networking/charybdis.nix
   ./services/networking/cjdns.nix
+  ./services/networking/cloudflared.nix
   ./services/networking/cntlm.nix
   ./services/networking/connman.nix
   ./services/networking/consul.nix

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -15,6 +15,8 @@ in
       package = lib.mkOption {
         type = lib.types.package;
         default = pkgs.cloudflared;
+        description = "The cloudflared package to use";
+        example = literalExpression ''pkgs.cloudflared'';
       };
       config = lib.mkOption {
         type = settingsFormat.type;
@@ -30,8 +32,8 @@ in
 
       configFile = mkOption {
         type = types.path;
-        example = literalExpression ''"/etc/cloudflared/config.yaml"'';
         description = "Path to cloudflared config.yaml.";
+        example = literalExpression ''"/etc/cloudflared/config.yaml"'';
       };
     };
   };

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -11,14 +11,14 @@ in
 
   options = {
     services.cloudflared = {
-      enable = lib.mkEnableOption "cloudflared";
-      package = lib.mkOption {
-        type = lib.types.package;
+      enable = mkEnableOption "cloudflared";
+      package = mkOption {
+        type = types.package;
         default = pkgs.cloudflared;
         description = "The cloudflared package to use";
         example = literalExpression ''pkgs.cloudflared'';
       };
-      config = lib.mkOption {
+      config = mkOption {
         type = settingsFormat.type;
         description = "Contents of the config.yaml as an attrset; see https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/configuration-file for documentation on the contents";
         example = literalExpression ''
@@ -38,7 +38,7 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable ({
+  config = mkIf cfg.enable ({
     # Prefer the config file over settings if both are set.
     services.cloudflared.configFile = mkDefault (settingsFormat.generate "cloudflared.yaml" cfg.config);
 

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.cloudflared;
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = with maintainers; [ pmc ];
+
+  options = {
+    services.cloudflared = {
+      enable = lib.mkEnableOption "cloudflared";
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.cloudflared;
+      };
+      config = lib.mkOption {
+        type = settingsFormat.type;
+        description = "Contents of the config.yaml as an attrset; see https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/configuration-file for documentation on the contents";
+        example = literalExpression ''
+          {
+            url = "http://localhost:3000";
+            tunnel = "505c8dd1-e4fb-4ea4-b909-26b8f61ceaaf";
+            credentials-file = "/var/lib/cloudflared/505c8dd1-e4fb-4ea4-b909-26b8f61ceaaf.json";
+          }
+        '';
+      };
+
+      configFile = mkOption {
+        type = types.path;
+        example = literalExpression ''"/etc/cloudflared/config.yaml"'';
+        description = "Path to cloudflared config.yaml.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable ({
+    # Prefer the config file over settings if both are set.
+    services.cloudflared.configFile = mkDefault (settingsFormat.generate "cloudflared.yaml" cfg.config);
+
+    systemd.services.cloudflared = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      description = "Cloudflare Argo Tunnel";
+      serviceConfig = {
+        TimeoutStartSec = 0;
+        Type = "notify";
+        ExecStart = "${cfg.package}/bin/cloudflared --config ${cfg.configFile} --no-autoupdate tunnel run";
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+  });
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I personally use this module for the services on my home network. It's based on the systemd unit generated by `cloudflared service install`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
