### PR TITLE
mpop: 1.4.14 -> 1.4.15

### DIFF
--- a/pkgs/applications/networking/mpop/default.nix
+++ b/pkgs/applications/networking/mpop/default.nix
@@ -1,26 +1,42 @@
-{ lib, stdenv, fetchurl, pkg-config, gnutls, gsasl, libidn, Security }:
-
-with lib;
+{ lib
+, stdenv
+, fetchurl
+, gnutls
+, gsasl
+, libidn
+, pkg-config
+, Security
+}:
 
 stdenv.mkDerivation rec {
   pname = "mpop";
-  version = "1.4.14";
+  version = "1.4.15";
 
   src = fetchurl {
     url = "https://marlam.de/${pname}/releases/${pname}-${version}.tar.xz";
-    sha256 = "046wbglvry54id9wik6c020fs09piv3gig3z0nh5nmyhsxjw4i18";
+    sha256 = "sha256-P1KytdS8WO2TzwsRRs7k903oHCwHol7gMu+mWUZaAnA=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ gnutls gsasl libidn ]
-    ++ optional stdenv.isDarwin Security;
+  nativeBuildInputs = [
+    pkg-config
+  ];
 
-  configureFlags = optional stdenv.isDarwin [ "--with-macosx-keyring" ];
+  buildInputs = [
+    gnutls
+    gsasl
+    libidn
+  ] ++ lib.optional stdenv.isDarwin [
+    Security
+  ];
 
-  meta = {
-      description = "POP3 mail retrieval agent";
-      homepage = "https://marlam.de/mpop";
-      license = licenses.gpl3Plus;
-      platforms = platforms.unix;
-    };
+  configureFlags = lib.optional stdenv.isDarwin [
+    "--with-macosx-keyring"
+  ];
+
+  meta = with lib;{
+    description = "POP3 mail retrieval agent";
+    homepage = "https://marlam.de/mpop";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.4.15

Change log: https://marlam.de/mpop/news/mpop-1-4-15/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
