### PR TITLE
taskwarrior-tui: 0.13.33 -> 0.13.34

### DIFF
--- a/pkgs/applications/misc/taskwarrior-tui/default.nix
+++ b/pkgs/applications/misc/taskwarrior-tui/default.nix
@@ -5,19 +5,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "taskwarrior-tui";
-  version = "0.13.33";
+  version = "0.13.34";
 
   src = fetchFromGitHub {
     owner = "kdheepak";
     repo = "taskwarrior-tui";
     rev = "v${version}";
-    sha256 = "sha256-vKmVScXQLDjhNJEzlhqiyhRZjR26xjrT1LijxzZK8Cg=";
+    sha256 = "0p0nkqvkir6lriq75ingpfywn2yvyn3l35yxzk4aiq6vr2n7h3mw";
   };
 
   # Because there's a test that requires terminal access
   doCheck = false;
 
-  cargoSha256 = "sha256-0E4nk8WLprumHKQjpdn+U36z7mdgFb7g/i7egLk4Jcs=";
+  cargoSha256 = "1mzc6rnqcv97dlkl4j4p180f46wlyq45lc6nq7gqw396wc6m04km";
 
   meta = with lib; {
     description = "A terminal user interface for taskwarrior ";


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
