### PR TITLE
zz: unstable-2021-03-07 -> unstable-2021-05-04

### DIFF
--- a/pkgs/development/compilers/zz/default.nix
+++ b/pkgs/development/compilers/zz/default.nix
@@ -1,20 +1,27 @@
-{ lib, rustPlatform, fetchFromGitHub, makeWrapper, z3 }:
+{ lib, rustPlatform, fetchFromGitHub, makeWrapper, z3, pkgsHostTarget }:
+
+let
+  runtimeDeps = [
+    z3
+    pkgsHostTarget.targetPackages.stdenv.cc
+  ];
+in
 
 rustPlatform.buildRustPackage rec {
   pname = "zz";
-  version = "unstable-2021-03-07";
+  version = "unstable-2021-05-04";
 
   # when updating, choose commit of the latest build on http://bin.zetz.it/
   src = fetchFromGitHub {
     owner = "zetzit";
     repo = "zz";
-    rev = "d3fc968ba2ae6668f930e39077f9a90aecb9fdc4";
-    sha256 = "18p17lgwq6rq1n76sj0dwb32bpxflfd7knky1v0sgmaxfpaq04y3";
+    rev = "18020b10b933cfe2fc7f2256b71e646889f9b1d2";
+    sha256 = "01nlyyk1qxk76dq2hw3wpbjwkh27zzp6mpczjnxdpv6rxs7mc825";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
-  cargoSha256 = "03xdmm4993hqdb3cihjjv4n4mdk8lnlccva08fh6m1d56p807rni";
+  cargoSha256 = "080rd8x4jsssnx4il80xcb81iw8pjcm70zckpa1hcijkw9104dgs";
 
   postPatch = ''
     # remove search path entry which would reference /build
@@ -26,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     cp -r modules "$out/share/zz/"
 
     wrapProgram $out/bin/zz \
-      --prefix PATH ":" "${lib.getBin z3}/bin" \
+      --prefix PATH ":" "${lib.makeBinPath runtimeDeps}" \
       --suffix ZZ_MODULE_PATHS ":" "$out/share/zz/modules"
   '';
 


### PR DESCRIPTION
Tested by compiling hello example from upstream repository.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
