### PR TITLE
rocketchat-desktop: init at 3.5.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4054,6 +4054,12 @@
     githubId = 16470252;
     name = "Gemini Lasswell";
   };
+  gbtb = {
+    email = "goodbetterthebeast3@gmail.com";
+    github = "gbtb";
+    githubId = 37017396;
+    name = "gbtb";
+  };
   gebner = {
     email = "gebner@gebner.org";
     github = "gebner";

--- a/pkgs/applications/networking/instant-messengers/rocketchat-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rocketchat-desktop/default.nix
@@ -1,0 +1,92 @@
+{ lib, stdenv, pkgs, fetchurl }:
+let
+  libPathNative = { packages }: lib.makeLibraryPath packages;
+in
+stdenv.mkDerivation rec {
+  pname = "rocketchat-desktop";
+  version = "3.5.7";
+
+  src = fetchurl {
+    url = "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/${version}/rocketchat_${version}_amd64.deb";
+    sha256 = "1ri8a60fsbqgq83f8wkyfnd59nqk4d0gpz1vanj54769zflpl71s";
+  };
+
+  buildInputs = with pkgs; [
+    gtk3
+    stdenv.cc.cc
+    zlib
+    glib
+    dbus
+    atk
+    pango
+    freetype
+    libgnome-keyring3
+    fontconfig
+    gdk-pixbuf
+    cairo
+    cups
+    expat
+    libgpgerror
+    alsa-lib
+    nspr
+    nss
+    xorg.libXrender
+    xorg.libX11
+    xorg.libXext
+    xorg.libXdamage
+    xorg.libXtst
+    xorg.libXcomposite
+    xorg.libXi
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libXcursor
+    xorg.libxkbfile
+    xorg.libXScrnSaver
+    systemd
+    libnotify
+    xorg.libxcb
+    at-spi2-atk
+    at-spi2-core
+    libdbusmenu
+    libdrm
+    mesa
+    xorg.libxshmfence
+    libxkbcommon
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = ''
+    ar p $src data.tar.xz | tar xJ ./opt/ ./usr/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv opt $out
+    mv usr/share $out
+    ln -s $out/opt/Rocket.Chat/rocketchat-desktop $out/bin/rocketchat-desktop
+    runHook postInstall
+  '';
+
+  postFixup =
+    let
+      libpath = libPathNative { packages = buildInputs; };
+    in
+    ''
+      app=$out/opt/Rocket.Chat
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${libpath}:$app" \
+        $app/rocketchat-desktop
+      sed -i -e "s|Exec=.*$|Exec=$out/bin/rocketchat-desktop|" $out/share/applications/rocketchat-desktop.desktop
+    '';
+
+  meta = with lib; {
+    description = "Official Desktop client for Rocket.Chat";
+    homepage = "https://github.com/RocketChat/Rocket.Chat.Electron";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gbtb ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27425,6 +27425,8 @@ with pkgs;
 
   rkdeveloptool = callPackage ../misc/rkdeveloptool { };
 
+  rocketchat-desktop = callPackage ../applications/networking/instant-messengers/rocketchat-desktop { };
+
   rofi-unwrapped = callPackage ../applications/misc/rofi {
     autoreconfHook = buildPackages.autoreconfHook269;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

Packaged rocketchat-desktop Electron app. Took atom package as a reference

- Built on platform(s)
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
