### PR TITLE
soco-cli: init at 0.4.21

### DIFF
--- a/pkgs/development/python-modules/rangehttpserver/default.nix
+++ b/pkgs/development/python-modules/rangehttpserver/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nose
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "rangehttpserver";
+  version = "1.2.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "danvk";
+    repo = "RangeHTTPServer";
+    rev = version;
+    sha256 = "1sy9j6y8kp5jiwv2vd652v94kspp1yd4dwxrfqfn6zwnfyv2mzv5";
+  };
+
+  checkInputs = [
+    nose
+    requests
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    nosetests
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [
+    "RangeHTTPServer"
+  ];
+
+  meta = with lib; {
+    description = "SimpleHTTPServer with support for Range requests";
+    homepage = "https://github.com/danvk/RangeHTTPServer";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/audio/soco-cli/default.nix
+++ b/pkgs/tools/audio/soco-cli/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "soco-cli";
+  version = "0.4.21";
+  format = "setuptools";
+
+  disabled = python3.pythonOlder "3.6";
+
+  src = fetchFromGitHub rec {
+    owner = "avantrec";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kz2zx59gjfs01jiyzmps8j6yca06yqn6wkidvdk4s3izdm0rarw";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    fastapi
+    rangehttpserver
+    soco
+    tabulate
+    uvicorn
+  ];
+
+  # Tests wants to communicate with hardware
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "soco_cli"
+  ];
+
+  meta = with lib; {
+    description = "Command-line interface to control Sonos sound systems";
+    homepage = "https://github.com/avantrec/soco-cli";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19258,6 +19258,8 @@ with pkgs;
 
   socket_wrapper = callPackage ../development/libraries/socket_wrapper { };
 
+  soco-cli = callPackage ../tools/audio/soco-cli { };
+
   sofia_sip = callPackage ../development/libraries/sofia-sip {
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7821,6 +7821,8 @@ in {
 
   random2 = callPackage ../development/python-modules/random2 { };
 
+  rangehttpserver = callPackage ../development/python-modules/rangehttpserver { };
+
   rapidfuzz = callPackage ../development/python-modules/rapidfuzz { };
 
   rarfile = callPackage ../development/python-modules/rarfile {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Command-line interface to control Sonos sound systems

https://github.com/avantrec/soco-cli

Successor of #139649

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
