### PR TITLE
connect-tunnel: init at 12.41.01005

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6915,6 +6915,12 @@
     githubId = 65531;
     name = "Mario Rodas";
   };
+  martfont = {
+    name = "Martino Fontana";
+    email = "tinozzo123@tutanota.com";
+    github = "SuperSamus";
+    githubId = 40663462;
+  };
   martijnvermaat = {
     email = "martijn@vermaat.name";
     github = "martijnvermaat";

--- a/pkgs/applications/networking/connect-tunnel/default.nix
+++ b/pkgs/applications/networking/connect-tunnel/default.nix
@@ -1,0 +1,92 @@
+{ lib, stdenv, fetchurl, autoPatchelfHook, makeDesktopItem, makeWrapper, copyDesktopItems, jre }:
+let
+  altVersion = "12.4.1";
+in
+stdenv.mkDerivation rec {
+  pname = "connect-tunnel";
+  version = "12.41.01005";
+
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://software.sonicwall.com/CT-NX-VPN%20Clients/CT-${altVersion}/ConnectTunnel_Linux64-${version}.tar";
+      sha256 = "3bf7c1cd7cc594ace2475a02454d2ab9926ffaf84fecc846ba6355c94c7a4e42";
+    };
+    i686-linux = fetchurl {
+      url = "https://software.sonicwall.com/CT-NX-VPN%20Clients/CT-${altVersion}/ConnectTunnel_Linux-{version}.tar";
+      sha256 = "2d0aa727b7cb141afb44b8c4470525287709d063b9dd0667ef8f85e92c983796";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper copyDesktopItems ];
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    tar -xf $src
+    # Name is different between 32/64 bit
+    ls ConnectTunnel*.tar.bz2 | xargs tar -xf
+    tar xf "usr/local/Aventail/certs.tar.bz2"
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 644 version $out/local/Aventail/version
+    install -Dm 644 cert.pem $out/local/Aventail/cert.pem
+    cd usr/local/Aventail
+
+    install -Dm 644 man/ct.5 $out/local/Aventail/man/ct.5
+    install -Dm 644 nui/nui.jar $out/local/Aventail/nui/nui.jar
+    install -Dm 755 AvConnect $out/local/Aventail/AvConnect # With the normal installer should be 4755
+
+    find help -type f -exec install -Dm 644 "{}" "$out/local/Aventail/{}" \; # Copy help directory
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    # install icon
+    install -Dm644 logo.png $out/share/icons/hicolor/128x128/apps/connect-tunnel.png
+  '';
+
+  preFixup = ''
+    makeWrapper ${jre}/bin/java $out/bin/startct \
+      --prefix PATH : ${lib.makeBinPath [ jre ]} \
+      --add-flags "-jar "$out/local/Aventail/nui/nui.jar""
+    makeWrapper ${jre}/bin/java $out/bin/startctui \
+      --prefix PATH : ${lib.makeBinPath [ jre ]} \
+      --add-flags "-jar "$out/local/Aventail/nui/nui.jar" --mode gui" # Todo: support debug and scale args
+  '';
+
+  sourceRoot = ".";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      exec = "startctui";
+      genericName = "SonicWall VPN Connection";
+      icon = "connect-tunnel";
+      name = "Connect Tunnel";
+      desktopName = "Connect Tunnel";
+      startupNotify = false;
+      terminal = false;
+      type = "Application";
+      categories = "GNOME;GTK;Network";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Provides an “in-office” experience for a remote working world with full access away from the office";
+    homepage = "https://www.sonicwall.com/products/remote-access/vpn-clients/";
+    maintainers = with maintainers; [ martfont ];
+    license = {
+      fullName = "SonicWall General Product Agreement";
+      url = "https://www.sonicwall.com/legal/general-product-agreement";
+      free = false;
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1519,6 +1519,8 @@ with pkgs;
 
   codespell = with python3Packages; toPythonApplication codespell;
 
+  connect-tunnel = callPackage ../applications/networking/connect-tunnel { };
+
   coolreader = libsForQt5.callPackage ../applications/misc/coolreader {};
 
   corsair = with python3Packages; toPythonApplication corsair-scan;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

I made a default.nix that installs the package. Unfortunately the executable uses hard-coded paths, these are:

- /bin/bash
- /usr/local/Aventail/AvConnect (that in theory would be installed by the program)

The program seems to run correctly if I make dirty symlinks, but they are of course not reproducible.
In order for the package to be reproducible, an FHS environment has to be made, but I'm not willing to finish making the package. I'm leaving this draft as a base in case anyone else wanted to package this.
Would close #140809.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
