### PR TITLE
python3Packages.types-pytz: 2021.1.2 -> 2021.3.0, python3Packages.types-requests: 2.25.9 -> 2.25.10, python3Packages.types-decorator: 0.1.7 -> 5.1.0

### DIFF
--- a/pkgs/development/python-modules/types-decorator/default.nix
+++ b/pkgs/development/python-modules/types-decorator/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "types-decorator";
-  version = "0.1.7";
+  version = "5.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0pmcc8xpsmij4174ky81vp811yxgic2lj1dfj2fa0ii87nlcfwhp";
+    sha256 = "sha256-mavQDGFOVOde4I2IeZiGrMKRjMiJBeymR0upF7Mncps=";
   };
 
   # Modules doesn't have tests

--- a/pkgs/development/python-modules/types-pytz/default.nix
+++ b/pkgs/development/python-modules/types-pytz/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "types-pytz";
-  version = "2021.1.2";
+  version = "2021.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "448828a06f2aaa840e57364d866c661645a045e532f817e4f10c8c3ab2b66651";
+    sha256 = "sha256-hqYZZ4NNzuqvmLaQLtg1fv3SYruK/K9LyMzs90hZJ3g=";
   };
 
   # Modules doesn't have tests

--- a/pkgs/development/python-modules/types-requests/default.nix
+++ b/pkgs/development/python-modules/types-requests/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "types-requests";
-  version = "2.25.9";
+  version = "2.25.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-Tsi3Hac+U0Stub7nJadOyFmOcob5vLF1ANYn8ln+T7k=";
+    sha256 = "sha256-PhIZiBaM/8+mHv+vSPkOvF7gI/bMUNBMAUTt16ImW2U=";
   };
 
   # Modules doesn't have tests


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2021.3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
