### PR TITLE
python3Packages.simple-rest-client: 1.0.8 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/simple-rest-client/default.nix
+++ b/pkgs/development/python-modules/simple-rest-client/default.nix
@@ -1,5 +1,4 @@
 { lib
-, asynctest
 , buildPythonPackage
 , fetchFromGitHub
 , httpx
@@ -13,15 +12,15 @@
 
 buildPythonPackage rec {
   pname = "simple-rest-client";
-  version = "1.0.8";
+  version = "1.1.0";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "allisson";
     repo = "python-simple-rest-client";
     rev = version;
-    sha256 = "12qxhrjhlbyyr1pkvwfkcxbsmyns5b0mfdn42vz310za5x76ldj3";
+    sha256 = "sha256-i+wUc9qxyei+Jbch8vyIrm9ElClnOIKp+YK6jIDkbTA=";
   };
 
   propagatedBuildInputs = [
@@ -31,7 +30,6 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    asynctest
     pytest-asyncio
     pytest-httpserver
     pytestCheckHook
@@ -42,9 +40,17 @@ buildPythonPackage rec {
       --replace "pytest-runner" ""
     substituteInPlace pytest.ini \
       --replace " --cov=simple_rest_client --cov-report=term-missing" ""
+    substituteInPlace requirements-dev.txt \
+      --replace "asyncmock" ""
   '';
 
-  pythonImportsCheck = [ "simple_rest_client" ];
+  disabledTestPaths = [
+    "tests/test_decorators.py"
+  ];
+
+  pythonImportsCheck = [
+    "simple_rest_client"
+  ];
 
   meta = with lib; {
     description = "Simple REST client for Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.1.0

Change log: https://github.com/allisson/python-simple-rest-client/blob/master/CHANGES.rst#110

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
