### PR TITLE
damon: init at unstable-2021-10-12

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -137,7 +137,7 @@ with lib.maintainers; {
       cleverca22
       disassembler
       jonringer
-      maveru
+      manveru
       nrdxp
     ];
     scope = "Input-Output Global employees, which maintain critical software";

--- a/pkgs/tools/admin/damon/default.nix
+++ b/pkgs/tools/admin/damon/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "damon";
+  version = "unstable-2021-10-06";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = "damon";
+    rev = "542c79aecc44b1d0500f9cb9b2e13f07db1e2f35";
+    sha256 = "sha256-vg5PISNqk8N2nn7eABm+/7qzePDbKPkvovdZk2sZYsg=";
+  };
+
+  vendorSha256 = "sha256-/ZZxw6qEUJQUz3J0TxUYJECCcX276r74g0N2tV77+8I=";
+
+  meta = with lib; {
+    homepage = "https://github.com/hashicorp/damon";
+    license = licenses.mpl20;
+    description = "A terminal UI (TUI) for HashiCorp Nomad";
+    maintainers = teams.iog.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2544,6 +2544,8 @@ with pkgs;
 
   dale = callPackage ../development/compilers/dale { };
 
+  damon = callPackage ../tools/admin/damon { };
+
   dante = callPackage ../servers/dante { };
 
   dapr-cli = callPackage ../development/tools/dapr/cli {};


### PR DESCRIPTION
###### Motivation for this change
TUI for interacting with nomad.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
