### PR TITLE
mdbook-graphviz: init at 0.1.2

### DIFF
--- a/pkgs/tools/text/mdbook-graphviz/default.nix
+++ b/pkgs/tools/text/mdbook-graphviz/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, CoreServices, graphviz }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-graphviz";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "dylanowen";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-wIgWaCjJrrajvUZbJjpx9P4urN2/eVo3+Za2NjTKWvM=";
+  };
+
+  cargoSha256 = "sha256-F8JuEk0ztB7jfcPNjU9vGsr3HLEJ2DmWGWxvdbLuyvQ=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
+
+  checkInputs = [ graphviz ];
+
+  meta = with lib; {
+    description = "A preprocessor for mdbook, rendering Graphviz graphs to HTML at build time.";
+    homepage = "https://github.com/dylanowen/${pname}";
+    license = [ licenses.mpl20 ];
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/tools/text/mdbook-graphviz/default.nix
+++ b/pkgs/tools/text/mdbook-graphviz/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "A preprocessor for mdbook, rendering Graphviz graphs to HTML at build time.";
-    homepage = "https://github.com/dylanowen/${pname}";
+    homepage = "https://github.com/dylanowen/mdbook-graphviz";
     license = [ licenses.mpl20 ];
     maintainers = with maintainers; [ lovesegfault ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6820,6 +6820,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  mdbook-graphviz = callPackage ../tools/text/mdbook-graphviz {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
+
   mdbook-katex = callPackage ../tools/text/mdbook-katex {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
