### PR TITLE
Patch glibc to look in /etc/zoneinfo in addition to the configured TZDIR

### DIFF
--- a/pkgs/development/libraries/glibc/check-etc-zoneinfo.patch
+++ b/pkgs/development/libraries/glibc/check-etc-zoneinfo.patch
@@ -1,0 +1,30 @@
+diff --git a/time/tzfile.c b/time/tzfile.c
+index 040a5e34..9533f66f 100644
+--- a/time/tzfile.c
++++ b/time/tzfile.c
+@@ -16,6 +16,7 @@
+    <https://www.gnu.org/licenses/>.  */
+ 
+ #include <assert.h>
++#include <errno.h>
+ #include <limits.h>
+ #include <stdio.h>
+ #include <stdio_ext.h>
+@@ -146,6 +147,17 @@ __tzfile_read (const char *file, size_t extra, char **extrap)
+ 	tzdir = default_tzdir;
+       if (__asprintf (&new, "%s/%s", tzdir, file) == -1)
+ 	goto ret_free_transitions;
++
++      // nixos specific adjustment - also check /etc/zoneinfo, but only when tzdir
++      // equals TZDIR (the default). In all other cases the user has asked
++      // for some other path and we can't default to /etc/zoneinfo.
++      if (memcmp (tzdir, TZDIR, sizeof TZDIR) == 0) {
++        struct stat64 st;
++        if (__stat64 (new, &st) == ENOENT) {
++          if (__asprintf (&new, "/etc/zoneinfo/%s", file) == -1)
++            goto ret_free_transitions;
++        }
++      }
+       file = new;
+     }
+ 

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -72,6 +72,9 @@ stdenv.mkDerivation ({
       /* Allow NixOS and Nix to handle the locale-archive. */
       ./nix-locale-archive.patch
 
+      /* Check /etc/zoneinfo, see https://github.com/NixOS/nixpkgs/issues/105049 */
+      ./check-etc-zoneinfo.patch
+
       /* Don't use /etc/ld.so.cache, for non-NixOS systems.  */
       ./dont-use-system-ld-so-cache.patch
 


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/NixOS/nixpkgs/issues/105049
* https://github.com/NixOS/nixpkgs/issues/65415
* and potentially https://github.com/NixOS/nixpkgs/issues/89487

###### Things done

I added a test case to detect this. Before fix:

```
Test "systemd reads timezone database in /etc/zoneinfo" failed with error: ""
Traceback (most recent call last):
...
```

after the fix it passes.

My main worry is introducing some kind of security issue which is why I put the fix _after_ the setuid checking code.

I don't have the CPU cycles on my laptop to check all glibc dependent packages so not sure what the protocol is here..

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
