### PR TITLE
writeShellApplication: init

### DIFF
--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -47,6 +47,28 @@ These functions write `text` to the Nix store. This is useful for creating scrip
 
 Many more commands wrap `writeTextFile` including `writeText`, `writeTextDir`, `writeScript`, and `writeScriptBin`. These are convenience functions over `writeTextFile`.
 
+## `writeShellApplication` {#trivial-builder-writeShellApplication}
+
+This can be used to easily produce a shell script that has some dependencies (`buildInputs`). It automatically sets the `PATH` of the script to contain all of the listed inputs, sets some sanity shellopts (`errexit`, `nounset`, `pipefail`), and checks the resulting script with [`shellcheck`](https://github.com/koalaman/shellcheck).
+
+For example, look at the following code:
+
+```nix
+writeShellApplication {
+  name = "show-nixos-org";
+
+  buildInputs = [ curl w3m ];
+
+  text = ''
+    curl -s 'https://nixos.org' | w3m -dump -T text/html
+  '';
+}
+```
+
+Unlike with normal `writeShellScriptBin`, there is no need to manually write out `${curl}/bin/curl`, setting the PATH
+was handled by `writeShellApplication`. Moreover, the script is being checked with `shellcheck` for more strict
+validation.
+
 ## `symlinkJoin` {#trivial-builder-symlinkJoin}
 
 This can be used to put many derivations into the same directory structure. It works by creating a new derivation and adding symlinks to each of the paths listed. It expects two arguments, `name`, and `paths`. `name` is the name used in the Nix store path for the created derivation. `paths` is a list of paths that will be symlinked. These paths can be to Nix store derivations or any other subdirectory contained within.

--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -49,7 +49,7 @@ Many more commands wrap `writeTextFile` including `writeText`, `writeTextDir`, `
 
 ## `writeShellApplication` {#trivial-builder-writeShellApplication}
 
-This can be used to easily produce a shell script that has some dependencies (`buildInputs`). It automatically sets the `PATH` of the script to contain all of the listed inputs, sets some sanity shellopts (`errexit`, `nounset`, `pipefail`), and checks the resulting script with [`shellcheck`](https://github.com/koalaman/shellcheck).
+This can be used to easily produce a shell script that has some dependencies (`runtimeInputs`). It automatically sets the `PATH` of the script to contain all of the listed inputs, sets some sanity shellopts (`errexit`, `nounset`, `pipefail`), and checks the resulting script with [`shellcheck`](https://github.com/koalaman/shellcheck).
 
 For example, look at the following code:
 
@@ -57,7 +57,7 @@ For example, look at the following code:
 writeShellApplication {
   name = "show-nixos-org";
 
-  buildInputs = [ curl w3m ];
+  runtimeInputs = [ curl w3m ];
 
   text = ''
     curl -s 'https://nixos.org' | w3m -dump -T text/html

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, makeBinPath, shellcheck }:
+{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, shellcheck }:
 
 rec {
 
@@ -282,7 +282,7 @@ rec {
         set -o nounset
         set- o pipefail
 
-        export PATH="${makeBinPath runtimeInputs}:$PATH"
+        export PATH="${lib.makeBinPath runtimeInputs}:$PATH"
 
         ${text}
       '';

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -280,7 +280,7 @@ rec {
         #!${runtimeShell}
         set -o errexit
         set -o nounset
-        set- o pipefail
+        set -o pipefail
 
         export PATH="${lib.makeBinPath runtimeInputs}:$PATH"
 

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -292,13 +292,16 @@ rec {
         ${text}
       '';
 
-      checkPhase = if checkPhase == null then ''
-        runHook preCheck
-        ${stdenv.shell} -n $out/bin/${name}
-        ${shellcheck}/bin/shellcheck $out/bin/${name}
-        runHook postCheck
-      ''
-      else checkPhase;
+      checkPhase =
+        if checkPhase == null then ''
+          runHook preCheck
+          ${stdenv.shell} -n $out/bin/${name}
+          ${shellcheck}/bin/shellcheck $out/bin/${name}
+          runHook postCheck
+        ''
+        else checkPhase;
+
+      meta.mainProgram = name;
     };
 
   # Create a C binary

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -254,7 +254,7 @@ rec {
    * Writes an executable Shell script to /nix/store/<store path>/bin/<name> and
    * checks its syntax with shellcheck and the shell's -n option.
    * Automatically includes sane set of shellopts (errexit, nounset, pipefail)
-   * and handles creation of PATH based on buildInputs
+   * and handles creation of PATH based on runtimeInputs
    *
    * Example:
    * # Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -292,8 +292,10 @@ rec {
       '';
 
       checkPhase = if checkPhase == null then ''
+        runHook preCheck
         ${stdenv.shell} -n $out/bin/${name}
         ${shellcheck}/bin/shellcheck $out/bin/${name}
+        runHook postCheck
       ''
       else checkPhase;
     };

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -260,7 +260,7 @@ rec {
    * # Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
    * writeShellApplication {
    *   name = "my-file";
-   *   buildInputs = [ curl w3m ];
+   *   runtimeInputs = [ curl w3m ];
    *   text = ''
    *     curl -s 'https://nixos.org' | w3m -dump -T text/html
    *    '';
@@ -269,7 +269,7 @@ rec {
   writeShellApplication =
     { name
     , text
-    , buildInputs ? [ ]
+    , runtimeInputs ? [ ]
     , checkPhase ? null
     }:
     writeTextFile {
@@ -282,7 +282,7 @@ rec {
         set -o nounset
         set- o pipefail
 
-        export PATH="${makeBinPath buildInputs}:$PATH"
+        export PATH="${makeBinPath runtimeInputs}:$PATH"
 
         ${text}
       '';

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -256,6 +256,10 @@ rec {
    * Automatically includes sane set of shellopts (errexit, nounset, pipefail)
    * and handles creation of PATH based on runtimeInputs
    *
+   * Note that the checkPhase uses stdenv.shell for the test run of the script,
+   * while the generated shebang uses runtimeShell. If, for whatever reason,
+   * those were to mismatch you might lose fidelity in the default checks.
+   *
    * Example:
    * # Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
    * writeShellApplication {

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -111,9 +111,10 @@ rec {
     , executable ? false # run chmod +x ?
     , destination ? ""   # relative path appended to $out eg "/bin/foo"
     , checkPhase ? ""    # syntax checks, e.g. for scripts
+    , meta ? { }
     }:
     runCommand name
-      { inherit text executable checkPhase;
+      { inherit text executable checkPhase meta;
         passAsFile = [ "text" ];
         # Pointless to do this on a remote machine.
         preferLocalBuild = true;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -76,7 +76,9 @@ let
 
   trivialBuilders = self: super:
     import ../build-support/trivial-builders.nix {
-      inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.pkgsBuildHost.xorg) lndir;
+      inherit lib; inherit (self) stdenv stdenvNoCC;
+      inherit (self.pkgsBuildHost) shellcheck;
+      inherit (self.pkgsBuildHost.xorg) lndir;
       inherit (self) runtimeShell;
     };
 

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -76,10 +76,10 @@ let
 
   trivialBuilders = self: super:
     import ../build-support/trivial-builders.nix {
-      inherit lib; inherit (self) stdenv stdenvNoCC;
+      inherit lib;
+      inherit (self) runtimeShell stdenv stdenvNoCC;
       inherit (self.pkgsBuildHost) shellcheck;
       inherit (self.pkgsBuildHost.xorg) lndir;
-      inherit (self) runtimeShell;
     };
 
   stdenvBootstappingAndPlatforms = self: super: let


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This adds a new trivial builder, `writeShellApplication`, which is roughtly
equivalent to `writeShellScript` except that it:

1. Sets some default sanity shellopts (`errexit`, `nounset`, `pipefail`)
2. Handles setting `PATH` based on `buildInputs`
3. Uses [`shellcheck`](https://github.com/koalaman/shellcheck) for the `checkPhase`

I've been using something [very similar to this](https://github.com/lovesegfault/nix-config/blob/292700c2c31d8398f87ca28331cf624901a24242/nix/overlays/write-sane-shell-script-bin.nix) in my personal overlay for a long time now, and it provides a _far_ better experience for packaging and maintaining personal apps written in bash.

I've decided to upstream as there's been interest in having something similar in
other projects, and I figured it's best to unify in `nixpkgs` than to end up
with many copy-pasta'd versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
