### PR TITLE
nixos/nginx: disable MemoryDenyWriteExecute for pkgs.openresty

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -889,7 +889,7 @@ in
         RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
         RestrictNamespaces = true;
         LockPersonality = true;
-        MemoryDenyWriteExecute = !(builtins.any (mod: (mod.allowMemoryWriteExecute or false)) cfg.package.modules);
+        MemoryDenyWriteExecute = !((builtins.any (mod: (mod.allowMemoryWriteExecute or false)) cfg.package.modules) || (cfg.package == pkgs.openresty));
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         RemoveIPC = true;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -322,6 +322,7 @@ in
   ombi = handleTest ./ombi.nix {};
   openarena = handleTest ./openarena.nix {};
   openldap = handleTest ./openldap.nix {};
+  openresty-lua = handleTest ./openresty-lua.nix {};
   opensmtpd = handleTest ./opensmtpd.nix {};
   opensmtpd-rspamd = handleTest ./opensmtpd-rspamd.nix {};
   openssh = handleTest ./openssh.nix {};

--- a/nixos/tests/openresty-lua.nix
+++ b/nixos/tests/openresty-lua.nix
@@ -1,0 +1,55 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+  let
+    lualibs = [
+      pkgs.lua.pkgs.markdown
+    ];
+
+    getPath = lib: type: "${lib}/share/lua/${pkgs.lua.luaversion}/?.${type}";
+    getLuaPath = lib: getPath lib "lua";
+    luaPath = lib.concatStringsSep ";" (map getLuaPath lualibs);
+  in
+  {
+    name = "openresty-lua";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ bbigras ];
+    };
+
+    nodes = {
+      webserver = { pkgs, lib, ... }: {
+        services.nginx = {
+          enable = true;
+          package = pkgs.openresty;
+
+          commonHttpConfig = ''
+            lua_package_path '${luaPath};;';
+          '';
+
+          virtualHosts."default" = {
+            default = true;
+            locations."/" = {
+              extraConfig = ''
+                default_type text/html;
+                access_by_lua '
+                  local markdown = require "markdown"
+                  markdown("source")
+                ';
+              '';
+            };
+          };
+        };
+      };
+    };
+
+    testScript = { nodes, ... }:
+      ''
+        url = "http://localhost"
+
+        webserver.wait_for_unit("nginx")
+        webserver.wait_for_open_port(80)
+
+        http_code = webserver.succeed(
+          f"curl -w '%{{http_code}}' --head --fail {url}"
+        )
+        assert http_code.split("\n")[-1] == "200"
+      '';
+  })

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -21,6 +21,7 @@
 , preConfigure ? ""
 , postInstall ? null
 , meta ? null
+, passthru ? { tests = {}; }
 }:
 
 with lib;
@@ -146,7 +147,7 @@ stdenv.mkDerivation {
       inherit (nixosTests) nginx nginx-auth nginx-etag nginx-pubhtml nginx-sandbox nginx-sso;
       variants = lib.recurseIntoAttrs nixosTests.nginx-variants;
       acme-integration = nixosTests.acme;
-    };
+    } // passthru.tests;
   };
 
   meta = if meta != null then meta else {

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -3,6 +3,7 @@
 , lib
 , fetchurl
 , postgresql
+, nixosTests
 , ...
 }@args:
 
@@ -41,6 +42,10 @@ callPackage ../nginx/generic.nix args rec {
     ln -s $out/nginx/conf $out/conf
     ln -s $out/nginx/html $out/html
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) openresty-lua;
+  };
 
   meta = {
     description = "A fast web application server built on Nginx";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

see #140655

###### Things done

All the NGINX tests seem to be passing.
```
❯ nix-build nginx*.nix
/nix/store/dwz5jczgrsamaxvfk6rv4zxw6pz6j6pp-vm-test-run-nginx-auth
/nix/store/sh6s1gc97s3426aa1q7408y5wh0kr33s-vm-test-run-nginx-etag
/nix/store/9196zqwvgmj7pssa6r839hrqqi61gn7y-vm-test-run-nginx
/nix/store/c9p2hp2h3z91mdp7r2kqjmqv5mdf9pc4-vm-test-run-nginx-pubhtml
/nix/store/s6ndxbii45rpj5nmw5nhnkwja09i8f0d-vm-test-run-nginx-sandbox
/nix/store/fvmpxx5j981mw1bbcipw84305196z867-vm-test-run-nginx-sso
/nix/store/qhdxvxxkank0v9zxfjkkymcz90x2n2y6-vm-test-run-nginx-variant-nginxMainline
/nix/store/vx9g43j4szf4nmlwcpg5k52q5d3wqzcj-vm-test-run-nginx-variant-nginxQuic
/nix/store/7xmgwb6qpp5bddlgkczw75bzpfnarry1-vm-test-run-nginx-variant-nginxShibboleth
/nix/store/l0hg26j19lzprp9fgxqxbhynd6vvp3qj-vm-test-run-nginx-variant-nginxStable
/nix/store/xcb880bjljkxl02v42n1x3rzfkn19x8v-vm-test-run-nginx-variant-openresty
/nix/store/zd18wb10k1h844xlh7ihh7ycgygrfysq-vm-test-run-nginx-variant-tengine
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
