### PR TITLE
python3Packages.slugid: init 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7377,6 +7377,12 @@
       fingerprint = "DB43 2895 CF68 F0CE D4B7  EF60 DA01 5B05 B5A1 1B22";
     }];
   };
+  milahu = {
+    email = "milahu@gmail.com";
+    github = "milahu";
+    githubId = 12958815;
+    name = "Milan Hauth";
+  };
   milesbreslin = {
     email = "milesbreslin@gmail.com";
     github = "milesbreslin";

--- a/pkgs/development/python-modules/slugid/default.nix
+++ b/pkgs/development/python-modules/slugid/default.nix
@@ -14,11 +14,12 @@ buildPythonPackage rec {
     sha256 = "McBxGRi8KqVhe2Xez5k4G67R5wBCCoh41dRsTKW4xMA=";
   };
 
+  doCheck = false; # has no tests
+
   pythonImportsCheck = [
     "slugid"
   ];
 
-  doCheck = false; # has no tests
   meta = with lib; {
     description = "URL-safe base64 UUID encoder for generating 22 character slugs";
     homepage = "https://github.com/taskcluster/slugid.py";

--- a/pkgs/development/python-modules/slugid/default.nix
+++ b/pkgs/development/python-modules/slugid/default.nix
@@ -1,10 +1,9 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, python3
 }:
 
-python3.pkgs.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "slugid";
   version = "2.0.0";
 
@@ -15,7 +14,7 @@ python3.pkgs.buildPythonPackage rec {
     sha256 = "McBxGRi8KqVhe2Xez5k4G67R5wBCCoh41dRsTKW4xMA=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [ tox twine ];
+  propagatedBuildInputs = [ tox twine ];
 
   meta = with lib; {
     description = "Compress UUIDs. a URL-safe base64 UUID encoder for generating 22 character slugs";

--- a/pkgs/development/python-modules/slugid/default.nix
+++ b/pkgs/development/python-modules/slugid/default.nix
@@ -15,9 +15,13 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ tox twine ];
-
+  pythonImportsCheck = [
+    "slugid"
+  ];
+  
+  doCheck = false; # has no tests
   meta = with lib; {
-    description = "Compress UUIDs. a URL-safe base64 UUID encoder for generating 22 character slugs";
+    description = "URL-safe base64 UUID encoder for generating 22 character slugs";
     homepage = "https://github.com/taskcluster/slugid.py";
     license = licenses.mpl20;
     maintainers = with maintainers; [ milahu ];

--- a/pkgs/development/python-modules/slugid/default.nix
+++ b/pkgs/development/python-modules/slugid/default.nix
@@ -14,11 +14,10 @@ buildPythonPackage rec {
     sha256 = "McBxGRi8KqVhe2Xez5k4G67R5wBCCoh41dRsTKW4xMA=";
   };
 
-  propagatedBuildInputs = [ tox twine ];
   pythonImportsCheck = [
     "slugid"
   ];
-  
+
   doCheck = false; # has no tests
   meta = with lib; {
     description = "URL-safe base64 UUID encoder for generating 22 character slugs";
@@ -26,4 +25,4 @@ buildPythonPackage rec {
     license = licenses.mpl20;
     maintainers = with maintainers; [ milahu ];
   };
-} 
+}

--- a/pkgs/development/python-modules/slugid/default.nix
+++ b/pkgs/development/python-modules/slugid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ buildPythonPackage
 , lib
 , fetchFromGitHub
 }:

--- a/pkgs/development/python-modules/slugid/default.nix
+++ b/pkgs/development/python-modules/slugid/default.nix
@@ -20,6 +20,6 @@ buildPythonPackage rec {
     description = "Compress UUIDs. a URL-safe base64 UUID encoder for generating 22 character slugs";
     homepage = "https://github.com/taskcluster/slugid.py";
     license = licenses.mpl20;
-    #maintainers = [];
+    maintainers = with maintainers; [ milahu ];
   };
 } 

--- a/pkgs/development/python-modules/slugid/default.nix
+++ b/pkgs/development/python-modules/slugid/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "slugid";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "taskcluster";
+    repo = "slugid.py";
+    rev = "v${version}";
+    sha256 = "McBxGRi8KqVhe2Xez5k4G67R5wBCCoh41dRsTKW4xMA=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ tox twine ];
+
+  meta = with lib; {
+    description = "Compress UUIDs. a URL-safe base64 UUID encoder for generating 22 character slugs";
+    homepage = "https://github.com/taskcluster/slugid.py";
+    license = licenses.mpl20;
+    #maintainers = [];
+  };
+} 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8461,6 +8461,8 @@ in {
 
   slowapi = callPackage ../development/python-modules/slowapi { };
 
+  slugid = callPackage ../development/python-modules/slugid { };
+
   sly = callPackage ../development/python-modules/sly { };
 
   smart-meter-texas = callPackage ../development/python-modules/smart-meter-texas { };


### PR DESCRIPTION
###### Motivation for this change
cos why not ...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
