### PR TITLE
devserver: init at 0.4.0

### DIFF
--- a/pkgs/development/tools/rust/devserver/default.nix
+++ b/pkgs/development/tools/rust/devserver/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchCrate
+, rustPlatform
+, openssl
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "devserver";
+  version = "0.4.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-UcrLzsALwl0zqNRMS1kTTXsR6wN8XDd5Iq+yrudh6M4=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  cargoSha256 = "sha256-XlrQ6CvjeWnzvfaeNbe8FtMXMVSQNLxDVIEjyHm57Js=";
+
+  meta = with lib; {
+    description = "An extremely tiny tool to serve a static folder locally";
+    homepage = "https://github.com/kettle11/devserver";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ nickhu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12690,6 +12690,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  devserver = callPackage ../development/tools/rust/devserver { };
+
   maturin = callPackage ../development/tools/rust/maturin {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[devserver](https://github.com/kettle11/devserver/) init

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
