### PR TITLE
git-privacy: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/git-filter-repo/default.nix
+++ b/pkgs/development/python-modules/git-filter-repo/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "git-filter-repo";
+  version = "2.33.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nxfd5yv8ri7w5pzxclxs0yd317nsdcwvw87ancmdkh69xvx1f2f";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "git_filter_repo"
+  ];
+
+  meta = with lib; {
+    description = "Quickly rewrite git repository history";
+    homepage = "https://github.com/newren/git-filter-repo";
+    license = with licenses; [ mit /* or */ gpl2Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/tools/git-privacy/default.nix
+++ b/pkgs/development/tools/git-privacy/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitHub
+, git
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "git-privacy";
+  version = "2.1.0";
+  format = "setuptools";
+
+  disabled = python3.pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "EMPRI-DEVOPS";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hfy43fip1l81672xfwqrz1jryzkjy7h9f2lyikxgibibil0p444";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    git-filter-repo
+    GitPython
+    pynacl
+    setuptools
+  ];
+
+  checkInputs = with python3.pkgs; [
+    git
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Tests want to interact with a git repo
+    "TestGitPrivacy"
+  ];
+
+  pythonImportsCheck = [
+    "gitprivacy"
+  ];
+
+  meta = with lib; {
+    description = "Tool to redact Git author and committer dates";
+    homepage = "https://github.com/EMPRI-DEVOPS/git-privacy";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1658,6 +1658,8 @@ with pkgs;
 
   git-fire = callPackage ../tools/misc/git-fire { };
 
+  git-privacy = callPackage ../development/tools/git-privacy { };
+
   git-repo-updater = python3Packages.callPackage ../development/tools/git-repo-updater { };
 
   git-revise = with python3Packages; toPythonApplication git-revise;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3019,6 +3019,8 @@ in {
   git-annex-adapter =
     callPackage ../development/python-modules/git-annex-adapter { };
 
+  git-filter-repo = callPackage ../development/python-modules/git-filter-repo { };
+
   gitdb = callPackage ../development/python-modules/gitdb { };
 
   github3_py = callPackage ../development/python-modules/github3_py { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to redact Git author and committer dates

https://github.com/EMPRI-DEVOPS/git-privacy

Fixes #83692

Success of  #98773

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
