### PR TITLE
swift-format: init at 0.50400.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9252,6 +9252,12 @@
     githubId = 165283;
     name = "Alexey Kutepov";
   };
+  rgnns = {
+    email = "gl@gabriellievano.com";
+    github = "rgnns";
+    githubId = 811827;
+    name = "Gabriel Lievano";
+  };
   rgrunbla = {
     email = "remy@grunblatt.org";
     github = "rgrunbla";

--- a/pkgs/development/tools/swift-format/default.nix
+++ b/pkgs/development/tools/swift-format/default.nix
@@ -1,0 +1,82 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+# This derivation is impure: it relies on Xcode's version of Swift to
+# be installed in its expected place.
+
+let version = "5.4";
+    swiftFormatVersion = "0.50400.0";
+    sources = {
+      format = fetchFromGitHub {
+        owner = "apple";
+        repo = "swift-format";
+        rev = "0.50400.0";
+        sha256 = "0skmmggsh31f3rnqcrx43178bc7scrjihibnwn68axagasgbqn4k";
+      };
+      argumentParser = fetchFromGitHub {
+        owner = "apple";
+        repo = "swift-argument-parser";
+        rev = "1.0.1";
+        name = "swift-argument-parser-1.0.1";
+        sha256 = "070gip241dgn3d0nxgwxva4vp6kbnf11g01q5yaq6kmflcmz58f2";
+      };
+      syntax = fetchFromGitHub {
+        owner = "apple";
+        repo = "swift-syntax";
+        rev = "swift-${version}-RELEASE";
+        sha256 = "02zrimxkily6b4iy7wbwj61w8bd13g060ibbk7z3bpymr3m9lrb4";
+      };
+    };
+in stdenv.mkDerivation rec {
+  pname = "swift-format";
+  version = "5.4";
+
+  src = sources.format;
+
+  unpackPhase = ''
+    mkdir src
+    cd src
+
+    export SWIFT_SOURCE_ROOT=$PWD
+
+    cp -r ${sources.format} swift-format
+    cp -r ${sources.argumentParser} swift-argument-parser
+    cp -r ${sources.syntax} swift-syntax
+
+    chmod -R u+w .
+  '';
+
+  configurePhase = ''
+    export SWIFT_FORMAT_ROOT=$SWIFT_SOURCE_ROOT/swift-format
+  '';
+
+  buildPhase = ''
+    cd $SWIFT_FORMAT_ROOT
+    SWIFTCI_USE_LOCAL_DEPS=1 /usr/bin/swift build -c release \
+      --disable-sandbox \
+      --manifest-cache none \
+      --disable-build-manifest-caching \
+      --disable-repository-cache
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 0555 $SWIFT_FORMAT_ROOT/.build/release/swift-format $out/bin/swift-format
+  '';
+
+  sandboxProfile = ''
+    (allow file-read* file-write* process-exec mach-lookup)
+    (deny file-read* file-write* process-exec mach-lookup (subpath "/usr/local") (with no-log))
+  '';
+
+  meta = with lib; {
+    description = ''
+      Provides the formatting technology for SourceKit-LSP and the building blocks
+      for doing code formatting transformations.
+    '';
+    homepage = "https://github.com/apple/swift-format";
+    license = licenses.asl20;
+    maintainers = [ maintainers.rgnns ];
+    platforms = platforms.darwin;
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14817,6 +14817,8 @@ with pkgs;
 
   swarm = callPackage ../development/tools/analysis/swarm { };
 
+  swift-format = callPackage ../development/tools/swift-format { };
+
   swiftformat = callPackage ../development/tools/swiftformat { };
 
   symfony-cli = callPackage ../development/tools/symfony-cli { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`swift-format` is available from the `swift` package which is not currently available for mac machines. This derivation allows to install `swift-format` on mac configurations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
