### PR TITLE
asphd-demo: init at 0.0.1-alpha

### DIFF
--- a/pkgs/development/tools/ashpd-demo/default.nix
+++ b/pkgs/development/tools/ashpd-demo/default.nix
@@ -1,0 +1,93 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, nix-update-script
+, meson
+, ninja
+, python3
+, rustPlatform
+, pkg-config
+, glib
+, libshumate
+, gst_all_1
+, gtk4
+, libadwaita
+, llvmPackages
+, glibc
+, pipewire
+, wayland
+, wrapGAppsHook4
+, desktop-file-utils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ashpd-demo";
+  version = "0.0.1-alpha";
+
+  src =
+    let
+      share = fetchFromGitHub {
+        owner = "bilelmoussaoui";
+        repo = "ashpd";
+        rev = version;
+        sha256 = "Lf3Wj4VTDyJ5a1bJTEI6R6aaeEHZ+4hO+BsD98sKb/s=";
+      };
+    in
+    "${share}/ashpd-demo";
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-npqC8lu7acAggJyR4iDkcQZYMNNnseV2pB3+j4G/nIk=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+    rustPlatform.rust.cargo
+    rustPlatform.cargoSetupHook
+    rustPlatform.rust.rustc
+    wrapGAppsHook4
+    desktop-file-utils
+    glib # for glib-compile-schemas
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    libadwaita
+    pipewire
+    wayland
+    libshumate
+  ];
+
+  # libspa-sys requires this for bindgen
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  # <spa-0.2/spa/utils/defs.h> included by libspa-sys requires <stdbool.h>
+  BINDGEN_EXTRA_CLANG_ARGS = "-I${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion llvmPackages.clang}/include -I${glibc.dev}/include";
+
+  postPatch = ''
+    patchShebangs build-aux/meson_post_install.py
+    # https://github.com/bilelmoussaoui/ashpd/pull/32
+    substituteInPlace build-aux/meson_post_install.py \
+      --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with lib; {
+    description = "Tool for playing with XDG desktop portals";
+    homepage = "https://github.com/bilelmoussaoui/ashpd/tree/master/ashpd-demo";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1269,6 +1269,8 @@ with pkgs;
 
   ashuffle = callPackage ../applications/audio/ashuffle {};
 
+  ashpd-demo = callPackage ../development/tools/ashpd-demo {};
+
   asls = callPackage ../development/tools/misc/asls { };
 
   astc-encoder = callPackage ../tools/graphics/astc-encoder { };


### PR DESCRIPTION
###### Motivation for this change
Tool for testing XDG portals.

###### Things done
<del>
Currently does not build for some reason.

```
/nix/store/2hyx4z7b6n886xg6zslp3al7yx2p6x84-pipewire-0.3.38-dev/include/spa-0.2/spa/utils/defs.h:31:10: fatal error: 'stdbool.h' file not found
/nix/store/2hyx4z7b6n886xg6zslp3al7yx2p6x84-pipewire-0.3.38-dev/include/spa-0.2/spa/utils/defs.h:31:10: fatal error: 'stdbool.h' file not found, err: true
```

Fixed that by passing `-I` flag with clang headers but now it tries to `#include_next` and I have no idea where else it should find `inttypes.h`. Does clang stdlib depend on gcc stdlib?

```
/nix/store/hzlf4pn19f6872yhsgkljkk0dmyq314p-clang-7.1.0-lib/lib/clang/7.1.0/include/inttypes.h:30:15: fatal error: 'inttypes.h' file not found
/nix/store/hzlf4pn19f6872yhsgkljkk0dmyq314p-clang-7.1.0-lib/lib/clang/7.1.0/include/inttypes.h:30:15: fatal error: 'inttypes.h' file not found, err: true
```

For now fixed it by adding glibc, now it fails on missing adw symbols, depends on #141299 
</del>

Works now.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
