### PR TITLE
python3Packages.kivy: add darwin support

### DIFF
--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -2,7 +2,9 @@
 , buildPythonPackage, fetchPypi
 , pkg-config, cython, docutils
 , kivy-garden
-, mesa, mtdev, SDL2, SDL2_image, SDL2_ttf, SDL2_mixer, gst_all_1
+, mesa, mtdev, SDL2, SDL2_image, SDL2_ttf, SDL2_mixer
+, withGstreamer ? true
+, gst_all_1
 , pillow, requests, pygments
 }:
 
@@ -28,13 +30,13 @@ buildPythonPackage rec {
     SDL2_image
     SDL2_ttf
     SDL2_mixer
-
+  ] ++ lib.optionals withGstreamer (with gst_all_1; [
     # NOTE: The degree to which gstreamer actually works is unclear
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-good
-    gst_all_1.gst-plugins-bad
-  ];
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+  ]);
 
   propagatedBuildInputs = [
     kivy-garden

--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -1,8 +1,9 @@
-{ lib
-, buildPythonPackage, fetchPypi
+{ lib, stdenv
+, buildPythonPackage, fetchFromGitHub, fetchpatch
 , pkg-config, cython, docutils
 , kivy-garden
 , mesa, mtdev, SDL2, SDL2_image, SDL2_ttf, SDL2_mixer
+, ApplicationServices, AVFoundation, libcxx
 , withGstreamer ? true
 , gst_all_1
 , pillow, requests, pygments
@@ -12,10 +13,20 @@ buildPythonPackage rec {
   pname = "Kivy";
   version = "2.0.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1n0j9046vgjncy50v06r3wcg3q2l37jp8n0cznr64dz48kml8pnj";
+  # use github since pypi line endings are CRLF and patches do not apply
+  src = fetchFromGitHub {
+    owner = "kivy";
+    repo = "kivy";
+    rev = version;
+    sha256 = "sha256-/7GSVQUkYSBEnLVBizMnZAZZxvXVN4r4lskyOgLEcew=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/kivy/kivy/commit/1c0656c4472817677cf3b08be504de9ca6b1713f.patch";
+      sha256 = "sha256-phAjMaC3LQuvufwiD0qXzie5B+kezCf8FpKeQMhy/ms=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -24,12 +35,17 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
-    mesa
-    mtdev
     SDL2
     SDL2_image
     SDL2_ttf
     SDL2_mixer
+  ] ++ lib.optionals stdenv.isLinux [
+    mesa
+    mtdev
+  ] ++ lib.optionals stdenv.isDarwin [
+    ApplicationServices
+    AVFoundation
+    libcxx
   ] ++ lib.optionals withGstreamer (with gst_all_1; [
     # NOTE: The degree to which gstreamer actually works is unclear
     gstreamer
@@ -48,8 +64,12 @@ buildPythonPackage rec {
   KIVY_NO_CONFIG = 1;
   KIVY_NO_ARGS = 1;
   KIVY_NO_FILELOG = 1;
+  # prefer pkg-config over hardcoded framework paths
+  USE_OSX_FRAMEWORKS = 0;
+  # work around python distutils compiling C++ with $CC (see issue #26709)
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
 
-  postPatch = ''
+  postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace kivy/lib/mtdev.py \
       --replace "LoadLibrary('libmtdev.so.1')" "LoadLibrary('${mtdev}/lib/libmtdev.so.1')"
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4075,6 +4075,7 @@ in {
 
   kivy = callPackage ../development/python-modules/kivy {
     inherit (pkgs) mesa;
+    inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices AVFoundation;
   };
 
   kivy-garden = callPackage ../development/python-modules/kivy-garden { };


### PR DESCRIPTION
###### Motivation for this change

- `python3Packages.kivy` could not be installed on darwin due to mandatory dependency on `mtdev` which is Linux-only
- also made gstreamer optional since it is large and upstream [documents it as optional](https://kivy.org/doc/master/installation/installation-linux.html#id1)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
