### PR TITLE
blackfire: 1.49.4 → 2.5.1

### DIFF
--- a/nixos/modules/services/development/blackfire.nix
+++ b/nixos/modules/services/development/blackfire.nix
@@ -19,7 +19,7 @@ in {
       enable = lib.mkEnableOption "Blackfire profiler agent";
       settings = lib.mkOption {
         description = ''
-          See https://blackfire.io/docs/configuration/agent
+          See https://blackfire.io/docs/up-and-running/configuration/agent
         '';
         type = lib.types.submodule {
           freeformType = with lib.types; attrsOf str;
@@ -53,13 +53,8 @@ in {
 
     services.blackfire-agent.settings.socket = "unix:///run/${agentSock}";
 
-    systemd.services.blackfire-agent = {
-      description = "Blackfire agent";
-
-      serviceConfig = {
-        ExecStart = "${pkgs.blackfire}/bin/blackfire-agent";
-        RuntimeDirectory = "blackfire";
-      };
-    };
+    systemd.packages = [
+      pkgs.blackfire
+    ];
   };
 }

--- a/nixos/modules/services/development/blackfire.xml
+++ b/nixos/modules/services/development/blackfire.xml
@@ -28,13 +28,14 @@ in {
     enable = true;
     settings = {
       # You will need to get credentials at https://blackfire.io/my/settings/credentials
-      # You can also use other options described in https://blackfire.io/docs/configuration/agent
+      # You can also use other options described in https://blackfire.io/docs/up-and-running/configuration/agent
       server-id = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX";
       server-token = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
     };
   };
 
   # Make the agent run on start-up.
+  # (WantedBy= from the upstream unit not respected: https://github.com/NixOS/nixpkgs/issues/81138)
   # Alternately, you can start it manually with `systemctl start blackfire-agent`.
   systemd.services.blackfire-agent.wantedBy = [ "phpfpm-foo.service" ];
 }</programlisting>

--- a/pkgs/development/tools/misc/blackfire/default.nix
+++ b/pkgs/development/tools/misc/blackfire/default.nix
@@ -10,12 +10,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "blackfire-agent";
-  version = "1.49.4";
+  pname = "blackfire";
+  version = "2.5.1";
 
   src = fetchurl {
-    url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire-php/blackfire-agent_${version}_amd64.deb";
-    sha256 = "t1S54z3xTMTUBWz0jCFX1A7GJdWWsP/lTa9MMjo8t1A=";
+    url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_amd64.deb";
+    sha256 = "wak7LE5j6OKIHqCsEGrxSq1FAFzehMetYj6c/Zkr9dk=";
   };
 
   nativeBuildInputs = [
@@ -32,13 +32,26 @@ stdenv.mkDerivation rec {
     mv $out/usr/* $out
     rmdir $out/usr
 
+    # Fix ExecStart path and replace deprecated directory creation method,
+    # use dynamic user.
+    substituteInPlace "$out/lib/systemd/system/blackfire-agent.service" \
+      --replace '/usr/' "$out/" \
+      --replace 'ExecStartPre=/bin/mkdir -p /var/run/blackfire' 'RuntimeDirectory=blackfire' \
+      --replace 'ExecStartPre=/bin/chown blackfire: /var/run/blackfire' "" \
+      --replace 'User=blackfire' 'DynamicUser=yes' \
+      --replace 'PermissionsStartOnly=true' ""
+
+    # Modernize socket path.
+    substituteInPlace "$out/etc/blackfire/agent" \
+      --replace '/var/run' '/run'
+
     runHook postInstall
   '';
 
   passthru = {
     updateScript = writeShellScript "update-${pname}" ''
       export PATH="${lib.makeBinPath [ curl jq common-updater-scripts ]}"
-      update-source-version "$UPDATE_NIX_ATTR_PATH" "$(curl https://blackfire.io/api/v1/releases | jq .agent --raw-output)"
+      update-source-version "$UPDATE_NIX_ATTR_PATH" "$(curl https://blackfire.io/api/v1/releases | jq .cli --raw-output)"
     '';
   };
 


### PR DESCRIPTION
###### Motivation for this change
https://blackfire.io/docs/up-and-running/agent-upgrade

Closes: #141429

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
