### PR TITLE
stdenv: add pure Linux stdenv support for powerpc64le and sparc64

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
 
       lib = import ./lib;
 
-      systems = lib.systems.supported.hydra;
+      systems = lib.platforms.all;
 
       forAllSystems = f: lib.genAttrs systems (system: f system);
 

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -76,6 +76,7 @@ in {
   x86           = filterDoubles predicates.isx86;
   i686          = filterDoubles predicates.isi686;
   x86_64        = filterDoubles predicates.isx86_64;
+  powerpc       = filterDoubles predicates.isPowerPC;
   mips          = filterDoubles predicates.isMips;
   mmix          = filterDoubles predicates.isMmix;
   riscv         = filterDoubles predicates.isRiscV;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -83,6 +83,8 @@ in {
   or1k          = filterDoubles predicates.isOr1k;
   m68k          = filterDoubles predicates.isM68k;
   s390          = filterDoubles predicates.isS390;
+  sparc         = filterDoubles predicates.isSparc;
+  sparc64       = filterDoubles predicates.isSparc64;
   js            = filterDoubles predicates.isJavaScript;
 
   bigEndian     = filterDoubles predicates.isBigEndian;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -13,7 +13,10 @@ let
     "x86_64-darwin" "i686-darwin" "aarch64-darwin" "armv7a-darwin"
 
     # FreeBSD
-    "i686-freebsd" "x86_64-freebsd"
+    "aarch64-freebsd" "armv5tel-freebsd" "armv6l-freebsd"
+    "armv7l-freebsd" "i686-freebsd" "mipsel-freebsd"
+    "powerpc64-freebsd" "riscv64-freebsd" "sparc64-freebsd"
+    "x86_64-freebsd"
 
     # Genode
     "aarch64-genode" "i686-genode" "x86_64-genode"
@@ -28,8 +31,8 @@ let
     "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux"
     "armv7l-linux" "i686-linux" "m68k-linux" "mipsel-linux"
     "powerpc64-linux" "powerpc64le-linux" "riscv32-linux"
-    "riscv64-linux" "s390-linux" "s390x-linux" "x86_64-linux"
-    "sparc64-linux"
+    "riscv64-linux" "s390-linux" "s390x-linux" "sparc64-linux"
+    "x86_64-linux"
 
     # MMIXware
     "mmix-mmixware"
@@ -37,16 +40,17 @@ let
     # NetBSD
     "aarch64-netbsd" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd"
     "i686-netbsd" "m68k-netbsd" "mipsel-netbsd" "powerpc-netbsd"
-    "riscv32-netbsd" "riscv64-netbsd" "x86_64-netbsd"
+    "riscv32-netbsd" "riscv64-netbsd" "sparc64-netbsd" "x86_64-netbsd"
 
     # none
     "aarch64-none" "arm-none" "armv6l-none" "avr-none" "i686-none"
     "msp430-none" "or1k-none" "m68k-none" "powerpc-none"
-    "riscv32-none" "riscv64-none" "s390-none" "s390x-none" "vc4-none"
-    "x86_64-none"
+    "riscv32-none" "riscv64-none" "s390-none" "s390x-none" "sparc64-none"
+    "vc4-none" "x86_64-none"
 
     # OpenBSD
-    "i686-openbsd" "x86_64-openbsd"
+    "aarch64-openbsd" "armv7l-openbsd" "i686-openbsd" "powerpc64-openbsd"
+    "riscv64-openbsd" "sparc64-openbsd" "x86_64-openbsd"
 
     # Redox
     "x86_64-redox"
@@ -55,7 +59,7 @@ let
     "wasm64-wasi" "wasm32-wasi"
 
     # Windows
-    "x86_64-windows" "i686-windows"
+    "x86_64-windows" "i686-windows" "aarch64-windows"
   ];
 
   allParsed = map parse.mkSystemFromString all;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -67,7 +67,7 @@ let
   filterDoubles = f: map parse.doubleFromSystem (lists.filter f allParsed);
 
 in {
-  inherit all;
+  inherit all filterDoubles;
 
   none = [];
 
@@ -76,7 +76,6 @@ in {
   x86           = filterDoubles predicates.isx86;
   i686          = filterDoubles predicates.isi686;
   x86_64        = filterDoubles predicates.isx86_64;
-  power         = filterDoubles predicates.isPower;
   mips          = filterDoubles predicates.isMips;
   mmix          = filterDoubles predicates.isMmix;
   riscv         = filterDoubles predicates.isRiscV;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -107,21 +107,5 @@ in {
 
   embedded      = filterDoubles predicates.isNone;
 
-  # See https://wiki.musl-libc.org/supported-platforms.html
-  supportsMusl  = filterDoubles (
-    double: (
-      (predicates.isLinux double)
-      && (
-        (predicates.isx86 double)
-        || (predicates.isAarch32 double)
-        || (predicates.isAarch64 double)
-        || (predicates.isMips double)
-        || (predicates.isPower double)
-        || (predicates.isOr1k double)
-        || (predicates.isS390 double)
-        || ((predicates.isRiscV double) && (predicates.is64bit double))
-      )
-    )
-  );
   mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "armv7a-linux" "aarch64-linux" "powerpc64-linux" "powerpc64le-linux" "aarch64-darwin" "riscv64-linux"];
 }

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -29,6 +29,7 @@ let
     "armv7l-linux" "i686-linux" "m68k-linux" "mipsel-linux"
     "powerpc64-linux" "powerpc64le-linux" "riscv32-linux"
     "riscv64-linux" "s390-linux" "s390x-linux" "x86_64-linux"
+    "sparc64-linux"
 
     # MMIXware
     "mmix-mmixware"

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -67,7 +67,7 @@ let
   filterDoubles = f: map parse.doubleFromSystem (lists.filter f allParsed);
 
 in {
-  inherit all filterDoubles;
+  inherit all;
 
   none = [];
 
@@ -107,5 +107,21 @@ in {
 
   embedded      = filterDoubles predicates.isNone;
 
+  # See https://wiki.musl-libc.org/supported-platforms.html
+  supportsMusl  = filterDoubles (
+    double: (
+      (predicates.isLinux double)
+      && (
+        (predicates.isx86 double)
+        || (predicates.isAarch32 double)
+        || (predicates.isAarch64 double)
+        || (predicates.isMips double)
+        || (predicates.isPower double)
+        || (predicates.isOr1k double)
+        || (predicates.isS390 double)
+        || ((predicates.isRiscV double) && (predicates.is64bit double))
+      )
+    )
+  );
   mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "armv7a-linux" "aarch64-linux" "powerpc64-linux" "powerpc64le-linux" "aarch64-darwin" "riscv64-linux"];
 }

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -76,7 +76,7 @@ in {
   x86           = filterDoubles predicates.isx86;
   i686          = filterDoubles predicates.isi686;
   x86_64        = filterDoubles predicates.isx86_64;
-  powerpc       = filterDoubles predicates.isPowerPC;
+  power         = filterDoubles predicates.isPower;
   mips          = filterDoubles predicates.isMips;
   mmix          = filterDoubles predicates.isMmix;
   riscv         = filterDoubles predicates.isRiscV;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -156,7 +156,7 @@ rec {
     config = "s390x-unknown-linux-gnu";
   };
 
-  sparc64 = {
+  sparc64-linux = {
     config = "sparc64-unknown-linux-gnu";
   };
 

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -156,6 +156,10 @@ rec {
     config = "s390x-unknown-linux-gnu";
   };
 
+  sparc64 = {
+    config = "sparc64-unknown-linux-gnu";
+  };
+
   arm-embedded = {
     config = "arm-none-eabi";
     libc = "newlib";

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -20,6 +20,7 @@ rec {
     isMmix         = { cpu = { family = "mmix"; }; };
     isRiscV        = { cpu = { family = "riscv"; }; };
     isSparc        = { cpu = { family = "sparc"; }; };
+    isSparc64      = { cpu = { family = "sparc"; bits = 64; }; };
     isWasm         = { cpu = { family = "wasm"; }; };
     isMsp430       = { cpu = { family = "msp430"; }; };
     isVc4          = { cpu = { family = "vc4"; }; };

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -28,7 +28,7 @@ with lib.systems.doubles; lib.runTests {
   testredox = mseteq redox [ "x86_64-redox" ];
   testgnu = mseteq gnu (linux /* ++ kfreebsd ++ ... */);
   testillumos = mseteq illumos [ "x86_64-solaris" ];
-  testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "mipsel-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux" "powerpc64-linux" "powerpc64le-linux" "m68k-linux" "s390-linux" "s390x-linux" ];
+  testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "mipsel-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux" "powerpc64-linux" "powerpc64le-linux" "m68k-linux" "s390-linux" "s390x-linux" "sparc64-linux" ];
   testnetbsd = mseteq netbsd [ "aarch64-netbsd" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd" "i686-netbsd" "m68k-netbsd" "mipsel-netbsd" "powerpc-netbsd" "riscv32-netbsd" "riscv64-netbsd" "x86_64-netbsd" ];
   testopenbsd = mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ];
   testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "i686-windows" "x86_64-windows" ];

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -15,22 +15,22 @@ in
 with lib.systems.doubles; lib.runTests {
   testall = mseteq all (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ wasi ++ windows ++ embedded ++ mmix ++ js ++ genode ++ redox);
 
-  testarm = mseteq arm [ "armv5tel-linux" "armv6l-linux" "armv6l-netbsd" "armv6l-none" "armv7a-linux" "armv7a-netbsd" "armv7l-linux" "armv7l-netbsd" "arm-none" "armv7a-darwin" ];
-  testi686 = mseteq i686 [ "i686-linux" "i686-freebsd" "i686-genode" "i686-netbsd" "i686-openbsd" "i686-cygwin" "i686-windows" "i686-none" "i686-darwin" ];
-  testmips = mseteq mips [ "mipsel-linux" "mipsel-netbsd" ];
+  testarm = mseteq arm [ "armv7a-darwin" "armv5tel-freebsd" "armv6l-freebsd" "armv7l-freebsd" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd" "arm-none" "armv6l-none" "armv7l-openbsd" ];
+  testi686 = mseteq i686 [ "i686-cygwin" "i686-darwin" "i686-freebsd" "i686-genode" "i686-linux" "i686-netbsd" "i686-none" "i686-openbsd" "i686-windows" ];
+  testmips = mseteq mips [ "mipsel-freebsd" "mipsel-linux" "mipsel-netbsd" ];
   testmmix = mseteq mmix [ "mmix-mmixware" ];
-  testx86_64 = mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-genode" "x86_64-redox" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" "x86_64-windows" "x86_64-none" ];
+  testx86_64 = mseteq x86_64 [ "x86_64-cygwin" "x86_64-darwin" "x86_64-freebsd" "x86_64-genode" "x86_64-solaris" "x86_64-linux" "x86_64-netbsd" "x86_64-none" "x86_64-openbsd" "x86_64-redox" "x86_64-windows" ];
 
   testcygwin = mseteq cygwin [ "i686-cygwin" "x86_64-cygwin" ];
   testdarwin = mseteq darwin [ "x86_64-darwin" "i686-darwin" "aarch64-darwin" "armv7a-darwin" ];
-  testfreebsd = mseteq freebsd [ "i686-freebsd" "x86_64-freebsd" ];
+  testfreebsd = mseteq freebsd [ "aarch64-freebsd" "armv5tel-freebsd" "armv6l-freebsd" "armv7l-freebsd" "i686-freebsd" "mipsel-freebsd" "powerpc64-freebsd" "riscv64-freebsd" "sparc64-freebsd" "x86_64-freebsd" ];
   testgenode = mseteq genode [ "aarch64-genode" "i686-genode" "x86_64-genode" ];
   testredox = mseteq redox [ "x86_64-redox" ];
   testgnu = mseteq gnu (linux /* ++ kfreebsd ++ ... */);
   testillumos = mseteq illumos [ "x86_64-solaris" ];
-  testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "mipsel-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux" "powerpc64-linux" "powerpc64le-linux" "m68k-linux" "s390-linux" "s390x-linux" "sparc64-linux" ];
-  testnetbsd = mseteq netbsd [ "aarch64-netbsd" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd" "i686-netbsd" "m68k-netbsd" "mipsel-netbsd" "powerpc-netbsd" "riscv32-netbsd" "riscv64-netbsd" "x86_64-netbsd" ];
-  testopenbsd = mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ];
-  testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "i686-windows" "x86_64-windows" ];
+  testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "m68k-linux" "mipsel-linux" "powerpc64-linux" "powerpc64le-linux" "riscv32-linux" "riscv64-linux" "s390-linux" "s390x-linux" "sparc64-linux" "x86_64-linux" ];
+  testnetbsd = mseteq netbsd [ "aarch64-netbsd" "armv6l-netbsd" "armv7a-netbsd" "armv7l-netbsd" "i686-netbsd" "m68k-netbsd" "mipsel-netbsd" "powerpc-netbsd" "riscv32-netbsd" "riscv64-netbsd" "sparc64-netbsd" "x86_64-netbsd" ];
+  testopenbsd = mseteq openbsd [ "aarch64-openbsd" "armv7l-openbsd" "i686-openbsd" "powerpc64-openbsd" "riscv64-openbsd" "sparc64-openbsd" "x86_64-openbsd" ];
+  testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "x86_64-windows" "i686-windows" "aarch64-windows" ];
   testunix = mseteq unix (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ cygwin ++ redox);
 }

--- a/nixos/lib/qemu-common.nix
+++ b/nixos/lib/qemu-common.nix
@@ -18,7 +18,7 @@ rec {
     ];
 
   qemuSerialDevice = if pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64 then "ttyS0"
-        else if (with pkgs.stdenv.hostPlatform; isAarch32 || isAarch64 || isPower) then "ttyAMA0"
+        else if (with pkgs.stdenv.hostPlatform; isAarch32 || isAarch64 || isPower || isSparc) then "ttyAMA0"
         else throw "Unknown QEMU serial device for system '${pkgs.stdenv.hostPlatform.system}'";
 
   qemuBinary = qemuPkg: {

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation {
   outputs = [ "bin" "dev" "out" "doc" "man" ];
 
   # Disable jit on Apple Silicon, https://github.com/zherczeg/sljit/issues/51
-  configureFlags = optional (!stdenv.hostPlatform.isRiscV && !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) "--enable-jit" ++ [
+  configureFlags = optional (!stdenv.hostPlatform.isRiscV && !stdenv.hostPlatform.isSparc && !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) "--enable-jit" ++ [
     "--enable-unicode-properties"
     "--disable-cpp"
   ]

--- a/pkgs/os-specific/linux/busybox/sandbox-shell.nix
+++ b/pkgs/os-specific/linux/busybox/sandbox-shell.nix
@@ -1,8 +1,7 @@
-{ stdenv, busybox }:
+{ busybox }:
 
 # Minimal shell for use as basic /bin/sh in sandbox builds
 busybox.override {
-  useMusl = (!stdenv.targetPlatform.isRiscV && !stdenv.targetPlatform.isSparc);
   enableStatic = true;
   enableMinimal = true;
   extraConfig = ''

--- a/pkgs/os-specific/linux/busybox/sandbox-shell.nix
+++ b/pkgs/os-specific/linux/busybox/sandbox-shell.nix
@@ -1,7 +1,8 @@
-{ busybox}:
+{ stdenv, busybox }:
 
 # Minimal shell for use as basic /bin/sh in sandbox builds
 busybox.override {
+  useMusl = (!stdenv.targetPlatform.isRiscV && !stdenv.targetPlatform.isSparc);
   enableStatic = true;
   enableMinimal = true;
   extraConfig = ''

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -147,7 +147,8 @@ stdenv.mkDerivation rec {
     homepage    = "https://musl.libc.org/";
     changelog   = "https://git.musl-libc.org/cgit/musl/tree/WHATSNEW?h=v${version}";
     license     = licenses.mit;
-    platforms   = platforms.linux;
+    # See https://wiki.musl-libc.org/supported-platforms.html
+    platforms   = with platforms; x86 ++ arm ++ aarch64 ++ mips ++ powerpc ++ or1k ++ s390 ++ riscv;
     maintainers = with maintainers; [ thoughtpolice dtzWill ];
   };
 }

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -148,7 +148,7 @@ stdenv.mkDerivation rec {
     changelog   = "https://git.musl-libc.org/cgit/musl/tree/WHATSNEW?h=v${version}";
     license     = licenses.mit;
     # See https://wiki.musl-libc.org/supported-platforms.html
-    platforms   = with platforms; x86 ++ arm ++ aarch64 ++ mips ++ powerpc ++ or1k ++ s390 ++ riscv;
+    platforms   = with platforms; x86 ++ arm ++ aarch64 ++ mips ++ power ++ or1k ++ s390 ++ riscv;
     maintainers = with maintainers; [ thoughtpolice dtzWill ];
   };
 }

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -148,7 +148,20 @@ stdenv.mkDerivation rec {
     changelog   = "https://git.musl-libc.org/cgit/musl/tree/WHATSNEW?h=v${version}";
     license     = licenses.mit;
     # See https://wiki.musl-libc.org/supported-platforms.html
-    platforms   = with platforms; x86 ++ arm ++ aarch64 ++ mips ++ power ++ or1k ++ s390 ++ riscv;
+    platforms   = platforms.filterDoubles (
+      double: with systems.inspect;
+        (isLinux double)
+        && (
+          (isx86 double)
+          || (isAarch32 double)
+          || (isAarch64 double)
+          || (isMips double)
+          || (isPower double)
+          || (isOr1k double)
+          || (isS390 double)
+          || ((isRiscV double) && (is64Bit double))
+        )
+    );
     maintainers = with maintainers; [ thoughtpolice dtzWill ];
   };
 }

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -147,7 +147,16 @@ stdenv.mkDerivation rec {
     homepage    = "https://musl.libc.org/";
     changelog   = "https://git.musl-libc.org/cgit/musl/tree/WHATSNEW?h=v${version}";
     license     = licenses.mit;
-    platforms   = platforms.supportsMusl;
+    # See https://wiki.musl-libc.org/supported-platforms.html
+    platforms   = [
+      "i386-linux" "x86_64-linux"
+      "armv5tel-linux" "armv6l-linux" "armv7l-linux" "armv7a-linux" "aarch64-linux"
+      "mipsel-linux"
+      "powerpc64-linux" "powerpc64le-linux"
+      "or1k-linux"
+      "s390x-linux"
+      "riscv64-linux"
+    ];
     maintainers = with maintainers; [ thoughtpolice dtzWill ];
   };
 }

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -147,22 +147,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://musl.libc.org/";
     changelog   = "https://git.musl-libc.org/cgit/musl/tree/WHATSNEW?h=v${version}";
     license     = licenses.mit;
-    # See https://wiki.musl-libc.org/supported-platforms.html
-    platforms   = platforms.filterDoubles (
-      double: with systems.inspect.predicates; (
-        (isLinux double)
-        && (
-          (isx86 double)
-          || (isAarch32 double)
-          || (isAarch64 double)
-          || (isMips double)
-          || (isPower double)
-          || (isOr1k double)
-          || (isS390 double)
-          || ((isRiscV double) && (is64bit double))
-        )
-      )
-    );
+    platforms   = platforms.supportsMusl;
     maintainers = with maintainers; [ thoughtpolice dtzWill ];
   };
 }

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -149,7 +149,7 @@ stdenv.mkDerivation rec {
     license     = licenses.mit;
     # See https://wiki.musl-libc.org/supported-platforms.html
     platforms   = platforms.filterDoubles (
-      double: with systems.inspect;
+      double: with systems.inspect.predicates; (
         (isLinux double)
         && (
           (isx86 double)
@@ -159,8 +159,9 @@ stdenv.mkDerivation rec {
           || (isPower double)
           || (isOr1k double)
           || (isS390 double)
-          || ((isRiscV double) && (is64Bit double))
+          || ((isRiscV double) && (is64bit double))
         )
+      )
     );
     maintainers = with maintainers; [ thoughtpolice dtzWill ];
   };

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -1,5 +1,5 @@
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], ...
 }:
 
 let

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -1,5 +1,5 @@
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? []
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
 }:
 
 let

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -1,5 +1,5 @@
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? []
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -1,5 +1,5 @@
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], ...
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -34,6 +34,8 @@
       cpio = fetch { file = "cpio"; sha256 = "sha256-SWkwvLaFyV44kLKL2nx720SvcL4ej/p2V/bX3uqAGO0="; };
       tarball = fetch { file = "bootstrap-tools.cpio.bz2"; sha256 = "sha256-b65dXbIm6o6s6U8tAiGpR6SMfvfn/VFcZgTHBetJZis="; executable = false; };
     }
+
+, ...
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -56,6 +56,7 @@ in
     powerpc-linux = /* stagesLinux */ stagesNative;
     powerpc64-linux = stagesLinux;
     powerpc64le-linux = stagesLinux;
+    sparc64-linux = stagesLinux;
     x86_64-darwin = stagesDarwin;
     aarch64-darwin = stagesDarwin;
     x86_64-solaris = stagesNix;

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -7,7 +7,7 @@
 { # Args just for stdenvs' usage
   lib
   # Args to pass on to the pkgset builder, too
-, localSystem, crossSystem, config, overlays, crossOverlays ? []
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
 } @ args:
 
 let

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -7,7 +7,7 @@
 { # Args just for stdenvs' usage
   lib
   # Args to pass on to the pkgset builder, too
-, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], ...
 } @ args:
 
 let

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -1,5 +1,5 @@
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? []
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -1,5 +1,5 @@
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], ...
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -69,14 +69,13 @@ let
       ../../build-support/setup-hooks/audit-tmpdir.sh
       ../../build-support/setup-hooks/move-systemd-user-units.sh
     ]
+    ++ lib.optional hasCC cc
     ++ [
       ../../build-support/setup-hooks/multiple-outputs.sh
       ../../build-support/setup-hooks/move-sbin.sh
       ../../build-support/setup-hooks/move-lib64.sh
       ../../build-support/setup-hooks/set-source-date-epoch-to-latest.sh
       ../../build-support/setup-hooks/reproducible-builds.sh
-      # TODO use lib.optional instead
-      (if hasCC then cc else null)
     ];
 
   defaultBuildInputs = extraBuildInputs;

--- a/pkgs/stdenv/linux/bootstrap-files/powerpc64le.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/powerpc64le.nix
@@ -1,0 +1,21 @@
+{
+  # Note: do not use Hydra as a source URL. Ask a member of the
+  # infrastructure team to mirror the job.
+  busybox = import <nix/fetchurl.nix> {
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.powerpc64le.dist
+    # from build: https://hydra.nixos.org/build/155848348
+    # TODO(pmc): ask infra to mirror this
+    # url = "http://tarballs.nixos.org/stdenv-linux/powerpc64le/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox";
+    url = "https://nix-cache.piperswe.me/bootstrap/7znrqcmp15b93k3bz0yyczqi73dj713v-stdenv-bootstrap-tools-powerpc64le-unknown-linux-gnu/on-server/busybox";
+    sha256 = "sha256-nOJImyOtWg2WuXgu9SLKKHiVtmygAQxDutmec98XD9A=";
+    executable = true;
+  };
+  bootstrapTools = import <nix/fetchurl.nix> {
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv7l.dist/latest
+    # from build: https://hydra.nixos.org/build/114203060
+    # TODO(pmc): ask infra to mirror this
+    # url = "http://tarballs.nixos.org/stdenv-linux/powerpc64le/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz";
+    url = "https://nix-cache.piperswe.me/bootstrap/7znrqcmp15b93k3bz0yyczqi73dj713v-stdenv-bootstrap-tools-powerpc64le-unknown-linux-gnu/on-server/bootstrap-tools.tar.xz";
+    sha256 = "sha256-QsTMZZF0GUFj+YQ5aF9YxEzyDSIhIYBBFVmpNYoDPdg=";
+  };
+}

--- a/pkgs/stdenv/linux/bootstrap-files/sparc64.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/sparc64.nix
@@ -1,0 +1,21 @@
+{
+  # Note: do not use Hydra as a source URL. Ask a member of the
+  # infrastructure team to mirror the job.
+  busybox = import <nix/fetchurl.nix> {
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.powerpc64le.dist
+    # from build: https://hydra.nixos.org/build/155848348
+    # TODO(pmc): ask infra to mirror this
+    # url = "http://tarballs.nixos.org/stdenv-linux/powerpc64le/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/busybox";
+    url = "https://nix-cache.piperswe.me/bootstrap/wnjkv15kl6pn4jw4dqwqy7i364w6qqvr-stdenv-bootstrap-tools-sparc64-unknown-linux-gnu/on-server/busybox";
+    sha256 = "sha256-T9ak4aH9LJBtFlT1fJWaw7xaYmMZOBMstrXCwq5MK+M=";
+    executable = true;
+  };
+  bootstrapTools = import <nix/fetchurl.nix> {
+    # from job: https://hydra.nixos.org/job/nixpkgs/cross-trunk/bootstrapTools.armv7l.dist/latest
+    # from build: https://hydra.nixos.org/build/114203060
+    # TODO(pmc): ask infra to mirror this
+    # url = "http://tarballs.nixos.org/stdenv-linux/powerpc64le/0eb0ddc4dbe3cd5415c6b6e657538eb809fc3778/bootstrap-tools.tar.xz";
+    url = "https://nix-cache.piperswe.me/bootstrap/wnjkv15kl6pn4jw4dqwqy7i364w6qqvr-stdenv-bootstrap-tools-sparc64-unknown-linux-gnu/on-server/bootstrap-tools.tar.xz";
+    sha256 = "sha256-2z5mNuGjS8lJVA/jEyu9lq/byIYUSAmCOM44p4YWnrg=";
+  };
+}

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -39,7 +39,8 @@
   files = archLookupTable.${localSystem.system} or (if getCompatibleTools != null then getCompatibleTools
     else (abort "unsupported platform for the pure Linux stdenv"));
   in files
-}:
+
+, ... }:
 
 assert crossSystem == localSystem;
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -6,23 +6,25 @@
 { lib
 , localSystem, crossSystem, config, overlays, crossOverlays ? []
 
-, bootstrapFiles ?
-  let table = {
-    glibc = {
-      i686-linux = import ./bootstrap-files/i686.nix;
-      x86_64-linux = import ./bootstrap-files/x86_64.nix;
-      armv5tel-linux = import ./bootstrap-files/armv5tel.nix;
-      armv6l-linux = import ./bootstrap-files/armv6l.nix;
-      armv7l-linux = import ./bootstrap-files/armv7l.nix;
-      aarch64-linux = import ./bootstrap-files/aarch64.nix;
-      mipsel-linux = import ./bootstrap-files/loongson2f.nix;
+, bootstrapFiles ? let
+    table = {
+      glibc = {
+        i686-linux = import ./bootstrap-files/i686.nix;
+        x86_64-linux = import ./bootstrap-files/x86_64.nix;
+        armv5tel-linux = import ./bootstrap-files/armv5tel.nix;
+        armv6l-linux = import ./bootstrap-files/armv6l.nix;
+        armv7l-linux = import ./bootstrap-files/armv7l.nix;
+        aarch64-linux = import ./bootstrap-files/aarch64.nix;
+        mipsel-linux = import ./bootstrap-files/loongson2f.nix;
+        powerpc64le-linux = import ./bootstrap-files/powerpc64le.nix;
+        sparc64-linux = import ./bootstrap-files/sparc64.nix;
+      };
+      musl = {
+        aarch64-linux = import ./bootstrap-files/aarch64-musl.nix;
+        armv6l-linux = import ./bootstrap-files/armv6l-musl.nix;
+        x86_64-linux = import ./bootstrap-files/x86_64-musl.nix;
+      };
     };
-    musl = {
-      aarch64-linux = import ./bootstrap-files/aarch64-musl.nix;
-      armv6l-linux  = import ./bootstrap-files/armv6l-musl.nix;
-      x86_64-linux  = import ./bootstrap-files/x86_64-musl.nix;
-    };
-  };
 
   # Try to find an architecture compatible with our current system. We
   # just try every bootstrap we’ve got and test to see if it is

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -21,4 +21,5 @@ in lib.mapAttrs (n: make) (with lib.systems.examples; {
   powerpc64-musl = ppc64-musl;
   powerpc64le = powernv;
   powerpc64le-musl = musl-power;
+  sparc64 = sparc64;
 })

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -19,7 +19,6 @@ in with pkgs; rec {
   tarMinimal = gnutar.override { acl = null; };
 
   busyboxMinimal = busybox.override {
-    useMusl = (!stdenv.targetPlatform.isRiscV && !stdenv.targetPlatform.isSparc);
     enableStatic = true;
     enableMinimal = true;
     extraConfig = ''

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -316,7 +316,7 @@ in with pkgs; rec {
   };
 
   # Get an instance of nixpkgs with these tools
-  pkgsWithTools = import nixpkgs {
+  pkgsWithTools = import pkgs.path {
     inherit localSystem crossSystem bootstrapFiles;
   };
 }

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -264,7 +264,7 @@ in with pkgs; rec {
     else throw "unsupported libc";
 
   test = derivation {
-    name = "test-bootstrap-tools${stage}";
+    name = "test-bootstrap-tools${suffix}";
     inherit (stdenv.hostPlatform) system; # We cannot "cross test"
     builder = bootstrapFiles.busybox;
     args = [ "ash" "-e" "-c" "eval \"$buildCommand\"" ];

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -19,7 +19,7 @@ in with pkgs; rec {
   tarMinimal = gnutar.override { acl = null; };
 
   busyboxMinimal = busybox.override {
-    useMusl = !stdenv.targetPlatform.isRiscV;
+    useMusl = (!stdenv.targetPlatform.isRiscV && !stdenv.targetPlatform.isSparc);
     enableStatic = true;
     enableMinimal = true;
     extraConfig = ''

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -19,6 +19,7 @@ in with pkgs; rec {
   tarMinimal = gnutar.override { acl = null; };
 
   busyboxMinimal = busybox.override {
+    useMusl = !stdenv.targetPlatform.isSparc;
     enableStatic = true;
     enableMinimal = true;
     extraConfig = ''

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -314,4 +314,9 @@ in with pkgs; rec {
       make install
     '';
   };
+
+  # Get an instance of nixpkgs with these tools
+  pkgsWithTools = import nixpkgs {
+    inherit localSystem crossSystem bootstrapFiles;
+  };
 }

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -1,9 +1,10 @@
 { localSystem ? { system = builtins.currentSystem; }
 , crossSystem ? null
+, nixpkgs ? import ../../..
+, pkgs ? import nixpkgs { inherit localSystem crossSystem; }
 }:
 
 let
-  pkgs = import ../../.. { inherit localSystem crossSystem; };
   libc = pkgs.stdenv.cc.libc;
 in with pkgs; rec {
 

--- a/pkgs/stdenv/linux/scratch/default.nix
+++ b/pkgs/stdenv/linux/scratch/default.nix
@@ -1,0 +1,9 @@
+# Usage: nix-build ./default.nix --argstr to powerpc64le-linux -A dist
+{ from ? builtins.currentSystem, to, nixpkgs ? import ../../../.. }:
+let
+  args = { inherit from to nixpkgs; };
+  stage1 = import ./stage1.nix args;
+  stage2 = import ./stage2.nix args stage1;
+  stage3 = import ./stage3.nix args stage2;
+in
+  stage3

--- a/pkgs/stdenv/linux/scratch/stage1.nix
+++ b/pkgs/stdenv/linux/scratch/stage1.nix
@@ -1,0 +1,17 @@
+# Stage 1 is to cross-compile seeds.
+{ from, to, nixpkgs }:
+let
+  make-bootstrap-tools = import ../make-bootstrap-tools.nix;
+in
+  make-bootstrap-tools rec {
+    localSystem = {
+      system = from;
+    };
+    crossSystem = {
+      system = to;
+    };
+    inherit nixpkgs;
+    pkgs = nixpkgs {
+      inherit localSystem crossSystem;
+    };
+  }

--- a/pkgs/stdenv/linux/scratch/stage1.nix
+++ b/pkgs/stdenv/linux/scratch/stage1.nix
@@ -4,6 +4,7 @@ let
   make-bootstrap-tools = import ../make-bootstrap-tools.nix;
 in
   make-bootstrap-tools rec {
+    stage = "stage1";
     localSystem = {
       system = from;
     };

--- a/pkgs/stdenv/linux/scratch/stage2.nix
+++ b/pkgs/stdenv/linux/scratch/stage2.nix
@@ -5,13 +5,14 @@ let
   make-bootstrap-tools = import ../make-bootstrap-tools.nix;
 in
   make-bootstrap-tools rec {
+    stage = "stage2";
     localSystem = {
       system = to;
     };
     inherit nixpkgs;
     pkgs = nixpkgs {
       inherit localSystem;
-      bootstrapTools = {
+      bootstrapFiles = {
         busybox = "${stage1.build}/on-server/busybox";
         bootstrapTools = "${stage1.build}/on-server/bootstrap-tools.tar.xz";
       };

--- a/pkgs/stdenv/linux/scratch/stage2.nix
+++ b/pkgs/stdenv/linux/scratch/stage2.nix
@@ -1,0 +1,19 @@
+# Stage 2 is to natively compile seeds using the cross-compiled seeds.
+{ from, to, nixpkgs }:
+stage1:
+let
+  make-bootstrap-tools = import ../make-bootstrap-tools.nix;
+in
+  make-bootstrap-tools rec {
+    localSystem = {
+      system = to;
+    };
+    inherit nixpkgs;
+    pkgs = nixpkgs {
+      inherit localSystem;
+      bootstrapTools = {
+        busybox = "${stage1.build}/on-server/busybox";
+        bootstrapTools = "${stage1.build}/on-server/bootstrap-tools.tar.xz";
+      };
+    };
+  }

--- a/pkgs/stdenv/linux/scratch/stage3.nix
+++ b/pkgs/stdenv/linux/scratch/stage3.nix
@@ -11,7 +11,7 @@ in
     inherit nixpkgs;
     pkgs = nixpkgs {
       inherit localSystem;
-      bootstrapTools = {
+      bootstrapFiles = {
         busybox = "${stage2.build}/on-server/busybox";
         bootstrapTools = "${stage2.build}/on-server/bootstrap-tools.tar.xz";
       };

--- a/pkgs/stdenv/linux/scratch/stage3.nix
+++ b/pkgs/stdenv/linux/scratch/stage3.nix
@@ -1,0 +1,19 @@
+# Stage 2 is to natively compile seeds using the native-cross hybrid seeds.
+{ from, to, nixpkgs }:
+stage2:
+let
+  make-bootstrap-tools = import ../make-bootstrap-tools.nix;
+in
+  make-bootstrap-tools rec {
+    localSystem = {
+      system = to;
+    };
+    inherit nixpkgs;
+    pkgs = nixpkgs {
+      inherit localSystem;
+      bootstrapTools = {
+        busybox = "${stage2.build}/on-server/busybox";
+        bootstrapTools = "${stage2.build}/on-server/bootstrap-tools.tar.xz";
+      };
+    };
+  }

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -1,5 +1,5 @@
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? []
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -1,5 +1,5 @@
 { lib
-, localSystem, crossSystem, config, overlays, crossOverlays ? [], bootstrapFiles ? null
+, localSystem, crossSystem, config, overlays, crossOverlays ? [], ...
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21451,8 +21451,7 @@ with pkgs;
 
   busybox = callPackage ../os-specific/linux/busybox { };
   busybox-sandbox-shell = callPackage ../os-specific/linux/busybox/sandbox-shell.nix {
-    # musl roadmap has RISC-V support projected for 1.1.20
-    busybox = if !stdenv.hostPlatform.isRiscV && stdenv.hostPlatform.libc != "bionic"
+    busybox = if !stdenv.hostPlatform.isSparc && stdenv.hostPlatform.libc != "bionic"
               then pkgsStatic.busybox
               else busybox;
   };

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -38,6 +38,9 @@
   # list it returns.
   stdenvStages ? import ../stdenv
 
+, # The bootstrap files (binary "seeds") used to bootstrap stdenv
+  bootstrapFiles ? null
+
 , # Ignore unexpected args.
   ...
 } @ args:
@@ -116,7 +119,7 @@ in let
   boot = import ../stdenv/booter.nix { inherit lib allPackages; };
 
   stages = stdenvStages {
-    inherit lib localSystem crossSystem config overlays crossOverlays;
+    inherit lib localSystem crossSystem config overlays crossOverlays bootstrapFiles;
   };
 
   pkgs = boot stages;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -38,9 +38,6 @@
   # list it returns.
   stdenvStages ? import ../stdenv
 
-, # The bootstrap files (binary "seeds") used to bootstrap stdenv
-  bootstrapFiles ? null
-
 , # Ignore unexpected args.
   ...
 } @ args:
@@ -118,9 +115,9 @@ in let
 
   boot = import ../stdenv/booter.nix { inherit lib allPackages; };
 
-  stages = stdenvStages {
-    inherit lib localSystem crossSystem config overlays crossOverlays bootstrapFiles;
-  };
+  stages = stdenvStages (args // {
+    inherit lib localSystem crossSystem config overlays crossOverlays;
+  });
 
   pkgs = boot stages;
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -164,15 +164,15 @@ let
         };
 
       stdenvBootstrapTools = with lib;
-        genAttrs systemsWithAnySupport
-          (system: {
-            inherit
-              (import ../stdenv/linux/scratch {
-                from = "x86_64-linux";
-                to = system;
-              })
-              dist test;
-          })
+        genAttrs supportedSystems
+          (from: genAttrs systemsWithAnySupport
+            (to: {
+              inherit
+                (import ../stdenv/linux/scratch {
+                  inherit from to;
+                })
+                dist test;
+            }))
         # darwin is special in this
         // optionalAttrs supportDarwin {
           x86_64-darwin =

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -12,7 +12,13 @@
 , officialRelease ? false
   # The platforms for which we build Nixpkgs.
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ]
-, limitedSupportedSystems ? [ "i686-linux" ]
+  # The platforms for which we build bootstrap-tools but not Nixpkgs.
+, limitedSupportedSystems ? [
+  "i686-linux" "x86_64-unknown-linux-musl"
+  "aarch64-unknown-linux-musl" "armv5tel-linux" "armv6l-unknown-linux-musl" "armv6l-linux" "armv7l-linux"
+  "mipsel-linux"
+  "powerpc64le-linux"
+  "sparc64-linux"]
   # Strip most of attributes when evaluating to spare memory usage
 , scrubJobs ? true
   # Attributes passed to nixpkgs. Don't build packages marked as unfree.
@@ -161,8 +167,9 @@ let
         genAttrs systemsWithAnySupport
           (system: {
             inherit
-              (import ../stdenv/linux/make-bootstrap-tools.nix {
-                localSystem = { inherit system; };
+              (import ../stdenv/linux/scratch {
+                from = "x86_64-linux";
+                to = system;
               })
               dist test;
           })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I have a sparc64 system I want to try to get NixOS running on, and if I can get NixOS working well in a powerpc64le emulator, I'll consider getting a ppc64le server to play around with (and probably use as a Hydra buildbox so I can add ppc64le to my binary cache).

I've been building things for this branch on my Hydra instance as part of my nixfiles project/jobset: https://hydra.piperswe.me/jobset/nixfiles/main

The results of basically all of my builds go into my binary cache, so if you want to play around with this branch you can use my binary cache to speed things up:

```nix
{
  nix = {
    binaryCaches = [
      "https://nix-cache.piperswe.me"
    ];
    binaryCachePublicKeys = [
      "nix-cache.piperswe.me:4r7vyJJ/0riN8ILB+YhSCnYeynvxOeZXNsPNV4Fn8mE="
    ];
  };
}
```

Since changing stdenv requires rebuilding the world, I might also add a few more interesting architectures to this PR so that we have bootstrap tools for most architectures out there at the cost of one world rebuild.

Fixes https://github.com/NixOS/nixpkgs/issues/113977. Depends on https://github.com/NixOS/nixpkgs/pull/141451.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
