### PR TITLE
cargo-deadlinks: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/tools/rust/cargo-deadlinks/default.nix
+++ b/pkgs/development/tools/rust/cargo-deadlinks/default.nix
@@ -2,22 +2,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deadlinks";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "deadlinks";
     repo = pname;
     rev = "${version}";
-    sha256 = "1zd5zgq3346xijllr0qdvvmsilpawisrqgdmsqir8v3bk55ybj4g";
+    sha256 = "0s5q9aghncsk9834azn5cgnn5ms3zzyjan2rq06kaqcgzhld4cjh";
   };
 
-  cargoSha256 = "1ar3iwpy9mng4j09z4g3ynxra2qwc8454dnc0wjal4h16fk8gxwv";
+  cargoSha256 = "00g06zf0m1wry0mhf098pw99kbb99d8a17985pb90yf1w74rdkh6";
 
   checkFlags = [
     # uses internet
     "--skip non_existent_http_link --skip working_http_check"
-    # expects top-level directory to be named "cargo-deadlinks"
-    "--skip simple_project::it_checks_okay_project_correctly"
   ];
 
   buildInputs = lib.optional stdenv.isDarwin Security;
@@ -25,6 +23,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "Cargo subcommand to check rust documentation for broken links";
     homepage = "https://github.com/deadlinks/cargo-deadlinks";
+    changelog = "https://github.com/deadlinks/cargo-deadlinks/blob/${version}/CHANGELOG.md";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ newam ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update `cargo-deadlinks`, a cargo subcommand to check rust documentation for broken links.

This release updates the dependencies to fix security vulnerabilities.

[CHANGELOG](https://github.com/deadlinks/cargo-deadlinks/blob/0.8.1/CHANGELOG.md#081-2021-10-12)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
