### PR TITLE
ocamlPackages.sawja: 1.5.8 → 1.5.10

### DIFF
--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, which, perl, ocaml, findlib, javalib }:
+{ lib, stdenv, fetchFromGitHub, which, ocaml, findlib, javalib }:
 
 let
   pname = "sawja";
-  version = "1.5.8";
+  version = "1.5.10";
   webpage = "http://sawja.inria.fr/";
 in
 
@@ -12,16 +12,20 @@ else
 
 stdenv.mkDerivation {
 
-  name = "ocaml${ocaml.version}-${pname}-${version}";
+  pname = "ocaml${ocaml.version}-${pname}";
+
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "javalib-team";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0rawr0jav33rvagm8sxc0arc7ya1fd9w5nng3lhfk8p02f9z8wrp";
+    rev = version;
+    sha256 = "sha256:0k51rscs9mdgpg3qn4cahql5ncdvlb207m015hr8v6r1vfgn0ddq";
   };
 
-  buildInputs = [ which perl ocaml findlib ];
+  nativeBuildInputs = [ which ];
+
+  buildInputs = [ ocaml findlib ];
 
   patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
 

--- a/pkgs/development/tools/java/sawjap/default.nix
+++ b/pkgs/development/tools/java/sawjap/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, ocamlPackages }:
+
+let inherit (ocamlPackages) ocaml findlib sawja; in
+
+stdenv.mkDerivation {
+
+  pname = "sawjap";
+
+  inherit (sawja) src version;
+
+  sourceRoot = "source/test";
+
+  buildInputs = [ ocaml findlib sawja ];
+
+  buildPhase = ''
+    runHook preBuild
+    mkdir -p $out/bin
+    ocamlfind opt -o $out/bin/sawjap -package sawja -linkpkg sawjap.ml
+    runHook postBuild
+  '';
+
+  dontInstall = true;
+
+  meta = sawja.meta // {
+    description = "Pretty-print .class files";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14889,6 +14889,8 @@ with pkgs;
 
   sauce-connect = callPackage ../development/tools/sauce-connect { };
 
+  sawjap = callPackage ../development/tools/java/sawjap { };
+
   sd-local = callPackage ../development/tools/sd-local { };
 
   selenium-server-standalone = callPackage ../development/tools/selenium/server { };


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/javalib-team/sawja/blob/1.5.10/CHANGELOG

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
