### PR TITLE
plasma5Packages.sonnet: make the build deterministic

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/sonnet.nix
+++ b/pkgs/development/libraries/kde-frameworks/sonnet.nix
@@ -1,10 +1,18 @@
 { mkDerivation
+, fetchpatch
 , extra-cmake-modules
 , aspell, qtbase, qttools
 }:
 
 mkDerivation {
   name = "sonnet";
+  patches = [
+    # Pull upstream path to fix determinism.
+    (fetchpatch {
+      url = "https://invent.kde.org/frameworks/sonnet/-/commit/a01fc66b8affb01221d1fdf84146a78c172d4c6b.patch";
+      sha256 = "1jzd65rmgvfpcxrsnsmdz8ac1ldqs9rjfryy8fryy0ibzbhc1050";
+    })
+  ];
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ aspell qttools ];
   propagatedBuildInputs = [ qtbase ];


### PR DESCRIPTION
plasma5Packages.sonnet is a non-deterministic package:

    $ nix build -f . plasma5Packages.sonnet --rebuild --keep-failed
    $ diffoscope ... ....check
    --- .../lib/libKF5SonnetCore.so.5.85.0
    +++ ....check/lib/libKF5SonnetCore.so.5.85.0
    - readelf --wide --decompress --hex-dump=.rodata {}
    <binary data changes>

It happens because `.rodata` contains a serialized QHash form of
on-disk trigram data. By default QHash is non-deterministic and
order of trigram entries varies from build to build. Let's
stabilize the output by making QHash deterministic just for build
time of sonnet.

Tested as:

    $ nix build -f . plasma5Packages.sonnet --repeat 1