### PR TITLE
cmake/setup-hook.sh: don't change timestamp of unmodified files

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -8,7 +8,16 @@ fixCmakeFiles() {
     find "$1" \( -type f -name "*.cmake" -o -name "*.cmake.in" -o -name CMakeLists.txt \) -print |
         while read fn; do
             sed -e 's^/usr\([ /]\|$\)^/var/empty\1^g' -e 's^/opt\([ /]\|$\)^/var/empty\1^g' < "$fn" > "$fn.tmp"
-            mv "$fn.tmp" "$fn"
+            if cmp -s "$fn.tmp" "$fn"; then
+                # Don't touch original file it it was unchanged.
+                # This way we preserve original timestamps that
+                # sometimes leak out to tarballs like in
+                # plasma5Packages.kirigami2 case.
+                rm "$fn.tmp"
+            else
+                echo "fixed '${fn}'"
+                mv "$fn.tmp" "$fn"
+            fi
         done
 }
 


### PR DESCRIPTION
Noticed the problem in non-deterministic plasma5Packages.kirigami2 package:

    $ nix build -f . plasma5Packages.kirigami2 --rebuild
    $ diffoscope ... ....check
    --- ...-kirigami2-5.85.0/share/kdevappwizard/templates/kirigami.tar.bz2
    +++ ...-kirigami2-5.85.0.check/share/kdevappwizard/templates/kirigami.tar.bz2
    ─ kirigami.tar
    ├── file list
    │ @@ -1,16 +1,16 @@
    │ -drwxr-xr-x   0        0        0        0 2021-10-10 00:56:49.334166 ./
    │ --rw-r--r--   0        0        0      974 2021-10-10 00:56:49.333166 ./CMakeLists.txt
    │ +drwxr-xr-x   0        0        0        0 2021-10-13 07:37:14.344414 ./
    │ +-rw-r--r--   0        0        0      974 2021-10-13 07:37:14.343414 ./CMakeLists.txt

It happens because cmake/setup-hook.sh always updates timestamp for
this template CMakeLists.txt file. Instead of working it around in
leaf package let's avoid changing any attributes on original
CMakeLists.txt if it was not modified by a sed statement.

While at it log file names that are actually changed by sed statement.