### PR TITLE
ranger: Add clipboard managers as runtime deps

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchFromGitHub, python3Packages, file, less, highlight
-, imagePreviewSupport ? true, w3m }:
+, imagePreviewSupport ? true, w3m, wl-clipboard, xclip }:
 
 python3Packages.buildPythonApplication rec {
   pname = "ranger";
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication rec {
   LC_ALL = "en_US.UTF-8";
 
   checkInputs = with python3Packages; [ pytestCheckHook ];
-  propagatedBuildInputs = [ file ]
+  propagatedBuildInputs = [ file xclip wl-clipboard ]
     ++ lib.optionals (imagePreviewSupport) [ python3Packages.pillow ];
 
   preConfigure = ''
@@ -40,7 +40,7 @@ python3Packages.buildPythonApplication rec {
       --replace "set preview_images false" "set preview_images true"
   '';
 
-  meta =  with lib; {
+  meta = with lib; {
     description = "File manager with minimalistic curses interface";
     homepage = "https://ranger.github.io/";
     license = licenses.gpl3Only;


### PR DESCRIPTION
###### Motivation for this change

`ranger` now has a `yank` command that can call an available clipboard manager.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
