### PR TITLE
alpnpass: init at 0.1

### DIFF
--- a/pkgs/applications/networking/alpnpass/default.nix
+++ b/pkgs/applications/networking/alpnpass/default.nix
@@ -1,0 +1,34 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "alpnpass";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "VerSprite";
+    repo = "alpnpass";
+    rev = version;
+    hash = "sha256-hNZqGTV17rFSKLhZzNqH2E4SSb6Jhk7YQ4TN0HnE+9g=";
+  };
+
+  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+
+  meta = with lib; {
+    description = "Inspect the plaintext payload inside of proxied TLS connections";
+    longDescription = ''
+      This tool will listen on a given port, strip SSL encryption,
+      forward traffic through a plain TCP proxy,
+      then encrypt the returning traffic again
+      and send it to the target of your choice.
+
+      Unlike most SSL stripping solutions this tool will negotiate ALPN and
+      preserve the negotiated protocol all the way to the target.
+    '';
+    homepage = "https://github.com/VerSprite/alpnpass";
+    license = licenses.unlicense;
+    maintainers = [ maintainers.raboof ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33216,6 +33216,8 @@ with pkgs;
 
   acpilight = callPackage ../misc/acpilight { };
 
+  alpnpass = callPackage ../applications/networking/alpnpass { };
+
   android-file-transfer = libsForQt5.callPackage ../tools/filesystems/android-file-transfer { };
 
   antimicrox = libsForQt5.callPackage ../tools/misc/antimicrox { };


### PR DESCRIPTION
###### Motivation for this change

A useful companion to e.g. Wireshark. Leaving the payloads untouched while still keeping the ALPN intact makes it fill a niche not yet covered by other tools like mitmproxy and sslsplit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
