### PR TITLE
mattermost-desktop: add libappindicator-gtk3 to rpath

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -2,7 +2,7 @@
 freetype, fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage,
 libXrandr, libXcomposite, libXext, libXfixes, libXrender, libXtst,
 libXScrnSaver, nss, nspr, alsa-lib, cups, expat, udev, wrapGAppsHook,
-hicolor-icon-theme, libuuid, at-spi2-core, at-spi2-atk }:
+hicolor-icon-theme, libuuid, at-spi2-core, at-spi2-atk, libappindicator-gtk3 }:
 
 let
   rpath = lib.makeLibraryPath [
@@ -21,6 +21,7 @@ let
     gnome2.GConf
     gtk3
     pango
+    libappindicator-gtk3
     libuuid
     libX11
     libXScrnSaver


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix/workaround for missing tray icon in GNOME: https://github.com/mattermost/desktop/issues/765

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
