### PR TITLE
nixos/prometheus: fix node exporter systemd collector

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -192,7 +192,7 @@ let
         serviceConfig.MemoryDenyWriteExecute = true;
         serviceConfig.NoNewPrivileges = true;
         serviceConfig.PrivateDevices = true;
-        serviceConfig.ProtectClock = true;
+        serviceConfig.ProtectClock = mkDefault true;
         serviceConfig.ProtectControlGroups = true;
         serviceConfig.ProtectHome = true;
         serviceConfig.ProtectHostname = true;

--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -35,6 +35,8 @@ in
           ${concatMapStringsSep " " (x: "--no-collector." + x) cfg.disabledCollectors} \
           --web.listen-address ${cfg.listenAddress}:${toString cfg.port} ${concatStringsSep " " cfg.extraFlags}
       '';
+      # The systemd collector needs AF_UNIX
+      RestrictAddressFamilies = lib.optional (lib.any (x: x == "systemd") cfg.enabledCollectors) "AF_UNIX";
     };
   };
 }

--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -37,6 +37,8 @@ in
       '';
       # The systemd collector needs AF_UNIX
       RestrictAddressFamilies = lib.optional (lib.any (x: x == "systemd") cfg.enabledCollectors) "AF_UNIX";
+      # The timex collector needs to access clock APIs
+      ProtectClock = lib.any (x: x == "timex") cfg.disabledCollectors;
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The systemd collector needs AF_UNIX to talk to
/var/run/dbus/system_bus_socket, which was broken
with 9fea6d4c8551b7c8783f23e011a2ba113c95d0dd.

This commit allows AF_UNIX when needed.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
