### PR TITLE
postman: 8.10.0 -> 9.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5467,6 +5467,12 @@
     githubId = 8735102;
     name = "John Ramsden";
   };
+  johnrichardrinehart = {
+    email = "johnrichardrinehart@gmail.com";
+    github = "johnrichardrinehart";
+    githubId = 6321578;
+    name = "John Rinehart";
+  };
   johntitor = {
     email = "huyuumi.dev@gmail.com";
     github = "JohnTitor";

--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "postman";
-  version = "8.10.0";
+  version = "9.0.4";
 
   src = fetchurl {
     url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha256 = "05f3eaa229483a7e1f698e6e2ea2031d37687de540d4fad05ce677ac216db24d";
+    sha256 = "9OX1rSNWq2YJQBCt64iE4osZvfVajgEC2F28w7HSs3U=";
     name = "${pname}.tar.gz";
   };
 
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     rm $out/share/postman/Postman
 
     mkdir -p $out/bin
-    ln -s $out/share/postman/_Postman $out/bin/postman
+    ln -s $out/share/postman/postman $out/bin/postman
 
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/
@@ -88,8 +88,8 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     pushd $out/share/postman
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" _Postman
-    for file in $(find . -type f \( -name \*.node -o -name _Postman -o -name \*.so\* \) ); do
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" postman
+    for file in $(find . -type f \( -name \*.node -o -name postman -o -name \*.so\* \) ); do
       ORIGIN=$(patchelf --print-rpath $file); \
       patchelf --set-rpath "${lib.makeLibraryPath buildInputs}:$ORIGIN" $file
     done
@@ -101,6 +101,6 @@ stdenv.mkDerivation rec {
     description = "API Development Environment";
     license = licenses.postman;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ xurei evanjs ];
+    maintainers = with maintainers; [ johnrichardrinehart evanjs ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`postman` 9.0.4 includes a feature for automating consecutive API calls. I want to use this :). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md). <-- I think so.....

I'm a little new to submitting changes. And I'm a little lazy, so I didn't follow all of the above steps. Please let me know if you need me to do any other tests or make any other changes.

I did test spinning up this build output (it's used in [my OS system flake](https://github.com/johnrichardrinehart/nix/blob/ef5db03a4148ac29e29aef77303aef7f28a42d3a/users/ardan.nix#L5)). `postman` seems to run just fine :) .