### PR TITLE
downonspot: init at unstable-2021-10-11

### DIFF
--- a/pkgs/applications/misc/downonspot/default.nix
+++ b/pkgs/applications/misc/downonspot/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "03g99yx9sldcg3i6hvpdxyk70f09f8kfj3kh283vl09b1a2c477w";
   };
 
-  cargoSha256 = "sha256:0k200p6wgwb60ax1r8mjn3aq08zxpkqbfqpi3b25zi3xf83my44d";
+  cargoSha256 = "0k200p6wgwb60ax1r8mjn3aq08zxpkqbfqpi3b25zi3xf83my44d";
 
   # fixes: error: the option `Z` is only accepted on the nightly compiler
   RUSTC_BOOTSTRAP = 1;

--- a/pkgs/applications/misc/downonspot/default.nix
+++ b/pkgs/applications/misc/downonspot/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, makeWrapper
+, alsa-lib
+, lame
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "downonspot";
+  version = "unstable-2021-10-13";
+
+  src = fetchFromGitHub {
+    owner = "oSumAtrIX";
+    repo = "DownOnSpot";
+    rev = "9d78ea2acad4dfe653a895a1547ad0abe7c5b47a";
+    sha256 = "03g99yx9sldcg3i6hvpdxyk70f09f8kfj3kh283vl09b1a2c477w";
+  };
+
+  cargoSha256 = "sha256:0k200p6wgwb60ax1r8mjn3aq08zxpkqbfqpi3b25zi3xf83my44d";
+
+  # fixes: error: the option `Z` is only accepted on the nightly compiler
+  RUSTC_BOOTSTRAP = 1;
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    openssl
+    alsa-lib
+    lame
+  ];
+
+  meta = with lib; {
+    description = "A Spotify downloader written in rust";
+    homepage = "https://github.com/oSumAtrIX/DownOnSpot";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4451,6 +4451,8 @@ with pkgs;
 
   dorkscout = callPackage ../tools/security/dorkscout { };
 
+  downonspot = callPackage ../applications/misc/downonspot { };
+
   sl1-to-photon = python3Packages.callPackage ../applications/misc/sl1-to-photon { };
 
   slade = callPackage ../applications/misc/slade {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [downonspot](https://github.com/oSumAtrIX/DownOnSpot) spotify downloader

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
