### PR TITLE
nsxiv: init at 27.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12845,5 +12845,11 @@
     github = "mbprtpmnr";
     githubId = 88109321;
   };
+  dillenburg = {
+    name = "Tiago Dillenburg";
+    email = "TiagoDillenburg@users.noreply.github.com";
+    github = "TiagoDillenburg";
+    githubId = 13285472;
+  };
 
 }

--- a/pkgs/applications/graphics/nsxiv/default.nix
+++ b/pkgs/applications/graphics/nsxiv/default.nix
@@ -24,10 +24,10 @@ stdenv.mkDerivation rec {
     install -Dt $out/share/applications nsxiv.desktop
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Neo Simple X Image Viewer";
     homepage = "https://github.com/nsxiv/nsxiv";
-    license = lib.licenses.gpl2Plus;
-    platforms = lib.platforms.linux;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/nsxiv/default.nix
+++ b/pkgs/applications/graphics/nsxiv/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1na7f0hpc9g04nm7991gzaqr5gkj08n2azx833hgxcm2w1pnn1bk";
   };
 
-  configFile = optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
-  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+  configFile = optionalString (conf != null) (builtins.toFile "config.def.h" conf);
+  preBuild = optionalString (conf != null) "cp ${configFile} config.def.h";
 
   buildInputs = [ libXft imlib2 giflib libexif ];
 

--- a/pkgs/applications/graphics/nsxiv/default.nix
+++ b/pkgs/applications/graphics/nsxiv/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Neo Simple X Image Viewer";
     homepage = "https://github.com/nsxiv/nsxiv";
+    maintainers = with maintainers; [ dillenburg ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/graphics/nsxiv/default.nix
+++ b/pkgs/applications/graphics/nsxiv/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, libXft, imlib2, giflib, libexif, conf ? null }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "nsxiv";
   version = "27.1";

--- a/pkgs/applications/graphics/nsxiv/default.nix
+++ b/pkgs/applications/graphics/nsxiv/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, libXft, imlib2, giflib, libexif, conf ? null }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  pname = "nsxiv";
+  version = "27.1";
+
+  src = fetchFromGitHub {
+    owner = "nsxiv";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1na7f0hpc9g04nm7991gzaqr5gkj08n2azx833hgxcm2w1pnn1bk";
+  };
+
+  configFile = optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
+  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+
+  buildInputs = [ libXft imlib2 giflib libexif ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postInstall = ''
+    install -Dt $out/share/applications nsxiv.desktop
+  '';
+
+  meta = {
+    description = "Neo Simple X Image Viewer";
+    homepage = "https://github.com/nsxiv/nsxiv";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -853,7 +853,7 @@ mapAliases ({
   solr_8 = solr; # added 2021-01-30
   spectral = neochat; # added 2020-12-27
   sundials_3 = throw "sundials_3 was removed in 2020-02. outdated and no longer needed";
-  sxiv = nsxiv; # added 2021-10-17 
+  sxiv = nsxiv; # added 2021-10-17
 
   # added 2020-02-10
   sourceHanSansPackages = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -853,6 +853,7 @@ mapAliases ({
   solr_8 = solr; # added 2021-01-30
   spectral = neochat; # added 2020-12-27
   sundials_3 = throw "sundials_3 was removed in 2020-02. outdated and no longer needed";
+  sxiv = nsxiv; # added 2021-10-17 
 
   # added 2020-02-10
   sourceHanSansPackages = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27659,6 +27659,8 @@ with pkgs;
 
   sxiv = callPackage ../applications/graphics/sxiv { };
 
+  nsxiv = callPackage ../applications/graphics/nsxiv { };
+
   resilio-sync = callPackage ../applications/networking/resilio-sync { };
 
   dropbox = callPackage ../applications/networking/dropbox { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27657,8 +27657,6 @@ with pkgs;
 
   swingsane = callPackage ../applications/graphics/swingsane { };
 
-  sxiv = callPackage ../applications/graphics/sxiv { };
-
   nsxiv = callPackage ../applications/graphics/nsxiv { };
 
   resilio-sync = callPackage ../applications/networking/resilio-sync { };


### PR DESCRIPTION
###### Motivation for this change
[sxiv](https://github.com/muennich/sxiv/) repository has been archived. Development's been moved to [nsxiv](https://github.com/nsxiv/nsxiv). Add nsxiv package to nixpkgs.

The package is essentially the same as [sxiv](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/graphics/sxiv/default.nix). I just ommited the maintainer because I was not sure it should be the same.

###### Things done

- Built on platform(s)
  - [X] NixOS 21.11
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
