### PR TITLE
gnomeExtensions.clock-override: add patch to support gnome 40

### DIFF
--- a/pkgs/desktops/gnome/extensions/clock-override/default.nix
+++ b/pkgs/desktops/gnome/extensions/clock-override/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
     extensionPortalSlug = "clock-override";
   };
 
+  # with small modifications of https://github.com/stuartlangridge/gnome-shell-clock-override/issues/57#issuecomment-942089876
+  patches = [ ./gnome-40.patch ];
+
   nativeBuildInputs = [ gettext glib ];
 
   buildPhase = ''
@@ -35,6 +38,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ rhoriguchi ];
     homepage = "https://github.com/stuartlangridge/gnome-shell-clock-override";
-    broken = versionOlder gnome.gnome-shell.version "3.18";
+    broken = versionOlder gnome.gnome-shell.version "3.40" && versionOlder gnome.gnome-shell.version "40";
   };
 }

--- a/pkgs/desktops/gnome/extensions/clock-override/gnome-40.patch
+++ b/pkgs/desktops/gnome/extensions/clock-override/gnome-40.patch
@@ -1,0 +1,56 @@
+diff --git a/metadata.json b/metadata.json
+index d0e7c0e..4b6195e 100644
+--- a/metadata.json
++++ b/metadata.json
+@@ -5,7 +5,8 @@
+   "settings-schema": "org.gnome.shell.extensions.clock-override", 
+   "shell-version": [
+     "3.18", 
+-    "3.28"
++    "3.28",
++    "40"
+   ], 
+   "url": "https://github.com/stuartlangridge/gnome-shell-clock-override", 
+   "uuid": "clock-override@gnomeshell.kryogenix.org", 
+diff --git a/prefs.js b/prefs.js
+index ea22dc2..ce27e2e 100644
+--- a/prefs.js
++++ b/prefs.js
+@@ -93,18 +93,13 @@ const ClockOverrideSettings = new GObject.Class({
+             /* It would be nicer to use just a Label with a hyperlink in it here, for accessibility
+                reasons, but god alone knows how to remove the underline on a label, thanks to the
+                lack of Gtk CSS examples. And a Button would be ugly. So an EventBox it is for now. */
+-            let eb = new Gtk.EventBox({
+-                hexpand: true,
+-                halign: Gtk.Align.START
+-            });
+             let r = new Gtk.Label({
+-                label: '<tt>' + eg[1] + '</tt>',
++                label: '<a href="#"><tt>' + eg[1] + '</tt></a>',
+                 use_markup: true,
+                 hexpand: true,
+                 halign: Gtk.Align.START
+             });
+-            eb.add(r);
+-            eb.connect("button-press-event", Lang.bind(grid, function(w) {
++            r.connect("activate-link", Lang.bind(grid, function(w) {
+                 this.update_textbox_value(eg[1]);
+                 grid._settings.set_string('override-string', eg[1]);
+                 return true;
+@@ -112,7 +107,7 @@ const ClockOverrideSettings = new GObject.Class({
+             r.get_style_context().add_provider(css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+ 
+             grid.attach(l, 0, rownumber, 1, 1);
+-            grid.attach(eb, 1, rownumber, 2, 1);
++            grid.attach(r, 1, rownumber, 2, 1);
+             rownumber += 1;
+         });
+ 
+@@ -136,7 +131,6 @@ const ClockOverrideSettings = new GObject.Class({
+ 
+ function buildPrefsWidget() {
+      let widget = new ClockOverrideSettings();
+-     widget.show_all();
+ 
+      return widget;
+ }


### PR DESCRIPTION
###### Motivation for this change

Makes the extension again usable and extension preference windows works more or less, styling is missing but brings back all functionality.

![image](https://user-images.githubusercontent.com/6047658/137146588-f7335a12-9d39-4bdc-829a-a118ed66be1f.png)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
