### PR TITLE
gnomeExtensions.dash-to-dock: unstable-2021-07-07 -> unstable-2021-10-03

### DIFF
--- a/pkgs/desktops/gnome/extensions/dash-to-dock/default.nix
+++ b/pkgs/desktops/gnome/extensions/dash-to-dock/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-dash-to-dock";
-  version = "unstable-2021-07-07";
+  version = "unstable-2021-10-03";
 
-  # temporarily switched to https://github.com/micheleg/dash-to-dock/pull/1402 because upstream doesn't work with GNOME 40 yet.
+  # temporarily switched to commit hash because GNOME 40 version is not released yet.
   src = fetchFromGitHub {
-    owner = "ewlsh";
+    owner = "micheleg";
     repo = "dash-to-dock";
-    rev = "e4beec847181e4163b0a99ceaef4c4582cc8ae4c";
-    hash = "sha256-7UVnLXH7COnIbqxbt3CCscuu1YyPH6ax5DlKdaHCT/0=";
+    rev = "9605dd69fe86d4f92416299c3f62605e75827dd3";
+    sha256 = "0vrkiq5z2f11gqlfyis2rsnp6j25hwsp24s21vr55qkzkfszsigg";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Should make the extension less buggy. Also contains the mentioned PR <https://github.com/micheleg/dash-to-dock/pull/1402>

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
