### PR TITLE
pythonPackages.typical: init at 2.7.9

### DIFF
--- a/pkgs/development/python-modules/future-typing/default.nix
+++ b/pkgs/development/python-modules/future-typing/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "future-typing";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    pname = "future_typing";
+    inherit version;
+    sha256 = "65fdc5034a95db212790fee5e977fb0a2df8deb60dccf3bac17d6d2b1a9bbacd";
+  };
+
+  doCheck = false; # No tests in pypi source
+
+  pythonImportsCheck = [ "future_typing" ];
+
+  meta = with lib; {
+    description = "Use generic type hints and new union syntax `|` with python 3.6+";
+    homepage = "https://github.com/PrettyWood/future-typing";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kfollesdal ];
+  };
+}

--- a/pkgs/development/python-modules/future-typing/default.nix
+++ b/pkgs/development/python-modules/future-typing/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "65fdc5034a95db212790fee5e977fb0a2df8deb60dccf3bac17d6d2b1a9bbacd";
   };
 
-  doCheck = false; # No tests in pypi source
+  doCheck = false; # No tests in pypi source. Did not get tests from GitHub source to work.
 
   pythonImportsCheck = [ "future_typing" ];
 

--- a/pkgs/development/python-modules/typical/default.nix
+++ b/pkgs/development/python-modules/typical/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, inflection
+, pendulum
+, fastjsonschema
+, typing-extensions
+, orjson
+, future-typing
+, poetry-core
+, pydantic
+, sqlalchemy
+, pandas
+, mypy
+}:
+
+buildPythonPackage rec {
+  pname = "typical";
+  version = "2.7.9";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "seandstewart";
+    repo = "typical";
+    rev = "v${version}";
+    sha256 = "sha256-ITIsSM92zftnvqLiVGFl//IbBb8N3ffkkqohzOx2JO4=";
+  };
+
+  patches = [
+    ./use-poetry-core.patch
+  ];
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    inflection
+    pendulum
+    fastjsonschema
+    orjson
+    typing-extensions
+    future-typing
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    mypy
+    pydantic
+    sqlalchemy
+    pandas
+  ];
+
+  disabledTests = [
+    "test_ujson" # We use orjson
+  ];
+
+  disabledTestPaths = [
+    "benchmark/"
+  ];
+
+  pythonImportsCheck = [ "typic" ];
+
+  meta = with lib; {
+    homepage = "https://python-typical.org/";
+    description = "Typical: Python's Typing Toolkit.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kfollesdal ];
+  };
+}

--- a/pkgs/development/python-modules/typical/use-poetry-core.patch
+++ b/pkgs/development/python-modules/typical/use-poetry-core.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index a588a0d..43da394 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -154,7 +154,7 @@ exclude = '''
+ 
+ [build-system]
+ requires = ["poetry>=0.12"]
+-build-backend = "poetry.masonry.api"
++build-backend = "poetry.core.masonry.api"
+ 
+ [bumpver]
+ current_version = "v2.7.5"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9523,6 +9523,8 @@ in {
 
   typesystem = callPackage ../development/python-modules/typesystem { };
 
+  typical = callPackage ../development/python-modules/typical { };
+
   typing = null;
 
   typing-extensions = callPackage ../development/python-modules/typing-extensions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2963,6 +2963,8 @@ in {
 
   future-fstrings = callPackage ../development/python-modules/future-fstrings { };
 
+  future-typing = callPackage ../development/python-modules/future-typing { };
+
   fuzzyfinder = callPackage ../development/python-modules/fuzzyfinder { };
 
   fuzzywuzzy = callPackage ../development/python-modules/fuzzywuzzy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add python package [typical](https://python-typical.org/) to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
