### PR TITLE
awslimitchecker: init at 12.0.0

### DIFF
--- a/pkgs/tools/admin/awslimitchecker/default.nix
+++ b/pkgs/tools/admin/awslimitchecker/default.nix
@@ -1,0 +1,58 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "awslimitchecker";
+  version = "12.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jantman";
+    repo = "awslimitchecker";
+    rev = version;
+    sha256 = "1p6n4kziyl6sfq7vgga9v88ddwh3sgnfb1m1cx6q25n0wyl7phgv";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    boto3
+    botocore
+    pytz
+    termcolor
+    versionfinder
+  ];
+
+  checkInputs = with python3Packages; [
+    freezegun
+    onetimepass
+    pytestCheckHook
+    pyotp
+    testfixtures
+  ];
+
+  patches = [
+    # Fix the version lookup to use only the hardcoded version in the source package
+    ./version.patch
+  ];
+
+  pytestFlagsArray = [
+    "awslimitchecker/tests"
+  ];
+
+  disabledTestPaths = [
+    # AWS tests that use the network
+    "awslimitchecker/tests/services"
+    "awslimitchecker/tests/test_checker.py"
+    "awslimitchecker/tests/test_runner.py"
+
+    # the version lookup tests as patched above
+    "awslimitchecker/tests/test_version.py"
+  ];
+
+  pythonImportsCheck = [ "awslimitchecker.checker" ];
+
+  meta = with lib; {
+    homepage = "http://awslimitchecker.readthedocs.org";
+    changelog = "https://github.com/jantman/awslimitchecker/blob/${version}/CHANGES.rst";
+    description = "A script and python package to check your AWS service limits and usage via boto3";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ zakame ];
+  };
+}

--- a/pkgs/tools/admin/awslimitchecker/version.patch
+++ b/pkgs/tools/admin/awslimitchecker/version.patch
@@ -1,0 +1,35 @@
+--- a/awslimitchecker/version.py
++++ b/awslimitchecker/version.py
+@@ -111,32 +106,5 @@ def _get_version_info():
+     :returns: awslimitchecker version
+     :rtype: str
+     """
+-    if os.environ.get('VERSIONCHECK_DEBUG', '') != 'true':
+-        for lname in ['versionfinder', 'pip', 'git']:
+-            l = logging.getLogger(lname)
+-            l.setLevel(logging.CRITICAL)
+-            l.propagate = True
+-    try:
+-        vinfo = find_version('awslimitchecker')
+-        dirty = ''
+-        if vinfo.git_is_dirty:
+-            dirty = '*'
+-        tag = vinfo.git_tag
+-        if tag is not None:
+-            tag += dirty
+-        commit = vinfo.git_commit
+-        if commit is not None:
+-            if len(commit) > 7:
+-                commit = commit[:8]
+-            commit += dirty
+-        return AWSLimitCheckerVersion(
+-            vinfo.version,
+-            vinfo.url,
+-            tag=tag,
+-            commit=commit
+-        )
+-    except Exception:
+-        logger.exception("Error checking installed version; this installation "
+-                         "may not be in compliance with the AGPLv3 license:")
+     # fall back to returning just the hard-coded release information
+     return AWSLimitCheckerVersion(_VERSION, _PROJECT_URL)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1312,6 +1312,8 @@ with pkgs;
 
   awsebcli = callPackage ../tools/virtualization/awsebcli {};
 
+  awslimitchecker = callPackage ../tools/admin/awslimitchecker { };
+
   awslogs = callPackage ../tools/admin/awslogs { };
 
   aws-lambda-rie = callPackage ../tools/admin/aws-lambda-runtime-interface-emulator { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/jantman/awslimitchecker is script and python package to check your AWS service limits and usage.

~This PR as stands currently will not build, since it still has some missing dependencies, each to follow in their own PRs in a little while:~

- [x] versionfinder
- [x] onetimepass
- [x] timecop

There is a small patch to `awslimitchecker.version` to use only the hard-coded version information, somewhat making the `versionfinder` dependency redundant, as otherwise we'd need a run-time dependency on `pytest` for `versionfinder` to behave correctly - I suspect there's a bug somewhere in between.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
