### PR TITLE
python3Packages.versionfinder: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/versionfinder/default.nix
+++ b/pkgs/development/python-modules/versionfinder/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchFromGitHub, GitPython, pytest, backoff, requests }:
+
+buildPythonPackage rec {
+  pname = "versionfinder";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "jantman";
+    repo = pname;
+    rev = version;
+    sha256 = "16mvjwyhmw39l8by69dgr9b9jnl7yav36523lkh7w7pwd529pbb9";
+  };
+
+  propagatedBuildInputs = [
+    GitPython
+    backoff
+  ];
+
+  checkInputs = [
+    pytest
+    requests
+  ];
+
+  pythonImportsCheck = [ "versionfinder" ];
+
+  meta = with lib; {
+    description = "Find the version of another package, whether installed via pip, setuptools or git";
+    homepage = "https://github.com/jantman/versionfinder";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ zakame ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9520,6 +9520,8 @@ in {
 
   versioneer = callPackage ../development/python-modules/versioneer { };
 
+  versionfinder = callPackage ../development/python-modules/versionfinder { };
+
   versiontag = callPackage ../development/python-modules/versiontag { };
 
   versiontools = callPackage ../development/python-modules/versiontools { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/jantman/versionfinder helps find the version of another Python package, whether installed via pip, setuptools or git.

Dependency for #141518.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
