### PR TITLE
python3Packages.onetimepass: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/onetimepass/default.nix
+++ b/pkgs/development/python-modules/onetimepass/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitHub, six, timecop }:
+
+buildPythonPackage rec {
+  pname = "onetimepass";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "tadeck";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0wmv62l3r8r4428gdzyj80lhgadfqvj220khz1wnm9alyzg60wkh";
+  };
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    timecop
+  ];
+
+  pythonImportsCheck = [ "onetimepass" ];
+
+  meta = with lib; {
+    description = "One-time password library for HMAC-based (HOTP) and time-based (TOTP) passwords";
+    homepage = "https://github.com/tadeck/onetimepass";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zakame ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5170,6 +5170,8 @@ in {
 
   ondilo = callPackage ../development/python-modules/ondilo { };
 
+  onetimepass = callPackage ../development/python-modules/onetimepass { };
+
   onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };
 
   onlykey-solo-python = callPackage ../development/python-modules/onlykey-solo-python { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/tadeck/onetimepass is a one-time password library for HMAC-based (HOTP) and time-based (TOTP) passwords for Python.

Dependency of #141518, and itself needs another Python library not yet in Nixpkgs: `timecop` (to follow shortly.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
