### PR TITLE
python3Packages.timecop: init at 0.5.0dev

### DIFF
--- a/pkgs/development/python-modules/timecop/default.nix
+++ b/pkgs/development/python-modules/timecop/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "timecop";
+  version = "0.5.0dev";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zbi58sw2yp1qchzfhyi7bsrwxajiypphg65fir98kvj03g011wd";
+  };
+
+  # test_epoch fails, see https://github.com/bluekelp/pytimecop/issues/4
+  preCheck = ''
+    sed -i 's/test_epoch/_test_epoch/' timecop/tests/test_freeze.py
+  '';
+
+  meta = with lib; {
+    description = "A port of the most excellent TimeCop Ruby Gem for Python";
+    homepage = "https://github.com/bluekelp/pytimecop";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ zakame ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9104,6 +9104,8 @@ in {
 
   timeago = callPackage ../development/python-modules/timeago { };
 
+  timecop = callPackage ../development/python-modules/timecop { };
+
   timelib = callPackage ../development/python-modules/timelib { };
 
   time-machine = callPackage ../development/python-modules/time-machine { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/bluekelp/pytimecop is a Python port of Ruby's https://github.com/travisjeffery/timecop, allowing to test time-dependent code.

Dependency of #141518 through #141522


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
