### PR TITLE
nixos/nvidia: fix typo in PM assert

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -213,7 +213,7 @@ in
       }
 
       {
-        assertion = cfg.powerManagement.enable -> offloadCfg.enable;
+        assertion = cfg.powerManagement.finegrained -> offloadCfg.enable;
         message = "Fine-grained power management requires offload to be enabled.";
       }
 


### PR DESCRIPTION
A simple typo fix. The finegrained power management is the only feature dependant on offload. The persistence daemon just helps to avoid corruption after system sleep and works without offload.