### PR TITLE
gnome: Try to reduce output closure

### DIFF
--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -65,7 +65,7 @@ buildPythonApplication rec {
     gobject-introspection
   ];
 
-  propagatedBuildInputs = [
+  pythonPath = [
     pygobject3
     pyatspi
     dbus-python

--- a/pkgs/data/themes/adwaita-qt/default.nix
+++ b/pkgs/data/themes/adwaita-qt/default.nix
@@ -14,6 +14,8 @@ mkDerivation rec {
   pname = "adwaita-qt";
   version = "1.4.0";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchFromGitHub {
     owner = "FedoraQt";
     repo = pname;

--- a/pkgs/desktops/gnome/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-music/default.nix
@@ -92,6 +92,13 @@ python3.pkgs.buildPythonApplication rec {
     done
   '';
 
+  # Prevent double wrapping, let the Python wrapper use the args in preFixup.
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   doCheck = false;
 
   # handle setup hooks better

--- a/pkgs/desktops/gnome/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-music/default.nix
@@ -79,12 +79,11 @@ python3.pkgs.buildPythonApplication rec {
     gst-plugins-ugly
   ]);
 
-  propagatedBuildInputs = with python3.pkgs; [
+  pythonPath = with python3.pkgs; [
     pycairo
     dbus-python
     pygobject3
   ];
-
 
   postPatch = ''
     for f in meson_post_conf.py meson_post_install.py; do

--- a/pkgs/desktops/gnome/core/gnome-user-share/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-user-share/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dhttpd=${apacheHttpd.out}/bin/httpd"
-    "-Dmodules_path=${apacheHttpd.dev}/modules"
+    "-Dmodules_path=${apacheHttpd}/modules"
     "-Dsystemduserunitdir=${placeholder "out"}/etc/systemd/user"
     # In 3.34.0 it defaults to false but it is silently ignored and always installed.
     # Let’s add it anyway in case they decide to make build respect the option in the future.

--- a/pkgs/desktops/gnome/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome/core/nautilus/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
   pname = "nautilus";
   version = "41.0";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
     sha256 = "+blBrcEEcAxn6kB2YiMV8fa3fc7BVMN/PUwLKDlQoeU=";

--- a/pkgs/desktops/gnome/misc/gnome-tweaks/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-tweaks/default.nix
@@ -56,7 +56,7 @@ python3Packages.buildPythonApplication rec {
     libsoup
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  pythonPath = with python3Packages; [
     pygobject3
   ];
 

--- a/pkgs/desktops/mate/mate-user-share/default.nix
+++ b/pkgs/desktops/mate/mate-user-share/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-httpd=${apacheHttpd.out}/bin/httpd"
-    "--with-modules-path=${apacheHttpd.dev}/modules"
+    "--with-modules-path=${apacheHttpd}/modules"
     "--with-cajadir=$(out)/lib/caja/extensions-2.0"
   ];
 

--- a/pkgs/development/libraries/dleyna-core/default.nix
+++ b/pkgs/development/libraries/dleyna-core/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
   pname = "dleyna-core";
   version = "0.6.0";
 
+  outputs = [ "out" "dev" ];
+
   setupHook = ./setup-hook.sh;
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -233,6 +233,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
     "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
+    "-Dglib-asserts=disabled" # asserts should be disabled on stable releases
 
     "-Davtp=disabled"
     "-Ddts=disabled" # required `libdca` library not packaged in nixpkgs as of writing, and marked as "BIG FAT WARNING: libdca is still in early development"

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -120,6 +120,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
     "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
+    "-Dglib-asserts=disabled" # asserts should be disabled on stable releases
   ] ++ lib.optionals (!qt5Support) [
     "-Dqt5=disabled"
   ] ++ lib.optionals (!gtkSupport) [

--- a/pkgs/development/libraries/libgxps/default.nix
+++ b/pkgs/development/libraries/libgxps/default.nix
@@ -6,6 +6,8 @@ stdenv.mkDerivation rec {
   pname = "libgxps";
   version = "0.3.2";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "bSeGclajXM+baSU+sqiKMrrKO5fV9O9/guNmf6Q1JRw=";

--- a/pkgs/development/python-modules/dogtail/default.nix
+++ b/pkgs/development/python-modules/dogtail/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage {
   pname = "dogtail";
   version = "0.9.11";
 
+  outputs = [ "out" "dev" ];
+
   # https://gitlab.com/dogtail/dogtail/issues/1
   # src = fetchPypi {
   #   inherit pname version;

--- a/pkgs/servers/http/apache-modules/mod_dnssd/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_dnssd/default.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  preFixup = ''
+    # TODO: Packages in non-standard directories not stripped.
+    # https://github.com/NixOS/nixpkgs/issues/141554
+    stripDebugList=modules
+  '';
+
   meta = with lib; {
     homepage = "http://0pointer.de/lennart/projects/mod_dnssd";
     description = "Provide Zeroconf support via DNS-SD using Avahi";

--- a/pkgs/servers/http/apache-modules/mod_dnssd/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_dnssd/default.nix
@@ -20,8 +20,12 @@ stdenv.mkDerivation rec {
   }) ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/modules
     cp src/.libs/mod_dnssd.so $out/modules
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Try to do something about https://github.com/NixOS/nixpkgs/issues/141521

Closes: https://github.com/NixOS/nixpkgs/pull/114486

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
