### PR TITLE
python3Packages.aioambient: 1.3.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/aioambient/default.nix
+++ b/pkgs/development/python-modules/aioambient/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "aioambient";
-  version = "2.0.0";
+  version = "2021.10.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "sha256-1Agai5o4L1zGdXgDUSPG31puu32mc11HZxD6srl+j1c=";
+    sha256 = "sha256-DCh/o7p+lO5BhN3JoLdhImkzfxoyqiscA/6CwwvAnc0=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/aioambient/default.nix
+++ b/pkgs/development/python-modules/aioambient/default.nix
@@ -16,18 +16,20 @@
 
 buildPythonPackage rec {
   pname = "aioambient";
-  version = "1.3.0";
+  version = "2.0.0";
   format = "pyproject";
-  disabled = pythonOlder "3.6";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "sha256-blejTXyLe3B2kNytBh+zJz0Q0xDP+Vo2SV9gc7OX6S0=";
+    sha256 = "sha256-1Agai5o4L1zGdXgDUSPG31puu32mc11HZxD6srl+j1c=";
   };
 
   postPatch = ''
+    # https://github.com/bachya/aioambient/pull/97
     substituteInPlace pyproject.toml \
       --replace 'websockets = ">=8.1,<10.0"' 'websockets = ">=8.1,<11.0"'
   '';
@@ -52,9 +54,13 @@ buildPythonPackage rec {
   ];
 
   # Ignore the examples directory as the files are prefixed with test_
-  disabledTestPaths = [ "examples/" ];
+  disabledTestPaths = [
+    "examples/"
+  ];
 
-  pythonImportsCheck = [ "aioambient" ];
+  pythonImportsCheck = [
+    "aioambient"
+  ];
 
   meta = with lib; {
     description = "Python library for the Ambient Weather API";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.0

Change log: https://github.com/bachya/aioambient/releases/tag/2.0.0

`websockets` is only available in `staging`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
