### PR TITLE
treewide: use stdenv.hostPlatform.extensions.sharedLibrary where appropriate

### DIFF
--- a/pkgs/applications/science/logic/z3/4.4.0.nix
+++ b/pkgs/applications/science/logic/z3/4.4.0.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   # z3's install phase is stupid because it tries to calculate the
   # python package store location itself, meaning it'll attempt to
   # write files into the nix store, and fail.
-  soext = if stdenv.system == "x86_64-darwin" then ".dylib" else ".so";
+  soext = stdenv.hostPlatform.extensions.sharedLibrary;
   installPhase = ''
     mkdir -p $out/bin $out/lib/${python.libPrefix}/site-packages $out/include
     cp ../src/api/z3*.h       $out/include

--- a/pkgs/development/libraries/nss/3.53.nix
+++ b/pkgs/development/libraries/nss/3.53.nix
@@ -151,13 +151,11 @@ stdenv.mkDerivation rec {
     in
     (lib.optionalString enableFIPS (''
       for libname in freebl3 nssdbm3 softokn3
-      do '' +
+      do libfile="$out/lib/lib$libname${stdenv.hostPlatform.extensions.sharedLibrary}"'' +
     (if stdenv.isDarwin
     then ''
-      libfile="$out/lib/lib$libname.dylib"
       DYLD_LIBRARY_PATH=$out/lib:${nspr.out}/lib \
     '' else ''
-      libfile="$out/lib/lib$libname.so"
       LD_LIBRARY_PATH=$out/lib:${nspr.out}/lib \
     '') + ''
           ${nss}/bin/shlibsign -v -i "$libfile"

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -166,13 +166,11 @@ stdenv.mkDerivation rec {
     in
     (lib.optionalString enableFIPS (''
       for libname in freebl3 nssdbm3 softokn3
-      do '' +
+      do libfile="$out/lib/lib$libname${stdenv.hostPlatform.extensions.sharedLibrary}"'' +
     (if stdenv.isDarwin
     then ''
-      libfile="$out/lib/lib$libname.dylib"
       DYLD_LIBRARY_PATH=$out/lib:${nspr.out}/lib \
     '' else ''
-      libfile="$out/lib/lib$libname.so"
       LD_LIBRARY_PATH=$out/lib:${nspr.out}/lib \
     '') + ''
           ${nss}/bin/shlibsign -v -i "$libfile"

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -57,7 +57,7 @@
 
     passthru = {
       fancyName = "MariaDB";
-      driver = if stdenv.isDarwin then "lib/libmaodbc.dylib" else "lib/libmaodbc.so";
+      driver = "lib/libmaodbc${stdenv.hostPlatform.extensions.sharedLibrary}";
     };
 
     meta = with lib; {

--- a/pkgs/development/python-modules/augeas/default.nix
+++ b/pkgs/development/python-modules/augeas/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
     # TODO: not very nice!
     postPatch =
-      let libname = if stdenv.isDarwin then "libaugeas.dylib" else "libaugeas.so";
+      let libname = "libaugeas${stdenv.hostPlatform.extensions.sharedLibrary}";
       in
       ''
         substituteInPlace augeas/ffi.py \

--- a/pkgs/development/python-modules/ifcopenshell/default.nix
+++ b/pkgs/development/python-modules/ifcopenshell/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     "-DOPENCOLLADA_LIBRARY_DIR=${opencollada}/lib/opencollada"
     "-DSWIG_EXECUTABLE=${swig}/bin/swig"
     "-DLIBXML2_INCLUDE_DIR=${libxml2.dev}/include/libxml2"
-    "-DLIBXML2_LIBRARIES=${libxml2.out}/lib/${if stdenv.isDarwin then "libxml2.dylib" else "libxml2.so"}"
+    "-DLIBXML2_LIBRARIES=${libxml2.out}/lib/libxml2${stdenv.hostPlatform.extensions.sharedLibrary}"
   ];
 
   meta = with lib; {

--- a/pkgs/development/tools/database/prisma-engines/default.nix
+++ b/pkgs/development/tools/database/prisma-engines/default.nix
@@ -8,9 +8,7 @@
 , stdenv
 }:
 
-let
-  node-api-lib = (if stdenv.isDarwin then "libquery_engine.dylib" else "libquery_engine.so");
-in rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage rec {
   pname = "prisma-engines";
   version = "3.2.0";
 
@@ -47,7 +45,7 @@ in rustPlatform.buildRustPackage rec {
   cargoBuildFlags = "-p query-engine -p query-engine-node-api -p migration-engine-cli -p introspection-core -p prisma-fmt";
 
   postInstall = ''
-    mv $out/lib/${node-api-lib} $out/lib/libquery_engine.node
+    mv $out/lib/libquery_engine${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libquery_engine.node
   '';
 
   # Tests are long to compile


### PR DESCRIPTION
Should be rebuild-0.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
