### PR TITLE
nixos/docker: add daemon.settings option

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -114,7 +114,7 @@
           If you previously used
           <literal>/etc/docker/daemon.json</literal>, you need to
           incorporate the changes into the new option
-          <literal>virtualisation.docker.daemonConfig</literal>.
+          <literal>virtualisation.docker.daemon.settings</literal>.
         </para>
       </listitem>
     </itemizedlist>

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -109,6 +109,14 @@
           <literal>writers.writePyPy2</literal> needs to be used.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          If you previously used
+          <literal>/etc/docker/daemon.json</literal>, you need to
+          incorporate the changes into the new option
+          <literal>virtualisation.docker.daemonConfig</literal>.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -41,6 +41,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The `writers.writePython2` and corresponding `writers.writePython2Bin` convenience functions to create executable Python 2 scripts in the store were removed in preparation of removal of the Python 2 interpreter.
   Scripts have to be converted to Python 3 for use with `writers.writePython3` or `writers.writePyPy2` needs to be used.
 
+- If you previously used `/etc/docker/daemon.json`, you need to incorporate the changes into the new option `virtualisation.docker.daemonConfig`.
+
 ## Other Notable Changes {#sec-release-22.05-notable-changes}
 
 - The option [services.redis.servers](#opt-services.redis.servers) was added

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -41,7 +41,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The `writers.writePython2` and corresponding `writers.writePython2Bin` convenience functions to create executable Python 2 scripts in the store were removed in preparation of removal of the Python 2 interpreter.
   Scripts have to be converted to Python 3 for use with `writers.writePython3` or `writers.writePyPy2` needs to be used.
 
-- If you previously used `/etc/docker/daemon.json`, you need to incorporate the changes into the new option `virtualisation.docker.daemonConfig`.
+- If you previously used `/etc/docker/daemon.json`, you need to incorporate the changes into the new option `virtualisation.docker.daemon.settings`.
 
 ## Other Notable Changes {#sec-release-22.05-notable-changes}
 

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -233,9 +233,9 @@ in
       virtualisation.docker.daemon.settings = {
         group = "docker";
         hosts = [ "fd://" ];
-        log-driver = cfg.logDriver;
-        storage-driver = mkIf (cfg.storageDriver != null) cfg.storageDriver;
-        live-restore = cfg.liveRestore;
+        log-driver = mkDefault cfg.logDriver;
+        storage-driver = mkIf (cfg.storageDriver != null) (mkDefault cfg.storageDriver);
+        live-restore = mkDefault cfg.liveRestore;
         runtimes = mkIf cfg.enableNvidia {
           nvidia = {
             path = "${pkgs.nvidia-docker}/bin/nvidia-container-runtime";

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -8,8 +8,8 @@ let
 
   cfg = config.virtualisation.docker;
   proxy_env = config.networking.proxy.envVars;
-  daemonSettingsJson = builtins.toJSON cfg.daemon.settings;
-  daemonSettingsFile = pkgs.writeText "daemon.json" daemonSettingsJson;
+  settingsFormat = pkgs.formats.json {};
+  daemonSettingsFile = settingsFormat.generate "daemon.json" cfg.daemon.settings;
 in
 
 {
@@ -55,7 +55,7 @@ in
 
     daemon.settings =
       mkOption {
-        type = types.anything;
+        type = settingsFormat.type;
         default = { };
         example = {
           ipv6 = true;

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -233,9 +233,9 @@ in
       virtualisation.docker.daemon.settings = {
         group = "docker";
         hosts = [ "fd://" ];
-        "log-driver" = cfg.logDriver;
-        "storage-driver" = mkIf (cfg.storageDriver != null) cfg.storageDriver;
-        "live-restore" = cfg.liveRestore;
+        log-driver = cfg.logDriver;
+        storage-driver = mkIf (cfg.storageDriver != null) cfg.storageDriver;
+        live-restore = cfg.liveRestore;
         runtimes = mkIf cfg.enableNvidia {
           nvidia = {
             path = "${pkgs.nvidia-docker}/bin/nvidia-container-runtime";

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -8,8 +8,8 @@ let
 
   cfg = config.virtualisation.docker;
   proxy_env = config.networking.proxy.envVars;
-  daemonConfigJson = builtins.toJSON cfg.daemonConfig;
-  daemonConfigFile = pkgs.writeText "daemon.json" daemonConfigJson;
+  daemonSettingsJson = builtins.toJSON cfg.daemon.settings;
+  daemonSettingsFile = pkgs.writeText "daemon.json" daemonSettingsJson;
 in
 
 {
@@ -53,7 +53,7 @@ in
           '';
       };
 
-    daemonConfig =
+    daemon.settings =
       mkOption {
         type = types.anything;
         default = { };
@@ -188,7 +188,7 @@ in
               ${cfg.package}/bin/dockerd \
                 --group=docker \
                 --host=fd:// \
-                --config-file=${daemonConfigFile} \
+                --config-file=${daemonSettingsFile} \
                 --log-driver=${cfg.logDriver} \
                 ${optionalString (cfg.storageDriver != null) "--storage-driver=${cfg.storageDriver}"} \
                 ${optionalString cfg.liveRestore "--live-restore" } \

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -186,13 +186,7 @@ in
             ""
             ''
               ${cfg.package}/bin/dockerd \
-                --group=docker \
-                --host=fd:// \
                 --config-file=${daemonSettingsFile} \
-                --log-driver=${cfg.logDriver} \
-                ${optionalString (cfg.storageDriver != null) "--storage-driver=${cfg.storageDriver}"} \
-                ${optionalString cfg.liveRestore "--live-restore" } \
-                ${optionalString cfg.enableNvidia "--add-runtime nvidia=${pkgs.nvidia-docker}/bin/nvidia-container-runtime" } \
                 ${cfg.extraOptions}
             ''];
           ExecReload=[
@@ -235,6 +229,19 @@ in
         { assertion = cfg.enableNvidia -> config.hardware.opengl.driSupport32Bit or false;
           message = "Option enableNvidia requires 32bit support libraries";
         }];
+
+      virtualisation.docker.daemon.settings = {
+        group = "docker";
+        hosts = [ "fd://" ];
+        "log-driver" = cfg.logDriver;
+        "storage-driver" = mkIf (cfg.storageDriver != null) cfg.storageDriver;
+        "live-restore" = cfg.liveRestore;
+        runtimes = mkIf cfg.enableNvidia {
+          nvidia = {
+            path = "${pkgs.nvidia-docker}/bin/nvidia-container-runtime";
+          };
+        };
+      };
     }
   ]);
 


### PR DESCRIPTION
###### Motivation for this change

Docker has quite a few configuration options. You can see them here: https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file

Some of these can be set using command-line options and thus using `virtualisation.docker.extraOptions`, but some of them are only available using the JSON configuration file. One example is `log-opts`.

In addition, serializing `types.anything` to JSON results in a nicer way to configure docker. For comparison:

```
extraOptions = "--ipv6 --fixed-cidr-v6 fd00::/80";
```
with:
```
daemon.settings = {
  ipv6 = true;
  "fixed-cidr-v6" = "fd00::/80";
};
```

This also allows the use of the mk* functions in order to modularize the configuration better.

Do note that anyone who has created `/etc/docker/daemon.conf` in the past to configure Docker ad-hoc must now migrate this configuration to NixOS's configuration. I have added a incompatibility note in the release notes.

###### Things done

I cherry-picked this commit to an older revision that I was able to build. I ran the docker tests:

```
nix-build nixos/tests/docker.nix
```

I confgured my system using:
```
  virtualisation.docker = {
    enable = true;
    daemon.settings = {
      ipv6 = true;
      "fixed-cidr-v6" = "fd00::/80";
    };
  };
```

I switched my system:

```
nix flake update --override-input nixpkgs $HOME/projects/nixpkgs && sudo nixos-rebuild --flake . switch
```

After that, the systemd service looks as follows:

```
$ systemctl is-active docker
active
$ systemctl cat docker
...
ExecStart=/nix/store/5m6801fx87daw9cd63dkii7qv998647s-docker-20.10.9/bin/dockerd \
  --config-file=/nix/store/pi1kc96nflwhaxzzfx295ds93j2fsh2p-daemon.json \
  

```

The config file looks as follows:

```
$ cat /nix/store/pi1kc96nflwhaxzzfx295ds93j2fsh2p-daemon.json                                                       
{
  "fixed-cidr-v6": "fd00::/80",
  "group": "docker",
  "hosts": [
    "fd://"
  ],
  "ipv6": true,
  "live-restore": true,
  "log-driver": "journald"
}
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
