### PR TITLE
ctx: init at 0.pre+date=2021-10-09

### DIFF
--- a/pkgs/applications/terminal-emulators/ctx/default.nix
+++ b/pkgs/applications/terminal-emulators/ctx/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchgit
+, SDL2
+, alsa-lib
+, babl
+, curl
+, libdrm # Not documented
+, pkg-config
+, enableFb ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ctx";
+  version = "0.pre+date=2021-10-09";
+
+  src = fetchgit {
+    name = "ctx-source"; # because of a dash starting the directory
+    url = "https://ctx.graphics/.git/";
+    rev = "d11d0d1a719a3c77712528e2feed8c0878e0ea64";
+    sha256 = "sha256-Az3POgdvDOVaaRtzLlISDODhAKbefpGx5KgwO3dttqs=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    alsa-lib
+    babl
+    curl
+    libdrm
+  ];
+
+  configureScript = "./configure.sh";
+  configureFlags = lib.optional enableFb "--enable-fb";
+  dontAddPrefix = true;
+
+  hardeningDisable = [ "format" ];
+
+  installFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://ctx.graphics/";
+    description = "Vector graphics terminal";
+    longDescription= ''
+      ctx is an interactive 2D vector graphics, audio, text- canvas and
+      terminal, with escape sequences that enable a 2D vector drawing API using
+      a vector graphics protocol.
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -999,6 +999,8 @@ with pkgs;
     inherit (lxqt) qtermwidget;
   };
 
+  ctx = callPackage ../applications/terminal-emulators/ctx { };
+
   darktile = callPackage ../applications/terminal-emulators/darktile { };
 
   eterm = callPackage ../applications/terminal-emulators/eterm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #138467

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
