### PR TITLE
 python3Packages.aioridwell: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/aioridwell/default.nix
+++ b/pkgs/development/python-modules/aioridwell/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, aiohttp
+, aresponses
+, buildPythonPackage
+, fetchFromGitHub
+, freezegun
+, poetry-core
+, pyjwt
+, pytest-aiohttp
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, pytz
+, titlecase
+, types-pytz
+}:
+
+buildPythonPackage rec {
+  pname = "aioridwell";
+  version = "0.2.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "bachya";
+    repo = pname;
+    rev = version;
+    sha256 = "0kzxh1igncql1rwh12n42qahlc94z0fsd344d1vgni50jg7i34v7";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    pyjwt
+    pytz
+    titlecase
+  ];
+
+  checkInputs = [
+    aresponses
+    freezegun
+    pytest-aiohttp
+    pytest-asyncio
+    pytestCheckHook
+    types-pytz
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'titlecase = "^2.3"' 'titlecase = "*"' \
+      --replace 'pytz = "^2021.3"' 'pytz = "*"'
+  '';
+
+  disabledTestPaths = [
+    # Ignore the examples directory as the files are prefixed with test_
+    "examples/"
+  ];
+
+  pythonImportsCheck = [
+    "aioridwell"
+  ];
+
+  meta = with lib; {
+    description = "Python library for interacting with Ridwell waste recycling";
+    homepage = "https://github.com/bachya/aioridwell";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/titlecase/default.nix
+++ b/pkgs/development/python-modules/titlecase/default.nix
@@ -1,24 +1,44 @@
-{ buildPythonPackage, lib, fetchPypi, regex }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, regex
+}:
 
 buildPythonPackage rec {
   pname = "titlecase";
   version = "2.3";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "9a1595ed9b88f3ce4362a7602ee63cf074e10ac80d1256b32ea1ec5ffa265fa0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "ppannuto";
+    repo = "python-titlecase";
+    rev = "v${version}";
+    sha256 = "169ywzn5wfzwyknqavspkdpwbx31nycxsxkl7iywwk71gs1lskkw";
   };
 
-  propagatedBuildInputs = [ regex ];
+  propagatedBuildInputs = [
+    regex
+  ];
 
-  # no tests run
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  pythonImportsCheck = [ "titlecase" ];
+  pytestFlagsArray = [
+    "titlecase/tests.py"
+  ];
+
+  pythonImportsCheck = [
+    "titlecase"
+  ];
 
   meta = with lib; {
+    description = "Python library to capitalize strings as specified by the New York Times";
     homepage = "https://github.com/ppannuto/python-titlecase";
-    description = "Python Port of John Gruber's titlecase.pl";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -365,6 +365,8 @@ in {
 
   aioresponses = callPackage ../development/python-modules/aioresponses { };
 
+  aioridwell = callPackage ../development/python-modules/aioridwell { };
+
   aiorpcx = callPackage ../development/python-modules/aiorpcx { };
 
   aiorun = callPackage ../development/python-modules/aiorun { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
aioridwell is a Python 3, asyncio-friendly library for interacting with Ridwell to view information on upcoming recycling pickups.

https://github.com/bachya/aioridwell

THis could become a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
