### PR TITLE
verco: 6.5.5 -> 6.6.0

### DIFF
--- a/pkgs/applications/version-management/verco/default.nix
+++ b/pkgs/applications/version-management/verco/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "verco";
-  version = "6.5.5";
+  version = "6.6.0";
 
   src = fetchFromGitHub {
     owner = "vamolessa";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-n+GGiu/xGGGC6FQPoASok87bCG0MFVIf6l6nt1lvw8A=";
+    sha256 = "sha256-ZfiGDEx6gjYziatbQSpqghmpXMXSPPBtTVYjll922t8=";
   };
 
-  cargoSha256 = "sha256-lNtR4N+bFFCr3Ct99DJCbtDeKxTzT7ZjvAWixbQm3jg=";
+  cargoSha256 = "sha256-jrA6vGw+lyfix8L3INBamrJ4pab5denPzWwjF0dRXB0=";
 
   meta = with lib; {
     description = "A simple Git/Mercurial/PlasticSCM tui client based on keyboard shortcuts";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/vamolessa/verco/compare/v6.5.5...v6.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
