### PR TITLE
vscode-extensions.ms-python.python: fix failing autoPatchelfHook

### DIFF
--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -82,6 +82,9 @@ in vscode-utils.buildVscodeMarketplaceExtension rec {
     cp -R --no-preserve=ownership ${languageServer}/* "$out/$installPrefix/languageServer.${languageServer.version}"
     chmod -R +wx "$out/$installPrefix/languageServer.${languageServer.version}"
 
+    patchelf "$out/$installPrefix/languageServer.${languageServer.version}/libcoreclrtraceptprovider.so" \
+      --replace-needed liblttng-ust.so.0 liblttng-ust.so
+
     patchPythonScript "$out/$installPrefix/pythonFiles/lib/python/isort/main.py"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Fix auto-patching:

```shell
autoPatchelfHook could not satisfy dependency liblttng-ust.so.0 wanted by /nix/store/zzkbmv6s9vxc2sx6455yca90izcili5k-vscode-extension-ms-python-python-2021.5.829140558/share/vscode/extensions/ms-python.python/languageServer.0.5.30/libcoreclrtraceptprovider.so
```

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
