### PR TITLE
qcoro: init at 0.3.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10484,6 +10484,13 @@
     githubId = 4477729;
     name = "Sergey Mironov";
   };
+  smitop = {
+    name = "Smitty van Bodegom";
+    email = "me@smitop.com";
+    matrix = "@smitop:kde.org";
+    github = "Smittyvb";
+    githubId = 10530973;
+  };
   sna = {
     email = "abouzahra.9@wright.edu";
     github = "s-na";

--- a/pkgs/development/libraries/qcoro/default.nix
+++ b/pkgs/development/libraries/qcoro/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, libpthreadstubs
+, qtbase
+}:
+
+mkDerivation rec {
+  pname = "qcoro";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "danvratil";
+    repo = "qcoro";
+    rev = "v${version}";
+    sha256 = "09543hpy590dndmlxmcm8c58m97blhaii4wbjr655qxdanhhxgzi";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    qtbase
+    libpthreadstubs
+  ];
+
+  meta = with lib; {
+    description = "Library for using C++20 coroutines in connection with certain asynchronous Qt actions";
+    homepage = "https://github.com/danvratil/qcoro";
+    license = licenses.mit;
+    maintainers = with maintainers; [ smitop ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -174,6 +174,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
+  qcoro = callPackage ../development/libraries/qcoro { };
+
   qcsxcad = callPackage ../development/libraries/science/electronics/qcsxcad { };
 
   qmltermwidget = callPackage ../development/libraries/qmltermwidget {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[qcoro](https://github.com/danvratil/qcoro) is a library for using C++20 coroutines with Qt. It appears it [will also be needed](https://invent.kde.org/network/neochat/-/blob/304c74101ea02668eadd83d2cfa376f167826ac7/CMakeLists.txt#L113) to build Neochat from source in the next release. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
