### PR TITLE
nixos/test-runner: Print exceptions that happen

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -1126,9 +1126,9 @@ class Driver:
             try:
                 yield
                 return True
-            except:
-                rootlog.error(f'Test "{name}" failed with error:')
-                raise
+            except Exception as e:
+                rootlog.error(f'Test "{name}" failed with error: "{e}"')
+                raise e
 
     def test_symbols(self) -> Dict[str, Any]:
         @contextmanager


### PR DESCRIPTION
###### Motivation for this change

It wasn't that hard… I just want to debug my tests.
Fixes the damage done by #126713