### PR TITLE
easyeffects: 6.0.3 → 6.1.3

### DIFF
--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -25,7 +25,7 @@
 , rnnoise
 , rubberband
 , speexdsp
-, wrapGAppsHook
+, wrapGAppsHook4
 , zam-plugins
 , zita-convolver
 }:
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -74,6 +74,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     chmod +x meson_post_install.py
     patchShebangs meson_post_install.py
+    # https://github.com/wwmm/easyeffects/pull/1205
+    substituteInPlace meson_post_install.py --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
   '';
 
   preFixup =

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -33,13 +33,13 @@
 
 stdenv.mkDerivation rec {
   pname = "easyeffects";
-  version = "6.0.3";
+  version = "6.1.3";
 
   src = fetchFromGitHub {
     owner = "wwmm";
     repo = "easyeffects";
     rev = "v${version}";
-    sha256 = "sha256-GzqPC/m/HMthLMamhJ4EXX6fxZYscdX1QmXgqHOPEcg=";
+    sha256 = "sha256-1UfeqPJxY4YT98UdqTZtG+QUBOZlKfK+7WbszhO22A0=";
   };
 
   nativeBuildInputs = [
@@ -82,8 +82,8 @@ stdenv.mkDerivation rec {
   preFixup =
     let
       lv2Plugins = [
-        calf # limiter, compressor exciter, bass enhancer and others
-        lsp-plugins # delay
+        calf # compressor exciter, bass enhancer and others
+        lsp-plugins # delay, limiter, multiband compressor
         mda_lv2 # loudness
         zam-plugins # maximizer
       ];

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -16,6 +16,7 @@
 , lilv
 , lsp-plugins
 , lv2
+, mda_lv2
 , meson
 , ninja
 , nlohmann_json
@@ -83,6 +84,7 @@ stdenv.mkDerivation rec {
       lv2Plugins = [
         calf # limiter, compressor exciter, bass enhancer and others
         lsp-plugins # delay
+        mda_lv2 # loudness
       ];
       ladspaPlugins = [
         rubberband # pitch shifting

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -85,10 +85,10 @@ stdenv.mkDerivation rec {
         calf # limiter, compressor exciter, bass enhancer and others
         lsp-plugins # delay
         mda_lv2 # loudness
+        zam-plugins # maximizer
       ];
       ladspaPlugins = [
         rubberband # pitch shifting
-        zam-plugins # maximizer
       ];
     in
     ''


### PR DESCRIPTION
###### Motivation for this change
https://github.com/wwmm/easyeffects/blob/v6.1.3/CHANGELOG.md

Closes: https://github.com/NixOS/nixpkgs/pull/136477
Closes: https://github.com/NixOS/nixpkgs/pull/139464

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
