### PR TITLE
python3Packages.ocrmypdf: 12.6.0 -> 12.7.0

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -3,9 +3,9 @@
 , cffi
 , coloredlogs
 , fetchFromGitHub
-, fetchpatch
 , ghostscript
 , img2pdf
+, importlib-metadata
 , importlib-resources
 , jbig2enc
 , leptonica
@@ -16,6 +16,7 @@
 , pngquant
 , pytest-xdist
 , pytestCheckHook
+, pythonOlder
 , reportlab
 , setuptools
 , setuptools-scm
@@ -29,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "12.6.0";
+  version = "12.7.0";
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
@@ -41,7 +42,7 @@ buildPythonPackage rec {
     extraPostFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    sha256 = "0zw7c6l9fkf128gxsbd7v4abazlxiygqys6627jpsjbmxg5jgp5w";
+    sha256 = "sha256-lpTuaZRrmFoKV1SAFoGpsYfPBkLB2+iB63fg3t9RC5o=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -56,12 +57,6 @@ buildPythonPackage rec {
       tesseract = "${lib.getBin tesseract4}/bin/tesseract";
       unpaper = "${lib.getBin unpaper}/bin/unpaper";
     })
-    # Fix support with pybind11 2.8.0
-    # https://github.com/jbarlow83/OCRmyPDF/issues/843
-    (fetchpatch {
-      url = "https://github.com/jbarlow83/OCRmyPDF/commit/690f88119d3ec24b17ddd14bb44832954a452e48.patch";
-      sha256 = "02z3jz85nmv1iilcp62hm5pyfgp6936ds67p1fhw49i8955q8pby";
-    })
   ];
 
   nativeBuildInputs = [
@@ -73,7 +68,6 @@ buildPythonPackage rec {
     cffi
     coloredlogs
     img2pdf
-    importlib-resources
     pdfminer
     pikepdf
     pillow
@@ -81,7 +75,11 @@ buildPythonPackage rec {
     reportlab
     setuptools
     tqdm
-  ];
+  ] ++ (lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ]) ++ (lib.optionals (pythonOlder "3.9") [
+    importlib-resources
+  ]);
 
   checkInputs = [
     pytest-xdist

--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -2,7 +2,7 @@
 , attrs
 , buildPythonPackage
 , defusedxml
-, fetchPypi
+, fetchFromGitHub
 , hypothesis
 , isPy3k
 , jbig2dec
@@ -27,9 +27,17 @@ buildPythonPackage rec {
   version = "3.2.0";
   disabled = ! isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a0582f00440668c07edb8403e82724961c7812c8e6c30655e34825b2645f15cd";
+  src = fetchFromGitHub {
+    owner = "pikepdf";
+    repo = "pikepdf";
+    rev = "v${version}";
+    # The content of .git_archival.txt is substituted upon tarball creation,
+    # which creates indeterminism if master no longer points to the tag.
+    # See https://github.com/jbarlow83/OCRmyPDF/issues/841
+    extraPostFetch = ''
+      rm "$out/.git_archival.txt"
+    '';
+    sha256 = "03c7ihd6rf6kdfc3cpgxy5pi6cj4zwscz8nyxmmp15fmdk3hkw4g";
   };
 
   patches = [
@@ -39,6 +47,8 @@ buildPythonPackage rec {
       mudraw = "${lib.getBin mupdf}/bin/mudraw";
     })
   ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   buildInputs = [
     pybind11

--- a/pkgs/development/python-modules/pluggy/default.nix
+++ b/pkgs/development/python-modules/pluggy/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchPypi
 , setuptools-scm
+, pythonOlder
 , importlib-metadata
 }:
 
@@ -23,12 +24,14 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  propagatedBuildInputs = [ importlib-metadata ];
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
 
   meta = {
     description = "Plugin and hook calling mechanisms for Python";
     homepage = "https://github.com/pytest-dev/pluggy";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
