### PR TITLE
tree-sitter: add alemuller/tree-sitter-make

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -24,6 +24,7 @@
   tree-sitter-julia = (builtins.fromJSON (builtins.readFile ./tree-sitter-julia.json));
   tree-sitter-latex = (builtins.fromJSON (builtins.readFile ./tree-sitter-latex.json));
   tree-sitter-lua = (builtins.fromJSON (builtins.readFile ./tree-sitter-lua.json));
+  tree-sitter-make = (builtins.fromJSON (builtins.readFile ./tree-sitter-make.json));
   tree-sitter-markdown = (builtins.fromJSON (builtins.readFile ./tree-sitter-markdown.json));
   tree-sitter-nix = (builtins.fromJSON (builtins.readFile ./tree-sitter-nix.json));
   tree-sitter-norg = (builtins.fromJSON (builtins.readFile ./tree-sitter-norg.json));

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-make.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-make.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/alemuller/tree-sitter-make",
+  "rev": "716c294283bc3dda263ccbdf55e38ec30aa0edba",
+  "date": "2021-04-30T16:37:32-03:00",
+  "path": "/nix/store/v2dvgqs3fxwh83dhc53xivrx8i0g519y-tree-sitter-make",
+  "sha256": "1fb6rf6pc6mdawphifhlbzbgppxvq6hj48cz6073schvavgjgchc",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -102,6 +102,10 @@ let
       orga = "travonted";
       repo = "tree-sitter-fennel";
     };
+    "tree-sitter-make" = {
+      orga = "alemuller";
+      repo = "tree-sitter-make";
+    };
     "tree-sitter-markdown" = {
       orga = "ikatyang";
       repo = "tree-sitter-markdown";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
