### PR TITLE
trellis: Revert removal of CMAKE_INSTALL_DATADIR

### DIFF
--- a/pkgs/development/embedded/fpga/trellis/default.nix
+++ b/pkgs/development/embedded/fpga/trellis/default.nix
@@ -31,6 +31,8 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 ];
   cmakeFlags = [
     "-DCURRENT_GIT_VERSION=${realVersion}"
+    # TODO: should this be in stdenv instead?
+    "-DCMAKE_INSTALL_DATADIR=${placeholder "out"}/share"
   ];
 
   preConfigure = ''

--- a/pkgs/development/embedded/fpga/trellis/default.nix
+++ b/pkgs/development/embedded/fpga/trellis/default.nix
@@ -41,6 +41,12 @@ in stdenv.mkDerivation rec {
     cd libtrellis
   '';
 
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/ecppack $out/share/trellis/misc/basecfgs/empty_lfe5u-85f.config /tmp/test.bin
+  '';
+
   meta = with lib; {
     description     = "Documentation and bitstream tools for Lattice ECP5 FPGAs";
     longDescription = ''
@@ -51,7 +57,7 @@ in stdenv.mkDerivation rec {
     '';
     homepage    = "https://github.com/YosysHQ/prjtrellis";
     license     = licenses.isc;
-    maintainers = with maintainers; [ q3k thoughtpolice emily ];
+    maintainers = with maintainers; [ q3k thoughtpolice emily rowanG077 ];
     platforms   = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`CMAKE_INSTALL_DATADIR` is used to refer to the database file. Without it
many tools can't be used. This used to be in the derivation but was recently
removed with [this commit](https://github.com/NixOS/nixpkgs/commit/4ebe496bad646a9e99f79250f885d7144fe39230#diff-df5e4c0ce381d6f35b2bed24e3b05957b0c4478456311f4c106ea8761caeeecd) leading to breakage for me.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
