### PR TITLE
stellaris: init at 3.1.2.50367

### DIFF
--- a/pkgs/build-support/build-gog-package/default.nix
+++ b/pkgs/build-support/build-gog-package/default.nix
@@ -1,0 +1,59 @@
+{ stdenv
+, gogextract
+, unzip
+, makeWrapper
+, autoPatchelfHook
+, imagemagick
+, makeDesktopItem
+}:
+
+{ pname
+, displayName ? pname
+, nativeBuildInputs ? [ ]
+, unpackPhase ? ""
+, installPhase ? ""
+, ...
+}@attrs:
+stdenv.mkDerivation (attrs // {
+  nativeBuildInputs = nativeBuildInputs ++ [
+    gogextract
+    unzip
+    makeWrapper
+    autoPatchelfHook
+    imagemagick
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    icon = pname;
+    desktopName = displayName;
+    categories = "Game;";
+  };
+
+  unpackPhase = ''
+    gogextract $src .
+    unzip data.zip
+    ${unpackPhase}
+  '';
+
+  # This was written for Stellaris, and might need tweaking to work with other games.
+  installPhase = ''
+    mkdir -p $out
+    echo '  copying files'
+    cp -R data/noarch $out/data
+    echo '  installing executables'
+    makeWrapper $out/data/game/$pname $out/bin/$pname
+    install -Dm644 -t $out/share/applications $desktopItem/share/applications/*
+
+    echo '  installing icons'
+    for n in 16 24 32 48 64 96 128 256; do
+      size=$n"x"$n
+      mkdir -p $out/share/icons/hicolor/$size/apps
+      convert data/noarch/support/icon.png \
+        -resize $size \
+        $out/share/icons/hicolor/$size/apps/$pname.png
+    done
+    ${installPhase}
+  '';
+})

--- a/pkgs/build-support/build-gog-package/gogextract.nix
+++ b/pkgs/build-support/build-gog-package/gogextract.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, python3, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  pname = "gogextract";
+  version = "6601b32feacecd18bc12f0a4c23a063c3545a095";
+
+  src = fetchFromGitHub {
+    owner = "Yepoleb";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-BTtm3Tn2hFS512w+IcJQfGKSgi2dpYLg1VxNXRODBEI=";
+  };
+
+  buildInputs = [ python3 ];
+
+  doBuild = false;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/gogextract.py $out/bin/gogextract
+  '';
+
+  meta = with lib; {
+    description = "Script for unpacking GOG Linux installers";
+    homepage = "https://github.com/Yepoleb/gogextract";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pmc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/build-support/fetchgog/default.nix
+++ b/pkgs/build-support/fetchgog/default.nix
@@ -1,0 +1,17 @@
+{ requireFile }:
+
+# How to find slug:
+# Go to the downloads page on your GOG account, hover over the game installer
+# download link, and check the part of the path following "downloads/".
+{ slug, filename, sha256 }:
+requireFile rec {
+  name = filename;
+  inherit sha256;
+  url = "https://www.gog.com/downloads/${slug}/en3installer0";
+  message = ''
+    Unfortunately, we cannot download ${slug} (${filename}) from GOG
+    automatically. Please go to ${url} to sign in to GOG and download it
+    yourself, and add it to the Nix store using
+      nix-store --add-fixed sha256 ${filename}
+  '';
+}

--- a/pkgs/games/stellaris/default.nix
+++ b/pkgs/games/stellaris/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, buildGOGPackage
+, fetchGOG
+, gtk2-x11
+, zlib
+, nss
+, xorg
+, dbus_libs
+, cairo
+, nspr
+, alsaLib
+, gdk_pixbuf
+, gnome2
+, glib
+, expat
+, libuuid
+, atk
+, vivaldi-widevine
+, stdenv
+}:
+
+buildGOGPackage rec {
+  displayName = "Stellaris";
+  pname = "stellaris";
+  version = "3.1.2.50367";
+
+  src = fetchGOG {
+    slug = "stellaris";
+    filename = "${pname}_${builtins.replaceStrings ["."] ["_"] version}.sh";
+    sha256 = "sha256-86rXYSAjoggvw1cem3GHbYlvKWy7MasXg20KelU3I9Q=";
+  };
+
+  buildInputs = [
+    gtk2-x11
+    zlib
+    nss
+    dbus_libs
+    cairo
+    nspr
+    alsaLib
+    gdk_pixbuf
+    stdenv.cc.cc.lib
+    glib
+    expat
+    (vivaldi-widevine.overrideAttrs (super: {
+      installPhase = ''
+        ${super.installPhase}
+        install -vD libwidevinecdm.so $out/lib/libwidevinecdm.so
+      '';
+    }))
+    libuuid
+    atk
+  ] ++ (with gnome2; [ gtk pango ]) ++ (with xorg; [
+    libxcb
+    libXdamage
+    libX11
+    libXrandr
+    libXi
+    libXcomposite
+    libXrender
+    libXext
+    libXcursor
+    libXScrnSaver
+    libXfixes
+    libICE
+    libXtst
+    libSM
+  ]);
+
+  meta = with lib; {
+    description = "A science fiction 4x grand strategy game, purchased from GOG.com";
+    homepage = "https://www.paradoxplaza.com/stellaris";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ pmc ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -220,6 +220,9 @@ with pkgs;
   buildFHSUserEnvChroot = callPackage ../build-support/build-fhs-userenv { };
   buildFHSUserEnvBubblewrap = callPackage ../build-support/build-fhs-userenv-bubblewrap { };
 
+  buildGOGPackage = callPackage ../build-support/build-gog-package { };
+  gogextract = callPackage ../build-support/build-gog-package/gogextract.nix { };
+
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
   castget = callPackage ../applications/networking/feedreaders/castget { };
@@ -467,6 +470,8 @@ with pkgs;
   };
 
   fetchgitLocal = callPackage ../build-support/fetchgitlocal { };
+
+  fetchGOG = callPackage ../build-support/fetchgog { };
 
   fetchmtn = callPackage ../build-support/fetchmtn (config.fetchmtn or {});
 
@@ -30167,6 +30172,8 @@ with pkgs;
   steamcmd = steamPackages.steamcmd;
 
   steam-acf = callPackage ../tools/games/steam-acf { };
+
+  stellaris = callPackage ../games/stellaris { };
 
   protontricks = python3Packages.callPackage ../tools/package-management/protontricks {
     winetricks = winetricks.override {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
