### PR TITLE
leo2: 1.6.2 → 1.7.0

### DIFF
--- a/pkgs/applications/science/logic/leo2/default.nix
+++ b/pkgs/applications/science/logic/leo2/default.nix
@@ -1,20 +1,31 @@
-{ lib, stdenv, fetchurl, makeWrapper, eprover, ocaml, perl, zlib }:
+{ lib, stdenv, fetchurl, fetchpatch, makeWrapper, eprover, ocaml, camlp4, perl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "leo2";
-  version = "1.6.2";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "https://page.mi.fu-berlin.de/cbenzmueller/leo/leo2_v${version}.tgz";
-    sha256 = "1wjpmizb181iygnd18lx7p77fwaci2clgzs5ix5j51cc8f3pazmv";
+    sha256 = "sha256:1b2q7vsz6s9ighypsigqjm1mzjiq3xgnz5id5ssb4rh9zm190r82";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ eprover ocaml perl zlib ];
+  buildInputs = [ eprover ocaml camlp4 perl zlib ];
 
-  sourceRoot = "leo2/src";
+  patches = [ (fetchpatch {
+      url = "https://github.com/niklasso/minisat/commit/7eb6015313561a2586032574788fcb133eeaa19f.patch";
+      stripLen = 1;
+      extraPrefix = "lib/";
+      sha256 = "sha256:01ln7hi6nvvkqkhn9hciqizizz5qspvqffgksvgmzn9x7kdd9pnh";
+    })
+  ];
 
-  preConfigure = "patchShebangs configure";
+  preConfigure = ''
+    cd src
+    patchShebangs configure
+    substituteInPlace Makefile.pre \
+      --replace '+camlp4' "${camlp4}/lib/ocaml/${ocaml.version}/site-lib/camlp4"
+  '';
 
   buildFlags = [ "opt" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31153,7 +31153,7 @@ with pkgs;
   mathlibtools = with python3Packages; toPythonApplication mathlibtools;
 
   leo2 = callPackage ../applications/science/logic/leo2
-    { ocaml = ocaml-ng.ocamlPackages_4_01_0.ocaml; };
+    { inherit (ocaml-ng.ocamlPackages_4_05) ocaml camlp4; };
 
   leo3-bin = callPackage ../applications/science/logic/leo3/binary.nix {};
 


### PR DESCRIPTION
Fix build with recent C++ compilers

Use a more recent OCaml (4.05)

###### Motivation for this change

Package has been broken for a while…

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
