### PR TITLE
ventoy-bin: 1.0.51 -> 1.0.56

### DIFF
--- a/pkgs/tools/cd-dvd/ventoy-bin/default.nix
+++ b/pkgs/tools/cd-dvd/ventoy-bin/default.nix
@@ -16,7 +16,7 @@ defaultGuiType = if withGtk3 then "gtk3"
                  else "";
 in stdenv.mkDerivation rec {
   pname = "ventoy-bin";
-  version = "1.0.54";
+  version = "1.0.56";
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ]
     ++ lib.optional withQt5 qt5.wrapQtAppsHook;
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz";
-    sha256 = "8304e7833b53e94c3989c57fcf4de16feab3e92cf6947485c92ab5e5aad5aaba";
+    sha256 = "da53d51e653092a170c11dd560e0ad6fb27c497dd77ad0ba483c32935c069dea";
   };
   patches = [
     (fetchpatch {

--- a/pkgs/tools/cd-dvd/ventoy-bin/default.nix
+++ b/pkgs/tools/cd-dvd/ventoy-bin/default.nix
@@ -22,10 +22,10 @@ in stdenv.mkDerivation rec {
   version = "1.0.54";
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ]
-  ++ optional withQt5 qt5.wrapQtAppsHook;
+    ++ optional withQt5 qt5.wrapQtAppsHook;
   buildInputs = [ hexdump exfat dosfstools e2fsprogs xz util-linux bash parted ]
-  ++ optional withGtk3 gtk3
-  ++ optionals withQt5 [ qt5.qtbase ];
+    ++ optional withGtk3 gtk3
+    ++ optional withQt5 qt5.qtbase;
 
   src = fetchurl {
     url = "https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz";

--- a/pkgs/tools/cd-dvd/ventoy-bin/default.nix
+++ b/pkgs/tools/cd-dvd/ventoy-bin/default.nix
@@ -5,8 +5,6 @@
 , withQt5 ? false, qt5
 }:
 
-assert withGtk3 -> gtk3 != null;
-assert withQt5 -> qt5 != null;
 
 with lib;
 

--- a/pkgs/tools/cd-dvd/ventoy-bin/default.nix
+++ b/pkgs/tools/cd-dvd/ventoy-bin/default.nix
@@ -5,9 +5,6 @@
 , withQt5 ? false, qt5
 }:
 
-
-with lib;
-
 let arch = {
   x86_64-linux = "x86_64";
   i686-linux = "i386";
@@ -22,10 +19,10 @@ in stdenv.mkDerivation rec {
   version = "1.0.54";
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ]
-    ++ optional withQt5 qt5.wrapQtAppsHook;
+    ++ lib.optional withQt5 qt5.wrapQtAppsHook;
   buildInputs = [ hexdump exfat dosfstools e2fsprogs xz util-linux bash parted ]
-    ++ optional withGtk3 gtk3
-    ++ optional withQt5 qt5.qtbase;
+    ++ lib.optional withGtk3 gtk3
+    ++ lib.optional withQt5 qt5.qtbase;
 
   src = fetchurl {
     url = "https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz";
@@ -84,18 +81,18 @@ in stdenv.mkDerivation rec {
                     --prefix PATH : "${lib.makeBinPath buildInputs}" \
                     --run "cd '$VENTOY_PATH' || exit 1"
     done
-  '' + optionalString (withGtk3 || withQt5) ''
+  '' + lib.optionalString (withGtk3 || withQt5) ''
     echo "${defaultGuiType}" > "$VENTOY_PATH/ventoy_gui_type"
     makeWrapper "$VENTOY_PATH/VentoyGUI.$ARCH" "$out/bin/ventoy-gui" \
                 --prefix PATH : "${lib.makeBinPath buildInputs}" \
                 --run "cd '$VENTOY_PATH' || exit 1"
-  '' + optionalString (!withGtk3) ''
+  '' + lib.optionalString (!withGtk3) ''
     rm "$out"/share/ventoy/tool/"$ARCH"/Ventoy2Disk.gtk3
-  '' + optionalString (!withQt5) ''
+  '' + lib.optionalString (!withQt5) ''
     rm "$out"/share/ventoy/tool/"$ARCH"/Ventoy2Disk.qt5
   '';
 
-  meta = {
+  meta = with lib; {
     description = "An open source tool to create bootable USB drive for ISO/WIM/IMG/VHD(x)/EFI files";
     longDescription = ''
       An open source tool to create bootable USB drive for


### PR DESCRIPTION
Version bump

Closes #138094
Closes #141548

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

