### PR TITLE
sscep: init at 0.10.0

### DIFF
--- a/pkgs/tools/security/sscep/default.nix
+++ b/pkgs/tools/security/sscep/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, libtool
+, pkg-config
+, m4
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sscep";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "certnanny";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0q25z4s5sq97yrpv54wsrxr3vz9cd31ci04ffj6znb42scw50p62";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    pkg-config
+    m4
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  preConfigure = "./bootstrap.sh";
+
+  meta = with lib; {
+    description = "Command line client for the SCEP protocol";
+    homepage = "https://github.com/certnanny/sscep";
+    license = [ licenses.bsd3 licenses.openssl licenses.vsl10 ];
+    maintainers = [ maintainers.sgo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3434,6 +3434,8 @@ with pkgs;
 
   spacevim = callPackage ../applications/editors/spacevim { };
 
+  sscep = callPackage ../tools/security/sscep { };
+
   ssmsh = callPackage ../tools/admin/ssmsh { };
 
   stagit = callPackage ../development/tools/stagit { };


### PR DESCRIPTION
###### Motivation for this change

Adds the `sscep` cli tool for the SCEP protocol

https://github.com/certnanny/sscep
https://repology.org/project/sscep/versions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
