### PR TITLE
nixos/xmrig: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -351,6 +351,14 @@
           <link linkend="opt-services.multipath.enable">services.multipath</link>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/xmrig/xmrig">xmrig</link>,
+          a high performance, open source, cross platform RandomX,
+          KawPow, CryptoNight and AstroBWT unified CPU/GPU miner and
+          RandomX benchmark.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-21.11-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -107,6 +107,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [multipath](https://github.com/opensvc/multipath-tools), the device mapper multipath (DM-MP) daemon. Available as [services.multipath](#opt-services.multipath.enable).
 
+- [xmrig](https://github.com/xmrig/xmrig), a high performance, open source, cross platform RandomX, KawPow, CryptoNight and AstroBWT unified CPU/GPU miner and RandomX benchmark.
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 - The `services.wakeonlan` option was removed, and replaced with `networking.interfaces.<name>.wakeOnLan`.

--- a/nixos/modules/services/misc/xmrig.nix
+++ b/nixos/modules/services/misc/xmrig.nix
@@ -1,0 +1,68 @@
+{ config, pkgs, lib, ... }:
+
+
+let
+  cfg = config.services.xmrig;
+
+  json = pkgs.formats.json { };
+
+  configJSON = builtins.toJSON cfg.config;
+  configFile = builtins.toFile "config.json" configJSON;
+in
+
+with lib;
+
+{
+  options = {
+    services.xmrig = {
+      enable = mkEnableOption "XMRig Mining Software";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.xmrig;
+        example = literalExpression "pkgs.xmrig-mo";
+        description = "XMRig package to use";
+      };
+
+      config = lib.mkOption {
+        default = {};
+        type = json.type;
+        example = literalExpression ''
+          {
+            "autosave": true,
+            "cpu": true,
+            "opencl": false,
+            "cuda": false,
+            "pools": [
+              {
+                "url": "pool.supportxmr.com:443",
+                "user": "your-wallet",
+                "keepalive": true,
+                "tls": true
+              }
+            ]
+          }
+        '';
+        description = "Configuration that would go into config.json file";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.xmrig = {
+      wantedBy = [ "multi-target.target" ];
+      after = [ "network.target" ];
+      description = "XMRig Mining Software Service";
+      serviceConfig = {
+        Type = "forking";
+        ExecStart = "${cfg.package}/bin/xmrig --config=${configFile}";
+      };
+    };
+  };
+
+  meta = with lib; {
+    description = "XMRig Mining Software Service";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ratsclub ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added a service to the xmrig miner.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
