### PR TITLE
ocamlPackages.ppxlib: 0.22.2 → 0.23.0

### DIFF
--- a/pkgs/development/ocaml-modules/bistro/default.nix
+++ b/pkgs/development/ocaml-modules/bistro/default.nix
@@ -28,9 +28,15 @@ buildDunePackage rec {
   })
   ];
 
+  # Fix build with ppxlib 0.23
+  postPatch = ''
+    substituteInPlace ppx/ppx_bistro.ml \
+      --replace 'Parser.parse_expression' 'Ocaml_common.Parser.parse_expression'
+  '';
+
   propagatedBuildInputs = [ base64 bos core lwt_react ocamlgraph rresult tyxml ];
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.12";
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -41,7 +41,7 @@ with self;
     version = "0.14.1";
     hash = "1cdkv34m6czhacivpbb2sasj83fgcid6gnqk30ig9i84z8nh2gw2";
     meta.description = "Accessors for Core types, for use with the Accessor library";
-    meta.broken = lib.versionAtLeast ocaml.version "4.12";
+    meta.broken = true; # Not compatible with ppxlib ≥ 0.23
     propagatedBuildInputs = [ accessor_base core_kernel ];
   };
 
@@ -375,9 +375,9 @@ with self;
 
   ppx_accessor = janePackage {
     pname = "ppx_accessor";
-    version = "0.14.2";
+    version = "0.14.3";
     minimumOCamlVersion = "4.09";
-    hash = "01nifsh7gap28cpvff6i569lqr1gmyhrklkisgri538cp4pf1wq1";
+    hash = "sha256:1c8blzh2f34vbm1z3mnvh670c6vda70chw805n2hmkd9j46l0cll";
     meta.description = "[@@deriving] plugin to generate accessors for use with the Accessor libraries";
     propagatedBuildInputs = [ accessor ];
   };
@@ -633,9 +633,9 @@ with self;
 
   ppx_variants_conv = janePackage {
     pname = "ppx_variants_conv";
-    version = "0.14.1";
+    version = "0.14.2";
     minimumOCamlVersion = "4.04.2";
-    hash = "0q6a43zrwqzdz7aja0k44a2llyjjj5xzi2kigwhsnww3g0r5ig84";
+    hash = "1p11fiz4m160hs0xzg4g9rxchp053sz3s3d1lyciqixad1xi47a4";
     meta.description = "Generation of accessor and iteration functions for ocaml variant types";
     propagatedBuildInputs = [ variantslib ppxlib ];
   };

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -2,7 +2,7 @@
 , version ?
   if lib.versionAtLeast ocaml.version "4.07"
   then if lib.versionAtLeast ocaml.version "4.08"
-  then "0.22.2" else "0.15.0" else "0.13.0"
+  then "0.23.0" else "0.15.0" else "0.13.0"
 , ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
 , stdlib-shims, ocaml-migrate-parsetree-2
 }:
@@ -36,6 +36,10 @@ let param = {
   };
   "0.22.2" = {
     sha256 = "0fysjqcpv281n52wl3h0dy2lzf9d61wdzk90ldv3p63a4i3mr1j2";
+    min_version = "4.07";
+  };
+  "0.23.0" = {
+    sha256 = "0jg5v4pssbl66hn5davpin1i57a0r3r54l96vpz5y99xk5w70xi1";
     min_version = "4.07";
   };
 }."${version}"; in


### PR DESCRIPTION
ocamlPackages.ppx_variants_conv: 0.14.1 → 0.14.2

ocamlPackages.ppx_accessor: mark as broken

###### Motivation for this change

Support for OCaml 4.13.

I believe that the breakage of `ppx_accessor` is not a big issue: only `accessor_base`, `accessor_core`, and `accessor_async` depend on that package in `nixpkgs`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
