### PR TITLE
proxysql: init at 2.3.2

### DIFF
--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -1,0 +1,151 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, autoconf
+, automake
+, bison
+, cmake
+, libtool
+, civetweb
+, coreutils
+, curl
+, flex
+, gnutls
+, jemalloc
+, libconfig
+, libdaemon
+, libev
+, libgcrypt
+, libinjection
+, libmicrohttpd_0_9_70
+, lz4
+, nlohmann_json
+, openssl
+, pcre
+, perl
+, prometheus-cpp
+, python
+, re2
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "proxysql";
+  version = "2.3.2";
+
+  src = fetchFromGitHub {
+    owner = "sysown";
+    repo = pname;
+    rev = version;
+    sha256 = "13l4bf7zhfjy701qx9hfr40vlsm4d0pbfmwr5d6lf514xznvsnzl";
+  };
+
+  patches = [
+    ./makefiles.patch
+    ./dont-phone-home.patch
+    (fetchpatch {
+      url = "https://github.com/sysown/proxysql/pull/3402.patch";
+      sha256 = "079jjhvx32qxjczmsplkhzjn9gl7c2a3famssczmjv2ffs65vibi";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    cmake
+    libtool
+    perl
+    python
+  ];
+
+  buildInputs = [
+    bison
+    curl
+    flex
+    gnutls
+    libgcrypt
+    openssl
+    zlib
+  ];
+
+  GIT_VERSION = version;
+
+  dontConfigure = true;
+
+  # replace and fix some vendored dependencies
+  preBuild = /* sh */ ''
+    pushd deps
+
+    function replace_dep() {
+      local folder="$1"
+      local src="$2"
+      local symlink="$3"
+      local name="$4"
+
+      pushd "$folder"
+
+      rm -rf "$symlink"
+      if [ -d "$src" ]; then
+        cp -R "$src"/. "$symlink"
+        chmod -R u+w "$symlink"
+      else
+        tar xf "$src"
+        ln -s "$name" "$symlink"
+      fi
+
+      popd
+    }
+
+    ${lib.concatMapStringsSep "\n"
+      (x: ''replace_dep "${x.f}" "${x.p.src}" "${x.p.pname or (builtins.parseDrvName x.p.name).name}" "${x.p.name}"'') [
+        { f = "curl"; p = curl; }
+        { f = "jemalloc"; p = jemalloc; }
+        { f = "libconfig"; p = libconfig; }
+        { f = "libdaemon"; p = libdaemon; }
+        { f = "libev"; p = libev; }
+        { f = "libinjection"; p = libinjection; }
+        { f = "libmicrohttpd"; p = libmicrohttpd_0_9_70; }
+        { f = "libssl"; p = openssl; }
+        { f = "lz4"; p = lz4; }
+        { f = "pcre"; p = pcre; }
+        { f = "prometheus-cpp"; p = prometheus-cpp; }
+        { f = "re2"; p = re2; }
+    ]}
+
+    pushd libhttpserver
+    tar xf libhttpserver-0.18.1.tar.gz
+    sed -i s_/bin/pwd_${coreutils}/bin/pwd_g libhttpserver/configure.ac
+    popd
+
+    pushd json
+    rm json.hpp
+    ln -s ${nlohmann_json.src}/single_include/nlohmann/json.hpp .
+    popd
+
+    pushd prometheus-cpp/prometheus-cpp/3rdparty
+    replace_dep . "${civetweb.src}" civetweb
+    popd
+
+    sed -i s_/usr/bin/env_${coreutils}/bin/env_g libssl/openssl/config
+
+    popd
+    patchShebangs .
+  '';
+
+  preInstall = ''
+    mkdir -p $out/{etc,bin,lib/systemd/system}
+  '';
+
+  postInstall = ''
+    sed -i s_/usr/bin/proxysql_$out/bin/proxysql_ $out/lib/systemd/system/*.service
+  '';
+
+  meta = with lib; {
+    homepage = "https://proxysql.com/";
+    broken = stdenv.isDarwin;
+    description = "High-performance MySQL proxy";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ ajs124 ];
+  };
+}

--- a/pkgs/servers/sql/proxysql/dont-phone-home.patch
+++ b/pkgs/servers/sql/proxysql/dont-phone-home.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main.cpp b/src/main.cpp
+index 39dfaa24..634b004b 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -237,6 +237,7 @@ static char * main_check_latest_version() {
+ 
+ 
+ void * main_check_latest_version_thread(void *arg) {
++	return NULL;
+ 	char * latest_version = main_check_latest_version();
+ 	if (latest_version) {
+ 		if (

--- a/pkgs/servers/sql/proxysql/makefiles.patch
+++ b/pkgs/servers/sql/proxysql/makefiles.patch
@@ -1,0 +1,172 @@
+--- a/Makefile
++++ b/Makefile
+@@ -46,11 +46,7 @@ endif
+ 
+ export MAKEOPT=-j ${NPROCS}
+ 
+-ifeq ($(wildcard /usr/lib/systemd/system), /usr/lib/systemd/system)
+-	SYSTEMD=1
+-else
+-	SYSTEMD=0
+-endif
++SYSTEMD=1
+ USERCHECK := $(shell getent passwd proxysql)
+ GROUPCHECK := $(shell getent group proxysql)
+ 
+@@ -523,16 +519,10 @@ cleanbuild:
+ 
+ .PHONY: install
+ install: src/proxysql
+-	install -m 0755 src/proxysql /usr/bin
+-	install -m 0600 etc/proxysql.cnf /etc
+-	if [ ! -d /var/lib/proxysql ]; then mkdir /var/lib/proxysql ; fi
+-ifeq ($(findstring proxysql,$(USERCHECK)),)
+-	@echo "Creating proxysql user and group"
+-	useradd -r -U -s /bin/false proxysql
+-endif
++	install -m 0755 src/proxysql $(out)/bin
++	install -m 0600 etc/proxysql.cnf $(out)/etc
+ ifeq ($(SYSTEMD), 1)
+-	install -m 0644 systemd/system/proxysql.service /usr/lib/systemd/system/
+-	systemctl enable proxysql.service
++	install -m 0644 systemd/system/proxysql.service $(out)/lib/systemd/system/
+ else
+ 	install -m 0755 etc/init.d/proxysql /etc/init.d
+ ifeq ($(DISTRO),"CentOS Linux")
+--- a/deps/Makefile
++++ b/deps/Makefile
+@@ -40,22 +40,10 @@ endif
+ 
+ 
+ libinjection/libinjection/src/libinjection.a:
+-	cd libinjection && rm -rf libinjection-3.10.0 || true
+-	cd libinjection && tar -zxf libinjection-3.10.0.tar.gz
+-	sed -i -e 's/python/python2/' libinjection/libinjection-3.10.0/src/make_parens.py
+-	sed -i -e 's/python/python2/' libinjection/libinjection-3.10.0/src/sqlparse_map.py
+-	sed -i -e 's/python/python2/' libinjection/libinjection-3.10.0/src/sqlparse2c.py
+ 	cd libinjection/libinjection && CC=${CC} CXX=${CXX} ${MAKE}
+ libinjection: libinjection/libinjection/src/libinjection.a
+ 
+ libssl/openssl/libssl.a:
+-#	cd libssl && rm -rf openssl-1.1.0h || true
+-#	cd libssl && tar -zxf openssl-1.1.0h.tar.gz
+-	cd libssl && rm -rf openssl-1.1.1d || true
+-	cd libssl && rm -rf openssl-1.1.0h || true
+-	cd libssl && rm -rf openssl-1.1.1g || true
+-	cd libssl && rm -rf openssl-1.1.1j || true
+-	cd libssl && tar -zxf openssl-1.1.1j.tar.gz
+ 	cd libssl/openssl  && ./config no-ssl3
+ 	cd libssl/openssl && CC=${CC} CXX=${CXX} ${MAKE}
+ 	cd libssl/openssl && ln -s . lib # curl wants this path
+@@ -70,9 +58,6 @@ ifeq ($(MIN_VERSION),$(lastword $(sort $(GCC_VERSION) $(MIN_VERSION))))
+ endif
+ 
+ libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
+-	cd libhttpserver && rm -rf libhttpserver-master_20191121 || true
+-	cd libhttpserver && rm -rf libhttpserver-0.18.1 || true
+-	cd libhttpserver && tar -zxf libhttpserver-0.18.1.tar.gz
+ ifeq ($(REQUIRE_PATCH), true)
+ 	cd libhttpserver/libhttpserver && patch src/httpserver/basic_auth_fail_response.hpp < ../basic_auth_fail_response.hpp.patch
+ 	cd libhttpserver/libhttpserver && patch src/httpserver/create_webserver.hpp < ../create_webserver.hpp.patch
+@@ -94,34 +79,15 @@ endif
+ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
+ 
+ libev/libev/.libs/libev.a:
+-	cd libev && rm -rf libev-4.24 || true
+-	cd libev && tar -zxf libev-4.24.tar.gz
+ 	cd libev/libev  && ./configure
+ 	cd libev/libev && CC=${CC} CXX=${CXX} ${MAKE}
+ ev: libev/libev/.libs/libev.a
+ 
+ curl/curl/lib/.libs/libcurl.a: libssl/openssl/libssl.a
+-	cd curl && rm -rf curl-7.57.0 || true
+-	cd curl && rm -rf curl-7.77.0 || true
+-	cd curl && tar -zxf curl-7.77.0.tar.gz
+-	#cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --with-ssl=$(shell pwd)/../../libssl/openssl/ && CC=${CC} CXX=${CXX} ${MAKE}
+ 	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --without-librtmp --without-libpsl --with-ssl=$(shell pwd)/libssl/openssl/ --enable-shared=no && CC=${CC} CXX=${CXX} ${MAKE}
+ curl: curl/curl/lib/.libs/libcurl.a
+ 
+ libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:
+-	cd libmicrohttpd && rm -rf libmicrohttpd-0.9.55 || true
+-	cd libmicrohttpd && rm -rf libmicrohttpd-0.9.68 || true
+-	cd libmicrohttpd && rm -f libmicrohttpd || true
+-ifeq ($(CENTOSVER),6)
+-	cd libmicrohttpd && ln -s libmicrohttpd-0.9.55 libmicrohttpd
+-	cd libmicrohttpd && tar -zxf libmicrohttpd-0.9.55.tar.gz
+-else
+-	cd libmicrohttpd && ln -s libmicrohttpd-0.9.68 libmicrohttpd
+-	cd libmicrohttpd && tar -zxf libmicrohttpd-0.9.68.tar.gz
+-endif
+-ifeq ($(OS),Darwin)
+-	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/mhd_sockets.c < ../mhd_sockets.c-issue-5977.patch
+-endif
+ 	cd libmicrohttpd/libmicrohttpd && ./configure --enable-https && CC=${CC} CXX=${CXX} ${MAKE}
+ microhttpd: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
+ 
+@@ -132,8 +98,6 @@ cityhash/cityhash/src/.libs/libcityhash.a:
+ cityhash: cityhash/cityhash/src/.libs/libcityhash.a
+ 
+ lz4/lz4/liblz4.a:
+-	cd lz4 && rm -rf lz4-1.7.5 || true
+-	cd lz4 && tar -zxf lz4-1.7.5.tar.gz
+ 	cd lz4/lz4 && CC=${CC} CXX=${CXX} ${MAKE}
+ lz4: lz4/lz4/liblz4.a
+ 
+@@ -148,16 +112,12 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib.a
+ 
+ 
+ libdaemon/libdaemon/libdaemon/.libs/libdaemon.a: 
+-	cd libdaemon && rm -rf libdaemon-0.14
+-	cd libdaemon && tar -zxf libdaemon-0.14.tar.gz
+ 	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && ./configure --disable-examples
+ 	cd libdaemon/libdaemon && CC=${CC} CXX=${CXX} ${MAKE}
+ 
+ libdaemon: libdaemon/libdaemon/libdaemon/.libs/libdaemon.a
+ 
+ jemalloc/jemalloc/lib/libjemalloc.a:
+-	cd jemalloc && rm -rf jemalloc-5.2.0
+-	cd jemalloc && tar -jxf jemalloc-5.2.0.tar.bz2
+ 	cd jemalloc/jemalloc && patch src/jemalloc.c < ../issue823.520.patch
+ 	cd jemalloc/jemalloc && patch src/jemalloc.c < ../issue2358.patch
+ 	cd jemalloc/jemalloc && ./configure ${MYJEOPT}
+@@ -210,17 +170,12 @@ sqlite3/sqlite3/sqlite3.o:
+ sqlite3: sqlite3/sqlite3/sqlite3.o
+ 
+ libconfig/libconfig/lib/.libs/libconfig++.a:
+-	cd libconfig && rm -rf libconfig-1.7.2
+-	cd libconfig && tar -zxf libconfig-1.7.2.tar.gz
+ 	cd libconfig/libconfig && ./configure --disable-examples
+ 	cd libconfig/libconfig && CC=${CC} CXX=${CXX} ${MAKE}
+ 
+ libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
+ 
+ prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
+-	cd prometheus-cpp && rm -rf prometheus-cpp-0.9.0
+-	cd prometheus-cpp && tar -zxf v0.9.0.tar.gz
+-	cd prometheus-cpp && tar --strip-components=1 -zxf civetweb-v1.11.tar.gz -C prometheus-cpp/3rdparty/civetweb
+ 	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../serial_exposer.patch
+ 	cd prometheus-cpp/prometheus-cpp && patch -p0 < ../registry_counters_reset.patch
+ 	cd prometheus-cpp/prometheus-cpp && cmake . -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTING=OFF -DENABLE_PUSH=OFF
+@@ -229,12 +184,6 @@ prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
+ prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
+ 
+ re2/re2/obj/libre2.a:
+-	cd re2 && rm -rf re2-2018-07-01 || true
+-	cd re2 && rm -rf re2-2020-07-06 || true
+-#	cd re2 && tar -zxf re2-20140304.tgz
+-	cd re2 && tar -zxf re2.tar.gz
+-#	cd re2/re2 && sed -i -e 's/-O3 -g /-O3 -fPIC /' Makefile
+-#	cd re2 && patch re2/util/mutex.h < mutex.h.patch
+ 	cd re2/re2 && sed -i -e 's/-O3 /-O3 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
+ 	cd re2/re2 && sed -i -e 's/RE2_CXXFLAGS?=-std=c++11 /RE2_CXXFLAGS?=-std=c++11 -fPIC /' Makefile
+ 	cd re2/re2 && CC=${CC} CXX=${CXX} ${MAKE}
+@@ -242,9 +191,6 @@ re2/re2/obj/libre2.a:
+ re2: re2/re2/obj/libre2.a
+ 
+ pcre/pcre/.libs/libpcre.a:
+-	cd pcre && rm -rf pcre-8.39
+-	cd pcre && rm -rf pcre-8.44
+-	cd pcre && tar -zxf pcre-8.44.tar.gz
+ 	cd pcre/pcre && ./configure
+ 	cd pcre/pcre && CC=${CC} CXX=${CXX} ${MAKE}
+ pcre: pcre/pcre/.libs/libpcre.a

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8544,6 +8544,8 @@ with pkgs;
 
   proxify = callPackage ../tools/networking/proxify { };
 
+  proxysql = callPackage ../servers/sql/proxysql { };
+
   proxytunnel = callPackage ../tools/misc/proxytunnel {
     openssl = openssl_1_0_2;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
