### PR TITLE
update script fix #3 for fluxcd, k3s, linode-cli, linkerd

### DIFF
--- a/pkgs/applications/networking/cluster/fluxcd/update.sh
+++ b/pkgs/applications/networking/cluster/fluxcd/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl gnugrep gnused jq
 
-set -eu -o pipefail
+set -x -eu -o pipefail
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
@@ -14,7 +14,7 @@ SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/archi
 SPEC_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/fluxcd/flux2/releases/download/${TAG}/manifests.tar.gz)
 
 setKV () {
-    sed -i "s|$1 = \".*\"|$1 = \"$2\"|" ./default.nix
+    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./default.nix
 }
 
 setKV version ${VERSION}
@@ -24,8 +24,15 @@ setKV vendorSha256 ""
 
 cd ../../../../../
 set +e
-VENDOR_SHA256=$(nix-build --no-out-link -A fluxcd 2>&1 | grep "got:" | cut -d':' -f2 | sed 's/ //g')
+VENDOR_SHA256=$(nix-build --no-out-link -A fluxcd 2>&1 | grep "got:" | cut -d':' -f2 | sed 's| ||g')
 set -e
 
 cd - > /dev/null
-setKV vendorSha256 ${VENDOR_SHA256}
+
+if [ -n "${VENDOR_SHA256:-}" ]; then
+    setKV vendorSha256 ${VENDOR_SHA256}
+else
+    echo "Update failed. VENDOR_SHA256 is empty."
+    exit 1
+fi
+

--- a/pkgs/applications/networking/cluster/k3s/update.sh
+++ b/pkgs/applications/networking/cluster/k3s/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl gnugrep gnused jq
 
-set -eu -o pipefail
+set -x -eu -o pipefail
 
 WORKDIR=$(mktemp -d)
 trap "rm -rf ${WORKDIR}" EXIT
@@ -45,7 +45,7 @@ CNIPLUGINS_SHA256=$(nix-prefetch-url --quiet --unpack \
     "https://github.com/rancher/plugins/archive/refs/tags/v${CNIPLUGINS_VERSION}.tar.gz")
 
 setKV () {
-    sed -i "s|$1 = \".*\"|$1 = \"$2\"|" ./default.nix
+    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./default.nix
 }
 
 setKV k3sVersion ${K3S_VERSION}

--- a/pkgs/applications/networking/cluster/linkerd/update-edge.sh
+++ b/pkgs/applications/networking/cluster/linkerd/update-edge.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl gnugrep gnused jq
 
-set -eu -o pipefail
+set -x -eu -o pipefail
 
 cd $(dirname "$0")
 
@@ -14,7 +14,7 @@ VERSION=$(echo ${TAG} | sed 's/^edge-//')
 SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/linkerd/linkerd2/archive/refs/tags/${TAG}.tar.gz)
 
 setKV () {
-    sed -i "s|$1 = \".*\"|$1 = \"$2\"|" ./edge.nix
+    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./edge.nix
 }
 
 setKV version ${VERSION}
@@ -25,9 +25,9 @@ cd ../../../../../
 set +e
 VENDOR_SHA256=$(nix-build --no-out-link -A linkerd_edge 2>&1 | grep "got:" | cut -d':' -f2 | sed 's| ||g')
 set -e
+cd - > /dev/null
 
 if [ -n "${VENDOR_SHA256:-}" ]; then
-    cd - > /dev/null
     setKV vendorSha256 ${VENDOR_SHA256}
 else
     echo "Update failed. VENDOR_SHA256 is empty."

--- a/pkgs/applications/networking/cluster/linkerd/update-stable.sh
+++ b/pkgs/applications/networking/cluster/linkerd/update-stable.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl gnugrep gnused jq
 
-set -eu -o pipefail
+set -x -eu -o pipefail
 
 cd $(dirname "$0")
 
@@ -14,7 +14,7 @@ VERSION=$(echo ${TAG} | sed 's/^stable-//')
 SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/linkerd/linkerd2/archive/refs/tags/${TAG}.tar.gz)
 
 setKV () {
-    sed -i "s|$1 = \".*\"|$1 = \"$2\"|" ./default.nix
+  sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./default.nix
 }
 
 setKV version ${VERSION}
@@ -25,11 +25,11 @@ cd ../../../../../
 set +e
 VENDOR_SHA256=$(nix-build --no-out-link -A linkerd 2>&1 | grep "got:" | cut -d':' -f2 | sed 's| ||g')
 set -e
+cd - > /dev/null
 
 if [ -n "${VENDOR_SHA256:-}" ]; then
-    cd - > /dev/null
-    setKV vendorSha256 ${VENDOR_SHA256}
+  setKV vendorSha256 ${VENDOR_SHA256}
 else
-    echo "Update failed. VENDOR_SHA256 is empty."
-    exit 1
+  echo "Update failed. VENDOR_SHA256 is empty."
+  exit 1
 fi

--- a/pkgs/tools/virtualization/linode-cli/update.sh
+++ b/pkgs/tools/virtualization/linode-cli/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl gnugrep gnused jq yq-go
 
-set -eu -o pipefail
+set -x -eu -o pipefail
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
@@ -21,7 +21,7 @@ VERSION=$(curl -s ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
 SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/linode/linode-cli/archive/refs/tags/${VERSION}.tar.gz)
 
 setKV () {
-    sed -i "s|$1 = \".*\"|$1 = \"$2\"|" ./default.nix
+    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./default.nix
 }
 
 setKV specVersion ${SPEC_VERSION}


### PR DESCRIPTION
All update scripts I have added so far are flawed. I don't have the means of testing it locally. I have to have the PR merged to gather feedback, which is quite unfortunate. I am always expecting this time it will work. But I can't guarantee. Any suggestion is appreciated. I did try things locally. But it doesn't error.

Logs at:
https://r.ryantm.com/log/updatescript/fluxcd/
https://r.ryantm.com/log/updatescript/linode-cli/
https://r.ryantm.com/log/updatescript/k3s/
https://r.ryantm.com/log/updatescript/linkerd/