### PR TITLE
gmid: init at 1.7.5

### DIFF
--- a/pkgs/servers/gemini/gmid/default.nix
+++ b/pkgs/servers/gemini/gmid/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, bison, libressl, libevent }:
+
+stdenv.mkDerivation rec {
+  pname = "gmid";
+  version = "1.7.5";
+
+  src = fetchFromGitHub {
+    owner = "omar-polo";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-BBd0AL5jRRslxzDnxcTZRR+8J5D23NAQ7mp9K+leXAQ=";
+  };
+
+  nativeBuildInputs = [ bison ];
+
+  buildInputs = [ libressl libevent ];
+
+  configurePhase = ''
+    runHook preConfigure
+    ./configure PREFIX=$out
+    runHook postConfigure
+  '';
+
+  meta = with lib; {
+    description = "Simple and secure Gemini server";
+    homepage = "https://gmid.omarpolo.com/";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1701,6 +1701,8 @@ with pkgs;
 
   glasgow = with python3Packages; toPythonApplication glasgow;
 
+  gmid = callPackage ../servers/gemini/gmid { };
+
   gmni = callPackage ../applications/networking/browsers/gmni { };
 
   gmnisrv = callPackage ../servers/gemini/gmnisrv { };


### PR DESCRIPTION
###### Motivation for this change
[**gmid**](https://github.com/omar-polo/gmid) is a fast Gemini server written with security in mind.
[![Packaging status](https://repology.org/badge/tiny-repos/gmid.svg)](https://repology.org/project/gmid/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
