### PR TITLE
vscode-extensions.hashicorp.terraform: 2.15.0 -> 2.16.0

### DIFF
--- a/pkgs/misc/vscode-extensions/terraform/default.nix
+++ b/pkgs/misc/vscode-extensions/terraform/default.nix
@@ -3,8 +3,8 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "terraform";
     publisher = "hashicorp";
-    version = "2.15.0";
-    sha256 = "0bqf9ry0idqw61714dc6y1rh5js35mi14q19yqhiwayyfakwraq9";
+    version = "2.16.0";
+    sha256 = "0ya0xmmn4rmbvh8mxz466msbb3y2xqi4bg9dgymy2wq8cwzbn81b";
   };
 
   patches = [ ./fix-terraform-ls.patch ];

--- a/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
+++ b/pkgs/misc/vscode-extensions/terraform/fix-terraform-ls.patch
@@ -1,5 +1,5 @@
 diff --git a/out/serverPath.js b/out/serverPath.js
-index ffb1b80..990ca2b 100644
+index d25f5d4..289f0dd 100644
 --- a/out/serverPath.js
 +++ b/out/serverPath.js
 @@ -8,7 +8,13 @@ exports.CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
@@ -16,4 +16,4 @@ index ffb1b80..990ca2b 100644
 +        }
      }
      installPath() {
-         return this.context.asAbsolutePath(INSTALL_FOLDER_NAME);
+         return path.join(this.context.globalStorageUri.fsPath, INSTALL_FOLDER_NAME);


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
