### PR TITLE
nomad_1_0: 1.0.11 -> 1.0.12, nomad_1_1: 1.1.5 -> 1.1.6

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/1.0.nix
+++ b/pkgs/applications/networking/cluster/nomad/1.0.nix
@@ -6,6 +6,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage nvidia_x11 nvidiaGpuSupport;
-  version = "1.0.11";
-  sha256 = "15h7w020p576zl91s5mr4npcmngrqqfj9xzlx6bk9i1cp6h4w0jy";
+  version = "1.0.12";
+  sha256 = "04fqliz7y4zzs4xraid54mqxwgrzh138nmfcs876vp534slvikpi";
 }

--- a/pkgs/applications/networking/cluster/nomad/1.1.nix
+++ b/pkgs/applications/networking/cluster/nomad/1.1.nix
@@ -6,7 +6,7 @@
 
 callPackage ./genericModule.nix {
   inherit buildGoModule nvidia_x11 nvidiaGpuSupport;
-  version = "1.1.5";
-  sha256 = "03gxh12bd5mj1l4q3xilil806dsqaqmz93ff7ysf441frgkx3iy3";
+  version = "1.1.6";
+  sha256 = "1q6fqay1s9qwimjwlldc8hr6009cgx3ghz142mdx36jjv9isj9ln";
   vendorSha256 = "0rfd22rf76mwj489zhswah4g3dhhz6davm336xgm9dbnyaz9d8r0";
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
