### PR TITLE
[Backport release-21.05] psi-plus: update to 1.5.1556-2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -40,15 +40,43 @@ assert builtins.elem (lib.toLower chatType) [
 
 assert enablePsiMedia -> enablePlugins;
 
-mkDerivation rec {
+mkDerivation {
   pname = "psi-plus";
-  version = "1.5.1520";
+
+  # Version mask is “X.X.XXXX-R” where “X.X.XXXX” is a mandatory version of Psi
+  # and “-R” ending is optional revision number.
+  #
+  # The “psi-plus-snapshots” generally provides snapshots of these separate
+  # repositories glued together (there are also dependencies/libraries):
+  #
+  # 1. Psi
+  # 2. Plugins pack for Psi
+  # 3. “psimedia” plugin
+  # 4. Resources for Psi (icons, skins, sounds)
+  #
+  # “X.X.XXXX” is literally a version of Psi.
+  # So often when for instance plugins are updated separately a new snapshot is
+  # created. And that snapshot would also be linked to “X.X.XXXX” version.
+  # So many commits may have the same associated version of the snapshot.
+  # But mind that only one Git tag is created for “X.X.XXXX” version.
+  #
+  # It’s not yet defined in the Psi+ project what value to use as a version for
+  # any further releases that don’t change Psi version.
+  #
+  # Let’s do what Debian does for instance (appends “-R” where “R” is a revision
+  # number).
+  # E.g. https://tracker.debian.org/news/1226321/psi-plus-14554-5-migrated-to-testing/
+  #
+  # This has been communicated with the Psi+ main devs in this XMPP MUC chat:
+  # psi-dev@conference.jabber.ru
+  #
+  version = "1.5.1556-2";
 
   src = fetchFromGitHub {
     owner = "psi-plus";
     repo = "psi-plus-snapshots";
-    rev = version;
-    sha256 = "0cj811qv0n8xck2qrnps2ybzrpvyjqz7nxkyccpaivq6zxj6mc12";
+    rev = "635879010b6697f7041a7bbea1853a1f4673c7f7";
+    sha256 = "18xvljcm0a9swkyz4diwxi4xaj0w27jnhfgpi8fv5fj11j0g1b3a";
   };
 
   cmakeFlags = [
@@ -96,8 +124,8 @@ mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://psi-plus.com";
-    description = "XMPP (Jabber) client";
-    maintainers = with maintainers; [ orivej misuzu ];
+    description = "XMPP (Jabber) client based on Qt5";
+    maintainers = with maintainers; [ orivej misuzu unclechu ];
     license = licenses.gpl2Only;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
(cherry picked from commit a0b8a902ff240c666f1fe103ba3e38cbce76872a)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport #141665 to release-21.05

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
