### PR TITLE
zephyr-sdk: init at 0.13.1

### DIFF
--- a/pkgs/development/embedded/zephyr-sdk/default.nix
+++ b/pkgs/development/embedded/zephyr-sdk/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, lib, fetchurl, python38, which, autoPatchelfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "zephyr-sdk";
+  version = "0.13.1";
+
+  nativeBuildInputs = [
+    python38
+    autoPatchelfHook # We can use normal autopatchelf since all the binaries in sysroots are static
+    which
+  ];
+
+  src =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      fetchurl
+        {
+          url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${version}/zephyr-sdk-${version}-linux-x86_64-setup.run";
+          sha256 = "14bbzq4as4kgk5s3z41pvdz6221agwkh76q21npzfvvkkz96lb38";
+        }
+    else if stdenv.hostPlatform.system == "aarch64-linux" then
+      fetchurl
+        {
+          url = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${version}/zephyr-sdk-${version}-linux-aarch64-setup.run";
+          sha256 = "1s0y5njccm3xsm3baah6mgglywxwg37zjrfcbr3zzycsxhn901qc";
+        }
+    else
+      throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  dontUnpack = true;
+
+  installPhase = ''
+    # Extract outer self-extracting archive
+    cp $src $TEMP/installer.run
+    chmod +x $TEMP/installer.run
+    $TEMP/installer.run --noexec --target $TEMP/outer
+
+    # Run the setup tool
+    cd $TEMP/outer
+    bash ./setup.sh -d $out -y -norc -nocmake
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.zephyrproject.org/";
+    description = "Collection of compilers and tools for the Zephyr RTOS";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ artemist ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12940,6 +12940,8 @@ with pkgs;
 
   z88dk = callPackage ../development/compilers/z88dk { };
 
+  zephyr-sdk = callPackage ../development/embedded/zephyr-sdk { };
+
   zulip = callPackage ../applications/networking/instant-messengers/zulip {
     # Bubblewrap breaks zulip, see https://github.com/NixOS/nixpkgs/pull/97264#issuecomment-704454645
     appimageTools = pkgs.appimageTools.override {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
West, the Zephyr build tool, is already packaged. However, you also need the SDKs in order to use it. You are supposed to download these binaries and install them but there are hundreds of non-patched dynamic ELFs. This installs the full SDK with support for a variety of architectures, which is the largest but the easiest

###### Things done
I created the new package, created a [shell](https://gist.github.com/artemist/445b000689f463fa427d9710af4d7528) then tested that Zephyr was able to build and and upload to 2 development boards using J-Link: an ARM Cortex-M baed STM32F4 Discovery and a RISC-V based Sparkfun RED-V Thing

I did not test execution of all binary files as there are hundreds. However, it appears to be functional


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
