### PR TITLE
powertop: fix musl build

### DIFF
--- a/pkgs/os-specific/linux/powertop/default.nix
+++ b/pkgs/os-specific/linux/powertop/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, gettext, libnl, ncurses, pciutils
+{ lib, stdenv, fetchFromGitHub, gettext, libnl, ncurses, pciutils
 , pkg-config, zlib, autoreconfHook }:
 
 stdenv.mkDerivation rec {
@@ -17,14 +17,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ gettext libnl ncurses pciutils zlib ];
 
-  patches = lib.optional stdenv.hostPlatform.isMusl (
-    fetchpatch {
-      name = "strerror_r.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/powertop/strerror_r.patch?id=3b9214d436f1611f297b01f72469d66bfe729d6e";
-      sha256 = "1kzddhcrb0n2iah4lhgxwwy4mkhq09ch25jjngyq6pdj6pmfkpfw";
-    }
-  );
-
   NIX_LDFLAGS = [ "-lpthread" ];
 
   postPatch = ''
@@ -36,7 +28,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Analyze power consumption on Intel-based laptops";
     homepage = "https://01.org/powertop";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ fpletz ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
* remove obsolete musl patch (merged in https://github.com/fenrus75/powertop/commit/c2a52f912de3e0d9a368b999a027ad9d36c1b67a)
* clarify license

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
