### PR TITLE
headphones: 0.5.19 -> 0.5.20

### DIFF
--- a/pkgs/servers/headphones/default.nix
+++ b/pkgs/servers/headphones/default.nix
@@ -2,13 +2,13 @@
 
 python2.pkgs.buildPythonApplication rec {
   pname = "headphones";
-  version = "0.5.19";
+  version = "0.5.20";
 
   src = fetchFromGitHub {
     owner = "rembo10";
     repo = "headphones";
     rev = "v${version}";
-    sha256 = "0z39gyan3ksdhnjxxs7byamrzmrk8cn15g300iqigzvgidff1lq0";
+    sha256 = "0m234fr1i8bb8mgmjsdpkbaa3l16y23ca6s7nyyl5ismmjxhi4mz";
   };
 
   dontBuild = true;
@@ -18,10 +18,12 @@ python2.pkgs.buildPythonApplication rec {
   buildInputs = [ python2 ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp -R {data,headphones,lib,Headphones.py} $out/
+    mkdir -p $out/bin $out/opt/headphones
+    cp -R {data,headphones,lib,Headphones.py} $out/opt/headphones
 
-    makeWrapper $out/Headphones.py $out/bin/headphones
+    echo v${version} > $out/opt/headphones/version.txt
+
+    makeWrapper $out/opt/headphones/Headphones.py $out/bin/headphones
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Update headphones version to the latest. 
Files will be kept in $out/opt/headphones instead of at the top-level
Echo the version into $out/opt/headphones/version.txt to appease the update checker :sweat_smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
