### PR TITLE
dcc: init at 2.3.168

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -304,6 +304,9 @@ let
           if [ -e renewed ]; then
             rm renewed
             ${data.postRun}
+            ${optionalString (data.reloadServices != [])
+                "systemctl --no-block try-reload-or-restart ${escapeShellArgs data.reloadServices}"
+            }
           fi
         '');
       };
@@ -462,6 +465,15 @@ let
         type = types.str;
         default = "acme";
         description = "Group running the ACME client.";
+      };
+
+      reloadServices = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          The list of systemd services to call <code>systemctl try-reload-or-restart</code>
+          on.
+        '';
       };
 
       postRun = mkOption {

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -313,6 +313,8 @@ in {
         ]);
         StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
         StateDirectoryMode = "600";
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
       };
     };
 

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -312,7 +312,7 @@ in {
           "-h" (lib.concatStringsSep " " cfg.urlList)
         ]);
         StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
-        StateDirectoryMode = "600";
+        StateDirectoryMode = "700";
         RuntimeDirectory = "openldap";
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -208,8 +208,7 @@ in {
         default = null;
         description = ''
           Use this config directory instead of generating one from the
-          <literal>settings</literal> option. Overrides all NixOS settings. If
-          you use this option,ensure `olcPidFile` is set to `/run/slapd/slapd.conf`.
+          <literal>settings</literal> option. Overrides all NixOS settings.
         '';
         example = "/var/db/slapd.d";
       };
@@ -259,7 +258,6 @@ in {
       attrs = {
         objectClass = "olcGlobal";
         cn = "config";
-        olcPidFile = "/run/slapd/slapd.pid";
       };
       children."cn=schema".attrs = {
         cn = "schema";
@@ -286,9 +284,6 @@ in {
           chown -R "${cfg.user}:${cfg.group}" ${dataDir}
         '';
       in ''
-        mkdir -p /run/slapd
-        chown -R "${cfg.user}:${cfg.group}" /run/slapd
-
         mkdir -p ${lib.escapeShellArg configDir} ${lib.escapeShellArgs (lib.attrValues dataDirs)}
         chown "${cfg.user}:${cfg.group}" ${lib.escapeShellArg configDir} ${lib.escapeShellArgs (lib.attrValues dataDirs)}
 
@@ -303,11 +298,9 @@ in {
       '';
       serviceConfig = {
         ExecStart = lib.escapeShellArgs ([
-          "${openldap}/libexec/slapd" "-u" cfg.user "-g" cfg.group "-F" configDir
+          "${openldap}/libexec/slapd" "-d" "0" "-u" cfg.user "-g" cfg.group "-F" configDir
           "-h" (lib.concatStringsSep " " cfg.urlList)
         ]);
-        Type = "forking";
-        PIDFile = cfg.settings.attrs.olcPidFile;
       };
     };
 

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -262,7 +262,7 @@ in {
       assertion = ((getAttr opt cfg) != "_mkMergedOptionModule") -> (cfg.database != "_mkMergedOptionModule");
       message = "Legacy OpenLDAP option `services.openldap.${opt}` requires `services.openldap.database` (use value \"mdb\" if unsure)";
     }) legacyOptions ++ map (dn: {
-      assertion = dataDirsMap ? dn;
+      assertion = dataDirsMap ? "${dn}";
       message = ''
         declarative DB ${dn} does not exist in "servies.openldap.settings" or it exists but the "olcDbDirectory"
         is not prefixed by "/var/lib/openldap/"

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -313,6 +313,7 @@ in {
         ]);
         StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
         StateDirectoryMode = "600";
+        RuntimeDirectory = "openldap";
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
       };

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -290,7 +290,7 @@ in {
         settingsFile = pkgs.writeText "config.ldif" (lib.concatStringsSep "\n" (attrsToLdif "cn=config" cfg.settings));
         dataFiles = lib.mapAttrs (dn: contents: pkgs.writeText "${dn}.ldif" contents) cfg.declarativeContents;
         mkLoadScript = dn: let
-          dataDir = lib.escapeShellArg (getAttr dn dataDirsMap);
+          dataDir = lib.escapeShellArg ("/var/lib/openldap/" + getAttr dn dataDirsMap);
         in  ''
           rm -rf ${dataDir}/*
           ${openldap}/bin/slapadd -F ${lib.escapeShellArg configDir} -b ${dn} -l ${getAttr dn dataFiles}

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -7,7 +7,98 @@ let
   dovecotPkg = pkgs.dovecot;
 
   baseDir = "/run/dovecot2";
-  stateDir = "/var/lib/dovecot";
+
+  sieveToPath = text:
+    # Sieve scripts can start with a block comment
+    if isString text && hasPrefix "/*" text
+      then pkgs.writeText "script.sieve" text
+    # Paths in the store are used as is
+    else if types.path.check text && hasPrefix "${builtins.storeDir}/" (toString text)
+      then text
+    # Paths outside the store get written to the store
+    else if types.path.check text
+      then pkgs.writeText "script.sieve" (fileContents text)
+    # All other is assumed to be file content
+    else pkgs.writeText "script.sieve" text;
+  scriptType = types.coercedTo types.lines sieveToPath types.path;
+
+  compileSieveScripts = pkgs.buildSieveScripts {
+    name = "dovecot2-sieveScripts";
+      plugins = cfg.sieve.plugins;
+      extensions = cfg.sieve.extensions;
+      globalExtensions = cfg.sieve.globalExtensions;
+      dontUnpack = true;
+      dontConfigure = true;
+      buildPhase = ''
+        mkdir sieve
+        cd sieve
+        ${concatStringsSep "\n" (imap1 (i: v: ''
+          if [ -d '${v}' ]; then
+            ln -s '${v}' after/${toString i}
+          else
+            mkdir -p after/${toString i}
+            ln -s '${v}' after/${toString i}/default.sieve
+          fi
+        '') cfg.sieve.afterScripts)}
+        ${concatStringsSep "\n" (imap1 (i: v: ''
+          if [ -d '${v}' ]; then
+            ln -s '${v}' before/${toString i}
+          else
+            mkdir -p before/${toString i}
+            ln -s '${v}' before/${toString i}/default.sieve
+          fi
+        '') cfg.sieve.beforeScripts)}
+        ${optionalString (cfg.sieve.defaultScript != null) ''
+          ln -s '${cfg.sieve.defaultScript}' default.sieve
+        ''}
+        ${optionalString (cfg.sieve.discardScript != null) ''
+          ln -s '${cfg.sieve.discardScript}' discard.sieve
+        ''}
+        ${concatStringsSep "\n" (imap1 (i: mb: ''
+          mkdir -p imapsieve/${toString i}
+          ${optionalString (mb.before != null)''
+            ln -s '${mb.before}' imapsieve/${toString i}/before.sieve
+          ''}
+          ${optionalString (mb.after != null)''
+            ln -s '${mb.after}' imapsieve/${toString i}/after.sieve
+          ''}
+        '') cfg.sieve.imapsieve.mailboxes)}
+      '';
+  };
+
+  listOfScripts = type: idx: config:
+    let indexName = optionalString (idx > 1) (toString idx);
+    in
+      if (hasAttr "${type}${indexName}" config.services.dovecot2.sieveScripts)
+      then let value = config.services.dovecot2.sieveScripts."${type}${indexName}";
+        in if (substring 0 1 (toString value) == "/")
+          then [value] ++ (listOfScripts type (idx + 1) config)
+          else []
+      else [];
+
+  mapScripts = type: scripts:
+    (imap1
+      (i: v: "sieve_${type}${optionalString (i != 1) (toString i)} = ${compileSieveScripts}/sieve/${type}/${toString i}")
+      scripts);
+
+  mapImapScripts = mailboxes:
+    (imap1
+      (i: mb: ''
+        imapsieve_mailbox${toString i}_name = ${mb.name}
+        ${optionalString (mb.before != null) ''
+          imapsieve_mailbox${toString i}_before = ${compileSieveScripts}/sieve/imapsieve/${toString i}/before.sieve"
+        ''}
+        ${optionalString (mb.after != null) ''
+          imapsieve_mailbox${toString i}_after = ${compileSieveScripts}/sieve/imapsieve/${toString i}/after.sieve"
+        ''}
+        ${optionalString (mb.from != null) ''
+          imapsieve_mailbox${toString i}_from = ${mb.from}
+        ''}
+        ${optionalString (mb.causes != []) ''
+          imapsieve_mailbox${toString i}_causes = ${concatStringsSep " " mb.causes}
+        ''}
+      '')
+      mailboxes);
 
   dovecotConf = concatStrings [
     ''
@@ -75,9 +166,63 @@ let
     )
 
     (
-      optionalString (cfg.sieveScripts != {}) ''
+      optionalString cfg.sieve.enable ''
         plugin {
-          ${concatStringsSep "\n" (mapAttrsToList (to: from: "sieve_${to} = ${stateDir}/sieve/${to}") cfg.sieveScripts)}
+          ${optionalString (cfg.sieve.plugins != [])
+            "sieve_plugins = ${concatStringsSep " " (map (e: "sieve_${e}") cfg.sieve.plugins)}"}
+          ${optionalString (cfg.sieve.extensions != [])
+            "sieve_extensions = ${concatStringsSep " " cfg.sieve.extensions}"}
+          ${optionalString (cfg.sieve.globalExtensions != [])
+            "sieve_global_extensions = ${concatStringsSep " " cfg.sieve.globalExtensions}"}
+        }
+        protocol lmtp {
+          mail_plugins = $mail_plugins sieve
+        }
+        protocol lda {
+          mail_plugins = $mail_plugins sieve
+        }
+      ''
+    )
+
+    (
+      optionalString cfg.sieve.imapsieve.enable ''
+        protocol imap {
+          mail_plugins = $mail_plugins imap_sieve
+        }
+        plugin {
+          ${concatStringsSep "\n" (mapImapScripts cfg.sieve.imapsieve.mailboxes)}
+        }
+      ''
+    )
+
+    (
+      optionalString (cfg.sieve.beforeScripts != []) ''
+        plugin {
+          ${concatStringsSep "\n" (mapScripts "before" cfg.sieve.beforeScripts)}
+        }
+      ''
+    )
+
+    (
+      optionalString (cfg.sieve.defaultScript != null) ''
+        plugin {
+          sieve_default = ${compileSieveScripts}/sieve/default.sieve}
+        }
+      ''
+    )
+
+    (
+      optionalString (cfg.sieve.afterScripts != []) ''
+        plugin {
+          ${concatStringsSep "\n" (mapScripts "after" cfg.sieve.afterScripts)}
+        }
+      ''
+    )
+
+    (
+      optionalString (cfg.sieve.discardScript != null) ''
+        plugin {
+          sieve_discard = ${compileSieveScripts}/sieve/discard.sieve}
         }
       ''
     )
@@ -161,12 +306,62 @@ let
       };
     };
   };
+
+  imapsieveMailboxes = {
+    options = {
+      name = mkOption {
+        type = types.str;
+        example = "Junk";
+        description = ''
+          Name of a mailbox for which administrator scripts are configured.
+          This setting supports wildcards with a syntax compatible with the
+          IMAP LIST command, meaning that this setting can apply to multiple or
+          even all ("*") mailboxes.
+        '';
+      };
+      beforeScript = mkOption {
+        type = types.nullOr scriptType;
+        default = null;
+        description = ''
+          Sieve script to run before any user script when an IMAP event of
+          interest occurs.
+        '';
+      };
+      afterScript = mkOption {
+        type = types.nullOr scriptType;
+        default = null;
+        description = ''
+          Sieve script to run after any user script when an IMAP event of
+          interest occurs.
+        '';
+      };
+      causes = mkOption {
+        type = types.listOf (types.enum ["APPEND" "COPY" "FLAG"]);
+        default = [];
+        description = ''
+          Only execute the administrator Sieve scripts for the mailbox
+          when one of the listed IMAPSIEVE causes apply (currently either
+          APPEND, COPY, or FLAG. This has no effect on the user script, which
+          is always executed no matter the cause.
+        '';
+      };
+      from = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "*";
+        description = ''
+          Only execute the administrator Sieve scripts for the mailbox
+          configured with name option when the message originates from the
+          indicated mailbox.
+          This setting supports wildcards with a syntax compatible with the
+          IMAP LIST command, meaning that this setting can apply to multiple or
+          even all ("*") mailboxes.
+        '';
+      };
+    };
+  };
 in
 {
-  imports = [
-    (mkRemovedOptionModule [ "services" "dovecot2" "package" ] "")
-  ];
-
   options.services.dovecot2 = {
     enable = mkEnableOption "Dovecot 2.x POP3/IMAP server";
 
@@ -321,10 +516,106 @@ in
       description = "Whether to create a own Dovecot PAM service and configure PAM user logins.";
     };
 
-    sieveScripts = mkOption {
-      type = types.attrsOf types.path;
-      default = {};
-      description = "Sieve scripts to be executed. Key is a sequence, e.g. 'before2', 'after' etc.";
+    sieve = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable and configure sieve support";
+      };
+
+      enableManageSieve = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Start the ManageSieve listener (when Sieve is enabled).";
+      };
+
+      plugins = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "imapsieve" "extprograms" ];
+        description = "Sieve plugins to load";
+      };
+
+      extensions = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = ["+editheader" "-duplicate"];
+        description = ''
+          Which Sieve language extensions are available to users. This can
+          either be a complete list or can be modifications to the default list
+          by prefixing with + or -.
+        '';
+      };
+
+      globalExtensions = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = ["+vnd.dovecot.pipe"];
+        description = ''
+          Which Sieve language extensions are ONLY avalable in global scripts.
+          This can be used to restrict the use of certain Sieve extensions to
+          administrator control, for instance when these extensions can cause
+          security concerns. This setting has higher precedence than the
+          extensions option, meaning that the extensions enabled with this
+          setting are never available to the user's personal script no matter
+          what is specified for the extensions option. The syntax of this
+          setting is similar to the extensions option, with the difference that
+          extensions are enabled or disabled for exclusive use in global
+          scripts.
+        '';
+      };
+
+      beforeScripts = mkOption {
+        type = types.listOf scriptType;
+        default = [];
+        description = ''
+          Sieve scripts to be executed before user script.
+        '';
+      };
+
+      defaultScript = mkOption {
+        type = types.nullOr scriptType;
+        default = null;
+        description = ''
+          Default sieve script to be executed if user has no active script.
+        '';
+      };
+
+      afterScripts = mkOption {
+        type = types.listOf scriptType;
+        default = [];
+        description = ''
+          Sieve scripts to be executed after user script.
+        '';
+      };
+
+      discardScript = mkOption {
+        type = types.nullOr scriptType;
+        default = null;
+        description = ''
+          The location of a Sieve script that is run for any message that is
+          about to be discarded; i.e., it is not delivered anywhere by the
+          normal Sieve execution. This only happens when the "implicit keep" is
+          canceled, by e.g. the "discard" action, and no actions that deliver
+          the message are executed. This "discard script" can prevent
+          discarding the message, by executing alternative actions. If the
+          discard script does nothing, the message is still discarded as it
+          would be when no discard script is configured.
+        '';
+      };
+
+      imapsieve = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Whether to enable imapsieve plugin.";
+        };
+        mailboxes = mkOption {
+          type = types.listOf (types.submodule imapsieveMailboxes);
+          default = [];
+          description = "Configure imapsieve mailbox rules.";
+        };
+      };
     };
 
     showPAMFailure = mkOption {
@@ -379,10 +670,13 @@ in
       enable = true;
       params.dovecot2 = {};
     };
+    services.dovecot2.modules = mkIf cfg.sieve.enable [pkgs.dovecot_pigeonhole];
+    services.dovecot2.sieve.plugins = mkIf cfg.sieve.imapsieve.enable ["imapsieve"];
     services.dovecot2.protocols =
       optional cfg.enableImap "imap"
       ++ optional cfg.enablePop3 "pop3"
-      ++ optional cfg.enableLmtp "lmtp";
+      ++ optional cfg.enableLmtp "lmtp"
+      ++ optional (cfg.sieve.enable && cfg.sieve.enableManageSieve) "sieve";
 
     services.dovecot2.mailPlugins = mkIf cfg.enableQuota {
       globally.enable = [ "quota" ];
@@ -436,29 +730,6 @@ in
         RestartSec = "1s";
         RuntimeDirectory = [ "dovecot2" ];
       };
-
-      # When copying sieve scripts preserve the original time stamp
-      # (should be 0) so that the compiled sieve script is newer than
-      # the source file and Dovecot won't try to compile it.
-      preStart = ''
-        rm -rf ${stateDir}/sieve
-      '' + optionalString (cfg.sieveScripts != {}) ''
-        mkdir -p ${stateDir}/sieve
-        ${concatStringsSep "\n" (
-        mapAttrsToList (
-          to: from: ''
-            if [ -d '${from}' ]; then
-              mkdir '${stateDir}/sieve/${to}'
-              cp -p "${from}/"*.sieve '${stateDir}/sieve/${to}'
-            else
-              cp -p '${from}' '${stateDir}/sieve/${to}'
-            fi
-            ${pkgs.dovecot_pigeonhole}/bin/sievec '${stateDir}/sieve/${to}'
-          ''
-        ) cfg.sieveScripts
-      )}
-        chown -R '${cfg.mailUser}:${cfg.mailGroup}' '${stateDir}/sieve'
-      '';
     };
 
     environment.systemPackages = [ dovecotPkg ];
@@ -477,12 +748,36 @@ in
         assertion = cfg.showPAMFailure -> cfg.enablePAM;
         message = "dovecot is configured with showPAMFailure while enablePAM is disabled";
       }
-      {
-        assertion = cfg.sieveScripts != {} -> (cfg.mailUser != null && cfg.mailGroup != null);
-        message = "dovecot requires mailUser and mailGroup to be set when sieveScripts is set";
-      }
     ];
 
   };
-
+  imports = [
+    (mkRemovedOptionModule [ "services" "dovecot2" "package" ] "")
+    (mkMergedOptionModule
+      [ [ "services" "dovecot2" "sieveScripts" "after" ]
+        [ "services" "dovecot2" "sieveScripts" "after2" ]
+        [ "services" "dovecot2" "sieveScripts" "after3" ]
+        [ "services" "dovecot2" "sieveScripts" "after4" ]
+        [ "services" "dovecot2" "sieveScripts" "after5" ]
+        [ "services" "dovecot2" "sieveScripts" "after6" ]
+        [ "services" "dovecot2" "sieveScripts" "after7" ]
+        [ "services" "dovecot2" "sieveScripts" "after8" ]
+        [ "services" "dovecot2" "sieveScripts" "after9" ]]
+      [ "services" "dovecot2" "sieve" "afterScripts" ]
+      (listOfScripts "after" 1))
+    (mkMergedOptionModule
+      [ [ "services" "dovecot2" "sieveScripts" "before" ]
+        [ "services" "dovecot2" "sieveScripts" "before2" ]
+        [ "services" "dovecot2" "sieveScripts" "before3" ]
+        [ "services" "dovecot2" "sieveScripts" "before4" ]
+        [ "services" "dovecot2" "sieveScripts" "before5" ]
+        [ "services" "dovecot2" "sieveScripts" "before6" ]
+        [ "services" "dovecot2" "sieveScripts" "before7" ]
+        [ "services" "dovecot2" "sieveScripts" "before8" ]
+        [ "services" "dovecot2" "sieveScripts" "before9" ]]
+      [ "services" "dovecot2" "sieve" "beforeScripts" ]
+      (listOfScripts "before" 1))
+    (mkRenamedOptionModule [ "services" "dovecot2" "sieveScripts" "default" ] [ "services" "dovecot2" "sieve" "defaultScript" ])
+    (mkRenamedOptionModule [ "services" "dovecot2" "sieveScripts" "discard" ] [ "services" "dovecot2" "sieve" "discardScript" ])
+  ];
 }

--- a/nixos/tests/dovecot.nix
+++ b/nixos/tests/dovecot.nix
@@ -3,13 +3,42 @@ import ./make-test-python.nix {
 
   machine = { pkgs, ... }: {
     imports = [ common/user-account.nix ];
-    services.postfix.enable = true;
+    users.users.timmy = {
+      isNormalUser = true;
+      description = "Timmy Foobar";
+      password = "foobar";
+    };
+    services.postfix = {
+      enable = true;
+      rootAlias = "timmy";
+      extraConfig = "mailbox_transport = lmtp:unix:/var/run/dovecot2/lmtp";
+    };
     services.dovecot2 = {
       enable = true;
-      protocols = [ "imap" "pop3" ];
+      protocols = [ "imap" "pop3" "lmtp" "sieve" ];
       modules = [ pkgs.dovecot_pigeonhole ];
       mailUser = "vmail";
       mailGroup = "vmail";
+      mailboxes.Junk = {
+        specialUse = "Junk";
+        auto = "subscribe";
+      };
+      extraConfig = ''
+        mail_debug = yes
+
+        protocol lmtp {
+          postmaster_address = root@localhost
+          auth_username_format = %n
+          mail_plugins = $mail_plugins sieve
+        }
+      '';
+      sieveScripts.before = pkgs.writeText "before.sieve" ''
+        require "fileinto";
+        if header :is "X-Spam" "Yes" {
+          fileinto "Junk";
+          stop;
+        }
+      '';
     };
     environment.systemPackages = let
       sendTestMail = pkgs.writeScriptBin "send-testmail" ''
@@ -35,6 +64,19 @@ import ./make-test-python.nix {
         MAIL
       '';
 
+      sendTestMail2 = pkgs.writeScriptBin "send-testmail2" ''
+        #!${pkgs.runtimeShell}
+
+        exec sendmail -vt <<MAIL
+        From: root@localhost
+        To: alice@localhost
+        Subject: Very spammy!
+        X-Spam: Yes
+
+        This is spam!
+        MAIL
+      '';
+
       testImap = pkgs.writeScriptBin "test-imap" ''
         #!${pkgs.python3.interpreter}
         import imaplib
@@ -42,12 +84,32 @@ import ./make-test-python.nix {
         with imaplib.IMAP4('localhost') as imap:
           imap.login('alice', 'foobar')
           imap.select()
-          status, refs = imap.search(None, 'ALL')
+          status, data = imap.search(None, 'ALL')
           assert status == 'OK'
+          assert len(data) == 1
+          refs = data[0].split()
+          print(refs)
+          for num in refs:
+            status, msg = imap.fetch(num, 'BODY[TEXT]')
+            print(msg[0][1].decode("utf-8"))
           assert len(refs) == 1
           status, msg = imap.fetch(refs[0], 'BODY[TEXT]')
           assert status == 'OK'
           assert msg[0][1].strip() == b'Hello world!'
+
+          imap.select(mailbox='Junk')
+          status, data = imap.search(None, 'ALL')
+          assert status == 'OK'
+          assert len(data) == 1
+          refs = data[0].split()
+          print(refs)
+          for num in refs:
+            status, msg = imap.fetch(num, 'BODY[TEXT]')
+            print(msg[0][1].decode("utf-8"))
+          assert len(refs) == 1
+          status, msg = imap.fetch(refs[0], 'BODY[TEXT]')
+          assert status == 'OK'
+          assert msg[0][1].strip() == b'This is spam!'
       '';
 
       testPop = pkgs.writeScriptBin "test-pop" ''
@@ -66,15 +128,14 @@ import ./make-test-python.nix {
         finally:
           pop.quit()
       '';
-
-    in [ sendTestMail sendTestMailViaDeliveryAgent testImap testPop ];
+    in [ sendTestMail sendTestMailViaDeliveryAgent sendTestMail2 testImap testPop ];
   };
-
   testScript = ''
     machine.wait_for_unit("postfix.service")
     machine.wait_for_unit("dovecot2.service")
     machine.succeed("send-testmail")
     machine.succeed("send-lda")
+    machine.succeed("send-testmail2")
     machine.wait_until_fails('[ "$(postqueue -p)" != "Mail queue is empty" ]')
     machine.succeed("test-imap")
     machine.succeed("test-pop")

--- a/pkgs/servers/mail/dcc/default.nix
+++ b/pkgs/servers/mail/dcc/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "dcc";
+  version = "2.3.168";
+
+  src = fetchurl {
+    url = "https://www.dcc-servers.net/dcc/source/old/${pname}-${version}.tar.Z";
+    sha256 = "sha256-P8kyMls2pGqTJYvapIPQDuOoJr6h0A3gT26Ez76mO8I=";
+  };
+
+  dontAddPrefix = true;
+  setOutputFlags = false;
+
+  configureFlags = [
+    "--disable-sys-inst"
+    "--with-installroot=${placeholder "out"}"
+    "--bindir=/bin"
+    "--mandir=/share/man"
+    "--homedir=/share/${pname}"
+    "--libexecdir=/libexec"
+  ];
+
+  outputs = [ "out" "data" ];
+
+  postInstall = ''
+    mv $out/share/* $data/
+    rmdir $out/share
+  '';
+
+  installFlags = [
+    "DESTDIR=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    description = "Distributed Checksum Clearinghouses";
+    homepage = "https://www.dcc-servers.net/dcc/";
+    license = licenses.free;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/compile.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/compile.nix
@@ -1,0 +1,38 @@
+{dovecot_pigeonhole, lib, writeText }:
+{ name, plugins ? [], extensions ? [], globalExtensions ? [], meta ? {}, ... } @ args:
+with lib;
+let
+  config = writeText "buildSieveScripts-${name}-config" ''
+    plugin {
+      ${optionalString (plugins != [])
+        "sieve_plugins = ${concatStringsSep " " (map (e: "sieve_${e}") plugins)}"}
+      ${optionalString (extensions != [])
+        "sieve_extensions = ${concatStringsSep " " extensions}"}
+      ${optionalString (globalExtensions != [])
+        "sieve_global_extensions = ${concatStringsSep " " globalExtensions}"}
+    }
+  '';
+in
+
+dovecot_pigeonhole.stdenv.mkDerivation (args // {
+  inherit name;
+
+  installPhase = ''
+    mkdir -p "$out/sieve/"
+    for k in $(find * -name \*.sieve); do
+      mkdir -p "$out/sieve/$(dirname "$k")"
+      cp -a "$k" "$out/sieve/$k"
+      if [[ ! -L "$k" ]]; then
+        echo "Compiling $k"
+        touch -m --date=@0 "$out/sieve/$k"
+      else
+        echo "Compiling $k -> $(readlink -f "$k")"
+      fi
+      ${dovecot_pigeonhole}/bin/sievec -c "${config}" "$out/sieve/$k"
+    done
+  '' + (args.installPhase or "");
+
+  meta = {
+    platforms = dovecot_pigeonhole.meta.platforms or lib.platforms.all;
+  } // meta;
+})

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, dovecot, openssl }:
+{ lib, stdenv, fetchpatch, fetchurl, dovecot, openssl }:
 let
   dovecotMajorMinor = lib.versions.majorMinor dovecot.version;
 in stdenv.mkDerivation rec {
@@ -11,6 +11,16 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = [ dovecot openssl ];
+
+  patches = [
+    # Fix mtime comparison so that scripts can be precompiled
+    # https://github.com/dovecot/pigeonhole/pull/4
+    (fetchpatch {
+      name = "binary-mtime.patch";
+      url = https://github.com/dovecot/pigeonhole/commit/3defbec146e195edad336a2c218f108462b0abd7.patch;
+      sha256 = "09mvdw8gjzq9s2l759dz4aj9man8q1akvllsq2j1xa2qmwjfxarp";
+    })
+  ];
 
   preConfigure = ''
     substituteInPlace src/managesieve/managesieve-settings.c --replace \

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -5,9 +5,13 @@
 , nettle
 , expat
 , libevent
+, libsodium
+, protobufc
+, hiredis
 , dns-root-data
 , pkg-config
 , makeWrapper
+, symlinkJoin
   #
   # By default unbound will not be built with systemd support. Unbound is a very
   # commmon dependency. The transitive dependency closure of systemd also
@@ -21,6 +25,11 @@
 , systemd ? null
   # optionally support DNS-over-HTTPS as a server
 , withDoH ? false
+, withECS ? false
+, withDNSCrypt ? false
+, withDNSTAP ? false
+, withTFO ? false
+, withCacheDB ? false
 , libnghttp2
 }:
 
@@ -57,7 +66,23 @@ stdenv.mkDerivation rec {
     "--enable-systemd"
   ] ++ lib.optionals withDoH [
     "--with-libnghttp2=${libnghttp2.dev}"
+  ] ++ lib.optionals withECS [
+    "--enable-subnet"
+  ] ++ lib.optionals withDNSCrypt [
+    "--enable-dnscrypt"
+    "--with-libsodium=${symlinkJoin { name = "libsodium-full"; paths = [ libsodium.dev libsodium.out ]; }}"
+  ] ++ lib.optionals withDNSTAP [
+    "--enable-dnstap"
+    "--with-protobuf-c=${protobufc}"
+  ] ++ lib.optionals withTFO [
+    "--enable-tfo-client"
+    "--enable-tfo-server"
+  ] ++ lib.optionals withCacheDB [
+    "--enable-cachedb"
+    "--with-libhiredis=${hiredis}"
   ];
+
+  PROTOC_C = if withDNSTAP then "${protobufc}/bin/protoc-c" else null;
 
   # Remove references to compile-time dependencies that are included in the configure flags
   postConfigure = let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10399,6 +10399,11 @@ with pkgs;
   unbound-full = unbound.override {
     withSystemd = true;
     withDoH = true;
+    withECS = true;
+    withDNSCrypt = true;
+    withDNSTAP = true;
+    withTFO = true;
+    withCacheDB = true;
   };
 
   unicorn = callPackage ../development/libraries/unicorn { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20283,6 +20283,7 @@ with pkgs;
   dovecot = callPackage ../servers/mail/dovecot { };
   dovecot_pigeonhole = callPackage ../servers/mail/dovecot/plugins/pigeonhole { };
   dovecot_fts_xapian = callPackage ../servers/mail/dovecot/plugins/fts_xapian { };
+  buildSieveScripts = callPackage ../servers/mail/dovecot/plugins/pigeonhole/compile.nix { };
 
   dspam = callPackage ../servers/mail/dspam { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -383,6 +383,8 @@ with pkgs;
 
   nix-prefetch-docker = callPackage ../build-support/docker/nix-prefetch-docker.nix { };
 
+  dcc = callPackage ../servers/mail/dcc { };
+
   docker-compose = python3Packages.callPackage ../applications/virtualization/docker-compose {};
 
   docker-ls = callPackage ../tools/misc/docker-ls { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
