### PR TITLE
dcc: init at 2.3.168

### DIFF
--- a/pkgs/servers/mail/dcc/default.nix
+++ b/pkgs/servers/mail/dcc/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "dcc";
+  version = "2.3.168";
+
+  src = fetchurl {
+    url = "https://www.dcc-servers.net/dcc/source/old/${pname}-${version}.tar.Z";
+    sha256 = "sha256-P8kyMls2pGqTJYvapIPQDuOoJr6h0A3gT26Ez76mO8I=";
+  };
+
+  dontAddPrefix = true;
+  setOutputFlags = false;
+
+  configureFlags = [
+    "--disable-sys-inst"
+    "--with-installroot=${placeholder "out"}"
+    "--bindir=/bin"
+    "--mandir=/share/man"
+    "--homedir=/share/${pname}"
+    "--libexecdir=/libexec"
+  ];
+
+  outputs = [ "out" "data" ];
+
+  postInstall = ''
+    mv $out/share/* $data/
+    rmdir $out/share
+  '';
+
+  installFlags = [
+    "DESTDIR=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    description = "Distributed Checksum Clearinghouses";
+    homepage = "https://www.dcc-servers.net/dcc/";
+    license = licenses.free;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -672,6 +672,8 @@ with pkgs;
 
   nix-prefetch-docker = callPackage ../build-support/docker/nix-prefetch-docker.nix { };
 
+  dcc = callPackage ../servers/mail/dcc { };
+
   docker-ls = callPackage ../tools/misc/docker-ls { };
 
   docker-slim = callPackage ../applications/virtualization/docker-slim { };


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
