### PR TITLE
emacs-sv-kalender: 1.9 -> 1.11

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/sv-kalender/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/sv-kalender/default.nix
@@ -2,14 +2,11 @@
 
 trivialBuild {
   pname = "sv-kalender";
-  version = "1.9";
+  version = "1.11";
 
   src = fetchurl {
     url = "http://bigwalter.net/daniel/elisp/sv-kalender.el";
-    sha256 = "0kilp0nyhj67qscy13s0g07kygz2qwmddklhan020sk7z7jv3lpi";
-    postFetch = ''
-      echo "(provide 'sv-kalender)" >> $out
-    '';
+    sha256 = "0mcx7g1pg6kfp0i4b9rh3q9csgdf3054ijswy368bxwdxsjgfz2m";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Bump the sv-kalendar package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
