### PR TITLE
ike-scan: 1.9.4 -> 1.9.5

### DIFF
--- a/pkgs/tools/security/ike-scan/default.nix
+++ b/pkgs/tools/security/ike-scan/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ike-scan";
-  version = "1.9.4";
+  version = "1.9.5";
 
   src = fetchFromGitHub {
     owner = "royhills";
     repo = pname;
     rev = version;
-    sha256 = "01a39bk9ma2lm59q320m9g11909if5gc3qynd8pzn6slqiq5r8kw";
+    sha256 = "sha256-mbfg8p3y4aKoXpmLuF9GXAMPEqV5CsvetwGCRDJ9UNY=";
   };
 
   nativeBuildInputs = [
@@ -32,11 +32,6 @@ stdenv.mkDerivation rec {
       # Memory leaks, https://github.com/royhills/ike-scan/pull/15
       url = "https://github.com/royhills/ike-scan/pull/15/commits/d864811de08dcddd65ac9b8d0f2acf5d7ddb9dea.patch";
       sha256 = "0wbrq89dl8js7cdivd0c45hckmflan33cpgc3qm5s3az6r4mjljm";
-    })
-    (fetchpatch {
-      # Unknown vendor IDs,  https://github.com/royhills/ike-scan/pull/18, was merged but not released
-      url = "https://github.com/royhills/ike-scan/pull/18/commits/e065ddbe471880275dc7975e7da235e7a2097c22.patch";
-      sha256 = "13ly01c96nnd5yh7rxrhv636csm264m5xf2a1inprrzxkkri5sls";
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.9.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
