### PR TITLE
protoc-gen-grpc-web: 1.2.1 -> 1.3.0

### DIFF
--- a/pkgs/development/tools/protoc-gen-grpc-web/default.nix
+++ b/pkgs/development/tools/protoc-gen-grpc-web/default.nix
@@ -1,28 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, protobuf }:
+{ lib, stdenv, fetchFromGitHub, protobuf }:
 
 stdenv.mkDerivation rec {
   pname = "protoc-gen-grpc-web";
-  version = "1.2.1";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "grpc";
     repo = "grpc-web";
     rev = version;
-    sha256 = "sha256-NBENyc01O8NPo84z1CeZ7YvFvVGY2GSlcdxacRrQALw=";
+    sha256 = "sha256-piKpaylzuanhGR+7BzApplv8e/CWPoR9tG3vHrF7WXw=";
   };
 
-  sourceRoot = "source/javascript/net/grpc/web";
-
-  # remove once PR merged
-  # https://github.com/grpc/grpc-web/pull/1107
-  patches = [
-    (fetchpatch {
-      name = "add-prefix.patch";
-      url = "https://github.com/06kellyjac/grpc-web/commit/b0803be1080fc635a8d5b88da971835a888a0c77.patch";
-      stripLen = 4;
-      sha256 = "sha256-Rw9Z7F8cYrc/UIGUN6yXOus4v+Qn9Yf1Nc301TFx85A=";
-    })
-  ];
+  sourceRoot = "source/javascript/net/grpc/web/generator";
 
   strictDeps = true;
   nativeBuildInputs = [ protobuf ];
@@ -30,11 +19,32 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
+  doCheck = true;
+  checkInputs = [ protobuf ];
+  checkPhase = ''
+    runHook preCheck
+
+    CHECK_TMPDIR="$TMPDIR/proto"
+    mkdir -p "$CHECK_TMPDIR"
+
+    protoc \
+      --proto_path="${src}/packages/grpc-web/test/protos" \
+      --plugin="./protoc-gen-grpc-web" \
+      --grpc-web_out="import_style=commonjs,mode=grpcwebtext:$CHECK_TMPDIR" \
+      echo.proto
+
+    # check for grpc-web generated file
+    [ -f "$CHECK_TMPDIR/echo_grpc_web_pb.js" ]
+
+    runHook postCheck
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/grpc/grpc-web";
     changelog = "https://github.com/grpc/grpc-web/blob/${version}/CHANGELOG.md";
     description = "gRPC web support for Google's protocol buffers";
     license = licenses.asl20;
     maintainers = with maintainers; [ jk ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump protoc-gen-grpc-web to `1.3.0`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
