### PR TITLE
python37Packages.flake8: don't run tests if older than python3.8

### DIFF
--- a/pkgs/development/python-modules/flake8/default.nix
+++ b/pkgs/development/python-modules/flake8/default.nix
@@ -19,6 +19,9 @@ buildPythonPackage rec {
     ++ lib.optionals (pythonOlder "3.5") [ typing ]
     ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
+  # Tests fail on Python 3.7 due to importlib using a deprecated interface
+  doCheck = !(pythonOlder "3.8");
+
   # fixtures fail to initialize correctly
   checkPhase = ''
     py.test tests --ignore=tests/integration/test_checker.py


### PR DESCRIPTION
Tests fail on Python 3.7 due to importlib using a deprecated interface.

Context: https://github.com/python/importlib_metadata/issues/298

###### Motivation for this change
```
building '/nix/store/ykjgwfrqqf6zjx2v9k8jl743aqsgpn1z-python3.7-flake8-3.9.2.drv' on 'ssh://flokli@172.20.42.15'...
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing setuptools-build-hook
Using setuptoolsBuildPhase
Using setuptoolsShellHook
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing setuptools-check-hook
unpacking sources
unpacking source archive /nix/store/6xigwvj8bbjm1lwwhqavz9sbmyvzxyln-flake8-3.9.2.tar.gz
source root is flake8-3.9.2
setting SOURCE_DATE_EPOCH to timestamp 1620503498 of file flake8-3.9.2/setup.cfg
patching sources
configuring
no configure script, doing nothing
building
Executing setuptoolsBuildPhase
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/flake8
copying src/flake8/utils.py -> build/lib/flake8
copying src/flake8/style_guide.py -> build/lib/flake8
copying src/flake8/statistics.py -> build/lib/flake8
copying src/flake8/processor.py -> build/lib/flake8
copying src/flake8/exceptions.py -> build/lib/flake8
copying src/flake8/defaults.py -> build/lib/flake8
copying src/flake8/checker.py -> build/lib/flake8
copying src/flake8/_compat.py -> build/lib/flake8
copying src/flake8/__main__.py -> build/lib/flake8
copying src/flake8/__init__.py -> build/lib/flake8
creating build/lib/flake8/plugins
copying src/flake8/plugins/pyflakes.py -> build/lib/flake8/plugins
copying src/flake8/plugins/manager.py -> build/lib/flake8/plugins
copying src/flake8/plugins/__init__.py -> build/lib/flake8/plugins
creating build/lib/flake8/options
copying src/flake8/options/manager.py -> build/lib/flake8/options
copying src/flake8/options/config.py -> build/lib/flake8/options
copying src/flake8/options/aggregator.py -> build/lib/flake8/options
copying src/flake8/options/__init__.py -> build/lib/flake8/options
creating build/lib/flake8/main
copying src/flake8/main/vcs.py -> build/lib/flake8/main
copying src/flake8/main/setuptools_command.py -> build/lib/flake8/main
copying src/flake8/main/options.py -> build/lib/flake8/main
copying src/flake8/main/mercurial.py -> build/lib/flake8/main
copying src/flake8/main/git.py -> build/lib/flake8/main
copying src/flake8/main/debug.py -> build/lib/flake8/main
copying src/flake8/main/cli.py -> build/lib/flake8/main
copying src/flake8/main/application.py -> build/lib/flake8/main
copying src/flake8/main/__init__.py -> build/lib/flake8/main
creating build/lib/flake8/formatting
copying src/flake8/formatting/default.py -> build/lib/flake8/formatting
copying src/flake8/formatting/base.py -> build/lib/flake8/formatting
copying src/flake8/formatting/__init__.py -> build/lib/flake8/formatting
creating build/lib/flake8/api
copying src/flake8/api/legacy.py -> build/lib/flake8/api
copying src/flake8/api/__init__.py -> build/lib/flake8/api
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/flake8
creating build/bdist.linux-x86_64/wheel/flake8/api
copying build/lib/flake8/api/__init__.py -> build/bdist.linux-x86_64/wheel/flake8/api
copying build/lib/flake8/api/legacy.py -> build/bdist.linux-x86_64/wheel/flake8/api
creating build/bdist.linux-x86_64/wheel/flake8/formatting
copying build/lib/flake8/formatting/__init__.py -> build/bdist.linux-x86_64/wheel/flake8/formatting
copying build/lib/flake8/formatting/base.py -> build/bdist.linux-x86_64/wheel/flake8/formatting
copying build/lib/flake8/formatting/default.py -> build/bdist.linux-x86_64/wheel/flake8/formatting
creating build/bdist.linux-x86_64/wheel/flake8/main
copying build/lib/flake8/main/__init__.py -> build/bdist.linux-x86_64/wheel/flake8/main
copying build/lib/flake8/main/application.py -> build/bdist.linux-x86_64/wheel/flake8/main
copying build/lib/flake8/main/cli.py -> build/bdist.linux-x86_64/wheel/flake8/main
copying build/lib/flake8/main/debug.py -> build/bdist.linux-x86_64/wheel/flake8/main
copying build/lib/flake8/main/git.py -> build/bdist.linux-x86_64/wheel/flake8/main
copying build/lib/flake8/main/mercurial.py -> build/bdist.linux-x86_64/wheel/flake8/main
copying build/lib/flake8/main/options.py -> build/bdist.linux-x86_64/wheel/flake8/main
copying build/lib/flake8/main/setuptools_command.py -> build/bdist.linux-x86_64/wheel/flake8/main
copying build/lib/flake8/main/vcs.py -> build/bdist.linux-x86_64/wheel/flake8/main
creating build/bdist.linux-x86_64/wheel/flake8/options
copying build/lib/flake8/options/__init__.py -> build/bdist.linux-x86_64/wheel/flake8/options
copying build/lib/flake8/options/aggregator.py -> build/bdist.linux-x86_64/wheel/flake8/options
copying build/lib/flake8/options/config.py -> build/bdist.linux-x86_64/wheel/flake8/options
copying build/lib/flake8/options/manager.py -> build/bdist.linux-x86_64/wheel/flake8/options
creating build/bdist.linux-x86_64/wheel/flake8/plugins
copying build/lib/flake8/plugins/__init__.py -> build/bdist.linux-x86_64/wheel/flake8/plugins
copying build/lib/flake8/plugins/manager.py -> build/bdist.linux-x86_64/wheel/flake8/plugins
copying build/lib/flake8/plugins/pyflakes.py -> build/bdist.linux-x86_64/wheel/flake8/plugins
copying build/lib/flake8/__init__.py -> build/bdist.linux-x86_64/wheel/flake8
copying build/lib/flake8/__main__.py -> build/bdist.linux-x86_64/wheel/flake8
copying build/lib/flake8/_compat.py -> build/bdist.linux-x86_64/wheel/flake8
copying build/lib/flake8/checker.py -> build/bdist.linux-x86_64/wheel/flake8
copying build/lib/flake8/defaults.py -> build/bdist.linux-x86_64/wheel/flake8
copying build/lib/flake8/exceptions.py -> build/bdist.linux-x86_64/wheel/flake8
copying build/lib/flake8/processor.py -> build/bdist.linux-x86_64/wheel/flake8
copying build/lib/flake8/statistics.py -> build/bdist.linux-x86_64/wheel/flake8
copying build/lib/flake8/style_guide.py -> build/bdist.linux-x86_64/wheel/flake8
copying build/lib/flake8/utils.py -> build/bdist.linux-x86_64/wheel/flake8
running install_egg_info
running egg_info
writing src/flake8.egg-info/PKG-INFO
writing dependency_links to src/flake8.egg-info/dependency_links.txt
writing entry points to src/flake8.egg-info/entry_points.txt
writing requirements to src/flake8.egg-info/requires.txt
writing top-level names to src/flake8.egg-info/top_level.txt
reading manifest file 'src/flake8.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '*.pyc' found anywhere in distribution
no previously-included directories found matching 'docs/build/'
adding license file 'LICENSE'
writing manifest file 'src/flake8.egg-info/SOURCES.txt'
Copying src/flake8.egg-info to build/bdist.linux-x86_64/wheel/flake8-3.9.2-py3.7.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/flake8-3.9.2.dist-info/WHEEL
creating 'dist/flake8-3.9.2-py2.py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'flake8/__init__.py'
adding 'flake8/__main__.py'
adding 'flake8/_compat.py'
adding 'flake8/checker.py'
adding 'flake8/defaults.py'
adding 'flake8/exceptions.py'
adding 'flake8/processor.py'
adding 'flake8/statistics.py'
adding 'flake8/style_guide.py'
adding 'flake8/utils.py'
adding 'flake8/api/__init__.py'
adding 'flake8/api/legacy.py'
adding 'flake8/formatting/__init__.py'
adding 'flake8/formatting/base.py'
adding 'flake8/formatting/default.py'
adding 'flake8/main/__init__.py'
adding 'flake8/main/application.py'
adding 'flake8/main/cli.py'
adding 'flake8/main/debug.py'
adding 'flake8/main/git.py'
adding 'flake8/main/mercurial.py'
adding 'flake8/main/options.py'
adding 'flake8/main/setuptools_command.py'
adding 'flake8/main/vcs.py'
adding 'flake8/options/__init__.py'
adding 'flake8/options/aggregator.py'
adding 'flake8/options/config.py'
adding 'flake8/options/manager.py'
adding 'flake8/plugins/__init__.py'
adding 'flake8/plugins/manager.py'
adding 'flake8/plugins/pyflakes.py'
adding 'flake8-3.9.2.dist-info/LICENSE'
adding 'flake8-3.9.2.dist-info/METADATA'
adding 'flake8-3.9.2.dist-info/WHEEL'
adding 'flake8-3.9.2.dist-info/entry_points.txt'
adding 'flake8-3.9.2.dist-info/top_level.txt'
adding 'flake8-3.9.2.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Finished executing setuptoolsBuildPhase
installing
Executing pipInstallPhase
/build/flake8-3.9.2/dist /build/flake8-3.9.2
Processing ./flake8-3.9.2-py2.py3-none-any.whl
Requirement already satisfied: pyflakes<2.4.0,>=2.3.0 in /nix/store/jj9dwa0ky75j50sr165qrxjkl4bpmacb-python3.7-pyflakes-2.3.1/lib/python3.7/site-packages (from flake8==3.9.2) (2.3.1)
Requirement already satisfied: mccabe<0.7.0,>=0.6.0 in /nix/store/ljvcik3l8pm9k9dhkxypj75dq5xsggi6-python3.7-mccabe-0.6.1/lib/python3.7/site-packages (from flake8==3.9.2) (0.6.1)
Requirement already satisfied: pycodestyle<2.8.0,>=2.7.0 in /nix/store/jpvghhn8cr3j3rrnrn5s4rk7rd34ihzm-python3.7-pycodestyle-2.7.0/lib/python3.7/site-packages (from flake8==3.9.2) (2.7.0)
Requirement already satisfied: importlib-metadata in /nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages (from flake8==3.9.2) (4.6.4)
Requirement already satisfied: zipp>=0.5 in /nix/store/77xq9qidrg94c2ddwcv7c8awphndir66-python3.7-zipp-3.5.0/lib/python3.7/site-packages (from importlib-metadata->flake8==3.9.2) (3.5.0)
Requirement already satisfied: typing-extensions>=3.6.4 in /nix/store/czmqjwmwmnb3i5nv4jhsrdvsrpblfs1w-python3.7-typing_extensions-3.10.0.2/lib/python3.7/site-packages (from importlib-metadata->flake8==3.9.2) (3.10.0.2)
Installing collected packages: flake8
Successfully installed flake8-3.9.2
/build/flake8-3.9.2
Finished executing pipInstallPhase
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2
strip is /nix/store/a4mmjm3bblxwp8h53bcfx3dly80ib0ba-binutils-2.35.1/bin/strip
stripping (with command strip and flags -S) in /nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib  /nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/bin
patching script interpreter paths in /nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2
checking for references to /build/ in /nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2...
Rewriting #!/nix/store/vpyhx3jp6s4ffpfp2ci4hqbg90a05izp-python3-3.7.11/bin/python3.7 to #!/nix/store/vpyhx3jp6s4ffpfp2ci4hqbg90a05izp-python3-3.7.11
wrapping `/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/bin/flake8'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
running install tests
============================= test session starts ==============================
platform linux -- Python 3.7.11, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /build/flake8-3.9.2, configfile: pytest.ini
collected 461 items

tests/integration/test_aggregator.py ..                                  [  0%]
tests/integration/test_api_legacy.py F                                   [  0%]
tests/integration/test_main.py FFFFFFFFFFFFFFFFFFF                       [  4%]
tests/integration/test_plugins.py FFF                                    [  5%]
tests/unit/test_application.py ............                              [  8%]
tests/unit/test_base_formatter.py ..............                         [ 11%]
tests/unit/test_checker_manager.py ....                                  [ 11%]
tests/unit/test_config_file_finder.py ...............                    [ 15%]
tests/unit/test_debug.py ........                                        [ 16%]
tests/unit/test_decision_engine.py ..................................... [ 24%]
...................................                                      [ 32%]
tests/unit/test_exceptions.py ....                                       [ 33%]
tests/unit/test_file_checker.py ....                                     [ 34%]
tests/unit/test_file_processor.py ...................................... [ 42%]
.....................................                                    [ 50%]
tests/unit/test_filenameonly_formatter.py ...                            [ 51%]
tests/unit/test_get_local_plugins.py ...                                 [ 51%]
tests/unit/test_git.py ..                                                [ 52%]
tests/unit/test_legacy_api.py ............                               [ 54%]
tests/unit/test_merged_config_parser.py ............                     [ 57%]
tests/unit/test_nothing_formatter.py ..                                  [ 57%]
tests/unit/test_option.py ......                                         [ 59%]
tests/unit/test_option_manager.py .................................      [ 66%]
tests/unit/test_plugin.py .............                                  [ 69%]
tests/unit/test_plugin_manager.py ....                                   [ 70%]
tests/unit/test_plugin_type_manager.py ..........                        [ 72%]
tests/unit/test_pyflakes_codes.py ..                                     [ 72%]
tests/unit/test_setuptools_command.py E                                  [ 72%]
tests/unit/test_statistics.py ...................                        [ 77%]
tests/unit/test_style_guide.py ....................                      [ 81%]
tests/unit/test_utils.py ............................................... [ 91%]
.............                                                            [ 94%]
tests/unit/test_violation.py ..........................                  [100%]

==================================== ERRORS ====================================
___________ ERROR at setup of test_package_files_removes_submodules ____________

distribution = <setuptools.dist.Distribution object at 0x7ffff53cf490>

    @pytest.fixture
    def command(distribution):
        """Create an instance of Flake8's setuptools command."""
>       return setuptools_command.Flake8(distribution)

tests/unit/test_setuptools_command.py:24:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/n75adx94rgsd8mlbkv4y5zkiq9d5glfc-python3.7-setuptools-57.2.0/lib/python3.7/site-packages/setuptools/__init__.py:172: in __init__
    _Command.__init__(self, dist)
/nix/store/vpyhx3jp6s4ffpfp2ci4hqbg90a05izp-python3-3.7.11/lib/python3.7/distutils/cmd.py:62: in __init__
    self.initialize_options()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/setuptools_command.py:29: in initialize_options
    self.flake8.initialize([])
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log setup ------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff53cf450>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:142 Found local configuration files: ['/build/flake8-3.9.2/setup.cfg', '/build/flake8-3.9.2/tox.ini']
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
=================================== FAILURES ===================================
_______________________________ test_legacy_api ________________________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_legacy_api0')

    def test_legacy_api(tmpdir):
        """A basic end-to-end test for the legacy api reporting errors."""
        with tmpdir.as_cwd():
            t_py = tmpdir.join('t.py')
            t_py.write('import os  # unused import\n')

>           style_guide = legacy.get_style_guide()

tests/integration/test_api_legacy.py:11:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/api/legacy.py:41: in get_style_guide
    application.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a5b6d0>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_______________________________ test_diff_option _______________________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_diff_option0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5af7610>

    def test_diff_option(tmpdir, capsys):
        """Ensure that `flake8 --diff` works."""
        t_py_contents = '''\
    import os
    import sys  # unused but not part of diff

    print('(to avoid trailing whitespace in test)')
    print('(to avoid trailing whitespace in test)')
    print(os.path.join('foo', 'bar'))

    y  # part of the diff and an error
    '''

        diff = '''\
    diff --git a/t.py b/t.py
    index d64ac39..7d943de 100644
    --- a/t.py
    +++ b/t.py
    @@ -4,3 +4,5 @@ import sys  # unused but not part of diff
     print('(to avoid trailing whitespace in test)')
     print('(to avoid trailing whitespace in test)')
     print(os.path.join('foo', 'bar'))
    +
    +y  # part of the diff and an error
    '''

        with mock.patch.object(utils, 'stdin_get_value', return_value=diff):
            with tmpdir.as_cwd():
                tmpdir.join('t.py').write(t_py_contents)
>               _call_main(['--diff'], retv=1)

tests/integration/test_main.py:47:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff57e4090>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
__________________________ test_form_feed_line_split ___________________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_form_feed_line_split0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5a5b410>

    def test_form_feed_line_split(tmpdir, capsys):
        """Test that form feed is treated the same for stdin."""
        src = 'x=1\n\f\ny=1\n'
        expected_out = '''\
    t.py:1:2: E225 missing whitespace around operator
    t.py:3:2: E225 missing whitespace around operator
    '''

        with tmpdir.as_cwd():
            tmpdir.join('t.py').write(src)

            with mock.patch.object(utils, 'stdin_get_value', return_value=src):
>               _call_main(['-', '--stdin-display-name=t.py'], retv=1)

tests/integration/test_main.py:66:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff57e4d90>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_____________________ test_e101_indent_char_does_not_reset _____________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_e101_indent_char_does_not0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff59a8950>

    def test_e101_indent_char_does_not_reset(tmpdir, capsys):
        """Ensure that E101 with an existing indent_char does not reset it."""
        t_py_contents = """\
    if True:
        print('space indented')

    s = '''\
    \ttab indented
    '''  # noqa: E101

    if True:
        print('space indented')
    """

        with tmpdir.as_cwd():
            tmpdir.join('t.py').write(t_py_contents)
>           _call_main(['t.py'])

tests/integration/test_main.py:93:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a58e50>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
____________________________ test_statistics_option ____________________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_statistics_option0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5a2d290>

    def test_statistics_option(tmpdir, capsys):
        """Ensure that `flake8 --statistics` works."""
        with tmpdir.as_cwd():
            tmpdir.join('t.py').write('import os\nimport sys\n')
>           _call_main(['--statistics', 't.py'], retv=1)

tests/integration/test_main.py:100:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a7a2d0>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
___________________________ test_show_source_option ____________________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_show_source_option0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5a6b210>

    def test_show_source_option(tmpdir, capsys):
        """Ensure that --show-source and --no-show-source work."""
        with tmpdir.as_cwd():
            tmpdir.join('tox.ini').write('[flake8]\nshow_source = true\n')
            tmpdir.join('t.py').write('import os\n')
>           _call_main(['t.py'], retv=1)

tests/integration/test_main.py:116:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a89c50>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:142 Found local configuration files: ['/build/pytest-of-nixbld/pytest-0/test_show_source_option0/tox.ini']
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_____________________________ test_extend_exclude ______________________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_extend_exclude0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5a69c50>

    def test_extend_exclude(tmpdir, capsys):
        """Ensure that `flake8 --extend-exclude` works."""
        for d in ['project', 'vendor', 'legacy', '.git', '.tox', '.hg']:
            tmpdir.mkdir(d).join('t.py').write('import os\nimport sys\n')

        with tmpdir.as_cwd():
>           _call_main(['--extend-exclude=vendor,legacy/'], retv=1)

tests/integration/test_main.py:142:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5783590>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
____________________ test_malformed_per_file_ignores_error _____________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_malformed_per_file_ignore0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5aa4ed0>

    def test_malformed_per_file_ignores_error(tmpdir, capsys):
        """Test the error message for malformed `per-file-ignores`."""
        setup_cfg = '''\
    [flake8]
    per-file-ignores =
        incorrect/*
        values/*
    '''

        with tmpdir.as_cwd():
            tmpdir.join('setup.cfg').write(setup_cfg)
>           _call_main(['.'], retv=1)

tests/integration/test_main.py:164:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a76310>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:142 Found local configuration files: ['/build/pytest-of-nixbld/pytest-0/test_malformed_per_file_ignore0/setup.cfg']
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_________________ test_tokenization_error_but_not_syntax_error _________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_tokenization_error_but_no0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5acbe90>

    def test_tokenization_error_but_not_syntax_error(tmpdir, capsys):
        """Test that flake8 does not crash on tokenization errors."""
        with tmpdir.as_cwd():
            # this is a crash in the tokenizer, but not in the ast
            tmpdir.join('t.py').write("b'foo' \\\n")
>           _call_main(['t.py'], retv=1)

tests/integration/test_main.py:183:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff59c7410>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
__________________ test_tokenization_error_is_a_syntax_error ___________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_tokenization_error_is_a_s0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff57cd8d0>

    def test_tokenization_error_is_a_syntax_error(tmpdir, capsys):
        """Test when tokenize raises a SyntaxError."""
        with tmpdir.as_cwd():
            tmpdir.join('t.py').write('if True:\n    pass\n pass\n')
>           _call_main(['t.py'], retv=1)

tests/integration/test_main.py:194:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a587d0>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
__________________________ test_bug_report_successful __________________________

capsys = <_pytest.capture.CaptureFixture object at 0x7ffff576ff10>

    def test_bug_report_successful(capsys):
        """Test that --bug-report does not crash."""
>       _call_main(['--bug-report'])

tests/integration/test_main.py:203:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5b10a10>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:142 Found local configuration files: ['/build/flake8-3.9.2/setup.cfg', '/build/flake8-3.9.2/tox.ini']
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_____________ test_specific_noqa_does_not_clobber_pycodestyle_noqa _____________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_specific_noqa_does_not_cl0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff59a8b10>

    def test_specific_noqa_does_not_clobber_pycodestyle_noqa(tmpdir, capsys):
        """See https://gitlab.com/pycqa/flake8/issues/552."""
        with tmpdir.as_cwd():
            tmpdir.join('t.py').write("test = ('ABC' == None)  # noqa: E501\n")
>           _call_main(['t.py'], retv=1)

tests/integration/test_main.py:213:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a21a50>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_________________ test_specific_noqa_on_line_with_continuation _________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_specific_noqa_on_line_wit0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5a89850>

    def test_specific_noqa_on_line_with_continuation(tmpdir, capsys):
        """See https://gitlab.com/pycqa/flake8/issues/375."""
        t_py_src = '''\
    from os \\
        import path  # noqa: F401

    x = """
        trailing whitespace: \n
    """  # noqa: W291
    '''

        with tmpdir.as_cwd():
            tmpdir.join('t.py').write(t_py_src)
>           _call_main(['t.py'], retv=0)

tests/integration/test_main.py:234:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a77090>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
________________ test_physical_line_file_not_ending_in_newline _________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_physical_line_file_not_en0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5a7a8d0>

    def test_physical_line_file_not_ending_in_newline(tmpdir, capsys):
        """See https://github.com/PyCQA/pycodestyle/issues/960."""
        t_py_src = 'def f():\n\tpass'

        with tmpdir.as_cwd():
            tmpdir.join('t.py').write(t_py_src)
>           _call_main(['t.py'], retv=1)

tests/integration/test_main.py:246:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a66b90>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
__________ test_physical_line_file_not_ending_in_newline_trailing_ws ___________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_physical_line_file_not_en1')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5819a10>

    def test_physical_line_file_not_ending_in_newline_trailing_ws(tmpdir, capsys):
        """See https://github.com/PyCQA/pycodestyle/issues/960."""
        t_py_src = 'x = 1   '

        with tmpdir.as_cwd():
            tmpdir.join('t.py').write(t_py_src)
>           _call_main(['t.py'], retv=1)

tests/integration/test_main.py:261:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff57ae8d0>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
________ test_obtaining_args_from_sys_argv_when_not_explicity_provided _________

capsys = <_pytest.capture.CaptureFixture object at 0x7ffff59c7110>

    def test_obtaining_args_from_sys_argv_when_not_explicity_provided(capsys):
        """Test that arguments are obtained from 'sys.argv'."""
        with mock.patch('sys.argv', ['flake8', '--help']):
>           _call_main(None)

tests/integration/test_main.py:273:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a28110>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:142 Found local configuration files: ['/build/flake8-3.9.2/setup.cfg', '/build/flake8-3.9.2/tox.ini']
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_______________________ test_cli_config_option_respected _______________________

tmp_path = PosixPath('/build/pytest-of-nixbld/pytest-0/test_cli_config_option_respect0')

    def test_cli_config_option_respected(tmp_path):
        """Test --config is used."""
        config = tmp_path / "flake8.ini"
        config.write_text(u"""\
    [flake8]
    ignore = F401
    """)

        py_file = tmp_path / "t.py"
        py_file.write_text(u"import os\n")

>       _call_main(["--config", str(config), str(py_file)])

tests/integration/test_main.py:291:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff698c1d0>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:338 Reading local plugins only from "/build/pytest-of-nixbld/pytest-0/test_cli_config_option_respect0/flake8.ini" specified via --config by the user
DEBUG    flake8.options.config:config.py:99 Found cli configuration files: ['/build/pytest-of-nixbld/pytest-0/test_cli_config_option_respect0/flake8.ini']
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
__________________ test_cli_isolated_overrides_config_option ___________________

tmp_path = PosixPath('/build/pytest-of-nixbld/pytest-0/test_cli_isolated_overrides_co0')

    def test_cli_isolated_overrides_config_option(tmp_path):
        """Test --isolated overrides --config."""
        config = tmp_path / "flake8.ini"
        config.write_text(u"""\
    [flake8]
    ignore = F401
    """)

        py_file = tmp_path / "t.py"
        py_file.write_text(u"import os\n")

>       _call_main(["--isolated", "--config", str(config), str(py_file)], retv=1)

tests/integration/test_main.py:305:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff55dbd50>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:329 Refusing to look for local plugins in configurationfiles due to user-requested isolation
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_____________________________ test_file_not_found ______________________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_file_not_found0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff57e4490>

    def test_file_not_found(tmpdir, capsys):
        """Ensure that a not-found file / directory is an error."""
        with tmpdir.as_cwd():
>           _call_main(["i-do-not-exist"], retv=1)

tests/integration/test_main.py:311:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff59c21d0>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_______________________________ test_output_file _______________________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_output_file0')
capsys = <_pytest.capture.CaptureFixture object at 0x7ffff5a76090>

    def test_output_file(tmpdir, capsys):
        """Ensure that --output-file is honored."""
        tmpdir.join('t.py').write('import os\n')

        with tmpdir.as_cwd():
>           _call_main(['t.py', '--output-file=f'], retv=1)

tests/integration/test_main.py:322:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/integration/test_main.py:14: in _call_main
    cli.main(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/cli.py:22: in main
    app.run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:363: in run
    self._run(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:350: in _run
    self.initialize(argv)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a58b50>), nargs=0, help='Print information necessary when preparing a bug report')".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_____________________ test_enable_local_plugin_from_config _____________________

    def test_enable_local_plugin_from_config():
        """App can load a local plugin from config file."""
        app = application.Application()
>       app.initialize(['flake8', '--config', LOCAL_PLUGIN_CONFIG])

tests/integration/test_plugins.py:43:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5a21c90>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:338 Reading local plugins only from "tests/fixtures/config_files/local-plugin.ini" specified via --config by the user
DEBUG    flake8.options.config:config.py:99 Found cli configuration files: ['tests/fixtures/config_files/local-plugin.ini']
DEBUG    flake8.plugins.manager:manager.py:278 Loaded Plugin(name="XE", entry_point="test_plugins:ExtensionTestPlugin") for plugin "XE".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
_______________________ test_local_plugin_can_add_option _______________________

    def test_local_plugin_can_add_option():
        """A local plugin can add a CLI option."""
        app = application.Application()
        app.initialize(
>           ['flake8', '--config', LOCAL_PLUGIN_CONFIG, '--anopt', 'foo'])

tests/integration/test_plugins.py:53:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff5acb490>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:338 Reading local plugins only from "tests/fixtures/config_files/local-plugin.ini" specified via --config by the user
DEBUG    flake8.options.config:config.py:99 Found cli configuration files: ['tests/fixtures/config_files/local-plugin.ini']
DEBUG    flake8.plugins.manager:manager.py:278 Loaded Plugin(name="XE", entry_point="test_plugins:ExtensionTestPlugin") for plugin "XE".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
________________ test_enable_local_plugin_at_non_installed_path ________________

    def test_enable_local_plugin_at_non_installed_path():
        """Can add a paths option in local-plugins config section for finding."""
        app = application.Application()
>       app.initialize(['flake8', '--config', LOCAL_PLUGIN_PATH_CONFIG])

tests/integration/test_plugins.py:61:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:330: in initialize
    self.find_plugins(config_finder)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/main/application.py:153: in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:357: in __init__
    self.namespace, local_plugins=local_plugins
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:238: in __init__
    self._load_entrypoint_plugins()
/nix/store/c6b1jix4w8jdj7pzmw4saswpz9bfcxkm-python3.7-flake8-3.9.2/lib/python3.7/site-packages/flake8/plugins/manager.py:254: in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = {'console_scripts': [EntryPoint(name='flake8', value='flake8.main.cli:main', group='console_scripts'), EntryPoint(name..._finalize', value='setuptools.dist:_Distribution.finalize_options', group='setuptools.finalize_distribution_options')]}
name = 'flake8.extension', default = ()

    def get(self, name, default=None):
>       self._warn()
E       DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.

/nix/store/njxn9irhqdk7ypq95jlxkk34qp9i3jw0-python3.7-importlib-metadata-4.6.4/lib/python3.7/site-packages/importlib_metadata/__init__.py:406: DeprecationWarning
------------------------------ Captured log call -------------------------------
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-q, --quiet, action='count', default=0, help='Report only file names, or nothing. This option is repeatable.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--count, action='store_true', help='Print total number of errors and warnings to standard error and set the exit code to 1 if total is not empty.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--diff, action='store_true', help='Report changes only within line number ranges in the unified diff provided on standard in by the user.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exclude, default='.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to exclude. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-exclude, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=True), help='Comma-separated list of files or directories to add to the list of excluded ones.', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--filename, default='*.py', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Only check for filenames matching the patterns in this comma-separated list. (Default: %(default)s)', metavar='patterns')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--stdin-display-name, default='stdin', help='The name used when reporting errors from code passed via stdin. This is useful for editors piping the file contents to flake8. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--format, default='default', help='Format errors according to the chosen formatter.', metavar='format')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--hang-closing, action='store_true', help="Hang closing bracket instead of matching indentation of opening bracket's line.")".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--ignore, default='E121,E123,E126,E226,E24,E704,W503,W504', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to ignore (or skip). For example, ``--ignore=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--extend-ignore, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to add to the list of ignored ones. For example, ``--extend-ignore=E4,E51,W234``.', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--per-file-ignores, default='', help='A pairing of filenames and violation codes that defines which violations to ignore in a particular file. The filenames can be specified in a manner similar to the ``--exclude`` option and the violations work similarly to the ``--ignore`` and ``--select`` options.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-line-length, default=79, type=<class 'int'>, help='Maximum allowed line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--max-doc-length, default=None, type=<class 'int'>, help='Maximum allowed doc line length for the entirety of this run. (Default: %(default)s)', metavar='n')".
WARNING  flake8.options.manager:manager.py:189 option --indent-size: please update `help=` text to use %(default)s instead of %default -- this will be an error in the future
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--indent-size, default=4, type=<class 'int'>, help='Number of spaces used for indentation (Default: %(default)s)', metavar='n')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--select, default='E,F,W,C90', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Comma-separated list of errors and warnings to enable. For example, ``--select=E4,E51,W234``. (Default: %(default)s)', metavar='errors')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--disable-noqa, action='store_true', default=False, help='Disable the effect of "# noqa". This will report errors on lines with "# noqa" at the end.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--show-source, action='store_true', help='Show the source generate each error or warning.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--no-show-source, action='store_false', dest='show_source', help='Negate --show-source')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--statistics, action='store_true', help='Count errors and warnings.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--enable-extensions, default='', type=functools.partial(<function _flake8_normalize at 0x7ffff641a320>, comma_separated_list=True, normalize_paths=False), help='Enable plugins and extensions that are otherwise disabled by default')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--exit-zero, action='store_true', help='Exit with status code "0" even if there are errors.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--install-hook, action=<class 'flake8.main.vcs.InstallAction'>, choices=['git', 'mercurial'], help='Install a hook that is run prior to a commit for the supported version control system.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(-j, --jobs, default='auto', type=<class 'flake8.main.options.JobsArgument'>, help='Number of subprocesses to use to run checks in parallel. This is ignored on Windows. The default, "auto", will auto-detect the number of processors available to use. (Default: %(default)s)')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--tee, action='store_true', default=False, help='Write to stdout and output-file.')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--benchmark, action='store_true', default=False, help='Print benchmark information about this run of Flake8')".
DEBUG    flake8.options.manager:manager.py:417 Registered option "Option(--bug-report, action=functools.partial(<class 'flake8.main.debug.DebugAction'>, option_manager=<flake8.options.manager.OptionManager object at 0x7ffff57ae610>), nargs=0, help='Print information necessary when preparing a bug report')".
DEBUG    flake8.options.config:config.py:338 Reading local plugins only from "tests/fixtures/config_files/local-plugin-path.ini" specified via --config by the user
DEBUG    flake8.options.config:config.py:99 Found cli configuration files: ['tests/fixtures/config_files/local-plugin-path.ini']
DEBUG    flake8.plugins.manager:manager.py:278 Loaded Plugin(name="XE", entry_point="aplugin:ExtensionTestPlugin2") for plugin "XE".
INFO     flake8.plugins.manager:manager.py:253 Loading entry-points for "flake8.extension".
=================== 23 failed, 437 passed, 1 error in 2.38s ====================
builder for '/nix/store/ykjgwfrqqf6zjx2v9k8jl743aqsgpn1z-python3.7-flake8-3.9.2.drv' failed with exit code 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
