### PR TITLE
kubernetes-helmPlugins.helm-git: init at 0.10.0

### DIFF
--- a/pkgs/applications/networking/cluster/helm/plugins/default.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/default.nix
@@ -2,10 +2,12 @@
 
 {
 
-  helm-diff = callPackage ./helm-diff.nix {};
+  helm-diff = callPackage ./helm-diff.nix { };
 
-  helm-s3 = callPackage ./helm-s3.nix {};
+  helm-git = callPackage ./helm-git.nix { };
 
-  helm-secrets = callPackage ./helm-secrets.nix {};
+  helm-s3 = callPackage ./helm-s3.nix { };
+
+  helm-secrets = callPackage ./helm-secrets.nix { };
 
 }

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-git.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-git.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, coreutils
+, findutils
+, git
+, gnugrep
+, gnused
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "helm-git";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "aslafy-z";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hvycqibmlw2zw3nm8rn73v5x1zcgm2jrfdlljbvc1n4n5vnzdrg";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # NOTE: helm-git is comprised of shell scripts.
+  dontBuild = true;
+
+  installPhase = ''
+    install -dm755 $out/helm-git
+    install -m644 -Dt $out/helm-git plugin.yaml
+    cp helm-git helm-git-plugin.sh $out/helm-git/
+
+    patchShebangs $out/helm-git/helm-git{,-plugin.sh}
+    wrapProgram $out/helm-git/helm-git \
+        --prefix PATH : ${lib.makeBinPath [ coreutils findutils git gnugrep gnused ]}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The Helm downloader plugin that provides GIT protocol support";
+    inherit (src.meta) homepage;
+    license = licenses.mit;
+    maintainers = with maintainers; [ flokli ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
This is necessary for running `helm` with a helmfile.yaml containing
git+https URLs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
