### PR TITLE
semgrep: init at 0.73.0

### DIFF
--- a/pkgs/development/tools/semgrep/default.nix
+++ b/pkgs/development/tools/semgrep/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchzip, stdenvNoCC }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "semgrep";
+  version = "0.73.0";
+
+  src = fetchzip {
+    url = "https://github.com/returntocorp/semgrep/releases/download/v${version}/semgrep-v${version}-ubuntu-16.04.tgz";
+    sha256 = "sha256-pdl5wqFtOW7TP/TQfj0yjtw+EkfOBGQvPOTBSuSGl0E=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp * $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Lightweight static analysis for many languages";
+    homepage = "https://semgrep.dev";
+    license = licenses.lgpl21Only;
+    mainProgram = "semgrep-core";
+    maintainers = with maintainers; [ ambroisie ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9149,6 +9149,8 @@ with pkgs;
 
   seexpr = callPackage ../development/compilers/seexpr { };
 
+  semgrep = callPackage ../development/tools/semgrep { };
+
   setroot = callPackage  ../tools/X11/setroot { };
 
   setserial = callPackage ../tools/system/setserial { };


### PR DESCRIPTION
###### Motivation for this change

Issue #138018.

This just relies on upstream's static binaries instead of building from source, as the packaging story is not great for now (see my WIP branch https://github.com/ambroisie/nixpkgs/tree/add-semgrep).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
