### PR TITLE
goredo: init at 1.21.0

### DIFF
--- a/pkgs/development/tools/build-managers/goredo/default.nix
+++ b/pkgs/development/tools/build-managers/goredo/default.nix
@@ -1,0 +1,58 @@
+{ buildGoModule
+, fetchurl
+, lib
+, zstd
+, sharness
+, python3
+, perl
+}:
+
+buildGoModule rec {
+  pname = "goredo";
+  version = "1.21.0";
+
+  src = fetchurl {
+    url = "http://www.goredo.cypherpunks.ru/download/${pname}-${version}.tar.zst";
+    hash = "sha256-h882pt+xZWlhFLQar1kfmSAzMscwMXAajT6ezZl9P8M=";
+  };
+
+  patches = [ ./fix-tests.diff ];
+
+  nativeBuildInputs = [ zstd ];
+
+  checkInputs = lib.optionals doCheck [ python3 perl ];
+
+  SHARNESS_TEST_SRCDIR = sharness + "/share/sharness";
+
+  vendorSha256 = null;
+  subPackages = [ "." ];
+
+  preBuild = "cd src";
+
+  postBuild = ''
+    ( cd $GOPATH/bin; ./goredo -symlinks )
+    cd ..
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    export PATH=$GOPATH/bin:$PATH
+    prove -f
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/share/info"
+    cp goredo.info "$out/share/info"
+  '';
+
+  outputs = [ "out" "info" ];
+
+  meta = with lib; {
+    description = "djb's redo, a system for building files from source files. Written in Go";
+    homepage = "https://www.goredo.cypherpunks.ru";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.spacefrogg ];
+  };
+}

--- a/pkgs/development/tools/build-managers/goredo/fix-tests.diff
+++ b/pkgs/development/tools/build-managers/goredo/fix-tests.diff
@@ -1,0 +1,36 @@
+diff -ur goredo-1.4.1/t/apenwarr/105-sympath/all.do goredo-1.4.1.new/t/apenwarr/105-sympath/all.do
+--- goredo-1.4.1/t/apenwarr/105-sympath/all.do	2021-04-29 14:03:11.000000000 +0200
++++ goredo-1.4.1.new/t/apenwarr/105-sympath/all.do	2021-05-10 15:04:46.912799930 +0200
+@@ -11,12 +11,13 @@
+ 	(
+ 		cd y/x/x/x/x/x
+ 		IFS=$(printf '\n')
++		_wd=$(env pwd)
+ 		redo-ifchange static x/x/x/static $PWD/static \
+-			$(/bin/pwd)/static /etc/passwd
++			$_wd/static /etc/passwd
+ 		# goredo: that symlink path is not resolving even at OS level
+ 		# redo-ifchange $PWD/../static 2>/dev/null && exit 35
+ 		redo-ifchange 1.dyn x/x/x/2.dyn $PWD/3.dyn \
+-			 $PWD/../4.dyn $(/bin/pwd)/5.dyn
++			 $PWD/../4.dyn $_wd/5.dyn
+ 	)
+ 	[ -e y/1.dyn ] || exit $((iter + 1))
+ 	[ -e y/2.dyn ] || exit $((iter + 2))
+diff -ur goredo-1.4.1/t/apenwarr/clean.do goredo-1.4.1.new/t/apenwarr/clean.do
+--- goredo-1.4.1/t/apenwarr/clean.do	2021-04-29 14:03:11.000000000 +0200
++++ goredo-1.4.1.new/t/apenwarr/clean.do	2021-05-10 15:06:07.099591609 +0200
+@@ -1,3 +1,3 @@
+-/bin/ls [0-9s][0-9][0-9]*/clean.do |
++env ls [0-9s][0-9][0-9]*/clean.do |
+ sed 's/\.do$//' |
+ xargs redo
+diff -ur goredo-1.4.1/t/redo-sh.tests/clean.do goredo-1.4.1.new/t/redo-sh.tests/clean.do
+--- goredo-1.4.1/t/redo-sh.tests/clean.do	2021-04-29 14:03:11.000000000 +0200
++++ goredo-1.4.1.new/t/redo-sh.tests/clean.do	2021-05-10 15:02:41.607562802 +0200
+@@ -1,4 +1,4 @@
+ for f in * ; do
+     [ -d $f ] || continue
+-    find $f ! -name test -delete
++    find $f ! -name test -delete || true
+ done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14376,6 +14376,8 @@ with pkgs;
 
   gocd-server = callPackage ../development/tools/continuous-integration/gocd-server { };
 
+  goredo = callPackage ../development/tools/build-managers/goredo { };
+
   gotify-server = callPackage ../servers/gotify { };
 
   gotty = callPackage ../servers/gotty { };


### PR DESCRIPTION
A new redo implementation written in go.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
