### PR TITLE
nixos/gdm: remove obsolete pulseaudio module

### DIFF
--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -26,7 +26,6 @@ let
     load-module module-udev-detect
     load-module module-native-protocol-unix
     load-module module-default-device-restore
-    load-module module-rescue-streams
     load-module module-always-sink
     load-module module-intended-roles
     load-module module-suspend-on-idle


### PR DESCRIPTION
###### Motivation for this change

PulseAudio 14.0 has deprecated that module and moved its functionality into
the core, it does nothing other than printing an error at every start.


###### Things done

Just removed the module as per PulseAudio's [14.0 release documentation](https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/14.0/#module-rescue-streamsisdeprecatedfunctionalitymovedtothecore).

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
