### PR TITLE
swtpm: improvements for use with libvirt

### DIFF
--- a/pkgs/tools/security/swtpm/default.nix
+++ b/pkgs/tools/security/swtpm/default.nix
@@ -42,7 +42,20 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-cuse"
+    "--localstatedir=/var"
   ];
+
+  prePatch = ''
+    # Makefile tries to create the directory /var/lib/swtpm-localcafor, which fails
+    substituteInPlace samples/Makefile.am \
+        --replace 'install-data-local:' 'do-not-execute:'
+
+    # Use the correct path to the certtool binary
+    # instead of relying on it being in the environment
+    substituteInPlace samples/swtpm_localca.c --replace \
+        '# define CERTTOOL_NAME "certtool"' \
+        '# define CERTTOOL_NAME "${gnutls}/bin/certtool"'
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
Before, the state directory was set to a path in the Nix store, which isn't writable and so makes for a terrible directory for storing state. See https://github.com/NixOS/nixpkgs/issues/141224 for a more detailed explanation.
Also, swtpm-localca tried to use certtool from the environment. Change the path so it refers directly to certtool in the Nix store.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).