### PR TITLE
ms-toolsai.jupyter: 2021.5.745244803 -> 2021.9.1101343141

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -1176,17 +1176,7 @@ let
         };
       };
 
-      ms-toolsai.jupyter = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "jupyter";
-          publisher = "ms-toolsai";
-          version = "2021.5.745244803";
-          sha256 = "0gjpsp61l8daqa87mpmxcrvsvb0pc2vwg7xbkvwn0f13c1739w9p";
-        };
-        meta = {
-          license = lib.licenses.unfree;
-        };
-      };
+      ms-toolsai.jupyter = callPackage ./ms-toolsai-jupyter {};
 
       mvllow.rose-pine = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/misc/vscode-extensions/ms-toolsai-jupyter/default.nix
+++ b/pkgs/misc/vscode-extensions/ms-toolsai-jupyter/default.nix
@@ -1,0 +1,43 @@
+{ lib, vscode-utils, jq, moreutils }:
+
+let
+  inherit (vscode-utils) buildVscodeMarketplaceExtension;
+
+
+in buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "jupyter";
+    publisher = "ms-toolsai";
+    version = "2021.9.1101343141";
+    sha256 = "1c5dgkk5yn6a8k3blbqakqdy8ppwgfbm0ciki7ix696bvlksbpdg";
+  };
+
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+
+  postPatch = ''
+    # Patch 'packages.json' so that the expected '__metadata' field exists.
+    # This works around observed extension load failure on vscode's attempt
+    # to rewrite 'packages.json' with this new information.
+    print_jq_query() {
+        cat <<"EOF"
+    .__metadata = {
+      "id": "6c2f1801-1e7f-45b2-9b5c-7782f1e076e8",
+      "publisherId": "ac8eb7c9-3e59-4b39-8040-f0484d8170ce",
+      "publisherDisplayName": "Microsoft",
+      "installedTimestamp": 0
+    }
+    EOF
+    }
+    jq "$(print_jq_query)" ./package.json | sponge ./package.json
+  '';
+
+  meta = with lib; {
+    description = "Jupyter extension for vscode";
+    homepage = "https://github.com/microsoft/vscode-jupyter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jraygauthier ];
+  };
+}

--- a/pkgs/misc/vscode-extensions/ms-toolsai-jupyter/default.nix
+++ b/pkgs/misc/vscode-extensions/ms-toolsai-jupyter/default.nix
@@ -3,7 +3,6 @@
 let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
 
-
 in buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "jupyter";


### PR DESCRIPTION
Also patches the extension to fix the observed load issue.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix broken extension observed on both stable (21.05) and unstable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested the extension using `code ` from the following nix env:

```bash
$ nix-shell -I nixpkgs=. -p 'with import <nixpkgs> {}; vscode-with-extensions.override{ vscodeExtensions = with vscode-extensions; [ ms-toolsai.jupyter ]; }'
```

Extension now properly load and is able to open and edit `*.ipynb` files.

Might be a good thing to backport to 21.05 as well.