### PR TITLE
google_cloud_sdk: 351.0.0 -> 360.0.0

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -13,7 +13,7 @@ let
   pythonEnv = python.withPackages (p: with p; [
     cffi
     cryptography
-    pyopenssl
+    openssl
     crcmod
   ] ++ lib.optional (with-gce) google-compute-engine);
 
@@ -21,33 +21,33 @@ let
   sources = name: system: {
     x86_64-darwin = {
       url = "${baseUrl}/${name}-darwin-x86_64.tar.gz";
-      sha256 = "1a17bbvimdqq4k25lprqk9cq3lpfchd65hzjf23ha4imndpbjgqr";
+      sha256 = "0cjy6znhpv90mj7463lghmzhivwhaxa7q9da37wdpwh53h7kf05r";
     };
 
     aarch64-darwin = {
       url = "${baseUrl}/${name}-darwin-arm.tar.gz";
-      sha256 = "184k1kv10g4zzzxgmwpakvg5ffxhz01dd01kb5h32mf1j5fid1zh";
+      sha256 = "0phby3s9375zyphjwk1hrpr8fiybik1ag3yfnpmi7msq54lf4h3x";
     };
 
     x86_64-linux = {
       url = "${baseUrl}/${name}-linux-x86_64.tar.gz";
-      sha256 = "0hhaq5hf5nvaah06h6v8q2hpn8hc815ihsi74dpwg6pmg9h266pr";
+      sha256 = "0j1n8mzck3sizjslm12x4lgxklw1xvbxp2186xnxm4pmj4kwp4k1";
     };
 
     i686-linux = {
       url = "${baseUrl}/${name}-linux-x86.tar.gz";
-      sha256 = "14z1nzwc0j3qhbw2ldrskd8zjsslwgsw7pxxq3v0ypc1rjibsql5";
+      sha256 = "1sll47bhd4x5r0z65325ak0wbbky07qbzqkf7w97nilv7wz5dgxa";
     };
 
     aarch64-linux = {
       url = "${baseUrl}/${name}-linux-arm.tar.gz";
-      sha256 = "0f6xrij2wbx57s4897bi12l9fz3flj1wyibbk7jjg0l5332h4yhr";
+      sha256 = "1jk17fn3q1i625q1cdyxlvv58rw9ma7lwvngc04jqrccczsl1jqr";
     };
   }.${system};
 
 in stdenv.mkDerivation rec {
   pname = "google-cloud-sdk";
-  version = "351.0.0";
+  version = "360.0.0";
 
   src = fetchurl (sources "${pname}-${version}" stdenv.hostPlatform.system);
 

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -43,7 +43,7 @@ let
       url = "${baseUrl}/${name}-linux-arm.tar.gz";
       sha256 = "1jk17fn3q1i625q1cdyxlvv58rw9ma7lwvngc04jqrccczsl1jqr";
     };
-  }.${system} or (throw "Unsopported system: ${system}");
+  }.${system} or (throw "Unsupported system: ${system}");
 
 in stdenv.mkDerivation rec {
   pname = "google-cloud-sdk";

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -43,7 +43,7 @@ let
       url = "${baseUrl}/${name}-linux-arm.tar.gz";
       sha256 = "1jk17fn3q1i625q1cdyxlvv58rw9ma7lwvngc04jqrccczsl1jqr";
     };
-  }.${system};
+  }.${system} or (throw "Unsopported system: ${system}");
 
 in stdenv.mkDerivation rec {
   pname = "google-cloud-sdk";

--- a/pkgs/tools/admin/google-cloud-sdk/gcloud-path.patch
+++ b/pkgs/tools/admin/google-cloud-sdk/gcloud-path.patch
@@ -33,15 +33,14 @@ diff --git a/lib/googlecloudsdk/api_lib/container/kubeconfig.py b/lib/googleclou
 index 4330988d6..37424b841 100644
 --- a/lib/googlecloudsdk/api_lib/container/kubeconfig.py
 +++ b/lib/googlecloudsdk/api_lib/container/kubeconfig.py
-@@ -255,7 +255,7 @@ def _AuthProvider(name='gcp'):
-       raise Error(SDK_BIN_PATH_NOT_FOUND)
+@@ -352,7 +352,7 @@ def _AuthProvider(name='gcp',
+       if sdk_bin_path is None:
+         log.error(SDK_BIN_PATH_NOT_FOUND)
+         raise Error(SDK_BIN_PATH_NOT_FOUND)
+-      cmd_path = os.path.join(sdk_bin_path, bin_name)
++      cmd_path = bin_name
+ 
      cfg = {
          # Command for gcloud credential helper
--        'cmd-path': os.path.join(sdk_bin_path, bin_name),
-+        'cmd-path': bin_name,
-         # Args for gcloud credential helper
-         'cmd-args': 'config config-helper --format=json',
-         # JSONpath to the field that is the raw access token
 -- 
 2.21.0
-

--- a/pkgs/tools/admin/google-cloud-sdk/gsutil-disable-updates.patch
+++ b/pkgs/tools/admin/google-cloud-sdk/gsutil-disable-updates.patch
@@ -2,7 +2,7 @@ diff --git a/platform/gsutil/gslib/command_runner.py b/platform/gsutil/gslib/com
 index f490bb3..dc6bbcc 100644
 --- a/platform/gsutil/gslib/command_runner.py
 +++ b/platform/gsutil/gslib/command_runner.py
-@@ -330,17 +330,6 @@ class CommandRunner(object):
+@@ -330,18 +330,6 @@ class CommandRunner(object):
      Returns:
        Return value(s) from Command that was run.
      """
@@ -17,10 +17,11 @@ index f490bb3..dc6bbcc 100644
 -      if system_util.IsRunningInteractively() and collect_analytics:
 -        metrics.CheckAndMaybePromptForAnalyticsEnabling()
 -
+-    self.MaybePromptForPythonUpdate(command_name)
+ 
      if not args:
        args = []
- 
-@@ -413,18 +402,10 @@ class CommandRunner(object):
+@@ -415,15 +403,6 @@ class CommandRunner(object):
        ShutDownGsutil()
      if GetFailureCount() > 0:
        return_code = 1
@@ -34,6 +35,10 @@ index f490bb3..dc6bbcc 100644
 -              'issued prior to the update was not executed and should be re-run.'
 -          )))
      return return_code
+ 
+   def SkipUpdateCheck(self):
+@@ -467,6 +446,7 @@ class CommandRunner(object):
+     return True
  
    def MaybeCheckForAndOfferSoftwareUpdate(self, command_name, debug):
 +    return False


### PR DESCRIPTION
###### Motivation for this change
351.0.0 depends on pyOpenSSL, which uses CFFI to write dynamic code to an executable memory page. This is an old style callback that is prohibited in Apple's silicon. 360.0.0 relies on openSSL instead. Updating will make the package work properly on Apple's silicon, and is an update for everyone.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
