### PR TITLE
terraform-provider-vault: 2.11.0 -> 2.24.1

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -1093,12 +1093,13 @@
     "version": "0.1.0"
   },
   "vault": {
-    "owner": "terraform-providers",
+    "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/vault",
     "repo": "terraform-provider-vault",
-    "rev": "v2.11.0",
-    "sha256": "1yzakc7jp0rs9axnfdqw409asrbjhq0qa7xn4xzpi7m94g1ii12d",
-    "version": "2.11.0"
+    "rev": "v2.24.1",
+    "sha256": "1xk14q06js774lqyylkbp53dnlsbgh3vi38mqqmndh80xigs6d99",
+    "version": "2.24.1",
+    "vendorSha256": "1ksla455qfgxpk2dmq3pg52nyyw3v0bg6fm5s60j6cb0lzvjbq48"
   },
   "vcd": {
     "owner": "terraform-providers",


### PR DESCRIPTION

###### Motivation for this change

Standard package bump.

Changelog:

2.24.0 (September 15, 2021)

FEATURES:

    New Database Resource: Added support for the snowflake-database-plugin to vault_database_secret_backend_connection (#983)
    resource/vault_raft_snapshot_agent_config: Provision Raft Snapshot Agent Configurations in Vault Enterprise. (#1139)

IMPROVEMENTS:

    resource/database_secret_backend_connection: Add username_template to vault_database_secret_backend_connection (#1103)
    resource/ldap_auth_backend: Allow the creation of local mounts (#1115)
    resource/jwt_auth_backend: Allow the creation of local mounts (#1115)
    resource/consul_secret_backend: Allow the creation of local mounts (#1115)

BUGS:

    resource/vault_identity_group: Fix bug where member_entity_ids & member_group_ids were attempted to be managed on external identity groups (#1134)

2.23.0 (August 18, 2021)

FEATURES:

    New Resource vault_gcp_secret_static_account: Provision Static Accounts in the GCP Secrets Engine (#1094)

IMPROVEMENTS:

    resource/database_secret_backend/mysql: Add tls_certificate_key and tls_ca options (#1098)

BUGS:

    resource/jwt_auth_backend: Fixed bug where provider_config did not configure non-string values correctly (#1118)
    resource/gcp_auth_backend: Support importing resource (#1125)
    resource/okta_auth_backend: Support importing resource (#1123)
    resource/audit: List audit only once during read (#1138)
    resource/identity_oidc_key: Error handling for identity oidc key vault calls (#1142)

2.22.1 (July 23, 2021)

BUGS:

    resource/vault_identity_group: Correctly handle the case of a preexisting identity group, suggest resource import in this case (#1014)
    resource/jwt_auth_backend: Reverted (#960) due to migration errors (#1114)

2.22.0 (July 22, 2021)

FEATURES:

    New Resource vault_quota_lease_count: Adds ability to manage lease-count quota's (Vault Enterprise Feature) (#948)

IMPROVEMENTS:

    Remove last dependency on github.com/terraform-providers (#1090)

BUGS:

    resource/vault_identity_group: Fix bug where metadata values are not removed if removed from file (#1061)
    resource/jwt_auth_backend: Fixed bug where provider_config only supported string values (#960)
    provider: Fix inconsistent handling of namespace when wrapping_ttl was specified in any resource (#1107)

2.21.0 (June 17, 2021)

FEATURES:

    data/vault_gcp_auth_backend_role: Added GCP auth role data source to fetch role ID (#1011)

IMPROVEMENTS:

    provider/auth_login: Supprt AWS STS signing when method=aws for in auth_type (#1060)
    resource/vault_ldap_auth_backend: Add client_tls_cert and client_tls_key options (#1074)
    resource/vault_identity_entityAdded additional logging information about entity (#987)

2.20.0 (May 19, 2021)

IMPROVEMENTS:

    resource/vault_azure_secret_backend: Added support for updating the backend (#1009)
    resource/vault_aws_secret_backend: Add iam_endpoint and sts_endpoint options (#1043)

BUG FIXES:

    resource/vault_gcp_auth_backend: Support nested backend paths (#1050)
    resource/vault_kubernetes_auth_backend_role: allow unset audience (#1022)
    resource/vault_identity_entity: Fix bug where values are not removed if removed from file (#1054)

2.19.1 (April 21, 2021)

SECURITY:

    resource/vault_gcp_auth_backend_role: Fixed typo in bound_labels parameter name causing no values to be applied to created roles CVE-2021-30476 (#1028)

2.19.0 (March 17, 2021)

FEATURES:

    New Resource: terraform_cloud_secret resources (#959)

IMPROVEMENTS:

    resource/pki_secret_backend: Support allowed_domains_template option for vault_pki_secret_backend_role (#869)

BUG FIXES:

    resource/vault_identity_group: Don't send name parameter unless specified (#1002)

2.18.0 (January 21, 2021)

FEATURES:

    New Resource: vault_password_policy resource (#927)

IMPROVEMENTS:

    resource/vault_consul_secret_backend: Extend consul secret engine definition to cover all vault parameters (#910)
    resource/vault_jwt_auth_backend: Added support for provider_config (#943)

2.17.0 (December 15, 2020)

FEATURES:

    New Data Source: vault_nomad_access_token data source (#923)
    New Resource: vault_nomad_secret_backend resource (#923)
    New Resource: vault_nomad_secret_role resource (#923)

IMPROVEMENTS:

    resource/vault_audit: added support for local mount to prevent replicating the audit backend (#915)
    resource/jwt_auth_backend_role: Added support for using globs in matching bound_claims (#877)
    resource/vault_aws_auth_backend_client: Added sts_region parameter (#931)
    resource/vault_azure_secret_backend_role: Added support for azure_groups (#891)
    resource/vault_identity_oidc_role: client_id parameter can optionally be configured (#815)

BUG FIXES:

    resource/vault_identity_entity: Fixed nil pointer exception (#899)
    resource/vault_mount: Fixed bug where mount was deleted when description was changed (#929)

2.16.0 (November 19, 2020)

FEATURES:

    New Data Source: vault_ad_access_credentials data source (#902)
    New Resource: vault_ad_secret_backend resource (#902)
    New Resource: vault_ad_secret_role resource (#902)
    New Resource: vault_ad_secret_library resource (#902)

IMPROVEMENTS:

    resource/vault_gcp_auth_backend: added support for local mount to prevent replicating the secret engine (#861)
    data.vault_aws_access_credentials: Add optional ttl parameter to data source (#878)

BUG FIXES:

    resource/vault_jwt_auth_backend: Fix possible reoccuring diff when using oidc_client_secret (#803)

2.15.0 (October 21, 2020)

FEATURES:

    New Data Source: vault_transit_decrypt data source (#872).
    New Data Source: vault_transit_encrypt data source (#872).

IMPROVEMENTS:

    resource/vault_gcp_secret_backend: added support for local mount to prevent replicating the secret engine (#855)
    resource/vault_ssh_secret_backend_role: added support for new allowed_users_template argument(#875)
    resource/vault_ssh_secret_backend_role: added support for new algorithm_signer argument(#809)
    resource/vault_kubernetes_auth_backend_config: Add disable_iss_validation and disable_local_ca_jwt config parameters to k8s auth backend (#870)
    data/vault_kubernetes_auth_backend_config: Add disable_iss_validation and disable_local_ca_jwt config parameters to k8s auth backend (#870)

2.14.0 (September 15, 2020)

FEATURES:

    New Resource: vault_quota_rate_limit resource to manage resource quota limit (#825).

BUG FIXES:

    resource/vault_aws_secret_backend_role: fix AWS Secrets Engine Role resource to allow only IAM Groups (#862)
    resource/vault_ssh_secret_backend_ca: detect misconfigured resource and remove from state (#856)

2.13.0 (August 27, 2020)

IMPROVEMENTS:

    resource/transit_secret_backend_key: add supported by Vault type of algorithm rsa-3072 (#773)
    data.vault_generic_secret: Mark data and data_json as Sensitive (#844)
    Add iam_groups to vault_aws_secret_backend_role (#826)
    Add support for uri_sans parameter for resource vault_pki_secret_backend_cert (#759)

BUG FIXES:

    data/vault_generic_secret: Fix perpetual diff when using Terraform v0.13.0 (#849)
    data.vault_aws_access_credentials: Re-add support for passing region information stored in Vault backend to AWS Config (#841)

2.12.2 (July 31, 2020)

BUG FIXES:

    data.vault_aws_access_credentials: Revert #832, which inadvertently introduced issues when the token policy did not have the required permissions to read the root configuration. (#837)

2.12.1 (July 30, 2020)

BUG FIXES:

    data.vault_aws_access_credentials: Add support for passing region information stored in Vault backend to AWS Config (#832)

2.12.0 (July 20, 2020)

FEATURES:

    New Resource: vault_identity_group_member_entity_ids (#724).
    New Resource: vault_transform_alphabet (#783).
    New Resource: vault_transform_role (#783).
    New Resource: vault_transform_template (#783).
    New Resource: vault_transform_transformation (#783).
    New Data Source: vault_transform_encode data source (#783).
    New Data Source: vault_transform_decode data source (#783).

IMPROVEMENTS:

    resource/vault_mount: Adds support for the external_entropy_access field (#792).
    resource/vault_jwt_auth_backend: enable existing JWT Auth backends to be imported (#806).
    resource/vault_jwt_auth_backend: store type and tune information in state (#806).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
