### PR TITLE
terraform-provider-libvirt: 0.6.3 -> 0.6.11

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
@@ -41,6 +41,9 @@ in buildGoModule {
   # Terraform allow checking the provider versions, but this breaks
   # if the versions are not provided via file paths.
   postBuild = "mv $GOPATH/bin/terraform-provider-libvirt{,_v${version}}";
+  
+  ldflags = [ "-X main.version=${version}" ];
+  passthru.provider-source-address = "registry.terraform.io/dmacvicar/libvirt";
 
   doCheck = false;
 

--- a/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub, fetchpatch, libvirt, pkg-config, makeWrapper, cdrtools }:
+{ buildGoModule, cdrtools, fetchFromGitHub, lib, libvirt, makeWrapper, pkg-config }:
 
 # USAGE:
 # install the following package globally or in nix-shell:
@@ -9,33 +9,25 @@
 #
 #   virtualisation.libvirtd.enable = true;
 #
-# terraform-provider-libvirt does not manage pools at the moment:
-#
-#   $ virsh --connect "qemu:///system" pool-define-as default dir - - - - /var/lib/libvirt/images
-#   $ virsh --connect "qemu:///system" pool-start default
-#
 # pick an example from (i.e ubuntu):
-# https://github.com/dmacvicar/terraform-provider-libvirt/tree/master/examples
+# https://github.com/dmacvicar/terraform-provider-libvirt/tree/main/examples
 
-buildGoPackage rec {
+let
+  sha256 = "sha256-8GGPd0+qdw7s4cr0RgLoS0Cu4C+RAuuboZzTyYN/kq8=";
+  vendorSha256 = "sha256-fpO2sGM+VUKLmdfJ9CQfTFnCfxVTK2m9Sirj9oerD/I=";
+  version = "0.6.11";
+in buildGoModule {
+  inherit version;
+  inherit vendorSha256;
+
   pname = "terraform-provider-libvirt";
-  version = "0.6.3";
-
-  goPackagePath = "github.com/dmacvicar/terraform-provider-libvirt";
-
-  patches = [
-    (fetchpatch {
-      name = "base_volume_copy.patch";
-      url = "https://github.com/cyril-s/terraform-provider-libvirt/commit/52df264e8a28c40ce26e2b614ee3daea882931c3.patch";
-      sha256 = "1fg7ii2fi4c93hl41nhcncy9bpw3avbh6yiq99p1vkf87hhrw72n";
-    })
-  ];
 
   src = fetchFromGitHub {
+    inherit sha256;
+
     owner = "dmacvicar";
     repo = "terraform-provider-libvirt";
     rev = "v${version}";
-    sha256 = "0ak2lpnv6h0i7lzfcggd90jpfhvsasdr6nflkflk2drlcpalggj9";
   };
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
@@ -48,7 +40,9 @@ buildGoPackage rec {
 
   # Terraform allow checking the provider versions, but this breaks
   # if the versions are not provided via file paths.
-  postBuild = "mv go/bin/terraform-provider-libvirt{,_v${version}}";
+  postBuild = "mv $GOPATH/bin/terraform-provider-libvirt{,_v${version}}";
+
+  doCheck = false;
 
   meta = with lib; {
     homepage = "https://github.com/dmacvicar/terraform-provider-libvirt";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version 0.6.11 has major improvement compared to the previous releases, namely https://github.com/dmacvicar/terraform-provider-libvirt/pull/870 which adds support for SSH Agent.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
