### PR TITLE
gnome.pomodoro: 0.19.1 → 0.20.0

### DIFF
--- a/pkgs/desktops/gnome/misc/pomodoro/fix-schema-path.patch
+++ b/pkgs/desktops/gnome/misc/pomodoro/fix-schema-path.patch
@@ -1,0 +1,40 @@
+diff --git a/data/meson.build b/data/meson.build
+index 5e4ce69..982b3c9 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -31,7 +31,7 @@ i18n.merge_file(
+ 
+ install_data(
+   'org.gnome.pomodoro.gschema.xml',
+-  install_dir: get_option('datadir') / 'glib-2.0' / 'schemas',
++  install_dir: gschema_dir,
+ )
+ 
+ subdir('icons')
+diff --git a/meson-post-install.sh b/meson-post-install.sh
+index bf4013a..c87fba4 100644
+--- a/meson-post-install.sh
++++ b/meson-post-install.sh
+@@ -7,7 +7,7 @@ datadir="${prefix}/$1"
+ # want/need us to do the below
+ if [ -z "${DESTDIR}" ]; then
+     echo "Compiling GSchema..."
+-    glib-compile-schemas "${datadir}/glib-2.0/schemas"
++    glib-compile-schemas "${datadir}/gsettings-schemas/@pname@-@version@/glib-2.0/schemas"
+ 
+     echo "Updating icon cache..."
+     gtk-update-icon-cache -f -t "${datadir}/icons/hicolor"
+diff --git a/meson.build b/meson.build
+index 09857a1..a07d27c 100644
+--- a/meson.build
++++ b/meson.build
+@@ -40,7 +40,8 @@ add_project_arguments(
+ )
+ 
+ # We are going to use these variables later on for the plugins
+-gschema_dir = get_option('prefix') / get_option('datadir') / 'glib-2.0' / 'schemas'
++nix_package_name = '@pname@' + '-' + '@version@'
++gschema_dir = get_option('prefix') / get_option('datadir') / 'gsettings-schemas' / nix_package_name / 'glib-2.0' / 'schemas'
+ plugin_libdir = get_option('prefix') / get_option('libdir') / meson.project_name() / 'plugins'
+ extension_dir = get_option('prefix') / get_option('datadir') / 'gnome-shell' / 'extensions' / 'pomodoro@arun.codito.in'
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/gnome-pomodoro/gnome-pomodoro/blob/0.20.0/NEWS

Fixes: https://github.com/NixOS/nixpkgs/issues/132303

cc @osslate @blablablerg

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
