### PR TITLE
tlp: 1.3.1 -> 1.4.0

### DIFF
--- a/pkgs/tools/misc/tlp/default.nix
+++ b/pkgs/tools/misc/tlp/default.nix
@@ -23,13 +23,13 @@
 , networkmanager
 }: stdenv.mkDerivation rec {
   pname = "tlp";
-  version = "1.3.1";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "linrunner";
     repo = "TLP";
     rev = version;
-    sha256 = "14fcnaz9pw534v4d8dddqq4wcvpf1kghr8zlrk62r5lrl46sp1p5";
+    sha256 = "sha256-Blwj4cqrrYXohnGyJYe+1NYifxqfS4DoVUHmxFf62i4=";
   };
 
   # XXX: See patch files for relevant explanations.

--- a/pkgs/tools/misc/tlp/patches/fix-makefile-sed.patch
+++ b/pkgs/tools/misc/tlp/patches/fix-makefile-sed.patch
@@ -1,26 +1,23 @@
-commit c44347b3b813e209fff537b4d46d23430727a5e2
-Author: Bernardo Meurer <meurerbernardo@gmail.com>
-Date:   Tue Feb 25 21:27:39 2020 -0800
 
     makefile: correctly sed paths
-    
+
     The default Makefile for tlp makes a mess with catenating `DESTDIR` to
     everything, but then not actualy using the catenated (_ prefixed)
     variables to sed it's `.in` files.
-    
+
     This patch makes sure that it correctly sets the paths, taking `DESTDIR`
     in account where it makes sense (e.g. /bin where we want $out/bin) but
     not where it doesn't (/etc/tlp.conf should be just that).
-    
+
     The reason DESTDIR is used at all, as opposed to the more appropriate
     PREFIX, is covered in the nix formula, and is (also) due to the Makefile
     being a bit "different."
 
 diff --git a/Makefile b/Makefile
-index b5af74e..95122df 100644
+index e9bbab4..6b66651 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -47,17 +47,17 @@ _TPACPIBAT = $(DESTDIR)$(TPACPIBAT)
+@@ -51,19 +51,19 @@ _TPACPIBAT = $(DESTDIR)$(TPACPIBAT)
  
  SED = sed \
  	-e "s|@TLPVER@|$(TLPVER)|g" \
@@ -28,14 +25,18 @@ index b5af74e..95122df 100644
 -	-e "s|@TLP_TLIB@|$(TLP_TLIB)|g" \
 -	-e "s|@TLP_FLIB@|$(TLP_FLIB)|g" \
 -	-e "s|@TLP_ULIB@|$(TLP_ULIB)|g" \
+-	-e "s|@TLP_BATD@|$(TLP_BATD)|g" \
 +	-e "s|@TLP_SBIN@|$(_SBIN)|g" \
 +	-e "s|@TLP_TLIB@|$(_TLIB)|g" \
 +	-e "s|@TLP_FLIB@|$(_FLIB)|g" \
 +	-e "s|@TLP_ULIB@|$(_ULIB)|g" \
++	-e "s|@TLP_BATD@|$(_BATD)|g" \
  	-e "s|@TLP_CONFUSR@|$(TLP_CONFUSR)|g" \
  	-e "s|@TLP_CONFDIR@|$(TLP_CONFDIR)|g" \
 -	-e "s|@TLP_CONFDEF@|$(TLP_CONFDEF)|g" \
+-	-e "s|@TLP_CONFREN@|$(TLP_CONFREN)|g" \
 +	-e "s|@TLP_CONFDEF@|$(_CONFDEF)|g" \
++	-e "s|@TLP_CONFREN@|$(_CONFREN)|g" \
  	-e "s|@TLP_CONF@|$(TLP_CONF)|g" \
  	-e "s|@TLP_RUN@|$(TLP_RUN)|g"   \
  	-e "s|@TLP_VAR@|$(TLP_VAR)|g"   \

--- a/pkgs/tools/misc/tlp/patches/tlp-sleep-service.patch
+++ b/pkgs/tools/misc/tlp/patches/tlp-sleep-service.patch
@@ -1,23 +1,20 @@
-commit ca94cd56210067e2a55c1f413bd7713f7d338f9f
-Author: Bernardo Meurer <meurerbernardo@gmail.com>
-Date:   Wed Feb 26 10:46:23 2020 -0800
 
     tlp-sleep.service: reintroduce
-    
+
     This patch reintroduces tlp-sleep as a systemd unit as opposed to a
     systemd system-sleep hook script. This is due to the recommendation by
     systemd itself to not use the hook scripts. As per the manual:
-    
+
     > Note that scripts or binaries dropped in /usr/lib/systemd/system-sleep/
     > are intended for local use only and should be considered hacks. If
     > applications want to react to system suspend/hibernation and resume,
     > they should rather use the Inhibitor interface[1].
 
 diff --git a/Makefile b/Makefile
-index 95122df..0e9230a 100644
+index e9bbab4..7d71e02 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -70,6 +70,7 @@ INFILES = \
+@@ -76,6 +76,7 @@ INFILES = \
  	tlp.rules \
  	tlp-readconfs \
  	tlp-run-on \
@@ -25,7 +22,7 @@ index 95122df..0e9230a 100644
  	tlp.service \
  	tlp-stat \
  	tlp.upstart \
-@@ -99,7 +100,6 @@ SHFILES = \
+@@ -106,7 +107,6 @@ SHFILES = \
  	tlp-rdw-udev.in \
  	tlp-rf.in \
  	tlp-run-on.in \
@@ -33,27 +30,27 @@ index 95122df..0e9230a 100644
  	tlp-sleep.elogind \
  	tlp-stat.in \
  	tlp-usb-udev.in
-@@ -147,7 +147,7 @@ ifneq ($(TLP_NO_INIT),1)
+@@ -159,7 +159,7 @@ ifneq ($(TLP_NO_INIT),1)
  endif
  ifneq ($(TLP_WITH_SYSTEMD),0)
  	install -D -m 644 tlp.service $(_SYSD)/tlp.service
 -	install -D -m 755 tlp-sleep $(_SDSL)/tlp
-+	install -D -m 644 tlp-sleep.service $(_SYSD)/tlp-sleep.service
++	install -D -m 644 tlp-sleep.service $(_SDSL)/tlp-sleep.service
  endif
  ifneq ($(TLP_WITH_ELOGIND),0)
  	install -D -m 755 tlp-sleep.elogind $(_ELOD)/49-tlp-sleep
-@@ -204,7 +204,7 @@ uninstall-tlp:
+@@ -216,7 +216,7 @@ uninstall-tlp:
  	rm $(_ULIB)/rules.d/85-tlp.rules
  	rm -f $(_SYSV)/tlp
  	rm -f $(_SYSD)/tlp.service
 -	rm -f $(_SDSL)/tlp-sleep
-+	rm -f $(_SYSD)/tlp-sleep.service
++	rm -f $(_SDSL)/tlp-sleep.service
  	rm -f $(_ELOD)/49-tlp-sleep
  	rm -f $(_SHCPL)/tlp-stat
  	rm -f $(_SHCPL)/bluetooth
 diff --git a/tlp-sleep b/tlp-sleep
 deleted file mode 100644
-index 3de85ce..0000000
+index e548d55..0000000
 --- a/tlp-sleep
 +++ /dev/null
 @@ -1,11 +0,0 @@
@@ -61,7 +58,7 @@ index 3de85ce..0000000
 -
 -# tlp - systemd suspend/resume hook
 -#
--# Copyright (c) 2020 Thomas Koch <linrunner at gmx.net> and others.
+-# Copyright (c) 2021 Thomas Koch <linrunner at gmx.net> and others.
 -# This software is licensed under the GPL v2 or later.
 -
 -case $1 in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix for #141617


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
