### PR TITLE
lua: add conditional to use linux-readline as the plat on 5.4+

### DIFF
--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -16,7 +16,8 @@ let
     overrides = packageOverrides;
   };
 
-plat = if stdenv.isLinux then "linux"
+plat = if (stdenv.isLinux && lib.versionOlder self.luaversion "5.4") then "linux"
+       else if (stdenv.isLinux && lib.versionAtLeast self.luaversion "5.4") then "linux-readline"
        else if stdenv.isDarwin then "macosx"
        else if stdenv.hostPlatform.isMinGW then "mingw"
        else if stdenv.isFreeBSD then "freebsd"


### PR DESCRIPTION
since 5.4 linux plat no longer builds with readline support

Closes https://github.com/NixOS/nixpkgs/issues/141701

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done
tested by adding a `echo ${plat}` to postPatch and seeing that it outputs `linux-readline` for 5.4 and `linux` for <5.4

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
