### PR TITLE
git-branchless: 0.3.2 -> 0.3.6

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-branchless/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-branchless/default.nix
@@ -1,9 +1,11 @@
-{ lib, fetchFromGitHub
-
-, coreutils
+{ lib
+, fetchFromGitHub
+, fetchpatch
 , git
 , libiconv
 , ncurses
+, openssl
+, pkg-config
 , rustPlatform
 , sqlite
 , stdenv
@@ -13,45 +15,38 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "git-branchless";
-  version = "0.3.2";
+  version = "0.3.6-nixos.0";
 
   src = fetchFromGitHub {
     owner = "arxanas";
     repo = "git-branchless";
     rev = "v${version}";
-    sha256 = "0pfiyb23ah1h6risrhjr8ky7b1k1f3yfc3z70s92q3czdlrk6k07";
+    sha256 = "sha256-Sq+43w7xgrCe2w+9A/gfe/34+K2IgZVholtD+WF59Qo=";
   };
 
-  cargoSha256 = "0gplx80xhpz8kwry7l4nv4rlj9z02jg0sgb6zy1y3vd9s2j5wals";
+  cargoSha256 = "sha256-tCpvIqGMklOUJ/+d8poq4uz2EyZTkBmtlkA/BUIVPxs=";
 
-  # Remove path hardcodes patching if they get fixed upstream, see:
-  # https://github.com/arxanas/git-branchless/issues/26
-  postPatch = ''
-    # Inline test hardcodes `echo` location.
-    substituteInPlace ./src/commands/wrap.rs --replace '/bin/echo' '${coreutils}/bin/echo'
-
-    # Tests in general hardcode `git` location.
-    substituteInPlace ./src/testing.rs --replace '/usr/bin/git' '${git}/bin/git'
-  '';
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
     ncurses
+    openssl
     sqlite
-  ] ++ lib.optionals (stdenv.isDarwin) [
+  ] ++ lib.optionals stdenv.isDarwin [
     Security
     SystemConfiguration
     libiconv
   ];
 
   preCheck = ''
-    # Tests require path to git.
     export PATH_TO_GIT=${git}/bin/git
+    export GIT_EXEC_PATH=$(${git}/bin/git --exec-path)
   '';
 
   meta = with lib; {
     description = "A suite of tools to help you visualize, navigate, manipulate, and repair your commit history";
     homepage = "https://github.com/arxanas/git-branchless";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ msfjarvis nh2 ];
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ msfjarvis nh2 hmenke ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There were a couple of new upstream releases:
https://github.com/arxanas/git-branchless/releases/tag/v0.3.3
https://github.com/arxanas/git-branchless/releases/tag/v0.3.4
https://github.com/arxanas/git-branchless/releases/tag/v0.3.5
https://github.com/arxanas/git-branchless/releases/tag/v0.3.6

In the meantime the license has changed from Apache to GPL.

~~To successfully run the tests in the Nix sandbox this pending patch is needed:
https://github.com/arxanas/git-branchless/pull/121~~

~~Currently the implementation of `git move` has a bug where the on-disk move fails when the temporary files are stored on a separate filesystem. This can happen when the user has `/tmp` on `tmpfs`. Within the Nix sandbox all filesystems are tmpfs or overlayfs, so the corresponding tests have to be disabled. They can be reenabled when this ticket is closed:
https://github.com/arxanas/git-branchless/issues/122~~

The upstream maintainer was very responsive and helpful and has fixed all these problems and even created a new tag just for us! :+1:

Also adding myself as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
