### PR TITLE
libsoup_3: support cross-compilation

### DIFF
--- a/pkgs/development/libraries/libsoup/3.x.nix
+++ b/pkgs/development/libraries/libsoup/3.x.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     glib
+    python3
   ] ++ lib.optionals withIntrospection [
     gobject-introspection
   ] ++ lib.optionals withVala [
@@ -42,7 +43,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    python3
     sqlite
     libpsl
     glib.out


### PR DESCRIPTION
###### Motivation for this change

Not sure why this is different between libsoup 2 and 3, but this fixes the build. Building with `__contentAddressed = true;` enabled the hashes stay the same, so this should have no impact for the native case.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
