### PR TITLE
mfcj5320dw{lpr,cupswrapper}: init at 3.0.1-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6927,6 +6927,12 @@
     githubId = 458783;
     name = "Martin Gammelsæter";
   };
+  martfont = {
+    name = "Martino Fontana";
+    email = "tinozzo123@tutanota.com";
+    github = "SuperSamus";
+    githubId = 40663462;
+  };
   marzipankaiser = {
     email = "nixos@gaisseml.de";
     github = "marzipankaiser";

--- a/pkgs/misc/cups/drivers/mfcj5320dwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj5320dwcupswrapper/default.nix
@@ -1,0 +1,45 @@
+{ coreutils, dpkg, fetchurl, gnugrep, gnused, makeWrapper, mfcj5320dwlpr, perl, lib, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "mfcj5320dwcupswrapper";
+  version = "3.0.1-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101592/${pname}-${version}.i386.deb";
+    sha256 = "VQcPSx+xWGZUDP8lklmf7Juz7fQ38eop2TfyUQrxXGM=";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    basedir=${mfcj5320dwlpr}/opt/brother/Printers/mfcj5320dw
+    dir=$out/opt/brother/Printers/mfcj5320dw
+
+    substituteInPlace $dir/cupswrapper/cupswrappermfcj5320dw \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "basedir =~" "basedir = \"$basedir\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"mfcj5320dw\"; #"
+
+    wrapProgram $dir/cupswrapper/cupswrappermfcj5320dw \
+      --prefix PATH : ${lib.makeBinPath [ coreutils gnugrep gnused ]}
+
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+
+    ln $dir/cupswrapper/cupswrappermfcj5320dw $out/lib/cups/filter
+    ln $dir/cupswrapper/brcupsconfpt1 $out/lib/cups/filter
+    ln $dir/cupswrapper/brother_mfcj5320dw_printer_en.ppd $out/share/cups/model
+  '';
+
+  meta = with lib; {
+    description = "Brother MFC-J5320DW CUPS wrapper driver";
+    homepage = "http://www.brother.com/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ martfont ];
+  };
+}

--- a/pkgs/misc/cups/drivers/mfcj5320dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj5320dwlpr/default.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv, fetchurl, pkgsi686Linux, dpkg, makeWrapper, coreutils, gnused, gawk, file, cups, util-linux, xxd, runtimeShell
+, ghostscript, a2ps }:
+
+stdenv.mkDerivation rec {
+  pname = "mfcj5320dwlpr";
+  version = "3.0.1-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101591/${pname}-${version}.i386.deb";
+    sha256 = "YoifiwyKen0BJBMXvuTcCP6sG+lII3ibea2/Fs5DqJA=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cups ghostscript dpkg a2ps ];
+
+  dontUnpack = true;
+
+  brprintconf_mfcj5320dw_script = ''
+    #!${runtimeShell}
+    cd $(mktemp -d)
+    ln -s @out@/usr/bin/brprintconf_mfcj5320dw_patched brprintconf_mfcj5320dw_patched
+    ln -s @out@/opt/brother/Printers/mfcj5320dw/inf/brmfcj5320dwfunc brmfcj5320dwfunc
+    ln -s @out@/opt/brother/Printers/mfcj5320dw/inf/brmfcj5320dwrc brmfcj5320dwrc
+    ./brprintconf_mfcj5320dw_patched "$@"
+  '';
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+    substituteInPlace $out/opt/brother/Printers/mfcj5320dw/lpd/filtermfcj5320dw \
+      --replace /opt "$out/opt"
+    substituteInPlace $out/opt/brother/Printers/mfcj5320dw/lpd/psconvertij2 \
+      --replace "GHOST_SCRIPT=`which gs`" "GHOST_SCRIPT=${ghostscript}/bin/gs"
+    substituteInPlace $out/opt/brother/Printers/mfcj5320dw/inf/setupPrintcapij \
+      --replace "/opt/brother/Printers" "$out/opt/brother/Printers" \
+      --replace "printcap.local" "printcap"
+
+    patchelf --set-interpreter ${pkgsi686Linux.stdenv.cc.libc.out}/lib/ld-linux.so.2 \
+      --set-rpath $out/opt/brother/Printers/mfcj5320dw/inf:$out/opt/brother/Printers/mfcj5320dw/lpd \
+      $out/opt/brother/Printers/mfcj5320dw/lpd/brmfcj5320dwfilter
+    patchelf --set-interpreter ${pkgsi686Linux.stdenv.cc.libc.out}/lib/ld-linux.so.2 $out/usr/bin/brprintconf_mfcj5320dw
+
+    #stripping the hardcoded path.
+    ${util-linux}/bin/hexdump -ve '1/1 "%.2X"' $out/usr/bin/brprintconf_mfcj5320dw | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F6272257366756E63.62726d66636a36353130647766756e63000000000000000000000000000000000000000000.' | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F627225737263.62726D66636A3635313064777263000000000000000000000000000000000000000000.' | \
+    ${xxd}/bin/xxd -r -p > $out/usr/bin/brprintconf_mfcj5320dw_patched
+    chmod +x $out/usr/bin/brprintconf_mfcj5320dw_patched
+    #executing from current dir. segfaults if it's not r\w.
+    mkdir -p $out/bin
+    echo -n "$brprintconf_mfcj5320dw_script" > $out/bin/brprintconf_mfcj5320dw
+    chmod +x $out/bin/brprintconf_mfcj5320dw
+    substituteInPlace $out/bin/brprintconf_mfcj5320dw --replace @out@ $out
+
+    mkdir -p $out/lib/cups/filter/
+    ln -s $out/opt/brother/Printers/mfcj5320dw/lpd/filtermfcj5320dw $out/lib/cups/filter/brother_lpdwrapper_mfcj5320dw
+
+    wrapProgram $out/opt/brother/Printers/mfcj5320dw/lpd/psconvertij2 \
+      --prefix PATH ":" ${ lib.makeBinPath [ coreutils gnused gawk ] }
+    wrapProgram $out/opt/brother/Printers/mfcj5320dw/lpd/filtermfcj5320dw \
+      --prefix PATH ":" ${ lib.makeBinPath [ coreutils gnused file ghostscript a2ps ] }
+    '';
+
+  meta = with lib; {
+    description = "Brother MFC-J5320DW LPR printer driver";
+    homepage = "http://www.brother.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ martfont ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32312,6 +32312,9 @@ with pkgs;
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };
   mfcj470dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj470dwlpr { };
 
+  mfcj5320dwcupswrapper = callPackage ../misc/cups/drivers/mfcj5320dwcupswrapper { };
+  mfcj5320dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj5320dwlpr { };
+
   mfcj6510dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj6510dwcupswrapper { };
   mfcj6510dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj6510dwlpr { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

I copy-pasted another Brother printer derivation and changed things accordingly.
What I didn't do is testing, because I don't know how to do it, I searched on the internet and the only thing I could find is how to test packages that can be built normally.
If you tell me how I can test it, I will.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
