### PR TITLE
waf: fix cross-compiling by not overriding python in all-packages.nix

### DIFF
--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -32,6 +32,9 @@ stdenv.mkDerivation rec {
     install -D waf $out/bin/waf
   '';
 
+  # Avoid regressions to cross-compiling
+  strictDeps = true;
+
   meta = with lib; {
     description = "Meta build system";
     homepage    = "https://waf.io";

--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitLab, python, ensureNewerSourcesForZipFilesHook
+{ lib, stdenv, fetchFromGitLab, python3, ensureNewerSourcesForZipFilesHook
 # optional list of extra waf tools, e.g. `[ "doxygen" "pytest" ]`
 , withTools ? null
 }:
@@ -17,7 +17,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-WGGyhvQdFYmC0NOA5VVqCRMF1fvfPcTI42x1nHvz0W0=";
   };
 
-  buildInputs = [ python ensureNewerSourcesForZipFilesHook ];
+  nativeBuildInputs = [ python3 ensureNewerSourcesForZipFilesHook ];
+
+  # waf bin has #!/usr/bin/env python
+  buildInputs = [ python3 ];
 
   configurePhase = ''
     python waf-light configure

--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation rec {
     install -D waf $out/bin/waf
   '';
 
-  # Avoid regressions to cross-compiling
   strictDeps = true;
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10559,7 +10559,7 @@ with pkgs;
 
   volumeicon = callPackage ../tools/audio/volumeicon { };
 
-  waf = callPackage ../development/tools/build-managers/waf { python = python3; };
+  waf = callPackage ../development/tools/build-managers/waf { };
   wafHook = callPackage ../development/tools/build-managers/wafHook { };
 
   wagyu = callPackage ../tools/misc/wagyu {


### PR DESCRIPTION
instead use python3 explicitly in the expression

the issue is caused by https://github.com/NixOS/nixpkgs/issues/49526

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Supersedes #107000

###### Things done
Tested cross with `nix build ".#pkgsCross.aarch64-multiplatform.waf"`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
