### PR TITLE
crater: init at 4.2.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -25,6 +25,11 @@ in mkLicense lset) ({
    * add it to this list. The URL mentioned above is a good source for inspiration.
    */
 
+  aal = {
+    spdxId = "AAL";
+    fullName = "Attribution Assurance License";
+  };
+
   abstyles = {
     spdxId = "Abstyles";
     fullName = "Abstyles License";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -967,6 +967,7 @@
   ./services/web-apps/bookstack.nix
   ./services/web-apps/calibre-web.nix
   ./services/web-apps/convos.nix
+  ./services/web-apps/crater.nix
   ./services/web-apps/cryptpad.nix
   ./services/web-apps/dex.nix
   ./services/web-apps/discourse.nix

--- a/nixos/modules/services/web-apps/crater.nix
+++ b/nixos/modules/services/web-apps/crater.nix
@@ -1,0 +1,119 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkDefault mkEnableOption mkIf mkOption types;
+
+  cfg = config.services.crater;
+  fpm = config.services.phpfpm.pools.crater;
+  package = pkgs.crater.override { dataDir = cfg.dataDir; };
+in
+{
+  options.services.crater = {
+
+    enable = mkEnableOption "Crater";
+
+    user = mkOption {
+      default = "crater";
+      description = "User crater runs as.";
+      type = types.str;
+    };
+
+    group = mkOption {
+      default = "crater";
+      description = "Group crater runs as.";
+      type = types.str;
+    };
+
+    dataDir = mkOption {
+      default = "/var/lib/crater";
+      description = "Directory to store Crater state/data files.";
+      type = types.str;
+    };
+
+    poolConfig = mkOption {
+      type = with types; attrsOf (oneOf [ str int bool ]);
+      default = {
+        "pm" = "dynamic";
+        "pm.max_children" = 32;
+        "pm.start_servers" = 2;
+        "pm.min_spare_servers" = 2;
+        "pm.max_spare_servers" = 4;
+        "pm.max_requests" = 500;
+      };
+      description = ''
+        Options for the crater PHP pool. See the documentation on <literal>php-fpm.conf</literal>
+        for details on configuration directives.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    services.phpfpm.pools.crater = {
+      inherit (cfg) user group;
+
+      # copy/paste from ${crater}/docker-compose/php/uploads.ini
+      phpOptions = ''
+        file_uploads = On
+        upload_max_filesize = 64M
+        post_max_size = 64M
+      '';
+
+      settings = {
+        "listen.mode" = "0660";
+        "listen.owner" = cfg.user;
+        "listen.group" = cfg.group;
+      } // cfg.poolConfig;
+    };
+
+    services.httpd = {
+      enable = true;
+      extraModules = [ "proxy_fcgi" ];
+      virtualHosts.crater = {
+        documentRoot = "${package}/public";
+
+        extraConfig = ''
+          <Directory ${package}/public>
+            <FilesMatch "\.php$">
+              <If "-f %{REQUEST_FILENAME}">
+                SetHandler "proxy:unix:${fpm.socket}|fcgi://localhost/"
+              </If>
+            </FilesMatch>
+
+            AllowOverride all
+            Require all granted
+            Options -Indexes
+            DirectoryIndex index.php
+          </Directory>
+        '';
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir}                            0711 ${cfg.user} ${cfg.group} - -"
+      "f ${cfg.dataDir}/database.sqlite            0700 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/public                     0755 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/storage                    0711 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/storage/app                0711 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/storage/fonts              0700 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/storage/framework          0700 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/storage/framework/cache    0700 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/storage/framework/sessions 0700 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/storage/framework/views    0700 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/storage/logs               0700 ${cfg.user} ${cfg.group} - -"
+      "C ${cfg.dataDir}/.env                       0700 ${cfg.user} ${cfg.group} - ${package}/.env.example"
+    ];
+
+    users.users.crater = mkIf (cfg.user == "crater") {
+      isSystemUser = true;
+      group = cfg.group;
+    };
+
+    users.groups.crater = mkIf (cfg.group == "crater") {};
+
+    # grant the web server user access required to present this site
+    users.users.wwwrun.extraGroups = [ cfg.user ];
+
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -91,6 +91,7 @@ in
   corerad = handleTest ./corerad.nix {};
   coturn = handleTest ./coturn.nix {};
   couchdb = handleTest ./couchdb.nix {};
+  crater = handleTest ./crater.nix {};
   cri-o = handleTestOn ["x86_64-linux"] ./cri-o.nix {};
   custom-ca = handleTest ./custom-ca.nix {};
   croc = handleTest ./croc.nix {};

--- a/nixos/tests/crater.nix
+++ b/nixos/tests/crater.nix
@@ -1,0 +1,44 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "crater";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ matthewcroughan ];
+  };
+
+  nodes = {
+    client = { config, pkgs, ... }: {
+      environment.systemPackages = [ pkgs.curl ];
+    };
+    crater = { config, pkgs, ... }: {
+      services.crater = {
+        enable = true;
+      };
+      networking.firewall.allowedTCPPorts =
+        [
+          # This is the same as the port defined below, via
+          # virtualHosts.crater.listen
+          (builtins.head config.services.httpd.virtualHosts.crater.listen).port
+        ];
+      services.httpd = {
+        virtualHosts.crater.listen =
+          [
+            {
+              "port" = 8070;
+            }
+          ];
+        adminAddr = "itchy@scratchy.xxx";
+      };
+    };
+  };
+  testScript = ''
+    start_all()
+    crater.wait_for_unit("httpd.service")
+    crater.wait_for_unit("phpfpm-crater.service")
+    crater.wait_for_open_port("8070")
+
+    client.wait_for_unit("multi-user.target")
+    with subtest("Check that the Crater webserver can be reached."):
+        assert "<title>Crater - Self Hosted Invoicing Platform</title>" in client.succeed(
+            "curl -sSf http://crater:8070/on-boarding | grep title"
+        )
+  '';
+})

--- a/pkgs/servers/web-apps/crater/default.nix
+++ b/pkgs/servers/web-apps/crater/default.nix
@@ -1,0 +1,56 @@
+{ pkgs, lib, stdenv, fetchzip, nixosTests, dataDir ? "/var/lib/crater" }:
+
+stdenv.mkDerivation rec {
+  pname = "crater";
+  version = "4.2.0";
+
+  src = fetchzip {
+    url = "https://craterapp.com/downloads/file/${version}";
+    sha256 = "sha256-7nqr4GtvW5m3qu6LJhulBbe+X7k1Thifa/X2aXFHz3Y=";
+    # postFetch is necessary because the downloaded file does not match the
+    # filename in the URL since it is a redirect. fetchzip attempts to wrongly use
+    # this name.
+    postFetch = ''unzip $downloadedFile -d $out '';
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -ra crater $out
+
+    # symlink mutable data into the nix store due to crater path requirements
+    rm -R $out/storage $out/.env
+    ln -s ${dataDir}/.env $out/.env
+    ln -s ${dataDir}/storage $out/storage
+    ln -s ${dataDir}/public/storage $out/public/storage
+
+    runHook postInstall
+  '';
+
+  # getPath() returns a nix store path, which may not be valid, requiring this
+  # patch. Upstream issue can be found here:
+  # https://github.com/bytefury/crater/issues/578
+  patches = [ ./remove-getpath.patch ];
+
+  patchFlags = [ "-p1" "-d crater" ];
+
+  postPatch = ''
+    substituteInPlace crater/app/Http/Controllers/V1/Onboarding/DatabaseConfigurationController.php \
+      --replace "database_path('database.sqlite')" "'${dataDir}/database.sqlite'"
+
+    substituteInPlace crater/config/mail.php \
+      --replace "'sendmail' => '/usr/sbin/sendmail -bs'" "'sendmail' => '${pkgs.system-sendmail}/bin/sendmail -bs'"
+  '';
+
+  passthru.tests = nixosTests.crater;
+
+  meta = with lib; {
+    description = "Free & Open Source Invoice App for Freelancers & Small Businesses";
+    license = licenses.aal ;
+    homepage = "https://craterapp.com/";
+    maintainers = with maintainers; [ matthewcroughan ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/servers/web-apps/crater/default.nix
+++ b/pkgs/servers/web-apps/crater/default.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation rec {
     # postFetch is necessary because the downloaded file does not match the
     # filename in the URL since it is a redirect. fetchzip attempts to wrongly use
     # this name.
-    postFetch = ''unzip $downloadedFile -d $out '';
+    postFetch = ''
+      unzip $downloadedFile -d $out
+    '';
   };
 
   dontBuild = true;
@@ -21,7 +23,7 @@ stdenv.mkDerivation rec {
     cp -ra crater $out
 
     # symlink mutable data into the nix store due to crater path requirements
-    rm -R $out/storage $out/.env
+    rm -r $out/storage $out/.env
     ln -s ${dataDir}/.env $out/.env
     ln -s ${dataDir}/storage $out/storage
     ln -s ${dataDir}/public/storage $out/public/storage

--- a/pkgs/servers/web-apps/crater/remove-getpath.patch
+++ b/pkgs/servers/web-apps/crater/remove-getpath.patch
@@ -1,0 +1,17 @@
+diff --git a/app/Models/Company.php b/app/Models/Company.php
+index c02706d..0b2325c 100644
+--- a/app/Models/Company.php
++++ b/app/Models/Company.php
+@@ -24,11 +24,7 @@ class Company extends Model implements HasMedia
+         $isSystem = FileDisk::whereSetAsDefault(true)->first()->isSystem();
+ 
+         if ($logo) {
+-            if ($isSystem) {
+-                return $logo->getPath();
+-            } else {
+-                return $logo->getFullUrl();
+-            }
++            return $logo->getFullUrl();
+         }
+ 
+         return null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20342,6 +20342,8 @@ with pkgs;
 
   couchpotato = callPackage ../servers/couchpotato {};
 
+  crater = callPackage ../servers/web-apps/crater { };
+
   dendrite = callPackage ../servers/dendrite { };
 
   dex-oidc = callPackage ../servers/dex { };


### PR DESCRIPTION
###### Motivation for this change

Note: opening this on behalf of @MatthewCroughan 

This adds a NixOS module and package for Crater, an invoicing app. Now Nix (ab)users can finally get paid!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
