### PR TITLE
nixos/prometheus-rtl_433-exporter: fix systemd hardening

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/rtl_433.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/rtl_433.nix
@@ -61,6 +61,11 @@ in
     serviceConfig = {
       # rtl-sdr udev rules make supported USB devices +rw by plugdev.
       SupplementaryGroups = "plugdev";
+      # rtl_433 needs rw access to the USB radio.
+      PrivateDevices = lib.mkForce false;
+      DeviceAllow = lib.mkForce "char-usb_device rw";
+      RestrictAddressFamilies = [ "AF_NETLINK" ];
+
       ExecStart = let
         matchers = (map (m:
           "--channel_matcher '${m.name},${toString m.channel},${m.location}'"


### PR DESCRIPTION
###### Motivation for this change
9fea6d4c8551b7c8783f23e011a2ba113c95d0dd broke rtl_433-exporter by introducing several hardening options which do not play well with rtl_433 requiring writing to USB. More precisely, rtl_433 requires (a) AF_NETLINK to configure the radio; (b) access to the USB device, but PrivateDevices=true hides them; (c) rw access to the USB device, but DeviceAllow= block-lists everything.

This commit was tested on real hardware with a standard NixOS setup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
