### PR TITLE
graalvm11-ce: add support for aarch64-linux

### DIFF
--- a/pkgs/development/compilers/graalvm/community-edition/default.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/default.nix
@@ -16,6 +16,6 @@ in {
   graalvm11-ce = mkGraal rec {
     version = "21.2.0";
     javaVersion = "11";
-    platforms = ["x86_64-linux" "x86_64-darwin"];
+    platforms = ["x86_64-linux" "aarch64-linux" "x86_64-darwin"];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This should add support for some GraalVM packages like `babashka` to things like Raspberry Pi 4.

Only adding support for graalvm11-ce. While there is a graalvm8 release for aarch64-linux, it is missing some support (like wasm). Java 8 is ancient by this point anyway.

Also, it is not used anywhere on the nixpkgs, while graalvm11 is used by multiple other packages (babashka, clj-kondo, clojure-lsp, etc.).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
