### PR TITLE
unbound: add withRedis

### DIFF
--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -20,8 +20,9 @@
 , withSystemd ? false
 , systemd ? null
   # optionally support DNS-over-HTTPS as a server
-, withDoH ? false
-, libnghttp2
+, withDoH ? false, libnghttp2
+  # optionally enable the redis backend to cachedb
+, withRedis ? false, hiredis
 }:
 
 stdenv.mkDerivation rec {
@@ -39,7 +40,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl nettle expat libevent ]
     ++ lib.optionals withSystemd [ pkg-config systemd ]
-    ++ lib.optionals withDoH [ libnghttp2 ];
+    ++ lib.optionals withDoH [ libnghttp2 ]
+    ++ lib.optionals withRedis [ hiredis ];
 
   configureFlags = [
     "--with-ssl=${openssl.dev}"
@@ -57,6 +59,9 @@ stdenv.mkDerivation rec {
     "--enable-systemd"
   ] ++ lib.optionals withDoH [
     "--with-libnghttp2=${libnghttp2.dev}"
+  ] ++ lib.optionals withRedis [
+    "--enable-cachedb"
+    "--with-libhiredis=${hiredis}"
   ];
 
   # Remove references to compile-time dependencies that are included in the configure flags


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add optional redis persistent caching support for unbound

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
