### PR TITLE
notejot: 3.1.5 -> 3.2.0

### DIFF
--- a/pkgs/applications/misc/notejot/default.nix
+++ b/pkgs/applications/misc/notejot/default.nix
@@ -2,47 +2,51 @@
 , stdenv
 , fetchFromGitHub
 , gtk4
-, gtksourceview
+, hicolor-icon-theme
 , json-glib
 , libadwaita
 , libgee
 , meson
 , ninja
 , nix-update-script
-, pantheon
 , pkg-config
 , python3
 , vala
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
   pname = "notejot";
-  version = "3.1.5";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "lainsce";
     repo = pname;
     rev = version;
-    hash = "sha256-wsHQvN+sqAMs1QldiRoc9JlF4d54JFqNkqC+lyuHC7M=";
+    hash = "sha256-WyW1tGhO3+OykNa8BRavi93cBMOSBJw0M+0bwQHJOjU=";
   };
+
+  patches = [
+    # build: use gtk4-update-icon-cache
+    # https://github.com/lainsce/notejot/pull/307
+    ./use-gtk4-update-icon-cache.patch
+  ];
 
   nativeBuildInputs = [
     meson
     ninja
-    vala
     pkg-config
     python3
-    wrapGAppsHook
+    vala
+    wrapGAppsHook4
   ];
+
   buildInputs = [
     gtk4
-    gtksourceview
+    hicolor-icon-theme
     json-glib
     libadwaita
     libgee
-    pantheon.elementary-icon-theme
-    pantheon.granite
   ];
 
   postPatch = ''
@@ -50,15 +54,15 @@ stdenv.mkDerivation rec {
     patchShebangs build-aux/post_install.py
   '';
 
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
   meta = with lib; {
     homepage = "https://github.com/lainsce/notejot";
     description = "Stupidly-simple sticky notes applet";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ] ++ teams.pantheon.members;
     platforms = platforms.linux;
-  };
-
-  passthru.updateScript = nix-update-script {
-    attrPath = pname;
   };
 }

--- a/pkgs/applications/misc/notejot/use-gtk4-update-icon-cache.patch
+++ b/pkgs/applications/misc/notejot/use-gtk4-update-icon-cache.patch
@@ -1,0 +1,20 @@
+diff --git a/build-aux/post_install.py b/build-aux/post_install.py
+index 1278304..fface6d 100644
+--- a/build-aux/post_install.py
++++ b/build-aux/post_install.py
+@@ -2,11 +2,13 @@
+ import os
+ import subprocess
+ 
+-schemadir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
++install_prefix = os.environ['MESON_INSTALL_PREFIX']
++icondir = os.path.join(install_prefix, 'share', 'icons', 'hicolor')
++schemadir = os.path.join(install_prefix, 'share', 'glib-2.0', 'schemas')
+ 
+ if not os.environ.get('DESTDIR'):
+     print('Compiling gsettings schemas…')
+     subprocess.call(['glib-compile-schemas', schemadir], shell=False)
+ 
+     print('Rebuilding desktop icons cache...')
+-    subprocess.call(['gtk-update-icon-cache', '/usr/share/icons/hicolor/'], shell=False)
++    subprocess.call(['gtk4-update-icon-cache', '-qtf', icondir], shell=False)


### PR DESCRIPTION
###### Motivation for this change

After the libadwaita 1.0.0.alpha.3 update, we can finally try this.

Also take the chance to cleanup some dependencies, hope I didn't do something wrong

- Changlog: https://github.com/lainsce/notejot/releases
- Diff: https://github.com/lainsce/notejot/compare/3.1.5...3.2.0
- Related: https://github.com/lainsce/notejot/pull/307

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
