### PR TITLE
fuzzel: 1.6.1 -> 1.6.4

### DIFF
--- a/pkgs/applications/misc/fuzzel/default.nix
+++ b/pkgs/applications/misc/fuzzel/default.nix
@@ -13,29 +13,24 @@
 , tllist
 , fcft
 , enableCairo ? true
-, enablePNG ? true
-, enableSVG ? true
+, withPNGBackend ? "libpng"
+, withSVGBackend ? "librsvg"
 # Optional dependencies
 , cairo
 , librsvg
 , libpng
 }:
 
-let
-  # Courtesy of sternenseemann and FRidh, commit c9a7fdfcfb420be8e0179214d0d91a34f5974c54
-  mesonFeatureFlag = opt: b: "-D${opt}=${if b then "enabled" else "disabled"}";
-in
-
 stdenv.mkDerivation rec {
   pname = "fuzzel";
-  version = "1.6.1";
+  version = "1.6.4";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "dnkl";
     repo = "fuzzel";
     rev = version;
-    sha256 = "sha256-JW5sAlTprSRIdFbmSaUreGtNccERgQMGEW+WCSscYQk=";
+    sha256 = "sha256-wl3dO6EwLXWf0XtAIml1NlNRIvpIQJuq1pxLmo/pAUE=";
   };
 
   nativeBuildInputs = [
@@ -54,15 +49,15 @@ stdenv.mkDerivation rec {
     tllist
     fcft
   ] ++ lib.optional enableCairo cairo
-    ++ lib.optional enablePNG libpng
-    ++ lib.optional enableSVG librsvg;
+    ++ lib.optional (withPNGBackend == "libpng") libpng
+    ++ lib.optional (withSVGBackend == "librsvg") librsvg;
 
   mesonBuildType = "release";
 
   mesonFlags = [
-    (mesonFeatureFlag "enable-cairo" enableCairo)
-    (mesonFeatureFlag "enable-png" enablePNG)
-    (mesonFeatureFlag "enable-svg" enableSVG)
+    "-Denable-cairo=${if enableCairo then "enabled" else "disabled"}"
+    "-Dpng-backend=${withPNGBackend}"
+    "-Dsvg-backend=${withSVGBackend}"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
The SVG and PNG options were adjusted to account for upstream changes
on the meson build options and additional nanosvg backend for SVG support
independent of cairo.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
