### PR TITLE
khronos: 3.5.9 -> 3.6.0

### DIFF
--- a/pkgs/applications/office/khronos/default.nix
+++ b/pkgs/applications/office/khronos/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , nix-update-script
 , meson
@@ -6,25 +7,24 @@
 , vala
 , pkg-config
 , desktop-file-utils
-, pantheon
 , python3
 , glib
 , gtk4
 , json-glib
 , libadwaita
 , libgee
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
   pname = "khronos";
-  version = "3.5.9";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "lainsce";
     repo = pname;
     rev = version;
-    sha256 = "sha256-3FatmyANB/tNYSN2hu5IVkyCy0YrC3uA2d/3+5u48w8=";
+    sha256 = "sha256-AETyVCBUuBzHwDgTkGRIokFYwcmXrb/F85J5GEIu4dE=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     vala
     pkg-config
     python3
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -43,12 +43,14 @@ stdenv.mkDerivation rec {
     json-glib
     libadwaita
     libgee
-    pantheon.granite
   ];
 
   postPatch = ''
     chmod +x build-aux/post_install.py
     patchShebangs build-aux/post_install.py
+    # https://github.com/lainsce/khronos/pull/75
+    substituteInPlace build-aux/post_install.py \
+      --replace 'gtk-update-icon-cache' 'gtk4-update-icon-cache'
   '';
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

After the libadwaita 1.0.0.alpha.3 update, we can finally try this.

Also take the chance to cleanup some dependencies, hope I didn't do something wrong

- Changlog: https://github.com/lainsce/khronos/releases/tag/3.6.0
- Diff: https://github.com/lainsce/khronos/compare/3.5.9...3.6.0
- Related: https://github.com/lainsce/khronos/pull/75

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
