### PR TITLE
[21.05] Kernel backports

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -7,9 +7,9 @@
     },
     "4.19": {
         "extra": "-hardened1",
-        "name": "linux-hardened-4.19.208-hardened1.patch",
-        "sha256": "0bg45n1kgd628gwjkp1vxslxyci6589ygy9mmmhpl7kj3y7370ck",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.208-hardened1/linux-hardened-4.19.208-hardened1.patch"
+        "name": "linux-hardened-4.19.210-hardened1.patch",
+        "sha256": "0lnv0ym6jcf460hsn26lax65n2yb1vvzsfmckaz04jb2kdgm6hr5",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.210-hardened1/linux-hardened-4.19.210-hardened1.patch"
     },
     "5.10": {
         "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -1,9 +1,9 @@
 {
     "4.14": {
         "extra": "-hardened1",
-        "name": "linux-hardened-4.14.248-hardened1.patch",
-        "sha256": "1lwqlpd21f8rwqfyz61083w0lg2bjzdjf7rzrqxsw1jz0l879035",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.248-hardened1/linux-hardened-4.14.248-hardened1.patch"
+        "name": "linux-hardened-4.14.250-hardened1.patch",
+        "sha256": "1jgqmrj5djapvk56jwlfq181knhywzrk9cswv1lp5y2jwnnvlj9x",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.250-hardened1/linux-hardened-4.14.250-hardened1.patch"
     },
     "4.19": {
         "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -13,9 +13,9 @@
     },
     "5.10": {
         "extra": "-hardened1",
-        "name": "linux-hardened-5.10.70-hardened1.patch",
-        "sha256": "12r6x7v7n3f7c7pn86ivykg6gqmqlzwrsncdkvj5qf7raw38ad5r",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.70-hardened1/linux-hardened-5.10.70-hardened1.patch"
+        "name": "linux-hardened-5.10.72-hardened1.patch",
+        "sha256": "14zchx1hc4jrq7prv4kkswjnmyqv74wfkjvky57scc8yl04yaqs6",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.72-hardened1/linux-hardened-5.10.72-hardened1.patch"
     },
     "5.14": {
         "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -19,9 +19,9 @@
     },
     "5.14": {
         "extra": "-hardened1",
-        "name": "linux-hardened-5.14.9-hardened1.patch",
-        "sha256": "190588p6xw65y1f106zgnv5s043yi633vg0zdbz85qjz27g49db8",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.14.9-hardened1/linux-hardened-5.14.9-hardened1.patch"
+        "name": "linux-hardened-5.14.11-hardened1.patch",
+        "sha256": "05n74rnq5c2jx7iynxwgj5wypb0i0p3dar0ri2zxmyssasmbkfa7",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.14.11-hardened1/linux-hardened-5.14.11-hardened1.patch"
     },
     "5.4": {
         "extra": "-hardened1",

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -25,8 +25,8 @@
     },
     "5.4": {
         "extra": "-hardened1",
-        "name": "linux-hardened-5.4.150-hardened1.patch",
-        "sha256": "0vaxp5lfs7d5py0530sdhz8yzbzjxlwaam63mflwfd4mm8gf3ggc",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.150-hardened1/linux-hardened-5.4.150-hardened1.patch"
+        "name": "linux-hardened-5.4.152-hardened1.patch",
+        "sha256": "01rf9za9sv14pxpi0pj1izq4bihhldi2qnhaka5rxlw7nifzzsj2",
+        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.152-hardened1/linux-hardened-5.4.152-hardened1.patch"
     }
 }

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "4.14.249";
+  version = "4.14.250";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,7 +13,7 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0wn4yw9fliw3a8knvj2hdprbyyx7akm9ycclr2y1whpa5gmrc3rj";
+    sha256 = "0zbf6gxm8iwf7cra310gfd0zyj8l9ckdahky9w6wb9wlznwkvd54";
   };
 
   kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_4_14 ];

--- a/pkgs/os-specific/linux/kernel/linux-4.19.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "4.19.209";
+  version = "4.19.210";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,7 +13,7 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "04z9hxgqw2p86xxi2667kaj2w99xxxiw9gn9i1217c305swxa9vk";
+    sha256 = "0cv126j4sghwgzjm9p5l1brcnxkbgggja2ai37gl8m2s99cj59wv";
   };
 
   kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_4_19 ];

--- a/pkgs/os-specific/linux/kernel/linux-4.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.4.nix
@@ -1,13 +1,13 @@
 { buildPackages, fetchurl, perl, buildLinux, nixosTests, stdenv, ... } @ args:
 
 buildLinux (args // rec {
-  version = "4.4.287";
+  version = "4.4.288";
   extraMeta.branch = "4.4";
   extraMeta.broken = stdenv.isAarch64;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0qraild006in01vsqbhx1lf585g34skzwi2m3hv3kal8s03q0gzw";
+    sha256 = "028w3yzmzymy7l1nf3n1pfbg95hfi4ilphkyl00ddgj8sfm542c7";
   };
 
   kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_4_4 ];

--- a/pkgs/os-specific/linux/kernel/linux-4.9.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.9.nix
@@ -1,13 +1,13 @@
 { buildPackages, fetchurl, perl, buildLinux, nixosTests, stdenv, ... } @ args:
 
 buildLinux (args // rec {
-  version = "4.9.285";
+  version = "4.9.286";
   extraMeta.branch = "4.9";
   extraMeta.broken = stdenv.isAarch64;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "1hkkk4mhr5qnrhwqcz0b20rff6j8pnwd868a5hsq8s867pa24ajb";
+    sha256 = "0id62p43dmkl9ir278p0dsfg3q7m1d8rlxv0c9qi1pzalkygv8p2";
   };
 
   kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_4_9 ];

--- a/pkgs/os-specific/linux/kernel/linux-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.10.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.10.71";
+  version = "5.10.72";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,7 +13,7 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "15x4jbwy6j78ss31avdl7nr0mw4w6a1y6c6dyljh6gwngp98irh2";
+    sha256 = "0z2cp8gqnbv7iz8kb5ydfmk019m0gds8wwvwc6kccsk4wypkbmml";
   };
 
   kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_5_10 ];

--- a/pkgs/os-specific/linux/kernel/linux-5.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.14.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.14.10";
+  version = "5.14.11";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "1n454038vp55wbi814fqpidjmk8k6p6h0jl07hknpd6imgh2bkj5";
+    sha256 = "0capilz3wx29pw7n2m5cn229vy9psrccmdspp27znhjkvwj0m0wk";
   };
 } // (args.argsOverride or { }))

--- a/pkgs/os-specific/linux/kernel/linux-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.4.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.4.151";
+  version = "5.4.152";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,7 +13,7 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "04rkymyg79mp1frdlkizc7k33palplmnnnz8klkag9ii7jw3zrxv";
+    sha256 = "1may19d47d06mplpk29dpjsq31sxk8wwbwb2jspj3vay9h9wfi40";
   };
 
   kernelTests = args.kernelTests or [ nixosTests.kernel-generic.linux_5_4 ];

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchsvn, linux
 , scripts ? fetchsvn {
     url = "https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/";
-    rev = "18298";
-    sha256 = "027fp6h7295cc9m5g46phqd6hixcnvihpfsyrnzvsxz6pkvjzpw4";
+    rev = "18314";
+    sha256 = "0fic073zafwdsw7i0j4z57a4aknk8kpgnbrxpbi181n5axdlm99k";
   }
 , ...
 }:

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -16,7 +16,7 @@ let
 
 in linux.override {
   argsOverride = {
-    modDirVersion = "${linux.modDirVersion}-gnu";
+    modDirVersion = "${linux.modDirVersion}-gnu1";
     isLibre = true;
 
     src = stdenv.mkDerivation {
@@ -34,8 +34,6 @@ in linux.override {
         cp -r . "$out"
       '';
     };
-
-    extraMeta.broken = true;
 
     passthru.updateScript = ./update-libre.sh;
 

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchsvn, linux
 , scripts ? fetchsvn {
     url = "https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/";
-    rev = "18314";
-    sha256 = "0fic073zafwdsw7i0j4z57a4aknk8kpgnbrxpbi181n5axdlm99k";
+    rev = "18380";
+    sha256 = "0sg7mnxqzc5zdnl8l7gfy1kc52w7c85fdhywvdbjgs7inx2bb1qd";
   }
 , ...
 }:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Contains a backport for #141854, https://github.com/NixOS/nixpkgs/commit/6a6ff4d0d8d04d1e4fac847fdf78071838143847, https://github.com/NixOS/nixpkgs/pull/141112

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
