### PR TITLE
lib/meta: add getLicenseFromSpdxId function (resumed)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -105,7 +105,7 @@ let
       makeScope makeScopeWithSplicing;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio
-      hiPrioSet;
+      hiPrioSet getLicenseFromSpdxId;
     inherit (self.sources) pathType pathIsDirectory cleanSourceFilter
       cleanSource sourceByRegex sourceFilesBySuffices
       commitIdFromGitRepo cleanSourceWith pathHasContext

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -99,4 +99,31 @@ rec {
   availableOn = platform: pkg:
     lib.any (platformMatch platform) pkg.meta.platforms &&
     lib.all (elem: !platformMatch platform elem) (pkg.meta.badPlatforms or []);
+
+  /* Get the corresponding attribute in lib.licenses
+     from the SPDX ID.
+     For SPDX IDs, see
+     https://spdx.org/licenses
+
+     Type:
+       getLicenseFromSpdxId :: str -> AttrSet
+
+     Example:
+       lib.getLicenseFromSpdxId "MIT" == lib.licenses.mit
+       => true
+       lib.getLicenseFromSpdxId "mIt" == lib.licenses.mit
+       => true
+       lib.getLicenseFromSpdxId "MY LICENSE"
+       => trace: warning: getLicenseFromSpdxId: No license matches the given SPDX ID: MY LICENSE
+       => { shortName = "MY LICENSE"; }
+  */
+  getLicenseFromSpdxId =
+    let
+      spdxLicenses = lib.mapAttrs (id: ls: assert lib.length ls == 1; builtins.head ls)
+        (lib.groupBy (l: lib.toLower l.spdxId) (lib.filter (l: l ? spdxId) (lib.attrValues lib.licenses)));
+    in licstr:
+      spdxLicenses.${ lib.toLower licstr } or (
+        lib.warn "getLicenseFromSpdxId: No license matches the given SPDX ID: ${licstr}"
+        { shortName = licstr; }
+      );
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Similar functions are implemented by `yarn2nix` and `poetry2nix` to search for the `spdxId` match in `lib.licenses`

It is worth it to be part of the standard library, so that we don't have to reinvent the wheel.

Breaking changes: Renaming from `yarn2nix-moretea.spdxLicense` to `yarn2nix-moretea.getLicenseFromSpdxId` is a breaking change that only affects people who call the function directly.

Resume #141221 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking (function renaming)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
