### PR TITLE
kumactl: init at 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12930,6 +12930,12 @@
       fingerprint = "61AE D40F 368B 6F26 9DAE  3892 6861 6B2D 8AC4 DCC5";
     }];
   };
+  zbioe = {
+    name = "Iury Fukuda";
+    email = "zbioe@protonmail.com";
+    github = "zbioe";
+    githubId = 7332055;
+  };
   zenithal = {
     name = "zenithal";
     email = "i@zenithal.me";

--- a/pkgs/applications/networking/cluster/kumactl/default.nix
+++ b/pkgs/applications/networking/cluster/kumactl/default.nix
@@ -1,10 +1,9 @@
 { lib, fetchFromGitHub, buildGoModule }:
 
 let
-  version = "1.3.1";
-in buildGoModule {
-  inherit version;
+in buildGoModule rec {
   pname = "kumactl";
+  version = "1.3.1";
   src = fetchFromGitHub {
     owner = "kumahq";
     repo = "kuma";

--- a/pkgs/applications/networking/cluster/kumactl/default.nix
+++ b/pkgs/applications/networking/cluster/kumactl/default.nix
@@ -1,10 +1,9 @@
 { lib, fetchFromGitHub, buildGoModule }:
 
-let
-  version = "1.3.1";
-in buildGoModule {
-  inherit version;
+buildGoModule rec {
   pname = "kumactl";
+  version = "1.3.1";
+
   src = fetchFromGitHub {
     owner = "kumahq";
     repo = "kuma";

--- a/pkgs/applications/networking/cluster/kumactl/default.nix
+++ b/pkgs/applications/networking/cluster/kumactl/default.nix
@@ -1,0 +1,35 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+let
+  version = "1.3.1";
+  pname = "kumactl";
+  home = "github.com/kumahq/kuma";
+in buildGoModule {
+  inherit pname version;
+  src = fetchFromGitHub {
+    owner = "kumahq";
+    repo = "kuma";
+    rev = version;
+    sha256 = "0b554cngg2j3wnadpqwhq3dv3la8vvvzyww2diw4il4gl4j6xj0j";
+  };
+
+  vendorSha256 = "0r26h4vp11wbl7nk3y7c22p60q7lspy8nr58khxyczdqjk6wrdjp";
+
+  subPackages = [ "app/kumactl" ];
+
+  ldflags = let
+    prefix = "${home}/pkg/version";
+  in [
+    "-s" "-w"
+    "-X ${prefix}.version=${version}"
+    "-X ${prefix}.gitTag=${version}"
+    "-X ${prefix}.gitCommit=${version}"
+    "-X ${prefix}.buildDate=${version}"
+  ];
+
+  meta = with lib; {
+    description = "Kuma service mesh controller";
+    homepage = "https://kuma.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ zbioe ];
+  };
+}

--- a/pkgs/applications/networking/cluster/kumactl/default.nix
+++ b/pkgs/applications/networking/cluster/kumactl/default.nix
@@ -1,10 +1,10 @@
 { lib, fetchFromGitHub, buildGoModule }:
+
 let
   version = "1.3.1";
-  pname = "kumactl";
-  home = "github.com/kumahq/kuma";
 in buildGoModule {
-  inherit pname version;
+  inherit version;
+  pname = "kumactl";
   src = fetchFromGitHub {
     owner = "kumahq";
     repo = "kuma";
@@ -17,7 +17,7 @@ in buildGoModule {
   subPackages = [ "app/kumactl" ];
 
   ldflags = let
-    prefix = "${home}/pkg/version";
+    prefix = "github.com/kumahq/kuma/pkg/version";
   in [
     "-s" "-w"
     "-X ${prefix}.version=${version}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26062,6 +26062,8 @@ with pkgs;
   linkerd_edge = callPackage ../applications/networking/cluster/linkerd/edge.nix { };
   linkerd_stable = linkerd;
 
+  kumactl = callPackage ../applications/networking/cluster/kumactl/default.nix { };
+
   kile-wl = callPackage ../applications/misc/kile-wl { };
 
   kiln = callPackage ../applications/misc/kiln { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26062,7 +26062,7 @@ with pkgs;
   linkerd_edge = callPackage ../applications/networking/cluster/linkerd/edge.nix { };
   linkerd_stable = linkerd;
 
-  kumactl = callPackage ../applications/networking/cluster/kumactl/default.nix { };
+  kumactl = callPackage ../applications/networking/cluster/kumactl { };
 
   kile-wl = callPackage ../applications/misc/kile-wl { };
 


### PR DESCRIPTION
###### Motivation for this change
Add kumactl package from nix to manage kuma mesh service

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
