### PR TITLE
nixos/samba: Add `openFirewall` option

### DIFF
--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -87,10 +87,17 @@ in
           <note>
             <para>If you use the firewall consider adding the following:</para>
           <programlisting>
-            networking.firewall.allowedTCPPorts = [ 139 445 ];
-            networking.firewall.allowedUDPPorts = [ 137 138 ];
+            services.samba.openFirewall = true;
           </programlisting>
           </note>
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to automatically open the necessary ports in the firewall.
         '';
       };
 
@@ -235,7 +242,10 @@ in
         };
 
         security.pam.services.samba = {};
-        environment.systemPackages = [ config.services.samba.package ];
+        environment.systemPackages = [ cfg.package ];
+
+        networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ 139 445 ];
+        networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall [ 137 138 ];
       })
     ];
 

--- a/nixos/tests/samba.nix
+++ b/nixos/tests/samba.nix
@@ -20,6 +20,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
       server =
         { ... }:
         { services.samba.enable = true;
+          services.samba.openFirewall = true;
           services.samba.shares.public =
             { path = "/public";
               "read only" = true;
@@ -27,8 +28,6 @@ import ./make-test-python.nix ({ pkgs, ... }:
               "guest ok" = "yes";
               comment = "Public samba share.";
             };
-          networking.firewall.allowedTCPPorts = [ 139 445 ];
-          networking.firewall.allowedUDPPorts = [ 137 138 ];
         };
     };
 


### PR DESCRIPTION
###### Motivation for this change

Change the `samba` module to be more in line with other services that also open the relevant ports for you by default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
