### PR TITLE
nixos/modules/services/backup/borgbackup.nix: Add retry on fail

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -90,6 +90,10 @@ let
           # Borg needs write access to repo if it is not remote
           ++ optional (isLocalPath cfg.repo) cfg.repo;
         PrivateTmp = cfg.privateTmp;
+      } //
+      mkIf cfg.restartOnFail.enable {
+        Restart = "on-failure";
+        RestartSec = cfg.restartOnFail.restartSec;
       };
       environment = {
         BORG_REPO = cfg.repo;
@@ -551,6 +555,24 @@ in {
             '';
             default = "";
             example = "--save-space";
+          };
+
+          restartOnFail.enable = mkOption {
+            type = types.bool;
+            description = ''
+              Wether borgbackup shall be restarted when it fails
+            '';
+            default = false;
+          };
+
+          restartOnFail.restartSec = mkOption {
+            type = types.str;
+            description = ''
+              Configures the time to sleep before restarting borgbackup . Takes a unit-less value
+              in seconds, or a time span value.
+            '';
+            default = "5min";
+            example = "5min 20s";
           };
 
         };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This service always fails for me.  I think this is because network isn't up when it gets executed.

I added an option to make it retry the service.  

Another fix would be depending on `network-online.target`.  But this can impact boot time (https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
