### PR TITLE
qtile: enable wayland backend

### DIFF
--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -47,6 +47,9 @@ let
       psutil
       pyxdg
       pygobject3
+      pywayland
+      pywlroots
+      xkbcommon
     ];
 
     doCheck = false; # Requires X server #TODO this can be worked out with the existing NixOS testing infrastructure.

--- a/pkgs/development/python-modules/pywayland/default.nix
+++ b/pkgs/development/python-modules/pywayland/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, cffi
+, pkg-config
+, wayland
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pywayland";
+  version = "0.4.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0IMNOPTmY22JCHccIVuZxDhVr41cDcKNkx8bp+5h2CU=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  propagatedNativeBuildInputs = [ cffi ];
+  buildInputs = [ wayland ];
+  propagatedBuildInputs = [ cffi ];
+  checkInputs = [ pytestCheckHook ];
+
+  postBuild = ''
+    ${python.interpreter} pywayland/ffi_build.py
+  '';
+
+  # Tests need this to create sockets
+  preCheck = ''
+    export XDG_RUNTIME_DIR="$PWD"
+  '';
+
+  pythonImportsCheck = [ "pywayland" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/flacjacket/pywayland";
+    description = "Python bindings to wayland using cffi";
+    license = licenses.ncsa;
+    maintainers = with maintainers; [ chvp ];
+  };
+}

--- a/pkgs/development/python-modules/pywlroots/default.nix
+++ b/pkgs/development/python-modules/pywlroots/default.nix
@@ -17,11 +17,11 @@
 
 buildPythonPackage rec {
   pname = "pywlroots";
-  version = "0.14.8";
+  version = "0.14.9";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "vCVgO26yv4wJ9cejfLfrRQkbuRJGLTfsqkA9xvbwyRE=";
+    sha256 = "jzHh5ubonn6pCaOp+Dnr7tA9n5DdZ28hBM+03jZZlvc=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/python-modules/pywlroots/default.nix
+++ b/pkgs/development/python-modules/pywlroots/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, cffi
+, pkg-config
+, libxkbcommon
+, libinput
+, pixman
+, udev
+, wlroots
+, wayland
+, pywayland
+, xkbcommon
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pywlroots";
+  version = "0.14.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "vCVgO26yv4wJ9cejfLfrRQkbuRJGLTfsqkA9xvbwyRE=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  propagatedNativeBuildInputs = [ cffi ];
+  buildInputs = [ libinput libxkbcommon pixman udev wayland wlroots ];
+  propagatedBuildInputs = [ cffi pywayland xkbcommon ];
+  checkInputs = [ pytestCheckHook ];
+
+  postBuild = ''
+    ${python.interpreter} wlroots/ffi_build.py
+  '';
+
+  pythonImportsCheck = [ "wlroots" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/flacjacket/pywlroots";
+    description = "Python bindings to wlroots using cffi";
+    license = licenses.ncsa;
+    maintainers = with maintainers; [ chvp ];
+  };
+}

--- a/pkgs/development/python-modules/xkbcommon/default.nix
+++ b/pkgs/development/python-modules/xkbcommon/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, cffi
+, pkg-config
+, libxkbcommon
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "xkbcommon";
+  version = "0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "V5LMaX5TPhk9x4ZA4MGFzDhUiC6NKPo4uTbW6Q7mdVw=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  propagatedNativeBuildInputs = [ cffi ];
+  buildInputs = [ libxkbcommon ];
+  propagatedBuildInputs = [ cffi ];
+  checkInputs = [ pytestCheckHook ];
+
+  postBuild = ''
+    ${python.interpreter} xkbcommon/ffi_build.py
+  '';
+
+  pythonImportsCheck = [ "xkbcommon" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/sde1000/python-xkbcommon";
+    description = "Python bindings for libxkbcommon using cffi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chvp ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7724,6 +7724,8 @@ in {
 
   pywavelets = callPackage ../development/python-modules/pywavelets { };
 
+  pywayland = callPackage ../development/python-modules/pywayland { };
+
   pywbem = callPackage ../development/python-modules/pywbem {
     inherit (pkgs) libxml2;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9841,6 +9841,8 @@ in {
 
   xhtml2pdf = callPackage ../development/python-modules/xhtml2pdf { };
 
+  xkbcommon = callPackage ../development/python-modules/xkbcommon { };
+
   xkcdpass = callPackage ../development/python-modules/xkcdpass { };
 
   xknx = callPackage ../development/python-modules/xknx { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7744,6 +7744,8 @@ in {
 
   pywizlight = callPackage ../development/python-modules/pywizlight { };
 
+  pywlroots = callPackage ../development/python-modules/pywlroots { };
+
   pyxattr = callPackage ../development/python-modules/pyxattr { };
 
   pyworld = callPackage ../development/python-modules/pyworld { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I wanted to try qtile as a wayland compositor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
