### PR TITLE
winbox: init at 3.31

### DIFF
--- a/pkgs/tools/admin/winbox/default.nix
+++ b/pkgs/tools/admin/winbox/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenv
+, fetchurl
+, makeDesktopItem
+, makeWrapper
+, symlinkJoin
+, writeShellScriptBin
+
+, wine
+, use64 ? false
+}:
+
+let
+  inherit (lib) last splitString;
+
+  pname = "winbox";
+  version = "3.31";
+  name = "${pname}-${version}";
+
+  executable = fetchurl (if use64 then {
+    url = "https://download.mikrotik.com/winbox/${version}/${pname}64.exe";
+    sha256 = "sha256-aE6RZ2bCYahxH5QWxBH4CJOjW9dbzibx8zQ4Z5652V4=";
+  } else {
+    url = "https://download.mikrotik.com/winbox/${version}/${pname}.exe";
+    sha256 = "sha256-yyKiU5xJlp/VQVYuX79pdCEve63yV3SUzi+/c915gAc=";
+  });
+  # This is from the winbox AUR package:
+  # https://aur.archlinux.org/cgit/aur.git/tree/winbox64?h=winbox64&id=8edd93792af84e87592e8645ca09e9795931e60e
+  wrapper = writeShellScriptBin pname ''
+    export WINEPREFIX="''${WINBOX_HOME:-"''${XDG_DATA_HOME:-"''${HOME}/.local/share"}/winbox"}/wine"
+    export WINEARCH=${if use64 then "win64" else "win32"}
+    export WINEDLLOVERRIDES="mscoree=" # disable mono
+    export WINEDEBUG=-all
+    if [ ! -d "$WINEPREFIX" ] ; then
+      mkdir -p "$WINEPREFIX"
+      ${wine}/bin/wineboot -u
+    fi
+
+    ${wine}/bin/wine ${executable} "$@"
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    desktopName = "Winbox";
+    comment = "GUI administration for Mikrotik RouterOS";
+    exec = pname;
+    icon = pname;
+    type = "Application";
+    categories = "Utility";
+    extraDesktopEntries = {
+      StartupWMClass = last (splitString "/" executable);
+    };
+  };
+
+  # The icon is also from the winbox AUR package (see above).
+  icon = fetchurl {
+    name = "winbox.png";
+    url = "https://aur.archlinux.org/cgit/aur.git/plain/winbox.png?h=winbox";
+    sha256 = "sha256-YD6u2N+1thRnEsXO6AHm138fRda9XEtUX5+EGTg004A=";
+  };
+in
+symlinkJoin {
+  inherit name pname version;
+  paths = [ wrapper desktopItem ];
+
+  postBuild = ''
+    mkdir -p "$out/share/pixmaps"
+    ln -s "${icon}" "$out/share/pixmaps/${pname}.png"
+  '';
+
+  meta = with lib; {
+    description = "Graphical configuration utility for RouterOS-based devices";
+    homepage = "https://mikrotik.com";
+    downloadPage = "https:/ /mikrotik.com/download";
+    changelog = "https://wiki.mikrotik.com/wiki/Winbox_changelog";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ yrd ];
+  };
+}

--- a/pkgs/tools/admin/winbox/default.nix
+++ b/pkgs/tools/admin/winbox/default.nix
@@ -71,7 +71,7 @@ symlinkJoin {
   meta = with lib; {
     description = "Graphical configuration utility for RouterOS-based devices";
     homepage = "https://mikrotik.com";
-    downloadPage = "https:/ /mikrotik.com/download";
+    downloadPage = "https://mikrotik.com/download";
     changelog = "https://wiki.mikrotik.com/wiki/Winbox_changelog";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ yrd ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -968,6 +968,11 @@ with pkgs;
 
   vopono = callPackage ../tools/networking/vopono { };
 
+  winbox = callPackage ../tools/admin/winbox {
+    wine = wineWowPackages.staging;
+    use64 = true;
+  };
+
   xcd = callPackage ../tools/misc/xcd { };
 
   xtrt = callPackage ../tools/archivers/xtrt { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds a package for Winbox, a graphical configuration utility for [RouterOS](https://mikrotik.com/)-based devices. Because the software is only available for windows, it has been packaged as a wine app (which works quite well, similarly to the [AUR package](https://aur.archlinux.org/packages/winbox/)). I'm not sure what the general Nix practice is on packaging individual Wine applications, but I thought it was fitting in this case because judging by the aforementioned arch package, some config is needed to run Winbox.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
