### PR TITLE
fetch-kde-qt.sh: use mirrorlist files to get sha256 sums

### DIFF
--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -14,16 +14,27 @@ fi
 
 tmp=$(mktemp -d)
 pushd $tmp >/dev/null
+
+# use mirrorlist files to get sha256 sums
+# patch WGET_ARGS from nixpkgs/pkgs/development/libraries/qt-6/6.2/fetch.sh etc
+[ "${WGET_ARGS[-1]}" = '*.tar.xz' ] && WGET_ARGS[-1]='*.tar.xz.mirrorlist'
+
+# debug
+echo "running wget in 5 seconds ..."
+echo wget -nH -r -c --no-parent "${WGET_ARGS[@]}"
+sleep 5
+
 wget -nH -r -c --no-parent "${WGET_ARGS[@]}" >/dev/null
 
 csv=$(mktemp)
-find . -type f | while read src; do
+find . -type f -name '*.mirrorlist' | while read mirrorlist; do
+    src="${mirrorlist%.*}" # remove extension
     # Sanitize file name
     filename=$(basename "$src" | tr '@' '_')
     nameVersion="${filename%.tar.*}"
     name=$(echo "$nameVersion" | sed -e 's,-[[:digit:]].*,,' | sed -e 's,-opensource-src$,,' | sed -e 's,-everywhere-src$,,')
     version=$(echo "$nameVersion" | sed -e 's,^\([[:alpha:]][[:alnum:]]*-\)\+,,')
-    echo "$name,$version,$src,$filename" >>$csv
+    echo "$name,$version,$src,$filename,$mirrorlist" >>$csv
 done
 
 cat >"$SRCS" <<EOF
@@ -39,8 +50,9 @@ gawk -F , "{ print \$1 }" $csv | sort | uniq | while read name; do
     latestVersion=$(echo "$versions" | sort -rV | head -n 1)
     src=$(gawk -F , "/^$name,$latestVersion,/ { print \$3 }" $csv)
     filename=$(gawk -F , "/^$name,$latestVersion,/ { print \$4 }" $csv)
+    mirrorlist=$(gawk -F , "/^$name,$latestVersion,/ { print \$5 }" $csv)
     url="${src:2}"
-    sha256=$(nix-hash --type sha256 --base32 --flat "$src")
+    sha256=$(grep -F '>SHA-256 Hash<' "$mirrorlist" | sed -E 's|^.*<tt>([0-9a-f]{64})</tt>.*|\1|')
     cat >>"$SRCS" <<EOF
   $name = {
     version = "$latestVersion";

--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -19,10 +19,8 @@ pushd $tmp >/dev/null
 # patch WGET_ARGS from nixpkgs/pkgs/development/libraries/qt-6/6.2/fetch.sh etc
 [ "${WGET_ARGS[-1]}" = '*.tar.xz' ] && WGET_ARGS[-1]='*.tar.xz.mirrorlist'
 
-# debug
-echo "running wget in 5 seconds ..."
+echo 'fetching mirrorlist files ...'
 echo wget -nH -r -c --no-parent "${WGET_ARGS[@]}"
-sleep 5
 
 wget -nH -r -c --no-parent "${WGET_ARGS[@]}" >/dev/null
 

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/release-service/21.08.1/src -A '*.tar.xz' )
+BASE_URL='https://download.kde.org/stable/release-service/21.08.1/src/'

--- a/pkgs/applications/plasma-mobile/fetch.sh
+++ b/pkgs/applications/plasma-mobile/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/plasma-mobile/21.05 -A '*.tar.xz' )
+BASE_URL='http://download.kde.org/stable/plasma-mobile/21.05/'

--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.22.5/ -A '*.tar.xz' )
+BASE_URL='https://download.kde.org/stable/plasma/5.22.5/'

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.85/ -A '*.tar.xz' )
+BASE_URL='https://download.kde.org/stable/frameworks/5.85/'

--- a/pkgs/development/libraries/qt-5/5.12/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.12/fetch.sh
@@ -1,2 +1,1 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.12/5.12.10/submodules/ \
-            -A '*.tar.xz' )
+BASE_URL='http://download.qt.io/official_releases/qt/5.12/5.12.10/submodules/'

--- a/pkgs/development/libraries/qt-5/5.14/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.14/fetch.sh
@@ -1,2 +1,1 @@
-WGET_ARGS=( https://download.qt.io/archive/qt/5.14/5.14.2/submodules/ \
-            -A '*.tar.xz' )
+BASE_URL='https://download.qt.io/archive/qt/5.14/5.14.2/submodules/'

--- a/pkgs/development/libraries/qt-5/5.15/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.15/fetch.sh
@@ -1,2 +1,1 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.15/5.15.2/submodules/ \
-            -A '*.tar.xz' )
+BASE_URL='http://download.qt.io/official_releases/qt/5.15/5.15.2/submodules/'


### PR DESCRIPTION
###### Motivation for this change
make this script much faster

checksums are stored in `*.mirrorlist` files, for example [qtwebview-everywhere-src-6.2.0.tar.xz.mirrorlist](https://download.qt.io/official_releases/qt/6.2/6.2.0/submodules/qtwebview-everywhere-src-6.2.0.tar.xz.mirrorlist)
i use grep + sed to parse the sha256 sums

tested with success, to update `qt-6/6.2/srcs.nix`

###### related

part of #141883

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
