### PR TITLE
pdftoipe: init at 7.2.24.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12353,6 +12353,12 @@
     githubId = 452;
     name = "Yurii Rashkovskii";
   };
+  yrd = {
+    name = "Yannik Rödel";
+    email = "nix@yannik.info";
+    github = "yrd";
+    githubId = 1820447;
+  };
   ysndr = {
     email = "me@ysndr.de";
     github = "ysndr";

--- a/pkgs/tools/graphics/pdftoipe/default.nix
+++ b/pkgs/tools/graphics/pdftoipe/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, poppler
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pdftoipe";
+  version = "7.2.24.1";
+
+  src = fetchFromGitHub {
+    owner = "otfried";
+    repo = "ipe-tools";
+    rev = "v${version}";
+    sha256 = "jlrjrjzZQo79CKMySayhCm1dqLh89wOQuXrXa2aqc0k=";
+  };
+  sourceRoot = "source/pdftoipe";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ poppler ];
+
+  installPhase = ''
+    install -D pdftoipe $out/bin/pdftoipe
+  '';
+
+  meta = with lib; {
+    description = "A program that tries to convert arbitrary PDF documents to Ipe files";
+    homepage = "https://github.com/otfried/ipe-tools";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ yrd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8315,6 +8315,8 @@ with pkgs;
 
   pdf2svg = callPackage ../tools/graphics/pdf2svg { };
 
+  pdftoipe = callPackage ../tools/graphics/pdftoipe { };
+
   fmodex = callPackage ../games/zandronum/fmod.nix { };
 
   pdfminer = with python3Packages; toPythonApplication pdfminer;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This tool is included in the [ipe-tools](https://github.com/otfried/ipe-tools/) repo, which is supplementary to the already packaged [ipe](https://github.com/NixOS/nixpkgs/blob/nixos-21.05/pkgs/applications/graphics/ipe/default.nix#L56) editor (cc @ttuegel).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
