### PR TITLE
ipe: add desktop file

### DIFF
--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -61,6 +61,7 @@ mkDerivation rec {
         comment = "A drawing editor for creating figures in PDF format";
         exec = "ipe";
         icon = "ipe";
+        mimeType = "text/xml;application/pdf";
         categories = "Graphics;Qt;";
         extraDesktopEntries = {
           StartupWMClass = "ipe";

--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -44,11 +44,11 @@ mkDerivation rec {
     zlib
   ];
 
-  IPEPREFIX=placeholder "out";
-  URWFONTDIR="${texlive}/texmf-dist/fonts/type1/urw/";
+  IPEPREFIX = placeholder "out";
+  URWFONTDIR = "${texlive}/texmf-dist/fonts/type1/urw/";
   LUA_PACKAGE = "lua";
 
-  qtWrapperArgs = [ "--prefix PATH : ${texlive}/bin"  ];
+  qtWrapperArgs = [ "--prefix PATH : ${texlive}/bin" ];
 
   enableParallelBuilding = true;
 
@@ -76,7 +76,7 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "An editor for drawing figures";
-    homepage = "http://ipe.otfried.org";  # https not available
+    homepage = "http://ipe.otfried.org"; # https not available
     license = licenses.gpl3Plus;
     longDescription = ''
       Ipe is an extensible drawing editor for creating figures in PDF and Postscript format.

--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -1,7 +1,9 @@
 { lib
 , mkDerivation
+, makeDesktopItem
 , fetchurl
 , pkg-config
+, copyDesktopItems
 , cairo
 , freetype
 , ghostscript
@@ -26,7 +28,7 @@ mkDerivation rec {
 
   sourceRoot = "${pname}-${version}/src";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config copyDesktopItems ];
 
   buildInputs = [
     cairo
@@ -50,7 +52,27 @@ mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # TODO: make .desktop entry
+  desktopItems = [
+    (makeDesktopItem
+      {
+        name = pname;
+        desktopName = "Ipe";
+        genericName = "Drawing editor";
+        comment = "A drawing editor for creating figures in PDF format";
+        exec = "ipe";
+        icon = "ipe";
+        categories = "Graphics;Qt;";
+        extraDesktopEntries = {
+          StartupWMClass = "ipe";
+          StartupNotify = "true";
+        };
+      })
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/icons/hicolor/128x128/apps
+    ln -s $out/share/ipe/${version}/icons/icon_128x128.png $out/share/icons/hicolor/128x128/apps/ipe.png
+  '';
 
   meta = with lib; {
     description = "An editor for drawing figures";

--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -48,26 +48,25 @@ mkDerivation rec {
   URWFONTDIR = "${texlive}/texmf-dist/fonts/type1/urw/";
   LUA_PACKAGE = "lua";
 
-  qtWrapperArgs = [ "--prefix PATH : ${texlive}/bin" ];
+  qtWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ texlive ]}" ];
 
   enableParallelBuilding = true;
 
   desktopItems = [
-    (makeDesktopItem
-      {
-        name = pname;
-        desktopName = "Ipe";
-        genericName = "Drawing editor";
-        comment = "A drawing editor for creating figures in PDF format";
-        exec = "ipe";
-        icon = "ipe";
-        mimeType = "text/xml;application/pdf";
-        categories = "Graphics;Qt;";
-        extraDesktopEntries = {
-          StartupWMClass = "ipe";
-          StartupNotify = "true";
-        };
-      })
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "Ipe";
+      genericName = "Drawing editor";
+      comment = "A drawing editor for creating figures in PDF format";
+      exec = "ipe";
+      icon = "ipe";
+      mimeType = "text/xml;application/pdf";
+      categories = "Graphics;Qt;";
+      extraDesktopEntries = {
+        StartupWMClass = "ipe";
+        StartupNotify = "true";
+      };
+    })
   ];
 
   postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The Ipe package does not currently contain a `.desktop` file, which is specified as a [TODO](https://github.com/NixOS/nixpkgs/blob/2d8959825023f296637432b067c4085c1a6a15ac/pkgs/applications/graphics/ipe/default.nix#L53). This PR adds such an entry, using the icon bundled with the program.

cc @ttuegel 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
