### PR TITLE
pythonPackages.debugpy: 1.4.3 → 1.5.0

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -4,26 +4,26 @@
 , fetchFromGitHub
 , substituteAll
 , gdb
+, django
 , flask
+, gevent
 , psutil
 , pytest-timeout
 , pytest-xdist
 , pytestCheckHook
 , requests
-, isPy27
-, django
-, gevent
+, isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.4.3";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-ULxVoZuMNDL0Win/+55RnbkCPZ8OI8nhSKshvJOMFQ4=";
+    sha256 = "sha256-xgxKyqtSqKITwze7DKDdkxZlq1mWM+x4C/eJlUJmYuk=";
   };
 
   patches = [
@@ -65,29 +65,20 @@ buildPythonPackage rec {
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}")}
   )'';
 
+  doCheck = isPy3k;
   checkInputs = [
+    django
     flask
+    gevent
     psutil
     pytest-timeout
     pytest-xdist
     pytestCheckHook
     requests
-  ] ++ lib.optionals (!isPy27) [
-    django
-    gevent
   ];
 
   # Override default arguments in pytest.ini
   pytestFlagsArray = [ "--timeout=0" "-n=$NIX_BUILD_CORES" ];
-
-  disabledTests = lib.optionals isPy27 [
-    # django 1.11 is the last version to support Python 2.7
-    # and is no longer built in nixpkgs
-    "django"
-
-    # gevent fails to import zope.interface with Python 2.7
-    "gevent"
-  ];
 
   pythonImportsCheck = [ "debugpy" ];
 


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/microsoft/debugpy/releases/tag/v1.5.0

Also, most of the `checkInputs` don't support Python 2.7 anymore, so I updated the tests to only run with Python 3.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files, only a Python library. Tested through `dap-mode` in Emacs.
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).