### PR TITLE
ibm-sw-tpm2: Fix build on RISC-V

### DIFF
--- a/pkgs/tools/security/ibm-sw-tpm2/default.nix
+++ b/pkgs/tools/security/ibm-sw-tpm2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, openssl }:
+{ stdenv, fetchurl, fetchpatch, lib, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "ibm-sw-tpm2";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/ibmswtpm2/ibmtpm${version}.tar.gz";
     sha256 = "sha256-VRRZKK0rJPNL5qDqz5+0kuEODqkZuEKMch+pcOhdYUc=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/kgoldman/ibmswtpm2/commit/e6684009aff9c1bad38875e3319c2e02ef791424.patch";
+      sha256 = "1flzlri807c88agmpb0w8xvh5f16mmqv86xw4ic4z272iynzd40j";
+    })
+  ];
+
+  patchFlags = [ "-p2" ];
 
   buildInputs = [ openssl ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

For native builds on riscv64, #141817 is required. Otherwise the crypt word size will be mismatched.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] riscv64-linux
  - [x] x86_64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
