### PR TITLE
ocamlPackages.carton: 0.4.2 → 0.4.3

### DIFF
--- a/pkgs/development/ocaml-modules/carton/default.nix
+++ b/pkgs/development/ocaml-modules/carton/default.nix
@@ -7,14 +7,14 @@
 
 buildDunePackage rec {
   pname = "carton";
-  version = "0.4.2";
+  version = "0.4.3";
 
   useDune2 = true;
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${pname}-v${version}/${pname}-${pname}-v${version}.tbz";
-    sha256 = "a0a03b2f7bb7dafe070bc6a74583b6d6da714d2c636dd4d5a6443c9f299ceacc";
+    sha256 = "sha256:0qz9ds5761wx4m7ly3av843b6dii7lmjpx2nnyijv8rm8aw95jgr";
   };
 
   # remove changelogs for mimic and the git* packages

--- a/pkgs/development/ocaml-modules/carton/git.nix
+++ b/pkgs/development/ocaml-modules/carton/git.nix
@@ -8,7 +8,7 @@
 buildDunePackage {
   pname = "carton-git";
 
-  inherit (carton) version src useDune2 minimumOCamlVersion postPatch;
+  inherit (carton) version src useDune2 postPatch;
 
   propagatedBuildInputs = [
     carton

--- a/pkgs/development/ocaml-modules/carton/lwt.nix
+++ b/pkgs/development/ocaml-modules/carton/lwt.nix
@@ -10,7 +10,7 @@
 buildDunePackage {
   pname = "carton-lwt";
 
-  inherit (carton) version src useDune2 minimumOCamlVersion postPatch;
+  inherit (carton) version src useDune2 postPatch;
 
   propagatedBuildInputs = [
     carton


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.13

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
