### PR TITLE
xorg.xinit: fix cross-compiling

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -779,6 +779,7 @@ self: super:
     stdenv = if isDarwin then clangStdenv else stdenv;
   }).overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ lib.optional isDarwin bootstrap_cmds;
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
     configureFlags = [
       "--with-xserver=${self.xorgserver.out}/bin/X"
     ] ++ lib.optionals isDarwin [
@@ -794,6 +795,10 @@ self: super:
         sha256 = "18kb88i3s9nbq2jxl7l2hyj6p56c993hivk8mzxg811iqbbawkp7";
       })
     ];
+    postPatch = ''
+      # Avoid replacement of word-looking cpp's builtin macros in Nix's cross-compiled paths
+      substituteInPlace Makefile.in --replace "PROGCPPDEFS =" "PROGCPPDEFS = -Dlinux=linux -Dunix=unix"
+    '';
     propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ self.xauth ]
                          ++ lib.optionals isDarwin [ self.libX11 self.xorgproto ];
     postFixup = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Being able to build `pkgsCross.armv7l-hf-multiplatform.xorg.xinit`.
It currently fails due to being unable to find a working `cpp`.

Tested with this `xinit.nix`:
```nix
let pkgs = import ./. {
  overlays = [
    (final: super: {
      # A working armv7l cross-compiling configuration for mesa
      # Because the default mesa fails with:
      # meson.build:1708:2: ERROR: Problem encountered: The following drivers require LLVM:
      # Radv, RadeonSI, SWR, Lavapipe. One of these is enabled, but LLVM is disabled.
      mesa = super.mesa.override {
        driDrivers = [];
        eglPlatforms = ["x11"];
        enableGalliumNine = false;
        galliumDrivers = ["lima" "panfrost" "kmsro" "swrast"];
        vulkanDrivers = [];
      };
    })
  ];
};
in
pkgs.pkgsCross.armv7l-hf-multiplatform.xorg.xinit
```
`nix -L build -f xinit.nix`

###### Things done
- [X] Add `buildPackages.stdenv.cc` to `xinit`'s `depsBuildBuild` so that it can find a working `cpp`.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
