### PR TITLE
github-runner: add aarch64-linux to platforms

### DIFF
--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -29,7 +29,10 @@ let
   nugetSource = linkFarm "nuget-packages" nugetPackages;
 
   dotnetSdk = dotnetCorePackages.sdk_3_1;
-  runtimeId = "linux-x64";
+  runtimeId =
+    if stdenv.isAarch64
+    then "linux-arm64"
+    else "linux-x64";
   fakeSha1 = "0000000000000000000000000000000000000000";
 in
 stdenv.mkDerivation rec {
@@ -271,7 +274,7 @@ stdenv.mkDerivation rec {
     description = "Self-hosted runner for GitHub Actions";
     homepage = "https://github.com/actions/runner";
     license = licenses.mit;
-    maintainers = with maintainers; [ veehaitch ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ veehaitch newam ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/development/tools/continuous-integration/github-runner/deps.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/deps.nix
@@ -19,6 +19,11 @@ in
     sha256 = "19z4zrchaxcz0a33c33n1qd11z9khj4323nfzsbzah0xxkkj8ka8";
   })
   (fetchNuGet {
+    name = "microsoft.aspnetcore.app.runtime.linux-arm64";
+    version = "3.1.19";
+    sha256 = "0xspb0xib1zsqnkkqm4s26z27v9idh9k09zziar1cavh2hxxxfcd";
+  })
+  (fetchNuGet {
     name = "microsoft.aspnet.webapi.client";
     version = "5.2.4";
     sha256 = "00fkczf69z2rwarcd8kjjdp47517a0ca6lggn72qbilsp03a5scj";
@@ -42,6 +47,11 @@ in
     name = "microsoft.netcore.app.runtime.linux-x64";
     version = "3.1.19";
     sha256 = "10c9bq1z8j173n9jzamgplbxq101yscwdhksshn1ybisn7cr5g0h";
+  })
+  (fetchNuGet {
+    name = "microsoft.netcore.app.runtime.linux-arm64";
+    version = "3.1.19";
+    sha256 = "0v9nc38bg4k2qk547pl1rlrslwprixqlbhcbbf6pw1ia6261wm5m";
   })
   (fetchNuGet {
     name = "microsoft.netcore.platforms";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add support for aarch64-linux to github-runner.

Tested on a raspberry pi 4 running NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
