### PR TITLE
aws-c-common: 0.6.12 -> 0.6.14

### DIFF
--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-common";
-  version = "0.6.12";
+  version = "0.6.14";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Bbb6YbPMpzVy+Pa9OGe62TXihTbUeKTlPS29sa70aQ8=";
+    sha256 = "sha256-JEaRB0k6zyk5UKuB2hEZUAsnp2SuI9mrok/EvwclUJk=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/aws-c-io/default.nix
+++ b/pkgs/development/libraries/aws-c-io/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-io";
-  version = "0.10.9";
+  version = "0.10.12";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-16MhOQlvFwbiSBNI1NWGjrLh0z/fCnAGmc8JguZQPZM=";
+    sha256 = "sha256-8v38NN9qrgdrshMx3l2wLrl7l77HjsW2GPu8IwkclJQ=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
aws-c-io needs to be updated at the same time, due to an API break in aws-c-common:
https://github.com/awslabs/aws-c-common/commit/8c51377ddff0aea9e21ecd9f58e9a4d283539751
https://github.com/awslabs/aws-c-io/commit/bb630775c6150eb87614e1dbb20223fa26cefa29

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
