### PR TITLE
purple-discord: 2018-04-10 -> 2021-10-17

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-discord/default.nix
@@ -1,17 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, pidgin, json-glib }:
+{ lib, stdenv, fetchFromGitHub, imagemagick, gettext, pidgin, json-glib }:
 
 stdenv.mkDerivation {
   pname = "purple-discord";
-  version = "unstable-2018-04-10";
+  version = "unstable-2021-10-17";
 
   src = fetchFromGitHub {
     owner = "EionRobb";
     repo = "purple-discord";
-    rev = "9a97886d15a1f028de54b5e6fc54e784531063b0";
-    sha256 = "0dc344zh1v4yh9c8javcw5ylzwc1wpx0ih8bww8p8cjmhr8kcl32";
+    rev = "b7ac72399218d2ce011ac84bb171b572560aa2d2";
+    sha256 = "0xvj9rdvgsvcr55sk9m40y07rchg699l1yr98xqwx7sc2sba3814";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ imagemagick gettext ];
   buildInputs = [ pidgin json-glib ];
 
   PKG_CONFIG_PURPLE_PLUGINDIR = "${placeholder "out"}/lib/purple-2";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update purple-discord to the latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
