### PR TITLE
kn: init at 0.26.0

### DIFF
--- a/pkgs/applications/networking/cluster/kn/default.nix
+++ b/pkgs/applications/networking/cluster/kn/default.nix
@@ -11,11 +11,11 @@ buildGoModule rec {
     sha256 = "sha256-hquxv1BluR535WvMtJlVyP7JuARDNGDjPAbdSSj2juo=";
   };
 
-  nativeBuildInputs = [ installShellFiles ];
-
   vendorSha256 = null;
 
   subPackages = [ "cmd/kn" ];
+
+  nativeBuildInputs = [ installShellFiles ];
 
   ldflags = [
     "-X knative.dev/client/pkg/kn/commands/version.Version=v${version}"

--- a/pkgs/applications/networking/cluster/kn/default.nix
+++ b/pkgs/applications/networking/cluster/kn/default.nix
@@ -1,0 +1,44 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "kn";
+  version = "0.26.0";
+
+  src = fetchFromGitHub {
+    owner = "knative";
+    repo = "client";
+    rev = "v${version}";
+    sha256 = "sha256-hquxv1BluR535WvMtJlVyP7JuARDNGDjPAbdSSj2juo=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  vendorSha256 = null;
+
+  subPackages = [ "cmd/kn" ];
+
+  ldflags = [
+    "-X knative.dev/client/pkg/kn/commands/version.Version=v${version}"
+    "-X knative.dev/client/pkg/kn/commands/version.VersionEventing=v${version}"
+    "-X knative.dev/client/pkg/kn/commands/version.VersionServing=v${version}"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd kn \
+      --bash <($out/bin/kn completion bash) \
+      --zsh <($out/bin/kn completion zsh)
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/kn version | grep ${version} > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "The Knative client kn is your door to the Knative world. It allows you to create Knative resources interactively from the command line or from within scripts";
+    homepage = "https://github.com/knative/client";
+    changelog = "https://github.com/knative/client/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25806,6 +25806,8 @@ with pkgs;
 
   kmymoney = libsForQt5.callPackage ../applications/office/kmymoney { };
 
+  kn = callPackage ../applications/networking/cluster/kn { };
+
   kodestudio = callPackage ../applications/editors/kodestudio { };
 
   kondo = callPackage ../applications/misc/kondo { };


### PR DESCRIPTION
###### Motivation for this change

Include Knative CLI client

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
