### PR TITLE
tidy-viewer: init at 0.0.21

### DIFF
--- a/pkgs/tools/text/tidy-viewer/default.nix
+++ b/pkgs/tools/text/tidy-viewer/default.nix
@@ -1,0 +1,29 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tidy-viewer";
+  version = "0.0.21";
+
+  src = fetchFromGitHub {
+    owner = "alexhallam";
+    repo = "tv";
+    rev = version;
+    sha256 = "1zjnc2b9y2f6x114svp31r1lzkak4xfn71qrxch30mq2aj4yzd2l";
+  };
+
+  cargoSha256 = "sha256-M6HInLevKvF4zBNe+Sg8fQK6koefRaO0l5AcrFhH+vI=";
+
+  # this test parses command line arguments
+  # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
+  checkFlags = [
+    "--skip=build_reader_can_create_reader_without_file_specified"
+  ];
+
+  meta = with lib; {
+    description = "A cross-platform CLI csv pretty printer that uses column styling to maximize viewer enjoyment";
+    homepage = "https://github.com/alexhallam/tv";
+    changelog = "https://github.com/alexhallam/tv/blob/${version}/CHANGELOG.md";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9776,6 +9776,8 @@ with pkgs;
 
   thinkpad-scripts = python3.pkgs.callPackage ../tools/misc/thinkpad-scripts { };
 
+  tidy-viewer = callPackage ../tools/text/tidy-viewer { };
+
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };
 
   tiledb = callPackage ../development/libraries/tiledb { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tidy Viewer is a cross-platform CLI csv pretty printer that uses column styling to maximize viewer enjoyment

https://github.com/alexhallam/tv

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
