### PR TITLE
krita-beta: 5.0.0-beta1 -> 5.0.0-beta2

### DIFF
--- a/pkgs/applications/graphics/krita/beta.nix
+++ b/pkgs/applications/graphics/krita/beta.nix
@@ -1,7 +1,7 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "5.0.0-beta1";
+  version = "5.0.0-beta2";
   kde-channel = "unstable";
-  sha256 = "1p5l2vpsgcp4wajgn5rgjcyb8l5ickm1nkmfx8zzr4rnwjnyxdbm";
+  sha256 = "0hwh6k40f4kmwg14dy0vvm0m8cx8n0q67lrrc620da9mign3hjs7";
 })


### PR DESCRIPTION
Update krita-beta to latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
