### PR TITLE
rtorrent-jesec: 0.9.8-r14 -> 0.9.8-r15

### DIFF
--- a/pkgs/tools/networking/p2p/libtorrent-jesec/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent-jesec/default.nix
@@ -2,22 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libtorrent-jesec";
-  version = "0.13.8-r2";
+  version = "0.13.8-r3";
 
   src = fetchFromGitHub {
     owner = "jesec";
     repo = "libtorrent";
     rev = "v${version}";
-    sha256 = "sha256-eIXVTbVOCRHcxSsLPvIm9F60t2upk5ORpDSOOYqTCJ4=";
+    sha256 = "0j84717wyai4iavrz2g6kix6fl09sw1cgsqp4yclzgg46lmwww2b";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "test-fallback";
-      url = "https://github.com/jesec/libtorrent/commit/a38205ce06aadc9908478ec3a9c8aefd9be06344.patch";
-      sha256 = "sha256-2TyQ9zYWZw6bzAfVZzTOQSkfIZnDU8ykgpRAFXscEH0=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ openssl zlib ];

--- a/pkgs/tools/networking/p2p/rtorrent-jesec/default.nix
+++ b/pkgs/tools/networking/p2p/rtorrent-jesec/default.nix
@@ -16,13 +16,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "rtorrent-jesec";
-  version = "0.9.8-r14";
+  version = "0.9.8-r15";
 
   src = fetchFromGitHub {
     owner = "jesec";
     repo = "rtorrent";
     rev = "v${version}";
-    sha256 = "sha256-AbjzNIha3MkCZi6MuyUfPx9r3zeXeTUzkbD7uHB85lo=";
+    sha256 = "0sdf76yhyzgbgfmqwxxhyzdk0sqixl1jx8wqy0xxwh921grv10y9";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

Bumps `libtorrent-jesec` and `rtorrent-jesec` to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
