### PR TITLE
ocamlPackages.ocaml-freestanding: 0.6.4 → 0.6.5

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-freestanding/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-freestanding/default.nix
@@ -22,13 +22,13 @@ else
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-${pname}-${version}";
   inherit pname;
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchFromGitHub {
     owner = "mirage";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0w3x2wfd04qr6mci4cp1gfqw33yysp8gamgkpgbgwslr0skryiq5";
+    sha256 = "sha256:1mbyjzwcs64n7i3xkkyaxgl3r46drbl0gkqf3fqgm2kh3q03638l";
   };
 
   postUnpack = ''
@@ -53,15 +53,6 @@ stdenv.mkDerivation rec {
     runHook preConfigure
     env PKG_CONFIG_DEPS=solo5-bindings-${target} sh configure.sh
     runHook postConfigure
-  '';
-
-  preBuild = ''
-    # perform substitutions, so opam isn't needed
-    for flags in flags/cflags.tmp flags/libs.tmp; do
-      substitute "$flags.in" "$flags" \
-        --replace "%{prefix}%" "$out" \
-        --replace "%{ocaml-freestanding:lib}%" "$out/lib"
-    done
   '';
 
   installPhase = ''

--- a/pkgs/development/ocaml-modules/ocaml-freestanding/no-opam.patch
+++ b/pkgs/development/ocaml-modules/ocaml-freestanding/no-opam.patch
@@ -22,43 +22,6 @@ Date:   Thu Mar 18 01:07:49 2021 +0100
     nice bonus). The Makefile needs no fix since the target ocaml/Makefile
     won't be built if it's already present.
 
-diff --git a/Makefile b/Makefile
-index b07b8c6..a68b31d 100644
---- a/Makefile
-+++ b/Makefile
-@@ -2,6 +2,12 @@
- 
- include Makeconf
- 
-+ifneq ($(shell command -v opam),)
-+	# only set if opam is available and PKG_CONFIG_PATH isn't
-+	# already set in the environment or on the command line
-+	PKG_CONFIG_PATH ?= $(shell opam config var prefix)/lib/pkgconfig
-+endif
-+
- FREESTANDING_LIBS=openlibm/libopenlibm.a \
- 		  ocaml/runtime/libasmrun.a \
- 		  nolibc/libnolibc.a
-@@ -73,8 +79,7 @@ flags/libs.tmp: flags/libs.tmp.in
- 	opam config subst $@
- 
- flags/libs: flags/libs.tmp Makeconf
--	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
--	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
-+	pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
- 	awk -v RS= -- '{ \
- 	    sub("@@PKG_CONFIG_EXTRA_LIBS@@", "$(PKG_CONFIG_EXTRA_LIBS)", $$0); \
- 	    print "(", $$0, ")" \
-@@ -84,8 +89,7 @@ flags/cflags.tmp: flags/cflags.tmp.in
- 	opam config subst $@
- 
- flags/cflags: flags/cflags.tmp Makeconf
--	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
--	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
-+	pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
- 	awk -v RS= -- '{ \
- 	    print "(", $$0, ")" \
- 	    }' $< >$@
 diff --git a/configure.sh b/configure.sh
 index 4d154ed..c254f7b 100755
 --- a/configure.sh


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.13.

cc maintainer @sternenseemann

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
