### PR TITLE
python3Packages.versionfinder: use pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/versionfinder/default.nix
+++ b/pkgs/development/python-modules/versionfinder/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, GitPython, pytest, backoff, requests }:
+{ lib, buildPythonPackage, fetchFromGitHub, GitPython, pytestCheckHook, backoff, requests }:
 
 buildPythonPackage rec {
   pname = "versionfinder";
@@ -17,8 +17,13 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
+    pytestCheckHook
     requests
+  ];
+
+  disabledTestPaths = [
+    # acceptance tests use the network
+    "versionfinder/tests/test_acceptance.py"
   ];
 
   pythonImportsCheck = [ "versionfinder" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Apply feedback from https://github.com/NixOS/nixpkgs/pull/141520/files#r730291984

Please also label for Hacktoberfest once accepted, thanks! :pray: 

###### Things done

- switch from using `pytest` directly to use `pytestCheckHook` instead
- disable acceptance tests from this package as it uses the network

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
