### PR TITLE
linux_latest-libre: fix build

### DIFF
--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -38,6 +38,9 @@ let
       linuxPackages_5_4_hardened
       linuxPackages_5_10_hardened
 
+      linuxPackages_latest-libre
+      linuxPackages-libre
+
       linuxPackages_testing;
   };
 

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -14,9 +14,11 @@ let
   minor = lib.versions.minor linux.modDirVersion;
   patch = lib.versions.patch linux.modDirVersion;
 
+  suffix = "gnu${lib.optionalString (!(lib.versionAtLeast linux.modDirVersion "5.14")) "1"}";
+
 in linux.override {
   argsOverride = {
-    modDirVersion = "${linux.modDirVersion}-gnu1";
+    modDirVersion = "${linux.modDirVersion}-${suffix}";
     isLibre = true;
 
     src = stdenv.mkDerivation {


### PR DESCRIPTION

###### Motivation for this change

It seems as if the `modDirVersion` is only called `{version}-gnu1` for
all Linux versions <5.14[1].

[1] https://web.archive.org/web/20211008193807/https://linux-libre.fsfla.org/pub/linux-libre/releases/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
