### PR TITLE
[21.05] yt-dlp: init at 2021.10.10

### DIFF
--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -1,0 +1,62 @@
+{ lib, fetchurl, buildPythonPackage
+, zip, ffmpeg, rtmpdump, phantomjs2, atomicparsley, pycryptodome, pandoc
+, fetchFromGitHub
+, websockets, mutagen
+, ffmpegSupport ? true
+, rtmpSupport ? true
+, phantomjsSupport ? false
+, hlsEncryptedSupport ? true
+, installShellFiles, makeWrapper }:
+
+buildPythonPackage rec {
+  pname = "yt-dlp";
+  # The websites yt-dlp deals with are a very moving target. That means that
+  # downloads break constantly. Because of that, updates should always be backported
+  # to the latest stable release.
+  version = "2021.07.21";
+
+  src = fetchFromGitHub {
+    owner = "yt-dlp";
+    repo = "yt-dlp";
+    rev = version;
+    sha256 = "ziOW52LJUBe0j7ru8GYgiUCE6YJeBTTjm+H6W8EZjuY=";
+  };
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+  buildInputs = [ zip pandoc ];
+  propagatedBuildInputs = [ websockets mutagen ]
+    ++ lib.optional hlsEncryptedSupport pycryptodome;
+
+  # Ensure these utilities are available in $PATH:
+  # - ffmpeg: post-processing & transcoding support
+  # - rtmpdump: download files over RTMP
+  # - atomicparsley: embedding thumbnails
+  makeWrapperArgs = let
+      packagesToBinPath = [ atomicparsley ]
+        ++ lib.optional ffmpegSupport ffmpeg
+        ++ lib.optional rtmpSupport rtmpdump
+        ++ lib.optional phantomjsSupport phantomjs2;
+    in [ ''--prefix PATH : "${lib.makeBinPath packagesToBinPath}"'' ];
+
+  setupPyBuildFlags = [
+    "build_lazy_extractors"
+  ];
+
+  # Requires network
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/yt-dlp/yt-dlp/";
+    description = "Command-line tool to download videos from YouTube.com and other sites (youtube-dl fork)";
+    longDescription = ''
+      yt-dlp is a youtube-dl fork based on the now inactive youtube-dlc.
+
+      youtube-dl is a small, Python-based command-line program
+      to download videos from YouTube.com and a few more sites.
+      youtube-dl is released to the public domain, which means
+      you can modify it, redistribute it or use it however you like.
+    '';
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ mkg20001 ];
+  };
+}

--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -13,13 +13,13 @@ buildPythonPackage rec {
   # The websites yt-dlp deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2021.07.21";
+  version = "2021.08.02";
 
   src = fetchFromGitHub {
     owner = "yt-dlp";
     repo = "yt-dlp";
     rev = version;
-    sha256 = "ziOW52LJUBe0j7ru8GYgiUCE6YJeBTTjm+H6W8EZjuY=";
+    sha256 = "QEJKOZGVQNXLU8GfTbwBx2Zv3KO++ozTJcXLWxXA4hI=";
   };
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];

--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -20,12 +20,12 @@ buildPythonPackage rec {
   # The websites yt-dlp deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2021.9.2";
+  version = "2021.9.25";
 
   src = fetchPypi {
     inherit pname;
     version = builtins.replaceStrings [ ".0" ] [ "." ] version;
-    sha256 = "sha256-yn53zbBVuiaD31sIB6qxweEgy+AsjzXZ0yk9lNva6mM=";
+    sha256 = "e7b8dd0ee9498abbd80eb38d9753696d6ca3d02f64980322ab3bf39ba1bc31ee";
   };
 
   propagatedBuildInputs = [ websockets mutagen ]

--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -12,6 +12,7 @@
 , rtmpSupport ? true
 , phantomjsSupport ? false
 , hlsEncryptedSupport ? true
+, withAlias ? false # Provides bin/youtube-dl for backcompat
 }:
 
 buildPythonPackage rec {
@@ -49,6 +50,10 @@ buildPythonPackage rec {
 
   # Requires network
   doCheck = false;
+
+  postInstall = lib.optionalString withAlias ''
+      ln -s "$out/bin/yt-dlp" "$out/bin/youtube-dl"
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/yt-dlp/yt-dlp/";

--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -27,12 +27,6 @@ buildPythonPackage rec {
     sha256 = "sha256-yn53zbBVuiaD31sIB6qxweEgy+AsjzXZ0yk9lNva6mM=";
   };
 
-  # build_lazy_extractors assumes this directory exists but it is not present in
-  # the PyPI package
-  postPatch = ''
-    mkdir -p ytdlp_plugins/extractor
-  '';
-
   propagatedBuildInputs = [ websockets mutagen ]
     ++ lib.optional hlsEncryptedSupport pycryptodome;
 

--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildPythonPackage
+{ lib, buildPythonPackage
 , zip, ffmpeg, rtmpdump, phantomjs2, atomicparsley, pycryptodome, pandoc
 , fetchFromGitHub
 , websockets, mutagen
@@ -13,13 +13,13 @@ buildPythonPackage rec {
   # The websites yt-dlp deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2021.08.02";
+  version = "2021.08.10";
 
   src = fetchFromGitHub {
     owner = "yt-dlp";
     repo = "yt-dlp";
     rev = version;
-    sha256 = "QEJKOZGVQNXLU8GfTbwBx2Zv3KO++ozTJcXLWxXA4hI=";
+    sha256 = "sha256-8mOjIvbC3AFHCXKV5G66cFy7SM7sULzM8czXcqQKbms=";
   };
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];

--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -1,12 +1,11 @@
-{ lib, buildPythonPackage
-, zip, ffmpeg, rtmpdump, phantomjs2, atomicparsley, pycryptodome, pandoc
-, fetchFromGitHub
+{ lib, buildPythonPackage, fetchPypi
+, ffmpeg, rtmpdump, phantomjs2, atomicparsley, pycryptodome
 , websockets, mutagen
 , ffmpegSupport ? true
 , rtmpSupport ? true
 , phantomjsSupport ? false
 , hlsEncryptedSupport ? true
-, installShellFiles, makeWrapper }:
+}:
 
 buildPythonPackage rec {
   pname = "yt-dlp";
@@ -15,15 +14,18 @@ buildPythonPackage rec {
   # to the latest stable release.
   version = "2021.08.10";
 
-  src = fetchFromGitHub {
-    owner = "yt-dlp";
-    repo = "yt-dlp";
-    rev = version;
-    sha256 = "sha256-8mOjIvbC3AFHCXKV5G66cFy7SM7sULzM8czXcqQKbms=";
+  src = fetchPypi {
+    inherit pname;
+    version = builtins.replaceStrings [ ".0" ] [ "." ] version;
+    sha256 = "8da1bf4dc4641d37d137443c4783109ee8393caad5e0d270d9d1d534e8f25240";
   };
 
-  nativeBuildInputs = [ installShellFiles makeWrapper ];
-  buildInputs = [ zip pandoc ];
+  # build_lazy_extractors assumes this directory exists but it is not present in
+  # the PyPI package
+  postPatch = ''
+    mkdir -p ytdlp_plugins/extractor
+  '';
+
   propagatedBuildInputs = [ websockets mutagen ]
     ++ lib.optional hlsEncryptedSupport pycryptodome;
 
@@ -48,6 +50,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/yt-dlp/yt-dlp/";
     description = "Command-line tool to download videos from YouTube.com and other sites (youtube-dl fork)";
+    changelog = "https://github.com/yt-dlp/yt-dlp/raw/${version}/Changelog.md";
     longDescription = ''
       yt-dlp is a youtube-dl fork based on the now inactive youtube-dlc.
 
@@ -56,7 +59,7 @@ buildPythonPackage rec {
       youtube-dl is released to the public domain, which means
       you can modify it, redistribute it or use it however you like.
     '';
-    license = licenses.publicDomain;
+    license = licenses.unlicense;
     maintainers = with maintainers; [ mkg20001 ];
   };
 }

--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -1,6 +1,13 @@
-{ lib, buildPythonPackage, fetchPypi
-, ffmpeg, rtmpdump, phantomjs2, atomicparsley, pycryptodome
-, websockets, mutagen
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ffmpeg
+, rtmpdump
+, phantomjs2
+, atomicparsley
+, pycryptodome
+, websockets
+, mutagen
 , ffmpegSupport ? true
 , rtmpSupport ? true
 , phantomjsSupport ? false
@@ -12,12 +19,12 @@ buildPythonPackage rec {
   # The websites yt-dlp deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2021.08.10";
+  version = "2021.9.2";
 
   src = fetchPypi {
     inherit pname;
     version = builtins.replaceStrings [ ".0" ] [ "." ] version;
-    sha256 = "8da1bf4dc4641d37d137443c4783109ee8393caad5e0d270d9d1d534e8f25240";
+    sha256 = "sha256-yn53zbBVuiaD31sIB6qxweEgy+AsjzXZ0yk9lNva6mM=";
   };
 
   # build_lazy_extractors assumes this directory exists but it is not present in
@@ -33,12 +40,14 @@ buildPythonPackage rec {
   # - ffmpeg: post-processing & transcoding support
   # - rtmpdump: download files over RTMP
   # - atomicparsley: embedding thumbnails
-  makeWrapperArgs = let
+  makeWrapperArgs =
+    let
       packagesToBinPath = [ atomicparsley ]
         ++ lib.optional ffmpegSupport ffmpeg
         ++ lib.optional rtmpSupport rtmpdump
         ++ lib.optional phantomjsSupport phantomjs2;
-    in [ ''--prefix PATH : "${lib.makeBinPath packagesToBinPath}"'' ];
+    in
+    [ ''--prefix PATH : "${lib.makeBinPath packagesToBinPath}"'' ];
 
   setupPyBuildFlags = [
     "build_lazy_extractors"

--- a/pkgs/tools/misc/yt-dlp/default.nix
+++ b/pkgs/tools/misc/yt-dlp/default.nix
@@ -5,7 +5,7 @@
 , rtmpdump
 , phantomjs2
 , atomicparsley
-, pycryptodome
+, pycryptodomex
 , websockets
 , mutagen
 , ffmpegSupport ? true
@@ -20,16 +20,16 @@ buildPythonPackage rec {
   # The websites yt-dlp deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2021.9.25";
+  version = "2021.10.10";
 
   src = fetchPypi {
     inherit pname;
     version = builtins.replaceStrings [ ".0" ] [ "." ] version;
-    sha256 = "e7b8dd0ee9498abbd80eb38d9753696d6ca3d02f64980322ab3bf39ba1bc31ee";
+    sha256 = "sha256-zJYhHo5V67tI0uZgnA0JQlB+tUcbLOdOOPe5X41wpOc=";
   };
 
   propagatedBuildInputs = [ websockets mutagen ]
-    ++ lib.optional hlsEncryptedSupport pycryptodome;
+    ++ lib.optional hlsEncryptedSupport pycryptodomex;
 
   # Ensure these utilities are available in $PATH:
   # - ffmpeg: post-processing & transcoding support

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27796,6 +27796,10 @@ in
 
   youtube-dl-light = with python3Packages; toPythonApplication youtube-dl-light;
 
+  yt-dlp = with python3Packages; toPythonApplication yt-dlp;
+
+  yt-dlp-light = with python3Packages; toPythonApplication yt-dlp-light;
+
   youtube-viewer = perlPackages.WWWYoutubeViewer;
 
   ytalk = callPackage ../applications/networking/instant-messengers/ytalk { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9029,6 +9029,13 @@ in {
     phantomjsSupport = false;
   };
 
+  yt-dlp = callPackage ../tools/misc/yt-dlp { };
+
+  yt-dlp-light = callPackage ../tools/misc/yt-dlp {
+    ffmpegSupport = false;
+    phantomjsSupport = false;
+  };
+
   yowsup = callPackage ../development/python-modules/yowsup { };
 
   yq = callPackage ../development/python-modules/yq {


### PR DESCRIPTION
Cherry picked from master:
- e40ceba3fc172b6610eb0da96384636e08a510e2
- 7b3170056d6e9f36a860b7ae11416b5ee5529ae3
- 288b36f84cb7b81af0541e6e5706460978ad70a5
- 0a7137a2dfe05ba080381fb8e4f311b43c534a01
- 225637dd596c14f63a5b9ebf54accd6e44997df1
- 560ce8d15c760b16b52606a678bc861d3a8908bc
- bac5fde048203c8cd5f1f5445f38757383223f4d
- 99b632b2208b69911f3ca48cc0f5fb095e2d2314
- 58269d4875b357fba7a34608bbe5691eecf30fb4


###### Motivation for this change

This would be useful to have on the stable distribution since `youtube-dl` is currently unusable.

###### Things done

- Tested the `yt-dlp` binary.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
