### PR TITLE
gitMinimal: Fix wrong shell for cross compiled package

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -97,8 +97,10 @@ stdenv.mkDerivation {
 
   makeFlags = [
     "prefix=\${out}"
-    "SHELL_PATH=${stdenv.shell}"
   ]
+  # Git does not allow setting a shell separately for building and run-time.
+  # Therefore lets leave it at the default /bin/sh when cross-compiling
+  ++ lib.optional (stdenv.buildPlatform == stdenv.hostPlatform) "SHELL_PATH=${stdenv.shell}"
   ++ (if perlSupport then ["PERL_PATH=${perlPackages.perl}/bin/perl"] else ["NO_PERL=1"])
   ++ (if pythonSupport then ["PYTHON_PATH=${python3}/bin/python"] else ["NO_PYTHON=1"])
   ++ lib.optionals stdenv.isSunOS ["INSTALL=install" "NO_INET_NTOP=" "NO_INET_PTON="]
@@ -114,6 +116,10 @@ stdenv.mkDerivation {
   #
   # See https://github.com/Homebrew/homebrew-core/commit/dfa3ccf1e7d3901e371b5140b935839ba9d8b706
   ++ lib.optional stdenv.isDarwin "TKFRAMEWORK=/nonexistent";
+
+  disallowedReferences = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    stdenv.shellPackage
+  ];
 
 
   postBuild = ''


### PR DESCRIPTION
The current package depends on the build hosts shell and therefor a lot of scripts can not be used on the target:
```sh
❯ nix-build -A pkgsCross.aarch64-multiplatform.gitMinimal
/nix/store/52lfla8dfp22520axc9jalz8bnp8l6xx-git-aarch64-unknown-linux-gnu-2.33.0

❯ nix-store -q --references ./result/
/nix/store/nrwmkyqhqczn61zrb3z05k31nnkqjqyb-glibc-aarch64-unknown-linux-gnu-2.33-50
/nix/store/hwzhnqhjgry727m5vkqy8zf9ppngbp3p-zlib-1.2.11-aarch64-unknown-linux-gnu
/nix/store/kkll2mjnj1dsdlhyvp78v9fjisvby86z-openssl-aarch64-unknown-linux-gnu-1.1.1l
/nix/store/2kjjiic8x1adyps4wn7p1w1ah404kdga-curl-aarch64-unknown-linux-gnu-7.76.1
/nix/store/7i3q6zdhwqfahyfm6a4lb7m4gh0m0ra4-aarch64-unknown-linux-gnu-stage-final-gcc-debug-9.3.0-lib
/nix/store/gixyqr6hc6d296ymgicklqnixv4dbfxd-expat-aarch64-unknown-linux-gnu-2.4.1
/nix/store/jwy7714ddm0yqzbii5hbj3ycn1xb7sdk-coreutils-aarch64-unknown-linux-gnu-8.32
/nix/store/k4ai6vqsqgixrbrjq14w5pg8z8pn9mfl-gettext-aarch64-unknown-linux-gnu-0.21
/nix/store/r7ag3jn3vgrr2s0jb5k9s98x7768dfgf-openssh-aarch64-unknown-linux-gnu-8.7p1
/nix/store/rgm0p4yrq6gl2475v779z25l355c9bdv-gnused-aarch64-unknown-linux-gnu-4.8
/nix/store/ss074bgk5fwz85mif0is1hwz6ig1mwaj-gnugrep-aarch64-unknown-linux-gnu-3.6
/nix/store/wadmyilr414n7bimxysbny876i2vlm5r-bash-5.1-p8
/nix/store/52lfla8dfp22520axc9jalz8bnp8l6xx-git-aarch64-unknown-linux-gnu-2.33.0
```

This patch fixed the dependency to the build hosts shell:
```sh
❯ nix-build -A pkgsCross.aarch64-multiplatform.gitMinimal
/nix/store/i08892l479l8yvbrlz64hh071kwky14r-git-aarch64-unknown-linux-gnu-2.33.0

❯ nix-store -q --references ./result/
/nix/store/nrwmkyqhqczn61zrb3z05k31nnkqjqyb-glibc-aarch64-unknown-linux-gnu-2.33-50
/nix/store/hwzhnqhjgry727m5vkqy8zf9ppngbp3p-zlib-1.2.11-aarch64-unknown-linux-gnu
/nix/store/kkll2mjnj1dsdlhyvp78v9fjisvby86z-openssl-aarch64-unknown-linux-gnu-1.1.1l
/nix/store/2kjjiic8x1adyps4wn7p1w1ah404kdga-curl-aarch64-unknown-linux-gnu-7.76.1
/nix/store/7i3q6zdhwqfahyfm6a4lb7m4gh0m0ra4-aarch64-unknown-linux-gnu-stage-final-gcc-debug-9.3.0-lib
/nix/store/gixyqr6hc6d296ymgicklqnixv4dbfxd-expat-aarch64-unknown-linux-gnu-2.4.1
/nix/store/jwy7714ddm0yqzbii5hbj3ycn1xb7sdk-coreutils-aarch64-unknown-linux-gnu-8.32
/nix/store/k4ai6vqsqgixrbrjq14w5pg8z8pn9mfl-gettext-aarch64-unknown-linux-gnu-0.21
/nix/store/r7ag3jn3vgrr2s0jb5k9s98x7768dfgf-openssh-aarch64-unknown-linux-gnu-8.7p1
/nix/store/rgm0p4yrq6gl2475v779z25l355c9bdv-gnused-aarch64-unknown-linux-gnu-4.8
/nix/store/ss074bgk5fwz85mif0is1hwz6ig1mwaj-gnugrep-aarch64-unknown-linux-gnu-3.6
/nix/store/i08892l479l8yvbrlz64hh071kwky14r-git-aarch64-unknown-linux-gnu-2.33.0
```

###### Motivation for this change

Want to use cross compiled gitMinimal package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
