### PR TITLE
vapoursynth: add fixes for API v4/R55+

### DIFF
--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -2,8 +2,6 @@
 , runCommandCC, runCommand, vapoursynth, writeText, patchelf, buildEnv
 , zimg, libass, python3, libiconv
 , ApplicationServices
-, ocrSupport ? false, tesseract
-, imwriSupport ? true, imagemagick
 }:
 
 with lib;
@@ -27,14 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     zimg libass
     (python3.withPackages (ps: with ps; [ sphinx cython ]))
-  ] ++ optionals stdenv.isDarwin [ libiconv ApplicationServices ]
-    ++ optional ocrSupport   tesseract
-    ++ optional imwriSupport imagemagick;
-
-  configureFlags = [
-    (optionalString (!ocrSupport)   "--disable-ocr")
-    (optionalString (!imwriSupport) "--disable-imwri")
-  ];
+  ] ++ optionals stdenv.isDarwin [ libiconv ApplicationServices ];
 
   enableParallelBuilding = true;
 
@@ -54,6 +45,10 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/vspipe \
         --prefix PYTHONPATH : $out/${python3.sitePackages}
+
+    # VapourSynth does not include any plugins by default
+    # and emits a warning when the system plugin directory does not exist.
+    mkdir $out/lib/vapoursynth
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -8,13 +8,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "vapoursynth";
-  version = "R55";
+  version = "R57";
 
   src = fetchFromGitHub {
     owner  = "vapoursynth";
     repo   = "vapoursynth";
     rev    = version;
-    sha256 = "sha256-91lPknNX3NM3NraIcPAR478paPoYvgjgCOIcdgaR5nE=";
+    sha256 = "sha256-tPQ1SOIpFevOYzL9a8Lc5+dv2egVX1CY3km8yWVv+Sk=";
   };
 
   patches = [

--- a/pkgs/development/libraries/vapoursynth/editor.nix
+++ b/pkgs/development/libraries/vapoursynth/editor.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromBitbucket, makeWrapper, runCommand
+{ lib, mkDerivation, fetchFromGitHub, makeWrapper, runCommand
 , python3, vapoursynth
 , qmake, qtbase, qtwebsockets
 }:
@@ -6,13 +6,13 @@
 let
   unwrapped = mkDerivation rec {
     pname = "vapoursynth-editor";
-    version = "R19";
+    version = "R19-mod-4";
 
-    src = fetchFromBitbucket {
-      owner = "mystery_keeper";
+    src = fetchFromGitHub {
+      owner = "YomikoR";
       repo = pname;
       rev = lib.toLower version;
-      sha256 = "1zlaynkkvizf128ln50yvzz3b764f5a0yryp6993s9fkwa7djb6n";
+      sha256 = "sha256-+/9j9DJDGXbuTvE8ZXIu6wjcof39SyatS36Q6y9hLPg=";
     };
 
     nativeBuildInputs = [ qmake ];
@@ -35,7 +35,7 @@ let
 
     meta = with lib; {
       description = "Cross-platform editor for VapourSynth scripts";
-      homepage = "https://bitbucket.org/mystery_keeper/vapoursynth-editor";
+      homepage = "https://github.com/YomikoR/VapourSynth-Editor";
       license = licenses.mit;
       maintainers = with maintainers; [ tadeokondrak ];
       platforms = platforms.all;


### PR DESCRIPTION
A few things changed with VapourSynth R55/the v4 API introduced in that release. This PR adds fixes for things that did not work correctly:

 * Since VapourSynth no longer bundles plugins, the flags to enable optional plugins are no longer needed. It also complains about an empty system plugin directory, which is fixed by creating an empty one.
 * VapourSynth is updated to R57 for fixes implemented upstream.
 * vsedit does not support the v4 API and therefore does not work with VapourSynth R55+. This is fixed by switching to [a fork](https://github.com/YomikoR/VapourSynth-Editor), which adds API v4 compatibility.

###### Motivation for this change

Having working packages in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
