### PR TITLE
python3Packages.databases: 0.5.2 -> 0.5.3

### DIFF
--- a/pkgs/development/python-modules/databases/default.nix
+++ b/pkgs/development/python-modules/databases/default.nix
@@ -3,7 +3,8 @@
 , fetchFromGitHub
 , sqlalchemy
 , aiocontextvars
-, isPy27
+, aiopg
+, pythonOlder
 , pytestCheckHook
 , pymysql
 , asyncpg
@@ -13,42 +14,48 @@
 
 buildPythonPackage rec {
   pname = "databases";
-  version = "0.5.2";
-  disabled = isPy27;
+  version = "0.5.3";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "sha256-OfBb78lKnAxPhyy2j4TzEZWBzbw64brTQcxuOPoW9pk=";
+    sha256 = "sha256-67ykx7HKGgRvJ+GRVEI/e2+x51kfHHFjh/iI4tY+6aE=";
   };
 
   propagatedBuildInputs = [
-    aiocontextvars
-    sqlalchemy
-  ];
-
-  checkInputs = [
+    aiopg
     aiomysql
     aiosqlite
     asyncpg
     pymysql
+    sqlalchemy
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    aiocontextvars
+  ];
+
+  checkInputs = [
     pytestCheckHook
   ];
 
   disabledTestPaths = [
-    # ModuleNotFoundError: No module named 'aiopg'
-    "tests/test_connection_options.py"
     # circular dependency on starlette
     "tests/test_integration.py"
     # TEST_DATABASE_URLS is not set.
     "tests/test_databases.py"
+    "tests/test_connection_options.py"
+  ];
+
+  pythonImportsCheck = [
+    "databases"
   ];
 
   meta = with lib; {
     description = "Async database support for Python";
     homepage = "https://github.com/encode/databases";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.5.3

Change log: https://github.com/encode/databases/releases/tag/0.5.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
