### PR TITLE
gamenetworkingsockets: 1.2.0 -> 1.3.0;  soldat-unstable: 2021-04-27 -> 2021-10-07 

### DIFF
--- a/pkgs/development/libraries/gamenetworkingsockets/default.nix
+++ b/pkgs/development/libraries/gamenetworkingsockets/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "GameNetworkingSockets";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1zghyc4liml8gzxflyh5gp6zi11ny6ng5hv9wyqvp32rfx221gc6";
+    sha256 = "1d3k1ciw8c8rznxsr4bfmw0f0srblpflv8xqavhcxx2zwvaya78c";
   };
 
   nativeBuildInputs = [ cmake ninja go ];
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ protobuf openssl ];
 
   meta = with lib; {
-    # build failure is resolved on master, remove at next release
-    broken = stdenv.isDarwin;
     description = "GameNetworkingSockets is a basic transport layer for games";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/gamenetworkingsockets/default.nix
+++ b/pkgs/development/libraries/gamenetworkingsockets/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
   # tmp home for go
   preBuild = "export HOME=\"$TMPDIR\"";
 
-  buildInputs = [ protobuf openssl ];
+  buildInputs = [ protobuf ];
+  propagatedBuildInputs = [ openssl ];
 
   meta = with lib; {
     description = "GameNetworkingSockets is a basic transport layer for games";

--- a/pkgs/games/soldat-unstable/default.nix
+++ b/pkgs/games/soldat-unstable/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fpc, zip, makeWrapper
 , SDL2, freetype, physfs, openal, gamenetworkingsockets
-, xorg, autoPatchelfHook
+, xorg, autoPatchelfHook, cmake
 }:
 
 let
@@ -49,45 +49,27 @@ stdenv.mkDerivation rec {
     sha256 = "0r39d1394q7kabsgq6vpdlzwsajxafsg23i0r273nggfvs3m805z";
   };
 
-  nativeBuildInputs = [ fpc makeWrapper autoPatchelfHook ];
+  patches = [
+    # Don't build GameNetworkingSockets as an ExternalProject,
+    # see https://github.com/Soldat/soldat/issues/73
+    ./gamenetworkingsockets-no-external.patch
+  ];
+
+  nativeBuildInputs = [ fpc makeWrapper autoPatchelfHook cmake ];
+
+  cmakeFlags = [
+    "-DADD_ASSETS=OFF" # We provide base's smods via nix
+  ];
 
   buildInputs = [ SDL2 freetype physfs openal gamenetworkingsockets ];
+  # TODO(@sternenseemann): set proper rpath via cmake, so we don't need autoPatchelfHook
   runtimeDependencies = [ xorg.libX11 ];
 
-  buildPhase = ''
-    runHook preBuild
-
-    mkdir -p client/build server/build
-
-    # build .so from stb headers
-    pushd client/libs/stb
-    make
-    popd
-
-    # build client
-    pushd client
-    make mode=release
-    popd
-
-    # build server
-    pushd server
-    make mode=release
-    popd
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 client/libs/stb/libstb.so -t $out/lib
-    install -Dm755 client/build/soldat_* $out/bin/soldat
-    install -Dm755 server/build/soldatserver_* $out/bin/soldatserver
-
-    # make sure soldat{,server} find their game archive,
-    # let them write their state and configuration files
-    # to $XDG_CONFIG_HOME/soldat/soldat{,server} unless
-    # the user specifies otherwise.
+  # make sure soldat{,server} find their game archive,
+  # let them write their state and configuration files
+  # to $XDG_CONFIG_HOME/soldat/soldat{,server} unless
+  # the user specifies otherwise.
+  postInstall = ''
     for p in $out/bin/soldatserver $out/bin/soldat; do
       configDir="\''${XDG_CONFIG_HOME:-\$HOME/.config}/soldat/$(basename "$p")"
 
@@ -97,8 +79,6 @@ stdenv.mkDerivation rec {
         --add-flags "-fs_userpath \"$configDir\"" \
         --add-flags "-fs_basepath \"${base}/share/soldat\""
     done
-
-    runHook postInstall
   '';
 
   meta = with lib; {
@@ -106,7 +86,7 @@ stdenv.mkDerivation rec {
     license = [ licenses.mit base.meta.license ];
     inherit (src.meta) homepage;
     maintainers = [ maintainers.sternenseemann ];
-    platforms = platforms.x86_64 ++ platforms.i686;
+    platforms = [ "x86_64-linux" "i686-linux" ];
     # portability currently mainly limited by fpc
     # in nixpkgs which doesn't work on darwin,
     # aarch64 and arm support should be possible:

--- a/pkgs/games/soldat-unstable/default.nix
+++ b/pkgs/games/soldat-unstable/default.nix
@@ -6,14 +6,14 @@
 let
   base = stdenv.mkDerivation rec {
     pname = "soldat-base";
-    version = "unstable-2020-11-26";
+    version = "unstable-2021-09-05";
 
     src = fetchFromGitHub {
       name = "base";
       owner = "Soldat";
       repo = "base";
-      rev = "e5f9c35ec12562595b248a7a921dd3458b36b605";
-      sha256 = "0qg0p2adb5v6di44iqczswldhypdqvn1nl96vxkfkxdg9i8x90w3";
+      rev = "6c74d768d511663e026e015dde788006c74406b5";
+      sha256 = "175gmkdccy8rnkd95h2zqldqfydyji1hfby8b1qbnl8wz4dh08mz";
     };
 
     nativeBuildInputs = [ zip ];
@@ -39,14 +39,14 @@ in
 
 stdenv.mkDerivation rec {
   pname = "soldat";
-  version = "unstable-2021-04-27";
+  version = "unstable-2021-11-01";
 
   src = fetchFromGitHub {
     name = "soldat";
     owner = "Soldat";
     repo = "soldat";
-    rev = "4d17667c316ff08934e97448b7f290a8dc434e81";
-    sha256 = "1pf557psmhfaagblfwdn36cw80j7bgs0lgjq8hmjbv58dysw3jdb";
+    rev = "7780d2948b724970af9f2aaf4fb4e4350d5438d9";
+    sha256 = "0r39d1394q7kabsgq6vpdlzwsajxafsg23i0r273nggfvs3m805z";
   };
 
   nativeBuildInputs = [ fpc makeWrapper autoPatchelfHook ];

--- a/pkgs/games/soldat-unstable/gamenetworkingsockets-no-external.patch
+++ b/pkgs/games/soldat-unstable/gamenetworkingsockets-no-external.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1084048..1ea4c84 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -143,7 +143,8 @@ if(BUILD_CLIENT OR BUILD_SERVER)
+     file(WRITE ${PROJECT_BINARY_DIR}/bin/steam_appid.txt "638490")
+   else()
+     # GameNetworkingSockets
+-    add_subdirectory(shared/libs/GameNetworkingSockets)
++    # add_subdirectory(shared/libs/GameNetworkingSockets)
++    find_package(GameNetworkingSockets REQUIRED)
+   endif()
+ endif()
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
