### PR TITLE
flameshot: 0.10.1 -> unstable-2021-10-17

### DIFF
--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -10,13 +10,13 @@
 
 mkDerivation rec {
   pname = "flameshot";
-  version = "0.10.1";
+  version = "unstable-2021-10-17";
 
   src = fetchFromGitHub {
     owner = "flameshot-org";
     repo = "flameshot";
-    rev = "v${version}";
-    sha256 = "1ncknjayl6am740f49g0lc28z1zsifbicxz1j1kwps3ksj15nl7a";
+    rev = "7977cbb52c2d785abd0d85d9df5991e8f7cae441";
+    sha256 = "1dljxin5zvlzwzdvggn6kf9q08wawlqcfk29kxwcjflx3279fnmr";
   };
 
   passthru = {
@@ -27,6 +27,8 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake qttools qtsvg ];
   buildInputs = [ qtbase ];
+
+  cmakeFlags = [ "-DUSE_LAUNCHER_ABSOLUTE_PATH:BOOL=OFF" ];
 
   meta = with lib; {
     description = "Powerful yet simple to use screenshot software";


### PR DESCRIPTION
###### Motivation for this change

This update fixes two problems:

1. autostart sometimes doesn't work in NixOS (fixed [upstream](https://github.com/flameshot-org/flameshot/issues/1975))
2. desktop file points to /usr/bin/flameshot instead of just flameshot
   (fixed by adding an extra cmake option)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
