### PR TITLE
synology-drive: init at 3.0.1-12674

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7657,7 +7657,7 @@
     email = "mail@moritzboeh.me";
     github = "MoritzBoehme";
     githubId = 42215704;
-    name = "Moritz Boehme";
+    name = "Moritz Böhme";
   };
   MostAwesomeDude = {
     email = "cds@corbinsimpson.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7653,6 +7653,12 @@
     githubId = 99988;
     name = "Maarten Hoogendoorn";
   };
+  MoritzBoehme = {
+    email = "mail@moritzboeh.me";
+    github = "MoritzBoehme";
+    githubId = 42215704;
+    name = "Moritz Boehme";
+  };
   MostAwesomeDude = {
     email = "cds@corbinsimpson.com";
     github = "MostAwesomeDude";

--- a/pkgs/applications/networking/synology-drive/default.nix
+++ b/pkgs/applications/networking/synology-drive/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, autoPatchelfHook, dpkg, glibc, gnome }:
+{ lib, mkDerivation, fetchurl, autoPatchelfHook, dpkg, glibc, gnome }:
 
 mkDerivation rec {
   pname = "synology-drive";

--- a/pkgs/applications/networking/synology-drive/default.nix
+++ b/pkgs/applications/networking/synology-drive/default.nix
@@ -35,8 +35,10 @@ qt5.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.synology.com/";
     description = "Synchronize files between client and Synology NAS.";
-    longDescription =
-      "Drive for PC, the desktop utility of the DSM add-on package, Drive, allows you to sync and share files owned by you or shared by others between a centralized Synology NAS and multiple client computers.";
+    longDescription = ''
+      Drive for PC, the desktop utility of the DSM add-on package.
+      Drive, allows you to sync and share files owned by you or shared by others between a centralized Synology NAS and multiple client computers.
+    '';
     license = licenses.unfree;
     maintainers = with maintainers; [ MoritzBoehme ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/networking/synology-drive/default.nix
+++ b/pkgs/applications/networking/synology-drive/default.nix
@@ -6,8 +6,7 @@ qt5.mkDerivation rec {
   version = "3.0.1-${subVersion}";
 
   src = fetchurl {
-    url =
-      "https://global.download.synology.com/download/Utility/SynologyDriveClient/${version}/Ubuntu/Installer/x86_64/synology-drive-client-${subVersion}.x86_64.deb";
+    url = "https://global.download.synology.com/download/Utility/SynologyDriveClient/${version}/Ubuntu/Installer/x86_64/synology-drive-client-${subVersion}.x86_64.deb";
     sha256 = "1yyv6zgszsym22kf4jvlan7n9lw09fw24fyrh7c8pzbb2029gp8a";
   };
 

--- a/pkgs/applications/networking/synology-drive/default.nix
+++ b/pkgs/applications/networking/synology-drive/default.nix
@@ -1,6 +1,6 @@
-{ lib, qt5, fetchurl, autoPatchelfHook, dpkg, glibc, gnome }:
+{ lib, fetchurl, autoPatchelfHook, dpkg, glibc, gnome }:
 
-qt5.mkDerivation rec {
+mkDerivation rec {
   pname = "synology-drive";
   subVersion = "12674";
   version = "3.0.1-${subVersion}";

--- a/pkgs/applications/networking/synology-drive/default.nix
+++ b/pkgs/applications/networking/synology-drive/default.nix
@@ -1,0 +1,44 @@
+{ autoPatchelfHook, dpkg, fetchurl, glibc, lib, gnome, qt5, stdenv, }:
+
+qt5.mkDerivation rec {
+  pname = "synology-drive";
+  subVersion = "12674";
+  version = "3.0.1-${subVersion}";
+
+  src = fetchurl {
+    url =
+      "https://global.download.synology.com/download/Utility/SynologyDriveClient/${version}/Ubuntu/Installer/x86_64/synology-drive-client-${subVersion}.x86_64.deb";
+    sha256 = "1yyv6zgszsym22kf4jvlan7n9lw09fw24fyrh7c8pzbb2029gp8a";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
+  buildInputs = [ glibc gnome.nautilus ];
+
+  unpackPhase = ''
+    mkdir -p $out
+    dpkg -x $src $out
+  '';
+
+  installPhase = ''
+    # synology-drive executable
+    cp -av $out/usr/* $out
+    rm -rf $out/usr
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/bin/synology-drive --replace /opt $out/opt
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.synology.com/";
+    description = "Synchronize files between client and Synology NAS.";
+    longDescription =
+      "Drive for PC, the desktop utility of the DSM add-on package, Drive, allows you to sync and share files owned by you or shared by others between a centralized Synology NAS and multiple client computers.";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ MoritzBoehme ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/synology-drive/default.nix
+++ b/pkgs/applications/networking/synology-drive/default.nix
@@ -1,4 +1,4 @@
-{ autoPatchelfHook, dpkg, fetchurl, glibc, lib, gnome, qt5, stdenv, }:
+{ lib, qt5, fetchurl, autoPatchelfHook, dpkg, glibc, gnome }:
 
 qt5.mkDerivation rec {
   pname = "synology-drive";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26728,7 +26728,7 @@ with pkgs;
     mlt-qt5 = libsForQt514.mlt;
   };
 
-  synology-drive = callPackage ../applications/networking/synology-drive { };
+  synology-drive = libsForQt5.callPackage ../applications/networking/synology-drive { };
 
   taxi = callPackage ../applications/networking/ftp/taxi { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26728,6 +26728,8 @@ with pkgs;
     mlt-qt5 = libsForQt514.mlt;
   };
 
+  synology-drive = callPackage ../applications/networking/synology-drive { };
+
   taxi = callPackage ../applications/networking/ftp/taxi { };
 
   librep = callPackage ../development/libraries/librep { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
