### PR TITLE
systemd: add musl patches

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -4,6 +4,7 @@
 , lib
 , fetchFromGitHub
 , fetchpatch
+, fetchzip
 , buildPackages
 , ninja
 , meson
@@ -75,24 +76,24 @@
 , withHomed ? false
 , withHostnamed ? true
 , withHwdb ? true
-, withImportd ? true
+, withImportd ? !stdenv.hostPlatform.isMusl
 , withLibBPF ? false # currently fails while generating BPF objects
 , withLocaled ? true
 , withLogind ? true
 , withMachined ? true
 , withNetworkd ? true
-, withNss ? true
+, withNss ? !stdenv.hostPlatform.isMusl
 , withOomd ? false
 , withPCRE2 ? true
 , withPolkit ? true
 , withPortabled ? false
-, withRemote ? true
+, withRemote ? !stdenv.hostPlatform.isMusl
 , withResolved ? true
 , withShellCompletions ? true
 , withTimedated ? true
 , withTimesyncd ? true
-, withTpm2Tss ? true
-, withUserDb ? true
+, withTpm2Tss ? !stdenv.hostPlatform.isMusl
+, withUserDb ? !stdenv.hostPlatform.isMusl
 , libfido2
 , p11-kit
 
@@ -163,7 +164,40 @@ stdenv.mkDerivation {
     # all our root unit dirs if they are symlinks. This does exactly what we
     # need (AFAICT).
     ./0019-core-handle-lookup-paths-being-symlinks.patch
-  ];
+  ] ++ lib.optional stdenv.hostPlatform.isMusl (let
+    oe-core = fetchzip {
+      url = "https://git.openembedded.org/openembedded-core/snapshot/openembedded-core-14c6e5a4b72d0e4665279158a0740dd1dc21f72f.tar.bz2";
+      sha256 = "1jixya4czkr5p5rdcw3d6ips8zzr82dvnanvzvgjh67730scflya";
+    };
+    musl-patches = oe-core + "/meta/recipes-core/systemd/systemd";
+  in [
+    (musl-patches + "/0002-don-t-use-glibc-specific-qsort_r.patch")
+    (musl-patches + "/0003-missing_type.h-add-__compare_fn_t-and-comparison_fn_.patch")
+    (musl-patches + "/0004-add-fallback-parse_printf_format-implementation.patch")
+    (musl-patches + "/0005-src-basic-missing.h-check-for-missing-strndupa.patch")
+    (musl-patches + "/0006-Include-netinet-if_ether.h.patch")
+    (musl-patches + "/0007-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch")
+    (musl-patches + "/0008-add-missing-FTW_-macros-for-musl.patch")
+    (musl-patches + "/0009-fix-missing-of-__register_atfork-for-non-glibc-build.patch")
+    (musl-patches + "/0010-Use-uintmax_t-for-handling-rlim_t.patch")
+    (musl-patches + "/0011-test-sizeof.c-Disable-tests-for-missing-typedefs-in-.patch")
+    (musl-patches + "/0012-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch")
+    (musl-patches + "/0013-Define-glibc-compatible-basename-for-non-glibc-syste.patch")
+    (musl-patches + "/0014-Do-not-disable-buffering-when-writing-to-oom_score_a.patch")
+    (musl-patches + "/0015-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch")
+    (musl-patches + "/0016-Hide-__start_BUS_ERROR_MAP-and-__stop_BUS_ERROR_MAP.patch")
+    (musl-patches + "/0017-missing_type.h-add-__compar_d_fn_t-definition.patch")
+    (musl-patches + "/0018-avoid-redefinition-of-prctl_mm_map-structure.patch")
+    (musl-patches + "/0019-Handle-missing-LOCK_EX.patch")
+    (musl-patches + "/0021-test-json.c-define-M_PIl.patch")
+    (musl-patches + "/0022-do-not-disable-buffer-in-writing-files.patch")
+    (musl-patches + "/0025-Handle-__cpu_mask-usage.patch")
+    (musl-patches + "/0026-Handle-missing-gshadow.patch")
+    (musl-patches + "/0028-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch")
+
+    # Being discussed upstream: https://lists.openembedded.org/g/openembedded-core/topic/86411771#157056
+    ./musl.diff
+  ]);
 
   postPatch = ''
     substituteInPlace src/basic/path-util.h --replace "@defaultPathNormal@" "${placeholder "out"}/bin/"
@@ -443,7 +477,13 @@ stdenv.mkDerivation {
     "-Dnss-systemd=false"
   ] ++ lib.optionals withLibBPF [
     "-Dbpf-framework=true"
-  ] ++ lib.optional withTpm2Tss "-Dtpm2=true";
+  ] ++ lib.optionals withTpm2Tss [
+    "-Dtpm2=true"
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+    "-Dgshadow=false"
+    "-Dutmp=false"
+    "-Didn=false"
+  ];
 
   preConfigure = ''
     mesonFlagsArray+=(-Dntp-servers="0.nixos.pool.ntp.org 1.nixos.pool.ntp.org 2.nixos.pool.ntp.org 3.nixos.pool.ntp.org")
@@ -505,7 +545,7 @@ stdenv.mkDerivation {
       --replace "SYSTEMD_CGROUP_AGENT_PATH" "_SYSTEMD_CGROUP_AGENT_PATH"
   '';
 
-  NIX_CFLAGS_COMPILE = toString [
+  NIX_CFLAGS_COMPILE = toString ([
     # Can't say ${polkit.bin}/bin/pkttyagent here because that would
     # lead to a cyclic dependency.
     "-UPOLKIT_AGENT_BINARY_PATH"
@@ -519,7 +559,10 @@ stdenv.mkDerivation {
 
     "-USYSTEMD_BINARY_PATH"
     "-DSYSTEMD_BINARY_PATH=\"/run/current-system/systemd/lib/systemd/systemd\""
-  ];
+
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+    "-D__UAPI_DEF_ETHHDR=0"
+  ]);
 
   doCheck = false; # fails a bunch of tests
 

--- a/pkgs/os-specific/linux/systemd/musl.diff
+++ b/pkgs/os-specific/linux/systemd/musl.diff
@@ -1,0 +1,12 @@
+diff --git a/src/shared/mount-setup.c b/src/shared/mount-setup.c
+index ef3527e..cc1ba23 100644
+--- a/src/shared/mount-setup.c
++++ b/src/shared/mount-setup.c
+@@ -32,6 +32,7 @@
+ #include "strv.h"
+ #include "user-util.h"
+ #include "virt.h"
++#include "missing_type.h"
+ 
+ typedef enum MountMode {
+         MNT_NONE           = 0,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes build of pkgsMusl.systemdMinimal and pkgsMusl.systemd.

This might be controversial, but it would be a big step towards building full NixOS systems against musl.

These patches are applied conditionally on purpose: They are not checked to be properly guarded. They should not block future systemd upgrades.

Also see the original RFC discussion around musl systemd: https://github.com/NixOS/rfcs/blob/master/rfcs/0023-musl-libc.md#systemd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
