### PR TITLE
clapper: add missing deps

### DIFF
--- a/pkgs/applications/video/clapper/default.nix
+++ b/pkgs/applications/video/clapper/default.nix
@@ -18,6 +18,8 @@
 , gtk4
 , gst_all_1
 , libadwaita
+, appstream-glib
+, libsoup
 }:
 
 stdenv.mkDerivation rec {
@@ -32,6 +34,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    appstream-glib
     desktop-file-utils # for update-desktop-database
     glib
     gobject-introspection
@@ -53,6 +56,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-ugly
     gtk4
     libadwaita
+    libsoup
     wayland
     wayland-protocols
   ];


### PR DESCRIPTION
###### Motivation for this change
See: https://github.com/NixOS/nixpkgs/issues/141937

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
