### PR TITLE
terminator: use `dontWrapGApps` to fix desktop icon

### DIFF
--- a/pkgs/applications/terminal-emulators/terminator/default.nix
+++ b/pkgs/applications/terminal-emulators/terminator/default.nix
@@ -56,6 +56,12 @@ python3.pkgs.buildPythonApplication rec {
 
   doCheck = false;
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = with lib; {
     description = "Terminal emulator with support for tiling and tabs";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

Terminator is currently wrapped twice, which makes the python hook use a
wrapped executable name to set argv[0]. As a result, Terminator can't be
matched to its desktop entry and fails to group correctly in e.g. the GNOME app
launcher. Ensuring we only wrap the executable once solves this.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Notes

Please backport to `nixos-21.05`.