### PR TITLE
vopono: init at 0.8.6

### DIFF
--- a/pkgs/tools/networking/vopono/default.nix
+++ b/pkgs/tools/networking/vopono/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, fetchCrate
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "vopono";
+  version = "0.8.6";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "0dsyav755mggnsybj7iwvdqbqzz0gfd3j9vh0hmg5b7pbffanzvy";
+  };
+
+  cargoHash = "sha256:187mi36dgr2f1klqclci175zqgyrm0b6awrcnav63vira7hqz076";
+
+  meta = with lib; {
+    description = "Run applications through VPN connections in network namespaces";
+    homepage = "https://github.com/jamesmcm/vopono";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -966,6 +966,8 @@ with pkgs;
 
   ventoy-bin = callPackage ../tools/cd-dvd/ventoy-bin { };
 
+  vopono = callPackage ../tools/networking/vopono { };
+
   xcd = callPackage ../tools/misc/xcd { };
 
   xtrt = callPackage ../tools/archivers/xtrt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [vopono](https://github.com/jamesmcm/vopono).

_vopono is a tool to run applications through VPN tunnels via temporary network namespaces. This allows you to run only a handful of applications through different VPNs simultaneously, whilst keeping your main connection as normal._

_vopono includes built-in killswitches for both Wireguard and OpenVPN._

_Currently Mullvad, AzireVPN, MozillaVPN, TigerVPN, ProtonVPN, iVPN, NordVPN, HMA (HideMyAss) and PrivateInternetAccess are supported directly, with custom configuration files also supported with the --custom argument._

_For custom connections the OpenConnect and OpenFortiVPN protocols are also supported (e.g. for enterprise VPNs). See the vopono User Guide for more details.__

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
