### PR TITLE
orchis-theme: 2021-06-25 -> 2021-12-13

### DIFF
--- a/pkgs/data/themes/orchis-theme/default.nix
+++ b/pkgs/data/themes/orchis-theme/default.nix
@@ -5,18 +5,28 @@
 , gnome-themes-extra
 , gtk-engine-murrine
 , sassc
-, accentColor ? "default"
+, tweaks ? [ ] # can be "solid" "compact" "black" "primary"
 }:
 
-stdenvNoCC.mkDerivation rec {
+let
+  validTweaks = [ "solid" "compact" "black" "primary" ];
+  unknownTweaks = lib.subtractLists validTweaks tweaks;
+in
+assert lib.assertMsg (unknownTweaks == [ ]) ''
+  You entered wrong tweaks: ${toString unknownTweaks}
+  Valid tweaks are: ${toString validTweaks}
+'';
+
+stdenvNoCC.mkDerivation
+rec {
   pname = "orchis-theme";
-  version = "2021-06-25";
+  version = "2021-12-13";
 
   src = fetchFromGitHub {
     repo = "Orchis-theme";
     owner = "vinceliuice";
     rev = version;
-    sha256 = "sha256-j0nsw1yR1yOckXiIMtzhC3w6kvfzxQQHgwdY6l0OuXw=";
+    sha256 = "sha256-PN2ucGMDzRv4v86X1zVIs9+GkbMWuja2WaSQLFvJYd0=";
   };
 
   nativeBuildInputs = [ gtk3 sassc ];
@@ -31,7 +41,7 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    bash install.sh -d $out/share/themes -t ${accentColor}
+    bash install.sh -d $out/share/themes -t all ${lib.optionalString (tweaks != []) "--tweaks " + builtins.toString tweaks}
     runHook postInstall
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package update. Now the theme includes all variants.
Added new `tweaks` flag for customisation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
