### PR TITLE
tnat64: 0.05 -> 0.06

### DIFF
--- a/pkgs/tools/networking/tnat64/default.nix
+++ b/pkgs/tools/networking/tnat64/default.nix
@@ -2,19 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "tnat64";
-  version = "0.05";
+  version = "0.06";
 
   src = fetchFromGitHub {
     owner = "andrewshadura";
     repo = pname;
     rev = "${pname}-${version}";
-    sha256 = "07lmzidbrd3aahk2jvv93cic9gf36pwmgfd63gmy6hjkxf9a6fw9";
+    sha256 = "191j1fpr3bw6fk48npl99z7iq6m1g33f15xk5cay1gnk5f46i2j6";
   };
-
-  postPatch = ''
-    # Fix usage of deprecated sys_errlist
-    substituteInPlace tnat64.c --replace 'sys_errlist[errno]' 'strerror(errno)'
-  '';
 
   configureFlags = [ "--libdir=$(out)/lib" ];
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- Built on platform(s)
  - [x] x86_64-linux NixOS
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change (none)
- [x] Tested execution of all binary files
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
