### PR TITLE
tinycc: fix pkgsStatic.tinycc (musl)

### DIFF
--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--cc=${stdenv.cc.targetPrefix}cc"
-    "--ar=${stdenv.cc.targetPrefix}ar"
+    "--cc=$CC"
+    "--ar=$AR"
     "--crtprefix=${lib.getLib stdenv.cc.libc}/lib"
     "--sysincludepaths=${lib.getDev stdenv.cc.libc}/include:{B}/include"
     "--libpaths=${lib.getLib stdenv.cc.libc}/lib"

--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -19,12 +19,15 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--cc=cc"
+    "--cc=${stdenv.cc.targetPrefix}cc"
+    "--ar=${stdenv.cc.targetPrefix}ar"
     "--crtprefix=${lib.getLib stdenv.cc.libc}/lib"
     "--sysincludepaths=${lib.getDev stdenv.cc.libc}/include:{B}/include"
     "--libpaths=${lib.getLib stdenv.cc.libc}/lib"
     # build cross compilers
     "--enable-cross"
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+    "--config-musl"
   ];
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

I wanted a statically-linked tcc and `pkgsStatic.tinycc` was broken. I've fixed it, hope that didn't break anything on other platforms.

###### Maintaner CC'ing

@joachifm

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (pkgsStatic and not)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
