### PR TITLE
perl: set 'configurePlatforms = [];' to prepare for default change

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -110,6 +110,9 @@ let
         sed -i 's,\(libswanted.*\)pthread,\1,g' Configure
       '';
 
+    # Default perl does not support --host= & co.
+    configurePlatforms = [];
+
     setupHook = ./setup-hook.sh;
 
     passthru = rec {


### PR DESCRIPTION
Prepare for default 'configurePlatforms = [ "build" "host" ];': perl
does not support gnu-stile target specification.

Extracted from PR#87909.