### PR TITLE
fossil: 2.16 -> 2.17

### DIFF
--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -6,6 +6,7 @@
 , zlib
 , openssl
 , readline
+, withInternalSqlite ? true
 , sqlite
 , ed
 , which
@@ -15,23 +16,25 @@
 
 stdenv.mkDerivation rec {
   pname = "fossil";
-  version = "2.16";
+  version = "2.17";
 
   src = fetchurl {
     url = "https://www.fossil-scm.org/home/tarball/version-${version}/fossil-${version}.tar.gz";
-    sha256 = "1z5ji25f2rqaxd1nj4fj84afl1v0m3mnbskgfwsjr3fr0h5p9aqy";
+    sha256 = "0539rsfvwv49qyrf36z5m0k74kvnn6y5xasm9vvi6lbphx8yxmi1";
   };
 
   nativeBuildInputs = [ installShellFiles tcl tcllib ];
 
-  buildInputs = [ zlib openssl readline sqlite which ed ]
-    ++ lib.optional stdenv.isDarwin libiconv;
+  buildInputs = [ zlib openssl readline which ed ]
+    ++ lib.optional stdenv.isDarwin libiconv
+    ++ lib.optional (!withInternalSqlite) sqlite;
 
   enableParallelBuilding = true;
 
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
-  configureFlags = [ "--disable-internal-sqlite" ]
+  configureFlags =
+    lib.optional (!withInternalSqlite) "--disable-internal-sqlite"
     ++ lib.optional withJson "--json";
 
   preBuild = ''


### PR DESCRIPTION
While here, also add option to prefer internal/bundled sqlite3 which is what `fossil` seems to prefer.

ATM, fossil 2.17 fails to build with sqlite 3.36.0:

```
       > gcc -Wall -Wdeclaration-after-statement -DFOSSIL_ENABLE_JSON -DFOSSIL_DYNAMIC_BUILD=1  -g -O2 -DHAVE_AUTOCONFIG_H -D_HAVE_SQLITE_CONFIG_H -o fossil   bld/linenoise.o bld/shell.o bld/th.o bld/th_lang.o bld/th_tcl.o bld/cson_amalgamation.o bld/add.o bld/ajax.o bld/alerts.o bld/allrepo.o bld/attach.o bld/backlink.o bld/backoffice.o bld/bag.o bld/bisect.o bld/blob.o bld/branch.o bld/browse.o bld/builtin.o bld/bundle.o bld/cache.o bld/capabilities.o bld/captcha.o bld/cgi.o bld/chat.o bld/checkin.o bld/checkout.o bld/clearsign.o bld/clone.o bld/color.o bld/comformat.o bld/configure.o bld/content.o bld/cookies.o bld/db.o bld/delta.o bld/deltacmd.o bld/deltafunc.o bld/descendants.o bld/diff.o bld/diffcmd.o bld/dispatch.o bld/doc.o bld/encode.o bld/etag.o bld/event.o bld/export.o bld/extcgi.o bld/file.o bld/fileedit.o bld/finfo.o bld/foci.o bld/forum.o bld/fshell.o bld/fusefs.o bld/fuzz.o bld/glob.o bld/graph.o bld/gzip.o bld/hname.o bld/hook.o bld/http.o bld/http_socket.o bld/http_ssl.o bld/http_transport.o bld/import.o bld/info.o bld/interwiki.o bld/json.o bld/json_artifact.o bld/json_branch.o bld/json_config.o bld/json_diff.o bld/json_dir.o bld/json_finfo.o bld/json_login.o bld/json_q
uery.o bld/json_report.o bld/json_status.o bld/json_tag.o bld/json_timeline.o bld/json_user.o bld/json_wiki.o bld/leaf.o bld/loadctrl.
o bld/login.o bld/lookslike.o bld/main.o bld/manifest.o bld/markdown.o bld/markdown_html.o bld/md5.o bld/merge.o bld/merge3.o bld/moderate.o bld/name.o bld/patch.o bld/path.o bld/piechart.o bld/pikchr.o bld/pikchrshow.o bld/pivot.o bld/popen.o bld/pqueue.o bld/printf.o bld/publish.o bld/purge.o bld/rebuild.o bld/regexp.o bld/repolist.o bld/report.o bld/rss.o bld/schema.o bld/search.o bld/security_audit.o bld/setup.o bld/setupuser.o bld/sha1.o bld/sha1hard.o bld/sha3.o bld/shun.o bld/sitemap.o bld/skins.o bld/smtp.o bld/sqlcmd.o bld/stash.o bld/stat.o bld/statrep.o bld/style.o bld/sync.o bld/tag.o bld/tar.o bld/terminal.o bld/th_main.o bld/timeline.o bld/tkt.o bld/tktsetup.o bld/undo.o bld/unicode.o bld/unversioned.o bld/update.o bld/url.o bld/user.o bld/utf8.o bld/util.o bld/verify.o bld/vfile.o bld/wiki.o bld/wikiformat.o bld/winfile.o bld/winhttp.o bld/xfer.o bld/xfersetup.o bld/zip.o -lm -lresolv -lsqlite3 -lssl -lcrypto -lz -ldl
       > /nix/store/a4mmjm3bblxwp8h53bcfx3dly80ib0ba-binutils-2.35.1/bin/ld: bld/shell.o: in function `runOneSqlLine':
       > /build/fossil-2.17/src/shell.c:21841: undefined reference to `sqlite3_total_changes64'
       > /nix/store/a4mmjm3bblxwp8h53bcfx3dly80ib0ba-binutils-2.35.1/bin/ld: /build/fossil-2.17/src/shell.c:21841: undefined reference to `sqlite3_changes64'
       > collect2: error: ld returned 1 exit status
       > make: *** [src/main.mk:749: fossil] Error 1
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
