### PR TITLE
[staging] binutils: 2.35.1 → 2.35.2

### DIFF
--- a/pkgs/development/tools/misc/binutils/CVE-2021-3487.patch
+++ b/pkgs/development/tools/misc/binutils/CVE-2021-3487.patch
@@ -1,0 +1,73 @@
+From: Nick Clifton <nickc@redhat.com>
+Date: Thu, 26 Nov 2020 17:08:33 +0000 (+0000)
+Subject: Prevent a memory allocation failure when parsing corrupt DWARF debug sections.
+X-Git-Tag: binutils-2_36~485
+X-Git-Url: https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff_plain;h=647cebce12a6b0a26960220caff96ff38978cf24;hp=239ca5e497dda2c151009d664d500086a5c2173a
+
+Prevent a memory allocation failure when parsing corrupt DWARF debug sections.
+
+	PR 26946
+	* dwarf2.c (read_section): Check for debug sections with excessive
+	sizes.
+---
+
+diff --git a/bfd/dwarf2.c b/bfd/dwarf2.c
+index 977bf43a6a1..8bbfc81d3e7 100644
+--- a/bfd/dwarf2.c
++++ b/bfd/dwarf2.c
+@@ -531,22 +531,24 @@ read_section (bfd *	      abfd,
+ 	      bfd_byte **     section_buffer,
+ 	      bfd_size_type * section_size)
+ {
+-  asection *msec;
+   const char *section_name = sec->uncompressed_name;
+   bfd_byte *contents = *section_buffer;
+-  bfd_size_type amt;
+ 
+   /* The section may have already been read.  */
+   if (contents == NULL)
+     {
++      bfd_size_type amt;
++      asection *msec;
++      ufile_ptr filesize;
++
+       msec = bfd_get_section_by_name (abfd, section_name);
+-      if (! msec)
++      if (msec == NULL)
+ 	{
+ 	  section_name = sec->compressed_name;
+ 	  if (section_name != NULL)
+ 	    msec = bfd_get_section_by_name (abfd, section_name);
+ 	}
+-      if (! msec)
++      if (msec == NULL)
+ 	{
+ 	  _bfd_error_handler (_("DWARF error: can't find %s section."),
+ 			      sec->uncompressed_name);
+@@ -554,12 +556,23 @@ read_section (bfd *	      abfd,
+ 	  return FALSE;
+ 	}
+ 
+-      *section_size = msec->rawsize ? msec->rawsize : msec->size;
++      amt = bfd_get_section_limit_octets (abfd, msec);
++      filesize = bfd_get_file_size (abfd);
++      if (amt >= filesize)
++	{
++	  /* PR 26946 */
++	  _bfd_error_handler (_("DWARF error: section %s is larger than its filesize! (0x%lx vs 0x%lx)"),
++			      section_name, (long) amt, (long) filesize);
++	  bfd_set_error (bfd_error_bad_value);
++	  return FALSE;
++	}
++      *section_size = amt;
+       /* Paranoia - alloc one extra so that we can make sure a string
+ 	 section is NUL terminated.  */
+-      amt = *section_size + 1;
++      amt += 1;
+       if (amt == 0)
+ 	{
++	  /* Paranoia - this should never happen.  */
+ 	  bfd_set_error (bfd_error_no_memory);
+ 	  return FALSE;
+ 	}
+

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -27,7 +27,7 @@ assert gold -> execFormatIsELF stdenv.targetPlatform;
 let
   reuseLibs = enableShared && withAllTargets;
 
-  version = "2.35.1";
+  version = "2.35.2";
   basename = "binutils";
   # The targetPrefix prepended to binary names to allow multiple binuntils on the
   # PATH to both be usable.
@@ -42,7 +42,7 @@ let
   # HACK to ensure that we preserve source from bootstrap binutils to not rebuild LLVM
   normal-src = stdenv.__bootPackages.binutils-unwrapped.src or (fetchurl {
     url = "mirror://gnu/binutils/${basename}-${version}.tar.bz2";
-    sha256 = "sha256-Mg56HQ9G/Nn0E/EEbiFsviO7K85t62xqYzBEJeSLGUI=";
+    sha256 = "sha256-z6dkTb7PRZHhNutAfBwdoWV4vSsD8MLorNzroZS7nWE=";
   });
 in
 

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation {
     ./gold-Update-GNU_PROPERTY_X86_XXX-macros.patch
 
     ./CVE-2020-35448.patch
+    ./CVE-2021-3487.patch
   ] ++ lib.optional stdenv.targetPlatform.isiOS ./support-ios.patch
     ++ # This patch was suggested by Nick Clifton to fix
        # https://sourceware.org/bugzilla/show_bug.cgi?id=16177


### PR DESCRIPTION
CVEs:

- https://nvd.nist.gov/vuln/detail/CVE-2020-35448 (3.3 Low)
- https://nvd.nist.gov/vuln/detail/CVE-2021-20284 (5.5 Medium)
- https://nvd.nist.gov/vuln/detail/CVE-2021-20294 (7.8 High)

CVEs information taken from https://repology.org/project/binutils/cves?version=2.35.1

Not addressed in this PR/Version Update:

- https://nvd.nist.gov/vuln/detail/CVE-2021-3487 (6.5 Medium, DoS via memory consumption)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Seems like #134917 missed the window before 21.11 freeze to update `binutils` from 2.35.1 → 2.37. This smaller version bump should address some security concerns while work on the major bump is underway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Currently doing a local rebuild on top of master with this version bump.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
