### PR TITLE
epick: init at 0.5.1

### DIFF
--- a/pkgs/applications/graphics/epick/default.nix
+++ b/pkgs/applications/graphics/epick/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, python3
+, libGL
+, libX11
+, libXcursor
+, libXi
+, libXrandr
+, libxcb
+, libxkbcommon
+, AppKit
+, IOKit
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "epick";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "vv9k";
+    repo = pname;
+    rev = version;
+    sha256 = "0l7m45bqx62nrwi0r4pdwxcq37s7h3nnawk9nq2zpvl9wcgnx3gc";
+  };
+
+  cargoSha256 = "sha256-LERV3+zwt5oVfyueGfxM7HsOha4cuWTkPyvPQwHSZqo=";
+
+  nativeBuildInputs = lib.optional stdenv.isLinux python3;
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    libGL
+    libX11
+    libXcursor
+    libXi
+    libXrandr
+    libxcb
+    libxkbcommon
+  ] ++ lib.optionals stdenv.isDarwin [
+    AppKit
+    IOKit
+  ];
+
+  postFixup = lib.optionalString stdenv.isLinux ''
+    patchelf --set-rpath ${lib.makeLibraryPath buildInputs} $out/bin/epick
+  '';
+
+  meta = with lib; {
+    description = "Simple color picker that lets the user create harmonic palettes with ease";
+    homepage = "https://github.com/vv9k/epick";
+    changelog = "https://github.com/vv9k/epick/blob/${version}/CHANGELOG.md";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24403,6 +24403,11 @@ with pkgs;
 
   epic5 = callPackage ../applications/networking/irc/epic5 { };
 
+  epick = callPackage ../applications/graphics/epick {
+    inherit (darwin.apple_sdk.frameworks) AppKit IOKit;
+    inherit (xorg) libX11 libXcursor libXi libXrandr libxcb;
+  };
+
   epr = callPackage ../applications/misc/epr { };
 
   eq10q = callPackage ../applications/audio/eq10q { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

epick is a simple color picker that lets the user create harmonic palettes with ease

It has darwin support, but I don't have a darwin machine, and I'm pretty sure it will fail looking at the dependencies.
It would be great if someone can test it out for me on darwin, just the error messages is enough to be helpful!

https://github.com/vv9k/epick

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
