### PR TITLE
coreutils: enable parallel builds and tests

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -121,9 +121,7 @@ stdenv.mkDerivation (rec {
   # Prevents attempts of running 'help2man' on cross-built binaries.
   PERL = if stdenv.hostPlatform == stdenv.buildPlatform then null else "missing";
 
-  # Saw random failures like ‘help2man: can't get '--help' info from
-  # man/sha512sum.td/sha512sum’.
-  enableParallelBuilding = false;
+  enableParallelBuilding = true;
 
   NIX_LDFLAGS = optionalString selinuxSupport "-lsepol";
   FORCE_UNSAFE_CONFIGURE = optionalString stdenv.hostPlatform.isSunOS "1";


### PR DESCRIPTION
Tested on 16-core machine with 10 rebuilds:
    $ nix build -f. coreutils --repeat 10

No failures. Original failure is probably fixed upstream
with a69e54cfdf7 ("maint: fix dependency of man/arch.1".)