### PR TITLE
factorio: Refactor update.py

### DIFF
--- a/pkgs/games/factorio/update.py
+++ b/pkgs/games/factorio/update.py
@@ -87,6 +87,16 @@ def generate_our_versions(factorio_versions: FactorioVersionsJSON) -> OurVersion
         if not factorio_versions[rc.name]:
             factorio_versions[rc.name] = factorio_versions['stable']
 
+    # Sometimes, factorio.com's API just doesn't advertise a demo version for experimental
+    if 'demo' not in factorio_versions['experimental']:
+        logging.debug("No 'demo' release in 'experimental' channel.")
+
+        if factorio_versions['experimental']['alpha'] == factorio_versions['stable']['alpha']:
+            logging.debug("'experimental' is the same as 'stable', setting 'demo' from it.")
+            factorio_versions['experimental']['demo'] = factorio_versions['stable']['demo']
+        else:
+            logging.error("'experimental' isn't the same version as 'stable' and doesn't have a 'demo' release.")
+
     for system in SYSTEMS:
         for release_type in RELEASE_TYPES:
             for release_channel in RELEASE_CHANNELS:

--- a/pkgs/games/factorio/update.py
+++ b/pkgs/games/factorio/update.py
@@ -23,6 +23,7 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string('username', '', 'Factorio username for retrieving binaries.')
 flags.DEFINE_string('token', '', 'Factorio token for retrieving binaries.')
 flags.DEFINE_string('out', '', 'Output path for versions.json.')
+flags.DEFINE_boolean('debug', False, 'Produces debugging output.')
 
 
 @dataclass
@@ -158,10 +159,14 @@ def fill_in_hash(versions: OurVersionJSON) -> OurVersionJSON:
 
 
 def main(argv):
+    if FLAGS.debug:
+        logging.set_verbosity(logging.DEBUG)
+
     factorio_versions = fetch_versions()
     new_our_versions = generate_our_versions(factorio_versions)
     old_our_versions = None
     our_versions_path = find_versions_json()
+
     if our_versions_path:
         logging.info('Loading old versions.json from %s', our_versions_path)
         with open(our_versions_path, 'r') as f:

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,56 +2,56 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.39.tar.xz",
+        "name": "factorio_alpha_x64-1.1.42.tar.xz",
         "needsAuth": true,
-        "sha256": "1wyvk0niyppg7h9ayfsiy6x309bjwsbgf62nah13aps89jk8n1pc",
+        "sha256": "08h2pxzsk7sigjqnqm1jxya3i9i5g2mgl378gmbp2jcy2mnn4dvm",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.39/alpha/linux64",
-        "version": "1.1.39"
+        "url": "https://factorio.com/get-download/1.1.42/alpha/linux64",
+        "version": "1.1.42"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.38.tar.xz",
+        "name": "factorio_alpha_x64-1.1.42.tar.xz",
         "needsAuth": true,
-        "sha256": "0cjhfyz4j06yn08n239ajjjpgykh39hzifhmd0ygr5szw9gdc851",
+        "sha256": "08h2pxzsk7sigjqnqm1jxya3i9i5g2mgl378gmbp2jcy2mnn4dvm",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.38/alpha/linux64",
-        "version": "1.1.38"
+        "url": "https://factorio.com/get-download/1.1.42/alpha/linux64",
+        "version": "1.1.42"
       }
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.37.tar.xz",
+        "name": "factorio_demo_x64-1.1.42.tar.xz",
         "needsAuth": false,
-        "sha256": "06qwx9wd3990d3256y9y5qsxa0936076jgwhinmrlvjp9lxwl4ly",
+        "sha256": "155m1ijdbc7szhpdw8f8g82ysd7av9zb6llqq4z96nn834px9m2d",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.37/demo/linux64",
-        "version": "1.1.37"
+        "url": "https://factorio.com/get-download/1.1.42/demo/linux64",
+        "version": "1.1.42"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.1.38.tar.xz",
+        "name": "factorio_demo_x64-1.1.42.tar.xz",
         "needsAuth": false,
-        "sha256": "0y53w01dyfmavw1yxbjqjiirmvw32bnf9bqz0isnd72dvkg0kziv",
+        "sha256": "155m1ijdbc7szhpdw8f8g82ysd7av9zb6llqq4z96nn834px9m2d",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.38/demo/linux64",
-        "version": "1.1.38"
+        "url": "https://factorio.com/get-download/1.1.42/demo/linux64",
+        "version": "1.1.42"
       }
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.39.tar.xz",
+        "name": "factorio_headless_x64-1.1.42.tar.xz",
         "needsAuth": false,
-        "sha256": "06figqmyd5bgwhpppziag4hs7x3ixr7wd8186cza3ly57bibha2m",
+        "sha256": "1l217fcjcwfi0g5dilsi703cl0wyxsqdqn422hwdbp2ql839k422",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.39/headless/linux64",
-        "version": "1.1.39"
+        "url": "https://factorio.com/get-download/1.1.42/headless/linux64",
+        "version": "1.1.42"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.38.tar.xz",
+        "name": "factorio_headless_x64-1.1.42.tar.xz",
         "needsAuth": false,
-        "sha256": "1c929pa9ifz0cvmx9k5yd267hjd5p7fdbln0czl3dq1vlskk1w71",
+        "sha256": "1l217fcjcwfi0g5dilsi703cl0wyxsqdqn422hwdbp2ql839k422",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.38/headless/linux64",
-        "version": "1.1.38"
+        "url": "https://factorio.com/get-download/1.1.42/headless/linux64",
+        "version": "1.1.42"
       }
     }
   }


### PR DESCRIPTION
###### Motivation for this change

New upstream version of `factorio`.  Users cannot play `factorio` on a server running a different version than theirs, so most multiplayer instances closely track the latest upstream.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))~~
- ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~ N/A
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
