### PR TITLE
[21.05] libressl_3_2: add patch for CVE-2021-41581

### DIFF
--- a/pkgs/development/libraries/libressl/CVE-2021-41581.patch
+++ b/pkgs/development/libraries/libressl/CVE-2021-41581.patch
@@ -1,0 +1,53 @@
+Based on upstream https://github.com/openbsd/src/commit/62ceddea5b1d64a1a362bbb7071d9e15adcde6b1
+with paths switched to apply to libressl-portable and CVS header
+hunk removed.
+
+--- a/crypto/x509/x509_constraints.c
++++ b/crypto/x509/x509_constraints.c
+@@ -339,16 +339,16 @@
+ 			if (c == '.')
+ 				goto bad;
+ 		}
+-		if (wi > DOMAIN_PART_MAX_LEN)
+-			goto bad;
+ 		if (accept) {
++			if (wi >= DOMAIN_PART_MAX_LEN)
++				goto bad;
+ 			working[wi++] = c;
+ 			accept = 0;
+ 			continue;
+ 		}
+ 		if (candidate_local != NULL) {
+ 			/* We are looking for the domain part */
+-			if (wi > DOMAIN_PART_MAX_LEN)
++			if (wi >= DOMAIN_PART_MAX_LEN)
+ 				goto bad;
+ 			working[wi++] = c;
+ 			if (i == len - 1) {
+@@ -363,7 +363,7 @@
+ 			continue;
+ 		}
+ 		/* We are looking for the local part */
+-		if (wi > LOCAL_PART_MAX_LEN)
++		if (wi >= LOCAL_PART_MAX_LEN)
+ 			break;
+ 
+ 		if (quoted) {
+@@ -383,6 +383,8 @@
+ 			 */
+ 			if (c == 9)
+ 				goto bad;
++			if (wi >= LOCAL_PART_MAX_LEN)
++				goto bad;
+ 			working[wi++] = c;
+ 			continue; /* all's good inside our quoted string */
+ 		}
+@@ -412,6 +414,8 @@
+ 		}
+ 		if (!local_part_ok(c))
+ 			goto bad;
++		if (wi >= LOCAL_PART_MAX_LEN)
++			goto bad;
+ 		working[wi++] = c;
+ 	}
+ 	if (candidate_local == NULL || candidate_domain == NULL)

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -71,5 +71,8 @@ in {
   libressl_3_2 = generic {
     version = "3.2.5";
     sha256 = "1zkwrs3b19s1ybz4q9hrb7pqsbsi8vxcs44qanfy11fkc7ynb2kr";
+    patches = [
+      ./CVE-2021-41581.patch
+    ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-41581

This introduces a patch added to `master` in #139545.

I'm not sure what to do about `libressl_3_1` here, because I'm fairly sure the vulnerable code just doesn't exist in 3.1, only introduced in https://github.com/openbsd/src/commit/d27446ede9e6006e354c72686f0ad11f1219b733. But I'd say I'm only 99% certain there so I'm not sure we should just decide it's not vulnerable based on me and my opinion. Even if we did, people with automated scanning tools would pick 3.1.5 up as "vulnerable" as the various CVE databases don't consider this vulnerability to have a "start version".

`libressl_3_1` doesn't actually appear to be used by anything in 21.05 currently, so I would probably be able to mark it as `knownVulnerabilities` without affecting any other packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
