### PR TITLE
discord,discord-ptb,discord-canary: added variant with Wayland support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/base.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/base.nix
@@ -5,7 +5,9 @@
 , libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
 , libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence
 , mesa, nspr, nss, pango, systemd, libappindicator-gtk3, libdbusmenu
-, writeScript, common-updater-scripts
+, writeScript, common-updater-scripts,
+
+  useWayland ? false
 }:
 
 let
@@ -52,7 +54,8 @@ in stdenv.mkDerivation rec {
     wrapProgram $out/opt/${binaryName}/${binaryName} \
         "''${gappsWrapperArgs[@]}" \
         --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-        --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/${binaryName}
+        --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/${binaryName} \
+        --add-flags "${lib.optionalString useWayland " --enable-features=UseOzonePlatform --ozone-platform=wayland"}"
 
     ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
     # Without || true the install would fail on case-insensitive filesystems
@@ -63,7 +66,7 @@ in stdenv.mkDerivation rec {
   '';
 
   desktopItem = makeDesktopItem {
-    name = pname;
+    name = "${pname}${lib.optionalString useWayland " (Wayland)"}";
     exec = binaryName;
     icon = pname;
     inherit desktopName;

--- a/pkgs/applications/networking/instant-messengers/discord/base.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/base.nix
@@ -5,9 +5,8 @@
 , libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
 , libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence
 , mesa, nspr, nss, pango, systemd, libappindicator-gtk3, libdbusmenu
-, writeScript, common-updater-scripts,
-
-  useWayland ? false
+, writeScript, common-updater-scripts
+, useWayland ? false
 }:
 
 let

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,4 +1,4 @@
-{ branch ? "stable", pkgs }:
+{ branch ? "stable", useWayland ? false, pkgs }:
 let
   inherit (pkgs) callPackage fetchurl;
 in {
@@ -11,6 +11,7 @@ in {
       url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz";
       sha256 = "UTVKjs/i7C/m8141bXBsakQRFd/c//EmqqhKhkr1OOk=";
     };
+    inherit useWayland;
   };
   ptb = callPackage ./base.nix rec {
     pname = "discord-ptb";
@@ -21,6 +22,7 @@ in {
       url = "https://dl-ptb.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz";
       sha256 = "1rlj76yhxjwwfmdln3azjr69hvfx1bjqdg9jhdn4fp6mlirkrcq4";
     };
+    inherit useWayland;
   };
   canary = callPackage ./base.nix rec {
     pname = "discord-canary";
@@ -31,5 +33,6 @@ in {
       url = "https://dl-canary.discordapp.net/apps/linux/${version}/discord-canary-${version}.tar.gz";
       sha256 = "087rzyivk0grhc73v7ldxxghks0n16ifrvpmk95vzaw99l9xv0v5";
     };
+    inherit useWayland;
   };
 }.${branch}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33007,14 +33007,32 @@ with pkgs;
     inherit pkgs;
   };
 
+  discord-wayland = import ../applications/networking/instant-messengers/discord {
+    branch = "stable";
+    inherit pkgs;
+    useWayland = true;
+  };
+
   discord-ptb = import ../applications/networking/instant-messengers/discord {
     branch = "ptb";
     inherit pkgs;
   };
 
+  discord-ptb-wayland = import ../applications/networking/instant-messengers/discord {
+    branch = "ptb";
+    inherit pkgs;
+    useWayland = true;
+  };
+
   discord-canary = import ../applications/networking/instant-messengers/discord {
     branch = "canary";
     inherit pkgs;
+  };
+
+  discord-canary-wayland = import ../applications/networking/instant-messengers/discord {
+    branch = "canary";
+    inherit pkgs;
+    useWayland = true;
   };
 
   golden-cheetah = libsForQt514.callPackage ../applications/misc/golden-cheetah {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added a Wayland variant for all the Discord packages which sets the necessary Ozone flags in the wrapper, similarly to #132776.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
