### PR TITLE
nixos/libvirtd: refactor module

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -1563,6 +1563,38 @@ Superuser created successfully.
           when they are socket-activated.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>virtualisation.libvirtd</literal> module has been
+          refactored and updated with new options:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              <literal>virtualisation.libvirtd.qemu*</literal> options
+              (e.g.:
+              <literal>virtualisation.libvirtd.qemuRunAsRoot</literal>)
+              were moved to
+              <link xlink:href="options.html#opt-virtualisation.libvirtd.qemu"><literal>virtualisation.libvirtd.qemu</literal></link>
+              submodule,
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              software TPM1/TPM2 support (e.g.: Windows 11 guests)
+              (<link xlink:href="options.html#opt-virtualisation.libvirtd.qemu.swtpm"><literal>virtualisation.libvirtd.qemu.swtpm</literal></link>),
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              custom OVMF package (e.g.:
+              <literal>pkgs.OVMFFull</literal> with HTTP, CSM and Secure
+              Boot support)
+              (<link xlink:href="options.html#opt-virtualisation.libvirtd.qemu.ovmf.package"><literal>virtualisation.libvirtd.qemu.ovmf.package</literal></link>).
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -451,3 +451,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - `networking.sits` now supports Foo-over-UDP encapsulation.
 
 - Changing systemd `.socket` units now restarts them and stops the service that is activated by them. Additionally, services with `stopOnChange = false` don't break anymore when they are socket-activated.
+
+-  The `virtualisation.libvirtd` module has been refactored and updated with new options:
+    - `virtualisation.libvirtd.qemu*` options (e.g.: `virtualisation.libvirtd.qemuRunAsRoot`) were moved to [`virtualisation.libvirtd.qemu`](options.html#opt-virtualisation.libvirtd.qemu) submodule,
+    - software TPM1/TPM2 support (e.g.: Windows 11 guests) ([`virtualisation.libvirtd.qemu.swtpm`](options.html#opt-virtualisation.libvirtd.qemu.swtpm)),
+    - custom OVMF package (e.g.: `pkgs.OVMFFull` with HTTP, CSM and Secure Boot support) ([`virtualisation.libvirtd.qemu.ovmf.package`](options.html#opt-virtualisation.libvirtd.qemu.ovmf.package)).

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -13,23 +13,140 @@ let
   '';
   ovmfFilePrefix = if pkgs.stdenv.isAarch64 then "AAVMF" else "OVMF";
   qemuConfigFile = pkgs.writeText "qemu.conf" ''
-    ${optionalString cfg.qemuOvmf ''
+    ${optionalString cfg.qemu.ovmf.enable ''
       nvram = [ "/run/libvirt/nix-ovmf/${ovmfFilePrefix}_CODE.fd:/run/libvirt/nix-ovmf/${ovmfFilePrefix}_VARS.fd" ]
     ''}
-    ${optionalString (!cfg.qemuRunAsRoot) ''
+    ${optionalString (!cfg.qemu.runAsRoot) ''
       user = "qemu-libvirtd"
       group = "qemu-libvirtd"
     ''}
-    ${cfg.qemuVerbatimConfig}
+    ${cfg.qemu.verbatimConfig}
   '';
   dirName = "libvirt";
   subDirs = list: [ dirName ] ++ map (e: "${dirName}/${e}") list;
 
-in {
+  ovmfModule = types.submodule {
+    options = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Allows libvirtd to take advantage of OVMF when creating new
+          QEMU VMs with UEFI boot.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.OVMF;
+        defaultText = literalExpression "pkgs.OVMF";
+        example = literalExpression "pkgs.OVMFFull";
+        description = ''
+          OVMF package to use.
+        '';
+      };
+    };
+  };
+
+  swtpmModule = types.submodule {
+    options = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Allows libvirtd to use swtpm to create an emulated TPM.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.swtpm;
+        defaultText = literalExpression "pkgs.swtpm";
+        description = ''
+          swtpm package to use.
+        '';
+      };
+    };
+  };
+
+  qemuModule = types.submodule {
+    options = {
+      package = mkOption {
+        type = types.package;
+        default = pkgs.qemu;
+        defaultText = literalExpression "pkgs.qemu";
+        description = ''
+          Qemu package to use with libvirt.
+          `pkgs.qemu` can emulate alien architectures (e.g. aarch64 on x86)
+          `pkgs.qemu_kvm` saves disk space allowing to emulate only host architectures.
+        '';
+      };
+
+      runAsRoot = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          If true,  libvirtd runs qemu as root.
+          If false, libvirtd runs qemu as unprivileged user qemu-libvirtd.
+          Changing this option to false may cause file permission issues
+          for existing guests. To fix these, manually change ownership
+          of affected files in /var/lib/libvirt/qemu to qemu-libvirtd.
+        '';
+      };
+
+      verbatimConfig = mkOption {
+        type = types.lines;
+        default = ''
+          namespaces = []
+        '';
+        description = ''
+          Contents written to the qemu configuration file, qemu.conf.
+          Make sure to include a proper namespace configuration when
+          supplying custom configuration.
+        '';
+      };
+
+      ovmf = mkOption {
+        type = ovmfModule;
+        default = { };
+        description = ''
+          QEMU's OVMF options.
+        '';
+      };
+
+      swtpm = mkOption {
+        type = swtpmModule;
+        default = { };
+        description = ''
+          QEMU's swtpm options.
+        '';
+      };
+    };
+  };
+in
+{
 
   imports = [
     (mkRemovedOptionModule [ "virtualisation" "libvirtd" "enableKVM" ]
-      "Set the option `virtualisation.libvirtd.qemuPackage' instead.")
+      "Set the option `virtualisation.libvirtd.qemu.package' instead.")
+    (mkRenamedOptionModule
+      [ "virtualisation" "libvirtd" "qemuPackage" ]
+      [ "virtualisation" "libvirtd" "qemu" "package" ])
+    (mkRenamedOptionModule
+      [ "virtualisation" "libvirtd" "qemuRunAsRoot" ]
+      [ "virtualisation" "libvirtd" "qemu" "runAsRoot" ])
+    (mkRenamedOptionModule
+      [ "virtualisation" "libvirtd" "qemuVerbatimConfig" ]
+      [ "virtualisation" "libvirtd" "qemu" "verbatimConfig" ])
+    (mkRenamedOptionModule
+      [ "virtualisation" "libvirtd" "qemuOvmf" ]
+      [ "virtualisation" "libvirtd" "qemu" "ovmf" "enable" ])
+    (mkRenamedOptionModule
+      [ "virtualisation" "libvirtd" "qemuOvmfPackage" ]
+      [ "virtualisation" "libvirtd" "qemu" "ovmf" "package" ])
+    (mkRenamedOptionModule
+      [ "virtualisation" "libvirtd" "qemuSwtpm" ]
+      [ "virtualisation" "libvirtd" "qemu" "swtpm" "enable" ])
   ];
 
   ###### interface
@@ -56,73 +173,12 @@ in {
       '';
     };
 
-    qemuPackage = mkOption {
-      type = types.package;
-      default = pkgs.qemu;
-      defaultText = literalExpression "pkgs.qemu";
-      description = ''
-        Qemu package to use with libvirt.
-        `pkgs.qemu` can emulate alien architectures (e.g. aarch64 on x86)
-        `pkgs.qemu_kvm` saves disk space allowing to emulate only host architectures.
-      '';
-    };
-
     extraConfig = mkOption {
       type = types.lines;
       default = "";
       description = ''
         Extra contents appended to the libvirtd configuration file,
         libvirtd.conf.
-      '';
-    };
-
-    qemuRunAsRoot = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        If true,  libvirtd runs qemu as root.
-        If false, libvirtd runs qemu as unprivileged user qemu-libvirtd.
-        Changing this option to false may cause file permission issues
-        for existing guests. To fix these, manually change ownership
-        of affected files in /var/lib/libvirt/qemu to qemu-libvirtd.
-      '';
-    };
-
-    qemuVerbatimConfig = mkOption {
-      type = types.lines;
-      default = ''
-        namespaces = []
-      '';
-      description = ''
-        Contents written to the qemu configuration file, qemu.conf.
-        Make sure to include a proper namespace configuration when
-        supplying custom configuration.
-      '';
-    };
-
-    qemuOvmf = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Allows libvirtd to take advantage of OVMF when creating new
-        QEMU VMs with UEFI boot.
-      '';
-    };
-
-    qemuOvmfPackage = mkOption {
-      type = types.package;
-      default = pkgs.OVMF;
-      defaultText = literalExpression "pkgs.OVMF";
-      example = literalExpression "pkgs.OVMFFull";
-      description = ''
-        OVMF package to use.
-      '';
-    };
-    qemuSwtpm = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Allows libvirtd to use swtpm to create an emulated TPM.
       '';
     };
 
@@ -136,7 +192,7 @@ in {
     };
 
     onBoot = mkOption {
-      type = types.enum ["start" "ignore" ];
+      type = types.enum [ "start" "ignore" ];
       default = "start";
       description = ''
         Specifies the action to be done to / on the guests when the host boots.
@@ -148,7 +204,7 @@ in {
     };
 
     onShutdown = mkOption {
-      type = types.enum ["shutdown" "suspend" ];
+      type = types.enum [ "shutdown" "suspend" ];
       default = "suspend";
       description = ''
         When shutting down / restarting the host what method should
@@ -166,6 +222,13 @@ in {
       '';
     };
 
+    qemu = mkOption {
+      type = qemuModule;
+      default = { };
+      description = ''
+        QEMU related options.
+      '';
+    };
   };
 
 
@@ -179,16 +242,18 @@ in {
         message = "The libvirtd module currently requires Polkit to be enabled ('security.polkit.enable = true').";
       }
       {
-        assertion = builtins.elem "fd" cfg.qemuOvmfPackage.outputs;
+        assertion = builtins.elem "fd" cfg.qemu.ovmf.package.outputs;
         message = "The option 'virtualisation.libvirtd.qemuOvmfPackage' needs a package that has an 'fd' output.";
       }
     ];
 
     environment = {
       # this file is expected in /etc/qemu and not sysconfdir (/var/lib)
-      etc."qemu/bridge.conf".text = lib.concatMapStringsSep "\n" (e:
-        "allow ${e}") cfg.allowedBridges;
-      systemPackages = with pkgs; [ libressl.nc iptables cfg.package cfg.qemuPackage ];
+      etc."qemu/bridge.conf".text = lib.concatMapStringsSep "\n"
+        (e:
+          "allow ${e}")
+        cfg.allowedBridges;
+      systemPackages = with pkgs; [ libressl.nc iptables cfg.package cfg.qemu.package ];
       etc.ethertypes.source = "${pkgs.ebtables}/etc/ethertypes";
     };
 
@@ -230,17 +295,17 @@ in {
         cp -f ${qemuConfigFile} /var/lib/${dirName}/qemu.conf
 
         # stable (not GC'able as in /nix/store) paths for using in <emulator> section of xml configs
-        for emulator in ${cfg.package}/libexec/libvirt_lxc ${cfg.qemuPackage}/bin/qemu-kvm ${cfg.qemuPackage}/bin/qemu-system-*; do
+        for emulator in ${cfg.package}/libexec/libvirt_lxc ${cfg.qemu.package}/bin/qemu-kvm ${cfg.qemu.package}/bin/qemu-system-*; do
           ln -s --force "$emulator" /run/${dirName}/nix-emulators/
         done
 
         for helper in libexec/qemu-bridge-helper bin/qemu-pr-helper; do
-          ln -s --force ${cfg.qemuPackage}/$helper /run/${dirName}/nix-helpers/
+          ln -s --force ${cfg.qemu.package}/$helper /run/${dirName}/nix-helpers/
         done
 
-        ${optionalString cfg.qemuOvmf ''
-          ln -s --force ${cfg.qemuOvmfPackage.fd}/FV/${ovmfFilePrefix}_CODE.fd /run/${dirName}/nix-ovmf/
-          ln -s --force ${cfg.qemuOvmfPackage.fd}/FV/${ovmfFilePrefix}_VARS.fd /run/${dirName}/nix-ovmf/
+        ${optionalString cfg.qemu.ovmf.enable ''
+          ln -s --force ${cfg.qemu.ovmf.package.fd}/FV/${ovmfFilePrefix}_CODE.fd /run/${dirName}/nix-ovmf/
+          ln -s --force ${cfg.qemu.ovmf.package.fd}/FV/${ovmfFilePrefix}_VARS.fd /run/${dirName}/nix-ovmf/
         ''}
       '';
 
@@ -256,16 +321,20 @@ in {
     systemd.services.libvirtd = {
       requires = [ "libvirtd-config.service" ];
       after = [ "libvirtd-config.service" ]
-              ++ optional vswitch.enable "ovs-vswitchd.service";
+        ++ optional vswitch.enable "ovs-vswitchd.service";
 
       environment.LIBVIRTD_ARGS = escapeShellArgs (
-        [ "--config" configFile
-          "--timeout" "120"     # from ${libvirt}/var/lib/sysconfig/libvirtd
-        ] ++ cfg.extraOptions);
+        [
+          "--config"
+          configFile
+          "--timeout"
+          "120" # from ${libvirt}/var/lib/sysconfig/libvirtd
+        ] ++ cfg.extraOptions
+      );
 
-      path = [ cfg.qemuPackage ] # libvirtd requires qemu-img to manage disk images
-             ++ optional vswitch.enable vswitch.package
-             ++ optional cfg.qemuSwtpm pkgs.swtpm;
+      path = [ cfg.qemu.package ] # libvirtd requires qemu-img to manage disk images
+        ++ optional vswitch.enable vswitch.package
+        ++ optional cfg.qemu.swtpm.enable cfg.qemu.swtpm.package;
 
       serviceConfig = {
         Type = "notify";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Move all `virtualisation.libvirtd.qemu*` options to a `virtualisation.libvirtd.qemu` submodule.

Also for consistency, add `virtualisation.libvirtd.qemu.swtpm.package` (only new option during this refactor.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
