### PR TITLE
mpv: replace youtube-dl with yt-dlp

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26486,7 +26486,7 @@ with pkgs;
   };
 
   # Wraps without trigerring a rebuild
-  wrapMpv = callPackage ../applications/video/mpv/wrapper.nix { };
+  wrapMpv = callPackage ../applications/video/mpv/wrapper.nix { youtube-dl = yt-dlp.override { withAlias = true; }; };
   mpv = wrapMpv mpv-unwrapped {};
 
   mpvScripts = recurseIntoAttrs {


### PR DESCRIPTION
(NOTE: opening this for @MatthewCroughan since he is currently banned from the NixOS
Github organization)

###### Motivation for this change
> Youtube has been throttling downloads and youtube-dl is now
undermaintained. This commit changes mpv to use yt-dlp for watching
Youtube videos, rather than youtube-dl.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
