### PR TITLE
snis: init at 20211017

### DIFF
--- a/pkgs/games/snis/default.nix
+++ b/pkgs/games/snis/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, coreutils
+, portaudio
+, libbsd
+, libpng
+, libvorbis
+, SDL2
+, lua5_2
+, glew
+, openssl
+, picotts
+, alsa-utils
+, espeak-classic
+, sox
+, libopus
+, openscad
+}:
+
+stdenv.mkDerivation {
+  pname = "snis_launcher";
+  version = "unstable-2021-10-17";
+
+  src = fetchFromGitHub {
+    owner = "smcameron";
+    repo = "space-nerds-in-space";
+    rev = "e70d3c63e33c940feb53c8d818ce2d8ea2aadf00";
+    sha256 = "sha256-HVCb1iFn7GWNpedtFCgLyd0It8s4PEmUwDfb8ap1TDc=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "OPUSARCHIVE=libopus.a" "OPUSARCHIVE=" \
+      --replace "-I./opus-1.3.1/include" "-I${libopus.dev}/include/opus"
+    substituteInPlace snis_launcher \
+      --replace "PREFIX=." "PREFIX=$out"
+    substituteInPlace snis_text_to_speech.sh \
+      --replace "pico2wave" "${sox}/bin/pico2wave" \
+      --replace "espeak" "${espeak-classic}/bin/espeak" \
+      --replace "play" "${sox}/bin/play" \
+      --replace "aplay" "${alsa-utils}/bin/aplay" \
+      --replace "/bin/rm" "${coreutils}/bin/rm"
+  '';
+
+  nativeBuildInputs = [ pkg-config openscad ];
+  buildInputs = [ coreutils portaudio libbsd libpng libvorbis SDL2 lua5_2 glew openssl picotts sox alsa-utils libopus ];
+
+  postBuild = ''
+    make models -j$NIX_BUILD_CORES
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -R share $out/share
+    cp -R bin $out/bin
+    cp snis_launcher $out/bin/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Space Nerds In Space, a multi-player spaceship bridge simulator";
+    homepage = "https://smcameron.github.io/space-nerds-in-space/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ alyaeanyx ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/snis/default.nix
+++ b/pkgs/games/snis/default.nix
@@ -8,6 +8,7 @@
 , libpng
 , libvorbis
 , SDL2
+, makeWrapper
 , lua5_2
 , glew
 , openssl
@@ -44,7 +45,7 @@ stdenv.mkDerivation {
       --replace "/bin/rm" "${coreutils}/bin/rm"
   '';
 
-  nativeBuildInputs = [ pkg-config openscad ];
+  nativeBuildInputs = [ pkg-config openscad makeWrapper ];
   buildInputs = [ coreutils portaudio libbsd libpng libvorbis SDL2 lua5_2 glew openssl picotts sox alsa-utils libopus ];
 
   postBuild = ''
@@ -57,6 +58,8 @@ stdenv.mkDerivation {
     cp -R share $out/share
     cp -R bin $out/bin
     cp snis_launcher $out/bin/
+    # without this, snis_client crashes on Wayland
+    wrapProgram $out/bin/snis_client --set SDL_VIDEODRIVER x11
     runHook postInstall
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30251,6 +30251,8 @@ with pkgs;
 
   synthv1 = libsForQt5.callPackage ../applications/audio/synthv1 { };
 
+  snis = callPackage ../games/snis { };
+
   system-syzygy = callPackage ../games/system-syzygy { };
 
   t4kcommon = callPackage ../games/t4kcommon { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[Space Nerds in Space](https://github.com/smcameron/space-nerds-in-space/) is a multiplayer spaceflight game that's (for example) already packaged in the [AUR](https://aur.archlinux.org/packages/snis-git/). It doesn't have any versioning, so the current date was chosen as the version of the derivation.

The derivation builds the 3D assets from the provided template files with `make models`. The makefile is patched so it uses Nixpkgs's `libopus` instead of downloading it as a zip archive while compiling. Additionally, the script `snis_text_to_speech.sh` is patched with the store paths of the binaries used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
