### PR TITLE
nixosTests.owncast: fix eval

### DIFF
--- a/nixos/tests/owncast.nix
+++ b/nixos/tests/owncast.nix
@@ -1,14 +1,14 @@
 { system ? builtins.currentSystem, config ? { }
 , pkgs ? import ../.. { inherit system config; } }:
 
-with import (nixpkgs + "/nixos/lib/testing-python.nix") { inherit system; };
+with import ../lib/testing-python.nix { inherit system; };
 makeTest {
   name = "owncast";
-  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ MayNiklas ]; };
+  meta = with pkgs.lib.maintainers; { maintainers = [ MayNiklas ]; };
 
   nodes = {
     client = { ... }: {
-      environment.systemPackages = [ curl ];
+      environment.systemPackages = with pkgs; [ curl ];
       services.owncast = { enable = true; };
     };
   };


### PR DESCRIPTION
The test is failing, but at least it evaluates now.

	curl: (7) Failed to connect to localhost port 8080: Connection refused

@MayNiklas, I'd appreciate it if you could share any insight about how we could make the test pass!  (And don't worry about the broken test slipping in — it didn't break anything important, and it's not just you who didn't catch it. :))

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
