### PR TITLE
python3Packages.cbor2: 5.4.1 -> 5.4.2

### DIFF
--- a/pkgs/development/python-modules/cbor2/default.nix
+++ b/pkgs/development/python-modules/cbor2/default.nix
@@ -3,25 +3,33 @@
 , buildPythonPackage
 , fetchPypi
 , pytestCheckHook
-, pytest-cov
+, pythonOlder
 , setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "cbor2";
-  version = "5.4.1";
+  version = "5.4.2";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1jga5wj3kalf6zj5gyrmy6kwmxxkld52mvcgxc5gb5dmdhpl7gx8";
+    sha256 = "sha256-4oPnC1WgSf82TMXmSP3lh+TZsOh+SyZkxp5jkTXms7g=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
   checkInputs = [
-    pytest-cov
     pytestCheckHook
   ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov" ""
+  '';
 
   # https://github.com/agronholm/cbor2/issues/99
   disabledTests = lib.optionals stdenv.is32bit [
@@ -29,7 +37,9 @@ buildPythonPackage rec {
     "test_huge_truncated_string"
   ];
 
-  pythonImportsCheck = [ "cbor2" ];
+  pythonImportsCheck = [
+    "cbor2"
+  ];
 
   meta = with lib; {
     description = "Python CBOR (de)serializer with extensive tag support";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 5.4.2

Change log: https://cbor2.readthedocs.io/en/latest/versionhistory.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
