### PR TITLE
sdrpp: init at 1.0.4

### DIFF
--- a/pkgs/applications/radio/airspyhf/default.nix
+++ b/pkgs/applications/radio/airspyhf/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libusb1 }:
+
+stdenv.mkDerivation rec {
+  pname = "airspyhf";
+  version = "1.6.8";
+
+  src = fetchFromGitHub {
+    owner = "airspy";
+    repo = pname;
+    rev = version;
+    hash = "sha256-RKTMEDPeKcerJZtXTn8eAShxDcZUMgeQg/+7pEpMyVg=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ libusb1 ];
+
+  meta = with lib; {
+    description = "User mode driver for Airspy HF+";
+    homepage = "https://github.com/airspy/airspyhf";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/radio/sdrpp/default.nix
+++ b/pkgs/applications/radio/sdrpp/default.nix
@@ -1,0 +1,107 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config
+, libX11, glfw, glew, fftwFloat, volk
+# Sources
+, airspy_source ? true, airspy
+, airspyhf_source ? true, airspyhf
+, bladerf_source ? false, libbladeRF
+, file_source ? true
+, hackrf_source ? true, hackrf
+, limesdr_source ? false, limesuite
+, sddc_source ? false
+, rtl_sdr_source ? true, librtlsdr, libusb1
+, rtl_tcp_source ? true
+, sdrplay_source ? false, sdrplay
+, soapy_source ? true, soapysdr
+, spyserver_source ? true
+, plutosdr_source ? true, libiio, libad9361
+# Sinks
+, audio_sink ? true, rtaudio
+, portaudio_sink ? false, portaudio
+, network_sink ? true
+# Decoders
+, falcon9_decoder ? false
+, m17_decoder ? false, codec2
+, meteor_demodulator ? true
+, radio ? true
+, weather_sat_decoder ? true
+# Misc
+, discord_presence ? true
+, frequency_manager ? true
+, recorder ? true
+, rigctl_server ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sdrpp";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "AlexandreRouma";
+    repo = "SDRPlusPlus";
+    rev = version;
+    hash = "sha256-g9tpWvVRMXRhPfgvOeJhX6IMouF9+tLUr9wo5r35i/c=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "/usr" $out
+    substituteInPlace decoder_modules/m17_decoder/src/m17dsp.h \
+      --replace "codec2.h" "codec2/codec2.h"
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ glfw glew fftwFloat volk ]
+    ++ lib.optional stdenv.isLinux libX11
+    ++ lib.optional airspy_source airspy
+    ++ lib.optional airspyhf_source airspyhf
+    ++ lib.optional bladerf_source libbladeRF
+    ++ lib.optional hackrf_source hackrf
+    ++ lib.optional limesdr_source limesuite
+    ++ lib.optionals rtl_sdr_source [ librtlsdr libusb1 ]
+    ++ lib.optional sdrplay_source sdrplay
+    ++ lib.optional soapy_source soapysdr
+    ++ lib.optionals plutosdr_source [ libiio libad9361 ]
+    ++ lib.optional audio_sink rtaudio
+    ++ lib.optional portaudio_sink portaudio
+    ++ lib.optional m17_decoder codec2;
+
+  cmakeFlags = lib.mapAttrsToList (k: v: "-D${k}=${if v then "ON" else "OFF"}") {
+    OPT_BUILD_AIRSPY_SOURCE = airspy_source;
+    OPT_BUILD_AIRSPYHF_SOURCE = airspyhf_source;
+    OPT_BUILD_BLADERF_SOURCE = bladerf_source;
+    OPT_BUILD_FILE_SOURCE = file_source;
+    OPT_BUILD_HACKRF_SOURCE = hackrf_source;
+    OPT_BUILD_LIMESDR_SOURCE = limesdr_source;
+    OPT_BUILD_SDDC_SOURCE = sddc_source;
+    OPT_BUILD_RTL_SDR_SOURCE = rtl_sdr_source;
+    OPT_BUILD_RTL_TCP_SOURCE = rtl_tcp_source;
+    OPT_BUILD_SDRPLAY_SOURCE = sdrplay_source;
+    OPT_BUILD_SOAPY_SOURCE = soapy_source;
+    OPT_BUILD_SPYSERVER_SOURCE = spyserver_source;
+    OPT_BUILD_PLUTOSDR_SOURCE = plutosdr_source;
+    OPT_BUILD_AUDIO_SINK = audio_sink;
+    OPT_BUILD_PORTAUDIO_SINK = portaudio_sink;
+    OPT_BUILD_NETWORK_SINK = network_sink;
+    OPT_BUILD_NEW_PORTAUDIO_SINK = portaudio_sink;
+    OPT_BUILD_FALCON9_DECODER = falcon9_decoder;
+    OPT_BUILD_M17_DECODER = m17_decoder;
+    OPT_BUILD_METEOR_DEMODULATOR = meteor_demodulator;
+    OPT_BUILD_RADIO = radio;
+    OPT_BUILD_WEATHER_SAT_DECODER = weather_sat_decoder;
+    OPT_BUILD_DISCORD_PRESENCE = discord_presence;
+    OPT_BUILD_FREQUENCY_MANAGER = frequency_manager;
+    OPT_BUILD_RECORDER = recorder;
+    OPT_BUILD_RIGCTL_SERVER = rigctl_server;
+  };
+
+  NIX_CFLAGS_COMPILE = "-fpermissive";
+
+  meta = with lib; {
+    description = "Cross-Platform SDR Software";
+    homepage = "https://github.com/AlexandreRouma/SDRPlusPlus";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/development/libraries/libad9361/default.nix
+++ b/pkgs/development/libraries/libad9361/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, cmake, libiio }:
+
+stdenv.mkDerivation rec {
+  pname = "libad9361";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "analogdevicesinc";
+    repo = "libad9361-iio";
+    rev = "v${version}";
+    hash = "sha256-dYoFWRnREvlOC514ZpmmvoS37DmIkVqfq7JPpTXqXd8=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libiio ];
+
+  meta = with lib; {
+    description = "IIO AD9361 library for filter design and handling, multi-chip sync, etc";
+    homepage = "http://analogdevicesinc.github.io/libad9361-iio/";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -901,6 +901,8 @@ with pkgs;
 
   airspy = callPackage ../applications/radio/airspy { };
 
+  airspyhf = callPackage ../applications/radio/airspyhf { };
+
   airtame = callPackage ../applications/misc/airtame { };
 
   aj-snapshot  = callPackage ../applications/audio/aj-snapshot { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16940,6 +16940,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
+  libad9361 = callPackage ../development/libraries/libad9361 { };
+
   libadwaita = callPackage ../development/libraries/libadwaita { };
 
   libaec = callPackage ../development/libraries/libaec { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19192,6 +19192,8 @@ with pkgs;
 
   sdrplay = callPackage ../applications/radio/sdrplay {};
 
+  sdrpp = callPackage ../applications/radio/sdrpp { };
+
   sblim-sfcc = callPackage ../development/libraries/sblim-sfcc {};
 
   selinux-sandbox = callPackage ../os-specific/linux/selinux-sandbox { };


### PR DESCRIPTION
###### Motivation for this change

> **[SDR++](https://github.com/AlexandreRouma/SDRPlusPlus)** is a cross-platform and open source SDR software with the aim of being bloat free and simple to use.

[![Packaging status](https://repology.org/badge/tiny-repos/sdr%2B%2B.svg)](https://repology.org/project/sdr%2B%2B/versions)

Packaged dependencies:
* [airspyhf](https://github.com/airspy/airspyhf) - user mode driver for Airspy HF+ [![Packaging status](https://repology.org/badge/tiny-repos/airspyhf.svg)](https://repology.org/project/airspyhf/versions)
* [libad9361](https://github.com/analogdevicesinc/libad9361-iio) - IIO AD9361 library [![Packaging status](https://repology.org/badge/tiny-repos/libad9361-iio.svg)](https://repology.org/project/libad9361-iio/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
