### PR TITLE
python3Packages.open-garage: 0.1.5 -> 0.1.6

### DIFF
--- a/pkgs/development/python-modules/open-garage/default.nix
+++ b/pkgs/development/python-modules/open-garage/default.nix
@@ -8,14 +8,15 @@
 
 buildPythonPackage rec {
   pname = "open-garage";
-  version = "0.1.5";
+  version = "0.1.6";
+
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "Danielhiversen";
     repo = "pyOpenGarage";
     rev = version;
-    sha256 = "1iqcqkbb1ik5lmsvwgy6i780x6y3wlm1gx257anxyvp1b21gm24p";
+    sha256 = "sha256-vm51Fjej0OQ7LftisS/tsnxZxa5c/j7eGIROMsEcXNE=";
   };
 
   propagatedBuildInputs = [
@@ -26,7 +27,9 @@ buildPythonPackage rec {
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "opengarage" ];
+  pythonImportsCheck = [
+    "opengarage"
+  ];
 
   meta = with lib; {
     description = "Python module to communicate with opengarage.io";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.1.6

Change log: https://github.com/Danielhiversen/pyOpenGarage/releases/tag/0.1.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
