### PR TITLE
aws-c-auth: 0.6.4 -> 0.6.5 

### DIFF
--- a/pkgs/development/libraries/aws-c-auth/default.nix
+++ b/pkgs/development/libraries/aws-c-auth/default.nix
@@ -5,19 +5,20 @@
 , aws-c-compression
 , aws-c-http
 , aws-c-io
+, aws-c-sdkutils
 , cmake
 , s2n-tls
 }:
 
 stdenv.mkDerivation rec {
   pname = "aws-c-auth";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-auth";
     rev = "v${version}";
-    sha256 = "120p69lj279yq3d2b81f45kgfrvf32j6m7s03m8hh27w8yd4vbfp";
+    sha256 = "sha256-d3UdZucicp+Z0EjWNE5Xa/EMIGPk6GtQc7f0H8RBHA8=";
   };
 
   nativeBuildInputs = [
@@ -31,6 +32,10 @@ stdenv.mkDerivation rec {
     aws-c-http
     aws-c-io
     s2n-tls
+  ];
+
+  propagatedBuildInputs = [
+    aws-c-sdkutils
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/aws-c-sdkutils/default.nix
+++ b/pkgs/development/libraries/aws-c-sdkutils/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv
+, fetchFromGitHub
+, aws-c-common
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "aws-c-sdkutils";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "aws-c-sdkutils";
+    rev = "v${version}";
+    sha256 = "sha256-jYeyNEoJsF67XQAkmC7oegnIRBRD3FXKf5wF/NCVb4o=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    aws-c-common
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "AWS SDK utility library";
+    homepage = "https://github.com/awslabs/aws-c-sdkutils";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ r-burns ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15431,6 +15431,8 @@ with pkgs;
 
   aws-c-s3 = callPackage ../development/libraries/aws-c-s3 { };
 
+  aws-c-sdkutils = callPackage ../development/libraries/aws-c-sdkutils { };
+
   aws-checksums = callPackage ../development/libraries/aws-checksums { };
 
   aws-crt-cpp = callPackage ../development/libraries/aws-crt-cpp { };


### PR DESCRIPTION
Also init new depenendency package aws-c-sdkutils. The dependency is propagated because it is required by the interface cmake package config file.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
