### PR TITLE
Fix zorns-lemma before 9.0.

### DIFF
--- a/pkgs/development/coq-modules/zorns-lemma/default.nix
+++ b/pkgs/development/coq-modules/zorns-lemma/default.nix
@@ -1,9 +1,8 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 with lib;
 
-mkCoqDerivation {
+(mkCoqDerivation {
   pname = "zorns-lemma";
-  repo = "topology";
 
   releaseRev = v: "v${v}";
 
@@ -38,4 +37,4 @@ mkCoqDerivation {
     maintainers = with maintainers; [ siraben ];
     license = licenses.lgpl21Plus;
   };
-}
+}).overrideAttrs({version, ...}: if versions.isGe "9.0" version then { repo =  "topology"; } else {})


### PR DESCRIPTION
The source was fetched from the wrong location and thus did not match the provided sha.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Previous commit (a864b59ef1a807586f2bccbca46ac1478d04138c) broke the compilation of zorns-lemma < 9.0 by always setting `repo = "topology"`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @siraben 