### PR TITLE
systemd: fix typo in comment

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -164,10 +164,11 @@ stdenv.mkDerivation {
     ./0019-core-respect-install_sysconfdir_samples-in-meson-fil.patch
     ./0020-login-respect-install_sysconfdir_samples-in-meson-fi.patch
 
-    # In v248 or v249 we started to get in trouble due to our /etc/systemd/sytem being
-    # a symlink and thus being treated differently by systemd. With the below
-    # patch we mitigate that effect by special casing all our root unit dirs
-    # if they are symlinks. This does exactly what we need (AFAICT).
+    # In v248 or v249 we started to get in trouble due to our
+    # /etc/systemd/system being a symlink and thus being treated differently by
+    # systemd. With the below patch we mitigate that effect by special casing
+    # all our root unit dirs if they are symlinks. This does exactly what we
+    # need (AFAICT).
     ./0021-core-handle-lookup-paths-being-symlinks.patch
 
     # The way files are being tested for being executable changed in v248/v249


### PR DESCRIPTION
###### Motivation for this change

Spotted this while looking at the file. Not a rebuild, but there's a bunch of other systemd changes queued up in staging, so might make sense to batch it with those here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
