### PR TITLE
q4wine: init at 1.3.13

### DIFF
--- a/pkgs/applications/misc/q4wine/default.nix
+++ b/pkgs/applications/misc/q4wine/default.nix
@@ -1,0 +1,37 @@
+{ lib, fetchFromGitHub, mkDerivation, cmake, sqlite
+, qtbase, qtsvg, qttools, wrapQtAppsHook
+, icoutils # build and runtime deps.
+, wget, fuseiso, wine, sudo, which # runtime deps.
+}:
+
+mkDerivation rec {
+  pname = "q4wine";
+  version = "1.3.13";
+
+  src = fetchFromGitHub {
+    owner = "brezerk";
+    repo = "q4wine";
+    rev = "v${version}";
+    sha256 = "04gw5y3dxdpivm2xqacqq85fdzx7xkl0c3h3hdazljb0c3cxxs6h";
+  };
+
+  buildInputs = [
+     sqlite icoutils qtbase qtsvg qttools
+  ];
+
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+
+  # Add runtime deps.
+  postInstall = ''
+    wrapProgram $out/bin/q4wine \
+      --prefix PATH : ${lib.makeBinPath [ icoutils wget fuseiso wine which ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://q4wine.brezblock.org.ua/";
+    description = "A Qt GUI for Wine to manage prefixes and applications";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ rkitover ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25168,6 +25168,8 @@ with pkgs;
 
   gtkpod = callPackage ../applications/audio/gtkpod { };
 
+  q4wine = libsForQt5.callPackage ../applications/misc/q4wine { };
+
   qrcodegen = callPackage ../development/libraries/qrcodegen { };
 
   qrencode = callPackage ../development/libraries/qrencode { };


### PR DESCRIPTION
Qt GUI application for Wine for managing prefixes and applications.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
