### PR TITLE
nim: use newer bootstrap repository for aarch64-darwin support

### DIFF
--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -72,15 +72,17 @@ let
   nimHost = parsePlatform stdenv.hostPlatform;
   nimTarget = parsePlatform stdenv.targetPlatform;
 
-  bootstrapCompiler = stdenv.mkDerivation rec {
+  bootstrapCompiler = let
+    revision = "561b417c65791cd8356b5f73620914ceff845d10";
+  in stdenv.mkDerivation {
     pname = "nim-bootstrap";
-    version = "0.20.0";
+    version = "g${lib.substring 0 7 revision}";
 
     src = fetchgit {
       # A Git checkout is much smaller than a GitHub tarball.
-      url = "https://github.com/nim-lang/csources.git";
-      rev = "v${version}";
-      sha256 = "0i6vsfy1sgapx43n226q8m0pvn159sw2mhp50zm3hhb9zfijanis";
+      url = "https://github.com/nim-lang/csources_v1.git";
+      rev = revision;
+      sha256 = "1c2k681knrha1zmf4abhb32i2wwd3nwflzylnqryxk753swla043";
     };
 
     enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

The old "csources" repo has been archived a while ago and a newer
csources_v1 repo has been published. The main advantage is that we now
have support for newer platorms (such as Apple M1's) and newer nim
versions in the bootstrap.

The new repository doesn't contain release tags thus I pinned it to the
latest revision that has been published.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] aarch64-darwin
