### PR TITLE
swaycwd: 0.0.1 -> 0.0.2

### DIFF
--- a/pkgs/tools/wayland/swaycwd/default.nix
+++ b/pkgs/tools/wayland/swaycwd/default.nix
@@ -1,36 +1,38 @@
-{ lib, nimPackages, fetchFromGitLab
+{ lib
+, nimPackages
+, fetchFromGitLab
 , enableShells ? [ "bash" "zsh" "fish" "sh" "posh" ]
 }:
+nimPackages.buildNimPackage rec{
 
-nimPackages.buildNimPackage {
-    name = "swaycwd";
-    version = "0.0.1";
+  name = "swaycwd";
+  version = "0.0.2";
 
-    src = fetchFromGitLab {
-      owner = "cab404";
-      repo = "swaycwd";
-      rev = "aca81695ec2102b9bca6f5bae364f69a8b9d399f";
-      hash = "sha256-MkyY3wWByQo0l0J28xKDfGtxfazVPRyZHCObl9Fszh4=";
-    };
+  src = fetchFromGitLab {
+    owner = "cab404";
+    repo = name;
+    rev = "v${version}";
+    hash = "sha256-OZWOPtOqcX+fVQCxWntrn98EzFu70WH55rfYCPDMSKk=";
+  };
 
-    preConfigure = ''
-      {
-        echo 'let enabledShells: seq[string] = @${builtins.toJSON enableShells}'
-        echo 'export enabledShells'
-      } > shells.nim
-      cat << EOF > swaycwd.nimble
-      srcDir = "."
-      bin = "swaycwd"
-      EOF
-    '';
+  preConfigure = ''
+    {
+      echo 'let enabledShells: seq[string] = @${builtins.toJSON enableShells}'
+      echo 'export enabledShells'
+    } > shells.nim
+    cat << EOF > swaycwd.nimble
+    srcDir = "."
+    bin = "swaycwd"
+    EOF
+  '';
 
-    nimFlags = [ "--opt:speed" ];
+  nimFlags = [ "--opt:speed" ];
 
-    meta = with lib; {
-      homepage = "https://gitlab.com/cab404/swaycwd";
-      description = "Returns cwd for shell in currently focused sway window, or home directory if cannot find shell";
-      maintainers = with maintainers; [ cab404 ];
-      platforms = platforms.linux;
-      license = licenses.gpl3Only;
-    };
+  meta = with lib; {
+    homepage = "https://gitlab.com/cab404/swaycwd";
+    description = "Returns cwd for shell in currently focused sway window, or home directory if cannot find shell";
+    maintainers = with maintainers; [ cab404 ];
+    platforms = platforms.linux;
+    license = licenses.gpl3Only;
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated (and fixed) swaycwd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
