### PR TITLE
drone-cli: add 'meta.mainProgram'

### DIFF
--- a/pkgs/development/tools/continuous-integration/drone-cli/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-cli/default.nix
@@ -21,6 +21,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
+    mainProgram = "drone";
     maintainers = with maintainers; [ ];
     license = licenses.asl20;
     description = "Command line client for the Drone continuous integration server";


### PR DESCRIPTION
###### Motivation for this change

Allows using `nix run nixpkgs#drone-cli`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
