### PR TITLE
Build Perl with GDBM

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -1,6 +1,7 @@
 { config, lib, stdenv, fetchurl, fetchpatch, fetchFromGitHub, pkgs, buildPackages
 , callPackage
 , enableThreading ? true, coreutils, makeWrapper
+, enableGdbm ? true, gdbm
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -31,6 +32,8 @@ let
     outputs = [ "out" "man" "devdoc" ] ++
       optional crossCompiling "mini";
     setOutputFlags = false;
+
+    buildInputs = lib.optionals enableGdbm [ gdbm ];
 
     disallowedReferences = [ stdenv.cc ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -539,7 +539,10 @@ with pkgs;
             fetchurl = stdenv.fetchurlBoot;
           };
         });
-        perl = buildPackages.perl.override { fetchurl = stdenv.fetchurlBoot; };
+        perl = buildPackages.perl.override {
+          enableGdbm = false;
+          fetchurl = stdenv.fetchurlBoot;
+        };
         openssl = buildPackages.openssl.override {
           fetchurl = stdenv.fetchurlBoot;
           buildPackages = {


### PR DESCRIPTION
###### Motivation for this change

This allows using the Perl-builtin module `GDBM_File`. This was previously needed in https://github.com/NixOS/nixpkgs/issues/4311, but I'm also having another use case that needs this.

###### Things done

- [x] Built Perl with this patch on _master_ successfully
- [x] Verified that the `GDBM_File.pm` file exists in the result