### PR TITLE
uwufetch: init at 1.7

### DIFF
--- a/pkgs/tools/misc/uwufetch/default.nix
+++ b/pkgs/tools/misc/uwufetch/default.nix
@@ -34,7 +34,8 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    wrapProgram $out/bin/uwufetch --prefix PATH ":" ${viu}/bin
+    wrapProgram $out/bin/uwufetch \
+    	--prefix PATH ":" ${lib.makeBinPath [ viu ]}
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/uwufetch/default.nix
+++ b/pkgs/tools/misc/uwufetch/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, makeWrapper, viu }:
+
+stdenv.mkDerivation rec {
+  pname = "uwufetch";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "TheDarkBug";
+    repo = pname;
+    rev = version;
+    hash = "sha256-6yfRWFKdg7wM18hD2Bn095HzpnURhZJtx+SYx8SVBLA=";
+  };
+
+  patches = [
+    # cannot find images in /usr
+    ./fix-paths.patch
+    # https://github.com/TheDarkBug/uwufetch/pull/150
+    (fetchpatch {
+      url = "https://github.com/lourkeur/uwufetch/commit/de561649145b57d8750843555e4ffbc1cbcb01f0.patch";
+      sha256 = "sha256-KR81zxGlmthcadYBdsiVwxa5+lZUtqP7w0O4uFuputE=";
+    })
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installFlags = [
+    "PREFIX=${placeholder "out"}/bin"
+    "LIBDIR=${placeholder "out"}/lib"
+    "MANDIR=${placeholder "out"}/share/man/man1"
+  ];
+
+  postPatch = ''
+    substituteAllInPlace uwufetch.c
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/uwufetch --prefix PATH ":" ${viu}/bin
+  '';
+
+  meta = with lib; {
+    description = "A meme system info tool for Linux";
+    homepage = "https://github.com/TheDarkBug/uwufetch";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lourkeur ];
+  };
+}

--- a/pkgs/tools/misc/uwufetch/fix-paths.patch
+++ b/pkgs/tools/misc/uwufetch/fix-paths.patch
@@ -1,0 +1,22 @@
+diff --git a/uwufetch.c b/uwufetch.c
+index 75863a2..ab31dda 100644
+--- a/uwufetch.c
++++ b/uwufetch.c
+@@ -921,7 +921,7 @@ void print_ascii()
+ 		}
+ 		else
+ 		{
+-			sprintf(ascii_file, "/usr/lib/uwufetch/ascii/%s.txt", version_name);
++			sprintf(ascii_file, "@out@/lib/uwufetch/ascii/%s.txt", version_name);
+ 		}
+ 		file = fopen(ascii_file, "r");
+ 		if (!file)
+@@ -1220,7 +1220,7 @@ void print_image()
+ 		if (strcmp(version_name, "android") == 0)
+ 			sprintf(command, "viu -t -w 18 -h 8 /data/data/com.termux/files/usr/lib/uwufetch/%s.png 2> /dev/null", version_name);
+ 		else
+-			sprintf(command, "viu -t -w 18 -h 8 /usr/lib/uwufetch/%s.png 2> /dev/null", version_name);
++			sprintf(command, "viu -t -w 18 -h 8 @out@/lib/uwufetch/%s.png 2> /dev/null", version_name);
+ 	}
+ 	printf("\n");
+ 	if (system(command) != 0)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9987,6 +9987,8 @@ with pkgs;
 
   uwsgi = callPackage ../servers/uwsgi { };
 
+  uwufetch = callPackage ../tools/misc/uwufetch { };
+
   v2ray = callPackage ../tools/networking/v2ray { };
 
   vacuum = callPackage ../applications/networking/instant-messengers/vacuum {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
