### PR TITLE
cmusfm: use versiont tags, add compile options

### DIFF
--- a/pkgs/applications/audio/cmusfm/default.nix
+++ b/pkgs/applications/audio/cmusfm/default.nix
@@ -4,16 +4,19 @@
 stdenv.mkDerivation rec {
   pname = "cmusfm";
   version = "0.4.1";
+
   src = fetchFromGitHub {
     owner = "Arkq";
     repo = pname;
     rev = "v${version}";
     sha256 = "1px2is80jdxchg8cpn5cizg6jvcbzyxl0qzs3bn0k3d10qjvdww5";
   };
+
   configureFlags = lib.optional libnotifySupport "--enable-libnotify"
     ++ lib.optional debug "--enable-debug";
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ curl gdk-pixbuf ] ++ lib.optional libnotifySupport libnotify;
+  buildInputs = [ curl gdk-pixbuf ]
+    ++ lib.optional libnotifySupport libnotify;
 
   meta = with lib; {
     description = "Last.fm and Libre.fm standalone scrobbler for the cmus music player";

--- a/pkgs/applications/audio/cmusfm/default.nix
+++ b/pkgs/applications/audio/cmusfm/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional libnotifySupport "--enable-libnotify"
     ++ lib.optional debug "--enable-debug";
+
   nativeBuildInputs = [ autoreconfHook pkg-config ];
+
   buildInputs = [ curl gdk-pixbuf ]
     ++ lib.optional libnotifySupport libnotify;
 

--- a/pkgs/applications/audio/cmusfm/default.nix
+++ b/pkgs/applications/audio/cmusfm/default.nix
@@ -1,18 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, curl, libnotify, gdk-pixbuf }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, curl, libnotify
+, gdk-pixbuf, libnotifySupport ? stdenv.isLinux, debug ? false }:
 
-stdenv.mkDerivation {
-  version = "2021-05-19";
-  pname = "cmusfm-unstable";
+stdenv.mkDerivation rec {
+  pname = "cmusfm";
+  version = "0.4.1";
   src = fetchFromGitHub {
     owner = "Arkq";
-    repo = "cmusfm";
-    rev = "a1f9f37c5819ca8a5b48e6185c2ec7ad478b9f1a";
-    sha256 = "19akgvh9gl99xvpmzgqv88w2mnnln7k6290dr5rn3h6a1ihvllaw";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1px2is80jdxchg8cpn5cizg6jvcbzyxl0qzs3bn0k3d10qjvdww5";
   };
-  # building
-  configureFlags = [ "--enable-libnotify" ];
+  configureFlags = lib.optional libnotifySupport "--enable-libnotify"
+    ++ lib.optional debug "--enable-debug";
   nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ curl libnotify gdk-pixbuf ];
+  buildInputs = [ curl gdk-pixbuf ] ++ lib.optional libnotifySupport libnotify;
 
   meta = with lib; {
     description = "Last.fm and Libre.fm standalone scrobbler for the cmus music player";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Use version numbers if possible. I also wanted to be able to easily turn on debugging.

###### Things done
Use tags instead of commit hashes, make libnotify and debug compile options overridable

```
for hash in x27w90b06bgi3mpnb0608bk4kbif6kjz 5hnll6ym04gqgaqa4syg9grkw5cyxbfh c44zk08q26xv6z52x7xbi2f0gljmq40b ylwlpm0ipggq826q8i9jnac2drpq69ni; do /nix/store/$hash-cmusfm-0.4.1/bin/cmusfm; done
usage: /nix/store/x27w90b06bgi3mpnb0608bk4kbif6kjz-cmusfm-0.4.1/bin/cmusfm [init]

NOTE: Before usage with the cmus you should invoke this program with the
      `init` argument. Afterwards you can set the status_display_program
      (for more information see `man cmus`). Enjoy!
usage: /nix/store/5hnll6ym04gqgaqa4syg9grkw5cyxbfh-cmusfm-0.4.1/bin/cmusfm [init]

NOTE: Before usage with the cmus you should invoke this program with the
      `init` argument. Afterwards you can set the status_display_program
      (for more information see `man cmus`). Enjoy!
usage: /nix/store/c44zk08q26xv6z52x7xbi2f0gljmq40b-cmusfm-0.4.1/bin/cmusfm [init]

NOTE: Before usage with the cmus you should invoke this program with the
      `init` argument. Afterwards you can set the status_display_program
      (for more information see `man cmus`). Enjoy!
usage: /nix/store/ylwlpm0ipggq826q8i9jnac2drpq69ni-cmusfm-0.4.1/bin/cmusfm [init]

NOTE: Before usage with the cmus you should invoke this program with the
      `init` argument. Afterwards you can set the status_display_program
      (for more information see `man cmus`). Enjoy!
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
