### PR TITLE
openseachest: init at 21.06.21

### DIFF
--- a/pkgs/tools/system/openseachest/default.nix
+++ b/pkgs/tools/system/openseachest/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openseachest";
+  version = "21.06.21";
+
+  src = fetchFromGitHub {
+    owner = "Seagate";
+    repo = "openSeaChest";
+    rev = "v${version}";
+    sha256 = "09xay3frk0yh48ww650dsjp0rx0w1m3ab3rpz5k1jizppv4kk9fi";
+    fetchSubmodules = true;
+  };
+
+  makeFlags = [ "-C Make/gcc" ];
+  buildFlags = [ "release" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+    cp -r Make/gcc/openseachest_exes/. $out/bin
+    cp -r docs/man $out/share
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A collection of command line diagnostic tools for storage devices";
+    homepage = "https://github.com/Seagate/openSeaChest";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ justinas ];
+    platforms = with platforms; freebsd ++ linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8061,6 +8061,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Carbon PCSC;
   };
 
+  openseachest = callPackage ../tools/system/openseachest { };
+
   opensm = callPackage ../tools/networking/opensm { };
 
   opensshPackages = dontRecurseIntoAttrs (callPackage ../tools/networking/openssh {});


### PR DESCRIPTION
###### Motivation for this change

Adding [openSeaChest](https://github.com/Seagate/openSeaChest).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
