### PR TITLE
buildRustPackage,fetchCargoTarball: accept empty hashes

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -17,12 +17,6 @@
 
 { name ? "${args.pname}-${args.version}"
 
-  # SRI hash
-, cargoHash ? ""
-
-  # Legacy hash
-, cargoSha256 ? ""
-
   # Name for the vendored dependencies tarball
 , cargoDepsName ? name
 
@@ -54,7 +48,7 @@
 , buildAndTestSubdir ? null
 , ... } @ args:
 
-assert cargoVendorDir == null && cargoLock == null -> cargoSha256 == "" && cargoHash == ""
+assert cargoVendorDir == null && cargoLock == null -> !(args ? cargoSha256) && !(args ? cargoHash)
   -> throw "cargoSha256, cargoHash, cargoVendorDir, or cargoLock must be set";
 assert buildType == "release" || buildType == "debug";
 
@@ -66,15 +60,17 @@ let
     else fetchCargoTarball ({
       inherit src srcs sourceRoot unpackPhase cargoUpdateHook;
       name = cargoDepsName;
-      hash = cargoHash;
       patches = cargoPatches;
-      sha256 = cargoSha256;
+    } // lib.optionalAttrs (args ? cargoHash) {
+      hash = args.cargoHash;
+    } // lib.optionalAttrs (args ? cargoSha256) {
+      sha256 = args.cargoSha256;
     } // depsExtraArgs)
     else null;
 
   # If we have a cargoSha256 fixed-output derivation, validate it at build time
   # against the src fixed-output derivation to check consistency.
-  validateCargoDeps = !(cargoHash == "" && cargoSha256 == "");
+  validateCargoDeps = args ? cargoHash || args ? cargoSha256;
 
   target = rust.toRustTargetSpec stdenv.hostPlatform;
   targetIsJSON = lib.hasSuffix ".json" target;

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -1,17 +1,15 @@
-{ stdenv
-, lib
-, buildPackages
+{ lib
+, importCargoLock
+, fetchCargoTarball
+, rust
+, stdenv
+, callPackage
 , cacert
+, git
 , cargoBuildHook
 , cargoCheckHook
 , cargoInstallHook
 , cargoSetupHook
-, fetchCargoTarball
-, importCargoLock
-, rustPlatform
-, callPackage
-, git
-, rust
 , rustc
 , libiconv
 , windows
@@ -88,7 +86,7 @@ let
       (lib.removeSuffix ".json" (builtins.baseNameOf "${target}"))
     else target;
 
-  sysroot = (callPackage ./sysroot {}) {
+  sysroot = callPackage ./sysroot { } {
     inherit target shortTarget;
     RUSTFLAGS = args.RUSTFLAGS or "";
     originalCargoToml = src + /Cargo.toml; # profile info is later extracted

--- a/pkgs/build-support/rust/fetchCargoTarball.nix
+++ b/pkgs/build-support/rust/fetchCargoTarball.nix
@@ -22,15 +22,13 @@ in
 , srcs ? []
 , patches ? []
 , sourceRoot ? ""
-, hash ? ""
-, sha256 ? ""
 , cargoUpdateHook ? ""
 , ...
 } @ args:
 
 let hash_ =
-  if hash != "" then { outputHashAlgo = null; outputHash = hash; }
-  else if sha256 != "" then { outputHashAlgo = "sha256"; outputHash = sha256; }
+  if args ? hash then { outputHashAlgo = null; outputHash = args.hash; }
+  else if args ? sha256 then { outputHashAlgo = "sha256"; outputHash = args.sha256; }
   else throw "fetchCargoTarball requires a hash for ${name}";
 in stdenv.mkDerivation ({
   name = "${name}-vendor.tar.gz";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

this allows setting `cargoSha256 = ""` inside `buildRustPackage` to generate a hash mismatch
previously this has to be done with things like `cargoSha256 = lib.fakeSha256`, and doing `cargoSha256 = null` would generate a useless error

this matches the behavior of other `fetch*` functions and makes manually fecthing `cargoSha256` 

`nixpkgs-review` shows 1 rebuild (elfcat) since it uses `cargoSha256 = null`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
