### PR TITLE
zbackup: fix

### DIFF
--- a/pkgs/tools/backup/zbackup/default.nix
+++ b/pkgs/tools/backup/zbackup/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, cmake, zlib, openssl, protobuf, protobufc, lzo, libunwind }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch
+, cmake, protobufc
+, libunwind, lzo, openssl, protobuf, zlib
+}:
+
 stdenv.mkDerivation rec {
   pname = "zbackup";
   version = "1.4.4";
@@ -9,6 +13,12 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-9Fk4EhEeQ2J4Kirc7oad4CzmW70Mmza6uozd87qfgZI=";
   };
+
+  patches = [
+    # compare with https://github.com/zbackup/zbackup/pull/158;
+    # but that doesn't apply cleanly to this version
+    ./protobuf-api-change.patch
+  ];
 
   buildInputs = [ zlib openssl protobuf lzo libunwind ];
   nativeBuildInputs = [ cmake protobufc ];

--- a/pkgs/tools/backup/zbackup/protobuf-api-change.patch
+++ b/pkgs/tools/backup/zbackup/protobuf-api-change.patch
@@ -1,0 +1,11 @@
+--- a/backup_restorer.cc
++++ b/backup_restorer.cc
+@@ -48,7 +48,7 @@
+   // TODO: this disables size checks for each separate message. Figure a better
+   // way to do this while keeping them enabled. It seems we need to create an
+   // instance of CodedInputStream for each message, but it might be expensive
+-  cis.SetTotalBytesLimit( backupData.size(), -1 );
++  cis.SetTotalBytesLimit( backupData.size() );
+ 
+   // Used when emitting chunks
+   string chunk;


### PR DESCRIPTION
Pin protobuf library to 3.17 as 3.18 contains an incompatible API change.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
