### PR TITLE
doc: rust: target escape hatch has been removed

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -237,22 +237,6 @@ where they are known to differ. But there are ways to customize the argument:
    --target /nix/store/asdfasdfsadf-thumb-crazy.json # contains {"foo":"","bar":""}
    ```
 
-Finally, as an ad-hoc escape hatch, a computed target (string or JSON file
-path) can be passed directly to `buildRustPackage`:
-
-```nix
-pkgs.rustPlatform.buildRustPackage {
-  /* ... */
-  target = "x86_64-fortanix-unknown-sgx";
-}
-```
-
-This is useful to avoid rebuilding Rust tools, since they are actually target
-agnostic and don't need to be rebuilt. But in the future, we should always
-build the Rust tools and standard library crates separately so there is no
-reason not to take the `stdenv.hostPlatform.rustc`-modifying approach, and the
-ad-hoc escape hatch to `buildRustPackage` can be removed.
-
 Note that currently custom targets aren't compiled with `std`, so `cargo test`
 will fail. This can be ignored by adding `doCheck = false;` to your derivation.
 


### PR DESCRIPTION
###### Motivation for this change

As far as I can tell, a8efb2053fd9c1e2fea97699754b5071e94c1649 removed the `target =` escape hatch.
See #112804

cc @danieldk @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
