### PR TITLE
rasdaemon: init at 0.6.7.

### DIFF
--- a/pkgs/os-specific/linux/rasdaemon/default.nix
+++ b/pkgs/os-specific/linux/rasdaemon/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchgit, stdenv, perl, autoreconfHook, ... }:
+stdenv.mkDerivation rec {
+  pname = "rasdaemon";
+  version = "0.6.7";
+
+  src = fetchgit {
+    url = "git://git.infradead.org/users/mchehab/rasdaemon.git";
+    rev = "v${version}";
+    sha256 = "sha256-vyUDwqDe+HD4mka6smdQuVSM5U9uMv/TrfHkyqVJMIo=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ perl ];
+  postPatch = ''
+    substituteInPlace util/ras-mc-ctl.in --replace @sysconfdir@ $out/etc
+  '';
+  configureFlags = [ "--sysconfdir=$(out)/etc" ];
+
+  meta = with lib; {
+    description = "a RAS (Reliability, Availability and Serviceability) logging tool";
+    longDescription = ''
+      Rasdaemon is a RAS (Reliability, Availability and
+      Serviceability) logging tool. It records memory errors, using
+      the EDAC tracing events. EDAC is a Linux kernel subsystem with
+      handles detection of ECC errors from memory controllers for most
+      chipsets on i386 and x86_64 architectures. EDAC drivers for
+      other architectures like arm also exists.
+    '';
+    homepage = "https://git.infradead.org/users/mchehab/rasdaemon.git";
+    maintainers = with maintainers; [ danderson ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8780,6 +8780,8 @@ with pkgs;
 
   rarian = callPackage ../development/libraries/rarian { };
 
+  rasdaemon = callPackage ../os-specific/linux/rasdaemon { };
+
   ratools = callPackage ../tools/networking/ratools { };
 
   rawdog = callPackage ../applications/networking/feedreaders/rawdog { };


### PR DESCRIPTION
Signed-off-by: David Anderson <dave@natulte.net>

###### Motivation for this change

nixpkgs ships mcelog for consulting ECC memory error logs, but mcelog relies on a kernel driver that's been obsoleted and disabled. Its replacement is rasdaemon, which uses a new driver infrastructure for machine error reporting.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
