### PR TITLE
hactool: add musl support && enable parallel building

### DIFF
--- a/pkgs/tools/compression/hactool/default.nix
+++ b/pkgs/tools/compression/hactool/default.nix
@@ -11,11 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "0305ngsnwm8npzgyhyifasi4l802xnfz19r0kbzzniirmcn4082d";
   };
 
+  patches = [ ./musl-compat.patch ];
+
   preBuild = ''
     mv config.mk.template config.mk
   '';
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+  enableParallelBuilding = true;
 
   installPhase = ''
     install -D hactool $out/bin/hactool

--- a/pkgs/tools/compression/hactool/musl-compat.patch
+++ b/pkgs/tools/compression/hactool/musl-compat.patch
@@ -1,0 +1,13 @@
+diff --git a/main.c b/main.c
+index 07f53cb..f2265df 100644
+--- a/main.c
++++ b/main.c
+@@ -369,7 +369,7 @@ int main(int argc, char **argv) {
+                     return EXIT_FAILURE;
+                 }
+                 nca_ctx.tool_ctx->base_file_type = BASEFILE_FAKE;
+-                nca_ctx.tool_ctx->base_file++; /* Guarantees base_file != NULL. I'm so sorry. */
++                if (!nca_ctx.tool_ctx->base_file) nca_ctx.tool_ctx->base_file = (FILE*) 1;
+                 break;
+             case 32:
+                 tool_ctx.action |= ACTION_ONLYUPDATEDROMFS;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
