### PR TITLE
fastp: 0.22.0 -> 0.23.1

### DIFF
--- a/pkgs/applications/science/biology/fastp/default.nix
+++ b/pkgs/applications/science/biology/fastp/default.nix
@@ -1,20 +1,23 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , zlib
+, libdeflate
+, isa-l
 }:
 
 stdenv.mkDerivation rec {
   pname = "fastp";
-  version = "0.22.0";
+  version = "0.23.1";
 
   src = fetchFromGitHub {
     owner = "OpenGene";
     repo = "fastp";
     rev = "v${version}";
-    sha256 = "sha256-XR76hNz7iGXQYSBbBandHZ+oU3wyTf1AKlu9Xeq/GyE=";
+    sha256 = "sha256-vRJlNtg2JabBAUaX91Y04z8MdyxEnreBAlIHn7VB+u4=";
   };
 
-  buildInputs = [ zlib ];
+  buildInputs = [ zlib libdeflate isa-l ];
 
   installPhase = ''
     install -D fastp $out/bin/fastp

--- a/pkgs/development/libraries/isa-l/default.nix
+++ b/pkgs/development/libraries/isa-l/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, nasm }:
+
+stdenv.mkDerivation rec {
+  pname = "isa-l";
+  version = "2.30.0";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "isa-l";
+    rev = "v${version}";
+    sha256 = "sha256-AAuSdDQfDW4QFRu0jHwCZ+ZCSjoVqlQiSW1OOFye1Rs=";
+  };
+
+  nativeBuildInputs = [ nasm autoreconfHook ];
+
+  preConfigure = ''
+    export AS=nasm
+  '';
+
+  meta = with lib; {
+    description = "A collection of optimised low-level functions targeting storage applications";
+    license = licenses.bsd3;
+    homepage = "https://github.com/intel/isa-l";
+    maintainers = with maintainers; [ jbedo ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15549,6 +15549,8 @@ with pkgs;
 
   hci = callPackage ../development/tools/continuous-integration/hci { };
 
+  isa-l = callPackage ../development/libraries/isa-l { };
+
   niv = lib.getBin (haskell.lib.justStaticExecutables haskellPackages.niv);
 
   ormolu = haskellPackages.ormolu.bin;


### PR DESCRIPTION
- isa-l: init 2.30.0
- fastp: 0.22.0 -> 0.23.1

###### Motivation for this change

Fastp version update. Now requires isa-l library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
