### PR TITLE
nixos/lib/test-driver: clean up threads correctly

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -405,14 +405,14 @@ class Machine:
     keep_vm_state: bool
     allow_reboot: bool
 
-    process: Optional[subprocess.Popen] = None
-    pid: Optional[int] = None
-    monitor: Optional[socket.socket] = None
-    shell: Optional[socket.socket] = None
+    process: Optional[subprocess.Popen]
+    pid: Optional[int]
+    monitor: Optional[socket.socket]
+    shell: Optional[socket.socket]
     serial_thread: Optional[threading.Thread]
 
-    booted: bool = False
-    connected: bool = False
+    booted: bool
+    connected: bool
     # Store last serial console lines for use
     # of wait_for_console_text
     last_lines: Queue = Queue()
@@ -445,7 +445,14 @@ class Machine:
             self.cleanup_statedir()
         self.state_dir.mkdir(mode=0o700, exist_ok=True)
 
+        self.process = None
+        self.pid = None
+        self.monitor = None
+        self.shell = None
         self.serial_thread = None
+
+        self.booted = False
+        self.connected = False
 
     @staticmethod
     def create_startcommand(args: Dict[str, str]) -> StartCommand:


### PR DESCRIPTION
The current implementation just forks off a thread to read QEMU's stdout and lets it exist forever. This, however, makes the interpreter shutdown racy, as the thread could still be running and writing out buffered stdout when the main thread exits (and since it's using the low level API, the worker thread does not get cleaned up by the atexit hooks installed by `threading`, either). So, instead of doing that, let's create a real `threading.Thread` object, and also explicitly `join` it along with the other stuff when cleaning up.

Tested by running `nixos/tests/simple.nix` a whole bunch of times without crashing.

CC @blaggacao 

###### Motivation for this change

Random crashes on Hydra: https://hydra.nixos.org/build/156393173/nixlog/1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
