### PR TITLE
clutter: enable wayland compositor

### DIFF
--- a/pkgs/development/libraries/clutter/default.nix
+++ b/pkgs/development/libraries/clutter/default.nix
@@ -1,30 +1,69 @@
-{ lib, stdenv, fetchurl, pkg-config, libGLU, libGL, libX11, libXext, libXfixes
-, libXdamage, libXcomposite, libXi, libxcb, cogl, pango, atk, json-glib
-, gobject-introspection, gtk3, gnome, libinput, libgudev, libxkbcommon
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, libGLU
+, libGL
+, libX11
+, libXext
+, libXfixes
+, libXdamage
+, libXcomposite
+, libXi
+, libxcb
+, cogl
+, pango
+, atk
+, json-glib
+, gobject-introspection
+, gtk3
+, gnome
+, libinput
+, libgudev
+, libxkbcommon
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "clutter";
   version = "1.26.4";
-in
-stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1rn4cd1an6a9dfda884aqpcwcgq8dgydpqvb19nmagw4b70zlj4b";
   };
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = [ gtk3 ];
-  nativeBuildInputs = [ pkg-config ];
-  propagatedBuildInputs =
-    [ libX11 libGL libGLU libXext libXfixes libXdamage libXcomposite libXi cogl pango
-      atk json-glib gobject-introspection libxcb libinput libgudev libxkbcommon
-    ];
+  buildInputs = [
+    gtk3
+  ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  propagatedBuildInputs = [
+    libX11
+    libGL
+    libGLU
+    libXext
+    libXfixes
+    libXdamage
+    libXcomposite
+    libXi
+    cogl
+    pango
+    atk
+    json-glib
+    gobject-introspection
+    libxcb
+    libinput
+    libgudev
+    libxkbcommon
+  ];
 
-  configureFlags = [ "--enable-introspection" ]; # needed by muffin AFAIK
+  configureFlags = [
+    "--enable-introspection" # needed by muffin AFAIK
+    "--enable-wayland-compositor"
+  ];
 
   #doCheck = true; # no tests possible without a display
 
@@ -38,25 +77,24 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Library for creating fast, dynamic graphical user interfaces";
 
-    longDescription =
-      '' Clutter is free software library for creating fast, compelling,
-         portable, and dynamic graphical user interfaces.  It is a core part
-         of MeeGo, and is supported by the open source community.  Its
-         development is sponsored by Intel.
+    longDescription = ''
+      Clutter is free software library for creating fast, compelling,
+       portable, and dynamic graphical user interfaces.  It is a core part
+       of MeeGo, and is supported by the open source community.  Its
+       development is sponsored by Intel.
 
-         Clutter uses OpenGL for rendering (and optionally OpenGL|ES for use
-         on mobile and embedded platforms), but wraps an easy to use,
-         efficient, flexible API around GL's complexity.
+       Clutter uses OpenGL for rendering (and optionally OpenGL|ES for use
+       on mobile and embedded platforms), but wraps an easy to use,
+       efficient, flexible API around GL's complexity.
 
-         Clutter enforces no particular user interface style, but provides a
-         rich, generic foundation for higher-level toolkits tailored to
-         specific needs.
-      '';
+       Clutter enforces no particular user interface style, but provides a
+       rich, generic foundation for higher-level toolkits tailored to
+       specific needs.
+    '';
 
     license = lib.licenses.lgpl2Plus;
     homepage = "http://www.clutter-project.org/";
-
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ doronbehar ];
     platforms = lib.platforms.mesaPlatforms;
   };
 }

--- a/pkgs/development/libraries/clutter/default.nix
+++ b/pkgs/development/libraries/clutter/default.nix
@@ -76,22 +76,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Library for creating fast, dynamic graphical user interfaces";
-
-    longDescription = ''
-      Clutter is free software library for creating fast, compelling,
-       portable, and dynamic graphical user interfaces.  It is a core part
-       of MeeGo, and is supported by the open source community.  Its
-       development is sponsored by Intel.
-
-       Clutter uses OpenGL for rendering (and optionally OpenGL|ES for use
-       on mobile and embedded platforms), but wraps an easy to use,
-       efficient, flexible API around GL's complexity.
-
-       Clutter enforces no particular user interface style, but provides a
-       rich, generic foundation for higher-level toolkits tailored to
-       specific needs.
-    '';
-
     license = lib.licenses.lgpl2Plus;
     homepage = "http://www.clutter-project.org/";
     maintainers = with lib.maintainers; [ doronbehar ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

So I'd be able to set `CLUTTER_BACKEND=wayland`, per: https://wiki.archlinux.org/title/Wayland#Clutter .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
