### PR TITLE
{btcpayserver,nbxplorer}: use buildDotnetModule

### DIFF
--- a/pkgs/applications/blockchains/btcpayserver/default.nix
+++ b/pkgs/applications/blockchains/btcpayserver/default.nix
@@ -1,19 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, linkFarmFromDrvs, makeWrapper,
-  dotnetPackages, dotnetCorePackages, altcoinSupport ? false
-}:
+{ lib, buildDotnetModule, fetchFromGitHub, dotnetCorePackages
+, altcoinSupport ? false }:
 
-let
-  deps = import ./deps.nix {
-    fetchNuGet = { name, version, sha256 }: fetchurl {
-      name = "nuget-${name}-${version}.nupkg";
-      url = "https://www.nuget.org/api/v2/package/${name}/${version}";
-      inherit sha256;
-    };
-  };
-  dotnetSdk = dotnetCorePackages.sdk_3_1;
-in
-
-stdenv.mkDerivation rec {
+buildDotnetModule rec {
   pname = "btcpayserver";
   version = "1.2.4";
 
@@ -24,35 +12,29 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-vjNJ08twsJ036TTFF6srOGshDpP7ZwWCGN0XjrtFT/g=";
   };
 
-  nativeBuildInputs = [ dotnetSdk dotnetPackages.Nuget makeWrapper ];
+  projectFile = "BTCPayServer/BTCPayServer.csproj";
+  nugetDeps = ./deps.nix;
 
-  buildPhase = ''
-    export HOME=$TMP/home
-    export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+  dotnet-sdk = dotnetCorePackages.sdk_3_1;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_3_1;
 
-    nuget sources Add -Name tmpsrc -Source $TMP/nuget
-    nuget init ${linkFarmFromDrvs "deps" deps} $TMP/nuget
-
-    dotnet restore --source $TMP/nuget ${lib.optionalString altcoinSupport ''/p:Configuration="Altcoins-Release"''} BTCPayServer/BTCPayServer.csproj
-    dotnet publish --no-restore --output $out/share/$pname ${lib.optionalString altcoinSupport "-c Altcoins-Release"} BTCPayServer/BTCPayServer.csproj
-  '';
+  dotnetFlags = lib.optionals altcoinSupport [ "/p:Configuration=Altcoins-Release" ];
 
   # btcpayserver requires the publish directory as its working dir
   # https://github.com/btcpayserver/btcpayserver/issues/1894
-  installPhase = ''
-    makeWrapper $out/share/$pname/BTCPayServer $out/bin/$pname \
-      --set DOTNET_ROOT "${dotnetSdk}" \
-      --run "cd $out/share/$pname"
+  preInstall = ''
+    makeWrapperArgs+=(--run "cd $out/lib/btcpayserver")
   '';
 
-  dontStrip = true;
+  postInstall = ''
+    mv $out/bin/{BTCPayServer,btcpayserver}
+  '';
 
   meta = with lib; {
     description = "Self-hosted, open-source cryptocurrency payment processor";
     homepage = "https://btcpayserver.org";
     maintainers = with maintainers; [ kcalvinalvin earvstedt ];
-    license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    license = licenses.mit;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/blockchains/nbxplorer/default.nix
+++ b/pkgs/applications/blockchains/nbxplorer/default.nix
@@ -1,19 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, linkFarmFromDrvs, makeWrapper,
-  dotnetPackages, dotnetCorePackages
-}:
+{ lib, buildDotnetModule, fetchFromGitHub, dotnetCorePackages }:
 
-let
-  deps = import ./deps.nix {
-    fetchNuGet = { name, version, sha256 }: fetchurl {
-      name = "nuget-${name}-${version}.nupkg";
-      url = "https://www.nuget.org/api/v2/package/${name}/${version}";
-      inherit sha256;
-    };
-  };
-  dotnetSdk = dotnetCorePackages.sdk_3_1;
-in
-
-stdenv.mkDerivation rec {
+buildDotnetModule rec {
   pname = "nbxplorer";
   version = "2.2.11";
 
@@ -24,31 +11,20 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ZDqzkANGMdvv3e5gWCYcacUYKLJRquXRHLr8RAzT9hY=";
   };
 
-  nativeBuildInputs = [ dotnetSdk dotnetPackages.Nuget makeWrapper ];
+  projectFile = "NBXplorer/NBXplorer.csproj";
+  nugetDeps = ./deps.nix;
 
-  buildPhase = ''
-    export HOME=$TMP/home
-    export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+  dotnet-sdk = dotnetCorePackages.sdk_3_1;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_3_1;
 
-    nuget sources Add -Name tmpsrc -Source $TMP/nuget
-    nuget init ${linkFarmFromDrvs "deps" deps} $TMP/nuget
-
-    dotnet restore --source $TMP/nuget NBXplorer/NBXplorer.csproj
-    dotnet publish --no-restore --output $out/share/$pname -c Release NBXplorer/NBXplorer.csproj
+  postInstall = ''
+    mv $out/bin/{NBXplorer,nbxplorer}
   '';
-
-  installPhase = ''
-    makeWrapper $out/share/$pname/NBXplorer $out/bin/$pname \
-      --set DOTNET_ROOT "${dotnetSdk}"
-  '';
-
-  dontStrip = true;
 
   meta = with lib; {
     description = "Minimalist UTXO tracker for HD Cryptocurrency Wallets";
     maintainers = with maintainers; [ kcalvinalvin earvstedt ];
-    license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    license = licenses.mit;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION

###### Motivation for this change
Done both for consistency, and easier package maintaining.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
