### PR TITLE
pavucontrol: 4.0 -> 5.0, format

### DIFF
--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -1,26 +1,35 @@
-{ fetchurl, fetchpatch, lib, stdenv, pkg-config, intltool, libpulseaudio,
-gtkmm3 , libcanberra-gtk3, gnome, wrapGAppsHook }:
+{ fetchurl
+, fetchpatch
+, lib
+, stdenv
+, pkg-config
+, intltool
+, libpulseaudio
+, gtkmm3
+, libsigcxx
+, libcanberra-gtk3
+, json-glib
+, gnome
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "pavucontrol";
-  version = "4.0";
+  version = "5.0";
 
   src = fetchurl {
     url = "https://freedesktop.org/software/pulseaudio/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1qhlkl3g8d7h72xjskii3g1l7la2cavwp69909pzmbi2jyn5pi4g";
+    sha256 = "sha256-zityw7XxpwrQ3xndgXUPlFW9IIcNHTo20gU2ry6PTno=";
   };
 
-  patches = [
-    # Can be removed with the next version bump
-    # https://gitlab.freedesktop.org/pulseaudio/pavucontrol/-/merge_requests/20
-    (fetchpatch {
-      name = "streamwidget-fix-drop-down-wayland.patch";
-      url = "https://gitlab.freedesktop.org/pulseaudio/pavucontrol/-/commit/ae278b8643cf1089f66df18713c8154208d9a505.patch";
-      sha256 = "066vhxjz6gmi2sp2n4pa1cdsxjnq6yml5js094g5n7ld34p84dpj";
-  })];
-
-  buildInputs = [ libpulseaudio gtkmm3 libcanberra-gtk3
-                  gnome.adwaita-icon-theme ];
+  buildInputs = [
+    libpulseaudio
+    gtkmm3
+    libsigcxx
+    libcanberra-gtk3
+    json-glib
+    gnome.adwaita-icon-theme
+  ];
 
   nativeBuildInputs = [ pkg-config intltool wrapGAppsHook ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
