### PR TITLE
python3Packages.afdko: disable broken test after ufonormalizer-0.6.1 …

### DIFF
--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -58,7 +58,13 @@ buildPythonPackage rec {
   # https://github.com/adobe-type-tools/afdko/issues/1216
   doCheck = stdenv.isx86_64;
   checkInputs = [ pytestCheckHook ];
-  preCheck = "export PATH=$PATH:$out/bin";
+  preCheck = ''
+    export PATH=$PATH:$out/bin
+
+    # Update tests to match ufinormalizer-0.6.1 expectations:
+    #   https://github.com/adobe-type-tools/afdko/issues/1418
+    find tests -name layerinfo.plist -delete
+  '';
   disabledTests = [
     # Disable slow tests, reduces test time ~25 %
     "test_report"


### PR DESCRIPTION
…update

Upstream confirmed test failure is benign and needs to update test output.
Let's unbreak staging-next build by disabling test.