### PR TITLE
pavucontrol: use gitlab source, clean up

### DIFF
--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -1,53 +1,55 @@
-{ fetchurl
-, fetchpatch
-, lib
+{ lib
 , stdenv
-, pkg-config
+, fetchFromGitLab
+, autoreconfHook
 , intltool
-, libpulseaudio
-, gtkmm3
-, libsigcxx
-, libcanberra-gtk3
-, json-glib
-, gnome
+, pkg-config
 , wrapGAppsHook
+, gnome
+, gtkmm3
+, json-glib
+, libcanberra-gtk3
+, libpulseaudio
+, libsigcxx
 }:
 
 stdenv.mkDerivation rec {
   pname = "pavucontrol";
   version = "5.0";
 
-  src = fetchurl {
-    url = "https://freedesktop.org/software/pulseaudio/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-zityw7XxpwrQ3xndgXUPlFW9IIcNHTo20gU2ry6PTno=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "pulseaudio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-0HfwqU58OsWOdbNKENQoFiW3nf9LEJog/wGiqMUvYCU=";
   };
 
-  buildInputs = [
-    libpulseaudio
-    gtkmm3
-    libsigcxx
-    libcanberra-gtk3
-    json-glib
-    gnome.adwaita-icon-theme
+  nativeBuildInputs = [
+    autoreconfHook
+    intltool
+    pkg-config
+    wrapGAppsHook
   ];
 
-  nativeBuildInputs = [ pkg-config intltool wrapGAppsHook ];
-
-  configureFlags = [ "--disable-lynx" ];
+  buildInputs = [
+    gnome.adwaita-icon-theme
+    gtkmm3
+    json-glib
+    libcanberra-gtk3
+    libpulseaudio
+    libsigcxx
+  ];
 
   meta = with lib; {
     description = "PulseAudio Volume Control";
-
     longDescription = ''
       PulseAudio Volume Control (pavucontrol) provides a GTK
       graphical user interface to connect to a PulseAudio server and
       easily control the volume of all clients, sinks, etc.
     '';
-
     homepage = "http://freedesktop.org/software/pulseaudio/pavucontrol/";
-
-    license = lib.licenses.gpl2Plus;
-
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ abbradar globin ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

follow up of #142220

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
