### PR TITLE
python3Packages.howdoi: 2.0.17 -> 2.0.19

### DIFF
--- a/pkgs/development/python-modules/howdoi/default.nix
+++ b/pkgs/development/python-modules/howdoi/default.nix
@@ -9,19 +9,18 @@
 , pygments
 , pyquery
 , requests
-, six
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "howdoi";
-  version = "2.0.17";
+  version = "2.0.19";
 
   src = fetchFromGitHub {
     owner = "gleitz";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1cc9hbnalbsd5la9wsm8s6drb79vlzin9qnv86ic81r5nq27n180";
+    sha256 = "0hl7cpxm4llsgw6390bpjgkzrprrpb0vxx2flgly7wiy9zl1rc5q";
   };
 
   propagatedBuildInputs = [
@@ -33,7 +32,6 @@ buildPythonPackage rec {
     pygments
     pyquery
     requests
-    six
   ];
 
   checkInputs = [
@@ -50,7 +48,9 @@ buildPythonPackage rec {
     "test_get_text_without_links"
   ];
 
-  pythonImportsCheck = [ "howdoi" ];
+  pythonImportsCheck = [
+    "howdoi"
+  ];
 
   meta = with lib; {
     description = "Instant coding answers via the command line";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.0.19

Change log: https://github.com/gleitz/howdoi/blob/master/CHANGES.txt

Fix build (https://hydra.nixos.org/build/155334895). I was not able to reproduce it locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
