### PR TITLE
jwm-settings-manager: 2018-10-19 -> 2019-01-27

### DIFF
--- a/pkgs/applications/window-managers/jwm/jwm-settings-manager.nix
+++ b/pkgs/applications/window-managers/jwm/jwm-settings-manager.nix
@@ -1,14 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, gettext, libXpm, libGL, fltk, hicolor-icon-theme, glib, gnome2, which }:
+{ lib, stdenv, fetchbzr, cmake, pkg-config, gettext, libXpm, libGL, fltk, hicolor-icon-theme, glib, gnome2, which }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "jwm-settings-manager";
-  version = "2018-10-19";
+  version = "2019-01-27";
 
-  src = fetchFromGitHub {
-    owner = "Israel-D";
-    repo = "jwm-settings-manager";
-    rev = "cb32a70563cf1f3927339093481542b85ec3c8c8";
-    sha256 = "0d5bqf74p8zg8azns44g46q973blhmp715k8kcd73x88g7sfir8s";
+  src = fetchbzr {
+    url = "lp:${pname}";
+    rev = "292";
+    sha256 = "1yqc1ac2pbkc88z7p1qags1jygdlr5y1rhc5mx6gapcf54bk0lmi";
   };
 
   nativeBuildInputs = [
@@ -32,6 +31,11 @@ stdenv.mkDerivation {
       --replace 'CMAKE_INSTALL_PREFIX "/usr"' "CMAKE_INSTALL_PREFIX $out"
     substituteInPlace data/CMakeLists.txt \
       --replace 'DESTINATION usr/share' "DESTINATION share"
+  '';
+
+  postConfigure = ''
+    substituteInPlace cmake_install.cmake \
+      --replace "/var/empty" "/usr"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update the source repository: upstream has removed the github repository, which as a copy from [the launchpad repository](https://launchpad.net/jwm-settings-manager)
- Update to revision 292, from 2019-01-27

Fixes https://github.com/NixOS/nixpkgs/issues/141493

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
