### PR TITLE
coqPackages.extructures: init at 0.3.0

### DIFF
--- a/pkgs/development/coq-modules/deriving/default.nix
+++ b/pkgs/development/coq-modules/deriving/default.nix
@@ -1,0 +1,29 @@
+{ lib, mkCoqDerivation, coq, version ? null
+, ssreflect
+}:
+with lib;
+
+mkCoqDerivation {
+  pname = "deriving";
+  owner = "arthuraa";
+
+  inherit version;
+  defaultVersion = with versions; switch coq.coq-version [
+    { case = range "8.11" "8.14"; out = "0.1.0"; }
+  ] null;
+
+  releaseRev = v: "v${v}";
+
+  release."0.1.0".sha256 = "sha256:11crnjm8hyis1qllkks3d7r07s1rfzwvyvpijya3s6iqfh8c7xwh";
+
+  propagatedBuildInputs = [ ssreflect ];
+
+  mlPlugin = true;
+
+  meta = {
+    description = "Generic instances of MathComp classes";
+    license = licenses.mit;
+    maintainers = [ maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/coq-modules/extructures/default.nix
+++ b/pkgs/development/coq-modules/extructures/default.nix
@@ -1,0 +1,33 @@
+{ lib, mkCoqDerivation, coq, version ? null
+, ssreflect
+, deriving
+}:
+with lib;
+
+(mkCoqDerivation {
+  pname = "extructures";
+  owner = "arthuraa";
+
+  inherit version;
+  defaultVersion = with versions; switch coq.coq-version [
+    { case = range "8.11" "8.14"; out = "0.3.0"; }
+    { case = range "8.10" "8.12"; out = "0.2.2"; }
+  ] null;
+
+  releaseRev = v: "v${v}";
+
+  release."0.3.0".sha256 = "sha256:14rm0726f1732ldds495qavg26gsn30w6dfdn36xb12g5kzavp38";
+  release."0.2.2".sha256 = "sha256:1clzza73gccy6p6l95n6gs0adkqd3h4wgl4qg5l0qm4q140grvm7";
+
+  propagatedBuildInputs = [ ssreflect ];
+
+  meta = {
+    description = "Finite data structures with extensional reasoning";
+    license = licenses.mit;
+    maintainers = [ maintainers.vbgl ];
+  };
+
+}).overrideAttrs (o: {
+  propagatedBuildInputs = o.propagatedBuildInputs
+  ++ optional (versionAtLeast o.version "0.3.0") deriving;
+})

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -40,6 +40,7 @@ let
       deriving = callPackage ../development/coq-modules/deriving {};
       dpdgraph = callPackage ../development/coq-modules/dpdgraph {};
       equations = callPackage ../development/coq-modules/equations { };
+      extructures = callPackage ../development/coq-modules/extructures { };
       fiat_HEAD = callPackage ../development/coq-modules/fiat/HEAD.nix {};
       flocq = callPackage ../development/coq-modules/flocq {};
       fourcolor = callPackage ../development/coq-modules/fourcolor {};

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -37,6 +37,7 @@ let
       coqtail-math = callPackage ../development/coq-modules/coqtail-math {};
       coquelicot = callPackage ../development/coq-modules/coquelicot {};
       corn = callPackage ../development/coq-modules/corn {};
+      deriving = callPackage ../development/coq-modules/deriving {};
       dpdgraph = callPackage ../development/coq-modules/dpdgraph {};
       equations = callPackage ../development/coq-modules/equations { };
       fiat_HEAD = callPackage ../development/coq-modules/fiat/HEAD.nix {};


### PR DESCRIPTION
Is there a better way to deal with the `deriving` dependency that is only needed for version 0.3.0 (and not available for all versions of Coq)? Ping @Zimmi48 @CohenCyril 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
