### PR TITLE
kicad: use new domain name

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -183,7 +183,7 @@ stdenv.mkDerivation rec {
       Just the build products, optionally with the i18n linked in
       the libraries are passed via an env var in the wrapper, default.nix
     '';
-    homepage = "https://www.kicad-pcb.org/";
+    homepage = "https://www.kicad.org/";
     license = lib.licenses.agpl3;
     platforms = lib.platforms.all;
   };

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -277,7 +277,7 @@ stdenv.mkDerivation rec {
     then "Open Source Electronics Design Automation suite"
     else "Open Source EDA suite, development build")
     + (if (!with3d) then ", without 3D models" else "");
-    homepage = "https://www.kicad-pcb.org/";
+    homepage = "https://www.kicad.org/";
     longDescription = ''
       KiCad is an open source software suite for Electronic Design Automation.
       The Programs handle Schematic Capture, and PCB Layout with Gerber output.


### PR DESCRIPTION
as the old one is now no longer controlled by the kicad organization

###### Motivation for this change
[the old domain name was sold to an unknown third party that is not affiliated with the KiCad project](https://forum.kicad.info/t/warning-about-potentially-malicious-software/31521)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
