### PR TITLE
tonelib-gfx: 4.6.6 -> 4.7.0

### DIFF
--- a/pkgs/applications/audio/tonelib-gfx/default.nix
+++ b/pkgs/applications/audio/tonelib-gfx/default.nix
@@ -1,65 +1,58 @@
-{ stdenv
-, dpkg
-, lib
-, autoPatchelfHook
+{ lib
+, stdenv
 , fetchurl
-, gtk3
-, glib
-, desktop-file-utils
+, autoPatchelfHook
+, dpkg
 , alsa-lib
-, libjack2
-, harfbuzz
-, fribidi
-, pango
 , freetype
+, libglvnd
 , curl
+, libXcursor
+, libXinerama
+, libXrandr
+, libXrender
+, libjack2
 }:
 
 stdenv.mkDerivation rec {
   pname = "tonelib-gfx";
-  version = "4.6.6";
+  version = "4.7.0";
 
   src = fetchurl {
-    url = "https://www.tonelib.net/download/0509/ToneLib-GFX-amd64.deb";
-    sha256 = "sha256-wdX3SQSr0IZHsTUl+1Y0iETme3gTyryexhZ/9XHkGeo=";
+    url = "https://www.tonelib.net/download/0930/ToneLib-GFX-amd64.deb";
+    hash = "sha256-BcbX0dz94B4mj6QeQsnuZmwXAaXH+yJjnrUPgEYVqkU=";
   };
 
+  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
   buildInputs = [
-    dpkg
-    gtk3
-    glib
-    desktop-file-utils
+    stdenv.cc.cc.lib
     alsa-lib
-    libjack2
-    harfbuzz
-    fribidi
-    pango
     freetype
+    libglvnd
+  ] ++ runtimeDependencies;
+
+  runtimeDependencies = map lib.getLib [
+    curl
+    libXcursor
+    libXinerama
+    libXrandr
+    libXrender
+    libjack2
   ];
 
-  nativeBuildInputs = [
-    autoPatchelfHook
-  ];
-
-  unpackPhase = ''
-    mkdir -p $TMP/ $out/
-    dpkg -x $src $TMP
-  '';
+  unpackCmd = "dpkg -x $curSrc source";
 
   installPhase = ''
-    cp -R $TMP/usr/* $out/
-    mv $out/bin/ToneLib-GFX $out/bin/tonelib-gfx
-  '';
-
-  runtimeDependencies = [
-    (lib.getLib curl)
-  ];
+    mv usr $out
+    substituteInPlace $out/share/applications/ToneLib-GFX.desktop --replace /usr/ $out/
+ '';
 
   meta = with lib; {
     description = "Tonelib GFX is an amp and effects modeling software for electric guitar and bass.";
     homepage = "https://tonelib.net/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ dan4ik605743 ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ dan4ik605743 orivej ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Regular update.

Fix runtime dependencies:
- libjack2 is needed for jack output
- libX* are needed to properly render the GUI

Missing runtime dependencies were discovered by running:
`strace -fe open,openat ToneLib-GFX |& grep glibc | grep ENOENT`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
