### PR TITLE
nix: add aws-crt-cpp

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -22,7 +22,7 @@ common =
   , stateDir
   , confDir
   , withLibseccomp ? lib.meta.availableOn stdenv.hostPlatform libseccomp, libseccomp
-  , withAWS ? !enableStatic && (stdenv.isLinux || stdenv.isDarwin), aws-sdk-cpp
+  , withAWS ? !enableStatic && (stdenv.isLinux || stdenv.isDarwin), aws-sdk-cpp, aws-crt-cpp
   , enableStatic ? stdenv.hostPlatform.isStatic
   , enableDocumentation ? lib.versionOlder version "2.4pre" ||
                           stdenv.hostPlatform == stdenv.buildPlatform
@@ -65,7 +65,8 @@ common =
         ++ lib.optionals is24 [ libarchive gtest lowdown ]
         ++ lib.optional (is24 && stdenv.isx86_64) libcpuid
         ++ lib.optional withLibseccomp libseccomp
-        ++ lib.optional withAWS
+        ++ lib.optionals withAWS [
+            aws-crt-cpp
             ((aws-sdk-cpp.override {
               apis = ["s3" "transfer"];
               customMemoryManagement = false;
@@ -73,7 +74,7 @@ common =
               patches = args.patches or [] ++ [
                 ./aws-sdk-cpp-TransferManager-ContentEncoding.patch
               ];
-            }));
+            }))];
 
       propagatedBuildInputs = [ boehmgc ];
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nix/issues/5404
https://github.com/NixOS/nixpkgs/issues/142107

Nix upstream will be fine until nixos-21.05-small includes https://github.com/NixOS/nixpkgs/commit/abbb7c6e60b60f2a516b8a69c45c5b8bb415cc0f.

###### Things done
added `aws-crt-cpp` to awsDeps

Only minimal testing done with minimal architectures and deployments. Needs additional review.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Fixes #142107