### PR TITLE
treewide: fix cffi-related cross-compilation

### DIFF
--- a/pkgs/development/python-modules/argon2_cffi/default.nix
+++ b/pkgs/development/python-modules/argon2_cffi/default.nix
@@ -8,19 +8,25 @@
 , fetchPypi
 , isPy3k
 , lib
+, stdenv
 }:
 
 buildPythonPackage rec {
   pname = "argon2_cffi";
-  version = "20.1.0";
+  version = "21.1.0";
 
   src = fetchPypi {
     pname = "argon2-cffi";
     inherit version;
-    sha256 = "0zgr4mnnm0p4i99023safb0qb8cgvl202nly1rvylk2b7qnrn0nq";
+    sha256 = "sha256-9xC2EQPRofaSyj7L0Tc+KKpeVFrGJboGf/L+yhsruHA=";
   };
 
   propagatedBuildInputs = [ cffi six ] ++ lib.optional (!isPy3k) enum34;
+
+  propagatedNativeBuildInputs = [ cffi ];
+
+  ARGON2_CFFI_USE_SSE2 = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) "0";
+
   checkInputs = [ hypothesis pytest wheel ];
   checkPhase = ''
     pytest tests

--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -15,6 +15,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six ] ++ lib.optional (!isPyPy) cffi;
 
+  propagatedNativeBuildInputs = lib.optional (!isPyPy) cffi;
+
   meta = with lib; {
     maintainers = with maintainers; [ domenkozar ];
     description = "Modern password hashing for your software and your servers";

--- a/pkgs/development/python-modules/brotlicffi/default.nix
+++ b/pkgs/development/python-modules/brotlicffi/default.nix
@@ -22,6 +22,10 @@ buildPythonPackage rec {
     brotli
   ];
 
+  propagatedNativeBuildInputs = [
+    cffi
+  ];
+
   propagatedBuildInputs = [
     cffi
   ];

--- a/pkgs/development/python-modules/brotlipy/default.nix
+++ b/pkgs/development/python-modules/brotlipy/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ cffi enum34 construct ];
 
+  propagatedNativeBuildInputs = [ cffi ];
+
   checkInputs = [ pytest hypothesis ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/cairocffi/default.nix
+++ b/pkgs/development/python-modules/cairocffi/default.nix
@@ -8,7 +8,6 @@
 , makeFontsConf
 , freefont_ttf
 , pytest
-, pytest-runner
 , glibcLocales
 , cairo
 , cffi

--- a/pkgs/development/python-modules/cairocffi/generic.nix
+++ b/pkgs/development/python-modules/cairocffi/generic.nix
@@ -23,8 +23,20 @@ buildPythonPackage rec {
     fontDirectories = [ freefont_ttf ];
   };
 
-  checkInputs = [ numpy pytest pytest-runner glibcLocales ];
   propagatedBuildInputs = [ cairo cffi ] ++ lib.optional withXcffib xcffib;
+  propagatedNativeBuildInputs = [ cffi ];
+
+  # pytestCheckHook does not work
+  checkInputs = [ numpy pytest glibcLocales ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "pytest-runner" "" \
+      --replace "pytest-cov" "" \
+      --replace "pytest-flake8" "" \
+      --replace "pytest-isort" "" \
+      --replace "--flake8 --isort" ""
+  '';
 
   checkPhase = ''
     py.test $out/${python.sitePackages}

--- a/pkgs/development/python-modules/cairosvg/default.nix
+++ b/pkgs/development/python-modules/cairosvg/default.nix
@@ -8,9 +8,6 @@
 , pillow
 , tinycss2
 , pytestCheckHook
-, pytest-runner
-, pytest-flake8
-, pytest-isort
 }:
 
 buildPythonPackage rec {
@@ -23,11 +20,21 @@ buildPythonPackage rec {
     sha256 = "sha256-sLmSnPXboAUXjXRqgDb88AJVUPSYylTbYYczIjhHg7w=";
   };
 
-  nativeBuildInputs = [ pytest-runner ];
-
   propagatedBuildInputs = [ cairocffi cssselect2 defusedxml pillow tinycss2 ];
 
-  checkInputs = [ pytestCheckHook pytest-flake8 pytest-isort ];
+  propagatedNativeBuildInputs = [ cairocffi ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "pytest-runner" "" \
+      --replace "pytest-flake8" "" \
+      --replace "pytest-isort" "" \
+      --replace "pytest-cov" "" \
+      --replace "--flake8" "" \
+      --replace "--isort" ""
+  '';
 
   pytestFlagsArray = [
     "cairosvg/test_api.py"

--- a/pkgs/development/python-modules/cmarkgfm/default.nix
+++ b/pkgs/development/python-modules/cmarkgfm/default.nix
@@ -14,6 +14,8 @@ buildPythonPackage rec {
     sha256 = "sha256-tqVJq6Mnq9mG1nSM8hyGN9dBx2hQ5/773vjSi/4TjjI=";
   };
 
+  propagatedNativeBuildInputs = [ cffi ];
+
   propagatedBuildInputs = [ cffi ];
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/editdistance-s/default.nix
+++ b/pkgs/development/python-modules/editdistance-s/default.nix
@@ -16,6 +16,8 @@ buildPythonPackage rec {
     sha256 = "0w2qd5b6a3c3ahd0xy9ykq4wzqk0byqwdqrr26dyn8j2425j46lg";
   };
 
+  propagatedNativeBuildInputs = [ cffi ];
+
   propagatedBuildInputs = [ cffi ];
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/fastpbkdf2/default.nix
+++ b/pkgs/development/python-modules/fastpbkdf2/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
   buildInputs = [ openssl ];
   checkInputs = [ pytest ];
   propagatedBuildInputs = [ cffi six ];
+  propagatedNativeBuildInputs = [ cffi ];
 
   meta = with lib; {
     homepage = "https://github.com/Ayrx/python-fastpbkdf2";

--- a/pkgs/development/python-modules/liquidctl/default.nix
+++ b/pkgs/development/python-modules/liquidctl/default.nix
@@ -35,6 +35,10 @@ buildPythonPackage rec {
     colorlog
   ];
 
+  propagatedNativeBuildInputs = [
+    smbus-cffi
+  ];
+
   outputs = [ "out" "man" ];
 
   postInstall = ''

--- a/pkgs/development/python-modules/miniaudio/default.nix
+++ b/pkgs/development/python-modules/miniaudio/default.nix
@@ -19,9 +19,8 @@ buildPythonPackage rec {
     sha256 = "1yx4n4zax103fmjzdiqzw37zibsh68b2p2l5qvgcnx2zrrjd31yl";
   };
 
-  propagatedBuildInputs = [
-    cffi
-  ];
+  propagatedNativeBuildInputs = [ cffi ];
+  propagatedBuildInputs = [ cffi ];
 
   checkInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/misaka/default.nix
+++ b/pkgs/development/python-modules/misaka/default.nix
@@ -8,6 +8,8 @@ buildPythonPackage rec {
     sha256 = "1mzc29wwyhyardclj1vg2xsfdibg2lzb7f1azjcxi580ama55wv2";
   };
 
+  propagatedNativeBuildInputs = [ cffi ];
+
   propagatedBuildInputs = [ cffi ];
 
   # The tests require write access to $out

--- a/pkgs/development/python-modules/passlib/default.nix
+++ b/pkgs/development/python-modules/passlib/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
 
   checkInputs = [ nose ];
   propagatedBuildInputs = [ bcrypt argon2_cffi ];
+  propagatedNativeBuildInputs = [ argon2_cffi ];
 
   meta = {
     description = "A password hashing library for Python";

--- a/pkgs/development/python-modules/prox-tv/default.nix
+++ b/pkgs/development/python-modules/prox-tv/default.nix
@@ -28,6 +28,8 @@ buildPythonPackage {
     cffi
   ];
 
+  propagatedNativeBuildInputs = [ cffi ];
+
   buildInputs = [ blas lapack ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/python-modules/pycares/default.nix
+++ b/pkgs/development/python-modules/pycares/default.nix
@@ -24,6 +24,10 @@ buildPythonPackage rec {
     idna
   ];
 
+  propagatedNativeBuildInputs = [
+    cffi
+  ];
+
   # Requires network access
   doCheck = false;
 

--- a/pkgs/development/python-modules/pycmarkgfm/default.nix
+++ b/pkgs/development/python-modules/pycmarkgfm/default.nix
@@ -10,6 +10,8 @@ buildPythonPackage rec {
     sha256 = "694cb242f4961437c30b5b015dfbce9d1a1fa48305c2e39f902ce7c65b4cbe0e";
   };
 
+  propagatedNativeBuildInputs = [ cffi ];
+
   propagatedBuildInputs = [ cffi ];
 
   # I would gladly use pytestCheckHook, but pycmarkgfm relies on a native

--- a/pkgs/development/python-modules/pygit2/default.nix
+++ b/pkgs/development/python-modules/pygit2/default.nix
@@ -21,6 +21,8 @@ buildPythonPackage rec {
     cached-property
   ] ++ lib.optional (!isPyPy) cffi;
 
+  propagatedNativeBuildInputs = lib.optional (!isPyPy) cffi;
+
   checkInputs = [ pytestCheckHook ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/pykeepass/default.nix
+++ b/pkgs/development/python-modules/pykeepass/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage rec {
     argon2_cffi python-dateutil future
   ];
 
+  propagatedNativeBuildInputs = [ argon2_cffi ];
+
   checkPhase = ''
     ${python.interpreter} -m unittest tests.tests
   '';

--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -6,6 +6,7 @@
 , libsodium
 , cffi
 , hypothesis
+, stdenv
 , six
 }:
 
@@ -29,6 +30,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    cffi
     six
   ];
 

--- a/pkgs/development/python-modules/python-olm/default.nix
+++ b/pkgs/development/python-modules/python-olm/default.nix
@@ -17,6 +17,10 @@ buildPythonPackage {
     future
   ] ++ lib.optionals (!isPy3k) [ typing ];
 
+  propagatedNativeBuildInputs = [
+    cffi
+  ];
+
   # Some required libraries for testing are not packaged yet.
   doCheck = false;
   pythonImportsCheck = [ "olm" ];

--- a/pkgs/development/python-modules/reflink/default.nix
+++ b/pkgs/development/python-modules/reflink/default.nix
@@ -3,7 +3,6 @@
 , fetchPypi
 , lib
 , pytestCheckHook
-, pytest-runner
 }:
 
 buildPythonPackage rec {
@@ -15,9 +14,16 @@ buildPythonPackage rec {
     sha256 = "sha256-ySU1gtskQTv9cDq/wbKkneePMbSQcjnyhumhkpoebjo=";
   };
 
-  propagatedBuildInputs = [ cffi pytest-runner ];
+  propagatedBuildInputs = [ cffi ];
+
+  propagatedNativeBuildInputs = [ cffi ];
 
   checkInputs = [ pytestCheckHook ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest-runner" ""
+  '';
 
   # FIXME: These do not work, and I have been unable to figure out why.
   doCheck = false;

--- a/pkgs/development/python-modules/smbus-cffi/default.nix
+++ b/pkgs/development/python-modules/smbus-cffi/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage rec {
     })
   ];
 
+  propagatedNativeBuildInputs = [ cffi ];
+
   propagatedBuildInputs = [ cffi ];
 
   installCheckPhase = ''

--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
 
     checkInputs = [ pytest ];
     propagatedBuildInputs = [ numpy libsndfile cffi ];
+    propagatedNativeBuildInputs = [ cffi ];
 
     meta = {
       description = "An audio library based on libsndfile, CFFI and NumPy";

--- a/pkgs/development/python-modules/tinycss2/default.nix
+++ b/pkgs/development/python-modules/tinycss2/default.nix
@@ -1,44 +1,36 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchPypi
-, fetchpatch
+, fetchFromGitHub
 , webencodings
-# Check inputs
-, pytest
-, pytest-runner
-, pytest-cov
-, pytest-flake8
-, pytest-isort
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "tinycss2";
-  version = "1.0.2";
+  version = "1.1.0";
   disabled = pythonOlder "3.5";
+  format = "flit";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1kw84y09lggji4krkc58jyhsfj31w8npwhznr7lf19d0zbix09v4";
+  src = fetchFromGitHub {
+    owner = "kozea";
+    repo = "tinycss2";
+    rev = "v${version}";
+    # for tests
+    fetchSubmodules = true;
+    sha256 = "sha256-WA88EYolL76WqeA1UKR3Sfw11j8NuOGOxPezujYizH8=";
   };
-
-  patches = [
-    (
-      fetchpatch {
-        name = "tinycss2-fix-pytest-flake8-fail.patch";
-        url = "https://github.com/Kozea/tinycss2/commit/6556604fb98c2153412384d6f0f705db2da1aa60.patch";
-        sha256 = "1srvdzg1bak65fawd611rlskcgn5abmwmyjnk8qrrrasr554bc59";
-      }
-    )
-  ];
 
   propagatedBuildInputs = [ webencodings ];
 
-  checkInputs = [ pytest pytest-runner pytest-cov pytest-flake8 pytest-isort ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  # https://github.com/PyCQA/pycodestyle/issues/598
-  preCheck = ''
-    printf "[flake8]\nignore=W504,E741,E126" >> setup.cfg
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "'pytest-cov', 'pytest-flake8', 'pytest-isort', 'coverage[toml]'" "" \
+      --replace "--isort --flake8 --cov" ""
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/xcffib/default.nix
+++ b/pkgs/development/python-modules/xcffib/default.nix
@@ -23,6 +23,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ cffi six ];
 
+  propagatedNativeBuildInputs = [ cffi ];
+
   checkInputs = [ nose ];
 
   pythonImportsCheck = [ "xcffib" ];

--- a/pkgs/development/python-modules/xpybutil/default.nix
+++ b/pkgs/development/python-modules/xpybutil/default.nix
@@ -13,7 +13,9 @@ buildPythonPackage rec {
   };
 
   # pillow is a dependency in image.py which is not listed in setup.py
-  propagatedBuildInputs = [ xcffib pillow ];
+  propagatedBuildInputs = [ pillow xcffib ];
+
+  propagatedNativeBuildInputs = [ xcffib ];
 
   checkInputs = [ nose ];
 

--- a/pkgs/development/python-modules/zstandard/default.nix
+++ b/pkgs/development/python-modules/zstandard/default.nix
@@ -14,6 +14,8 @@ buildPythonPackage rec {
     sha256 = "52de08355fd5cfb3ef4533891092bb96229d43c2069703d4aff04fdbedf9c92f";
   };
 
+  propagatedNativeBuildInputs = [ cffi ];
+
   propagatedBuildInputs = [ cffi ];
 
   checkInputs = [ hypothesis ];


### PR DESCRIPTION
###### Motivation for this change
I made a list of all packages listing `cffi` incorrectly (as described here: https://github.com/NixOS/nixpkgs/pull/135447) and went through all of them manually to fix it. It worked for maybe 1/10th of the packages, while I was working I removed the ones from the list that built and added comments to the ones that didn't:
```
All tests were run with nix build nixpkgs#pkgsCross.raspberryPi.*

~~Sometimes packages will cross compile, even though when I try to cross compile one of their dependencies it fails... No idea what's going on there - probably some python weirdness~~


# rust boostrap, don't want to lol
pkgs/tools/security/sequoia/default.nix
# cc command not found
pkgs/development/python-modules/angr/default.nix
# the cffi error, after fixing that: wrong ELF class: ELFCLASS32 when loading a library
pkgs/development/python-modules/augeas/default.nix
# issue doesn't go away
pkgs/development/python-modules/autobahn/default.nix
# wrong ELF class: ELFCLASS32
pkgs/development/python-modules/bedup/default.nix
# cc not found
pkgs/development/python-modules/cle/default.nix
# idk what the derivation name is
pkgs/development/python-modules/cld2-cffi/default.nix
# doesn't work
pkgs/development/python-modules/deltachat/default.nix
# doesn't work
pkgs/development/python-modules/etesync/default.nix
# /nix/store/mij848h2x5wiqkwhg027byvmf9x3gx7y-glibc-2.33-50/lib/librt.so: file not recognized: file format not recognized
pkgs/development/python-modules/google-crc32c/default.nix
# unsupported
pkgs/development/python-modules/jupyter_server/default.nix
# cffi issue is fixed, but other issue: checking for a version of Python >= '2.1.0'... ./configure: line 12491: /nix/store/.../bin/python: cannot execute binary file: Exec format
pkgs/development/python-modules/keyrings-cryptfile/default.nix
# unsupported
pkgs/development/python-modules/notebook/default.nix
# Please install the program "msgfmt" in advance.
pkgs/development/python-modules/notmuch/2.nix
# /nix/store/9qsrf2ddrd1s3myyk89w94wcyw0w3idq-postgresql-13.4-lib/lib/libpq.so: file not recognized: file format not recognized
pkgs/development/python-modules/psycopg2/default.nix
# doesn't work
pkgs/development/python-modules/pyspice/default.nix
# unsupported
pkgs/development/python-modules/pyspotify/default.nix
# not even gonna try
pkgs/development/python-modules/pytorch/default.nix
# cc no such file or directory
pkgs/development/python-modules/pyvex/default.nix
# idk billion deps and some pkg-config error
pkgs/development/python-modules/pyvips/default.nix
# can't find ar
pkgs/development/python-modules/rtmixer/default.nix
# unsupported
pkgs/development/python-modules/rpy2/default.nix
# ERROR: Could not find a version that satisfies the requirement pytest-runner (from versions: none)
pkgs/development/python-modules/weasyprint/default.nix
# stdenv-linux/setup: /nix/store/h6g8yf6p2rc36hcvshkdh23xxpc5c4kv-python3-armv6l-unknown-linux-gnueabihf-3.9.6/bin/python3.9: cannot execute binary file: Exec format error
pkgs/development/python-modules/xattr/default.nix
# stdenv-linux/setup: /nix/store/h6g8yf6p2rc36hcvshkdh23xxpc5c4kv-python3-armv6l-unknown-linux-gnueabihf-3.9.6/bin/python3.9: cannot execute binary file: Exec format error
pkgs/development/python-modules/pymunk/default.nix
# ./autogen.sh: line 29: libtoolize: not found
pkgs/development/python-modules/ocrmypdf/default.nix
# configure: error: in `/build/source':
# configure: error: cannot run test program while cross compiling
pkgs/development/python-modules/kaldi-active-grammar/default.nix
# wrong ELF class: ELFCLASS32 when loading a lib
pkgs/development/python-modules/ssdeep/default.nix
# can't find ar
pkgs/development/python-modules/sounddevice/default.nix
# line 3: syntax error near unexpected token `lambda'
pkgs/development/python-modules/snowflake-connector-python/default.nix
# no c compiler found
pkgs/development/python-modules/secp256k1/default.nix
#   line 1: syntax error: unexpected word (expecting ")")
pkgs/development/python-modules/pyopencl/default.nix
#/nix/store/9qsrf2ddrd1s3myyk89w94wcyw0w3idq-postgresql-13.4-lib/lib/libpq.so: file not recognized: file format not recognized
#collect2: error: ld returned 1 exit status
#Traceback (most recent call last):
#  File "/build/source/psycopg2cffi/_impl/libpq.py", line 2, in <module>
#    from psycopg2cffi._impl._libpq import ffi, lib as libpq
#ModuleNotFoundError: No module named 'psycopg2cffi._impl._libpq'
pkgs/development/python-modules/psycopg2cffi/default.nix
# some syntax error
pkgs/development/python-modules/islpy/default.nix
# no thing found setuptools
pkgs/development/python-modules/httpx/default.nix
# some syntax error
pkgs/development/python-modules/graphite-web/default.nix
# dunno the attribute name
pkgs/development/python-modules/graphite-api/default.nix
# unsupported
pkgs/development/python-modules/bwapy/default.nix
# unsupported
pkgs/development/interpreters/python/pypy/default.nix
# 2gb of deps, don't feel like testing
pkgs/applications/networking/irc/hexchat/default.nix
# An exe_wrapper is needed but was not found. Please define one in cross file and check the command and/or add it to PATH.
pkgs/applications/networking/mailreaders/notmuch/default.nix
```


~~One thing to notice is that it seems like some packages are cross-compiling, while some of their dependencies - when I cross compile them separately don't... I don't know enough python to know if this is a bug and should be a huge alarm signal or is just expected~~
~~Maybe someone else could shed some light onto this?~~
"Fixed" with https://github.com/NixOS/nixpkgs/pull/142301#issuecomment-948045461 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
