### PR TITLE
aws-sdk-cpp: propagate aws-crt-cpp

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake curl ];
 
   buildInputs = [
-    aws-crt-cpp
     curl openssl zlib
   ] ++ lib.optionals (stdenv.isDarwin &&
                         ((builtins.elem "text-to-speech" apis) ||
@@ -50,14 +49,7 @@ stdenv.mkDerivation rec {
          [ CoreAudio AudioToolbox ];
 
   # propagation is needed for Security.framework to be available when linking
-  propagatedBuildInputs = [
-    aws-c-cal
-    aws-c-event-stream
-    aws-c-io
-    aws-c-common
-    aws-checksums
-    s2n-tls
-  ];
+  propagatedBuildInputs = [ aws-crt-cpp ];
 
   cmakeFlags = [
     "-DBUILD_DEPS=OFF"


### PR DESCRIPTION
###### Motivation for this change
Alternative to closes #142300

Fixes #142107

###### Things done
make aws-crt-cpp propagate

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
