### PR TITLE
libtorrent: enable paralell building

### DIFF
--- a/pkgs/tools/networking/p2p/libtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ cppunit openssl libsigcxx zlib ];
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     homepage = "https://github.com/rakshasa/libtorrent";
     description = "A BitTorrent library written in C++ for *nix, with focus on high performance and good code";


### PR DESCRIPTION
On 16-core machine build speeds up from 81s to 16s (~5x).