### PR TITLE
rtorrent: enable paralell building

### DIFF
--- a/pkgs/tools/networking/p2p/rtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/rtorrent/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-xmlrpc-c" "--with-posix-fallocate" ];
 
+  enableParallelBuilding = true;
+
   postInstall = ''
     mkdir -p $out/share/man/man1 $out/share/doc/rtorrent
     mv doc/old/rtorrent.1 $out/share/man/man1/rtorrent.1


### PR DESCRIPTION
On 16-core machine build speeds up from 90s to 19s (~4.7x).