### PR TITLE
kubecfg: add -s, -w and version to ldflags

### DIFF
--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -15,7 +15,7 @@ buildGoPackage {
 
   goPackagePath = "github.com/bitnami/kubecfg";
 
-  ldflags = [ "-X main.version=v${version}" ];
+  ldflags = [ "-s" "-w" "-X main.version=v${version}" ];
 
   meta = {
     description = "A tool for managing Kubernetes resources as code";

--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -15,6 +15,8 @@ buildGoPackage {
 
   goPackagePath = "github.com/bitnami/kubecfg";
 
+  ldflags = [ "-X main.version=v${version}" ];
+
   meta = {
     description = "A tool for managing Kubernetes resources as code";
     homepage = "https://github.com/bitnami/kubecfg";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without the ldflags, `kubecfg version` will print `kubecfg version: (dev build)` instead of the real version number. 

###### Things done

Added the appropriate ldflags to the package. Built on x86_64-linux, verified outcome:

```
$ /nix/store/x92198rjyllybrb9ihlgl616lydb7rhq-kubecfg-0.21.0/bin/kubecfg version
kubecfg version: v0.21.0
jsonnet version: v0.16.0
client-go version: v0.0.0-master+ee64d79d
```

Also added -s and -w in order to have a smaller binary.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
