### PR TITLE
pythonPackages.pyatome: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/pyatome/default.nix
+++ b/pkgs/development/python-modules/pyatome/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, simplejson
+, fake-useragent
+}:
+
+buildPythonPackage rec {
+  pname = "pyatome";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    pname = "pyAtome";
+    inherit version;
+    sha256 = "7282e7ec258c69d4ddf2a5754ff07680a1ac92f9bfb478d601fd9e944fccd834";
+  };
+
+  propagatedBuildInputs = [ requests simplejson fake-useragent ];
+
+  # no tests  in PyPI tarballs
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "pyatome"
+  ];
+
+  meta = with lib; {
+    description = "Python module to get energy consumption data from Atome";
+    homepage = "https://github.com/baqs/pyAtome";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ uvnikita ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -62,7 +62,7 @@
     "asuswrt" = ps: with ps; [ aioasuswrt ];
     "atag" = ps: with ps; [ pyatag ];
     "aten_pe" = ps: with ps; [ atenpdu ];
-    "atome" = ps: with ps; [ ]; # missing inputs: pyatome
+    "atome" = ps: with ps; [ pyatome ];
     "august" = ps: with ps; [ yalexs ];
     "aurora" = ps: with ps; [ auroranoaa ];
     "aurora_abb_powerone" = ps: with ps; [ ]; # missing inputs: aurorapy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5623,6 +5623,8 @@ in {
 
   pyatag = callPackage ../development/python-modules/pyatag { };
 
+  pyatome = callPackage ../development/python-modules/pyatome { };
+
   pycontrol4 = callPackage ../development/python-modules/pycontrol4 { };
 
   pycoolmasternet-async = callPackage ../development/python-modules/pycoolmasternet-async { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Needed for `atome` home-assistant component:

https://github.com/NixOS/nixpkgs/blob/e06171f926295789358ce8f3b2ebdf5c0208e898/pkgs/servers/home-assistant/component-packages.nix#L65

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
