### PR TITLE
python3Packages.adb-enhanced: 2.5.11 -> 2.5.12

### DIFF
--- a/pkgs/development/python-modules/adb-enhanced/default.nix
+++ b/pkgs/development/python-modules/adb-enhanced/default.nix
@@ -1,8 +1,15 @@
-{ lib, jdk11, fetchFromGitHub, buildPythonPackage, docopt, psutil, pythonOlder }:
+{ lib
+, buildPythonPackage
+, docopt
+, fetchFromGitHub
+, jdk11
+, psutil
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "adb-enhanced";
-  version = "2.5.11";
+  version = "2.5.12";
 
   disabled = pythonOlder "3.4";
 
@@ -10,20 +17,25 @@ buildPythonPackage rec {
     owner = "ashishb";
     repo = pname;
     rev = version;
-    sha256 = "sha256-jb5O7Qxk2xAX5sax6nqywcGBJao5Xfff9s1yvdfvDCs=";
+    sha256 = "sha256-OZSLk5qXX6rEclo6JC8o/7Mz0Y2sJqUsLhnrVK4gkVI=";
   };
+
+  propagatedBuildInputs = [
+    psutil
+    docopt
+  ];
 
   postPatch = ''
     substituteInPlace adbe/adb_enhanced.py \
       --replace "cmd = 'java" "cmd = '${jdk11}/bin/java"
   '';
 
-  propagatedBuildInputs = [ psutil docopt ];
-
-  # Disable tests because they require a dedicated android emulator
+  # Disable tests because they require a dedicated Android emulator
   doCheck = false;
 
-  pythonImportsCheck = [ "adbe" ];
+  pythonImportsCheck = [
+    "adbe"
+  ];
 
   meta = with lib; {
     description = "Tool for Android testing and development";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.5.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
