### PR TITLE
gnomeExtensions.night-theme-switcher: 50 -> 53

### DIFF
--- a/pkgs/desktops/gnome/extensions/night-theme-switcher/default.nix
+++ b/pkgs/desktops/gnome/extensions/night-theme-switcher/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "rmnvgr";
     repo = "nightthemeswitcher-gnome-shell-extension";
-    rev = "${version}";
+    rev = version;
     sha256 = "0dgnh1aj0y89jzfkpj8zs4gdbmyc1v8lbki2q30gld17ljv4l6lh";
   };
 

--- a/pkgs/desktops/gnome/extensions/night-theme-switcher/default.nix
+++ b/pkgs/desktops/gnome/extensions/night-theme-switcher/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-night-theme-switcher";
-  version = "50";
+  version = "53";
 
   src = fetchFromGitLab {
     owner = "rmnvgr";
     repo = "nightthemeswitcher-gnome-shell-extension";
-    rev = "v${version}";
-    sha256 = "0rs08kr3wizs1vpkmm6pbcvnn7rz47yrq7vnb1s8d58yda9a850d";
+    rev = "${version}";
+    sha256 = "0dgnh1aj0y89jzfkpj8zs4gdbmyc1v8lbki2q30gld17ljv4l6lh";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

Support for GNOME 41 was added in night-theme-switcher version 52.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
