### PR TITLE
image-roll: init at 1.3.1

### DIFF
--- a/pkgs/applications/graphics/image-roll/default.nix
+++ b/pkgs/applications/graphics/image-roll/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, glib
+, pkg-config
+, wrapGAppsHook
+, gtk3
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "image-roll";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "weclaw1";
+    repo = pname;
+    rev = version;
+    sha256 = "007jzmrn4cnqbi6fy5lxanbwa4pc72fbcv9irk3pfd0wspp05s8j";
+  };
+
+  cargoSha256 = "sha256-dRRBfdGTXtoNbp7OWqOdNECXHCpj0ipkCOvcdekW+G4=";
+
+  nativeBuildInputs = [ glib pkg-config wrapGAppsHook ];
+
+  buildInputs = [ gtk3 ];
+
+  meta = with lib; {
+    description = "Simple and fast GTK image viewer with basic image manipulation tools";
+    homepage = "https://github.com/weclaw1/image-roll";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25600,6 +25600,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  image-roll = callPackage ../applications/graphics/image-roll { };
+
   imagej = callPackage ../applications/graphics/imagej { };
 
   imagemagick6_light = imagemagick6.override {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

fixes #131232

Thank you @Artturin for the original code snippet https://github.com/NixOS/nixpkgs/issues/131232#issuecomment-885883817

image-roll is a simple and fast GTK image viewer with basic image manipulation tools

https://github.com/weclaw1/image-roll

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
