### PR TITLE
pythonPackages.py-synologydsm-api: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/py-synologydsm-api/default.nix
+++ b/pkgs/development/python-modules/py-synologydsm-api/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, urllib3
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "py-synologydsm-api";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    pname = "synologydsm-api";
+    inherit version;
+    sha256 = "42ea453ef5734dd5b8163e3d18ef309658f0298411720e6b834bededd28c5d53";
+  };
+
+  propagatedBuildInputs = [ urllib3 requests ];
+
+  pythonImportsCheck = [
+    "synology_dsm"
+  ];
+
+  meta = with lib; {
+    description = "Python API for Synology DSM";
+    homepage = "https://github.com/hacf-fr/synologydsm-api";
+    license = licenses.mit;
+    maintainers = with maintainers; [ uvnikita ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5995,6 +5995,8 @@ in {
 
   py-dmidecode = callPackage ../development/python-modules/py-dmidecode { };
 
+  py-synologydsm-api = callPackage ../development/python-modules/py-synologydsm-api { };
+
   py-ubjson = callPackage ../development/python-modules/py-ubjson { };
 
   py17track = callPackage ../development/python-modules/py17track { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Needed for `synology_dsm` home-assistant component

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
