### PR TITLE
lumina.lumina: 1.6.0 -> 1.6.1

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lumina.nix
+++ b/nixos/modules/services/x11/desktop-managers/lumina.nix
@@ -38,5 +38,11 @@ in
       "/share"
     ];
 
+    security.wrappers.lumina-checkpass-wrapped = {
+      source = "${pkgs.lumina.lumina}/bin/lumina-checkpass";
+      owner = "root";
+      group = "root";
+    };
+
   };
 }

--- a/pkgs/desktops/lumina/lumina/default.nix
+++ b/pkgs/desktops/lumina/lumina/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , fluxbox
 , libarchive
+, linux-pam
 , numlockx
 , qmake
 , qtbase
@@ -17,13 +18,13 @@
 
 mkDerivation rec {
   pname = "lumina";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "lumina-desktop";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0bvs12c9pkc6fnkfcr7rrxc8jfbzbslch4nlfjrzwi203fcv4avw";
+    sha256 = "0wc8frhw1yv07n05r33c4zilq5lgn5gw07a9n37g6nyn5sgrbp4f";
   };
 
   nativeBuildInputs = [
@@ -35,6 +36,7 @@ mkDerivation rec {
   buildInputs = [
     fluxbox # window manager for Lumina DE
     libarchive # make `bsdtar` available for lumina-archiver
+    linux-pam
     numlockx # required for changing state of numlock at login
     qtbase
     qtmultimedia
@@ -49,7 +51,6 @@ mkDerivation rec {
   ];
 
   patches = [
-    ./avoid-absolute-path-on-sessdir.patch
     ./LuminaOS-NixOS.cpp.patch
   ];
 
@@ -60,6 +61,14 @@ mkDerivation rec {
   '';
 
   postPatch = ''
+    # Avoid absolute path on sessdir
+    substituteInPlace src-qt5/OS-detect.pri \
+      --replace L_SESSDIR=/usr/share/xsessions '#L_SESSDIR=/usr/share/xsessions'
+
+    # Do not set special permission
+    substituteInPlace src-qt5/core/lumina-checkpass/lumina-checkpass.pro \
+      --replace "chmod 4555" "chmod 555"
+
     # Fix plugin dir
     substituteInPlace src-qt5/core/lumina-theme-engine/lthemeengine.pri \
       --replace "\$\$[QT_INSTALL_PLUGINS]" "$out/$qtPluginPrefix"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [1.6.1](https://github.com/lumina-desktop/lumina/releases/tag/v1.6.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
