### PR TITLE
timelimit: init at 1.9.2

### DIFF
--- a/pkgs/tools/misc/timelimit/default.nix
+++ b/pkgs/tools/misc/timelimit/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitLab, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "timelimit";
+  version = "1.9.2";
+
+  src = fetchFromGitLab {
+    owner = "timelimit";
+    repo = pname;
+    rev = "release/${version}";
+    sha256 = "sha256-5IEAF8zCKaCVH6BAxjoa/2rrue9pRGBBkFzN57d+g+g=";
+  };
+
+  checkInputs = [ perl ];
+  doCheck = true;
+
+  installFlags = [ "PREFIX=$(out)" ];
+  INSTALL_PROGRAM = "install -m755";
+  INSTALL_DATA = "install -m644";
+
+  meta = with lib; {
+    description = "Execute a command and terminates the spawned process after a given time with a given signal";
+    homepage = "https://devel.ringlet.net/sysutils/timelimit/";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28121,6 +28121,8 @@ with pkgs;
     fftw = fftwSinglePrec;
   };
 
+  timelimit = callPackage ../tools/misc/timelimit { };
+
   timewarrior = callPackage ../applications/misc/timewarrior { };
 
   timew-sync-server = callPackage ../applications/misc/timew-sync-server { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

fixes #140557

`timelimit` executes a command and terminates the spawned process after a given time with a given signal. A “warning” signal is sent first, then, after a timeout, a “kill” signal, similar to the way init(8) operates on shutdown.

https://devel.ringlet.net/sysutils/timelimit/
https://gitlab.com/timelimit/timelimit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
