### PR TITLE
snowflake: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11996,6 +11996,16 @@
     githubId = 42300264;
     name = "wishfort36";
   };
+  witchof0x20 = {
+   name = "Jade";
+   email = "jade@witchof.space";
+   github = "witchof0x20";
+   githubId = 36118348;
+   keys = [{
+     longkeyid = "rsa4096/0x80A1F76FC9F954AE";
+     fingerprint = "69C9 876B 5797 1B2E 11C5  7C39 80A1 F76F C9F9 54AE";
+   }];
+  };
   wizeman = {
     email = "rcorreia@wizy.org";
     github = "wizeman";

--- a/pkgs/tools/networking/snowflake/default.nix
+++ b/pkgs/tools/networking/snowflake/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchgit, buildGoModule }:
+
+buildGoModule rec {
+  pname = "snowflake";
+  version = "1.1.0";
+
+  src = fetchgit {
+    url = "https://git.torproject.org/pluggable-transports/snowflake.git";
+    rev = "v${version}";
+    sha256 = "0d5ddhg2p0mbcj1cmklwn04za2x1khxgm5x9qlsg1ywkn6ngnxad";
+  };
+
+  vendorSha256 = "15nzqibrymbbn6cwz3267jxk60xr5f6v3akwplhjzcc16bgrcx57";
+
+  meta = with lib; {
+    description = "A pluggable transport proxy";
+    homepage = "https://snowflake.torproject.org";
+    maintainers = with maintainers; [ witchof0x20 ];
+    license = with lib.licenses; [
+      # common/nat/nat.go is licensed under the Expat license
+      mit
+      # All other files are licensed under bsd3
+      licenses.bsd3
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9255,6 +9255,8 @@ with pkgs;
 
   snort = callPackage ../applications/networking/ids/snort { };
 
+  snowflake = callPackage ../tools/networking/snowflake { };
+
   so = callPackage ../development/tools/so {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change
!!!WIP!!!
Add snowflake, a Tor pluggable transport. The derivation is mostly identical to the one for obfs4.

I asked the upstream developers about packaging considerations and a couple things need to be done here before it's ready for push. Posting the mostly done WIP to ask for feedback / assistance.

- One file in this project (common/nat/nat.go) has a separate license from the the rest. Rather than being BSD3, it's licensed under the expat license. I'm not sure how to indicate this in the derivation.
- The developers also mentioned that only 2 of the generated executables from building the Go module should be included in the package. I'm not sure how to do this using `buildGoModule`
- A module would be nice to allow users to run snowflake servers more easily, but I think that is more suitable for another PR?



###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
