### PR TITLE
lvm2: 2.03.12 -> 2.03.14

### DIFF
--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -561,24 +561,14 @@ in {
           + " mkpart primary 2048M -1s"  # PV2
           + " set 2 lvm on",
           "udevadm settle",
-          "sleep 1",
           "pvcreate /dev/vda1 /dev/vda2",
-          "sleep 1",
           "vgcreate MyVolGroup /dev/vda1 /dev/vda2",
-          "sleep 1",
           "lvcreate --size 1G --name swap MyVolGroup",
-          "sleep 1",
           "lvcreate --size 3G --name nixos MyVolGroup",
-          "sleep 1",
           "mkswap -f /dev/MyVolGroup/swap -L swap",
           "swapon -L swap",
           "mkfs.xfs -L nixos /dev/MyVolGroup/nixos",
           "mount LABEL=nixos /mnt",
-      )
-    '';
-    postBootCommands = ''
-      assert "loaded active" in machine.succeed(
-          "systemctl list-units 'lvm2-pvscan@*' -ql --no-legend | tee /dev/stderr"
       )
     '';
   };

--- a/pkgs/os-specific/linux/lvm2/2_02.nix
+++ b/pkgs/os-specific/linux/lvm2/2_02.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
   version = "2.02.187";
-  sha256Hash = "sha256-Dg1SGoY6XbJEDy4edie6grcCc65KsLvhMIUdsNWOWvE=";
+  sha256 = "sha256-Dg1SGoY6XbJEDy4edie6grcCc65KsLvhMIUdsNWOWvE=";
 }

--- a/pkgs/os-specific/linux/lvm2/2_03.nix
+++ b/pkgs/os-specific/linux/lvm2/2_03.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "2.03.12";
-  sha256Hash = "1shczwfd0888dchjiaqzd48ampm6f8y0ngsqd99fy4nxlbr5q1vn";
+  version = "2.03.14";
+  sha256 = "0p5077h3z7mrr0b49ikmhlhrs4v4qb530raypk3y72ja125bqqsa";
 }

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -1,4 +1,4 @@
-{ version, sha256Hash }:
+{ version, sha256 }:
 
 { lib, stdenv
 , fetchpatch
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${version}.tgz";
-    sha256 = sha256Hash;
+    inherit sha256;
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -58,8 +58,8 @@ stdenv.mkDerivation rec {
     substituteInPlace scripts/lvm2_activation_generator_systemd_red_hat.c \
       --replace /usr/bin/udevadm /run/current-system/systemd/bin/udevadm
     # https://github.com/lvmteam/lvm2/issues/36
-    substituteInPlace udev/69-dm-lvm-metad.rules.in \
-      --replace "(BINDIR)/systemd-run" /run/current-system/systemd/bin/systemd-run
+    substituteInPlace udev/69-dm-lvm.rules.in \
+      --replace "/usr/bin/systemd-run" /run/current-system/systemd/bin/systemd-run
 
     substituteInPlace make.tmpl.in --replace "@systemdsystemunitdir@" "$out/lib/systemd/system"
   '' + lib.optionalString (lib.versionAtLeast version "2.03") ''


### PR DESCRIPTION
###### Motivation for this change
https://github.com/lvmteam/lvm2/releases/tag/v2_03_13
https://github.com/lvmteam/lvm2/releases/tag/v2_03_14

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
