### PR TITLE
cointop: 1.6.8 -> 1.6.9

### DIFF
--- a/pkgs/applications/misc/cointop/default.nix
+++ b/pkgs/applications/misc/cointop/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "cointop";
-  version = "1.6.8";
+  version = "1.6.9";
 
   src = fetchFromGitHub {
     owner = "miguelmota";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-uENfTj+pJjX4t+yrd7zrn3LHRbJJSZFCN1N6Ce47wcE=";
+    sha256 = "1qxx6li9x72gkq0x79w49s4zmiq6kw88lr49d1g6ah1jyrwvvnc5";
   };
 
   goPackagePath = "github.com/miguelmota/cointop";


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Does not build yet, don't know why because I am not a go person.

Pinging pkg maintainer for help @marsam 
