### PR TITLE
wiki-tui: init at unstable-2021-10-20

### DIFF
--- a/pkgs/misc/wiki-tui/default.nix
+++ b/pkgs/misc/wiki-tui/default.nix
@@ -1,0 +1,25 @@
+{ lib, rustPlatform, fetchCrate, ncurses, openssl, pkg-config }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wiki-tui";
+  version = "0.3.4";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-H+C1AbZ2zUhw6TNlSPaNaNuY5iNf39JW4q2g6uolevM=";
+  };
+
+  buildInputs = [ ncurses openssl ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  cargoSha256 = "sha256-PIt592nGtNEREQMukqRl/6KSJ/P32fWucHEMyOOc7BA=";
+
+  meta = with lib; {
+    description = "A simple and easy to use Wikipedia Text User Interface";
+    homepage = "https://github.com/builditluc/wiki-tui";
+    license = licenses.mit;
+    maintainers = with maintainers; [ legendofmiracles ];
+    mainProgram = "wiki-tui";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32438,6 +32438,8 @@ with pkgs;
 
   wiki-js = callPackage ../servers/web-apps/wiki-js { };
 
+  wiki-tui = callPackage ../misc/wiki-tui { };
+
   winePackagesFor = wineBuild: lib.makeExtensible (self: with self; {
     callPackage = newScope self;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
