### PR TITLE
nixos/manual: doc of wait_until_succeeds timeout

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -181,7 +181,8 @@ The following methods are available on machine objects:
 
 `wait_until_succeeds`
 
-:   Repeat a shell command with 1-second intervals until it succeeds.
+:   Repeat a shell command with 1-second intervals until it succeeds or
+    timeout is reached, e.g., `wait_until_succeeds( "cmd", timeout=30)`.
 
 `wait_until_fails`
 

--- a/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
+++ b/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
@@ -321,7 +321,8 @@ start_all()
       <listitem>
         <para>
           Repeat a shell command with 1-second intervals until it
-          succeeds.
+          succeeds or timeout is reached, e.g.,
+          <literal>wait_until_succeeds( &quot;cmd&quot;, timeout=30)</literal>.
         </para>
       </listitem>
     </varlistentry>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
As part of writing a NixOS [test for Jibri](https://github.com/cleeyv/nixpkgs/blob/jibri/nixos/tests/jibri.nix) I used the `wait_until_succeeds` method in my testScript in a way that would plausibly result in the test running indefinitely if the condition for the method's test was not met. After reading the documentation of all the methods in the manual, I didn't find any that would give me the kind of timeout that I thought was called for, so I wrote one myself using the `timeout` command and a bash `until` loop to test the condition. After having done this, someone recommended that it may be worth adding this functionality to nixos/lib/test-driver/test-driver.py and when I went and looked at that file I saw that the `wait_until_succeeds` method already accepts a timeout parameter, but this functionality is not documented anywhere outside of the file itself! So in my Jibri test I replaced my custom timeout solution with the built-in one that had existed all along, and then decided to update the NixOS manual docs for the `wait_until_succeeds` method so that others won't have the same problem I did. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
