### PR TITLE
k3s: fix updateScript 5th attempt

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -243,6 +243,9 @@ stdenv.mkDerivation rec {
   pname = "k3s";
   version = k3sVersion;
 
+  # `src` here is a workaround for the updateScript bot. It couldn't be empty.
+  src = builtins.filterSource (path: type: false) ./.;
+
   # Important utilities used by the kubelet, see
   # https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-237202494
   # Note the list in that issue is stale and some aren't relevant for k3s.

--- a/pkgs/applications/networking/cluster/k3s/update.sh
+++ b/pkgs/applications/networking/cluster/k3s/update.sh
@@ -12,7 +12,7 @@ LATEST_TAG_RAWFILE=${WORKDIR}/latest_tag.json
 curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \
     https://api.github.com/repos/k3s-io/k3s/releases > ${LATEST_TAG_RAWFILE}
 
-LATEST_TAG_NAME=$(jq 'map(.tag_name)' ${LATEST_TAG_RAWFILE} | grep -v -e rc -e engine | sed 's/["|,| ]//g' | sort -r | head -n1)
+LATEST_TAG_NAME=$(jq 'map(.tag_name)' ${LATEST_TAG_RAWFILE} | grep -v -e rc -e engine | sed 's/["|,| ]//g' | sort -V -r | head -n1)
 K3S_VERSION=$(echo ${LATEST_TAG_NAME} | sed 's/^v//')
 
 K3S_COMMIT=$(curl --silent ${GITHUB_TOKEN:+"-u \":$GITHUB_TOKEN\""} \


### PR DESCRIPTION
k3s: fix updateScript 5th attempt

https://r.ryantm.com/log/updatescript/k3s/2021-10-20.log

On error:
`nix eval -f . --raw pkgs.k3s.drvAttrs.outputHash`

The last K3s's mkDerivation doesn't have src field. Seems the problem.