### PR TITLE
pythonPackages.allure-pytest: init at 2.9.45

### DIFF
--- a/pkgs/development/python-modules/allure-pytest/default.nix
+++ b/pkgs/development/python-modules/allure-pytest/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, six
+, pythonOlder
+, allure-python-commons
+, pytest
+, pytestCheckHook
+, pytest-check
+, pytest-flakes
+, pytest-lazy-fixture
+, pytest-rerunfailures
+, pytest-xdist
+, pyhamcrest
+, mock
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "allure-pytest";
+  version = "2.9.45";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "18ys5gi64jlfya6a7shj5lqhwc6cplwgyq3s2n5mg5x513g0yqi0";
+  };
+
+  buildInputs = [
+    pytest
+  ];
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  pythonImportsCheck = [ "allure_pytest" ];
+
+  propagatedBuildInputs = [
+    allure-python-commons
+    six
+  ];
+
+  checkInputs = [
+    pyhamcrest
+    mock
+    pytestCheckHook
+    pytest-check
+    pytest-flakes
+    pytest-lazy-fixture
+    pytest-rerunfailures
+    pytest-xdist
+  ];
+
+  pytestFlagsArray = [
+    "--basetemp"
+    "$(mktemp -d)"
+    "--alluredir"
+    "$(mktemp -d allure-results.XXXXXXX)"
+    "-W"
+    "ignore::pytest.PytestExperimentalApiWarning"
+    "-p"
+    "pytester"
+  ];
+
+  # we are skipping some of the integration tests for now
+  disabledTests = [
+    "test_pytest_check"
+    "test_pytest_check_example"
+    "test_select_by_testcase_id_test"
+  ];
+
+  meta = with lib; {
+    description = "Allure pytest integration. It's developed as pytest plugin and distributed via pypi";
+    homepage = "https://github.com/allure-framework/allure-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/development/python-modules/allure-python-commons-test/default.nix
+++ b/pkgs/development/python-modules/allure-python-commons-test/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, attrs
+, pluggy
+, six
+, pyhamcrest
+, setuptools-scm
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "allure-python-commons-test";
+  version = "2.9.45";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rn8ccxxrm27skv3avdiw56zc4fk2h7nrk3jamqmx6fnvmshiz5f";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [ attrs pluggy six pyhamcrest ];
+
+  checkPhase = ''
+    ${python.interpreter} -m doctest ./src/container.py
+    ${python.interpreter} -m doctest ./src/report.py
+    ${python.interpreter} -m doctest ./src/label.py
+    ${python.interpreter} -m doctest ./src/result.py
+  '';
+
+  pythonImportsCheck = [ "allure_commons_test" ];
+
+  meta = with lib; {
+    description = "Just pack of hamcrest matchers for validation result in allure2 json format";
+    homepage = "https://github.com/allure-framework/allure-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/development/python-modules/allure-python-commons/default.nix
+++ b/pkgs/development/python-modules/allure-python-commons/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, attrs
+, pluggy
+, six
+, allure-python-commons-test
+, setuptools-scm
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "allure-python-commons";
+  version = "2.9.45";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17alymsivw8fs89j6phbqgrbprasw8kj72kxa5y8qpn3xa5d4f62";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [ attrs pluggy six allure-python-commons-test ];
+
+  checkPhase = ''
+    ${python.interpreter} -m doctest ./src/utils.py
+    ${python.interpreter} -m doctest ./src/mapping.py
+  '';
+
+  pythonImportsCheck = [ "allure" "allure_commons" ];
+
+  meta = with lib; {
+    description = "Common engine for all modules. It is useful for make integration with your homemade frameworks";
+    homepage = "https://github.com/allure-framework/allure-python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -435,6 +435,8 @@ in {
 
   allure-python-commons-test = callPackage ../development/python-modules/allure-python-commons-test { };
 
+  allure-pytest = callPackage ../development/python-modules/allure-pytest { };
+
   alot = callPackage ../development/python-modules/alot { };
 
   alpha-vantage = callPackage ../development/python-modules/alpha-vantage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -431,6 +431,8 @@ in {
 
   allpairspy = callPackage ../development/python-modules/allpairspy { };
 
+  allure-python-commons = callPackage ../development/python-modules/allure-python-commons { };
+
   allure-python-commons-test = callPackage ../development/python-modules/allure-python-commons-test { };
 
   alot = callPackage ../development/python-modules/alot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -431,6 +431,8 @@ in {
 
   allpairspy = callPackage ../development/python-modules/allpairspy { };
 
+  allure-python-commons-test = callPackage ../development/python-modules/allure-python-commons-test { };
+
   alot = callPackage ../development/python-modules/alot { };
 
   alpha-vantage = callPackage ../development/python-modules/alpha-vantage { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
## Add `allure-pytest` to nixpkgs
## Add `allure-python-commons` to nixpkgs 
## Add `allure-python-commons-test` to nixpkgs 

###### Notes
~Tests are currently disabled.~
A few integration tests are being skipped.

I am not familiar with how `tox` tests are usually handled, but some lazy grepping shows some packages removing `tox.ini` completely, etc.

See [this issue](https://github.com/allure-framework/allure-python/issues/438) for more information

___
## Allure Python packages
I only added `allure-pytest` and `allure-python-commons`
There is also e.g. `allure-python-commons-test`, `allure-pytest-bdd`, etc.


I have added the packages required to get Allure reporting working for Pytest, and it seems to be collecting valid results, which are rendered nicely on Jenkins using the associated Allure plugin.

![image](https://user-images.githubusercontent.com/1847524/138602419-2d1f101b-51da-4c32-8538-e8c63800b6aa.jpeg)

___

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @addict3d