### PR TITLE
ocamlPackages.ocp-build: fix build

### DIFF
--- a/pkgs/development/tools/ocaml/ocp-build/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-build/default.nix
@@ -4,7 +4,7 @@ let
 in
 stdenv.mkDerivation {
 
-  name = "ocaml${ocaml.version}-ocp-build-${version}-beta";
+  name = "ocaml${ocaml.version}-ocp-build-${version}";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";
@@ -24,9 +24,6 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib cmdliner re ];
   propagatedBuildInputs = [ ncurses ];
   preInstall = "mkdir -p $out/bin";
-  preConfigure = ''
-  export configureFlags="$configureFlags --with-metadir=$OCAMLFIND_DESTDIR"
-  '';
 
   meta = with lib; {
     homepage = "https://www.typerex.org/ocp-build.html";


### PR DESCRIPTION
###### Motivation for this change

Package is broken.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
