### PR TITLE
nixos/vmware-guest: fix headless option

### DIFF
--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -38,7 +38,7 @@ in
       };
 
     # Mount the vmblock for drag-and-drop and copy-and-paste.
-    systemd.mounts = [
+    systemd.mounts = mkIf (!cfg.headless) [
       {
         description = "VMware vmblock fuse mount";
         documentation = [ "https://github.com/vmware/open-vm-tools/blob/master/open-vm-tools/vmblock-fuse/design.txt" ];
@@ -52,8 +52,8 @@ in
       }
     ];
 
-    security.wrappers.vmware-user-suid-wrapper =
-      { setuid = true;
+    security.wrappers.vmware-user-suid-wrapper = mkIf (!cfg.headless) {
+        setuid = true;
         owner = "root";
         group = "root";
         source = "${open-vm-tools}/bin/vmware-user-suid-wrapper";


### PR DESCRIPTION
The headless option broke with 7d8b303e3fd76ccf58cfe26348e889def3663546
because the path `/bin/vmware-user-suid-wrapper` does not exist in the
headless variant of the open-vm-tools package.

Since the vmblock fuse mount and vmware-user-suid-wrapper seem to only
be used for shared folders and drag and drop, they should not exist in
the vmware-guest module if it is configured as headless.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Without this change building a machine with a NixOS config including

```
virtualisation.vmware.guest = {
  enable = true;
  headless = true;
};
```

leads to an error like:

```
error: builder for '/nix/store/i4kx9b1yf38l8bsqm5z6p2s8xng881d0-ensure-all-wrappers-paths-exist.drv' failed with exit code 1;
       last 4 log lines:
       > Checking that Nix store paths of all wrapped programs exist... FAIL
       > The path /nix/store/sszc7nzqh3xkpahcl4r4j3i3067863rg-open-vm-tools-11.3.5/bin/vmware-user-suid-wrapper does not exist!
       > Please, check the value of `security.wrappers."vmware-user-suid-wrapper".source`.
       > 
       For full logs, run 'nix log /nix/store/i4kx9b1yf38l8bsqm5z6p2s8xng881d0-ensure-all-wrappers-paths-exist.drv'.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
