### PR TITLE
linkerd: fix updateScript 5th attempt

### DIFF
--- a/pkgs/applications/networking/cluster/linkerd/update-edge.sh
+++ b/pkgs/applications/networking/cluster/linkerd/update-edge.sh
@@ -5,13 +5,11 @@ set -x -eu -o pipefail
 
 cd $(dirname "$0")
 
-TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} \
+VERSION=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} \
     --silent https://api.github.com/repos/linkerd/linkerd2/releases | \
-    jq 'map(.tag_name)' | grep edge | sed 's/["|,| ]//g' | sort -r | head -n1)
+    jq 'map(.tag_name)' | grep edge | sed 's/["|,| ]//g' | sed 's/edge-//' | sort -V -r | head -n1)
 
-VERSION=$(echo ${TAG} | sed 's/^edge-//')
-
-SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/linkerd/linkerd2/archive/refs/tags/${TAG}.tar.gz)
+SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/linkerd/linkerd2/archive/refs/tags/edge-${VERSION}.tar.gz)
 
 setKV () {
     sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./edge.nix
@@ -19,11 +17,11 @@ setKV () {
 
 setKV version ${VERSION}
 setKV sha256 ${SHA256}
-setKV vendorSha256 "" # Necessary to force clean build.
+setKV vendorSha256 "0000000000000000000000000000000000000000000000000000" # Necessary to force clean build.
 
 cd ../../../../../
 set +e
-VENDOR_SHA256=$(nix-build --no-out-link -A linkerd_edge 2>&1 | grep "got:" | cut -d':' -f2 | sed 's| ||g')
+VENDOR_SHA256=$(nix-build --no-out-link -A linkerd_edge 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
 set -e
 cd - > /dev/null
 


### PR DESCRIPTION
linkerd: fix updateScript 5th attempt

I have high hopes for this fix.

Error logs at:
https://r.ryantm.com/log/updatescript/linkerd_edge/2021-10-20.log

But the solution here is obviously right. It will work. Did I tell you I have high hopes for this fix?