### PR TITLE
electrs/update.sh: ensure tag is checked out

### DIFF
--- a/pkgs/applications/blockchains/electrs/update.sh
+++ b/pkgs/applications/blockchains/electrs/update.sh
@@ -21,6 +21,7 @@ repo=$tmpdir/repo
 trap "rm -rf $tmpdir" EXIT
 
 git clone --depth 1 --branch v${version} -c advice.detachedHead=false https://github.com/romanz/electrs $repo
+git -C $repo checkout tags/v${version}
 
 export GNUPGHOME=$tmpdir
 echo


### PR DESCRIPTION
#### Copy of commit msg
Cloning a tag-named branch introduced a supply chain attack vector, because branch and tag contents might differ.
Now the hashed worktree always corresponds to the tag that is GPG-verified.

#### Discussion
This was spotted by @SuperSandro2000 in https://github.com/NixOS/nixpkgs/pull/142155. Thanks a lot!

I prefer to keep the SRI hash format because the current nix version prints these when manually generating `cargoHash` by evaluating.
Would a tool driven update (like `ryantm/nixpkgs-update`) be able to run `update.sh` and update `cargoSha256` when switching to `base32`?
