### PR TITLE
Various cross improvements

### DIFF
--- a/pkgs/tools/inputmethods/m17n-db/default.nix
+++ b/pkgs/tools/inputmethods/m17n-db/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, gettext }:
+{ lib, stdenv, fetchurl, gettext, gawk, bash }:
 
 stdenv.mkDerivation rec {
   pname = "m17n-db";
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "0vfw7z9i2s9np6nmx1d4dlsywm044rkaqarn7akffmb6bf1j6zv5";
   };
 
-  buildInputs = [ gettext ];
+  nativeBuildInputs = [ gettext ];
+  buildInputs = [ gettext gawk bash ];
+
+  strictDeps = true;
 
   configureFlags = lib.optional (stdenv ? glibc)
     "--with-charmaps=${stdenv.glibc.out}/share/i18n/charmaps"

--- a/pkgs/tools/inputmethods/m17n-lib/default.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, m17n_db}:
+{ lib, stdenv, fetchurl, m17n_db, autoreconfHook, pkg-config }:
 stdenv.mkDerivation rec {
   pname = "m17n-lib";
   version = "1.8.0";
@@ -7,6 +7,11 @@ stdenv.mkDerivation rec {
     url = "https://download.savannah.gnu.org/releases/m17n/m17n-lib-${version}.tar.gz";
     sha256 = "0jp61y09xqj10mclpip48qlfhniw8gwy8b28cbzxy8hq8pkwmfkq";
   };
+
+  strictDeps = true;
+
+  # reconf needed to sucesfully cross-compile
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [ m17n_db ];
 

--- a/pkgs/tools/inputmethods/m17n-lib/otf.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/otf.nix
@@ -35,13 +35,12 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  postInstall =
-    ''
-      mkdir -p $dev/bin
-      mv $out/bin/libotf-config $dev/bin/
-      substituteInPlace $dev/bin/libotf-config \
-        --replace "pkg-config" "${pkg-config}/bin/pkg-config"
-    '';
+  postInstall = ''
+    mkdir -p $dev/bin
+    mv $out/bin/libotf-config $dev/bin/
+    substituteInPlace $dev/bin/libotf-config \
+      --replace "pkg-config" "${pkg-config}/bin/pkg-config"
+  '';
 
   meta = {
     homepage = "https://www.nongnu.org/m17n/";

--- a/pkgs/tools/inputmethods/m17n-lib/otf.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/otf.nix
@@ -1,21 +1,46 @@
-{ lib, stdenv, fetchurl, libXaw, freetype }:
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, autoreconfHook, libXaw, freetype }:
 
 stdenv.mkDerivation rec {
-  name = "libotf-0.9.16";
+  pname = "libotf";
+  version = "0.9.16";
 
   src = fetchurl {
-    url = "https://download.savannah.gnu.org/releases/m17n/${name}.tar.gz";
+    url = "https://download.savannah.gnu.org/releases/m17n/${pname}-${version}.tar.gz";
     sha256 = "0sq6g3xaxw388akws6qrllp3kp2sxgk2dv4j79k6mm52rnihrnv8";
   };
 
-  outputs = [ "out" "dev" ];
+  patches = [
+    # https://salsa.debian.org/debian/libotf/-/tree/master/debian/patches
+    # Fix cross-compilation
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/libotf/-/raw/1be04cedf887720eb8f5efb3594dc2cefd96b1f1/debian/patches/0002-use-pkg-config-not-freetype-config.patch";
+      sha256 = "sha256-VV9iGoNWIEie6UiLLTJBD+zxpvj0acgqkcBeAN1V6Kc=";
+    })
+    # these 2 are required by the above patch
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/libotf/-/raw/1be04cedf887720eb8f5efb3594dc2cefd96b1f1/debian/patches/0001-do-not-add-flags-for-required-packages-to-pc-file.patch";
+      sha256 = "sha256-3kzqNPAHNVJQ1F4fyifq3AqLdChWli/k7wOq+ha+iDs=";
+    })
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/libotf/-/raw/1be04cedf887720eb8f5efb3594dc2cefd96b1f1/debian/patches/0001-libotf-config-modify-to-support-multi-arch.patch";
+      sha256 = "sha256-SUlI87h+MtYWWtrAegzAnSds8JhxZwTJltDcj/se/Qc=";
+    })
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
 
   buildInputs = [ libXaw freetype ];
+
+  outputs = [ "out" "dev" ];
 
   postInstall =
     ''
       mkdir -p $dev/bin
       mv $out/bin/libotf-config $dev/bin/
+      substituteInPlace $dev/bin/libotf-config \
+        --replace "pkg-config" "${pkg-config}/bin/pkg-config"
     '';
 
   meta = {


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).