### PR TITLE
dracula-theme: copy kde theme components to expected locations

### DIFF
--- a/pkgs/data/themes/dracula-theme/default.nix
+++ b/pkgs/data/themes/dracula-theme/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/dracula/gtk";
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ alexarice vonfry ];
+    maintainers = with maintainers; [ alexarice ];
   };
 }

--- a/pkgs/data/themes/dracula-theme/default.nix
+++ b/pkgs/data/themes/dracula-theme/default.nix
@@ -22,7 +22,14 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/themes/${themeName}
-    cp -a {assets,cinnamon,gnome-shell,gtk-2.0,gtk-3.0,gtk-3.20,index.theme,kde,metacity-1,unity,xfwm4} $out/share/themes/${themeName}
+    cp -a {assets,cinnamon,gnome-shell,gtk-2.0,gtk-3.0,gtk-3.20,index.theme,metacity-1,unity,xfwm4} $out/share/themes/${themeName}
+
+    cp -a kde/{color-schemes,plasma} $out/share/
+    cp -a kde/kvantum $out/share/Kvantum
+    mkdir -p $out/share/aurorae/themes
+    cp -a kde/aurorae/* $out/share/aurorae/themes/
+    mkdir -p $out/share/sddm/themes
+    cp -a kde/sddm/* $out/share/sddm/themes/
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Instead of copying the kde/ subdir to $out/share, copy the individual KDE themes to where they're expected. I mainly wanted to put the SDDM theme where the NixOS SDDM module will look for it, so with this package in `environment.systemPackages`, you can set `services.xserver.displayManager.sddm.theme = "Dracula"` and have it work. 

The Kvantum settings are copied to where Kvantum expects them (`$PREFIX/share/Kvantum`), but actually won't work anyway, because Kvantum will only look inside its own $out (see #82769)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
