### PR TITLE
haskellPackages.ghc-vis: Disable library profiling

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -49,6 +49,7 @@ self: super: {
   # These packages (and their reverse deps) cannot be built with profiling enabled.
   ghc-heap-view = disableLibraryProfiling super.ghc-heap-view;
   ghc-datasize = disableLibraryProfiling super.ghc-datasize;
+  ghc-vis = disableLibraryProfiling super.ghc-vis;
 
   # This test keeps being aborted because it runs too quietly for too long
   Lazy-Pbkdf2 = if pkgs.stdenv.isi686 then dontCheck super.Lazy-Pbkdf2 else super.Lazy-Pbkdf2;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1655,7 +1655,6 @@ broken-packages:
   - ghc-tcplugin-api
   - ghc-time-alloc-prof
   - ghc-usage
-  - ghc-vis
   - gh-labeler
   - giak
   - Gifcurry

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -154,6 +154,7 @@ package-maintainers:
     - spago
     - termonad
   dalpd:
+    - ghc-vis
     - svgcairo
   domenkozar:
     - cachix


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`ghc-vis` is currently broken because it doesn't support library profiling, as noted in:
> http://felsin9.de/nnis/ghc-vis/#installation

###### Things done
I disabled library profiling and that seemed to fix the build though there's this caveat I tried to explain in the commit description that I haven't been able to figure out. As far as I understand the problem is caused by the fact that `ghc-vis` is a library but functions as an executable, one that needs `dot` (provided by `graphviz`) at runtime. Including `graphviz` in my shell works around the issue.

Since the said package already is listed as a dependency I think it's somewhat OK but I'd appreciate suggestions on how to make it work out of the box so I can add it in a future PR.

Oh and I took the liberty of adding myself as the maintainer for `ghc-vis` as well. :)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
