### PR TITLE
quicklisp: 2021-08-07 -> 2021-10-21

### DIFF
--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -24,8 +24,8 @@ let lispPackages = rec {
       quicklispdist = pkgs.fetchurl {
         # Will usually be replaced with a fresh version anyway, but needs to be
         # a valid distinfo.txt
-        url = "http://beta.quicklisp.org/dist/quicklisp/2021-08-07/distinfo.txt";
-        sha256 = "sha256:05hby6rbsxk3pisjzr9gqjw0cdk2rq8hc4j544hqf11y6451k37v";
+        url = "http://beta.quicklisp.org/dist/quicklisp/2021-10-21/distinfo.txt";
+        sha256 = "sha256:0ihi3p6fvagzfzkkyzs6b3jrz5yidj4f5dcgnh73qas19mk345ai";
       };
       buildPhase = "true; ";
       postInstall = ''

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ansi-text.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-ansi-text.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-ansi-text";
-  version = "20210124-git";
+  version = "20211020-git";
 
   description = "ANSI control string characters, focused on color";
 
   deps = [ args."alexandria" args."cl-colors2" args."cl-ppcre" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-ansi-text/2021-01-24/cl-ansi-text-20210124-git.tgz";
-    sha256 = "1l7slqk26xznfyn0zpp5l32v6xfpj4qj42h4x4ds5s1yncq306cm";
+    url = "http://beta.quicklisp.org/archive/cl-ansi-text/2021-10-20/cl-ansi-text-20211020-git.tgz";
+    sha256 = "1lmxmdf4sm7apkczp0y07rlsayc5adyv2i85r6p7s60w6sianjr6";
   };
 
   packageName = "cl-ansi-text";
@@ -20,11 +20,11 @@ rec {
 }
 /* (SYSTEM cl-ansi-text DESCRIPTION
     ANSI control string characters, focused on color SHA256
-    1l7slqk26xznfyn0zpp5l32v6xfpj4qj42h4x4ds5s1yncq306cm URL
-    http://beta.quicklisp.org/archive/cl-ansi-text/2021-01-24/cl-ansi-text-20210124-git.tgz
-    MD5 76f54998b056919978737815468e31b6 NAME cl-ansi-text FILENAME
+    1lmxmdf4sm7apkczp0y07rlsayc5adyv2i85r6p7s60w6sianjr6 URL
+    http://beta.quicklisp.org/archive/cl-ansi-text/2021-10-20/cl-ansi-text-20211020-git.tgz
+    MD5 5411766beeb4180218b449454b67837f NAME cl-ansi-text FILENAME
     cl-ansi-text DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME cl-colors2 FILENAME cl-colors2) (NAME cl-ppcre FILENAME cl-ppcre))
-    DEPENDENCIES (alexandria cl-colors2 cl-ppcre) VERSION 20210124-git SIBLINGS
+    DEPENDENCIES (alexandria cl-colors2 cl-ppcre) VERSION 20211020-git SIBLINGS
     (cl-ansi-text.test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-repl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-repl.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-async-repl";
-  version = "cl-async-20210531-git";
+  version = "cl-async-20211020-git";
 
   description = "REPL integration for CL-ASYNC.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-async" args."cl-async-base" args."cl-async-util" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-async/2021-05-31/cl-async-20210531-git.tgz";
-    sha256 = "0hvgxkdvz1hz9ysyajlsnckcypfqka6h5payy3chxbnbvis4kkqw";
+    url = "http://beta.quicklisp.org/archive/cl-async/2021-10-20/cl-async-20211020-git.tgz";
+    sha256 = "1b3bwqvzw2pc83m4x8vbbxyriq58g0j3738mzq68v689zl071dl0";
   };
 
   packageName = "cl-async-repl";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-async-repl DESCRIPTION REPL integration for CL-ASYNC. SHA256
-    0hvgxkdvz1hz9ysyajlsnckcypfqka6h5payy3chxbnbvis4kkqw URL
-    http://beta.quicklisp.org/archive/cl-async/2021-05-31/cl-async-20210531-git.tgz
-    MD5 bf2b1337e09df5ecca329c3e92622376 NAME cl-async-repl FILENAME
+    1b3bwqvzw2pc83m4x8vbbxyriq58g0j3738mzq68v689zl071dl0 URL
+    http://beta.quicklisp.org/archive/cl-async/2021-10-20/cl-async-20211020-git.tgz
+    MD5 0e0cd11758e93a91b39ad726fb1051cc NAME cl-async-repl FILENAME
     cl-async-repl DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -40,5 +40,5 @@ rec {
     (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain cl-async
      cl-async-base cl-async-util cl-libuv cl-ppcre fast-io static-vectors
      trivial-features trivial-gray-streams vom)
-    VERSION cl-async-20210531-git SIBLINGS
+    VERSION cl-async-20211020-git SIBLINGS
     (cl-async-ssl cl-async-test cl-async) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async-ssl.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-async-ssl";
-  version = "cl-async-20210531-git";
+  version = "cl-async-20211020-git";
 
   description = "SSL Wrapper around cl-async socket implementation.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-async" args."cl-async-base" args."cl-async-util" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."vom" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-async/2021-05-31/cl-async-20210531-git.tgz";
-    sha256 = "0hvgxkdvz1hz9ysyajlsnckcypfqka6h5payy3chxbnbvis4kkqw";
+    url = "http://beta.quicklisp.org/archive/cl-async/2021-10-20/cl-async-20211020-git.tgz";
+    sha256 = "1b3bwqvzw2pc83m4x8vbbxyriq58g0j3738mzq68v689zl071dl0";
   };
 
   packageName = "cl-async-ssl";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM cl-async-ssl DESCRIPTION
     SSL Wrapper around cl-async socket implementation. SHA256
-    0hvgxkdvz1hz9ysyajlsnckcypfqka6h5payy3chxbnbvis4kkqw URL
-    http://beta.quicklisp.org/archive/cl-async/2021-05-31/cl-async-20210531-git.tgz
-    MD5 bf2b1337e09df5ecca329c3e92622376 NAME cl-async-ssl FILENAME
+    1b3bwqvzw2pc83m4x8vbbxyriq58g0j3738mzq68v689zl071dl0 URL
+    http://beta.quicklisp.org/archive/cl-async/2021-10-20/cl-async-20211020-git.tgz
+    MD5 0e0cd11758e93a91b39ad726fb1051cc NAME cl-async-ssl FILENAME
     cl-async-ssl DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -41,5 +41,5 @@ rec {
     (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain cl-async
      cl-async-base cl-async-util cl-libuv cl-ppcre fast-io static-vectors
      trivial-features trivial-gray-streams vom)
-    VERSION cl-async-20210531-git SIBLINGS
+    VERSION cl-async-20211020-git SIBLINGS
     (cl-async-repl cl-async-test cl-async) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-async.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-async";
-  version = "20210531-git";
+  version = "20211020-git";
 
   parasites = [ "cl-async-base" "cl-async-util" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-libuv" args."cl-ppcre" args."fast-io" args."static-vectors" args."trivial-features" args."trivial-gray-streams" args."uiop" args."vom" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-async/2021-05-31/cl-async-20210531-git.tgz";
-    sha256 = "0hvgxkdvz1hz9ysyajlsnckcypfqka6h5payy3chxbnbvis4kkqw";
+    url = "http://beta.quicklisp.org/archive/cl-async/2021-10-20/cl-async-20211020-git.tgz";
+    sha256 = "1b3bwqvzw2pc83m4x8vbbxyriq58g0j3738mzq68v689zl071dl0";
   };
 
   packageName = "cl-async";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-async DESCRIPTION Asynchronous operations for Common Lisp. SHA256
-    0hvgxkdvz1hz9ysyajlsnckcypfqka6h5payy3chxbnbvis4kkqw URL
-    http://beta.quicklisp.org/archive/cl-async/2021-05-31/cl-async-20210531-git.tgz
-    MD5 bf2b1337e09df5ecca329c3e92622376 NAME cl-async FILENAME cl-async DEPS
+    1b3bwqvzw2pc83m4x8vbbxyriq58g0j3738mzq68v689zl071dl0 URL
+    http://beta.quicklisp.org/archive/cl-async/2021-10-20/cl-async-20211020-git.tgz
+    MD5 0e0cd11758e93a91b39ad726fb1051cc NAME cl-async FILENAME cl-async DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
@@ -38,5 +38,5 @@ rec {
     (alexandria babel bordeaux-threads cffi cffi-grovel cffi-toolchain cl-libuv
      cl-ppcre fast-io static-vectors trivial-features trivial-gray-streams uiop
      vom)
-    VERSION 20210531-git SIBLINGS (cl-async-repl cl-async-ssl cl-async-test)
+    VERSION 20211020-git SIBLINGS (cl-async-repl cl-async-ssl cl-async-test)
     PARASITES (cl-async-base cl-async-util)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-colors2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-colors2.nix
@@ -2,15 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-colors2";
-  version = "20210630-git";
+  version = "20211020-git";
+
+  parasites = [ "cl-colors2/tests" ];
 
   description = "Simple color library for Common Lisp";
 
-  deps = [ args."alexandria" args."cl-ppcre" ];
+  deps = [ args."alexandria" args."cl-ppcre" args."clunit2" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-colors2/2021-06-30/cl-colors2-20210630-git.tgz";
-    sha256 = "00mb239p4r30fm7b0qwfg1vfyp83h2h87igk3hqqgvadp6infi7g";
+    url = "http://beta.quicklisp.org/archive/cl-colors2/2021-10-20/cl-colors2-20211020-git.tgz";
+    sha256 = "1vkhcyflp173szwnd1xg7hk0h1f3144qzwnsdv6a16rlxjz9h804";
   };
 
   packageName = "cl-colors2";
@@ -19,10 +21,11 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-colors2 DESCRIPTION Simple color library for Common Lisp SHA256
-    00mb239p4r30fm7b0qwfg1vfyp83h2h87igk3hqqgvadp6infi7g URL
-    http://beta.quicklisp.org/archive/cl-colors2/2021-06-30/cl-colors2-20210630-git.tgz
-    MD5 50a5885e2b55239d5904b0a0134e0be3 NAME cl-colors2 FILENAME cl-colors2
+    1vkhcyflp173szwnd1xg7hk0h1f3144qzwnsdv6a16rlxjz9h804 URL
+    http://beta.quicklisp.org/archive/cl-colors2/2021-10-20/cl-colors2-20211020-git.tgz
+    MD5 13fd422daa03328c909d1578d65f6222 NAME cl-colors2 FILENAME cl-colors2
     DEPS
-    ((NAME alexandria FILENAME alexandria) (NAME cl-ppcre FILENAME cl-ppcre))
-    DEPENDENCIES (alexandria cl-ppcre) VERSION 20210630-git SIBLINGS NIL
-    PARASITES NIL) */
+    ((NAME alexandria FILENAME alexandria) (NAME cl-ppcre FILENAME cl-ppcre)
+     (NAME clunit2 FILENAME clunit2))
+    DEPENDENCIES (alexandria cl-ppcre clunit2) VERSION 20211020-git SIBLINGS
+    NIL PARASITES (cl-colors2/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-dbi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-dbi.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-dbi";
-  version = "20210228-git";
+  version = "20211020-git";
 
   description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."closer-mop" args."dbi" args."split-sequence" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
-    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz";
+    sha256 = "1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr";
   };
 
   packageName = "cl-dbi";
@@ -19,13 +19,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-dbi DESCRIPTION System lacks description SHA256
-    0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk URL
-    http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz
-    MD5 7cfb5ad172bc30906ae32ca620099a1f NAME cl-dbi FILENAME cl-dbi DEPS
+    1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr URL
+    http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz
+    MD5 565a1f32b2d924ad59876afcdc5cf263 NAME cl-dbi FILENAME cl-dbi DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME closer-mop FILENAME closer-mop) (NAME dbi FILENAME dbi)
      (NAME split-sequence FILENAME split-sequence))
     DEPENDENCIES (alexandria bordeaux-threads closer-mop dbi split-sequence)
-    VERSION 20210228-git SIBLINGS
+    VERSION 20211020-git SIBLINGS
     (dbd-mysql dbd-postgres dbd-sqlite3 dbi-test dbi) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-digraph.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-digraph.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-digraph";
-  version = "20210411-hg";
+  version = "20211020-hg";
 
   description = "Simple directed graphs for Common Lisp.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-digraph/2021-04-11/cl-digraph-20210411-hg.tgz";
-    sha256 = "1g9l3dzw4ykvprl3id7xv4brpzz86jk70z4wfw5lkq8vpxv397fi";
+    url = "http://beta.quicklisp.org/archive/cl-digraph/2021-10-20/cl-digraph-20211020-hg.tgz";
+    sha256 = "0iqzqy322xywmal7y7vhn1myhdglr78fj89maiwfx6yjppcyd1i1";
   };
 
   packageName = "cl-digraph";
@@ -19,8 +19,8 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-digraph DESCRIPTION Simple directed graphs for Common Lisp.
-    SHA256 1g9l3dzw4ykvprl3id7xv4brpzz86jk70z4wfw5lkq8vpxv397fi URL
-    http://beta.quicklisp.org/archive/cl-digraph/2021-04-11/cl-digraph-20210411-hg.tgz
-    MD5 c7c947fb7471213b24505bff1e9287de NAME cl-digraph FILENAME cl-digraph
-    DEPS NIL DEPENDENCIES NIL VERSION 20210411-hg SIBLINGS
+    SHA256 0iqzqy322xywmal7y7vhn1myhdglr78fj89maiwfx6yjppcyd1i1 URL
+    http://beta.quicklisp.org/archive/cl-digraph/2021-10-20/cl-digraph-20211020-hg.tgz
+    MD5 737c3640b4b079ce0ee730525aa8b6de NAME cl-digraph FILENAME cl-digraph
+    DEPS NIL DEPENDENCIES NIL VERSION 20211020-hg SIBLINGS
     (cl-digraph.dot cl-digraph.test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-environments.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-environments.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-environments";
-  version = "20210807-git";
+  version = "20211020-git";
 
   parasites = [ "cl-environments/test" ];
 
@@ -13,8 +13,8 @@ rec {
   deps = [ args."alexandria" args."anaphora" args."closer-mop" args."collectors" args."fiveam" args."iterate" args."optima" args."parse-declarations-1_dot_0" args."symbol-munger" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-environments/2021-08-07/cl-environments-20210807-git.tgz";
-    sha256 = "1i544zz9v49b0mdv96sr17ivnz4s84lgw4vypq9v9w6cmhz5v8am";
+    url = "http://beta.quicklisp.org/archive/cl-environments/2021-10-20/cl-environments-20211020-git.tgz";
+    sha256 = "0aryb40nmmw34xl6h0fp8i43d2x7zlwysim365c171mcyxh3w9lr";
   };
 
   packageName = "cl-environments";
@@ -26,9 +26,9 @@ rec {
     Implements the CLTL2 environment access functionality
                 for implementations which do not provide the
                 functionality to the programmer.
-    SHA256 1i544zz9v49b0mdv96sr17ivnz4s84lgw4vypq9v9w6cmhz5v8am URL
-    http://beta.quicklisp.org/archive/cl-environments/2021-08-07/cl-environments-20210807-git.tgz
-    MD5 6884f21f315c5082fd6db7233497497d NAME cl-environments FILENAME
+    SHA256 0aryb40nmmw34xl6h0fp8i43d2x7zlwysim365c171mcyxh3w9lr URL
+    http://beta.quicklisp.org/archive/cl-environments/2021-10-20/cl-environments-20211020-git.tgz
+    MD5 a796decf21a5b595ff591ffca378994a NAME cl-environments FILENAME
     cl-environments DEPS
     ((NAME alexandria FILENAME alexandria) (NAME anaphora FILENAME anaphora)
      (NAME closer-mop FILENAME closer-mop)
@@ -39,4 +39,4 @@ rec {
     DEPENDENCIES
     (alexandria anaphora closer-mop collectors fiveam iterate optima
      parse-declarations-1.0 symbol-munger)
-    VERSION 20210807-git SIBLINGS NIL PARASITES (cl-environments/test)) */
+    VERSION 20211020-git SIBLINGS NIL PARASITES (cl-environments/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-form-types.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-form-types.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-form-types";
-  version = "20210807-git";
+  version = "20211020-git";
 
   parasites = [ "cl-form-types/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."closer-mop" args."collectors" args."fiveam" args."introspect-environment" args."iterate" args."optima" args."parse-declarations-1_dot_0" args."symbol-munger" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-form-types/2021-08-07/cl-form-types-20210807-git.tgz";
-    sha256 = "1hv78ygnzf67f8ww22bmc2nx2gmw3lg7qc3navmd541jivx6v0lp";
+    url = "http://beta.quicklisp.org/archive/cl-form-types/2021-10-20/cl-form-types-20211020-git.tgz";
+    sha256 = "1f5wni1jrd5jbra2z2smw4vdw4k3bkbas8n676y3g3yv10lhddg8";
   };
 
   packageName = "cl-form-types";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM cl-form-types DESCRIPTION
     Library for determining types of Common Lisp forms. SHA256
-    1hv78ygnzf67f8ww22bmc2nx2gmw3lg7qc3navmd541jivx6v0lp URL
-    http://beta.quicklisp.org/archive/cl-form-types/2021-08-07/cl-form-types-20210807-git.tgz
-    MD5 1b1415794a4e9cd6716ee3b5eb0f658a NAME cl-form-types FILENAME
+    1f5wni1jrd5jbra2z2smw4vdw4k3bkbas8n676y3g3yv10lhddg8 URL
+    http://beta.quicklisp.org/archive/cl-form-types/2021-10-20/cl-form-types-20211020-git.tgz
+    MD5 53e67d9fd55ac6a382635b119aeb5431 NAME cl-form-types FILENAME
     cl-form-types DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -39,4 +39,4 @@ rec {
     (agutil alexandria anaphora arrows cl-environments closer-mop collectors
      fiveam introspect-environment iterate optima parse-declarations-1.0
      symbol-munger)
-    VERSION 20210807-git SIBLINGS NIL PARASITES (cl-form-types/test)) */
+    VERSION 20211020-git SIBLINGS NIL PARASITES (cl-form-types/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-pdf";
-  version = "20210531-git";
+  version = "20211020-git";
 
   description = "Common Lisp PDF Generation Library";
 
   deps = [ args."iterate" args."uiop" args."zpb-ttf" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-pdf/2021-05-31/cl-pdf-20210531-git.tgz";
-    sha256 = "0f5flqci615ck0ncq4f7x67x31m9715750r0wg3gx6qrdpi0k1cx";
+    url = "http://beta.quicklisp.org/archive/cl-pdf/2021-10-20/cl-pdf-20211020-git.tgz";
+    sha256 = "0wyh7iv86sqzdn5xj5crrip8iri5a64qzc6cczgbj1gkv65i28bk";
   };
 
   packageName = "cl-pdf";
@@ -19,10 +19,10 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-pdf DESCRIPTION Common Lisp PDF Generation Library SHA256
-    0f5flqci615ck0ncq4f7x67x31m9715750r0wg3gx6qrdpi0k1cx URL
-    http://beta.quicklisp.org/archive/cl-pdf/2021-05-31/cl-pdf-20210531-git.tgz
-    MD5 675d3498976f4cb118dc72fa71829f5c NAME cl-pdf FILENAME cl-pdf DEPS
+    0wyh7iv86sqzdn5xj5crrip8iri5a64qzc6cczgbj1gkv65i28bk URL
+    http://beta.quicklisp.org/archive/cl-pdf/2021-10-20/cl-pdf-20211020-git.tgz
+    MD5 c8a9cfd5d65eae217bd55d786d31dca9 NAME cl-pdf FILENAME cl-pdf DEPS
     ((NAME iterate FILENAME iterate) (NAME uiop FILENAME uiop)
      (NAME zpb-ttf FILENAME zpb-ttf))
-    DEPENDENCIES (iterate uiop zpb-ttf) VERSION 20210531-git SIBLINGS
+    DEPENDENCIES (iterate uiop zpb-ttf) VERSION 20211020-git SIBLINGS
     (cl-pdf-parser) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-postgres.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-postgres";
-  version = "postmodern-20210807-git";
+  version = "postmodern-20211020-git";
 
   parasites = [ "cl-postgres/simple-date-tests" "cl-postgres/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-ppcre" args."fiveam" args."ironclad" args."md5" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-08-07/postmodern-20210807-git.tgz";
-    sha256 = "01l0zk5f3z1cxb6rspvagjl1fy8v3jwm62p2975cgl45aspp18fp";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz";
+    sha256 = "0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6";
   };
 
   packageName = "cl-postgres";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-postgres DESCRIPTION Low-level client library for PostgreSQL
-    SHA256 01l0zk5f3z1cxb6rspvagjl1fy8v3jwm62p2975cgl45aspp18fp URL
-    http://beta.quicklisp.org/archive/postmodern/2021-08-07/postmodern-20210807-git.tgz
-    MD5 aa951f2ad4ce59fce588a62afa34f3ec NAME cl-postgres FILENAME cl-postgres
+    SHA256 0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6 URL
+    http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz
+    MD5 84f4ad8ce7ac0f7f78cbfcf2f0bd3aa4 NAME cl-postgres FILENAME cl-postgres
     DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -37,5 +37,5 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads cl-base64 cl-ppcre fiveam ironclad md5
      simple-date simple-date/postgres-glue split-sequence uax-15 uiop usocket)
-    VERSION postmodern-20210807-git SIBLINGS (postmodern s-sql simple-date)
+    VERSION postmodern-20211020-git SIBLINGS (postmodern s-sql simple-date)
     PARASITES (cl-postgres/simple-date-tests cl-postgres/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-smt-lib.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-smt-lib.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-smt-lib";
-  version = "20210630-git";
+  version = "20211020-git";
 
   description = "SMT object supporting SMT-LIB communication over input and output streams";
 
   deps = [ args."asdf-package-system" args."named-readtables" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-smt-lib/2021-06-30/cl-smt-lib-20210630-git.tgz";
-    sha256 = "0vrqzp6im2nvq6yfv4ysq4zv3m80v33apggzqq8r8j1zvbjjzrvm";
+    url = "http://beta.quicklisp.org/archive/cl-smt-lib/2021-10-20/cl-smt-lib-20211020-git.tgz";
+    sha256 = "1x2d79xcc0c56cb02axly6c10y6dmvxcpr3f16qry02rpfqys3qm";
   };
 
   packageName = "cl-smt-lib";
@@ -20,12 +20,12 @@ rec {
 }
 /* (SYSTEM cl-smt-lib DESCRIPTION
     SMT object supporting SMT-LIB communication over input and output streams
-    SHA256 0vrqzp6im2nvq6yfv4ysq4zv3m80v33apggzqq8r8j1zvbjjzrvm URL
-    http://beta.quicklisp.org/archive/cl-smt-lib/2021-06-30/cl-smt-lib-20210630-git.tgz
-    MD5 a10f913b43ba0ca99ee87a66e2f508ac NAME cl-smt-lib FILENAME cl-smt-lib
+    SHA256 1x2d79xcc0c56cb02axly6c10y6dmvxcpr3f16qry02rpfqys3qm URL
+    http://beta.quicklisp.org/archive/cl-smt-lib/2021-10-20/cl-smt-lib-20211020-git.tgz
+    MD5 f22b48a87b78fb5b38b35d780d34cd77 NAME cl-smt-lib FILENAME cl-smt-lib
     DEPS
     ((NAME asdf-package-system FILENAME asdf-package-system)
      (NAME named-readtables FILENAME named-readtables)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams))
     DEPENDENCIES (asdf-package-system named-readtables trivial-gray-streams)
-    VERSION 20210630-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-webkit2.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl-webkit2";
-  version = "cl-webkit-20210807-git";
+  version = "cl-webkit-20211020-git";
 
   description = "An FFI binding to WebKit2GTK+";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-cffi-gtk" args."cl-cffi-gtk-cairo" args."cl-cffi-gtk-gdk" args."cl-cffi-gtk-gdk-pixbuf" args."cl-cffi-gtk-gio" args."cl-cffi-gtk-glib" args."cl-cffi-gtk-gobject" args."cl-cffi-gtk-pango" args."closer-mop" args."iterate" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-webkit/2021-08-07/cl-webkit-20210807-git.tgz";
-    sha256 = "12n2zjl8kpji5b24jj1jhnlw16ylkxw4czc1dynx3ligj17qf1an";
+    url = "http://beta.quicklisp.org/archive/cl-webkit/2021-10-20/cl-webkit-20211020-git.tgz";
+    sha256 = "0kx9mjk8zgzkm60g0469mp53mj2jzxdb2baqr7sj0rkijc609821";
   };
 
   packageName = "cl-webkit2";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl-webkit2 DESCRIPTION An FFI binding to WebKit2GTK+ SHA256
-    12n2zjl8kpji5b24jj1jhnlw16ylkxw4czc1dynx3ligj17qf1an URL
-    http://beta.quicklisp.org/archive/cl-webkit/2021-08-07/cl-webkit-20210807-git.tgz
-    MD5 25b73593e97d7c075cb791a896e5b1d1 NAME cl-webkit2 FILENAME cl-webkit2
+    0kx9mjk8zgzkm60g0469mp53mj2jzxdb2baqr7sj0rkijc609821 URL
+    http://beta.quicklisp.org/archive/cl-webkit/2021-10-20/cl-webkit-20211020-git.tgz
+    MD5 fc73d56d8289729e93dd8c4793ea82e4 NAME cl-webkit2 FILENAME cl-webkit2
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -41,4 +41,4 @@ rec {
      cl-cffi-gtk-gdk cl-cffi-gtk-gdk-pixbuf cl-cffi-gtk-gio cl-cffi-gtk-glib
      cl-cffi-gtk-gobject cl-cffi-gtk-pango closer-mop iterate trivial-features
      trivial-garbage)
-    VERSION cl-webkit-20210807-git SIBLINGS NIL PARASITES NIL) */
+    VERSION cl-webkit-20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl_plus_ssl.nix
@@ -2,15 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "cl_plus_ssl";
-  version = "cl+ssl-20210807-git";
+  version = "cl+ssl-20211020-git";
+
+  parasites = [ "cl+ssl/config" ];
 
   description = "Common Lisp interface to OpenSSL.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."flexi-streams" args."split-sequence" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl+ssl/2021-08-07/cl+ssl-20210807-git.tgz";
-    sha256 = "04kk392r7w5xq414vaf3wnkrlhczdn863x3jj3vmrp7ppr9cwy57";
+    url = "http://beta.quicklisp.org/archive/cl+ssl/2021-10-20/cl+ssl-20211020-git.tgz";
+    sha256 = "05yzc736lnsaniv76753flsbzvip0sma4jy3fl124r704gknsvsl";
   };
 
   packageName = "cl+ssl";
@@ -19,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM cl+ssl DESCRIPTION Common Lisp interface to OpenSSL. SHA256
-    04kk392r7w5xq414vaf3wnkrlhczdn863x3jj3vmrp7ppr9cwy57 URL
-    http://beta.quicklisp.org/archive/cl+ssl/2021-08-07/cl+ssl-20210807-git.tgz
-    MD5 d2267b96fcd5ee4ad2f9fc11a7a3f0b2 NAME cl+ssl FILENAME cl_plus_ssl DEPS
+    05yzc736lnsaniv76753flsbzvip0sma4jy3fl124r704gknsvsl URL
+    http://beta.quicklisp.org/archive/cl+ssl/2021-10-20/cl+ssl-20211020-git.tgz
+    MD5 2122250563c6454ba1abdd36e9432f0c NAME cl+ssl FILENAME cl_plus_ssl DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME flexi-streams FILENAME flexi-streams)
@@ -33,4 +35,5 @@ rec {
     DEPENDENCIES
     (alexandria babel bordeaux-threads cffi flexi-streams split-sequence
      trivial-features trivial-garbage trivial-gray-streams uiop usocket)
-    VERSION cl+ssl-20210807-git SIBLINGS (cl+ssl.test) PARASITES NIL) */
+    VERSION cl+ssl-20211020-git SIBLINGS (cl+ssl.test) PARASITES
+    (cl+ssl/config)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/closer-mop.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "closer-mop";
-  version = "20210807-git";
+  version = "20211020-git";
 
   description = "Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/closer-mop/2021-08-07/closer-mop-20210807-git.tgz";
-    sha256 = "1b3h6fw4wh11brmvi9p0j50zynbp7bgbhshcbngmd0ffdpinkh15";
+    url = "http://beta.quicklisp.org/archive/closer-mop/2021-10-20/closer-mop-20211020-git.tgz";
+    sha256 = "1m5ri5br262li2w4qljbplrgk6pm1w5vil5qa71bc1h7fbl0qh07";
   };
 
   packageName = "closer-mop";
@@ -20,7 +20,7 @@ rec {
 }
 /* (SYSTEM closer-mop DESCRIPTION
     Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features across a broad range of Common Lisp implementations.
-    SHA256 1b3h6fw4wh11brmvi9p0j50zynbp7bgbhshcbngmd0ffdpinkh15 URL
-    http://beta.quicklisp.org/archive/closer-mop/2021-08-07/closer-mop-20210807-git.tgz
-    MD5 02b29c503d823ca9701b231c23bbd3cd NAME closer-mop FILENAME closer-mop
-    DEPS NIL DEPENDENCIES NIL VERSION 20210807-git SIBLINGS NIL PARASITES NIL) */
+    SHA256 1m5ri5br262li2w4qljbplrgk6pm1w5vil5qa71bc1h7fbl0qh07 URL
+    http://beta.quicklisp.org/archive/closer-mop/2021-10-20/closer-mop-20211020-git.tgz
+    MD5 09606b3803a2b3d727fb94cc59313bd8 NAME closer-mop FILENAME closer-mop
+    DEPS NIL DEPENDENCIES NIL VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clunit2.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clunit2";
-  version = "20210630-git";
+  version = "20211020-git";
 
   description = "CLUnit is a Common Lisp unit testing framework.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clunit2/2021-06-30/clunit2-20210630-git.tgz";
-    sha256 = "0vrjgf8rcdhvap9fvq4k543276ybjs5jqxj6zxbhrkfw2p26s445";
+    url = "http://beta.quicklisp.org/archive/clunit2/2021-10-20/clunit2-20211020-git.tgz";
+    sha256 = "0qly5gk1fn0bd0kx6spdhmnsf58gdg19py46w10p5vvs41vvriy3";
   };
 
   packageName = "clunit2";
@@ -19,7 +19,7 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM clunit2 DESCRIPTION CLUnit is a Common Lisp unit testing framework.
-    SHA256 0vrjgf8rcdhvap9fvq4k543276ybjs5jqxj6zxbhrkfw2p26s445 URL
-    http://beta.quicklisp.org/archive/clunit2/2021-06-30/clunit2-20210630-git.tgz
-    MD5 d76550549dec0dca9207970919a8b952 NAME clunit2 FILENAME clunit2 DEPS NIL
-    DEPENDENCIES NIL VERSION 20210630-git SIBLINGS NIL PARASITES NIL) */
+    SHA256 0qly5gk1fn0bd0kx6spdhmnsf58gdg19py46w10p5vvs41vvriy3 URL
+    http://beta.quicklisp.org/archive/clunit2/2021-10-20/clunit2-20211020-git.tgz
+    MD5 0ee5b2d53c81e9640d3aa8c904b0b236 NAME clunit2 FILENAME clunit2 DEPS NIL
+    DEPENDENCIES NIL VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clx.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clx.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "clx";
-  version = "20210630-git";
+  version = "20211020-git";
 
   parasites = [ "clx/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."fiasco" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/clx/2021-06-30/clx-20210630-git.tgz";
-    sha256 = "0pr4majs7d6d14p52zapn5knvf7hhwm6s8abkn3xbfxgzi9np556";
+    url = "http://beta.quicklisp.org/archive/clx/2021-10-20/clx-20211020-git.tgz";
+    sha256 = "1mgqcqakbm8s4w2r9831xzhy9lyifcl2b3rhl5p76s5vpnjmp88k";
   };
 
   packageName = "clx";
@@ -22,8 +22,8 @@ rec {
 }
 /* (SYSTEM clx DESCRIPTION
     An implementation of the X Window System protocol in Lisp. SHA256
-    0pr4majs7d6d14p52zapn5knvf7hhwm6s8abkn3xbfxgzi9np556 URL
-    http://beta.quicklisp.org/archive/clx/2021-06-30/clx-20210630-git.tgz MD5
-    095657b0f48ff5602525faa2d4ff7a3e NAME clx FILENAME clx DEPS
-    ((NAME fiasco FILENAME fiasco)) DEPENDENCIES (fiasco) VERSION 20210630-git
+    1mgqcqakbm8s4w2r9831xzhy9lyifcl2b3rhl5p76s5vpnjmp88k URL
+    http://beta.quicklisp.org/archive/clx/2021-10-20/clx-20211020-git.tgz MD5
+    ac10db96a6426cf462f8d417a7797621 NAME clx FILENAME clx DEPS
+    ((NAME fiasco FILENAME fiasco)) DEPENDENCIES (fiasco) VERSION 20211020-git
     SIBLINGS NIL PARASITES (clx/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-mysql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-mysql.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "dbd-mysql";
-  version = "cl-dbi-20210228-git";
+  version = "cl-dbi-20211020-git";
 
   description = "Database driver for MySQL.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."cl-mysql" args."closer-mop" args."dbi" args."split-sequence" args."trivial-features" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
-    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz";
+    sha256 = "1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr";
   };
 
   packageName = "dbd-mysql";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbd-mysql DESCRIPTION Database driver for MySQL. SHA256
-    0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk URL
-    http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz
-    MD5 7cfb5ad172bc30906ae32ca620099a1f NAME dbd-mysql FILENAME dbd-mysql DEPS
+    1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr URL
+    http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz
+    MD5 565a1f32b2d924ad59876afcdc5cf263 NAME dbd-mysql FILENAME dbd-mysql DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cffi FILENAME cffi) (NAME cl-mysql FILENAME cl-mysql)
@@ -31,5 +31,5 @@ rec {
     DEPENDENCIES
     (alexandria babel bordeaux-threads cffi cl-mysql closer-mop dbi
      split-sequence trivial-features)
-    VERSION cl-dbi-20210228-git SIBLINGS
+    VERSION cl-dbi-20211020-git SIBLINGS
     (cl-dbi dbd-postgres dbd-sqlite3 dbi-test dbi) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-postgres.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-postgres.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "dbd-postgres";
-  version = "cl-dbi-20210228-git";
+  version = "cl-dbi-20211020-git";
 
   description = "Database driver for PostgreSQL.";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-ppcre" args."closer-mop" args."dbi" args."ironclad" args."md5" args."split-sequence" args."trivial-garbage" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
-    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz";
+    sha256 = "1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr";
   };
 
   packageName = "dbd-postgres";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbd-postgres DESCRIPTION Database driver for PostgreSQL. SHA256
-    0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk URL
-    http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz
-    MD5 7cfb5ad172bc30906ae32ca620099a1f NAME dbd-postgres FILENAME
+    1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr URL
+    http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz
+    MD5 565a1f32b2d924ad59876afcdc5cf263 NAME dbd-postgres FILENAME
     dbd-postgres DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -35,5 +35,5 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads cl-base64 cl-postgres cl-ppcre closer-mop dbi
      ironclad md5 split-sequence trivial-garbage uax-15 usocket)
-    VERSION cl-dbi-20210228-git SIBLINGS
+    VERSION cl-dbi-20211020-git SIBLINGS
     (cl-dbi dbd-mysql dbd-sqlite3 dbi-test dbi) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-sqlite3.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbd-sqlite3.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "dbd-sqlite3";
-  version = "cl-dbi-20210228-git";
+  version = "cl-dbi-20211020-git";
 
   description = "Database driver for SQLite3.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."cffi" args."closer-mop" args."dbi" args."iterate" args."split-sequence" args."sqlite" args."trivial-features" args."trivial-garbage" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
-    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz";
+    sha256 = "1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr";
   };
 
   packageName = "dbd-sqlite3";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbd-sqlite3 DESCRIPTION Database driver for SQLite3. SHA256
-    0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk URL
-    http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz
-    MD5 7cfb5ad172bc30906ae32ca620099a1f NAME dbd-sqlite3 FILENAME dbd-sqlite3
+    1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr URL
+    http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz
+    MD5 565a1f32b2d924ad59876afcdc5cf263 NAME dbd-sqlite3 FILENAME dbd-sqlite3
     DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -34,5 +34,5 @@ rec {
     DEPENDENCIES
     (alexandria babel bordeaux-threads cffi closer-mop dbi iterate
      split-sequence sqlite trivial-features trivial-garbage)
-    VERSION cl-dbi-20210228-git SIBLINGS
+    VERSION cl-dbi-20211020-git SIBLINGS
     (cl-dbi dbd-mysql dbd-postgres dbi-test dbi) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi-test.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi-test.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "dbi-test";
-  version = "cl-dbi-20210228-git";
+  version = "cl-dbi-20211020-git";
 
   description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."closer-mop" args."dbi" args."dissect" args."rove" args."split-sequence" args."trivial-gray-streams" args."trivial-types" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
-    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz";
+    sha256 = "1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr";
   };
 
   packageName = "dbi-test";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbi-test DESCRIPTION System lacks description SHA256
-    0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk URL
-    http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz
-    MD5 7cfb5ad172bc30906ae32ca620099a1f NAME dbi-test FILENAME dbi-test DEPS
+    1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr URL
+    http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz
+    MD5 565a1f32b2d924ad59876afcdc5cf263 NAME dbi-test FILENAME dbi-test DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME closer-mop FILENAME closer-mop) (NAME dbi FILENAME dbi)
@@ -32,5 +32,5 @@ rec {
     DEPENDENCIES
     (alexandria bordeaux-threads closer-mop dbi dissect rove split-sequence
      trivial-gray-streams trivial-types)
-    VERSION cl-dbi-20210228-git SIBLINGS
+    VERSION cl-dbi-20211020-git SIBLINGS
     (cl-dbi dbd-mysql dbd-postgres dbd-sqlite3 dbi) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbi.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "dbi";
-  version = "cl-20210228-git";
+  version = "cl-20211020-git";
 
   parasites = [ "dbi/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."cl-mysql" args."cl-postgres" args."closer-mop" args."dbd-mysql" args."dbd-postgres" args."dbd-sqlite3" args."dbi-test" args."rove" args."split-sequence" args."sqlite" args."trivial-garbage" args."trivial-types" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz";
-    sha256 = "0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk";
+    url = "http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz";
+    sha256 = "1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr";
   };
 
   packageName = "dbi";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbi DESCRIPTION Database independent interface for Common Lisp
-    SHA256 0yfs7k6samv6q0n1bvscvcck7qg3c4g03qn7i81619q7g2f98jdk URL
-    http://beta.quicklisp.org/archive/cl-dbi/2021-02-28/cl-dbi-20210228-git.tgz
-    MD5 7cfb5ad172bc30906ae32ca620099a1f NAME dbi FILENAME dbi DEPS
+    SHA256 1khvf4b2pa9wv8blcwb77byi5nyb8g8bnaq4ml20g674iwgvvvmr URL
+    http://beta.quicklisp.org/archive/cl-dbi/2021-10-20/cl-dbi-20211020-git.tgz
+    MD5 565a1f32b2d924ad59876afcdc5cf263 NAME dbi FILENAME dbi DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-mysql FILENAME cl-mysql) (NAME cl-postgres FILENAME cl-postgres)
@@ -38,5 +38,5 @@ rec {
     (alexandria bordeaux-threads cl-mysql cl-postgres closer-mop dbd-mysql
      dbd-postgres dbd-sqlite3 dbi-test rove split-sequence sqlite
      trivial-garbage trivial-types)
-    VERSION cl-20210228-git SIBLINGS
+    VERSION cl-20211020-git SIBLINGS
     (cl-dbi dbd-mysql dbd-postgres dbd-sqlite3 dbi-test) PARASITES (dbi/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbus.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/dbus.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "dbus";
-  version = "20200610-git";
+  version = "20211020-git";
 
   description = "A D-BUS client library for Common Lisp";
 
-  deps = [ args."alexandria" args."asdf-package-system" args."babel" args."cl-xmlspam" args."flexi-streams" args."ieee-floats" args."iolib" args."ironclad" args."trivial-garbage" ];
+  deps = [ args."alexandria" args."asdf-package-system" args."babel" args."bordeaux-threads" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."cl-ppcre" args."cl-xmlspam" args."closure-common" args."cxml" args."flexi-streams" args."idna" args."ieee-floats" args."iolib" args."iolib_dot_asdf" args."iolib_dot_base" args."iolib_dot_common-lisp" args."iolib_dot_conf" args."ironclad" args."puri" args."split-sequence" args."swap-bytes" args."trivial-features" args."trivial-garbage" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/dbus/2020-06-10/dbus-20200610-git.tgz";
-    sha256 = "1njwjf1z9xngsfmlddmbcan49vcjqvvxfkhbi62xcxwbn9rgqn79";
+    url = "http://beta.quicklisp.org/archive/dbus/2021-10-20/dbus-20211020-git.tgz";
+    sha256 = "1h0qa609qplq3grjf3n31h1bcdj154ww2dn29mjxlkm76n5asz14";
   };
 
   packageName = "dbus";
@@ -19,17 +19,33 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM dbus DESCRIPTION A D-BUS client library for Common Lisp SHA256
-    1njwjf1z9xngsfmlddmbcan49vcjqvvxfkhbi62xcxwbn9rgqn79 URL
-    http://beta.quicklisp.org/archive/dbus/2020-06-10/dbus-20200610-git.tgz MD5
-    421fb481812b2da62fa5ee424f607b12 NAME dbus FILENAME dbus DEPS
+    1h0qa609qplq3grjf3n31h1bcdj154ww2dn29mjxlkm76n5asz14 URL
+    http://beta.quicklisp.org/archive/dbus/2021-10-20/dbus-20211020-git.tgz MD5
+    f3fb2ad37c197d99d9c446f556a12bdb NAME dbus FILENAME dbus DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME asdf-package-system FILENAME asdf-package-system)
-     (NAME babel FILENAME babel) (NAME cl-xmlspam FILENAME cl-xmlspam)
-     (NAME flexi-streams FILENAME flexi-streams)
+     (NAME babel FILENAME babel)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
+     (NAME cffi-toolchain FILENAME cffi-toolchain)
+     (NAME cl-ppcre FILENAME cl-ppcre) (NAME cl-xmlspam FILENAME cl-xmlspam)
+     (NAME closure-common FILENAME closure-common) (NAME cxml FILENAME cxml)
+     (NAME flexi-streams FILENAME flexi-streams) (NAME idna FILENAME idna)
      (NAME ieee-floats FILENAME ieee-floats) (NAME iolib FILENAME iolib)
-     (NAME ironclad FILENAME ironclad)
-     (NAME trivial-garbage FILENAME trivial-garbage))
+     (NAME iolib.asdf FILENAME iolib_dot_asdf)
+     (NAME iolib.base FILENAME iolib_dot_base)
+     (NAME iolib.common-lisp FILENAME iolib_dot_common-lisp)
+     (NAME iolib.conf FILENAME iolib_dot_conf)
+     (NAME ironclad FILENAME ironclad) (NAME puri FILENAME puri)
+     (NAME split-sequence FILENAME split-sequence)
+     (NAME swap-bytes FILENAME swap-bytes)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-garbage FILENAME trivial-garbage)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams))
     DEPENDENCIES
-    (alexandria asdf-package-system babel cl-xmlspam flexi-streams ieee-floats
-     iolib ironclad trivial-garbage)
-    VERSION 20200610-git SIBLINGS NIL PARASITES NIL) */
+    (alexandria asdf-package-system babel bordeaux-threads cffi cffi-grovel
+     cffi-toolchain cl-ppcre cl-xmlspam closure-common cxml flexi-streams idna
+     ieee-floats iolib iolib.asdf iolib.base iolib.common-lisp iolib.conf
+     ironclad puri split-sequence swap-bytes trivial-features trivial-garbage
+     trivial-gray-streams)
+    VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/djula.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "djula";
-  version = "20210630-git";
+  version = "20211020-git";
 
   description = "An implementation of Django templates for Common Lisp.";
 
   deps = [ args."access" args."alexandria" args."anaphora" args."arnesi" args."babel" args."cl-annot" args."cl-interpol" args."cl-locale" args."cl-ppcre" args."cl-slice" args."cl-syntax" args."cl-syntax-annot" args."cl-unicode" args."closer-mop" args."collectors" args."flexi-streams" args."gettext" args."iterate" args."let-plus" args."local-time" args."named-readtables" args."parser-combinators" args."split-sequence" args."symbol-munger" args."trivial-backtrace" args."trivial-features" args."trivial-gray-streams" args."trivial-types" args."yacc" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/djula/2021-06-30/djula-20210630-git.tgz";
-    sha256 = "083psy8x9ni2d5pzmz46pcp0z3kysr8wbnankd656p4ilvajcgbj";
+    url = "http://beta.quicklisp.org/archive/djula/2021-10-20/djula-20211020-git.tgz";
+    sha256 = "1izz1bl5yjcfx7hldj2scdwwr6fybxrw2h4wwkpkwisadh42b648";
   };
 
   packageName = "djula";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM djula DESCRIPTION
     An implementation of Django templates for Common Lisp. SHA256
-    083psy8x9ni2d5pzmz46pcp0z3kysr8wbnankd656p4ilvajcgbj URL
-    http://beta.quicklisp.org/archive/djula/2021-06-30/djula-20210630-git.tgz
-    MD5 ec46616b626ece388bba77671d2aa321 NAME djula FILENAME djula DEPS
+    1izz1bl5yjcfx7hldj2scdwwr6fybxrw2h4wwkpkwisadh42b648 URL
+    http://beta.quicklisp.org/archive/djula/2021-10-20/djula-20211020-git.tgz
+    MD5 0b6464f786f65c14d71499fc0114733d NAME djula FILENAME djula DEPS
     ((NAME access FILENAME access) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arnesi FILENAME arnesi)
      (NAME babel FILENAME babel) (NAME cl-annot FILENAME cl-annot)
@@ -51,4 +51,4 @@ rec {
      named-readtables parser-combinators split-sequence symbol-munger
      trivial-backtrace trivial-features trivial-gray-streams trivial-types
      yacc)
-    VERSION 20210630-git SIBLINGS (djula-demo djula-test) PARASITES NIL) */
+    VERSION 20211020-git SIBLINGS (djula-demo djula-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/esrap.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "esrap";
-  version = "20201220-git";
+  version = "20211020-git";
 
   parasites = [ "esrap/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."fiveam" args."trivial-with-current-source-form" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/esrap/2020-12-20/esrap-20201220-git.tgz";
-    sha256 = "0yhi4ay98i81nqv9yjlj321azwmiylsw0afdd6y1c1zflfcrzkrk";
+    url = "http://beta.quicklisp.org/archive/esrap/2021-10-20/esrap-20211020-git.tgz";
+    sha256 = "06cqvalqsid82an8c4acbf13y65gw8nb4pckm8gv8fknvh4k1x7h";
   };
 
   packageName = "esrap";
@@ -22,11 +22,11 @@ rec {
 }
 /* (SYSTEM esrap DESCRIPTION
     A Packrat / Parsing Grammar / TDPL parser for Common Lisp. SHA256
-    0yhi4ay98i81nqv9yjlj321azwmiylsw0afdd6y1c1zflfcrzkrk URL
-    http://beta.quicklisp.org/archive/esrap/2020-12-20/esrap-20201220-git.tgz
-    MD5 cc33cc8dbc236403f6b285c8eae0ce3b NAME esrap FILENAME esrap DEPS
+    06cqvalqsid82an8c4acbf13y65gw8nb4pckm8gv8fknvh4k1x7h URL
+    http://beta.quicklisp.org/archive/esrap/2021-10-20/esrap-20211020-git.tgz
+    MD5 9657755b3fe896c1252dc7fdd22320b7 NAME esrap FILENAME esrap DEPS
     ((NAME alexandria FILENAME alexandria) (NAME fiveam FILENAME fiveam)
      (NAME trivial-with-current-source-form FILENAME
       trivial-with-current-source-form))
     DEPENDENCIES (alexandria fiveam trivial-with-current-source-form) VERSION
-    20201220-git SIBLINGS NIL PARASITES (esrap/tests)) */
+    20211020-git SIBLINGS NIL PARASITES (esrap/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl";
-  version = "20210807-git";
+  version = "20211020-git";
 
   parasites = [ "generic-cl/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-custom-hash-table" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."fiveam" args."generic-cl_dot_arithmetic" args."generic-cl_dot_collector" args."generic-cl_dot_comparison" args."generic-cl_dot_container" args."generic-cl_dot_internal" args."generic-cl_dot_iterator" args."generic-cl_dot_lazy-seq" args."generic-cl_dot_map" args."generic-cl_dot_math" args."generic-cl_dot_object" args."generic-cl_dot_sequence" args."generic-cl_dot_set" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM generic-cl DESCRIPTION
     Standard Common Lisp functions implemented using generic functions. SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl FILENAME generic-cl
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl FILENAME generic-cl
     DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -68,7 +68,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION 20210807-git SIBLINGS
+    VERSION 20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl.collector generic-cl.comparison
      generic-cl.container generic-cl.internal generic-cl.iterator
      generic-cl.lazy-seq generic-cl.map generic-cl.math generic-cl.object

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_arithmetic.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_arithmetic.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_arithmetic";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic arithmetic function interface";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_comparison" args."generic-cl_dot_internal" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.arithmetic";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM generic-cl.arithmetic DESCRIPTION
     Generic arithmetic function interface SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.arithmetic FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.arithmetic FILENAME
     generic-cl_dot_arithmetic DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -52,7 +52,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl generic-cl.collector generic-cl.comparison generic-cl.container
      generic-cl.internal generic-cl.iterator generic-cl.lazy-seq generic-cl.map
      generic-cl.math generic-cl.object generic-cl.sequence generic-cl.set

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_collector.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_collector.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_collector";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic collector interface";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_comparison" args."generic-cl_dot_container" args."generic-cl_dot_internal" args."generic-cl_dot_iterator" args."generic-cl_dot_object" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.collector";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM generic-cl.collector DESCRIPTION Generic collector interface SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.collector FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.collector FILENAME
     generic-cl_dot_collector DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -54,7 +54,7 @@ rec {
      lisp-namespace optima parse-declarations-1.0 static-dispatch symbol-munger
      trivia trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.comparison
      generic-cl.container generic-cl.internal generic-cl.iterator
      generic-cl.lazy-seq generic-cl.map generic-cl.math generic-cl.object

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_comparison.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_comparison.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_comparison";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic comparison interface";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_internal" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.comparison";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM generic-cl.comparison DESCRIPTION Generic comparison interface
-    SHA256 0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.comparison FILENAME
+    SHA256 0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.comparison FILENAME
     generic-cl_dot_comparison DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -49,7 +49,7 @@ rec {
      lisp-namespace optima parse-declarations-1.0 static-dispatch symbol-munger
      trivia trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector generic-cl.container
      generic-cl.internal generic-cl.iterator generic-cl.lazy-seq generic-cl.map
      generic-cl.math generic-cl.object generic-cl.sequence generic-cl.set

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_container.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_container.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_container";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic container interface";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_comparison" args."generic-cl_dot_internal" args."generic-cl_dot_object" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.container";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM generic-cl.container DESCRIPTION Generic container interface SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.container FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.container FILENAME
     generic-cl_dot_container DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -52,7 +52,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector
      generic-cl.comparison generic-cl.internal generic-cl.iterator
      generic-cl.lazy-seq generic-cl.map generic-cl.math generic-cl.object

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_internal.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_internal.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_internal";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Utilities used internally by generic-cl";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.internal";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM generic-cl.internal DESCRIPTION
     Utilities used internally by generic-cl SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.internal FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.internal FILENAME
     generic-cl_dot_internal DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -49,7 +49,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector
      generic-cl.comparison generic-cl.container generic-cl.iterator
      generic-cl.lazy-seq generic-cl.map generic-cl.math generic-cl.object

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_iterator.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_iterator.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_iterator";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic iterator interface";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_comparison" args."generic-cl_dot_container" args."generic-cl_dot_internal" args."generic-cl_dot_object" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.iterator";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM generic-cl.iterator DESCRIPTION Generic iterator interface SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.iterator FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.iterator FILENAME
     generic-cl_dot_iterator DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -53,7 +53,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector
      generic-cl.comparison generic-cl.container generic-cl.internal
      generic-cl.lazy-seq generic-cl.map generic-cl.math generic-cl.object

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_lazy-seq.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_lazy-seq.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_lazy-seq";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Lazy sequences";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-custom-hash-table" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_collector" args."generic-cl_dot_comparison" args."generic-cl_dot_container" args."generic-cl_dot_internal" args."generic-cl_dot_iterator" args."generic-cl_dot_map" args."generic-cl_dot_object" args."generic-cl_dot_sequence" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.lazy-seq";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM generic-cl.lazy-seq DESCRIPTION Lazy sequences SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.lazy-seq FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.lazy-seq FILENAME
     generic-cl_dot_lazy-seq DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -60,7 +60,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector
      generic-cl.comparison generic-cl.container generic-cl.internal
      generic-cl.iterator generic-cl.map generic-cl.math generic-cl.object

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_map.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_map.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_map";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic map and hash-table interface";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-custom-hash-table" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_collector" args."generic-cl_dot_comparison" args."generic-cl_dot_container" args."generic-cl_dot_internal" args."generic-cl_dot_iterator" args."generic-cl_dot_object" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.map";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM generic-cl.map DESCRIPTION Generic map and hash-table interface
-    SHA256 0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.map FILENAME
+    SHA256 0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.map FILENAME
     generic-cl_dot_map DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -57,7 +57,7 @@ rec {
      lisp-namespace optima parse-declarations-1.0 static-dispatch symbol-munger
      trivia trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector
      generic-cl.comparison generic-cl.container generic-cl.internal
      generic-cl.iterator generic-cl.lazy-seq generic-cl.math generic-cl.object

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_math.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_math.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_math";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic math function interface";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_arithmetic" args."generic-cl_dot_comparison" args."generic-cl_dot_internal" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.math";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM generic-cl.math DESCRIPTION Generic math function interface SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.math FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.math FILENAME
     generic-cl_dot_math DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -52,7 +52,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector
      generic-cl.comparison generic-cl.container generic-cl.internal
      generic-cl.iterator generic-cl.lazy-seq generic-cl.map generic-cl.object

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_object.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_object.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_object";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic object copying and type conversion interface";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_comparison" args."generic-cl_dot_internal" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.object";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM generic-cl.object DESCRIPTION
     Generic object copying and type conversion interface SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.object FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.object FILENAME
     generic-cl_dot_object DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -52,7 +52,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector
      generic-cl.comparison generic-cl.container generic-cl.internal
      generic-cl.iterator generic-cl.lazy-seq generic-cl.map generic-cl.math

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_sequence.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_sequence.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_sequence";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic sequence operations";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-custom-hash-table" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_collector" args."generic-cl_dot_comparison" args."generic-cl_dot_container" args."generic-cl_dot_internal" args."generic-cl_dot_iterator" args."generic-cl_dot_map" args."generic-cl_dot_object" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.sequence";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM generic-cl.sequence DESCRIPTION Generic sequence operations SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.sequence FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.sequence FILENAME
     generic-cl_dot_sequence DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -59,7 +59,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector
      generic-cl.comparison generic-cl.container generic-cl.internal
      generic-cl.iterator generic-cl.lazy-seq generic-cl.map generic-cl.math

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_set.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/generic-cl_dot_set.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "generic-cl_dot_set";
-  version = "generic-cl-20210807-git";
+  version = "generic-cl-20211020-git";
 
   description = "Generic set interface";
 
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-custom-hash-table" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."generic-cl_dot_arithmetic" args."generic-cl_dot_collector" args."generic-cl_dot_comparison" args."generic-cl_dot_container" args."generic-cl_dot_internal" args."generic-cl_dot_iterator" args."generic-cl_dot_map" args."generic-cl_dot_object" args."generic-cl_dot_sequence" args."introspect-environment" args."iterate" args."lisp-namespace" args."optima" args."parse-declarations-1_dot_0" args."static-dispatch" args."symbol-munger" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz";
-    sha256 = "0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b";
+    url = "http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz";
+    sha256 = "0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa";
   };
 
   packageName = "generic-cl.set";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM generic-cl.set DESCRIPTION Generic set interface SHA256
-    0jn1hw0m3906iyyg337kb6dfnmyj95l7s9lx1glvgcas450wkk0b URL
-    http://beta.quicklisp.org/archive/generic-cl/2021-08-07/generic-cl-20210807-git.tgz
-    MD5 38e30f287963d66f4d56b48918f71568 NAME generic-cl.set FILENAME
+    0jryfmxwqhrarmpbb643b7iv5rlib5pcx4i4jcd6h2rscnrbj8sa URL
+    http://beta.quicklisp.org/archive/generic-cl/2021-10-20/generic-cl-20211020-git.tgz
+    MD5 ce42f45dd7c5be44de45ee259a46d7b8 NAME generic-cl.set FILENAME
     generic-cl_dot_set DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -61,7 +61,7 @@ rec {
      parse-declarations-1.0 static-dispatch symbol-munger trivia
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION generic-cl-20210807-git SIBLINGS
+    VERSION generic-cl-20211020-git SIBLINGS
     (generic-cl.arithmetic generic-cl generic-cl.collector
      generic-cl.comparison generic-cl.container generic-cl.internal
      generic-cl.iterator generic-cl.lazy-seq generic-cl.map generic-cl.math

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/ironclad.nix
@@ -2,17 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "ironclad";
-  version = "v0.55";
+  version = "v0.56";
 
-  parasites = [ "ironclad/tests" ];
+  parasites = [ "ironclad/aead/eax" "ironclad/aead/etm" "ironclad/aead/gcm" "ironclad/aeads" "ironclad/cipher/aes" "ironclad/cipher/arcfour" "ironclad/cipher/aria" "ironclad/cipher/blowfish" "ironclad/cipher/camellia" "ironclad/cipher/cast5" "ironclad/cipher/chacha" "ironclad/cipher/des" "ironclad/cipher/idea" "ironclad/cipher/kalyna" "ironclad/cipher/keystream" "ironclad/cipher/kuznyechik" "ironclad/cipher/misty1" "ironclad/cipher/rc2" "ironclad/cipher/rc5" "ironclad/cipher/rc6" "ironclad/cipher/salsa20" "ironclad/cipher/seed" "ironclad/cipher/serpent" "ironclad/cipher/sm4" "ironclad/cipher/sosemanuk" "ironclad/cipher/square" "ironclad/cipher/tea" "ironclad/cipher/threefish" "ironclad/cipher/twofish" "ironclad/cipher/xchacha" "ironclad/cipher/xor" "ironclad/cipher/xsalsa20" "ironclad/cipher/xtea" "ironclad/ciphers" "ironclad/core" "ironclad/digest/adler32" "ironclad/digest/blake2" "ironclad/digest/blake2s" "ironclad/digest/crc24" "ironclad/digest/crc32" "ironclad/digest/groestl" "ironclad/digest/jh" "ironclad/digest/kupyna" "ironclad/digest/md2" "ironclad/digest/md4" "ironclad/digest/md5" "ironclad/digest/ripemd-128" "ironclad/digest/ripemd-160" "ironclad/digest/sha1" "ironclad/digest/sha256" "ironclad/digest/sha3" "ironclad/digest/sha512" "ironclad/digest/skein" "ironclad/digest/sm3" "ironclad/digest/streebog" "ironclad/digest/tiger" "ironclad/digest/tree-hash" "ironclad/digest/whirlpool" "ironclad/digests" "ironclad/kdf/argon2" "ironclad/kdf/bcrypt" "ironclad/kdf/hmac" "ironclad/kdf/password-hash" "ironclad/kdf/pkcs5" "ironclad/kdf/scrypt" "ironclad/kdfs" "ironclad/mac/blake2-mac" "ironclad/mac/blake2s-mac" "ironclad/mac/cmac" "ironclad/mac/gmac" "ironclad/mac/hmac" "ironclad/mac/poly1305" "ironclad/mac/siphash" "ironclad/mac/skein-mac" "ironclad/macs" "ironclad/prng/fortuna" "ironclad/prngs" "ironclad/public-key/curve25519" "ironclad/public-key/curve448" "ironclad/public-key/dsa" "ironclad/public-key/ed25519" "ironclad/public-key/ed448" "ironclad/public-key/elgamal" "ironclad/public-key/rsa" "ironclad/public-key/secp256k1" "ironclad/public-key/secp256r1" "ironclad/public-key/secp384r1" "ironclad/public-key/secp521r1" "ironclad/public-keys" "ironclad/tests" ];
 
-  description = "A cryptographic toolkit written in pure Common Lisp";
+  description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."rt" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/ironclad/2021-04-11/ironclad-v0.55.tgz";
-    sha256 = "0vdqaad9i3dkz6z2y1iqmh6m77kc9jy49xh9bysgywl0gfdyhnq6";
+    url = "http://beta.quicklisp.org/archive/ironclad/2021-10-20/ironclad-v0.56.tgz";
+    sha256 = "06jya7y8xlwak84akhp4qg9x6nyjrnnzqmzdigxc5a3c77mk3p6k";
   };
 
   packageName = "ironclad";
@@ -20,12 +20,43 @@ rec {
   asdFilesToKeep = ["ironclad.asd"];
   overrides = x: x;
 }
-/* (SYSTEM ironclad DESCRIPTION
-    A cryptographic toolkit written in pure Common Lisp SHA256
-    0vdqaad9i3dkz6z2y1iqmh6m77kc9jy49xh9bysgywl0gfdyhnq6 URL
-    http://beta.quicklisp.org/archive/ironclad/2021-04-11/ironclad-v0.55.tgz
-    MD5 c3c4a88e71ef37c9604662071069afcc NAME ironclad FILENAME ironclad DEPS
+/* (SYSTEM ironclad DESCRIPTION System lacks description SHA256
+    06jya7y8xlwak84akhp4qg9x6nyjrnnzqmzdigxc5a3c77mk3p6k URL
+    http://beta.quicklisp.org/archive/ironclad/2021-10-20/ironclad-v0.56.tgz
+    MD5 3ea7bf7271864fd960d7e06a4e5aa9b7 NAME ironclad FILENAME ironclad DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads) (NAME rt FILENAME rt))
-    DEPENDENCIES (alexandria bordeaux-threads rt) VERSION v0.55 SIBLINGS
-    (ironclad-text) PARASITES (ironclad/tests)) */
+    DEPENDENCIES (alexandria bordeaux-threads rt) VERSION v0.56 SIBLINGS
+    (ironclad-text) PARASITES
+    (ironclad/aead/eax ironclad/aead/etm ironclad/aead/gcm ironclad/aeads
+     ironclad/cipher/aes ironclad/cipher/arcfour ironclad/cipher/aria
+     ironclad/cipher/blowfish ironclad/cipher/camellia ironclad/cipher/cast5
+     ironclad/cipher/chacha ironclad/cipher/des ironclad/cipher/idea
+     ironclad/cipher/kalyna ironclad/cipher/keystream
+     ironclad/cipher/kuznyechik ironclad/cipher/misty1 ironclad/cipher/rc2
+     ironclad/cipher/rc5 ironclad/cipher/rc6 ironclad/cipher/salsa20
+     ironclad/cipher/seed ironclad/cipher/serpent ironclad/cipher/sm4
+     ironclad/cipher/sosemanuk ironclad/cipher/square ironclad/cipher/tea
+     ironclad/cipher/threefish ironclad/cipher/twofish ironclad/cipher/xchacha
+     ironclad/cipher/xor ironclad/cipher/xsalsa20 ironclad/cipher/xtea
+     ironclad/ciphers ironclad/core ironclad/digest/adler32
+     ironclad/digest/blake2 ironclad/digest/blake2s ironclad/digest/crc24
+     ironclad/digest/crc32 ironclad/digest/groestl ironclad/digest/jh
+     ironclad/digest/kupyna ironclad/digest/md2 ironclad/digest/md4
+     ironclad/digest/md5 ironclad/digest/ripemd-128 ironclad/digest/ripemd-160
+     ironclad/digest/sha1 ironclad/digest/sha256 ironclad/digest/sha3
+     ironclad/digest/sha512 ironclad/digest/skein ironclad/digest/sm3
+     ironclad/digest/streebog ironclad/digest/tiger ironclad/digest/tree-hash
+     ironclad/digest/whirlpool ironclad/digests ironclad/kdf/argon2
+     ironclad/kdf/bcrypt ironclad/kdf/hmac ironclad/kdf/password-hash
+     ironclad/kdf/pkcs5 ironclad/kdf/scrypt ironclad/kdfs
+     ironclad/mac/blake2-mac ironclad/mac/blake2s-mac ironclad/mac/cmac
+     ironclad/mac/gmac ironclad/mac/hmac ironclad/mac/poly1305
+     ironclad/mac/siphash ironclad/mac/skein-mac ironclad/macs
+     ironclad/prng/fortuna ironclad/prngs ironclad/public-key/curve25519
+     ironclad/public-key/curve448 ironclad/public-key/dsa
+     ironclad/public-key/ed25519 ironclad/public-key/ed448
+     ironclad/public-key/elgamal ironclad/public-key/rsa
+     ironclad/public-key/secp256k1 ironclad/public-key/secp256r1
+     ironclad/public-key/secp384r1 ironclad/public-key/secp521r1
+     ironclad/public-keys ironclad/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-component.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack-component";
-  version = "lack-20210807-git";
+  version = "lack-20211020-git";
 
   description = "System lacks description";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-08-07/lack-20210807-git.tgz";
-    sha256 = "0zyyr9wkncf03l4jf54mkjm4kaiswmwj5y198kp9v00x2ljjnkjn";
+    url = "http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz";
+    sha256 = "0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2";
   };
 
   packageName = "lack-component";
@@ -19,15 +19,15 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-component DESCRIPTION System lacks description SHA256
-    0zyyr9wkncf03l4jf54mkjm4kaiswmwj5y198kp9v00x2ljjnkjn URL
-    http://beta.quicklisp.org/archive/lack/2021-08-07/lack-20210807-git.tgz MD5
-    76b3ab979e6c3d7d33dd2fd3864692ca NAME lack-component FILENAME
-    lack-component DEPS NIL DEPENDENCIES NIL VERSION lack-20210807-git SIBLINGS
-    (lack-middleware-accesslog lack-middleware-auth-basic
-     lack-middleware-backtrace lack-middleware-csrf lack-middleware-mount
-     lack-middleware-session lack-middleware-static lack-request lack-response
-     lack-session-store-dbi lack-session-store-redis lack-test
-     lack-util-writer-stream lack-util lack t-lack-component
+    0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2 URL
+    http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz MD5
+    4a98955fb9cd5db45b796a0b269a57e1 NAME lack-component FILENAME
+    lack-component DEPS NIL DEPENDENCIES NIL VERSION lack-20211020-git SIBLINGS
+    (lack-app-directory lack-app-file lack-middleware-accesslog
+     lack-middleware-auth-basic lack-middleware-backtrace lack-middleware-csrf
+     lack-middleware-mount lack-middleware-session lack-middleware-static
+     lack-request lack-response lack-session-store-dbi lack-session-store-redis
+     lack-test lack-util-writer-stream lack-util lack t-lack-component
      t-lack-middleware-accesslog t-lack-middleware-auth-basic
      t-lack-middleware-backtrace t-lack-middleware-csrf t-lack-middleware-mount
      t-lack-middleware-session t-lack-middleware-static t-lack-request

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-middleware-backtrace.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack-middleware-backtrace";
-  version = "lack-20210807-git";
+  version = "lack-20211020-git";
 
   description = "System lacks description";
 
   deps = [ args."uiop" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-08-07/lack-20210807-git.tgz";
-    sha256 = "0zyyr9wkncf03l4jf54mkjm4kaiswmwj5y198kp9v00x2ljjnkjn";
+    url = "http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz";
+    sha256 = "0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2";
   };
 
   packageName = "lack-middleware-backtrace";
@@ -19,16 +19,17 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-middleware-backtrace DESCRIPTION System lacks description
-    SHA256 0zyyr9wkncf03l4jf54mkjm4kaiswmwj5y198kp9v00x2ljjnkjn URL
-    http://beta.quicklisp.org/archive/lack/2021-08-07/lack-20210807-git.tgz MD5
-    76b3ab979e6c3d7d33dd2fd3864692ca NAME lack-middleware-backtrace FILENAME
+    SHA256 0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2 URL
+    http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz MD5
+    4a98955fb9cd5db45b796a0b269a57e1 NAME lack-middleware-backtrace FILENAME
     lack-middleware-backtrace DEPS ((NAME uiop FILENAME uiop)) DEPENDENCIES
-    (uiop) VERSION lack-20210807-git SIBLINGS
-    (lack-component lack-middleware-accesslog lack-middleware-auth-basic
-     lack-middleware-csrf lack-middleware-mount lack-middleware-session
-     lack-middleware-static lack-request lack-response lack-session-store-dbi
-     lack-session-store-redis lack-test lack-util-writer-stream lack-util lack
-     t-lack-component t-lack-middleware-accesslog t-lack-middleware-auth-basic
+    (uiop) VERSION lack-20211020-git SIBLINGS
+    (lack-app-directory lack-app-file lack-component lack-middleware-accesslog
+     lack-middleware-auth-basic lack-middleware-csrf lack-middleware-mount
+     lack-middleware-session lack-middleware-static lack-request lack-response
+     lack-session-store-dbi lack-session-store-redis lack-test
+     lack-util-writer-stream lack-util lack t-lack-component
+     t-lack-middleware-accesslog t-lack-middleware-auth-basic
      t-lack-middleware-backtrace t-lack-middleware-csrf t-lack-middleware-mount
      t-lack-middleware-session t-lack-middleware-static t-lack-request
      t-lack-session-store-dbi t-lack-session-store-redis t-lack-util t-lack)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack-util.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack-util";
-  version = "lack-20210807-git";
+  version = "lack-20211020-git";
 
   description = "System lacks description";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-08-07/lack-20210807-git.tgz";
-    sha256 = "0zyyr9wkncf03l4jf54mkjm4kaiswmwj5y198kp9v00x2ljjnkjn";
+    url = "http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz";
+    sha256 = "0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2";
   };
 
   packageName = "lack-util";
@@ -19,21 +19,21 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack-util DESCRIPTION System lacks description SHA256
-    0zyyr9wkncf03l4jf54mkjm4kaiswmwj5y198kp9v00x2ljjnkjn URL
-    http://beta.quicklisp.org/archive/lack/2021-08-07/lack-20210807-git.tgz MD5
-    76b3ab979e6c3d7d33dd2fd3864692ca NAME lack-util FILENAME lack-util DEPS
+    0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2 URL
+    http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz MD5
+    4a98955fb9cd5db45b796a0b269a57e1 NAME lack-util FILENAME lack-util DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME ironclad FILENAME ironclad))
     DEPENDENCIES (alexandria bordeaux-threads ironclad) VERSION
-    lack-20210807-git SIBLINGS
-    (lack-component lack-middleware-accesslog lack-middleware-auth-basic
-     lack-middleware-backtrace lack-middleware-csrf lack-middleware-mount
-     lack-middleware-session lack-middleware-static lack-request lack-response
-     lack-session-store-dbi lack-session-store-redis lack-test
-     lack-util-writer-stream lack t-lack-component t-lack-middleware-accesslog
-     t-lack-middleware-auth-basic t-lack-middleware-backtrace
-     t-lack-middleware-csrf t-lack-middleware-mount t-lack-middleware-session
-     t-lack-middleware-static t-lack-request t-lack-session-store-dbi
-     t-lack-session-store-redis t-lack-util t-lack)
+    lack-20211020-git SIBLINGS
+    (lack-app-directory lack-app-file lack-component lack-middleware-accesslog
+     lack-middleware-auth-basic lack-middleware-backtrace lack-middleware-csrf
+     lack-middleware-mount lack-middleware-session lack-middleware-static
+     lack-request lack-response lack-session-store-dbi lack-session-store-redis
+     lack-test lack-util-writer-stream lack t-lack-component
+     t-lack-middleware-accesslog t-lack-middleware-auth-basic
+     t-lack-middleware-backtrace t-lack-middleware-csrf t-lack-middleware-mount
+     t-lack-middleware-session t-lack-middleware-static t-lack-request
+     t-lack-session-store-dbi t-lack-session-store-redis t-lack-util t-lack)
     PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lack.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lack";
-  version = "20210807-git";
+  version = "20211020-git";
 
   description = "A minimal Clack";
 
   deps = [ args."alexandria" args."bordeaux-threads" args."ironclad" args."lack-component" args."lack-util" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lack/2021-08-07/lack-20210807-git.tgz";
-    sha256 = "0zyyr9wkncf03l4jf54mkjm4kaiswmwj5y198kp9v00x2ljjnkjn";
+    url = "http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz";
+    sha256 = "0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2";
   };
 
   packageName = "lack";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM lack DESCRIPTION A minimal Clack SHA256
-    0zyyr9wkncf03l4jf54mkjm4kaiswmwj5y198kp9v00x2ljjnkjn URL
-    http://beta.quicklisp.org/archive/lack/2021-08-07/lack-20210807-git.tgz MD5
-    76b3ab979e6c3d7d33dd2fd3864692ca NAME lack FILENAME lack DEPS
+    0ly7bdvrl5xsls9syybcf0qm2981m434rhr3gr756kvvk4s9mdn2 URL
+    http://beta.quicklisp.org/archive/lack/2021-10-20/lack-20211020-git.tgz MD5
+    4a98955fb9cd5db45b796a0b269a57e1 NAME lack FILENAME lack DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME ironclad FILENAME ironclad)
@@ -29,12 +29,12 @@ rec {
      (NAME lack-util FILENAME lack-util))
     DEPENDENCIES
     (alexandria bordeaux-threads ironclad lack-component lack-util) VERSION
-    20210807-git SIBLINGS
-    (lack-component lack-middleware-accesslog lack-middleware-auth-basic
-     lack-middleware-backtrace lack-middleware-csrf lack-middleware-mount
-     lack-middleware-session lack-middleware-static lack-request lack-response
-     lack-session-store-dbi lack-session-store-redis lack-test
-     lack-util-writer-stream lack-util t-lack-component
+    20211020-git SIBLINGS
+    (lack-app-directory lack-app-file lack-component lack-middleware-accesslog
+     lack-middleware-auth-basic lack-middleware-backtrace lack-middleware-csrf
+     lack-middleware-mount lack-middleware-session lack-middleware-static
+     lack-request lack-response lack-session-store-dbi lack-session-store-redis
+     lack-test lack-util-writer-stream lack-util t-lack-component
      t-lack-middleware-accesslog t-lack-middleware-auth-basic
      t-lack-middleware-backtrace t-lack-middleware-csrf t-lack-middleware-mount
      t-lack-middleware-session t-lack-middleware-static t-lack-request

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-namespace.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-namespace.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "lisp-namespace";
-  version = "20171130-git";
+  version = "20211020-git";
 
   description = "Provides LISP-N --- extensible namespaces in Common Lisp.";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/lisp-namespace/2017-11-30/lisp-namespace-20171130-git.tgz";
-    sha256 = "0vxk06c5434kcjv9p414yk23gs4rkibfq695is9y7wglck31fz2j";
+    url = "http://beta.quicklisp.org/archive/lisp-namespace/2021-10-20/lisp-namespace-20211020-git.tgz";
+    sha256 = "1vw7zxzhlxqjnas3cxk0f58hxvlvki78vbqsabj6f3n1rq6yx7b7";
   };
 
   packageName = "lisp-namespace";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM lisp-namespace DESCRIPTION
     Provides LISP-N --- extensible namespaces in Common Lisp. SHA256
-    0vxk06c5434kcjv9p414yk23gs4rkibfq695is9y7wglck31fz2j URL
-    http://beta.quicklisp.org/archive/lisp-namespace/2017-11-30/lisp-namespace-20171130-git.tgz
-    MD5 d3052a13db167c6a53487f31753b7467 NAME lisp-namespace FILENAME
+    1vw7zxzhlxqjnas3cxk0f58hxvlvki78vbqsabj6f3n1rq6yx7b7 URL
+    http://beta.quicklisp.org/archive/lisp-namespace/2021-10-20/lisp-namespace-20211020-git.tgz
+    MD5 71d02a1704c93281028316e96ecaead2 NAME lisp-namespace FILENAME
     lisp-namespace DEPS ((NAME alexandria FILENAME alexandria)) DEPENDENCIES
-    (alexandria) VERSION 20171130-git SIBLINGS (lisp-namespace.test) PARASITES
+    (alexandria) VERSION 20211020-git SIBLINGS (lisp-namespace.test) PARASITES
     NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/log4cl.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/log4cl.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "log4cl";
-  version = "20200925-git";
+  version = "20211020-git";
 
   parasites = [ "log4cl/syslog" "log4cl/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."bordeaux-threads" args."stefil" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/log4cl/2020-09-25/log4cl-20200925-git.tgz";
-    sha256 = "1z98ly71hsbd46i0dqqv2s3cm9y8bi0pl3yg8a168vz629c6mdrf";
+    url = "http://beta.quicklisp.org/archive/log4cl/2021-10-20/log4cl-20211020-git.tgz";
+    sha256 = "1nqryqd5z4grg75hffqs2x6nzdf972cp4f41l1dr8wdf3fp0ifz8";
   };
 
   packageName = "log4cl";
@@ -21,11 +21,12 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM log4cl DESCRIPTION System lacks description SHA256
-    1z98ly71hsbd46i0dqqv2s3cm9y8bi0pl3yg8a168vz629c6mdrf URL
-    http://beta.quicklisp.org/archive/log4cl/2020-09-25/log4cl-20200925-git.tgz
-    MD5 80b347666af496142581e9e0c029d181 NAME log4cl FILENAME log4cl DEPS
+    1nqryqd5z4grg75hffqs2x6nzdf972cp4f41l1dr8wdf3fp0ifz8 URL
+    http://beta.quicklisp.org/archive/log4cl/2021-10-20/log4cl-20211020-git.tgz
+    MD5 d4eb0d4c8a9bc2f2037d7a64d44292d4 NAME log4cl FILENAME log4cl DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME stefil FILENAME stefil))
-    DEPENDENCIES (alexandria bordeaux-threads stefil) VERSION 20200925-git
-    SIBLINGS (log4cl-examples log4slime) PARASITES (log4cl/syslog log4cl/test)) */
+    DEPENDENCIES (alexandria bordeaux-threads stefil) VERSION 20211020-git
+    SIBLINGS (log4cl-examples log4cl.log4slime log4cl.log4sly) PARASITES
+    (log4cl/syslog log4cl/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/marshal.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/marshal.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "marshal";
-  version = "cl-20210411-git";
+  version = "cl-20211020-git";
 
   description = "marshal: Simple (de)serialization of Lisp datastructures.";
 
   deps = [ ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/cl-marshal/2021-04-11/cl-marshal-20210411-git.tgz";
-    sha256 = "0wi4csgl5qxgl0si5mcg19xx4qlmw125qn0w1i2f3dvvrzp20qrp";
+    url = "http://beta.quicklisp.org/archive/cl-marshal/2021-10-20/cl-marshal-20211020-git.tgz";
+    sha256 = "0zv4bpj352frdrsk7r1yc67385h2n00cy19nz3b72sznsjynqvk8";
   };
 
   packageName = "marshal";
@@ -20,8 +20,8 @@ rec {
 }
 /* (SYSTEM marshal DESCRIPTION
     marshal: Simple (de)serialization of Lisp datastructures. SHA256
-    0wi4csgl5qxgl0si5mcg19xx4qlmw125qn0w1i2f3dvvrzp20qrp URL
-    http://beta.quicklisp.org/archive/cl-marshal/2021-04-11/cl-marshal-20210411-git.tgz
-    MD5 2463314a6bcd1a18bea2690deb6bce55 NAME marshal FILENAME marshal DEPS NIL
-    DEPENDENCIES NIL VERSION cl-20210411-git SIBLINGS (marshal-tests) PARASITES
+    0zv4bpj352frdrsk7r1yc67385h2n00cy19nz3b72sznsjynqvk8 URL
+    http://beta.quicklisp.org/archive/cl-marshal/2021-10-20/cl-marshal-20211020-git.tgz
+    MD5 52eaad7da569610099d15c1d91020e17 NAME marshal FILENAME marshal DEPS NIL
+    DEPENDENCIES NIL VERSION cl-20211020-git SIBLINGS (marshal-tests) PARASITES
     NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mgl-pax.nix
@@ -2,18 +2,18 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "mgl-pax";
-  version = "20210411-git";
+  version = "20211020-git";
 
-  parasites = [ "mgl-pax/test" ];
+  parasites = [ "mgl-pax/full" ];
 
   description = "Exploratory programming tool and documentation
   generator.";
 
-  deps = [ args."_3bmd" args."_3bmd-ext-code-blocks" args."alexandria" args."babel" args."bordeaux-threads" args."cl-fad" args."colorize" args."esrap" args."html-encode" args."ironclad" args."named-readtables" args."pythonic-string-reader" args."split-sequence" args."swank" args."trivial-features" args."trivial-with-current-source-form" ];
+  deps = [ args."_3bmd" args."_3bmd-ext-code-blocks" args."alexandria" args."babel" args."cl-fad" args."colorize" args."ironclad" args."named-readtables" args."pythonic-string-reader" args."swank" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/mgl-pax/2021-04-11/mgl-pax-20210411-git.tgz";
-    sha256 = "0dq5jkb6li0s1gqj6hfhifs6cd4kypavv2kjqg5zgs6zfs82sxh3";
+    url = "http://beta.quicklisp.org/archive/mgl-pax/2021-10-20/mgl-pax-20211020-git.tgz";
+    sha256 = "04vddyvyxja8dabksfqqr80xjnvdiiv61zidjvijlpkk8shwaw1g";
   };
 
   packageName = "mgl-pax";
@@ -23,25 +23,18 @@ rec {
 }
 /* (SYSTEM mgl-pax DESCRIPTION Exploratory programming tool and documentation
   generator.
-    SHA256 0dq5jkb6li0s1gqj6hfhifs6cd4kypavv2kjqg5zgs6zfs82sxh3 URL
-    http://beta.quicklisp.org/archive/mgl-pax/2021-04-11/mgl-pax-20210411-git.tgz
-    MD5 44cf1bd71e6c40c256a43a87efa2c2a1 NAME mgl-pax FILENAME mgl-pax DEPS
+    SHA256 04vddyvyxja8dabksfqqr80xjnvdiiv61zidjvijlpkk8shwaw1g URL
+    http://beta.quicklisp.org/archive/mgl-pax/2021-10-20/mgl-pax-20211020-git.tgz
+    MD5 2ad25d62d83b98e3e855b35414a5093d NAME mgl-pax FILENAME mgl-pax DEPS
     ((NAME 3bmd FILENAME _3bmd)
      (NAME 3bmd-ext-code-blocks FILENAME _3bmd-ext-code-blocks)
      (NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
-     (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-fad FILENAME cl-fad) (NAME colorize FILENAME colorize)
-     (NAME esrap FILENAME esrap) (NAME html-encode FILENAME html-encode)
      (NAME ironclad FILENAME ironclad)
      (NAME named-readtables FILENAME named-readtables)
      (NAME pythonic-string-reader FILENAME pythonic-string-reader)
-     (NAME split-sequence FILENAME split-sequence) (NAME swank FILENAME swank)
-     (NAME trivial-features FILENAME trivial-features)
-     (NAME trivial-with-current-source-form FILENAME
-      trivial-with-current-source-form))
+     (NAME swank FILENAME swank))
     DEPENDENCIES
-    (3bmd 3bmd-ext-code-blocks alexandria babel bordeaux-threads cl-fad
-     colorize esrap html-encode ironclad named-readtables
-     pythonic-string-reader split-sequence swank trivial-features
-     trivial-with-current-source-form)
-    VERSION 20210411-git SIBLINGS NIL PARASITES (mgl-pax/test)) */
+    (3bmd 3bmd-ext-code-blocks alexandria babel cl-fad colorize ironclad
+     named-readtables pythonic-string-reader swank)
+    VERSION 20211020-git SIBLINGS NIL PARASITES (mgl-pax/full)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/osicat.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "osicat";
-  version = "20210228-git";
+  version = "20211020-git";
 
   parasites = [ "osicat/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."babel" args."cffi" args."cffi-grovel" args."cffi-toolchain" args."rt" args."trivial-features" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/osicat/2021-02-28/osicat-20210228-git.tgz";
-    sha256 = "0g9frahjr2i6fvwd3bzvcz9icx4n4mnwcmsz6gvg5s6wmq5ny6wb";
+    url = "http://beta.quicklisp.org/archive/osicat/2021-10-20/osicat-20211020-git.tgz";
+    sha256 = "0rb53m4hg8dllljjvj9a76mq4hn9cl7wp0lqg50gs0l6v2c7qlbw";
   };
 
   packageName = "osicat";
@@ -21,13 +21,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM osicat DESCRIPTION A lightweight operating system interface SHA256
-    0g9frahjr2i6fvwd3bzvcz9icx4n4mnwcmsz6gvg5s6wmq5ny6wb URL
-    http://beta.quicklisp.org/archive/osicat/2021-02-28/osicat-20210228-git.tgz
-    MD5 22c1b81abfe4fb30a2789877d2f85a86 NAME osicat FILENAME osicat DEPS
+    0rb53m4hg8dllljjvj9a76mq4hn9cl7wp0lqg50gs0l6v2c7qlbw URL
+    http://beta.quicklisp.org/archive/osicat/2021-10-20/osicat-20211020-git.tgz
+    MD5 2cf6739bb39a2bf414de19037f867c87 NAME osicat FILENAME osicat DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME cffi FILENAME cffi) (NAME cffi-grovel FILENAME cffi-grovel)
      (NAME cffi-toolchain FILENAME cffi-toolchain) (NAME rt FILENAME rt)
      (NAME trivial-features FILENAME trivial-features))
     DEPENDENCIES
     (alexandria babel cffi cffi-grovel cffi-toolchain rt trivial-features)
-    VERSION 20210228-git SIBLINGS NIL PARASITES (osicat/tests)) */
+    VERSION 20211020-git SIBLINGS NIL PARASITES (osicat/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/parachute.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/parachute.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "parachute";
-  version = "20210807-git";
+  version = "20211020-git";
 
   description = "An extensible and cross-compatible testing framework.";
 
   deps = [ args."documentation-utils" args."form-fiddle" args."trivial-indent" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/parachute/2021-08-07/parachute-20210807-git.tgz";
-    sha256 = "0h20f73781qpylhs3v0gywzz3iwkxh1bksl7d674dxdl988ngzbs";
+    url = "http://beta.quicklisp.org/archive/parachute/2021-10-20/parachute-20211020-git.tgz";
+    sha256 = "1sc63a6z3zwdsc9h3w0dbx7yssvg2zzdyhh81kqc5cx17vcdqyk0";
   };
 
   packageName = "parachute";
@@ -20,12 +20,12 @@ rec {
 }
 /* (SYSTEM parachute DESCRIPTION
     An extensible and cross-compatible testing framework. SHA256
-    0h20f73781qpylhs3v0gywzz3iwkxh1bksl7d674dxdl988ngzbs URL
-    http://beta.quicklisp.org/archive/parachute/2021-08-07/parachute-20210807-git.tgz
-    MD5 3a25227cffef9f2d9947750490d643ec NAME parachute FILENAME parachute DEPS
+    1sc63a6z3zwdsc9h3w0dbx7yssvg2zzdyhh81kqc5cx17vcdqyk0 URL
+    http://beta.quicklisp.org/archive/parachute/2021-10-20/parachute-20211020-git.tgz
+    MD5 85eba816a1e7a43a154e6a1544e15e52 NAME parachute FILENAME parachute DEPS
     ((NAME documentation-utils FILENAME documentation-utils)
      (NAME form-fiddle FILENAME form-fiddle)
      (NAME trivial-indent FILENAME trivial-indent))
     DEPENDENCIES (documentation-utils form-fiddle trivial-indent) VERSION
-    20210807-git SIBLINGS
+    20211020-git SIBLINGS
     (parachute-fiveam parachute-lisp-unit parachute-prove) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/physical-quantities.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/physical-quantities.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "physical-quantities";
-  version = "20201220-git";
+  version = "20211020-git";
 
   parasites = [ "physical-quantities/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."parseq" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/physical-quantities/2020-12-20/physical-quantities-20201220-git.tgz";
-    sha256 = "0731q6skgnl95jmw82pfkw6y3bdaw5givdlgbk93jql251wfvmf5";
+    url = "http://beta.quicklisp.org/archive/physical-quantities/2021-10-20/physical-quantities-20211020-git.tgz";
+    sha256 = "1ix04gjcsjzry5rl1rqsrg1r3hw985gfvl1847va36y03qzbmhgx";
   };
 
   packageName = "physical-quantities";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM physical-quantities DESCRIPTION
     A library that provides a numeric type with optional unit and/or uncertainty for computations with automatic error propagation.
-    SHA256 0731q6skgnl95jmw82pfkw6y3bdaw5givdlgbk93jql251wfvmf5 URL
-    http://beta.quicklisp.org/archive/physical-quantities/2020-12-20/physical-quantities-20201220-git.tgz
-    MD5 428232d463c45259dd2c18fa8ff3dd6e NAME physical-quantities FILENAME
+    SHA256 1ix04gjcsjzry5rl1rqsrg1r3hw985gfvl1847va36y03qzbmhgx URL
+    http://beta.quicklisp.org/archive/physical-quantities/2021-10-20/physical-quantities-20211020-git.tgz
+    MD5 a322db845056f78a237630a565b41490 NAME physical-quantities FILENAME
     physical-quantities DEPS ((NAME parseq FILENAME parseq)) DEPENDENCIES
-    (parseq) VERSION 20201220-git SIBLINGS NIL PARASITES
+    (parseq) VERSION 20211020-git SIBLINGS NIL PARASITES
     (physical-quantities/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/postmodern.nix
@@ -2,17 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "postmodern";
-  version = "20210807-git";
+  version = "20211020-git";
 
   parasites = [ "postmodern/tests" ];
 
   description = "PostgreSQL programming API";
 
-  deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_plus_local-time" args."cl-postgres_slash_tests" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."fiveam" args."flexi-streams" args."global-vars" args."ironclad" args."local-time" args."md5" args."s-sql" args."s-sql_slash_tests" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."uiop" args."usocket" ];
+  deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_plus_local-time" args."cl-postgres_slash_tests" args."cl-ppcre" args."closer-mop" args."fiveam" args."global-vars" args."ironclad" args."local-time" args."md5" args."s-sql" args."s-sql_slash_tests" args."simple-date" args."simple-date_slash_postgres-glue" args."split-sequence" args."uax-15" args."uiop" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-08-07/postmodern-20210807-git.tgz";
-    sha256 = "01l0zk5f3z1cxb6rspvagjl1fy8v3jwm62p2975cgl45aspp18fp";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz";
+    sha256 = "0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6";
   };
 
   packageName = "postmodern";
@@ -21,9 +21,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM postmodern DESCRIPTION PostgreSQL programming API SHA256
-    01l0zk5f3z1cxb6rspvagjl1fy8v3jwm62p2975cgl45aspp18fp URL
-    http://beta.quicklisp.org/archive/postmodern/2021-08-07/postmodern-20210807-git.tgz
-    MD5 aa951f2ad4ce59fce588a62afa34f3ec NAME postmodern FILENAME postmodern
+    0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6 URL
+    http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz
+    MD5 84f4ad8ce7ac0f7f78cbfcf2f0bd3aa4 NAME postmodern FILENAME postmodern
     DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
@@ -31,12 +31,11 @@ rec {
      (NAME cl-postgres FILENAME cl-postgres)
      (NAME cl-postgres+local-time FILENAME cl-postgres_plus_local-time)
      (NAME cl-postgres/tests FILENAME cl-postgres_slash_tests)
-     (NAME cl-ppcre FILENAME cl-ppcre) (NAME cl-unicode FILENAME cl-unicode)
-     (NAME closer-mop FILENAME closer-mop) (NAME fiveam FILENAME fiveam)
-     (NAME flexi-streams FILENAME flexi-streams)
-     (NAME global-vars FILENAME global-vars) (NAME ironclad FILENAME ironclad)
-     (NAME local-time FILENAME local-time) (NAME md5 FILENAME md5)
-     (NAME s-sql FILENAME s-sql) (NAME s-sql/tests FILENAME s-sql_slash_tests)
+     (NAME cl-ppcre FILENAME cl-ppcre) (NAME closer-mop FILENAME closer-mop)
+     (NAME fiveam FILENAME fiveam) (NAME global-vars FILENAME global-vars)
+     (NAME ironclad FILENAME ironclad) (NAME local-time FILENAME local-time)
+     (NAME md5 FILENAME md5) (NAME s-sql FILENAME s-sql)
+     (NAME s-sql/tests FILENAME s-sql_slash_tests)
      (NAME simple-date FILENAME simple-date)
      (NAME simple-date/postgres-glue FILENAME simple-date_slash_postgres-glue)
      (NAME split-sequence FILENAME split-sequence)
@@ -44,8 +43,8 @@ rec {
      (NAME usocket FILENAME usocket))
     DEPENDENCIES
     (alexandria bordeaux-threads cl-base64 cl-postgres cl-postgres+local-time
-     cl-postgres/tests cl-ppcre cl-unicode closer-mop fiveam flexi-streams
-     global-vars ironclad local-time md5 s-sql s-sql/tests simple-date
-     simple-date/postgres-glue split-sequence uax-15 uiop usocket)
-    VERSION 20210807-git SIBLINGS (cl-postgres s-sql simple-date) PARASITES
+     cl-postgres/tests cl-ppcre closer-mop fiveam global-vars ironclad
+     local-time md5 s-sql s-sql/tests simple-date simple-date/postgres-glue
+     split-sequence uax-15 uiop usocket)
+    VERSION 20211020-git SIBLINGS (cl-postgres s-sql simple-date) PARASITES
     (postmodern/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/rove.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "rove";
-  version = "20210807-git";
+  version = "20211020-git";
 
   description = "Yet another testing framework intended to be a successor of Prove";
 
-  deps = [ args."bordeaux-threads" args."dissect" args."trivial-gray-streams" ];
+  deps = [ args."alexandria" args."bordeaux-threads" args."dissect" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/rove/2021-08-07/rove-20210807-git.tgz";
-    sha256 = "1zg9jch2q8946a1bsjykq0bw86zh9gqvvqbqa8k4njvqbc42kqn8";
+    url = "http://beta.quicklisp.org/archive/rove/2021-10-20/rove-20211020-git.tgz";
+    sha256 = "1p54dp4m2wnmff6dyfh2k4crk83n38nyix1g8csixvn8jkk2gi4b";
   };
 
   packageName = "rove";
@@ -20,11 +20,12 @@ rec {
 }
 /* (SYSTEM rove DESCRIPTION
     Yet another testing framework intended to be a successor of Prove SHA256
-    1zg9jch2q8946a1bsjykq0bw86zh9gqvvqbqa8k4njvqbc42kqn8 URL
-    http://beta.quicklisp.org/archive/rove/2021-08-07/rove-20210807-git.tgz MD5
-    502337a1120b19d1d70bb06191323ee0 NAME rove FILENAME rove DEPS
-    ((NAME bordeaux-threads FILENAME bordeaux-threads)
+    1p54dp4m2wnmff6dyfh2k4crk83n38nyix1g8csixvn8jkk2gi4b URL
+    http://beta.quicklisp.org/archive/rove/2021-10-20/rove-20211020-git.tgz MD5
+    119a5c0f506db2b301eb19bfed7c403d NAME rove FILENAME rove DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME dissect FILENAME dissect)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams))
-    DEPENDENCIES (bordeaux-threads dissect trivial-gray-streams) VERSION
-    20210807-git SIBLINGS NIL PARASITES NIL) */
+    DEPENDENCIES (alexandria bordeaux-threads dissect trivial-gray-streams)
+    VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/s-sql.nix
@@ -2,17 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "s-sql";
-  version = "postmodern-20210807-git";
+  version = "postmodern-20211020-git";
 
   parasites = [ "s-sql/tests" ];
 
   description = "Lispy DSL for SQL";
 
-  deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_slash_tests" args."cl-ppcre" args."cl-unicode" args."closer-mop" args."fiveam" args."global-vars" args."ironclad" args."md5" args."postmodern" args."split-sequence" args."uax-15" args."usocket" ];
+  deps = [ args."alexandria" args."bordeaux-threads" args."cl-base64" args."cl-postgres" args."cl-postgres_slash_tests" args."cl-ppcre" args."closer-mop" args."fiveam" args."global-vars" args."ironclad" args."md5" args."postmodern" args."split-sequence" args."uax-15" args."usocket" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-08-07/postmodern-20210807-git.tgz";
-    sha256 = "01l0zk5f3z1cxb6rspvagjl1fy8v3jwm62p2975cgl45aspp18fp";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz";
+    sha256 = "0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6";
   };
 
   packageName = "s-sql";
@@ -21,23 +21,23 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM s-sql DESCRIPTION Lispy DSL for SQL SHA256
-    01l0zk5f3z1cxb6rspvagjl1fy8v3jwm62p2975cgl45aspp18fp URL
-    http://beta.quicklisp.org/archive/postmodern/2021-08-07/postmodern-20210807-git.tgz
-    MD5 aa951f2ad4ce59fce588a62afa34f3ec NAME s-sql FILENAME s-sql DEPS
+    0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6 URL
+    http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz
+    MD5 84f4ad8ce7ac0f7f78cbfcf2f0bd3aa4 NAME s-sql FILENAME s-sql DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME cl-base64 FILENAME cl-base64)
      (NAME cl-postgres FILENAME cl-postgres)
      (NAME cl-postgres/tests FILENAME cl-postgres_slash_tests)
-     (NAME cl-ppcre FILENAME cl-ppcre) (NAME cl-unicode FILENAME cl-unicode)
-     (NAME closer-mop FILENAME closer-mop) (NAME fiveam FILENAME fiveam)
-     (NAME global-vars FILENAME global-vars) (NAME ironclad FILENAME ironclad)
-     (NAME md5 FILENAME md5) (NAME postmodern FILENAME postmodern)
+     (NAME cl-ppcre FILENAME cl-ppcre) (NAME closer-mop FILENAME closer-mop)
+     (NAME fiveam FILENAME fiveam) (NAME global-vars FILENAME global-vars)
+     (NAME ironclad FILENAME ironclad) (NAME md5 FILENAME md5)
+     (NAME postmodern FILENAME postmodern)
      (NAME split-sequence FILENAME split-sequence)
      (NAME uax-15 FILENAME uax-15) (NAME usocket FILENAME usocket))
     DEPENDENCIES
     (alexandria bordeaux-threads cl-base64 cl-postgres cl-postgres/tests
-     cl-ppcre cl-unicode closer-mop fiveam global-vars ironclad md5 postmodern
+     cl-ppcre closer-mop fiveam global-vars ironclad md5 postmodern
      split-sequence uax-15 usocket)
-    VERSION postmodern-20210807-git SIBLINGS
+    VERSION postmodern-20211020-git SIBLINGS
     (cl-postgres postmodern simple-date) PARASITES (s-sql/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/salza2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/salza2.nix
@@ -2,16 +2,18 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "salza2";
-  version = "2.0.9";
+  version = "2.1";
+
+  parasites = [ "salza2/test" ];
 
   description = "Create compressed data in the ZLIB, DEFLATE, or GZIP
   data formats";
 
-  deps = [ ];
+  deps = [ args."chipz" args."flexi-streams" args."parachute" args."trivial-gray-streams" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/salza2/2013-07-20/salza2-2.0.9.tgz";
-    sha256 = "1m0hksgvq3njd9xa2nxlm161vgzw77djxmisq08v9pz2bz16v8va";
+    url = "http://beta.quicklisp.org/archive/salza2/2021-10-20/salza2-2.1.tgz";
+    sha256 = "0ymx3bm2a9a3fwxbvcyzfy0cdfl5y0csyw5cybxy0whkwipgra0x";
   };
 
   packageName = "salza2";
@@ -22,7 +24,11 @@ rec {
 /* (SYSTEM salza2 DESCRIPTION
     Create compressed data in the ZLIB, DEFLATE, or GZIP
   data formats
-    SHA256 1m0hksgvq3njd9xa2nxlm161vgzw77djxmisq08v9pz2bz16v8va URL
-    http://beta.quicklisp.org/archive/salza2/2013-07-20/salza2-2.0.9.tgz MD5
-    e62383de435081c0f1f888ec363bb32c NAME salza2 FILENAME salza2 DEPS NIL
-    DEPENDENCIES NIL VERSION 2.0.9 SIBLINGS NIL PARASITES NIL) */
+    SHA256 0ymx3bm2a9a3fwxbvcyzfy0cdfl5y0csyw5cybxy0whkwipgra0x URL
+    http://beta.quicklisp.org/archive/salza2/2021-10-20/salza2-2.1.tgz MD5
+    867f3e0543a7e34d1be802062cf4893d NAME salza2 FILENAME salza2 DEPS
+    ((NAME chipz FILENAME chipz) (NAME flexi-streams FILENAME flexi-streams)
+     (NAME parachute FILENAME parachute)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams))
+    DEPENDENCIES (chipz flexi-streams parachute trivial-gray-streams) VERSION
+    2.1 SIBLINGS NIL PARASITES (salza2/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "serapeum";
-  version = "20210807-git";
+  version = "20211020-git";
 
   description = "Utilities beyond Alexandria.";
 
   deps = [ args."alexandria" args."babel" args."bordeaux-threads" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."parse-declarations-1_dot_0" args."parse-number" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-features" args."trivial-file-size" args."trivial-garbage" args."trivial-macroexpand-all" args."type-i" args."uiop" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/serapeum/2021-08-07/serapeum-20210807-git.tgz";
-    sha256 = "0ddkn6kfmfamnylfcmcix1z8knd7zj6x8x6a7aalk41f91phl93a";
+    url = "http://beta.quicklisp.org/archive/serapeum/2021-10-20/serapeum-20211020-git.tgz";
+    sha256 = "1lax10p8apgsm09wcnmxn1p52hgngwp8j6dsk5y8r2dj7h73529v";
   };
 
   packageName = "serapeum";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM serapeum DESCRIPTION Utilities beyond Alexandria. SHA256
-    0ddkn6kfmfamnylfcmcix1z8knd7zj6x8x6a7aalk41f91phl93a URL
-    http://beta.quicklisp.org/archive/serapeum/2021-08-07/serapeum-20210807-git.tgz
-    MD5 7027ae4f769f0b64ab65afc30811f6ab NAME serapeum FILENAME serapeum DEPS
+    1lax10p8apgsm09wcnmxn1p52hgngwp8j6dsk5y8r2dj7h73529v URL
+    http://beta.quicklisp.org/archive/serapeum/2021-10-20/serapeum-20211020-git.tgz
+    MD5 2f15c5635215fd23ddd43dba01647f82 NAME serapeum FILENAME serapeum DEPS
     ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
      (NAME bordeaux-threads FILENAME bordeaux-threads)
      (NAME closer-mop FILENAME closer-mop)
@@ -60,4 +60,4 @@ rec {
      trivia.level2 trivia.quasiquote trivia.trivial trivial-cltl2
      trivial-features trivial-file-size trivial-garbage trivial-macroexpand-all
      type-i uiop)
-    VERSION 20210807-git SIBLINGS NIL PARASITES NIL) */
+    VERSION 20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-date.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "simple-date";
-  version = "postmodern-20210807-git";
+  version = "postmodern-20211020-git";
 
   parasites = [ "simple-date/tests" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."fiveam" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/postmodern/2021-08-07/postmodern-20210807-git.tgz";
-    sha256 = "01l0zk5f3z1cxb6rspvagjl1fy8v3jwm62p2975cgl45aspp18fp";
+    url = "http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz";
+    sha256 = "0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6";
   };
 
   packageName = "simple-date";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM simple-date DESCRIPTION
     Simple date library that can be used with postmodern SHA256
-    01l0zk5f3z1cxb6rspvagjl1fy8v3jwm62p2975cgl45aspp18fp URL
-    http://beta.quicklisp.org/archive/postmodern/2021-08-07/postmodern-20210807-git.tgz
-    MD5 aa951f2ad4ce59fce588a62afa34f3ec NAME simple-date FILENAME simple-date
+    0iw0sbjra3g57ivfqgx3c97mlcdzlh2kgqp12d1r2i9pw8z0ckh6 URL
+    http://beta.quicklisp.org/archive/postmodern/2021-10-20/postmodern-20211020-git.tgz
+    MD5 84f4ad8ce7ac0f7f78cbfcf2f0bd3aa4 NAME simple-date FILENAME simple-date
     DEPS ((NAME fiveam FILENAME fiveam)) DEPENDENCIES (fiveam) VERSION
-    postmodern-20210807-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
+    postmodern-20211020-git SIBLINGS (cl-postgres postmodern s-sql) PARASITES
     (simple-date/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/smart-buffer.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/smart-buffer.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "smart-buffer";
-  version = "20210630-git";
+  version = "20211020-git";
 
   description = "Smart octets buffer";
 
   deps = [ args."flexi-streams" args."trivial-gray-streams" args."uiop" args."xsubseq" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/smart-buffer/2021-06-30/smart-buffer-20210630-git.tgz";
-    sha256 = "1j90cig9nkh9bim1h0jmgi73q8j3sja6bnn18bb85lalng0p4c2p";
+    url = "http://beta.quicklisp.org/archive/smart-buffer/2021-10-20/smart-buffer-20211020-git.tgz";
+    sha256 = "0v25s4msnwi9vn0cwfv3kxamj0mr2xdwngwmxmhh93mr4fkqzdnv";
   };
 
   packageName = "smart-buffer";
@@ -19,12 +19,12 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM smart-buffer DESCRIPTION Smart octets buffer SHA256
-    1j90cig9nkh9bim1h0jmgi73q8j3sja6bnn18bb85lalng0p4c2p URL
-    http://beta.quicklisp.org/archive/smart-buffer/2021-06-30/smart-buffer-20210630-git.tgz
-    MD5 3533a4884c2c7852961377366627727a NAME smart-buffer FILENAME
+    0v25s4msnwi9vn0cwfv3kxamj0mr2xdwngwmxmhh93mr4fkqzdnv URL
+    http://beta.quicklisp.org/archive/smart-buffer/2021-10-20/smart-buffer-20211020-git.tgz
+    MD5 d09d02788667d987b3988b6de09d09c3 NAME smart-buffer FILENAME
     smart-buffer DEPS
     ((NAME flexi-streams FILENAME flexi-streams)
      (NAME trivial-gray-streams FILENAME trivial-gray-streams)
      (NAME uiop FILENAME uiop) (NAME xsubseq FILENAME xsubseq))
     DEPENDENCIES (flexi-streams trivial-gray-streams uiop xsubseq) VERSION
-    20210630-git SIBLINGS (smart-buffer-test) PARASITES NIL) */
+    20211020-git SIBLINGS (smart-buffer-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-dispatch.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/static-dispatch.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "static-dispatch";
-  version = "20210807-git";
+  version = "20211020-git";
 
   parasites = [ "static-dispatch/test" ];
 
@@ -11,8 +11,8 @@ rec {
   deps = [ args."agutil" args."alexandria" args."anaphora" args."arrows" args."cl-environments" args."cl-form-types" args."closer-mop" args."collectors" args."fiveam" args."introspect-environment" args."iterate" args."optima" args."parse-declarations-1_dot_0" args."symbol-munger" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/static-dispatch/2021-08-07/static-dispatch-20210807-git.tgz";
-    sha256 = "1r5sz45mng0dvl77dv771ji95b9csxc0784b7igrk9bcz8npwc2g";
+    url = "http://beta.quicklisp.org/archive/static-dispatch/2021-10-20/static-dispatch-20211020-git.tgz";
+    sha256 = "0zm8haaf65a6mw1jwkzf2fhlh19ixq1asjc2kiz1jhdy40qdkkfj";
   };
 
   packageName = "static-dispatch";
@@ -22,9 +22,9 @@ rec {
 }
 /* (SYSTEM static-dispatch DESCRIPTION
     Static generic function dispatch for Common Lisp. SHA256
-    1r5sz45mng0dvl77dv771ji95b9csxc0784b7igrk9bcz8npwc2g URL
-    http://beta.quicklisp.org/archive/static-dispatch/2021-08-07/static-dispatch-20210807-git.tgz
-    MD5 b9724a680d9802ff690de24193583e20 NAME static-dispatch FILENAME
+    0zm8haaf65a6mw1jwkzf2fhlh19ixq1asjc2kiz1jhdy40qdkkfj URL
+    http://beta.quicklisp.org/archive/static-dispatch/2021-10-20/static-dispatch-20211020-git.tgz
+    MD5 f26f461213b1c8b78ede26c692e00442 NAME static-dispatch FILENAME
     static-dispatch DEPS
     ((NAME agutil FILENAME agutil) (NAME alexandria FILENAME alexandria)
      (NAME anaphora FILENAME anaphora) (NAME arrows FILENAME arrows)
@@ -40,4 +40,4 @@ rec {
     (agutil alexandria anaphora arrows cl-environments cl-form-types closer-mop
      collectors fiveam introspect-environment iterate optima
      parse-declarations-1.0 symbol-munger)
-    VERSION 20210807-git SIBLINGS NIL PARASITES (static-dispatch/test)) */
+    VERSION 20211020-git SIBLINGS NIL PARASITES (static-dispatch/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/sycamore.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/sycamore.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "sycamore";
-  version = "20200610-git";
+  version = "20211020-git";
 
   description = "A fast, purely functional data structure library";
 
   deps = [ args."alexandria" args."cl-fuzz" args."cl-ppcre" args."lisp-unit" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/sycamore/2020-06-10/sycamore-20200610-git.tgz";
-    sha256 = "0dn4vmbyz1ix34hjnmzjw8imh2s1p52y6fvgx2ppyqr61vdzn34p";
+    url = "http://beta.quicklisp.org/archive/sycamore/2021-10-20/sycamore-20211020-git.tgz";
+    sha256 = "1msh2kpd96s7jfm565snf71bbsmnjmsf8b31y1xg9vkk7xp01cf4";
   };
 
   packageName = "sycamore";
@@ -20,10 +20,10 @@ rec {
 }
 /* (SYSTEM sycamore DESCRIPTION
     A fast, purely functional data structure library SHA256
-    0dn4vmbyz1ix34hjnmzjw8imh2s1p52y6fvgx2ppyqr61vdzn34p URL
-    http://beta.quicklisp.org/archive/sycamore/2020-06-10/sycamore-20200610-git.tgz
-    MD5 7e06bc7db251f8f60231ff966846c7d4 NAME sycamore FILENAME sycamore DEPS
+    1msh2kpd96s7jfm565snf71bbsmnjmsf8b31y1xg9vkk7xp01cf4 URL
+    http://beta.quicklisp.org/archive/sycamore/2021-10-20/sycamore-20211020-git.tgz
+    MD5 0a9f35519b5cb3e5f9467427632ff0f8 NAME sycamore FILENAME sycamore DEPS
     ((NAME alexandria FILENAME alexandria) (NAME cl-fuzz FILENAME cl-fuzz)
      (NAME cl-ppcre FILENAME cl-ppcre) (NAME lisp-unit FILENAME lisp-unit))
-    DEPENDENCIES (alexandria cl-fuzz cl-ppcre lisp-unit) VERSION 20200610-git
+    DEPENDENCIES (alexandria cl-fuzz cl-ppcre lisp-unit) VERSION 20211020-git
     SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia";
-  version = "20210630-git";
+  version = "20211020-git";
 
   description = "NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase";
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."iterate" args."lisp-namespace" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz";
-    sha256 = "065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz";
+    sha256 = "0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g";
   };
 
   packageName = "trivia";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM trivia DESCRIPTION
     NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase
-    SHA256 065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas URL
-    http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz
-    MD5 e048a0e20ca12904c032d933795c5e31 NAME trivia FILENAME trivia DEPS
+    SHA256 0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g URL
+    http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz
+    MD5 db933e44824514d8ccc9b2a119008051 NAME trivia FILENAME trivia DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
      (NAME introspect-environment FILENAME introspect-environment)
@@ -38,7 +38,7 @@ rec {
     (alexandria closer-mop introspect-environment iterate lisp-namespace
      trivia.balland2006 trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2 type-i)
-    VERSION 20210630-git SIBLINGS
+    VERSION 20211020-git SIBLINGS
     (trivia.balland2006 trivia.benchmark trivia.cffi trivia.fset trivia.level0
      trivia.level1 trivia.level2 trivia.ppcre trivia.quasiquote trivia.test
      trivia.trivial)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_balland2006.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_balland2006.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_balland2006";
-  version = "trivia-20210630-git";
+  version = "trivia-20211020-git";
 
   description = "Optimizer for Trivia based on (Balland 2006)";
 
   deps = [ args."alexandria" args."closer-mop" args."introspect-environment" args."iterate" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" args."type-i" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz";
-    sha256 = "065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz";
+    sha256 = "0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g";
   };
 
   packageName = "trivia.balland2006";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM trivia.balland2006 DESCRIPTION
     Optimizer for Trivia based on (Balland 2006) SHA256
-    065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas URL
-    http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz
-    MD5 e048a0e20ca12904c032d933795c5e31 NAME trivia.balland2006 FILENAME
+    0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g URL
+    http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz
+    MD5 db933e44824514d8ccc9b2a119008051 NAME trivia.balland2006 FILENAME
     trivia_dot_balland2006 DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -38,7 +38,7 @@ rec {
     (alexandria closer-mop introspect-environment iterate lisp-namespace
      trivia.level0 trivia.level1 trivia.level2 trivia.trivial trivial-cltl2
      type-i)
-    VERSION trivia-20210630-git SIBLINGS
+    VERSION trivia-20211020-git SIBLINGS
     (trivia trivia.benchmark trivia.cffi trivia.fset trivia.level0
      trivia.level1 trivia.level2 trivia.ppcre trivia.quasiquote trivia.test
      trivia.trivial)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level0.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level0.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_level0";
-  version = "trivia-20210630-git";
+  version = "trivia-20211020-git";
 
   description = "Bootstrapping Pattern Matching Library for implementing Trivia";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz";
-    sha256 = "065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz";
+    sha256 = "0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g";
   };
 
   packageName = "trivia.level0";
@@ -20,11 +20,11 @@ rec {
 }
 /* (SYSTEM trivia.level0 DESCRIPTION
     Bootstrapping Pattern Matching Library for implementing Trivia SHA256
-    065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas URL
-    http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz
-    MD5 e048a0e20ca12904c032d933795c5e31 NAME trivia.level0 FILENAME
+    0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g URL
+    http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz
+    MD5 db933e44824514d8ccc9b2a119008051 NAME trivia.level0 FILENAME
     trivia_dot_level0 DEPS ((NAME alexandria FILENAME alexandria)) DEPENDENCIES
-    (alexandria) VERSION trivia-20210630-git SIBLINGS
+    (alexandria) VERSION trivia-20211020-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.fset
      trivia.level1 trivia.level2 trivia.ppcre trivia.quasiquote trivia.test
      trivia.trivial)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level1.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level1.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_level1";
-  version = "trivia-20210630-git";
+  version = "trivia-20211020-git";
 
   description = "Core patterns of Trivia";
 
   deps = [ args."alexandria" args."trivia_dot_level0" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz";
-    sha256 = "065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz";
+    sha256 = "0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g";
   };
 
   packageName = "trivia.level1";
@@ -19,13 +19,13 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM trivia.level1 DESCRIPTION Core patterns of Trivia SHA256
-    065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas URL
-    http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz
-    MD5 e048a0e20ca12904c032d933795c5e31 NAME trivia.level1 FILENAME
+    0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g URL
+    http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz
+    MD5 db933e44824514d8ccc9b2a119008051 NAME trivia.level1 FILENAME
     trivia_dot_level1 DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME trivia.level0 FILENAME trivia_dot_level0))
-    DEPENDENCIES (alexandria trivia.level0) VERSION trivia-20210630-git
+    DEPENDENCIES (alexandria trivia.level0) VERSION trivia-20211020-git
     SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.fset
      trivia.level0 trivia.level2 trivia.ppcre trivia.quasiquote trivia.test

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level2.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_level2.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_level2";
-  version = "trivia-20210630-git";
+  version = "trivia-20211020-git";
 
   description = "NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase";
 
   deps = [ args."alexandria" args."closer-mop" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz";
-    sha256 = "065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz";
+    sha256 = "0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g";
   };
 
   packageName = "trivia.level2";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM trivia.level2 DESCRIPTION
     NON-optimized pattern matcher compatible with OPTIMA, with extensible optimizer interface and clean codebase
-    SHA256 065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas URL
-    http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz
-    MD5 e048a0e20ca12904c032d933795c5e31 NAME trivia.level2 FILENAME
+    SHA256 0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g URL
+    http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz
+    MD5 db933e44824514d8ccc9b2a119008051 NAME trivia.level2 FILENAME
     trivia_dot_level2 DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -33,7 +33,7 @@ rec {
     DEPENDENCIES
     (alexandria closer-mop lisp-namespace trivia.level0 trivia.level1
      trivial-cltl2)
-    VERSION trivia-20210630-git SIBLINGS
+    VERSION trivia-20211020-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.fset
      trivia.level0 trivia.level1 trivia.ppcre trivia.quasiquote trivia.test
      trivia.trivial)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_quasiquote";
-  version = "trivia-20210630-git";
+  version = "trivia-20211020-git";
 
   description = "fare-quasiquote extension for trivia";
 
   deps = [ args."alexandria" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-readtable" args."fare-utils" args."lisp-namespace" args."named-readtables" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz";
-    sha256 = "065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz";
+    sha256 = "0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g";
   };
 
   packageName = "trivia.quasiquote";
@@ -19,9 +19,9 @@ rec {
   overrides = x: x;
 }
 /* (SYSTEM trivia.quasiquote DESCRIPTION fare-quasiquote extension for trivia
-    SHA256 065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas URL
-    http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz
-    MD5 e048a0e20ca12904c032d933795c5e31 NAME trivia.quasiquote FILENAME
+    SHA256 0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g URL
+    http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz
+    MD5 db933e44824514d8ccc9b2a119008051 NAME trivia.quasiquote FILENAME
     trivia_dot_quasiquote DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -39,7 +39,7 @@ rec {
     (alexandria closer-mop fare-quasiquote fare-quasiquote-readtable fare-utils
      lisp-namespace named-readtables trivia.level0 trivia.level1 trivia.level2
      trivia.trivial trivial-cltl2)
-    VERSION trivia-20210630-git SIBLINGS
+    VERSION trivia-20211020-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.fset
      trivia.level0 trivia.level1 trivia.level2 trivia.ppcre trivia.test
      trivia.trivial)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_trivial.nix
@@ -2,7 +2,7 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivia_dot_trivial";
-  version = "trivia-20210630-git";
+  version = "trivia-20211020-git";
 
   description = "Base level system of Trivia with a trivial optimizer.
  Systems that intend to enhance Trivia should depend on this package, not the TRIVIA system,
@@ -11,8 +11,8 @@ rec {
   deps = [ args."alexandria" args."closer-mop" args."lisp-namespace" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivial-cltl2" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz";
-    sha256 = "065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas";
+    url = "http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz";
+    sha256 = "0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g";
   };
 
   packageName = "trivia.trivial";
@@ -24,9 +24,9 @@ rec {
     Base level system of Trivia with a trivial optimizer.
  Systems that intend to enhance Trivia should depend on this package, not the TRIVIA system,
  in order to avoid the circular dependency.
-    SHA256 065bfypzahli8pvnbpiwsvxdp2i216gqr1a1algxkpikifrxkjas URL
-    http://beta.quicklisp.org/archive/trivia/2021-06-30/trivia-20210630-git.tgz
-    MD5 e048a0e20ca12904c032d933795c5e31 NAME trivia.trivial FILENAME
+    SHA256 0gf63v42pq8cxr7an177p2mf25n5jpqxdf0zb4xqlm2sydk7ng1g URL
+    http://beta.quicklisp.org/archive/trivia/2021-10-20/trivia-20211020-git.tgz
+    MD5 db933e44824514d8ccc9b2a119008051 NAME trivia.trivial FILENAME
     trivia_dot_trivial DEPS
     ((NAME alexandria FILENAME alexandria)
      (NAME closer-mop FILENAME closer-mop)
@@ -38,7 +38,7 @@ rec {
     DEPENDENCIES
     (alexandria closer-mop lisp-namespace trivia.level0 trivia.level1
      trivia.level2 trivial-cltl2)
-    VERSION trivia-20210630-git SIBLINGS
+    VERSION trivia-20211020-git SIBLINGS
     (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.fset
      trivia.level0 trivia.level1 trivia.level2 trivia.ppcre trivia.quasiquote
      trivia.test)

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-with-current-source-form.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-with-current-source-form.nix
@@ -2,15 +2,15 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "trivial-with-current-source-form";
-  version = "20210630-git";
+  version = "20211020-git";
 
   description = "Helps macro writers produce better errors for macro users";
 
   deps = [ args."alexandria" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/trivial-with-current-source-form/2021-06-30/trivial-with-current-source-form-20210630-git.tgz";
-    sha256 = "0xa4mmrrkqr8lg74wk04ccgx06r17jskhrfmw23ywpbi2yy1qyhp";
+    url = "http://beta.quicklisp.org/archive/trivial-with-current-source-form/2021-10-20/trivial-with-current-source-form-20211020-git.tgz";
+    sha256 = "03x8yx5hqfydxbdy9nxpaqn6yfjv7hvw8idscx66ns4qcpw6p825";
   };
 
   packageName = "trivial-with-current-source-form";
@@ -20,9 +20,9 @@ rec {
 }
 /* (SYSTEM trivial-with-current-source-form DESCRIPTION
     Helps macro writers produce better errors for macro users SHA256
-    0xa4mmrrkqr8lg74wk04ccgx06r17jskhrfmw23ywpbi2yy1qyhp URL
-    http://beta.quicklisp.org/archive/trivial-with-current-source-form/2021-06-30/trivial-with-current-source-form-20210630-git.tgz
-    MD5 0b4fe9e9a99e0729cc8ecf851df2a6c5 NAME trivial-with-current-source-form
+    03x8yx5hqfydxbdy9nxpaqn6yfjv7hvw8idscx66ns4qcpw6p825 URL
+    http://beta.quicklisp.org/archive/trivial-with-current-source-form/2021-10-20/trivial-with-current-source-form-20211020-git.tgz
+    MD5 b4a3721cbef6101de1c43c540b446efc NAME trivial-with-current-source-form
     FILENAME trivial-with-current-source-form DEPS
     ((NAME alexandria FILENAME alexandria)) DEPENDENCIES (alexandria) VERSION
-    20210630-git SIBLINGS NIL PARASITES NIL) */
+    20211020-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/uax-15.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/uax-15.nix
@@ -2,17 +2,17 @@
 args @ { fetchurl, ... }:
 rec {
   baseName = "uax-15";
-  version = "20210531-git";
+  version = "20211020-git";
 
   parasites = [ "uax-15/tests" ];
 
   description = "Common lisp implementation of Unicode normalization functions :nfc, :nfd, :nfkc and :nfkd (Uax-15)";
 
-  deps = [ args."cl-ppcre" args."parachute" args."split-sequence" args."uiop" ];
+  deps = [ args."cl-ppcre" args."parachute" args."split-sequence" ];
 
   src = fetchurl {
-    url = "http://beta.quicklisp.org/archive/uax-15/2021-05-31/uax-15-20210531-git.tgz";
-    sha256 = "0yz4zi13iybpwa2bw5r6cjdbkw1njrbb6vgjwmm3msnl1paxr3wg";
+    url = "http://beta.quicklisp.org/archive/uax-15/2021-10-20/uax-15-20211020-git.tgz";
+    sha256 = "1g6mbwxv8cbv9gbpkj267lwdgq8k21qx0isy1gbrc158h0al7bp9";
   };
 
   packageName = "uax-15";
@@ -22,10 +22,10 @@ rec {
 }
 /* (SYSTEM uax-15 DESCRIPTION
     Common lisp implementation of Unicode normalization functions :nfc, :nfd, :nfkc and :nfkd (Uax-15)
-    SHA256 0yz4zi13iybpwa2bw5r6cjdbkw1njrbb6vgjwmm3msnl1paxr3wg URL
-    http://beta.quicklisp.org/archive/uax-15/2021-05-31/uax-15-20210531-git.tgz
-    MD5 bceff07d037c7daccbdd5c84683fcddd NAME uax-15 FILENAME uax-15 DEPS
+    SHA256 1g6mbwxv8cbv9gbpkj267lwdgq8k21qx0isy1gbrc158h0al7bp9 URL
+    http://beta.quicklisp.org/archive/uax-15/2021-10-20/uax-15-20211020-git.tgz
+    MD5 27503fd1e91e494cc9ac10a985dbf95e NAME uax-15 FILENAME uax-15 DEPS
     ((NAME cl-ppcre FILENAME cl-ppcre) (NAME parachute FILENAME parachute)
-     (NAME split-sequence FILENAME split-sequence) (NAME uiop FILENAME uiop))
-    DEPENDENCIES (cl-ppcre parachute split-sequence uiop) VERSION 20210531-git
+     (NAME split-sequence FILENAME split-sequence))
+    DEPENDENCIES (cl-ppcre parachute split-sequence) VERSION 20211020-git
     SIBLINGS NIL PARASITES (uax-15/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/vecto.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/vecto.nix
@@ -6,7 +6,7 @@ rec {
 
   description = "Create vector graphics in PNG files.";
 
-  deps = [ args."cl-aa" args."cl-paths" args."cl-vectors" args."salza2" args."zpb-ttf" args."zpng" ];
+  deps = [ args."cl-aa" args."cl-paths" args."cl-vectors" args."salza2" args."trivial-gray-streams" args."zpb-ttf" args."zpng" ];
 
   src = fetchurl {
     url = "http://beta.quicklisp.org/archive/vecto/2017-12-27/vecto-1.5.tgz";
@@ -24,6 +24,8 @@ rec {
     69e6b2f7fa10066d50f9134942afad73 NAME vecto FILENAME vecto DEPS
     ((NAME cl-aa FILENAME cl-aa) (NAME cl-paths FILENAME cl-paths)
      (NAME cl-vectors FILENAME cl-vectors) (NAME salza2 FILENAME salza2)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams)
      (NAME zpb-ttf FILENAME zpb-ttf) (NAME zpng FILENAME zpng))
-    DEPENDENCIES (cl-aa cl-paths cl-vectors salza2 zpb-ttf zpng) VERSION 1.5
-    SIBLINGS (vectometry) PARASITES NIL) */
+    DEPENDENCIES
+    (cl-aa cl-paths cl-vectors salza2 trivial-gray-streams zpb-ttf zpng)
+    VERSION 1.5 SIBLINGS (vectometry) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/zpng.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/zpng.nix
@@ -6,7 +6,7 @@ rec {
 
   description = "Create PNG files";
 
-  deps = [ args."salza2" ];
+  deps = [ args."salza2" args."trivial-gray-streams" ];
 
   src = fetchurl {
     url = "http://beta.quicklisp.org/archive/zpng/2015-04-07/zpng-1.2.2.tgz";
@@ -22,5 +22,7 @@ rec {
     0932gq9wncibm1z81gbvdc3ip6n118wwzmjnpxaqdy9hk5bs2w1x URL
     http://beta.quicklisp.org/archive/zpng/2015-04-07/zpng-1.2.2.tgz MD5
     0a208f4ce0087ef578d477341d5f4078 NAME zpng FILENAME zpng DEPS
-    ((NAME salza2 FILENAME salza2)) DEPENDENCIES (salza2) VERSION 1.2.2
-    SIBLINGS NIL PARASITES NIL) */
+    ((NAME salza2 FILENAME salza2)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams))
+    DEPENDENCIES (salza2 trivial-gray-streams) VERSION 1.2.2 SIBLINGS NIL
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -292,16 +292,14 @@ $out/lib/common-lisp/query-fs"
     };
   };
   lla = addNativeLibs [ pkgs.openblas ];
-  esrap = x: {
+  uax-15 = x: {
     overrides = y: (x.overrides y) // {
       postPatch = ''
         patch -p1 < ${
-          # Quicklisp 2021-08-07 packages an Esrap that doesn't build with SBCL 2.1.9.
-          # Therefore we pull patches from the Esrap repo to fix this.
-          # See https://github.com/scymtym/parser.common-rules/issues/1
           pkgs.fetchurl {
-            url = https://github.com/scymtym/esrap/compare/4034df872c2b1b8e91adbccab491645c8138253b...c99c33a33ff58ca85e8ba73912eba45d458eaa72.diff;
-            sha256 = "sha256:1sg2mgzilmwj5kwlmx0s60wk2769c3mpqjl00ga2p74ra5hykvx8";
+            # https://github.com/sabracrolleton/uax-15/pull/12
+            url = https://github.com/nuddyco/uax-15/commit/d553181669f488636df03d60ad7f5bec64d566bf.diff;
+            sha256 = "sha256:1608jzw7giy18vlw7pz4pl8prwlprgif8zcl9hwa0wf5gdxwd7gn";
           }}
       '';
     };

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -6,11 +6,20 @@ let quicklisp-to-nix-packages = rec {
   buildLispPackage = callPackage ./define-package.nix;
   qlOverrides = callPackage ./quicklisp-to-nix-overrides.nix {};
 
+  "html-encode" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."html-encode" or (x: {}))
+       (import ./quicklisp-to-nix-output/html-encode.nix {
+         inherit fetchurl;
+       }));
+
+
   "rove" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."rove" or (x: {}))
        (import ./quicklisp-to-nix-output/rove.nix {
          inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
            "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
            "dissect" = quicklisp-to-nix-packages."dissect";
            "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
@@ -59,6 +68,7 @@ let quicklisp-to-nix-packages = rec {
        (import ./quicklisp-to-nix-output/zpng.nix {
          inherit fetchurl;
            "salza2" = quicklisp-to-nix-packages."salza2";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
        }));
 
 
@@ -199,7 +209,6 @@ let quicklisp-to-nix-packages = rec {
            "cl-postgres" = quicklisp-to-nix-packages."cl-postgres";
            "cl-postgres_slash_tests" = quicklisp-to-nix-packages."cl-postgres_slash_tests";
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
-           "cl-unicode" = quicklisp-to-nix-packages."cl-unicode";
            "closer-mop" = quicklisp-to-nix-packages."closer-mop";
            "fiveam" = quicklisp-to-nix-packages."fiveam";
            "global-vars" = quicklisp-to-nix-packages."global-vars";
@@ -238,14 +247,6 @@ let quicklisp-to-nix-packages = rec {
     ((f: x: (x // (f x)))
        (qlOverrides."parseq" or (x: {}))
        (import ./quicklisp-to-nix-output/parseq.nix {
-         inherit fetchurl;
-       }));
-
-
-  "html-encode" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."html-encode" or (x: {}))
-       (import ./quicklisp-to-nix-output/html-encode.nix {
          inherit fetchurl;
        }));
 
@@ -302,49 +303,6 @@ let quicklisp-to-nix-packages = rec {
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
            "usocket" = quicklisp-to-nix-packages."usocket";
-       }));
-
-
-  "iolib_dot_conf" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."iolib_dot_conf" or (x: {}))
-       (import ./quicklisp-to-nix-output/iolib_dot_conf.nix {
-         inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "iolib_dot_asdf" = quicklisp-to-nix-packages."iolib_dot_asdf";
-       }));
-
-
-  "iolib_dot_common-lisp" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."iolib_dot_common-lisp" or (x: {}))
-       (import ./quicklisp-to-nix-output/iolib_dot_common-lisp.nix {
-         inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "iolib_dot_asdf" = quicklisp-to-nix-packages."iolib_dot_asdf";
-           "iolib_dot_conf" = quicklisp-to-nix-packages."iolib_dot_conf";
-       }));
-
-
-  "iolib_dot_base" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."iolib_dot_base" or (x: {}))
-       (import ./quicklisp-to-nix-output/iolib_dot_base.nix {
-         inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
-           "iolib_dot_asdf" = quicklisp-to-nix-packages."iolib_dot_asdf";
-           "iolib_dot_common-lisp" = quicklisp-to-nix-packages."iolib_dot_common-lisp";
-           "iolib_dot_conf" = quicklisp-to-nix-packages."iolib_dot_conf";
-           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
-       }));
-
-
-  "iolib_dot_asdf" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."iolib_dot_asdf" or (x: {}))
-       (import ./quicklisp-to-nix-output/iolib_dot_asdf.nix {
-         inherit fetchurl;
-           "alexandria" = quicklisp-to-nix-packages."alexandria";
        }));
 
 
@@ -1044,6 +1002,49 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "iolib_dot_conf" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."iolib_dot_conf" or (x: {}))
+       (import ./quicklisp-to-nix-output/iolib_dot_conf.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "iolib_dot_asdf" = quicklisp-to-nix-packages."iolib_dot_asdf";
+       }));
+
+
+  "iolib_dot_common-lisp" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."iolib_dot_common-lisp" or (x: {}))
+       (import ./quicklisp-to-nix-output/iolib_dot_common-lisp.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "iolib_dot_asdf" = quicklisp-to-nix-packages."iolib_dot_asdf";
+           "iolib_dot_conf" = quicklisp-to-nix-packages."iolib_dot_conf";
+       }));
+
+
+  "iolib_dot_base" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."iolib_dot_base" or (x: {}))
+       (import ./quicklisp-to-nix-output/iolib_dot_base.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "iolib_dot_asdf" = quicklisp-to-nix-packages."iolib_dot_asdf";
+           "iolib_dot_common-lisp" = quicklisp-to-nix-packages."iolib_dot_common-lisp";
+           "iolib_dot_conf" = quicklisp-to-nix-packages."iolib_dot_conf";
+           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
+       }));
+
+
+  "iolib_dot_asdf" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."iolib_dot_asdf" or (x: {}))
+       (import ./quicklisp-to-nix-output/iolib_dot_asdf.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+       }));
+
+
   "cl-xmlspam" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."cl-xmlspam" or (x: {}))
@@ -1068,7 +1069,6 @@ let quicklisp-to-nix-packages = rec {
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
            "parachute" = quicklisp-to-nix-packages."parachute";
            "split-sequence" = quicklisp-to-nix-packages."split-sequence";
-           "uiop" = quicklisp-to-nix-packages."uiop";
        }));
 
 
@@ -1566,6 +1566,7 @@ let quicklisp-to-nix-packages = rec {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "clunit2" = quicklisp-to-nix-packages."clunit2";
        }));
 
 
@@ -1822,6 +1823,7 @@ let quicklisp-to-nix-packages = rec {
            "cl-paths" = quicklisp-to-nix-packages."cl-paths";
            "cl-vectors" = quicklisp-to-nix-packages."cl-vectors";
            "salza2" = quicklisp-to-nix-packages."salza2";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
            "zpb-ttf" = quicklisp-to-nix-packages."zpb-ttf";
            "zpng" = quicklisp-to-nix-packages."zpng";
        }));
@@ -2247,6 +2249,10 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."salza2" or (x: {}))
        (import ./quicklisp-to-nix-output/salza2.nix {
          inherit fetchurl;
+           "chipz" = quicklisp-to-nix-packages."chipz";
+           "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
+           "parachute" = quicklisp-to-nix-packages."parachute";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
        }));
 
 
@@ -2361,10 +2367,8 @@ let quicklisp-to-nix-packages = rec {
            "cl-postgres_plus_local-time" = quicklisp-to-nix-packages."cl-postgres_plus_local-time";
            "cl-postgres_slash_tests" = quicklisp-to-nix-packages."cl-postgres_slash_tests";
            "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
-           "cl-unicode" = quicklisp-to-nix-packages."cl-unicode";
            "closer-mop" = quicklisp-to-nix-packages."closer-mop";
            "fiveam" = quicklisp-to-nix-packages."fiveam";
-           "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
            "global-vars" = quicklisp-to-nix-packages."global-vars";
            "ironclad" = quicklisp-to-nix-packages."ironclad";
            "local-time" = quicklisp-to-nix-packages."local-time";
@@ -2579,18 +2583,12 @@ let quicklisp-to-nix-packages = rec {
            "_3bmd-ext-code-blocks" = quicklisp-to-nix-packages."_3bmd-ext-code-blocks";
            "alexandria" = quicklisp-to-nix-packages."alexandria";
            "babel" = quicklisp-to-nix-packages."babel";
-           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
            "cl-fad" = quicklisp-to-nix-packages."cl-fad";
            "colorize" = quicklisp-to-nix-packages."colorize";
-           "esrap" = quicklisp-to-nix-packages."esrap";
-           "html-encode" = quicklisp-to-nix-packages."html-encode";
            "ironclad" = quicklisp-to-nix-packages."ironclad";
            "named-readtables" = quicklisp-to-nix-packages."named-readtables";
            "pythonic-string-reader" = quicklisp-to-nix-packages."pythonic-string-reader";
-           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
            "swank" = quicklisp-to-nix-packages."swank";
-           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
-           "trivial-with-current-source-form" = quicklisp-to-nix-packages."trivial-with-current-source-form";
        }));
 
 
@@ -3361,12 +3359,29 @@ let quicklisp-to-nix-packages = rec {
            "alexandria" = quicklisp-to-nix-packages."alexandria";
            "asdf-package-system" = quicklisp-to-nix-packages."asdf-package-system";
            "babel" = quicklisp-to-nix-packages."babel";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "cffi-grovel" = quicklisp-to-nix-packages."cffi-grovel";
+           "cffi-toolchain" = quicklisp-to-nix-packages."cffi-toolchain";
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
            "cl-xmlspam" = quicklisp-to-nix-packages."cl-xmlspam";
+           "closure-common" = quicklisp-to-nix-packages."closure-common";
+           "cxml" = quicklisp-to-nix-packages."cxml";
            "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
+           "idna" = quicklisp-to-nix-packages."idna";
            "ieee-floats" = quicklisp-to-nix-packages."ieee-floats";
            "iolib" = quicklisp-to-nix-packages."iolib";
+           "iolib_dot_asdf" = quicklisp-to-nix-packages."iolib_dot_asdf";
+           "iolib_dot_base" = quicklisp-to-nix-packages."iolib_dot_base";
+           "iolib_dot_common-lisp" = quicklisp-to-nix-packages."iolib_dot_common-lisp";
+           "iolib_dot_conf" = quicklisp-to-nix-packages."iolib_dot_conf";
            "ironclad" = quicklisp-to-nix-packages."ironclad";
+           "puri" = quicklisp-to-nix-packages."puri";
+           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
+           "swap-bytes" = quicklisp-to-nix-packages."swap-bytes";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
            "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
        }));
 
 


### PR DESCRIPTION
###### Motivation for this change

Update `lispPackages` to the new Quicklisp release 2021-10-21 from today.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
