### PR TITLE
file: 5.40 -> 5.41

### DIFF
--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://darwinsys.com/file";
     description = "A program that shows the type of files";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ doronbehar ];
     license = licenses.bsd2;
     platforms = platforms.all;
   };

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -1,28 +1,20 @@
-{ lib, stdenv, fetchurl, file, zlib, libgnurx, fetchpatch }:
+{ lib, stdenv, fetchurl, file, zlib, libgnurx }:
 
 stdenv.mkDerivation rec {
   pname = "file";
-  version = "5.40";
+  version = "5.41";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.astron.com/pub/file/${pname}-${version}.tar.gz"
       "https://distfiles.macports.org/file/${pname}-${version}.tar.gz"
     ];
-    sha256 = "0myxlpj9gy2diqavx33vq88kpvr1k1bpzsm0d0zmb2hl7ks22wqn";
+    sha256 = "sha256-E+Uyx7Nk99V+I9/uoxRxAxUMuQWTpXr4bBDk9uQRYD8=";
   };
 
   nativeBuildInputs = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
   buildInputs = [ zlib ]
     ++ lib.optional stdenv.hostPlatform.isWindows libgnurx;
-
-  patches = [
-    # Fix the mime type detection of xz file. Is merged in master.
-    (fetchpatch {
-      url = "https://github.com/file/file/commit/9b0459afab309a82aa4e46f73a4e50dd641f3d39.patch";
-      sha256 = "sha256-6vjyIn5gVbgmhUlfXJKFRVltm8YKATKmh0/X6+2lLnM=";
-    })
-  ];
 
   doCheck = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
