### PR TITLE
kubecfg: install shell completions

### DIFF
--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -1,6 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub, installShellFiles, ... }:
-
-let version = "0.21.0"; in
+{ lib, buildGoPackage, fetchFromGitHub, installShellFiles }:
 
 buildGoPackage {
   pname = "kubecfg";

--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "kubecfg";
-  inherit version;
+  version = "0.21.0";
 
   src = fetchFromGitHub {
     owner = "bitnami";

--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub, ... }:
+{ lib, buildGoPackage, fetchFromGitHub, installShellFiles, ... }:
 
 let version = "0.21.0"; in
 
@@ -16,6 +16,14 @@ buildGoPackage {
   goPackagePath = "github.com/bitnami/kubecfg";
 
   ldflags = [ "-s" "-w" "-X main.version=v${version}" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd kubecfg \
+      --bash <($out/bin/kubecfg completion --shell=bash) \
+      --zsh  <($out/bin/kubecfg completion --shell=zsh)
+  '';
 
   meta = {
     description = "A tool for managing Kubernetes resources as code";

--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -1,6 +1,6 @@
 { lib, buildGoPackage, fetchFromGitHub, installShellFiles }:
 
-buildGoPackage {
+buildGoPackage rec {
   pname = "kubecfg";
   inherit version;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Have shell completions installed.

###### Things done

Added the completions for bash and zsh to postInstall. No fish completion support in kubecfg.

Verified the output:

```
$ ls -la /nix/store/imbf2f4mw4p6pscjdrgqr6w3kjyqiily-kubecfg-0.21.0/share/*/*
/nix/store/imbf2f4mw4p6pscjdrgqr6w3kjyqiily-kubecfg-0.21.0/share/bash-completion/completions:
total 36
dr-xr-xr-x 1 root root    24 Jan  1  1970 .
dr-xr-xr-x 1 root root    22 Jan  1  1970 ..
-r--r--r-- 2 root root 35392 Jan  1  1970 kubecfg.bash

/nix/store/imbf2f4mw4p6pscjdrgqr6w3kjyqiily-kubecfg-0.21.0/share/zsh/site-functions:
total 32
dr-xr-xr-x 1 root root    16 Jan  1  1970 .
dr-xr-xr-x 1 root root    28 Jan  1  1970 ..
-r--r--r-- 2 root root 28814 Jan  1  1970 _kubecfg
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
