### PR TITLE
postgresql11Packages.age: use latest bison

### DIFF
--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -1,8 +1,6 @@
 self: super: {
 
-    age = super.callPackage ./ext/age.nix {
-      bison = self.bison_3_5;
-    };
+    age = super.callPackage ./ext/age.nix { };
 
     periods = super.callPackage ./ext/periods.nix { };
 


### PR DESCRIPTION
The package builds successfully with bison-3.7.6 and 3.8.2.