### PR TITLE
python3Packages.jupyterlab-git: 0.32.2 -> 0.33.0

### DIFF
--- a/pkgs/development/python-modules/jupyterlab-git/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-git/default.nix
@@ -1,40 +1,76 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
-, notebook
-, nbdime
 , git
-, pytest
+, jupyter_server
+, jupyter-packaging
+, jupyterlab
+, nbdime
+, nbformat
+, pexpect
+, pytest-asyncio
+, pytest-tornasync
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  pname = "jupyterlab_git";
-  version = "0.32.2";
-  disabled = pythonOlder "3.5";
+  pname = "jupyterlab-git";
+  version = "0.33.0";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "4c5743a05150ed7736e028aac15787a66735f160e9ae198dacc5a4bd1a727ce2";
+    pname = "jupyterlab_git";
+    inherit version;
+    sha256 = "0rbl472k66asfq9n9xqd2zpw8z7yrk6ka411vhvlvvszzb7g6w13";
   };
 
-  propagatedBuildInputs = [ notebook nbdime git ];
+  nativeBuildInputs = [
+    jupyter-packaging
+  ];
 
-  # all Tests on darwin fail or are skipped due to sandbox
+  propagatedBuildInputs = [
+    jupyter_server
+    nbdime
+    git
+    nbformat
+    pexpect
+  ];
+
+  checkInputs = [
+    jupyterlab
+    pytest-asyncio
+    pytest-tornasync
+    pytestCheckHook
+  ];
+
+  # All Tests on darwin fail or are skipped due to sandbox
   doCheck = !stdenv.isDarwin;
 
-  checkInputs = [ pytest ];
+  disabledTestPaths = [
+    "jupyterlab_git/tests/test_handlers.py"
+    # PyPI doesn't ship all required files for the tests
+    "jupyterlab_git/tests/test_config.py"
+    "jupyterlab_git/tests/test_integrations.py"
+    "jupyterlab_git/tests/test_remote.py"
+    "jupyterlab_git/tests/test_settings.py"
+  ];
 
-  checkPhase = ''
-    pytest jupyterlab_git/ --ignore=jupyterlab_git/tests/test_handlers.py
-  '';
+  disabledTests = [
+    "test_Git_get_nbdiff_file"
+    "test_Git_get_nbdiff_dict"
+  ];
 
-  pythonImportsCheck = [ "jupyterlab_git" ];
+  pythonImportsCheck = [
+    "jupyterlab_git"
+  ];
 
   meta = with lib; {
-    description = "Jupyter lab extension for version control with Git.";
-    license = with licenses; [ bsd3 ];
+    description = "Jupyter lab extension for version control with Git";
     homepage = "https://github.com/jupyterlab/jupyterlab-git";
+    license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ chiroptical ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.33.0

Change log: https://github.com/jupyterlab/jupyterlab-git/releases/tag/v0.33.0

Fix build failure detected in #142432

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
