### PR TITLE
pantheon.file-roller: init

### DIFF
--- a/nixos/modules/programs/file-roller.nix
+++ b/nixos/modules/programs/file-roller.nix
@@ -4,7 +4,9 @@
 
 with lib;
 
-{
+let cfg = config.programs.file-roller;
+
+in {
 
   # Added 2019-08-09
   imports = [
@@ -21,6 +23,13 @@ with lib;
 
       enable = mkEnableOption "File Roller, an archive manager for GNOME";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.gnome.file-roller;
+        defaultText = literalExpression "pkgs.gnome.file-roller";
+        description = "File Roller derivation to use.";
+      };
+
     };
 
   };
@@ -28,11 +37,11 @@ with lib;
 
   ###### implementation
 
-  config = mkIf config.programs.file-roller.enable {
+  config = mkIf cfg.enable {
 
-    environment.systemPackages = [ pkgs.gnome.file-roller ];
+    environment.systemPackages = [ cfg.package ];
 
-    services.dbus.packages = [ pkgs.gnome.file-roller ];
+    services.dbus.packages = [ cfg.package ];
 
   };
 

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -221,6 +221,7 @@ in
       programs.evince.enable = mkDefault true;
       programs.evince.package = pkgs.pantheon.evince;
       programs.file-roller.enable = mkDefault true;
+      programs.file-roller.package = pkgs.pantheon.file-roller;
 
       # Settings from elementary-default-settings
       environment.sessionVariables.GTK_CSD = "1";

--- a/pkgs/desktops/gnome/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome/apps/file-roller/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , desktop-file-utils
 , gettext
 , glibcLocales
@@ -20,7 +21,9 @@
 , libarchive
 , libnotify
 , nautilus
+, pantheon
 , unzip
+, withPantheon ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -31,6 +34,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "039w1dcpa5ypmv6sm634alk9vbcdkyvy595vkh5gn032jsiqca2a";
   };
+
+  patches = lib.optionals withPantheon [
+    # Make this respect dark mode settings from Pantheon
+    # https://github.com/elementary/fileroller/
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/elementary/fileroller/f183eac36c68c9c9441e72294d4e305cf5fe36ed/fr-application-prefers-color-scheme.patch";
+      sha256 = "sha256-d/sqf4Oen9UrzYqru7Ck15o/6g6WfxRDH/iAGFXgYAA=";
+    })
+  ];
 
   LANG = "en_US.UTF-8"; # postinstall.py
 
@@ -57,6 +69,8 @@ stdenv.mkDerivation rec {
     libarchive
     libnotify
     nautilus
+  ] ++ lib.optionals withPantheon [
+    pantheon.granite
   ];
 
   PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/lib/nautilus/extensions-3.0";
@@ -86,6 +100,6 @@ stdenv.mkDerivation rec {
     description = "Archive manager for the GNOME desktop environment";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = teams.gnome.members;
+    maintainers = teams.gnome.members ++ teams.pantheon.members;
   };
 }

--- a/pkgs/desktops/gnome/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome/apps/file-roller/default.nix
@@ -1,6 +1,27 @@
-{ lib, stdenv, fetchurl, glib, gtk3, meson, ninja, pkg-config, gnome, gettext, itstool, libxml2, libarchive
-, file, json-glib, python3, wrapGAppsHook, desktop-file-utils, libnotify, nautilus, glibcLocales
-, unzip, cpio }:
+{ lib
+, stdenv
+, fetchurl
+, desktop-file-utils
+, gettext
+, glibcLocales
+, itstool
+, libxml2
+, meson
+, ninja
+, pkg-config
+, python3
+, wrapGAppsHook
+, cpio
+, file
+, glib
+, gnome
+, gtk3
+, json-glib
+, libarchive
+, libnotify
+, nautilus
+, unzip
+}:
 
 stdenv.mkDerivation rec {
   pname = "file-roller";
@@ -13,9 +34,30 @@ stdenv.mkDerivation rec {
 
   LANG = "en_US.UTF-8"; # postinstall.py
 
-  nativeBuildInputs = [ meson ninja gettext itstool pkg-config libxml2 python3 wrapGAppsHook glibcLocales desktop-file-utils ];
+  nativeBuildInputs = [
+    desktop-file-utils
+    gettext
+    glibcLocales
+    itstool
+    libxml2
+    meson
+    ninja
+    pkg-config
+    python3
+    wrapGAppsHook
+  ];
 
-  buildInputs = [ glib gtk3 json-glib libarchive file gnome.adwaita-icon-theme libnotify nautilus cpio ];
+  buildInputs = [
+    cpio
+    file
+    glib
+    gnome.adwaita-icon-theme
+    gtk3
+    json-glib
+    libarchive
+    libnotify
+    nautilus
+  ];
 
   PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/lib/nautilus/extensions-3.0";
 

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -73,6 +73,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   evince = pkgs.evince.override { withPantheon = true; };
 
+  file-roller = pkgs.gnome.file-roller.override { withPantheon = true; };
+
   sideload = callPackage ./apps/sideload { };
 
   #### DESKTOP


### PR DESCRIPTION
~~This is not tested and related upstream PR hasn't merged yet.~~

- https://github.com/elementary/fileroller/pull/8

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
