### PR TITLE
coqPackages.paramcoq: 1.1.2 -> 1.1.3

### DIFF
--- a/pkgs/development/coq-modules/paramcoq/default.nix
+++ b/pkgs/development/coq-modules/paramcoq/default.nix
@@ -4,12 +4,15 @@ with lib; mkCoqDerivation {
   pname = "paramcoq";
   inherit version;
   defaultVersion = with versions; switch coq.version [
-    { case = range "8.13" "8.14"; out = "1.1.3+coq${coq.coq-version}"; }
-    { case = range "8.7"  "8.13"; out = "1.1.2+coq${coq.coq-version}"; }
+    { case = range "8.10" "8.14"; out = "1.1.3+coq${coq.coq-version}"; }
+    { case = range "8.7"  "8.10"; out = "1.1.2+coq${coq.coq-version}"; }
   ] null;
   displayVersion = { paramcoq = "..."; };
   release."1.1.3+coq8.14".sha256 = "00zqq9dc2p5v0ib1jgizl25xkwxrs9mrlylvy0zvb96dpridjc71";
   release."1.1.3+coq8.13".sha256 = "06ndly736k4pmdn4baqa7fblp6lx7a9pxm9gvz1vzd6ic51825wp";
+  release."1.1.3+coq8.12".sha256 = "10j23ws8ymqpxhapni75sxbzz0dl4n9sgasrx618i7s7b705y2rh";
+  release."1.1.3+coq8.11".sha256 = "1wbvcmkr7q106418bvvc2rj2d7s03wdhhxar0hicy1rr267w2bs6";
+  release."1.1.3+coq8.10".sha256 = "0kv3k3y2fck1qz83pqmihyh98swicnpx0n6fzkis1n2g39qjfz91";
   release."1.1.2+coq8.13".sha256 = "02vnf8p04ynf3qk8myvjzsbga15395235mpdpj54pvxis3h5qq22";
   release."1.1.2+coq8.12".sha256 = "0qd72r45if4h7c256qdfiimv75zyrs0w0xqij3m866jxaq591v4i";
   release."1.1.2+coq8.11".sha256 = "09c6813988nvq4fpa45s33k70plnhxsblhm7cxxkg0i37mhvigsa";


### PR DESCRIPTION
Add 1.1.3+coq8.10, 1.1.3+coq8.11 and 1.1.3+coq8.12 that were recently
released in order to keep CoqEAL dev compatible with Coq >= 8.10.
* https://github.com/coq-community/coqeal/pull/52
* https://github.com/coq/opam-coq-archive/pull/1867

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
