### PR TITLE
xdg-desktop-portal-pantheon: init at 1.0.0

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -226,8 +226,9 @@ in
       environment.sessionVariables.GTK_CSD = "1";
       environment.etc."gtk-3.0/settings.ini".source = "${pkgs.pantheon.elementary-default-settings}/etc/gtk-3.0/settings.ini";
 
-      xdg.portal.extraPortals = [
-        pkgs.pantheon.elementary-files
+      xdg.portal.extraPortals = with pkgs; [
+        pantheon.elementary-files
+        xdg-desktop-portal-pantheon
       ];
 
       # Override GSettings schemas

--- a/pkgs/development/libraries/xdg-desktop-portal-pantheon/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-pantheon/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, nix-update-script
+, meson
+, ninja
+, pkg-config
+, vala
+, wrapGAppsHook
+, glib
+, gtk3
+, libhandy
+, pantheon
+, systemd
+, vte
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xdg-desktop-portal-pantheon";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "elementary";
+    repo = "portals";
+    rev = "d12f82e6d55ea2f1555441e7f2244363b3383506";
+    sha256 = "sha256-vZ4CPyWR5QXS5uFQ1lCZmE4uvfU8IHABWVO1KHFIV5U=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libhandy
+    pantheon.granite
+    systemd
+    vte
+  ];
+
+  mesonFlags = [
+    "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with lib; {
+    description = "Backend implementation for xdg-desktop-portal for the Pantheon desktop environment";
+    homepage = "https://github.com/elementary/portals";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.pantheon.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28870,6 +28870,8 @@ with pkgs;
 
   xdg-desktop-portal-gtk = callPackage ../development/libraries/xdg-desktop-portal-gtk { };
 
+  xdg-desktop-portal-pantheon = callPackage ../development/libraries/xdg-desktop-portal-pantheon { };
+
   xdg-desktop-portal-wlr = callPackage ../development/libraries/xdg-desktop-portal-wlr { };
 
   xdg-user-dirs = callPackage ../tools/X11/xdg-user-dirs { };


### PR DESCRIPTION
#### **Drafting as 1.0.0 is not released yet**.

I haven't tested this yet.

###### Motivation for this change

https://github.com/elementary/portals/blob/main/data/portals.appdata.xml.in

> 1.0.0 First release!
> - Add OpenURI Portal

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
