### PR TITLE
ddosify: init at 0.4.1

### DIFF
--- a/pkgs/development/tools/ddosify/default.nix
+++ b/pkgs/development/tools/ddosify/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "ddosify";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-z7jYnEZSHh/Omg5DMNFzuPhV1d8lZSy8I+8tM86O43s=";
+  };
+
+  vendorSha256 = "sha256-VWWik7oovVJq0J/tj/2Mm5QtvRkJLtMROJhRC2JFZdw=";
+
+  # triggers a different set of tests that seems to be interactive and fail (no url target defined)
+  ldflags = [
+    "-s -w"
+    "-X main.GitVersion=${version}"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/ddosify -version | grep ${version} > /dev/null
+  '';
+
+  meta = with lib; {
+    description = "High-performance load testing tool, written in Golang";
+    homepage = "https://ddosify.com/";
+    changelog = "https://github.com/ddosify/ddosify/releases/tag/v${version}";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2586,6 +2586,8 @@ with pkgs;
 
   ddate = callPackage ../tools/misc/ddate { };
 
+  ddosify = callPackage ../development/tools/ddosify { };
+
   dduper = callPackage ../tools/filesystems/dduper { };
 
   dedup = callPackage ../tools/backup/dedup { };


### PR DESCRIPTION
###### Motivation for this change

Init ddosify, a high-performance load testing tool, written in Golang.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
