### PR TITLE
stdenv.mkDerivation: default meta.mainProgram to pname

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -357,6 +357,7 @@ else let
         in [( lib.findFirst hasOutput null (["bin" "out"] ++ outputs) )]
           ++ lib.optional (hasOutput "man") "man";
     }
+    // lib.optionalAttrs (attrs ? pname) { mainProgram = attrs.pname; }
     // attrs.meta or {}
     # Fill `meta.position` to identify the source location of the package.
     // lib.optionalAttrs (pos != null) {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A lot of packages in have version numbers that doesn't start with numbers, mostly `"unstable-<date>"`, which makes `nix run` fail to find the executable since it parses the executable name as `"<pname>-unstable"`

There is a rfc trying to solve this issue (https://github.com/NixOS/rfcs/pull/107), but the existing unstable version numbers probably won't be all changed long after the rfc gets through

This pull request defaults `meta.mainProgram` to `pname` in `stdenv.mkDerivation` which should solve the issue for most of these packages. If it gets merged, I will make a follow up removing unnecessary `mainProgram`s  in packages with unstable version numbers

Before:
```console
$ nix run .#ion
error: unable to execute '/nix/store/r2cw08kck7wznxc1bhs4phjn0xa7713k-ion-unstable-2021-05-10/bin/ion-unstable': No such file or directory
```

After:
```console
$ nix run .#ion
figsoda:~/.nixpkgs#
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
