### PR TITLE
python3Packages.paho-mqtt: 1.5.1 -> 1.6.1

### DIFF
--- a/pkgs/development/python-modules/paho-mqtt/default.nix
+++ b/pkgs/development/python-modules/paho-mqtt/default.nix
@@ -1,30 +1,46 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
-, stdenv, pytest-runner, pytest, mock }:
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, pytestCheckHook
+, mock
+}:
 
 buildPythonPackage rec {
   pname = "paho-mqtt";
-  version = "1.5.1";
+  version = "1.6.1";
 
-  # No tests in PyPI tarball
   src = fetchFromGitHub {
     owner = "eclipse";
     repo = "paho.mqtt.python";
     rev = "v${version}";
-    sha256 = "1y537i6zxkjkmi80w5rvd18npz1jm5246i2x8p3q7ycx94i8ixs0";
+    sha256 = "sha256-9nH6xROVpmI+iTKXfwv2Ar1PAmWbEunI3HO0pZyK6Rg=";
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace "pylama" ""
-    substituteInPlace setup.cfg --replace "--pylama" ""
+    substituteInPlace setup.py \
+      --replace "pylama" "" \
+      --replace "'pytest-runner'" ""
+    substituteInPlace setup.cfg \
+      --replace "--pylama" ""
   '';
 
-  checkInputs = [ pytest-runner pytest ] ++ lib.optional (!isPy3k) mock;
+  checkInputs = [
+    pytestCheckHook
+  ] ++ lib.optional (!isPy3k) [
+    mock
+  ];
 
   doCheck = !stdenv.isDarwin;
 
+  pythonImportsCheck = [
+    "paho.mqtt"
+  ];
+
   meta = with lib; {
-    homepage = "https://eclipse.org/paho";
     description = "MQTT version 3.1.1 client class";
+    homepage = "https://eclipse.org/paho";
     license = licenses.epl10;
     maintainers = with maintainers; [ mog dotlambda ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.6.1

Change log: https://github.com/eclipse/paho.mqtt.python/blob/master/ChangeLog.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
