### PR TITLE
cramfsswap: fix parallel build failure

### DIFF
--- a/pkgs/os-specific/linux/cramfsswap/default.nix
+++ b/pkgs/os-specific/linux/cramfsswap/default.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation rec {
     url = "mirror://debian/pool/main/c/cramfsswap/${pname}_${version}.tar.xz";
     sha256 = "10mj45zx71inaa3l1d81g64f7yn1xcprvq4v4yzpdwbxqmqaikw1";
   };
+  patches = [ ./parallel-make.patch ];
 
   # Needed for cross-compilation
   postPatch = ''

--- a/pkgs/os-specific/linux/cramfsswap/default.nix
+++ b/pkgs/os-specific/linux/cramfsswap/default.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation rec {
     url = "mirror://debian/pool/main/c/cramfsswap/${pname}_${version}.tar.xz";
     sha256 = "10mj45zx71inaa3l1d81g64f7yn1xcprvq4v4yzpdwbxqmqaikw1";
   };
+  #  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=996964
   patches = [ ./parallel-make.patch ];
 
   # Needed for cross-compilation

--- a/pkgs/os-specific/linux/cramfsswap/parallel-make.patch
+++ b/pkgs/os-specific/linux/cramfsswap/parallel-make.patch
@@ -1,0 +1,14 @@
+Fix parallel build failure bya dding the dependency.
+
+https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=996964
+--- a/Makefile
++++ b/Makefile
+@@ -6,7 +6,7 @@ debian: cramfsswap
+ cramfsswap: cramfsswap.c
+ 	$(CC) -Wall -g -O $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o cramfsswap cramfsswap.c -lz
+ 
+-strip:
++strip: cramfsswap
+ 	strip cramfsswap
+ 
+ install: cramfsswap


### PR DESCRIPTION
Proposed the same patch upstream as:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=996964