### PR TITLE
headscale: 0.9.2 -> 0.10.5

### DIFF
--- a/pkgs/servers/headscale/default.nix
+++ b/pkgs/servers/headscale/default.nix
@@ -1,26 +1,49 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "headscale";
-  version = "0.9.2";
+  version = "0.10.5";
 
   src = fetchFromGitHub {
     owner = "juanfont";
     repo = "headscale";
     rev = "v${version}";
-    sha256 = "sha256-1YxcfSOGGdyUZyQdKSHUiK5/43Ki/QvHvIZ/Ai5Mq7E=";
+    sha256 = "sha256-cUDLqSMEw1SRMskHx3hhb/y7N7ZQEDEAZ40X5J53Bow=";
   };
 
-  vendorSha256 = "sha256-LJajQDk+r9Wt2t/kwNhsCoSlU+EjSNc1WT2vqtqg4LI=";
+  vendorSha256 = "sha256-t7S1jE76AFFIePrFtvrIQcId7hLeNIAm/eA9AVoFy5E=";
 
-  # Ldflags are same as build target in the project's Makefile
-  # https://github.com/juanfont/headscale/blob/main/Makefile
-  ldflags = [ "-s" "-w" "-X main.version=v${version}" ];
+  ldflags = [ "-s" "-w" "-X github.com/juanfont/headscale/cmd/headscale/cli.Version=v${version}" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd headscale \
+      --bash <($out/bin/headscale completion bash) \
+      --fish <($out/bin/headscale completion fish) \
+      --zsh <($out/bin/headscale completion zsh)
+  '';
 
   meta = with lib; {
-    description = "An implementation of the Tailscale coordination server";
     homepage = "https://github.com/juanfont/headscale";
+    description = "An open source, self-hosted implementation of the Tailscale control server";
+    longDescription = ''
+      Tailscale is a modern VPN built on top of Wireguard. It works like an
+      overlay network between the computers of your networks - using all kinds
+      of NAT traversal sorcery.
+
+      Everything in Tailscale is Open Source, except the GUI clients for
+      proprietary OS (Windows and macOS/iOS), and the
+      'coordination/control server'.
+
+      The control server works as an exchange point of Wireguard public keys for
+      the nodes in the Tailscale network. It also assigns the IP addresses of
+      the clients, creates the boundaries between each user, enables sharing
+      machines between users, and exposes the advertised routes of your nodes.
+
+      Headscale implements this coordination server.
+    '';
     license = licenses.bsd3;
-    maintainers = with maintainers; [ nkje ];
+    maintainers = with maintainers; [ nkje jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump headscale to `0.10.5`

I noticed when running `--help` that there's a tag for `v0.10.6` but there's no release. (https://github.com/juanfont/headscale/issues/189)

@NKJe

Also:

* fix the version ldflag
* add completions
* add long description
* add myself as a maintainer


Test with aarch64 - related: https://github.com/juanfont/headscale/issues/168

```
$ uname -sm
Linux aarch64

$ ./result/bin/headscale --help
An updated version of Headscale has been found (0.10.6 vs. your current v0.10.5). Check it out https://github.com/juanfont/headscale/releases

headscale is an open source implementation of the Tailscale control server

https://github.com/juanfont/headscale

Usage:
  headscale [command]

Available Commands:
  completion  generate the autocompletion script for the specified shell
  help        Help about any command
  namespaces  Manage the namespaces of Headscale
  nodes       Manage the nodes of Headscale
  preauthkeys Handle the preauthkeys in Headscale
  routes      Manage the routes of Headscale
  serve       Launches the headscale server
  version     Print the version.

Flags:
      --force           Disable prompts and forces the execution
  -h, --help            help for headscale
  -o, --output string   Output format. Empty for human-readable, 'json' or 'json-line'

Use "headscale [command] --help" for more information about a command.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
