### PR TITLE
mpv: use yt-dlp instead of youtube-dl

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -112,6 +112,15 @@ in stdenv.mkDerivation rec {
       url = "https://github.com/mpv-player/mpv/commit/7c4465cefb27d4e0d07535d368febdf77b579566.patch";
       sha256 = "1yfc6220ak5kc5kf7zklmsa944nr9q0qaa27l507pgrmvcyiyzrx";
     })
+    # TOREMOVE when > 0.33.1
+    # youtube-dl has been abandonned and is now unusable w/
+    # youtube.com. Mpv migrated to yt-dlp since the 0.33.1 but did not
+    # cut a new release yet. See
+    # https://github.com/mpv-player/mpv/pull/9209
+    (fetchpatch {
+      url = "https://github.com/mpv-player/mpv/commit/d1c92bfd79ef81ac804fcc20aee2ed24e8d587aa.patch";
+      sha256 = "1dwxzng3gsrx0gjljm5jmfcjz3pzdss9z2l0n25rmmb4nbcrcx1f";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -3,7 +3,7 @@
 , lib
 , symlinkJoin
 , makeWrapper
-, youtube-dl
+, yt-dlp
 }:
 
 # the unwrapped mpv derivation - 1st argument to `wrapMpv`
@@ -25,7 +25,7 @@ let
     binPath = lib.makeBinPath ([
       mpv.luaEnv
     ] ++ lib.optionals youtubeSupport [
-      youtube-dl
+      yt-dlp
     ] ++ lib.optionals mpv.vapoursynthSupport [
       mpv.vapoursynth.python3
     ]);


### PR DESCRIPTION
youtube-dl has been abandoned and is now unusable to stream a
youtube.com video.

The mpv team decided to move on with the yt-dlp fork[1]. However, they
did not cut a new mpv release yet.

Backporting the relevant commit and updating the wrapper to expose
yt-dlp instead of youtube-dl.

[1] https://github.com/mpv-player/mpv/pull/9209

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
