### PR TITLE
python3Packages.py-synologydsm-api: enable tests

### DIFF
--- a/pkgs/development/python-modules/py-synologydsm-api/default.nix
+++ b/pkgs/development/python-modules/py-synologydsm-api/default.nix
@@ -9,26 +9,20 @@
 
 buildPythonPackage rec {
   pname = "py-synologydsm-api";
-  version = "1.0.2";
+  version = "1.0.4";
   format = "pyproject";
 
   src = fetchFromGitHub {
-    owner = "hacf-fr";
+    owner = "mib1185";
     repo = "synologydsm-api";
     rev = "v${version}";
-    sha256 = "sha256-UQdPwvRdv7SCOTxkA1bfskQ9oL/DB0j1TdJE04ODyj8=";
+    sha256 = "1f9fbcp6dbh1c7q1cpppwggnw4m89w14cjdgl64f1bzv72rggpn1";
   };
 
   nativeBuildInputs = [ poetry-core ];
   propagatedBuildInputs = [ urllib3 requests ];
   pythonImportsCheck = [ "synology_dsm" ];
   checkInputs = [ pytestCheckHook ];
-
-  postPatch = ''
-    # was fixed upstream but not released, remove after upgrade to version > 1.0.2
-    substituteInPlace pyproject.toml \
-      --replace "poetry.masonry.api" "poetry.core.masonry.api"
-  '';
 
   meta = with lib; {
     description = "Python API for Synology DSM";

--- a/pkgs/development/python-modules/py-synologydsm-api/default.nix
+++ b/pkgs/development/python-modules/py-synologydsm-api/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, pytestCheckHook
+, poetry-core
 , urllib3
 , requests
 }:
@@ -8,18 +10,25 @@
 buildPythonPackage rec {
   pname = "py-synologydsm-api";
   version = "1.0.2";
+  format = "pyproject";
 
-  src = fetchPypi {
-    pname = "synologydsm-api";
-    inherit version;
-    sha256 = "42ea453ef5734dd5b8163e3d18ef309658f0298411720e6b834bededd28c5d53";
+  src = fetchFromGitHub {
+    owner = "hacf-fr";
+    repo = "synologydsm-api";
+    rev = "v${version}";
+    sha256 = "sha256-UQdPwvRdv7SCOTxkA1bfskQ9oL/DB0j1TdJE04ODyj8=";
   };
 
+  nativeBuildInputs = [ poetry-core ];
   propagatedBuildInputs = [ urllib3 requests ];
+  pythonImportsCheck = [ "synology_dsm" ];
+  checkInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [
-    "synology_dsm"
-  ];
+  postPatch = ''
+    # was fixed upstream but not released, remove after upgrade to version > 1.0.2
+    substituteInPlace pyproject.toml \
+      --replace "poetry.masonry.api" "poetry.core.masonry.api"
+  '';
 
   meta = with lib; {
     description = "Python API for Synology DSM";

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -845,7 +845,7 @@
     "syncthing" = ps: with ps; [ aiosyncthing ];
     "syncthru" = ps: with ps; [ pysyncthru url-normalize ];
     "synology_chat" = ps: with ps; [ ];
-    "synology_dsm" = ps: with ps; [ ]; # missing inputs: py-synologydsm-api
+    "synology_dsm" = ps: with ps; [ py-synologydsm-api ];
     "synology_srm" = ps: with ps; [ ]; # missing inputs: synology-srm
     "syslog" = ps: with ps; [ ];
     "system_bridge" = ps: with ps; [ aiohttp-cors ifaddr systembridge zeroconf ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -640,6 +640,7 @@ in with py.pkgs; buildPythonApplication rec {
     "switcher_kis"
     "syncthing"
     "syncthru"
+    "synology_dsm"
     "system_health"
     "system_log"
     "tado"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Download sources from GitHub since PyPI package doesn't contain tests.
See also #142359.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
