### PR TITLE
hilbish: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/shells/hilbish/default.nix
+++ b/pkgs/shells/hilbish/default.nix
@@ -2,26 +2,25 @@
 
 buildGoModule rec {
   pname = "hilbish";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "Rosettea";
     repo = "Hilbish";
     rev = "v${version}";
-    sha256 = "sha256-ACHHHGT3VGnvZVi1UZb57+g/slcld5e3bh+DDhUVVpQ=";
+    sha256 = "sha256-3qU1gQSWxyKgQcHgT61Q+n6u0rGU0vqTdT/VwMN20yw=";
     fetchSubmodules = true;
   };
 
-  vendorSha256 = "sha256-SVGPMFpQjVOWCfiPpEmqhp6MEO0wqeyAZVyeNmTuXl0=";
+  vendorSha256 = "sha256-xnq0CEfz9uVpDkqY5/Sw9O5uMTHV74vQBXrav3bbH7E=";
 
   buildInputs = [ readline ];
 
-  ldflags = [ "-s" "-w" ];
-
-  postPatch = ''
-    substituteInPlace vars_linux.go \
-      --replace "/usr/share" "${placeholder "out"}/share/"
-  '';
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.dataDir=${placeholder "out"}/share/hilbish"
+  ];
 
   postInstall = ''
     mkdir -p "$out/share/hilbish"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
