### PR TITLE
python3Packages.param: 1.11.1 -> 1.12.0, python3Packages.intake: 0.6.3 -> 0.6.4

### DIFF
--- a/pkgs/development/python-modules/colorcet/default.nix
+++ b/pkgs/development/python-modules/colorcet/default.nix
@@ -1,12 +1,11 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, nbsmoke
 , param
 , pyct
-, nbsmoke
-, flake8
-, pytest
 , pytest-mpl
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -24,25 +23,29 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
-    flake8
     pytest-mpl
+    pytestCheckHook
   ];
 
-  checkPhase = ''
+  preCheck = ''
     export HOME=$(mktemp -d)
     mkdir -p $HOME/.config/matplotlib
     echo "backend: ps" > $HOME/.config/matplotlib/matplotlibrc
     ln -s $HOME/.config/matplotlib $HOME/.matplotlib
-
-    # requires other backends to be available
-    pytest colorcet -k 'not matplotlib_default_colormap_plot'
   '';
+
+  disabledTests = [
+    "matplotlib_default_colormap_plot"
+  ];
+
+  pythonImportsCheck = [
+    "colorcet"
+  ];
 
   meta = with lib; {
     description = "Collection of perceptually uniform colormaps";
     homepage = "https://colorcet.pyviz.org";
     license = licenses.cc-by-40;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/hvplot/default.nix
+++ b/pkgs/development/python-modules/hvplot/default.nix
@@ -1,18 +1,10 @@
 { lib
-, buildPythonPackage
-, fetchPypi
 , bokeh
+, buildPythonPackage
+, colorcet
+, fetchPypi
 , holoviews
 , pandas
-, pytest
-, parameterized
-, nbsmoke
-, flake8
-, coveralls
-, xarray
-, networkx
-, streamz
-, colorcet
 , pythonImportsCheckHook
 }:
 
@@ -29,7 +21,6 @@ buildPythonPackage rec {
     pythonImportsCheckHook
   ];
 
-  checkInputs = [ pytest parameterized nbsmoke flake8 coveralls xarray networkx streamz ];
   propagatedBuildInputs = [
     bokeh
     colorcet
@@ -37,11 +28,7 @@ buildPythonPackage rec {
     pandas
   ];
 
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
-
-  # many tests require a network connection
+  # Many tests require a network connection
   doCheck = false;
 
   pythonImportsCheck = [
@@ -52,6 +39,6 @@ buildPythonPackage rec {
     description = "A high-level plotting API for the PyData ecosystem built on HoloViews";
     homepage = "https://hvplot.pyviz.org";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -1,67 +1,71 @@
 { lib
-, buildPythonPackage
-, fetchPypi
 , appdirs
+, bokeh
+, buildPythonPackage
 , dask
+, entrypoints
+, fetchFromGitHub
+, fsspec
 , holoviews
 , hvplot
-, fsspec
+, intake-parquet
 , jinja2
 , msgpack
 , msgpack-numpy
 , numpy
 , pandas
 , panel
-, intake-parquet
 , pyarrow
 , pytestCheckHook
-, pythonOlder
 , python-snappy
+, pythonOlder
+, pyyaml
 , requests
-, ruamel_yaml
-, six
 , tornado
 }:
 
 buildPythonPackage rec {
   pname = "intake";
-  version = "0.6.3";
+  version = "0.6.4";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f64543353f30d9440b953984f78b7a0954e5756d70c64243609d307ba488014f";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "194cdd6lx92zcpkn3wgm490kxvw0c58ziix8hcihsr5ayfr1wdsl";
   };
 
   propagatedBuildInputs = [
     appdirs
+    bokeh
     dask
+    entrypoints
+    fsspec
     holoviews
     hvplot
     jinja2
-    msgpack-numpy
     msgpack
+    msgpack-numpy
     numpy
     pandas
     panel
+    pyarrow
     python-snappy
+    pyyaml
     requests
-    ruamel_yaml
-    six
     tornado
   ];
 
   checkInputs = [
-    fsspec
     intake-parquet
-    pyarrow
     pytestCheckHook
   ];
 
   postPatch = ''
-    # Is in setup_requires but not used in setup.py...
-    substituteInPlace setup.py --replace "'pytest-runner'" ""
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'" ""
   '';
 
   # test_discover requires driver_with_entrypoints-0.1.dist-info, which is not included in tarball
@@ -72,7 +76,7 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    # disable tests which touch network and are broken
+    # Disable tests which touch network and are broken
     "test_discover"
     "test_filtered_compressed_cache"
     "test_get_dir"
@@ -80,6 +84,10 @@ buildPythonPackage rec {
     "http"
     "test_read_pattern"
     "test_remote_arr"
+  ];
+
+  pythonImportsCheck = [
+    "intake"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/param/default.nix
+++ b/pkgs/development/python-modules/param/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "param";
-  version = "1.11.1";
+  version = "1.12.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b9857df01495bd55ddafb214fd1ed017d20699ce42ec2a0fd190d99caa03099f";
+    sha256 = "sha256-NdAoHI47623UafRv8LkXdSpUvtlNGwxWc0bHbQ/1nEo=";
   };
 
   checkInputs = [ flake8 nose ];
@@ -19,10 +19,14 @@ buildPythonPackage rec {
   # tests not included with pypi release
   doCheck = false;
 
+  pythonImportsCheck = [
+    "param"
+  ];
+
   meta = with lib; {
     description = "Declarative Python programming using Parameters";
     homepage = "https://github.com/pyviz/param";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/param/default.nix
+++ b/pkgs/development/python-modules/param/default.nix
@@ -1,23 +1,29 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, flake8
-, nose
+, fetchFromGitHub
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "param";
   version = "1.12.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-NdAoHI47623UafRv8LkXdSpUvtlNGwxWc0bHbQ/1nEo=";
+  src = fetchFromGitHub {
+    owner = "holoviz";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "02zmd4bwyn8b4q1l9jgddc70ii1i7bmynacanl1cvbr6la4v9b2c";
   };
 
-  checkInputs = [ flake8 nose ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  # tests not included with pypi release
-  doCheck = false;
+  postPatch = ''
+    # Version is not set properly
+    substituteInPlace setup.py \
+      --replace 'version=get_setup_version("param"),' 'version="${version}",'
+  '';
 
   pythonImportsCheck = [
     "param"

--- a/pkgs/development/python-modules/pyct/default.nix
+++ b/pkgs/development/python-modules/pyct/default.nix
@@ -3,9 +3,9 @@
 , fetchPypi
 , isPy27
 , param
+, pytestCheckHook
 , pyyaml
 , requests
-, pytest
 }:
 
 buildPythonPackage rec {
@@ -17,22 +17,26 @@ buildPythonPackage rec {
     sha256 = "23d7525b5a1567535c093aea4b9c33809415aa5f018dd77f6eb738b1226df6f7";
   };
 
-  doCheck = !isPy27;
-  checkInputs = [ pytest ];
   propagatedBuildInputs = [
     param
     pyyaml
     requests
   ];
 
-  checkPhase = ''
-    pytest
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  doCheck = !isPy27;
+
+  pythonImportsCheck = [
+    "pyct"
+  ];
 
   meta = with lib; {
-    description = "Cli for python common tasks for users";
+    description = "ClI for Python common tasks for users";
     homepage = "https://github.com/pyviz/pyct";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.12.0

Change log: https://github.com/holoviz/param/releases/tag/v1.12.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
