### PR TITLE
bubblemail: 1.3 -> 1.4

### DIFF
--- a/pkgs/applications/networking/mailreaders/bubblemail/default.nix
+++ b/pkgs/applications/networking/mailreaders/bubblemail/default.nix
@@ -17,14 +17,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "bubblemail";
-  version = "1.3";
+  version = "1.4";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "razer";
     repo = "bubblemail";
     rev = "v${version}";
-    sha256 = "FEIdEoZBlM28F5kSMoln7KACwetb8hp+qix1P+DIE8k=";
+    sha256 = "sha256-MPl4pXvdhwCFWTepn/Mxp8ZMs+HCzXC59qdKZp3mHdw=";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).