### PR TITLE
pth: disable parallel building

### DIFF
--- a/pkgs/development/libraries/pth/default.nix
+++ b/pkgs/development/libraries/pth/default.nix
@@ -14,6 +14,13 @@ stdenv.mkDerivation rec {
     configureFlagsArray+=("ac_cv_check_sjlj=ssjlj")
   '';
 
+  # Fails parallel build due to missing dependency on autogenrated
+  # 'pth_p.h' file:
+  #     ./shtool scpp -o pth_p.h ...
+  #     ./libtool --mode=compile --quiet gcc -c -I. -O2 -pipe pth_uctx.c
+  #     pth_uctx.c:31:10: fatal error: pth_p.h: No such file
+  enableParallelBuilding = false;
+
   meta = with lib; {
     description = "The GNU Portable Threads library";
     homepage = "https://www.gnu.org/software/pth";


### PR DESCRIPTION
Manually written makefile relies on correct dependencies specificed
explicitly in the Makefile. Unfortunately they at least lack dependency
on common pre-generated 'pth_p.h' file.

Let's disable parallel build explicitly.