### PR TITLE
parquet-tools: init at 0.2.9

### DIFF
--- a/pkgs/tools/misc/parquet-tools/default.nix
+++ b/pkgs/tools/misc/parquet-tools/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, python3Packages
+}:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "parquet-tools";
+  version = "0.2.9";
+  disabled = pythonOlder "3.8";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "ktrueda";
+    repo = "parquet-tools";
+    rev = version;
+    sha256 = "0aw0x7lhagp4dwis09fsizr7zbhdpliav0ns5ll5qny7x4m6rkfy";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/ktrueda/parquet-tools/commit/1c70a07e1c9f17c8890d23aad3ded5dd6c706cb3.patch";
+      sha256 = "08j1prdqj8ksw8gwiyj7ivshk82ahmywbzmywclw52nlnniig0sa";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'thrift = "^0.13.0"' 'thrift = "*"' \
+      --replace 'halo = "^0.0.29"' 'halo = "*"'
+    substituteInPlace tests/test_inspect.py \
+      --replace "parquet-cpp-arrow version 5.0.0" "parquet-cpp-arrow version 6.0.0" \
+      --replace "serialized_size: 2222" "serialized_size: 2221"
+  '';
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    boto3
+    colorama
+    halo
+    pandas
+    pyarrow
+    tabulate
+    thrift
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    moto
+    pytest-mock
+  ];
+
+  disabledTests = [
+    # these tests try to read python code as parquet and fail
+    "test_local_wildcard"
+    "test_local_and_s3_wildcard_files"
+  ];
+
+  meta = with lib; {
+    description = "A CLI tool for parquet files";
+    homepage = "https://github.com/ktrueda/parquet-tools";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1839,6 +1839,8 @@ with pkgs;
 
   pacparser = callPackage ../tools/networking/pacparser { };
 
+  parquet-tools = callPackage ../tools/misc/parquet-tools { };
+
   pass = callPackage ../tools/security/pass { };
 
   passphrase2pgp = callPackage ../tools/security/passphrase2pgp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5505,8 +5505,6 @@ in {
 
   parquet = callPackage ../development/python-modules/parquet { };
 
-  parquet-tools = callPackage ../development/python-modules/parquet-tools { };
-
   parse = callPackage ../development/python-modules/parse { };
 
   parsedatetime = callPackage ../development/python-modules/parsedatetime { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5505,6 +5505,8 @@ in {
 
   parquet = callPackage ../development/python-modules/parquet { };
 
+  parquet-tools = callPackage ../development/python-modules/parquet-tools { };
+
   parse = callPackage ../development/python-modules/parse { };
 
   parsedatetime = callPackage ../development/python-modules/parsedatetime { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add `parquet-tools` to nixpkgs.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
