### PR TITLE
nixos/latte-dock: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -160,6 +160,7 @@
   ./programs/java.nix
   ./programs/kdeconnect.nix
   ./programs/kbdlight.nix
+  ./programs/latte-dock.nix
   ./programs/less.nix
   ./programs/liboping.nix
   ./programs/light.nix

--- a/nixos/modules/programs/latte-dock.nix
+++ b/nixos/modules/programs/latte-dock.nix
@@ -1,0 +1,24 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.latte-dock;
+in
+{
+  meta.maintainers = [ maintainers.diffumist ];
+
+  ###### interface
+  options.programs.latte-dock = {
+    enable = mkEnableOption "Latte Dock";
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    systemd.user.services.latte-dock = {
+      script = "${pkgs.latte-dock}/bin/latte-dock";
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -19,10 +19,6 @@ mkDerivation rec {
   patches = [
     ./0001-close-user-autostart.patch
   ];
-  fixupPhase = ''
-    mkdir -p $out/etc/xdg/autostart
-    cp $out/share/applications/org.kde.latte-dock.desktop $out/etc/xdg/autostart
-  '';
 
   meta = with lib; {
     description = "Dock-style app launcher based on Plasma frameworks";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Initialization latte dock module: Use systemd user service to start latte dock to avoid generating user cache in wrong location

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
