### PR TITLE
python3Packages.certbot-dns-google: init at 1.20.0

### DIFF
--- a/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
@@ -2,15 +2,15 @@
 , acme
 , certbot
 , cloudflare
-, isPy3k
-, pytest
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  inherit (certbot) src version;
-
   pname = "certbot-dns-cloudflare";
+
+  inherit (certbot) src version;
+  disabled = pythonOlder "3.6";
 
   propagatedBuildInputs = [
     acme
@@ -19,15 +19,12 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
     pytestCheckHook
   ];
 
-  disabled = !isPy3k;
-
   pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "source/certbot-dns-cloudflare";
 
   meta = certbot.meta // {
     description = "Cloudflare DNS Authenticator plugin for Certbot";

--- a/pkgs/development/python-modules/certbot-dns-google/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-google/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage
+, acme
+, certbot
+, google-api-python-client
+, isPy3k
+, oauth2client
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "certbot-dns-google";
+
+  inherit (certbot) src version;
+  disabled = pythonOlder "3.6";
+
+  propagatedBuildInputs = [
+    acme
+    certbot
+    google-api-python-client
+    oauth2client
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
+
+  sourceRoot = "source/certbot-dns-google";
+
+  meta = certbot.meta // {
+    description = "Google Cloud DNS Authenticator plugin for Certbot";
+  };
+}

--- a/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
@@ -3,14 +3,15 @@
 , certbot
 , dnspython
 , isPy3k
-, pytest
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  inherit (certbot) src version;
-
   pname = "certbot-dns-rfc2136";
+
+  inherit (certbot) src version;
+  disabled = pythonOlder "3.6";
 
   propagatedBuildInputs = [
     acme
@@ -19,15 +20,12 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
     pytestCheckHook
   ];
 
-  disabled = !isPy3k;
-
   pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "source/certbot-dns-rfc2136";
 
   meta = certbot.meta // {
     description = "RFC 2136 DNS Authenticator plugin for Certbot";

--- a/pkgs/development/python-modules/certbot-dns-route53/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-route53/default.nix
@@ -3,14 +3,15 @@
 , boto3
 , certbot
 , isPy3k
-, pytest
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  inherit (certbot) src version;
-
   pname = "certbot-dns-route53";
+
+  inherit (certbot) src version;
+  disabled = pythonOlder "3.6";
 
   propagatedBuildInputs = [
     acme
@@ -19,15 +20,12 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
     pytestCheckHook
   ];
 
-  disabled = !isPy3k;
-
   pytestFlagsArray = [ "-o cache_dir=$(mktemp -d)" ];
 
-  sourceRoot = "source/${pname}";
+  sourceRoot = "source/certbot-dns-route53";
 
   meta = certbot.meta // {
     description = "Route53 DNS Authenticator plugin for Certbot";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1423,6 +1423,8 @@ in {
 
   certbot-dns-rfc2136 = callPackage ../development/python-modules/certbot-dns-rfc2136 { };
 
+  certbot-dns-google = callPackage ../development/python-modules/certbot-dns-google { };
+
   certbot-dns-route53 = callPackage ../development/python-modules/certbot-dns-route53 { };
 
   certifi = callPackage ../development/python-modules/certifi { };


### PR DESCRIPTION
###### Motivation for this change

I would like to be able to use the GCP DNS plugin for Certbot to provision new LetsEncrypt certificates!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
