### PR TITLE
gitoxide: 0.8.4 -> 0.10.0

### DIFF
--- a/pkgs/applications/version-management/gitoxide/default.nix
+++ b/pkgs/applications/version-management/gitoxide/default.nix
@@ -1,22 +1,31 @@
-{ lib, stdenv, rustPlatform, cmake, fetchFromGitHub, pkg-config, openssl
-, libiconv, Security, SystemConfiguration }:
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, cmake
+, pkg-config
+, stdenv
+, libiconv
+, Security
+, SystemConfiguration
+, openssl
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "gitoxide";
-  version = "0.8.4";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "Byron";
     repo = "gitoxide";
     rev = "v${version}";
-    sha256 = "WH8YiW1X7TkURjncm0OefxrZhnhGHaGLwxRNxe17g/0=";
+    sha256 = "sha256-c29gmmkIOyS+HNq2kv53yq+sdEDmQbSmcvVGcd55/hk=";
   };
 
-  cargoSha256 = "eTPJMYl9m81o4PJKfpDs61KmehSvKnY+bgybEodOhAM=";
+  cargoSha256 = "sha256-oc7XpiOZj4bfqdwrEHj/CzNtWzYWFkgMJOySJNgxAGQ=";
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = if stdenv.isDarwin
-    then [ libiconv Security SystemConfiguration]
+    then [ libiconv Security SystemConfiguration ]
     else [ openssl ];
 
   # Needed to get openssl-sys to use pkg-config.
@@ -25,7 +34,8 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "A command-line application for interacting with git repositories";
     homepage = "https://github.com/Byron/gitoxide";
+    changelog = "https://github.com/Byron/gitoxide/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ mit /* or */ asl20 ];
-    maintainers = [ maintainers.syberant ];
+    maintainers = with maintainers; [ syberant ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/byron/gitoxide/blob/main/CHANGELOG.md
https://github.com/byron/gitoxide/compare/v0.8.4...v0.10.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
