### PR TITLE
hash-slinger: 2.7 -> 3.1

### DIFF
--- a/pkgs/tools/security/hash-slinger/default.nix
+++ b/pkgs/tools/security/hash-slinger/default.nix
@@ -1,45 +1,63 @@
-{ lib, stdenv, fetchFromGitHub, python2Packages, unbound, libreswan }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, unbound
+, libreswan
+}:
 
-let
-  pythonPackages = python2Packages;
-in stdenv.mkDerivation rec {
-  pname    = "hash-slinger";
-  version = "2.7";
+stdenv.mkDerivation rec {
+  pname = "hash-slinger";
+  version = "3.1";
 
   src = fetchFromGitHub {
     owner = "letoams";
     repo = pname;
     rev = version;
-    sha256 = "05wn744ydclpnpyah6yfjqlfjlasrrhzj48lqmm5a91nyps5yqyn";
+    sha256 = "sha256-mhMUdZt846QjwRIh2m/4EE+93fUcCKc2FFeoFpzKYvk=";
   };
 
-  pythonPath = with pythonPackages; [ dnspython m2crypto ipaddr python-gnupg
-                                      pyunbound ];
+  pythonPath = with python3.pkgs; [
+    dnspython
+    m2crypto
+    python-gnupg
+    pyunbound
+  ];
 
-  buildInputs = [ pythonPackages.wrapPython ];
-  propagatedBuildInputs = [ unbound libreswan ] ++ pythonPath;
-  propagatedUserEnvPkgs = [ unbound libreswan ];
+  buildInputs = [
+    python3.pkgs.wrapPython
+  ];
 
-  patchPhase = ''
+  propagatedBuildInputs = [
+    unbound
+    libreswan
+  ] ++ pythonPath;
+
+  propagatedUserEnvPkgs = [
+    unbound
+    libreswan
+  ];
+
+  postPatch = ''
     substituteInPlace Makefile \
       --replace "$(DESTDIR)/usr" "$out"
     substituteInPlace ipseckey \
       --replace "/usr/sbin/ipsec" "${libreswan}/sbin/ipsec"
     substituteInPlace tlsa \
-      --replace "/var/lib/unbound/root" "${pythonPackages.pyunbound}/etc/pyunbound/root"
+      --replace "/var/lib/unbound/root" "${python3.pkgs.pyunbound}/etc/pyunbound/root"
     patchShebangs *
-    '';
+  '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/man $out/${pythonPackages.python.sitePackages}/
+    mkdir -p $out/bin $out/man $out/lib/${python3.libPrefix}/site-packages
     make install
     wrapPythonPrograms
-   '';
+  '';
 
-   meta = {
+  meta = with lib; {
     description = "Various tools to generate special DNS records";
-    homepage    = "https://github.com/letoams/hash-slinger";
-    license     = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.leenaars ];
+    homepage = "https://github.com/letoams/hash-slinger";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ leenaars ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.1

Change log: https://github.com/letoams/hash-slinger/releases/tag/3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
