### PR TITLE
lucky-commit: init at 2.1.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/lucky-commit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lucky-commit/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, withOpenCL ? true
+, ocl-icd
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lucky-commit";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "not-an-aardvark";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vs668i1yglfcqs94jhwdk90v0lja2w5kr5gakz082wykilms0zg";
+  };
+
+  cargoSha256 = "sha256-MvopLKhovwXaEmRgXnAzJeuhPgqnMjt0EtKUGSWFpaY=";
+
+  buildInputs = lib.optional withOpenCL [ ocl-icd ];
+
+  cargoBuildFlags = lib.optional (!withOpenCL) "--no-default-features";
+
+  # disable tests that require gpu
+  cargoTestFlags = [ "--no-default-features" ];
+
+  meta = with lib; {
+    description = "Change the start of your git commit hashes to whatever you want";
+    homepage = "https://github.com/not-an-aardvark/lucky-commit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+    mainProgram = "lucky_commit";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26207,6 +26207,8 @@ with pkgs;
 
   lscolors = callPackage ../applications/misc/lscolors { };
 
+  lucky-commit = callPackage ../applications/version-management/git-and-tools/lucky-commit { };
+
   luddite = with python3Packages; toPythonApplication luddite;
 
   lumail = callPackage ../applications/networking/mailreaders/lumail {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

With lucky-commit, you can change the start of your git commit hashes to whatever you want

https://github.com/not-an-aardvark/lucky-commit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
