### PR TITLE
mtxclient: fix compilation with olm-3.2.6

### DIFF
--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -21,6 +21,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-UKroV1p7jYuNzCAFMsuUsYC/C9AZ1D4rhwpwuER39vc=";
   };
 
+  # This patch should be obsolete and should stop applying the in next release.
+  patches = [ ./fix-compilation-with-olm-3.2.5.patch ];
+
   cmakeFlags = [
     # Network requiring tests can't be disabled individually:
     # https://github.com/Nheko-Reborn/mtxclient/issues/22

--- a/pkgs/development/libraries/mtxclient/fix-compilation-with-olm-3.2.5.patch
+++ b/pkgs/development/libraries/mtxclient/fix-compilation-with-olm-3.2.5.patch
@@ -1,0 +1,22 @@
+diff -Naur old/lib/crypto/client.cpp c5pf6ygk9v9rdwwr3dyd24wghflp0vmx-source/lib/crypto/client.cpp
+--- old/lib/crypto/client.cpp	2021-10-22 19:31:52.159836190 +0300
++++ c5pf6ygk9v9rdwwr3dyd24wghflp0vmx-source/lib/crypto/client.cpp	2021-10-22 19:30:42.882010441 +0300
+@@ -37,15 +37,15 @@
+ 
+ };
+ 
+-OlmErrorCode
++mtx::crypto::OlmErrorCode
+ olm_exception::ec_from_string(std::string_view error)
+ {
+         for (size_t i = 0; i < olmErrorStrings.size(); i++) {
+                 if (olmErrorStrings[i] == error)
+-                        return static_cast<OlmErrorCode>(i);
++			return static_cast<mtx::crypto::OlmErrorCode>(i);
+         }
+ 
+-        return OlmErrorCode::UNKNOWN_ERROR;
++        return mtx::crypto::OlmErrorCode::UNKNOWN_ERROR;
+ }
+ 
+ void


### PR DESCRIPTION
Patch adapted from upstream b452a984b0fc522c21bb8df7d320bf13960974d0,
which did not apply due to whitespace changes.


https://github.com/Nheko-Reborn/mtxclient/commit/b452a984b0fc522c21bb8df7d320bf13960974d0.patch

###### Motivation for this change
fix compilation

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
