### PR TITLE
jrnl: 2.8 -> 2.8.3

### DIFF
--- a/pkgs/applications/misc/jrnl/default.nix
+++ b/pkgs/applications/misc/jrnl/default.nix
@@ -1,36 +1,26 @@
 { lib
-, ansiwrap
-, asteval
-, buildPythonApplication
-, colorama
-, cryptography
 , fetchFromGitHub
-, keyring
-, parsedatetime
-, poetry
-, pytestCheckHook
-, python-dateutil
-, pytz
-, pyxdg
-, pyyaml
-, tzlocal
+, fetchpatch
+, python3
 }:
 
-buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "jrnl";
-  version = "2.8";
+  version = "2.8.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "jrnl-org";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1zpsvrjhami9y7204yjbdzi04bkkz6i3apda9fh3hbq83y6wzprz";
+    sha256 = "sha256-+kPr7ndY6u1HMw6m0UZJ5jxVIPNjlTfQt7OYEdZkHBE=";
   };
 
-  nativeBuildInputs = [ poetry ];
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3.pkgs; [
     ansiwrap
     asteval
     colorama
@@ -44,12 +34,32 @@ buildPythonApplication rec {
     tzlocal
   ];
 
-  checkInputs = [ pytestCheckHook ];
-  pythonImportsCheck = [ "jrnl" ];
+  checkInputs = with python3.pkgs; [
+    pytest-bdd
+    pytestCheckHook
+    toml
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/jrnl-org/jrnl/pull/1359
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/jrnl-org/jrnl/commit/a55a240eff7a167af5974a03e9de6f7b818eafd9.patch";
+      sha256 = "1w3gb4vasvh51nggf89fsqsm4862m0g7hr36qz22n4vg9dds175m";
+    })
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d);
+  '';
+
+  pythonImportsCheck = [
+    "jrnl"
+  ];
 
   meta = with lib; {
-    homepage = "http://maebert.github.io/jrnl/";
-    description = "A simple command line journal application that stores your journal in a plain text file";
+    description = "Simple command line journal application that stores your journal in a plain text file";
+    homepage = "https://jrnl.sh/";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ zalakain ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6529,7 +6529,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
   };
 
-  jrnl = python3Packages.callPackage ../applications/misc/jrnl { };
+  jrnl = callPackage ../applications/misc/jrnl { };
 
   jsawk = callPackage ../tools/text/jsawk { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.8.3

Change log:
- https://github.com/jrnl-org/jrnl/blob/develop/CHANGELOG.md#v283-2021-09-06
- https://github.com/jrnl-org/jrnl/blob/develop/CHANGELOG.md#v282-2021-07-31
- https://github.com/jrnl-org/jrnl/blob/develop/CHANGELOG.md#v281-2021-04-24

Other:
- Refactoring
- Switch to `poetry-core`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
