### PR TITLE
werf: init at 1.2.55

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1170,6 +1170,17 @@
     githubId = 56650223;
     name = "Artturi N";
   };
+  azahi = {
+    email = "azahi@teknik.io";
+    matrix = "@azahi:matrix.org";
+    github = "azahi";
+    githubId = 22211000;
+    name = "Azat Bahawi";
+    keys = [{
+      longkeyid = "rsa2048/0xB40FCB6608BBE3B6";
+      fingerprint = "E9F3 483F 31C7 29B4 4CA2  7C38 B40F CB66 08BB E3B6";
+    }];
+  };
   ayazhafiz = {
     email = "ayaz.hafiz.1@gmail.com";
     github = "ayazhafiz";

--- a/pkgs/applications/networking/cluster/werf/default.nix
+++ b/pkgs/applications/networking/cluster/werf/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+, pkg-config
+, gpgme
+, glibc
+, lvm2
+, btrfs-progs
+}:
+
+buildGoModule rec {
+  pname = "werf";
+  version = "1.2.55";
+
+  src = fetchFromGitHub {
+    owner = "werf";
+    repo = "werf";
+    rev = "v${version}";
+    sha256 = "sha256-yLrCE0C8+LIXnBm4xG4q0vXtjTyau6mjkZ+/o/lbGhI=";
+  };
+  vendorSha256 = "sha256-xALB4QCIVpN0s1rR/fvHZFlFDf2trtG8yJKJLBRH4pw=";
+  proxyVendor = true;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ gpgme ]
+    ++ lib.optionals stdenv.isLinux [ glibc.static lvm2 btrfs-progs ];
+
+  # Flags are derived from
+  # https://github.com/werf/werf/blob/main/scripts/build_release_v3.sh
+  ldflags = [ "-s" "-w" "-X github.com/werf/werf/pkg/werf.Version=v${version}" ]
+    ++ lib.optionals stdenv.isLinux [
+    "-linkmode external"
+    "-extldflags=-static"
+  ];
+  tags = [ "dfrunmount" "dfssh" "containers_image_openpgp" ]
+    ++ lib.optionals stdenv.isLinux [
+    "exclude_graphdriver_devicemapper"
+    "netgo"
+    "no_devmapper"
+    "osusergo"
+    "static_build"
+  ];
+
+  subPackages = [ "cmd/werf" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/werf/werf";
+    description = "GitOps delivery tool";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ azahi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34089,6 +34089,8 @@ with pkgs;
 
   webwormhole = callPackage ../tools/networking/webwormhole { };
 
+  werf = callPackage ../applications/networking/cluster/werf {};
+
   wifi-password = callPackage ../os-specific/darwin/wifi-password {};
 
   qubes-core-vchan-xen = callPackage ../applications/qubes/qubes-core-vchan-xen {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Desire to use this package in NixOS.

werf is a GitOps delivery tool.
https://werf.io/
https://github.com/werf/werf

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
