### PR TITLE
sdrangel: 6.16.3 → 6.17.1

### DIFF
--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -33,13 +33,13 @@
 
 mkDerivation rec {
   pname = "sdrangel";
-  version = "6.16.3";
+  version = "6.17.1";
 
   src = fetchFromGitHub {
     owner = "f4exb";
     repo = "sdrangel";
     rev = "v${version}";
-    sha256 = "sha256-qgFnl9IliKRI4TptpXyK9JHzpLEUQ7NZLIfc0AROCvA=";
+    sha256 = "sha256-VWHFrgJVyI3CtLXUiG3/4/cRTD8jSdunbrro34yLKvs=";
     fetchSubmodules = false;
   };
 


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/f4exb/sdrangel/blob/master/CHANGELOG)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
