### PR TITLE
gnome2.ORBit2: explicitly disable build parallelism due to missing depends

### DIFF
--- a/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
@@ -22,6 +22,14 @@ stdenv.mkDerivation rec {
     moveToOutput "bin/orbit2-config" "$dev"
   '';
 
+  # Parallel build fails due to missing internal library dependency:
+  #    libtool --tag=CC   --mode=link gcc ... -o orbit-name-server-2 ...
+  #    ld: cannot find libname-server-2.a: No such file or directory
+  # It happens because orbit-name-server-2 should have libname-server-2.a
+  # in _DEPENDENCIES but does not. Instead of fixing it and regenerating
+  # Makefile.in let's just disable parallel build.
+  enableParallelBuilding = false;
+
   meta = with lib; {
     homepage    = "https://developer-old.gnome.org/ORBit2/";
     description = "A CORBA 2.4-compliant Object Request Broker";

--- a/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage    = "https://projects.gnome.org/ORBit2/";
+    homepage    = "https://developer-old.gnome.org/ORBit2/";
     description = "A CORBA 2.4-compliant Object Request Broker";
     platforms   = platforms.unix;
     maintainers = with maintainers; [ lovek323 ];


### PR DESCRIPTION
Parallel build fails due to missing internal library dependency:
```
   libtool --tag=CC   --mode=link gcc ... -o orbit-name-server-2 ...
   ld: cannot find libname-server-2.a: No such file or directory
```
It happens because orbit-name-server-2 should have libname-server-2.a
in _DEPENDENCIES but does not. Instead of fixing it and regenerating
Makefile.in let's just disable parallel build.
