### PR TITLE
discourse: Fix the public directory path reported by Discourse

### DIFF
--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -266,6 +266,11 @@ let
 
       # Make sure the notification email setting applies
       ./notification_email.patch
+
+      # Change the path to the public directory reported by Discourse
+      # to its real path instead of the symlink in the store, since
+      # the store path won't be matched by any nginx rules
+      ./public_dir_path.patch
     ];
 
     postPatch = ''

--- a/pkgs/servers/web-apps/discourse/public_dir_path.patch
+++ b/pkgs/servers/web-apps/discourse/public_dir_path.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/file_store/local_store.rb b/lib/file_store/local_store.rb
+index 25649532c0..614e062dc1 100644
+--- a/lib/file_store/local_store.rb
++++ b/lib/file_store/local_store.rb
+@@ -88,7 +88,7 @@ module FileStore
+     end
+ 
+     def public_dir
+-      File.join(Rails.root, "public")
++      "/run/discourse/public"
+     end
+ 
+     def tombstone_dir


### PR DESCRIPTION
Change the path to the public directory reported by Discourse to its real path instead of the symlink in the store, since the store path won't be matched by any `nginx` rules.

Fixes #142528.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
