### PR TITLE
python3Packages.tuya-iot-py-sdk: 0.5.0 -> 0.6.3

### DIFF
--- a/pkgs/development/python-modules/tuya-iot-py-sdk/default.nix
+++ b/pkgs/development/python-modules/tuya-iot-py-sdk/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "tuya-iot-py-sdk";
-  version = "0.6.2";
+  version = "0.6.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "tuya";
     repo = "tuya-iot-python-sdk";
     rev = "v${version}";
-    sha256 = "sha256-AGzPEt79qjN4z83TWloMzWQZ9f5EVevt5GnJ7FComoo=";
+    sha256 = "sha256-i3VECGGpnvbogZ46PJh4Eto7neSZOJCUdOmAU/sMKEw=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/tuya-iot-py-sdk/default.nix
+++ b/pkgs/development/python-modules/tuya-iot-py-sdk/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "tuya-iot-py-sdk";
-  version = "0.5.0";
+  version = "0.6.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "tuya";
     repo = "tuya-iot-python-sdk";
     rev = "v${version}";
-    sha256 = "1qfjq4h62phsrmrfb11xwd6gjc28vhs90g3mmx7d8ikgsgnqlvza";
+    sha256 = "sha256-AGzPEt79qjN4z83TWloMzWQZ9f5EVevt5GnJ7FComoo=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.6.2

Change log: https://github.com/tuya/tuya-iot-python-sdk/releases/tag/v0.6.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
