### PR TITLE
treewide: remove toplevel `system` attr

### DIFF
--- a/pkgs/applications/virtualization/crun/default.nix
+++ b/pkgs/applications/virtualization/crun/default.nix
@@ -11,7 +11,6 @@
 , yajl
 , nixosTests
 , criu
-, system
 }:
 
 let
@@ -52,7 +51,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libcap libseccomp systemd yajl ]
     # Criu currently only builds on x86_64-linux
-    ++ lib.optional (lib.elem system criu.meta.platforms) criu;
+    ++ lib.optional (lib.elem stdenv.hostPlatform.system criu.meta.platforms) criu;
 
   enableParallelBuilding = true;
 

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -31,8 +31,6 @@
 , writeText
 , writeTextDir
 , writePython3
-, system
-, # Note: This is the cross system we're compiling for
 }:
 
 let

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, fetchurl, fetchzip, system ? stdenv.targetPlatform }:
+{ lib, stdenv, fetchurl, fetchzip }:
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
   version = "0.106.3";
 
-  src = (import ./bins.nix { inherit fetchurl fetchzip; }).${system};
+  src = (import ./bins.nix { inherit fetchurl fetchzip; }).${stdenv.hostPlatform.system};
 
   installPhase = ''
     install -m755 -D ./AdGuardHome $out/bin/adguardhome

--- a/pkgs/servers/misc/navidrome/default.nix
+++ b/pkgs/servers/misc/navidrome/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, pkgs, fetchurl, ffmpeg, ffmpegSupport ? true, makeWrapper, nixosTests }:
+{ lib, stdenv, fetchurl, ffmpeg, ffmpegSupport ? true, makeWrapper, nixosTests }:
 
 with lib;
 
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "0.45.1";
 
 
-  src = fetchurl (if pkgs.system == "x86_64-linux"
+  src = fetchurl (if stdenv.hostPlatform.system == "x86_64-linux"
   then {
     url = "https://github.com/deluan/navidrome/releases/download/v${version}/navidrome_${version}_Linux_x86_64.tar.gz";
     sha256 = "sha256-TZcXq51sKoeLPmcRpv4VILDmS6dsS7lxlJzTDH0tEWM=";

--- a/pkgs/servers/web-apps/bookstack/default.nix
+++ b/pkgs/servers/web-apps/bookstack/default.nix
@@ -1,8 +1,9 @@
-{ pkgs, system, lib, fetchFromGitHub, dataDir ? "/var/lib/bookstack" }:
+{ pkgs, stdenv, lib, fetchFromGitHub, dataDir ? "/var/lib/bookstack" }:
 
 let
   package = (import ./composition.nix {
-    inherit pkgs system;
+    inherit pkgs;
+    inherit (stdenv.hostPlatform) system;
     noDev = true; # Disable development dependencies
   }).overrideAttrs (attrs : {
     installPhase = attrs.installPhase + ''

--- a/pkgs/servers/zigbee2mqtt/default.nix
+++ b/pkgs/servers/zigbee2mqtt/default.nix
@@ -1,6 +1,6 @@
-{ pkgs, system, dataDir ? "/opt/zigbee2mqtt/data", nixosTests }:
+{ pkgs, stdenv, dataDir ? "/opt/zigbee2mqtt/data", nixosTests }:
 let
-  package = (import ./node.nix { inherit pkgs system; }).package;
+  package = (import ./node.nix { inherit pkgs; inherit (stdenv.hostPlatform) system; }).package;
 in
 package.override rec {
   # don't upgrade! Newer versions cause stack overflows and fail trunk-combined

--- a/pkgs/tools/misc/fx_cast/default.nix
+++ b/pkgs/tools/misc/fx_cast/default.nix
@@ -8,7 +8,7 @@
 # nix run nixpkgs.nodePackages.node2nix -c node2nix -l package-lock.json -d
 # cp -v node-*.nix package*.json ~/p/nixpkgs/pkgs/tools/misc/fx_cast/app
 # ```
-{ pkgs, stdenv, system }: let
+{ pkgs, stdenv }: let
   nodeEnv = import ./node-env.nix {
     inherit (pkgs) nodejs stdenv lib python2 runCommand writeTextFile;
     inherit pkgs;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1246,4 +1246,6 @@ mapAliases ({
     targetLlvmLibraries = targetPackages.llvmPackages_git.libraries;
   });
 
+  inherit (stdenv.hostPlatform) system; # added 2021-10-22
+
 })

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -116,7 +116,6 @@ let
     inherit (super.stdenv) buildPlatform hostPlatform targetPlatform;
   in {
     inherit buildPlatform hostPlatform targetPlatform;
-    inherit (hostPlatform) system;
   };
 
   splice = self: super: import ./splice.nix lib self (adjacentPackages != null);


### PR DESCRIPTION

###### Motivation for this change

This is motivated by https://github.com/NixOS/nixpkgs/issues/27069, but intentionally avoids any of the sticky deprecation questions which have caused that issue to stall out. The alias is still going to be there for the foreseeable future - this PR just fixes the few remaining uses in nixpkgs, and guards it behind allowAliases so we don't have to worry about it reappearing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
