### PR TITLE
libsixel: 1.10.1 -> 1.10.3

### DIFF
--- a/pkgs/development/libraries/libsixel/default.nix
+++ b/pkgs/development/libraries/libsixel/default.nix
@@ -3,33 +3,24 @@
 , fetchFromGitHub
 , meson
 , ninja
-, libbsd
 , gdk-pixbuf
 , gd
 , libjpeg
 , pkg-config
-, fetchpatch
 }:
 stdenv.mkDerivation rec {
   pname = "libsixel";
-  version = "1.10.1";
+  version = "1.10.3";
 
   src = fetchFromGitHub {
     owner = "libsixel";
     repo = "libsixel";
     rev = "v${version}";
-    sha256 = "sha256-ACypJTFjXSzBjo4hQzUiJOqnaRaZnYX+/NublN9sbBo=";
+    sha256 = "1nny4295ipy4ajcxmmh04c796hcds0y7z7rv3qd17mj70y8j0r2d";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/libsixel/libsixel/commit/4d3e53ee007f3b71f638875f9fabbba658b2ca8a.patch";
-      sha256 = "sha256-iDfsTyUczjtzV3pt1ZErbhVO2rMm2ZYKWSBl+ru+5HA=";
-    })
-  ];
-
   buildInputs = [
-    libbsd gdk-pixbuf gd
+    gdk-pixbuf gd
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update libsixel and drop the patch that is now upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I confirmed that img2sixel still works.

cc maintainer @vrthra 