### PR TITLE
python38Packages.proton-client: init at 0.7.0

### DIFF
--- a/pkgs/development/python-modules/proton-client/default.nix
+++ b/pkgs/development/python-modules/proton-client/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, bcrypt
+, pyopenssl
+, python-gnupg
+, requests
+, openssl
+}:
+
+buildPythonPackage rec {
+  pname = "proton-client";
+  version = "0.7.0";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ProtonMail";
+    repo = "proton-python-client";
+    rev = version;
+    sha256 = "sha256-98tEL3DUYtx27JcI6pPFS2iDJXS8K3yyvCU9UVrg1EM=";
+  };
+
+  propagatedBuildInputs = [
+    bcrypt
+    pyopenssl
+    python-gnupg
+    requests
+  ];
+
+  buildInputs = [ openssl ];
+
+  # This patch is supposed to indicate where to load OpenSSL library,
+  # but it is not working as intended.
+  #patchPhase = ''
+  #  substituteInPlace proton/srp/_ctsrp.py --replace \
+  #    "ctypes.cdll.LoadLibrary('libssl.so.10')" "'${openssl.out}/lib/libssl.so'"
+  #'';
+  # Regarding the issue above, I'm disabling tests for now
+  doCheck = false;
+
+  pythonImportsCheck = [ "proton" ];
+
+  meta = with lib; {
+    description = "Python Proton client module";
+    homepage = "https://github.com/ProtonMail/proton-python-client";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5935,6 +5935,8 @@ in {
 
   protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };
 
+  proton-client = callPackage ../development/python-modules/proton-client { };
+
   protonup = callPackage ../development/python-modules/protonup { };
 
   prov = callPackage ../development/python-modules/prov { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Necessary for #140367.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

There are tests on the project, but they require loading `libssl.so` and even by patching the module, there are errors, hence the `doCheck = false`.