### PR TITLE
sc3-plugins: init at 3.11.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5230,6 +5230,12 @@
     githubId = 9425955;
     name = "Jean-François Labonté";
   };
+  jeffBrown = {
+    name = "Jeffrey Benjamin Brown";
+    email = "jeffbrown.the@gmail.com";
+    github = "JeffreyBenjaminBrown";
+    githubId = 8900687;
+  };
   jensbin = {
     email = "jensbin+git@pm.me";
     github = "jensbin";

--- a/pkgs/development/libraries/sc3-plugins/default.nix
+++ b/pkgs/development/libraries/sc3-plugins/default.nix
@@ -1,0 +1,41 @@
+# Based on
+# https://gist.github.com/gosub/a42e265ec38d9df203d6
+
+{ stdenv, lib, fetchgit,
+  cmake,
+  supercollider, fftw, libsndfile }:
+
+stdenv.mkDerivation {
+
+  name = "sc3-plugins";
+  version = "3.11.1";
+
+  meta = with lib; {
+    description = "Synths and other tools for SuperCollider";
+    homepage = "https://supercollider.github.io/";
+    license = "GPL version 2.0";
+    branch = "Version-3.11.1";
+    platforms = lib.platforms.linux;
+    maintainers = [ maintainers.jeffBrown ];
+  };
+
+  src = fetchgit {
+    url = "https://github.com/supercollider/sc3-plugins";
+    rev = "209cf4ffdcc9181b37aedbf4902e4b4d4090d505"; # This is an ordinary git commit hash, the one corresponding to tag "Version-3.11.1".
+    sha256 = "1cy7g2mvmikml4dg6v4fzw6qr2yv9c94531iwxp501fr9j6z5jh8";
+      # To determine this sha256 value, I first supplied a garbage one
+      # and ran `nix-build -L` in the folder containing this file.
+      # The resulting error suggested this one.
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ cmake
+                  supercollider
+                  fftw
+                  libsndfile ];
+
+  cmakeFlags = [
+    "-DSUPERNOVA=OFF"
+    "-DSC_PATH=${supercollider}/include/SuperCollider"
+    "-DFFTW3F_LIBRARY=${fftw}/lib/" ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13549,6 +13549,8 @@ with pkgs;
 
   supercollider_scel = supercollider.override { useSCEL = true; };
 
+  sc3-plugins = callPackage ../development/libraries/sc3-plugins { };
+
   taktuk = callPackage ../applications/networking/cluster/taktuk { };
 
   tcl = tcl-8_6;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
