### PR TITLE
Pantheon updates 2021-10-22

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -1,11 +1,12 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pantheon
 , meson
 , ninja
 , pkg-config
-, vala_0_52
+, vala
 , desktop-file-utils
 , gtk3
 , libaccounts-glib
@@ -45,11 +46,14 @@ stdenv.mkDerivation rec {
     sha256 = "1zq9zfsc987vvrzadw9xqi3rlbi4jv2s82axkgy7ijm3ibi58ddc";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
+  patches = [
+    # Fix build with vala 0.54
+    # https://github.com/elementary/photos/pull/650
+    (fetchpatch {
+      url = "https://github.com/elementary/photos/commit/bc7feca8caa4c8fc076a759a2d36e26e93c75596.patch";
+      sha256 = "sha256-iOHYKV7rSAuMm4ZhoJWjlpu96zlxwTosQe+z/iEVFR8=";
+    })
+  ];
 
   nativeBuildInputs = [
     appstream
@@ -58,9 +62,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    # Does not build with vala 0.54
-    # https://github.com/elementary/photos/issues/638
-    vala_0_52
+    vala
     wrapGAppsHook
   ];
 
@@ -99,6 +101,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta =  with lib; {
     description = "Photo viewer and organizer designed for elementary OS";

--- a/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-gtk-theme";
-  version = "6.0.0";
+  version = "6.1.0";
 
   repoName = "stylesheet";
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "08iga854s6w77xr5rhvr74pgn2lc884aigc7gkn0xjlwysd195fr";
+    sha256 = "sha256-YvBjMbC3aQtYc/jPZmGdL4VfBH/VuxQ70PD0BWg9DTg=";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
@@ -7,7 +7,7 @@
 , meson
 , python3
 , ninja
-, vala_0_52
+, vala
 , gtk3
 , granite
 , wingpanel
@@ -36,13 +36,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/elementary/wingpanel-indicator-sound/commit/df816104c15e4322c1077313b1f43114cdaf710e.patch";
       sha256 = "029z7l467jz1ymxwrzrf874062r6xmskl7mldpq39jh110fijy5l";
     })
+    # Fix build with vala 0.54
+    # https://github.com/elementary/wingpanel-indicator-sound/pull/221
+    (fetchpatch {
+      url = "https://github.com/elementary/wingpanel-indicator-sound/commit/398d181eabe3dd803dc0ba335ac629902ec5b5ab.patch";
+      sha256 = "1r2x3n6ws56jk7xcgk60am8mc5dgf8pz5ipsydxvmlrmipkjxyqi";
+    })
   ];
-
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
 
   nativeBuildInputs = [
     libxml2
@@ -50,9 +50,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    # Does not build with vala 0.54
-    # https://github.com/elementary/wingpanel-indicator-sound/issues/219
-    vala_0_52
+    vala
   ];
 
   buildInputs = [
@@ -69,6 +67,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Sound Indicator for Wingpanel";


### PR DESCRIPTION
###### Motivation for this change

Part of Pantheon **6.0.3** updates.

For upcoming package updates, see https://github.com/orgs/elementary/projects/90#column-16173879

---

pantheon.elementary-gtk-theme 6.1.0

https://github.com/elementary/stylesheet/releases/tag/6.1.0
https://github.com/elementary/stylesheet/compare/6.0.0...6.1.0

> - Support for Hdy.Tabbar
> - Fix accent class for Gtk.Scale
> - Flat titlebars inherit background color for views and sidebars

This PR also adds two patches which fix build with vala 0.54.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
