### PR TITLE
 thunderbird: 91.2.0 -> 91.2.1,  thunderbird-bin: 91.1.2 -> 91.2.1 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,655 +1,655 @@
 {
-  version = "91.1.2";
+  version = "91.2.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/af/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/af/thunderbird-91.2.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "f786ba47061600b2a4fce6dc537e4d5f41ef7e496ddd24e06e5cf2d2bc7ae615";
+      sha256 = "953e07d7198b8b13f312ef620caf6e232c361f78dd04ebd69c753f7b75e55f42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ar/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ar/thunderbird-91.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "70e13fa57939ec35fed7e537c282411e022e2e596af298ff68ed06d29149ad44";
+      sha256 = "29f34eac79855c01550a259d3663c662ec9bd259c0b20bf392efb0de1f44af8d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ast/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ast/thunderbird-91.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "22ac54e15cc8d89412f26906b10d7274a90d86f298948998dabbbb63000fd9bd";
+      sha256 = "284d8935a5527b58f84ba9acabc0a67c51a7e1587f843d8b0ec9555e6f6d8f4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/be/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/be/thunderbird-91.2.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "bb59b38220fc5a2e429df9bf521610678b7b3c7e47e4a3208c9e0e54860ae098";
+      sha256 = "6a535aac3b4eb839a2aca1df28ac8425c142c68bd5c6907f5b9999a45b62c9c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/bg/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/bg/thunderbird-91.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "7a0d50876f51664074b6eefd20dc727cea2d4a0feceb721c63fa9e3872ea6d07";
+      sha256 = "74dde907aaa3877651e1f2bec43a208ff36bf7d860333eaac6f8cdd20d48dc39";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/br/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/br/thunderbird-91.2.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "8a49fe9b26d1a5c5b3c28209cbb6d81e785235f4e1b24e4638cf5a5fa720d68e";
+      sha256 = "6b396a289addae8d5ade8355f8c93c285ce6833852149a0fed3f741d9ceea220";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ca/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ca/thunderbird-91.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "380d655a39c7f20067045cf2ec75e5bca0ba0e8291d187fd87ac42abbbce7dc7";
+      sha256 = "0611d49fd90777b3af1bd5b5effd3b4a5b267c7c33e6476ceed906a070a0e675";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/cak/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/cak/thunderbird-91.2.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "ff12816d6dac6311b2f0a358ee4a30e80d3a346c9a2fc08c9c4d72b2e7421b03";
+      sha256 = "032e7034ab5aada649258dfa43cc10d6e00cf5be6f06b8bede06d2ca19625d79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/cs/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/cs/thunderbird-91.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "fc8ed1c83b76329aecd9b6b7b4c2278b2703dc267ef25ad973deefff01cbb29d";
+      sha256 = "b0591e3bdf5e9273269354924fcfa8001579961f089f1011226faf1f4b0ab2e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/cy/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/cy/thunderbird-91.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "50e10c11f341b75e4ca464911a7229d22073d72b53731ba92cbd39c52694e0d2";
+      sha256 = "4087f5c5609169b6834e2eed3fdaf614826c47f3ca99177292fd379ef5d430b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/da/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/da/thunderbird-91.2.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "1c041fb7c71e9d0f07c82652129a6b48f2f633a7781c41a3c439dec1d7fcabee";
+      sha256 = "b72f768cc2d9c2bad536e2467d1abfe68671b242fcac801e57297694fd41d231";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/de/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/de/thunderbird-91.2.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "c9ed27ee3f1a631c6a7d7a5a854e48f3285b9f01c81bc9ee3611bbdd9f483cdc";
+      sha256 = "48990ead3d84cb023e8c3e6e34113209b49e6ed3e29766fb5374fe577cd5cd94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/dsb/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/dsb/thunderbird-91.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "3c00604247dee961915f2aff628bd7d1f53c4f7e48bb848ef6065e41f189495d";
+      sha256 = "c7e93ffe9d8ab0bc00db145771e65fec6c589208c28c3e0ecb5bb49471b9ed61";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/el/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/el/thunderbird-91.2.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "b9ad1ab6b7d33f477f51e4337d914f8f8d2f6d7bc1b3b884d8b71b17547c3fa0";
+      sha256 = "c35372524d77123bb9827d26efcd29e0fb9de402744b22a3c99563531410e2b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/en-CA/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/en-CA/thunderbird-91.2.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "80e6b5785d334bec69455ca5f5039bbd4fbebd663ea91d17d0fbe8e33d747670";
+      sha256 = "d20fa4b8c7224f35f06d384b5f37c277c56ac35f2099f59735197a0334c9f3ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/en-GB/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/en-GB/thunderbird-91.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "da2388577784df3faad7b40566e2e1eab2b95dd9455a1e4e3ee43433f4fb189e";
+      sha256 = "af0787957918aee6bb931b30ab92722c3ea8fe1e3fd60602d172a598422f7896";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/en-US/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/en-US/thunderbird-91.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "1354e3ad2989749fe79b404ccae3002de8b4e269c98388d9abebe456f3de47d2";
+      sha256 = "f8968d5ecf27e37bb8204291a9739ab804ef77c082e11b4e82fc7e02c8bf0da4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/es-AR/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/es-AR/thunderbird-91.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "f51d4a1109d30d4857673575aef173026e2c90fc7ece6835a34a0e792672cf8b";
+      sha256 = "ec281675876941240ccebe0c48bbb4ae0ed442b795cd7ee1be51ec59c4331220";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/es-ES/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/es-ES/thunderbird-91.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "38196b265eeaef2222e624e2fb0cb7742b2171965aa0725b3d524e9199ea4f91";
+      sha256 = "6436ab381f1ab7fbcf1289d50300d7238f1095022cf18d6441832a8f61df68ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/et/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/et/thunderbird-91.2.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "ab3b04c02b730f92db4f24daac688e1966349cf4c978ed06138285fcb2d72769";
+      sha256 = "1e49089b98dcfebdc1465b93d625b6ea1b6fee4642ca915035fabdc97710eb0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/eu/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/eu/thunderbird-91.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "4431e16f70b6182b1ec2bed64d149ffc7e46f1b2536268e973eb984439eda400";
+      sha256 = "c6a1418f15a019924b459b952330b9851c50907a7c12f3d430a79268ebdb7bac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/fi/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/fi/thunderbird-91.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "8ee9b2983d1f214f4589d7d99d1ac1a577f92dd3cc73f516dcc050079ed85904";
+      sha256 = "588261a4c0e9cfa0c9f506f4fd2e9e14f123d10e96f0cc1724b4ea4607151264";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/fr/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/fr/thunderbird-91.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "b614dadf34774ebf45c88ae0c72c6d8779beb8310a8353aedeca1a493178c376";
+      sha256 = "9ca2d54c6f6f04ee887621332cc35aeabd0f9b73db621c41e8925bafb316670a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/fy-NL/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/fy-NL/thunderbird-91.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "00693bbfda9377d2695fc8c7c242b0e4a3c1b745e8779ebabe5686eca4fc928a";
+      sha256 = "df9bae4cc2d3bd2778047d4589ec1a8e23f7b8c7fc760817decb9341b59dc0b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ga-IE/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ga-IE/thunderbird-91.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "00d26b39726e2de2e799b3dff97c79a590f712f3347232600d1f2771523d0ab4";
+      sha256 = "8d6445032f39152c62e98fe9093cefbaa383d2bff203734ca04a501b44a3a0c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/gd/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/gd/thunderbird-91.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "d9a35fbf9f4069c6f4dd796c8f9465053413d806093d1456e643c9bdb081ad45";
+      sha256 = "b947847398a8e086d062f8e54f515d53e39afab48ec59ca0aceb956ea0e0917f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/gl/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/gl/thunderbird-91.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "9e7f237b55f81a44a984be4b4e1001c8ffd7742eb14e654397e80b4e4b765d0c";
+      sha256 = "3dddbb5cc78171719ed2e7c3ba854c0a346ca5324a898c698dfb79c7881051c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/he/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/he/thunderbird-91.2.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b86d479dd64ac86d43fbfb54c8ec36ea6b4516ded0383f81b78c11365290f21b";
+      sha256 = "e77eb74db9111e54b1e492fb5752fa92ec6eed96a7146392d1ba19d63b5e2ab8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/hr/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/hr/thunderbird-91.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "cb7e8d0dd04c5883f2ec0f47d81a751b901e0036f151ab1c0f3043ba7ebf4a74";
+      sha256 = "3e4d46ecc0ef83a619775d48e4df81295e3e95ad1e9a96efeafa26d7f24b85ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/hsb/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/hsb/thunderbird-91.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "d3141a413d82814067de2791091473e0b44f8939825cc3071b1fbe86e08dd49a";
+      sha256 = "36453d6aca463fce338ac4a15c438290bdaa377aff72a56f0acefeba19860986";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/hu/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/hu/thunderbird-91.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "b76860152f68b2dfabef9847c83356af34b8fb1913d0d55a397be3d4e4e08b31";
+      sha256 = "dd05c379727762fde0c2456a7bbd67cc45fb7ccfbbf88958b887d6637867e80e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/hy-AM/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/hy-AM/thunderbird-91.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "5aa35ed5d577befb7a37d5407bc7ff78c54314a7e5ed77bda588bd74111e263b";
+      sha256 = "35e4db20ff927cf079607fd0e7d207c155f23c7890cc6347ac069c9d252f6ad3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/id/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/id/thunderbird-91.2.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "0bb53b2cbed8a9412c6776435381d5c859a9993b4bd2cdf5ecd4145d13776d09";
+      sha256 = "9cc7a35aed1e5808a80cade5b77d064f3bd36f08107dbbdd3b92ac11c8c83766";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/is/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/is/thunderbird-91.2.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "566058b39d98a777cb1c333b66cac66851d0c369918e58c592b8e0151b778f6f";
+      sha256 = "de645fdf79f33195a7caed9461214f834fb2e52f3da764bde71608fd3783305e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/it/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/it/thunderbird-91.2.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "b88fb1b473a7b0b1a4af08a09aadf5b7502f03462a1f4661ed2897c2705e5b4d";
+      sha256 = "f9a80f01d18cd36ac5c0a18d65908f329bc3d7ec506e0f201b833ed973528dca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ja/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ja/thunderbird-91.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "6b69cd834280b36182656bd97b117c3f70bbcd947ab25e1936294a85149d3501";
+      sha256 = "9345cfdb7e35fc15e94bab52f058dacecd813da210c81770f3037c6f3f982478";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ka/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ka/thunderbird-91.2.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "87d8bc04c278d8c675665d0211917a854d43a17d24173627703268a785ff2206";
+      sha256 = "49e535b7b8322645b81b8137ded607cbe54e70977a07b800114421fb529b045b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/kab/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/kab/thunderbird-91.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "fad11f653198314683faaa758422506d27706b6dca90a4d5b0d3693810843fba";
+      sha256 = "9e66e0654c5ca2d4fec6101bd40a2ab68f17ad4a27ff58db4a1c5d927d76761d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/kk/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/kk/thunderbird-91.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "67469c2c4e1352db94339687f93c0afefe41244bfc952d77c2e41e31a652f095";
+      sha256 = "c929ef91d1ed17db64a36b5c8653e98e1be05b7bef48c062c40c0e37a88f6844";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ko/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ko/thunderbird-91.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "93bb5a6973bbd0eaac721ffd59c19edce400471c08d76aa629b2fe66fc98ddf9";
+      sha256 = "758c31e642a796e3c8be2848e9789bf9c3d4f896790c80603491235ba126a195";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/lt/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/lt/thunderbird-91.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "f4dda73c80cee8aaceee0f4ea0956303f9a50aa2431c6eb8a34d7d22b5fe53e9";
+      sha256 = "7173cb778a4f1bc625b5dde4eedf59911eb649e29c20f8f2a2eca455696fbdfb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/lv/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/lv/thunderbird-91.2.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "65325a804f5aec439501bd70e5423d56ddc5a10636b639e8db85ce8881c1586e";
+      sha256 = "ec9ef897898c788521725879906c56593dd08e9b862b1ad32f7133bba7843b94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ms/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ms/thunderbird-91.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "f2715978bc8e2d7878f8ec47b4a29cccaa42a24bd97f013f6b66aaf47db83359";
+      sha256 = "1f95835843d33a80821c077b26ea5e6330ea3d1a818bb122623a6024dc98515c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/nb-NO/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/nb-NO/thunderbird-91.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "c252fdee3a9d9c43b46786c528bb8ac39203b7d7c746f9c9f04287cb1253ded6";
+      sha256 = "f5aff84dd6016a4223df28fc92185cffc1771107bc4f7c442bef0d19ae4cccf5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/nl/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/nl/thunderbird-91.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "1708531ca0b765292206fa9c533200266f5eb48fbbc74daade404bdcbfdcc750";
+      sha256 = "1146a72a68b454abdb3ab19e0a487e0aa46af0fec4c9261459ac20785a66f8ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/nn-NO/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/nn-NO/thunderbird-91.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "dc26c1333787accc73624bc5bac820af1743ea30d85e9da9a0c30f6b9b0c3bcf";
+      sha256 = "a63d1124b72b4ad1e26f34b26792e576a63ade3aee161965058f6ba2144f4edc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/pa-IN/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/pa-IN/thunderbird-91.2.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "fc508dd719c18c250560b5d4fc4672ce83a9f52b6103d3f33034eca89ed2935f";
+      sha256 = "245692605721b9610bb730f7164c64daebad372f881842a3e2d92dd27cf2c23c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/pl/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/pl/thunderbird-91.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "eb54040a841d0da1e84dd2a6ba3c894a57d40fdb0bf99f21b7fbbe3ea8cd755c";
+      sha256 = "b3b3f9b4f4e2f310b24b148960dbbada8dedd444968f923e7295ce2e3f561bc0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/pt-BR/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/pt-BR/thunderbird-91.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "45226857a691f8568c769f652820eb5b86b0928c271b2751014bd6e7ab29ab80";
+      sha256 = "dc0a70cb19880a9ea7a076ea03c12150bf2ed6349bee7f7cd64b9ba261366e99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/pt-PT/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/pt-PT/thunderbird-91.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "532f18bbe7fc09793bd688e5bc48c65658e2a48285b97c611b68611e9f13257d";
+      sha256 = "be20940db6d0b0399ea90e97ce4073c698c9caa822535cfdadaf5019aaa283f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/rm/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/rm/thunderbird-91.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "8d0f2ec43e6e00118d7c1d5877bfbc5b5c87a8e449a0358acc6e71244a0716b3";
+      sha256 = "8e996281032049eeb70c12ecc10dd321b055d917edc3f16c12b073160552a76a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ro/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ro/thunderbird-91.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "dbfd5500b337132ab14266d2b87224c917086afe3f210127d73848d360299241";
+      sha256 = "d015483952516c37169d263660776a572877d6db50b4e4bc42c9d285cc413032";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/ru/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/ru/thunderbird-91.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "06f6077ba98fc2605718266e57b9c5c54c3d7901f2b7233f38d7fd02d6d063a0";
+      sha256 = "90404c19d3ab7d5142310ae23699b346ee07ab5704b02f3b89e1972737460448";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/sk/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/sk/thunderbird-91.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "af1224613b3e962265d83b154cbf69053906197f2b7f12e5004ad862bef09aaa";
+      sha256 = "2ed8cea88291714fe25b3f06777340536e24c1837743e6dd16bf2e66e90ed057";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/sl/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/sl/thunderbird-91.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "597cd2732960eadd0121c4089a703cc86a0d9a361ff024fe047c8c624dc05afc";
+      sha256 = "be29a12cd0d52f11f19cff89df0d0a883802328cbe036e9f01c2be7d296d5a4a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/sq/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/sq/thunderbird-91.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "c107fb5653cb7adfa79aad501e585943159fa9297ef360b193075a9b49e91d54";
+      sha256 = "b9f0b22b8004af1e7704048eb7223bda77723f664aab3596a3e2fed538eab39f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/sr/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/sr/thunderbird-91.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "33964cc6308a8e7ebc154c057f90729a92d2a9127f9d8c4592f884531d094334";
+      sha256 = "1edd87244be553d61bd5db1de74068130e9a3ccfa387d21c489f9a777bbae732";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/sv-SE/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/sv-SE/thunderbird-91.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "91fa282c3baee03653ffe5164844e06a9813a40c360ef24e94ff525638f187de";
+      sha256 = "e218a20074e50dbe20d2dba7e81d5febdbcad8031e0fd9d88aca469da9cea267";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/th/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/th/thunderbird-91.2.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "99ea8b61e102c3394073f3a817d3eeddc3cedb51436b66303730394f362e91f7";
+      sha256 = "fa65b90c1cc903f3e1b743e142736b1c7e897eb6bf9a80cb0bffa60db627aba2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/tr/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/tr/thunderbird-91.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "bb1d417239c31c6ae9bf62cd545f2fad316915ce6bcb707f2deb65f0cc24425c";
+      sha256 = "5af2e6453aa5523169d6922a8a888b757accad60802d7a457a1ee244cd74c3bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/uk/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/uk/thunderbird-91.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "8464520b025c29dcf3376d7c47d6c7596ff60eeabe63fc5c41082ceb4fbe148c";
+      sha256 = "effad7de717f0597447a7559e666ee3cdb0a1270daa01226d662cab0be84a4dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/uz/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/uz/thunderbird-91.2.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "d4ba9eaafed3d475dd0fe3a7df7f9910fe3a95a74b9a83f2a00aa73441ae8a64";
+      sha256 = "f3c8d3d4ca4c076eb8bcc8a06df32622b87b4d4ae397ee36f5de27a947d443ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/vi/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/vi/thunderbird-91.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "8c7f222e0c65ad2daaf37ab46fbe58e005aa89379a0a87f4b2a5f19528e0e5b2";
+      sha256 = "ac464ab32927c822776b1cf873ea9b9a9473c18ac08b18534332050bde7b1dfe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/zh-CN/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/zh-CN/thunderbird-91.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "1cc053e2e9e751ca14da4a09c276d2c78f61ef4e7d74ac4019849f6ebc044d0d";
+      sha256 = "44869c19113316a02518eb19fb5b1a7a85e266fccf7a3172d1938d758a5efa6a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-x86_64/zh-TW/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-x86_64/zh-TW/thunderbird-91.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "b77a3eb6d1e51388d1b084956b7cc579e1e3c8ed2bc72d7943ac5d6188e43938";
+      sha256 = "82d915747e3e5459acba3e17663de422586f27e7bbc3a5698d992f82ee3d0cc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/af/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/af/thunderbird-91.2.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "c2015b0cfa07309ca6afe5fefb24c1393a397b1d592dd80ec8b62bd4ef8a3d35";
+      sha256 = "5ccbc3453b76c3e02a05b94905c48cdad99bb15042fb2cfc58c7f619a263da07";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ar/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ar/thunderbird-91.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "f36b4e7452ae39bd2bf63231ab884356c7b77d6015993e09046b3d6a63443920";
+      sha256 = "616fc2f0265f204b8699dd0beafc02220d7ba9b2243350730573824f6fa49462";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ast/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ast/thunderbird-91.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "600d102bbb18bac81e3d50c9ef9a578820b0fa1ba2a6f6d756da6e391fe0f241";
+      sha256 = "046386e67e1b775f1f228e3056660db023093180f1c200f6380b6d3744b8ce4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/be/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/be/thunderbird-91.2.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "46032acc1c16e2c9bd7905799db6253cb16fb6269bb79edf6141b9d2bd5c0b15";
+      sha256 = "bf64b91b16bdf4dbdfb88972432f2d2cce002a6ff8c708779511b54a05a7008f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/bg/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/bg/thunderbird-91.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "d21bfe3ad0c2c900de1ab9a88d62fc74c4c1767bb41121159c5c0c9bfe270a8c";
+      sha256 = "f544fbff341165e8e304a8a643be60c8b742973402861b298171699c45fe622b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/br/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/br/thunderbird-91.2.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "8e20c1ce0867bafde00c3e8fc55d5841a14e91fa8039fc7259269da8bfbd4373";
+      sha256 = "c76ec7e65fc4980f12e05f863d8babab09d771f9679d21c93d8dab0f76d16898";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ca/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ca/thunderbird-91.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "175bfb1b0ef94897ecd359c54a2767ca039a259300a5716211fa0c0593b81023";
+      sha256 = "6c609f7b5886e7a7c70470d4bb35370284a454b109ca92cff9741bcc3086e9f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/cak/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/cak/thunderbird-91.2.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "65cf8763200cd10cbc016c9d447703b640c52165c691a604092376de09dc1376";
+      sha256 = "f210ac1e0740c7105abd388e9b5e22d9e199ab3deb43842c3a82ecf5e6d15f01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/cs/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/cs/thunderbird-91.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "8d019c4f92f60c44f1340f96892c0a4060d4ceb86d188f5f81911d92ff2957f0";
+      sha256 = "108d9bfa0b9bef9433f4837517d3d157d46c8578f889b9fb81bc72178f6dfe52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/cy/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/cy/thunderbird-91.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "29049a5f4849f7e2bde8ec122de33edb7c86e87eca46b72086e53caedcad7ef1";
+      sha256 = "1bd421b89cded34d9a656b4e44b78c7b07557221b87dc99831ea7029ff6eead2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/da/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/da/thunderbird-91.2.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "39d9b429b8ee92b045abf48a605e32a577da1f61459b597698f87b1972993f2d";
+      sha256 = "4db52d6017baeb8a5f925b7cfcdfb89a3ed8af9d3c1a41c4a63d122e4f214ecd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/de/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/de/thunderbird-91.2.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "b8ccae9622a8fa684c48a39a409af461238325d91db5edd8d9ecbeaebf2fa999";
+      sha256 = "584c0e8a03b068652f61978af053028ca3793e1679ff0ea214bc6f8a99761f0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/dsb/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/dsb/thunderbird-91.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "a32e1ec050968c94c2b2c1c175d13629fb5feda14e91a0e6c78a9e1bf4092ebe";
+      sha256 = "f838e8b6fdfb09e44771cfe02d22abb63722c65a0e430c77aca9fb5a53a97c4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/el/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/el/thunderbird-91.2.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "7599c18f5c79d6aebb652308fa3fa9b13a4883c0dfc47e8bef6b6c118a2ed909";
+      sha256 = "0b0a6cb3c77e0a4f86bd3adbd4bac229d50323a88b355e470184f932b9602e4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/en-CA/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/en-CA/thunderbird-91.2.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "47c49908cf59a8fa6ec1de512cd01907412cfc5b0f56709611b71eb0b3e6cdee";
+      sha256 = "7e22ff64aed5187db9621754f1eedb158285c2514f3eca836103833ac6183f7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/en-GB/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/en-GB/thunderbird-91.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "9f379c2837dab6ece5306117065ddb1f19d3fa08900d5ed63abc34fff8755dda";
+      sha256 = "a3be3dec0ec4789f8370c23e47b7ed0bef6802d28e3985c66d1a531a3aa986cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/en-US/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/en-US/thunderbird-91.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "97aaf105ff5fd3ac8b2b85ba0de87b1fe6ba01f647d32571b787591ba5f6e1cd";
+      sha256 = "31c35df101e8d3f97c3df72b7660086fdf4f6612068fd03558d5f9dca2d23507";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/es-AR/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/es-AR/thunderbird-91.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "4db46b699d6a65fe482dd8f7bde005b5a4cccfbe7ef777f23f1aa57577d33a33";
+      sha256 = "70db1a684f76886131214bb0c48dccd75763f041e06428ee6fef54a3a8d524c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/es-ES/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/es-ES/thunderbird-91.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "0a63e85f6992ce683f35ecfe6f0e10854fd8cada33f8a2e066d5ab140ef8c401";
+      sha256 = "d0b792b494bea690adc6a2eb967a988920ca497db08c539f92349c925ccb7c33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/et/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/et/thunderbird-91.2.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "522ec0185345054abf61b84dfdb36ce3dbe01c70f5bae11aa17321d18091d759";
+      sha256 = "2e4c3111435cb965972aec73eb181f7e3aac8faa03c8c8f0d7869ace109b433c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/eu/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/eu/thunderbird-91.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "c4e28df0193175149303d80617f04df4d229d8eee2a75129b315a0c23b22aba5";
+      sha256 = "875e98a6ffcb614b3f062b7d12069eeb9f1c9dcd62916020369ede9ac76b8f92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/fi/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/fi/thunderbird-91.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "046b39db1f3f7c4fbe23e93053d43fe81e1b8751bb0558ad1bad3a50ab698673";
+      sha256 = "982a28220ed9d6881d83baaf99540e7eb5d689b0b7fca179d4847838f2596a3c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/fr/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/fr/thunderbird-91.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "39d15a1aa3f7c3e360e817baeb3747a49ae8f42d1b46208832eccb0107ca1b3b";
+      sha256 = "f0421269313849e90eab46698176f1ca425d2bf8136748628a35b0a8baf26c06";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/fy-NL/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/fy-NL/thunderbird-91.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "17c971a57634050faa9fe747055a671ac1ae0022a9b06a957eb05f7bb64f31cb";
+      sha256 = "d49aafc5baebb88b4b2ef7ea5240babe09b16632edebf9a39081aaf183e9ae3b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ga-IE/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ga-IE/thunderbird-91.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "58c17ea964de2b60440bb1a078222ab5b6199b83fa5f2854926b9f0c2a6cb3d3";
+      sha256 = "665df98e5dd0ab4cff25b530bccfdfe4b44f2a81da9167b37aeedf7f05e1f59e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/gd/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/gd/thunderbird-91.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "4ee45ae272d53f523d2855083f27a0ce005d93ca95d13c2037621a87c294413c";
+      sha256 = "28acbaec011f0222530d0f8411444fdf0743d05c05c1fc04a0c130208dd5e9f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/gl/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/gl/thunderbird-91.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "68012e665dea95fd4ce4f76dee0b246d2f94890e5a9b3c797e93ae7d450adc58";
+      sha256 = "97c23e4eac308b51252c0532770961133f2540b94a9dc095c0351e39f42ab038";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/he/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/he/thunderbird-91.2.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "57125635f8fe2cb50cfe9aecdfe06502cce9c746b346083b329d5e1123d4956d";
+      sha256 = "dfd4f5b4c9f396b4a512b38292b73f5a44146b3b46ab0d4e448067481e940914";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/hr/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/hr/thunderbird-91.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "f6f28200c32cc2faa4a4e4a49eed5b4343586b52ca123dbce43d32a1c5059835";
+      sha256 = "07a1f4a58af9172912237c35c220efbe80fbcd44151dc0bce3e40ede38dff054";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/hsb/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/hsb/thunderbird-91.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6290282252b9a61fc7ffb1e29b14f31c87832bd60a066c73f9966a10f75ac327";
+      sha256 = "c1b4e64ebdcc1a06d4428d3507aa1899f3d4c27ae428161f7219ea34302b1946";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/hu/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/hu/thunderbird-91.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "fbd6be01153d67870565fc7230fba7b4a1f6151eeda54e84008b0943acfc4564";
+      sha256 = "c57005f3f10938b8cfc6adef1d5452b3235605b97a23d22da1f4528b1e356d2d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/hy-AM/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/hy-AM/thunderbird-91.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "3bfb7979fbfbf0cbdecb8b8030dd209a6e18020ff34a30223ce893c0cfe0a282";
+      sha256 = "73525dc142b6762f803ced2b567a23244b22239d355fe89507cbe59ad1130edc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/id/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/id/thunderbird-91.2.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "4a8801e97b001c0e30ffc4f4a7c712017c1b1a96bf226ddc341728b22599920d";
+      sha256 = "3f79327af36f3174cb303c65b13a0ae164bf24c87e367ba14bb46b1b6e2370b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/is/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/is/thunderbird-91.2.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "871a6393a716c4c8b2255a8903a4584c8ad4a7f5e1423550d3d96b9866929433";
+      sha256 = "58f7012723cf4ce6673fed01d038b2517c710585c6f8724181e4a91d717b2351";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/it/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/it/thunderbird-91.2.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "8919dbd9e7b0155de288322f10bbb664189d03c1442657d07d577b33cfce0929";
+      sha256 = "b0e7b9aa39a05148a0ef83d860fd2ab40d2aa1a66a31dd1e9a59d390d56c6e42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ja/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ja/thunderbird-91.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "42e1e1a2b55c97b05ec5424f6318d286f7fa497276ff745c6c221ee2b4c072cd";
+      sha256 = "e02978eef0fc814ca190bf8bde29ae382fc2e14c61200e78ec1f43809d7cca9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ka/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ka/thunderbird-91.2.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "4da9353667f109938ebc6740039a915f67d518c109915c1ed42f1552c3be719d";
+      sha256 = "b11a6e09556d9f943765badb6145c5db2b7bb54cd3016de686e821aa66308bd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/kab/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/kab/thunderbird-91.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "87c960236895eb1af70d2f50a839e55befc6486c4883d786b14a67e569c396ae";
+      sha256 = "604f1c4a21b58b995e72ac48549802c588b0542c352de813aa4dcc02bbc0c686";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/kk/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/kk/thunderbird-91.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "38fdc0aa8fe98d83e52cf266776ebe7a52d7c80e98bc2372afcdeaf709ee8a06";
+      sha256 = "29479a9970a622e23901c6022058d635874b41e24c7f5aef42536abc922dd1ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ko/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ko/thunderbird-91.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "c960038e1764cc3a0203e2cdf8349ecfee951dbeb470cb58b66c66f0542ee790";
+      sha256 = "f34050010ff533a1c3949b11ad51c6902d6efec8c92904b2906ab80f95291e6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/lt/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/lt/thunderbird-91.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "6387197f1fa9095d64ef3e7c73272f0e0a4a7b857d4be29899bfe2c7aa88a5ec";
+      sha256 = "be3e4c5bff078c2129d6f4e1a6a820efa62cce2750e3e1359dfba0ea93e58b5a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/lv/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/lv/thunderbird-91.2.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "66021a590bb89b9fb50c90bc07788cbbb3d1acaceac5ebf562805d39bb59be3c";
+      sha256 = "bd6ec1783bcd5efbf51f963eef3db42f71b50e8826fe4896dc7356d10f4eefce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ms/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ms/thunderbird-91.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "a120efceac13b976b77a49dd2883f66a03c13f3243a53b66afbb372b87c15b16";
+      sha256 = "6279588bd47020c61250c211849b8fcbc4f480318a725090f316bb9f2099c31f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/nb-NO/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/nb-NO/thunderbird-91.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "ac5f404b3635b9b327458eb461148d94b52501621e78f2fafeff09c019651948";
+      sha256 = "0f0a0fb9f6556f4207e63a12e846d2917d8e221321b51ba34860094876c3528f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/nl/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/nl/thunderbird-91.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "f9dbbb9789a81ee6a40756039afefe542e1369b5de15d4ea728bd5fb5326c728";
+      sha256 = "2f3c40fffa081ec62396fc3b715331280603b38b6d5fe5f4b16de1ab6727a713";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/nn-NO/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/nn-NO/thunderbird-91.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "36d0cf0f3132f5365a9cfe5b2175ac6f42dbe25c41a03fbd177509b2cf13abce";
+      sha256 = "da9c9cc55abbd4f0679b53b6635868fb2a5f56165292a82903512058fa57f988";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/pa-IN/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/pa-IN/thunderbird-91.2.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "776c3c215fd0e66eb81c2c91855233c4a7476aad534de555a6317b6a4f664b67";
+      sha256 = "065db90edaec65fc7cb240d7793afae97110761bca269ffc4e172d0fd5dcbeae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/pl/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/pl/thunderbird-91.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "ba2aa2dda6c477f3ecb06d0f1d223928adc9a82e46432055783741064cf1e8f6";
+      sha256 = "4e0a43f1633728dbb25dcd60218b31fa45131a8189f94d8ebeff202bc251ac55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/pt-BR/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/pt-BR/thunderbird-91.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "314023714b6babde392b8a30d11e67fe5af9f47e2738d63a6231aa72e6e0b792";
+      sha256 = "a013acdee4b7e983c71dd39607103f1794b967addc57c538a8ca94437551743c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/pt-PT/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/pt-PT/thunderbird-91.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "ea5895b796bbdf9ed5be1277dc0f32c70abb46f37a7d48ecacf39e7b7a5af082";
+      sha256 = "4bf7b530490f1fc1d031040790a568bee42206f393f8c13994551e6ff4d1ede2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/rm/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/rm/thunderbird-91.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "d295f9390b7dedec8592751142a42bc134ff3fca5a228d084eb176677c15c4bc";
+      sha256 = "829ffbd9402f5cf80cdd8b001081d6f67628c842cc3c73f8191b6f6ff1d54d52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ro/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ro/thunderbird-91.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "b4504dd29ce68009c78b7194914c20d41024f92420564d6f4f34369717a49a90";
+      sha256 = "6bc72633a3b45faf2aa51627caf5674f1b05e16840b952f58f7f86ef6ad483b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/ru/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/ru/thunderbird-91.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "a8ba363a9bee130d05d028a84bfc10e8614ac3e3ee7e747d4987691d25423bb0";
+      sha256 = "141787ba7f5aeb0faa2a33e0d84fda8fa8d31681c6fdd0e884a69cc339042048";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/sk/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/sk/thunderbird-91.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "347a0e3e794bebc570aac65005edef1c311d7685d9b7ee4559121945cec1a40e";
+      sha256 = "90363481a491a239e4c3da49bc87ed3ca795e4ce0eaf2239ac5a298e5d7abc10";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/sl/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/sl/thunderbird-91.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "1ae4c2615d9fc4e6b1ab270988de63ff425779945684811a1c9093940e7a9d0a";
+      sha256 = "95e57777da6f9fcb41bb3116771be2e90b023315433d41e21884b34feb6a38e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/sq/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/sq/thunderbird-91.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "207fb12cf9415e5a66bee33ee2f50adb970343b90bdde2c00c5b149e9ec829ad";
+      sha256 = "d7e0a12bd5c7edfb130e4defdc25b8776fb71722fb146cd5309d52405ad231bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/sr/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/sr/thunderbird-91.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "45e7cb91506dfe353d86b8c6ae172b4a925f6b9ee631b542bc9a0fc77315d482";
+      sha256 = "b17dbc3424ce90c0360a75476d1d25568fb4e7c6e1e90a197ab332e5584cb88e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/sv-SE/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/sv-SE/thunderbird-91.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "634b1581237baa140d8711458cff99e979b3e33316b24925c6e5700da9603127";
+      sha256 = "027f7f817823e939261c05113b3cc5518b3fff1d061e66e8fcd5703504259f2b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/th/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/th/thunderbird-91.2.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "a09336e75d270e9fdfaefd4f9e90cddf1f5135602998bfdd9a198e3f1544838c";
+      sha256 = "268473436cc5230bc60b38c0678eaa71c64b5f9c3780120df51c1063790e1855";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/tr/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/tr/thunderbird-91.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "37874416c7bdd2c2b4303a55d14a82ce55a7d8cc6d51bc3b3d215489be3bc055";
+      sha256 = "79bad44e8e9dd7962d67b395d27c046d84c50f3eb66c53bc10de8a9c3d94a059";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/uk/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/uk/thunderbird-91.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "faa0c411431a9b27a7c58c0c394804d3125e4f4e927387df8580c37738c2db44";
+      sha256 = "c363f700537f3a466fb438ec4339b5e83b60c721faa647b4ab77c907ab9b1f21";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/uz/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/uz/thunderbird-91.2.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "095e56a0fa0e85bebe9bc0044fc13f5da67c7267461b27fb8024947da3f423ba";
+      sha256 = "2de957d36eb6c2b5a7d33d6a06e9f4f1072981fd8530aa18d609a892f963c975";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/vi/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/vi/thunderbird-91.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "cae3582b504a38497dc63ba25d4be45e450b14cb588a9f52919d0fb4a5a04446";
+      sha256 = "5006d6c79aff928e307a92eb3867364f206ee1d872e275d3ebf63b9a4cf286de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/zh-CN/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/zh-CN/thunderbird-91.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "58d542c3ceb5e36a83e424250c171477543bcd046f325c89b06f76090410b633";
+      sha256 = "4893ea232fa746efc32cb0d84800b46fbdffb49a13fbc244559ca0382561ebca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.1.2/linux-i686/zh-TW/thunderbird-91.1.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.2.1/linux-i686/zh-TW/thunderbird-91.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "13dfa3e7a8b5a69ab9072c21eb22373ff36bd54c9c7c39c3480681bd911043c0";
+      sha256 = "37ad46134d268639514eeb267a89aeb20fc318bde923b9eb552c281b23ae153e";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -10,12 +10,12 @@ in
 rec {
   thunderbird = common rec {
     pname = "thunderbird";
-    version = "91.2.0";
+    version = "91.2.1";
     application = "comm/mail";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "1f21f77069490be2de131f6125a498c6ed0a7d10b2ff787891d8dea10019719fea8014a8b2d626a2365f10f6307b616e5f1eef2c601e4da5402c9d5fc7d35049";
+      sha512 = "3152f20ad5f0fd3ce2c1672e91f07ab8921ffb5ecf487e6b0d7d7464445c8d8df106eea0bd8d912ffa84ab0ad403dfcfb19be97f50a015150c9091201a0dff6d";
     };
     patches = [
     ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Preference added to disable automatic pausing RSS feed updates after a fetch failure.
- Bug fixes.

https://www.thunderbird.net/en-US/thunderbird/91.2.1/releasenotes/

Supersedes #141165.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
