### PR TITLE
schildichat-web, schildichat-desktop: init at 1.9.0-sc.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/schildichat/pin.json
+++ b/pkgs/applications/networking/instant-messengers/schildichat/pin.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.9.0-sc.1",
+  "srcHash": "10swz5gwz1izryzllmjm8mhhd0vqk2cp8qjcmmr5gbzspj7p3xgw",
+  "webYarnHash": "134llyh0197andpnbmfcxnidcgi3xxnb9v10bwfvrqysgnhb5z8v",
+  "desktopYarnHash": "150jc6p9kbdz599bdkinrhbhncpamhz35j6rcc008qxg2d9qfhwr"
+}

--- a/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
@@ -1,0 +1,128 @@
+{ lib
+, element-desktop # for seshat and keytar
+, schildichat-web
+, stdenv
+, fetchgit
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+, fetchYarnDeps
+, yarn, nodejs, fixup_yarn_lock
+, electron
+, Security
+, AppKit
+, CoreServices
+
+, useWayland ? false
+}:
+
+let
+  pinData = lib.importJSON ./pin.json;
+  executableName = "schildichat-desktop";
+  electron_exec = if stdenv.isDarwin then "${electron}/Applications/Electron.app/Contents/MacOS/Electron" else "${electron}/bin/electron";
+in
+stdenv.mkDerivation rec {
+  pname = "schildichat-desktop";
+  inherit (pinData) version;
+
+  src = fetchgit {
+    url = "https://github.com/SchildiChat/schildichat-desktop/";
+    rev = "v${version}";
+    sha256 = pinData.srcHash;
+    fetchSubmodules = true;
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = src + "/element-desktop/yarn.lock";
+    sha256 = pinData.desktopYarnHash;
+  };
+
+  nativeBuildInputs = [ yarn fixup_yarn_lock nodejs makeWrapper copyDesktopItems ];
+  inherit (element-desktop) seshat keytar;
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    pushd element-desktop
+    yarn config --offline set yarn-offline-mirror $offlineCache
+    fixup_yarn_lock yarn.lock
+    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+    rm -rf node_modules/matrix-seshat node_modules/keytar
+    ln -s $keytar node_modules/keytar
+    ln -s $seshat node_modules/matrix-seshat
+    patchShebangs node_modules/
+    popd
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd element-desktop
+    npx tsc
+    yarn run i18n
+    node ./scripts/copy-res.js
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # resources
+    mkdir -p "$out/share/element"
+    ln -s '${schildichat-web}' "$out/share/element/webapp"
+    mv element-desktop "$out/share/element/electron"
+    cp -r "$out/share/element/electron/res/img" "$out/share/element"
+    cp $out/share/element/electron/lib/i18n/strings/en_EN.json $out/share/element/electron/lib/i18n/strings/en-us.json
+    ln -s $out/share/element/electron/lib/i18n/strings/en{-us,}.json
+
+    # icons
+    for icon in $out/share/element/electron/build/icons/*.png; do
+      mkdir -p "$out/share/icons/hicolor/$(basename $icon .png)/apps"
+      ln -s "$icon" "$out/share/icons/hicolor/$(basename $icon .png)/apps/schildichat.png"
+    done
+
+    # executable wrapper
+    makeWrapper '${electron_exec}' "$out/bin/${executableName}" \
+      --add-flags "$out/share/element/electron${lib.optionalString useWayland " --enable-features=UseOzonePlatform --ozone-platform=wayland"}"
+
+    runHook postInstall
+  '';
+
+  # Do not attempt generating a tarball for element-web again.
+  # note: `doDist = false;` does not work.
+  distPhase = ";";
+
+  # The desktop item properties should be kept in sync with data from upstream:
+  # https://github.com/schildichat/element-desktop/blob/sc/package.json
+  desktopItems = [
+    (makeDesktopItem {
+     name = "schildichat-desktop";
+     exec = "${executableName} %u";
+     icon = "schildichat";
+     desktopName = "SchildiChat";
+     genericName = "Matrix Client";
+     comment = meta.description;
+     categories = "Network;InstantMessaging;Chat;";
+     extraEntries = ''
+       StartupWMClass=schildichat
+       MimeType=x-scheme-handler/element;
+     '';
+    })
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Matrix client / Element Desktop fork";
+    homepage = "https://schildi.chat/";
+    changelog = "https://github.com/SchildiChat/schildichat-desktop/releases";
+    maintainers = lib.teams.matrix.members;
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/schildichat/schildichat-web.nix
+++ b/pkgs/applications/networking/instant-messengers/schildichat/schildichat-web.nix
@@ -1,0 +1,86 @@
+{ stdenv, lib
+, fetchgit
+, fetchYarnDeps
+, nodejs
+, yarn
+, fixup_yarn_lock
+, writeText, jq, conf ? {}
+}:
+
+let
+  pinData = builtins.fromJSON (builtins.readFile ./pin.json);
+  noPhoningHome = {
+    disable_guests = true; # disable automatic guest account registration at matrix.org
+  };
+  configOverrides = writeText "element-config-overrides.json" (builtins.toJSON (noPhoningHome // conf));
+
+in stdenv.mkDerivation rec {
+  pname = "schildichat-web";
+  inherit (pinData) version;
+
+  src = fetchgit {
+    url = "https://github.com/SchildiChat/schildichat-desktop/";
+    rev = "v${version}";
+    sha256 = pinData.srcHash;
+    fetchSubmodules = true;
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = src + "/element-web/yarn.lock";
+    sha256 = pinData.webYarnHash;
+  };
+
+  nativeBuildInputs = [ yarn fixup_yarn_lock jq nodejs ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$PWD/tmp
+    mkdir -p $HOME
+    pushd element-web
+    yarn config --offline set yarn-offline-mirror $offlineCache
+    fixup_yarn_lock yarn.lock
+    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+    rm -rf node_modules/matrix-react-sdk
+    patchShebangs node_modules/ ../matrix-react-sdk/scripts/
+    ln -s $PWD/../matrix-react-sdk node_modules/
+    ln -s $PWD/node_modules ../matrix-react-sdk/
+    popd
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd matrix-react-sdk
+    node_modules/.bin/reskindex -h ../element-web/src/header
+    popd
+
+    pushd element-web
+    node scripts/copy-res.js
+    node_modules/.bin/reskindex -h ../element-web/src/header
+    node_modules/.bin/webpack --progress --mode production
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mv element-web/webapp $out
+    jq -s '.[0] * .[1]' "configs/sc/config.json" "${configOverrides}" > "$out/config.json"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Matrix client / Element Web fork";
+    homepage = "https://schildi.chat/";
+    changelog = "https://github.com/SchildiChat/schildichat-desktop/releases";
+    maintainers = lib.teams.matrix.members;
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/schildichat/update.sh
+++ b/pkgs/applications/networking/instant-messengers/schildichat/update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=../../../../../ -i bash -p nix wget prefetch-yarn-deps nix-prefetch-git jq
+
+if [[ "$#" -gt 1 || "$1" == -* ]]; then
+  echo "Regenerates packaging data for the SchildiChat packages."
+  echo "Usage: $0 [git release tag]"
+  exit 1
+fi
+
+version="$1"
+
+set -euo pipefail
+
+if [ -z "$version" ]; then
+  version="$(wget -O- "https://api.github.com/repos/SchildiChat/schildichat-desktop/releases?per_page=1" | jq -r '.[0].tag_name')"
+fi
+
+# strip leading "v"
+version="${version#v}"
+
+src_data=$(nix-prefetch-git https://github.com/SchildiChat/schildichat-desktop --fetch-submodules --rev v${version})
+src=$(echo $src_data | jq -r .path)
+src_hash=$(echo $src_data | jq -r .sha256)
+
+web_yarn_hash=$(prefetch-yarn-deps $src/element-web/yarn.lock)
+desktop_yarn_hash=$(prefetch-yarn-deps $src/element-desktop/yarn.lock)
+
+cat > pin.json << EOF
+{
+  "version": "$version",
+  "srcHash": "$src_hash",
+  "webYarnHash": "$web_yarn_hash",
+  "desktopYarnHash": "$desktop_yarn_hash"
+}
+EOF

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4699,6 +4699,18 @@ with pkgs;
 
   strawberry = libsForQt5.callPackage ../applications/audio/strawberry { };
 
+  schildichat-desktop = callPackage ../applications/networking/instant-messengers/schildichat/schildichat-desktop.nix {
+    inherit (darwin.apple_sdk.frameworks) Security AppKit CoreServices;
+    electron = electron_13;
+  };
+  schildichat-desktop-wayland = schildichat-desktop.override {
+    useWayland = true;
+  };
+
+  schildichat-web = callPackage ../applications/networking/instant-messengers/schildichat/schildichat-web.nix {
+    conf = config.schildichat-web.conf or {};
+  };
+
   tealdeer = callPackage ../tools/misc/tealdeer {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/110856

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
