### PR TITLE
prefetch-yarn-deps: add nix dependency

### DIFF
--- a/pkgs/build-support/node/fetch-yarn-deps/default.nix
+++ b/pkgs/build-support/node/fetch-yarn-deps/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, makeWrapper, coreutils, nix-prefetch-git, fetchurl, nodejs-slim, prefetch-yarn-deps, cacert, callPackage }:
+{ stdenv, lib, makeWrapper, coreutils, nix-prefetch-git, fetchurl, nodejs-slim, prefetch-yarn-deps, cacert, callPackage, nix }:
 
 let
   yarnpkg-lockfile-tar = fetchurl {
@@ -13,7 +13,7 @@ in {
     dontUnpack = true;
 
     nativeBuildInputs = [ makeWrapper ];
-    buildInputs = [ coreutils nix-prefetch-git nodejs-slim ];
+    buildInputs = [ coreutils nix-prefetch-git nodejs-slim nix ];
 
     buildPhase = ''
       runHook preBuild
@@ -33,7 +33,7 @@ in {
       mkdir -p $out/bin
       cp -r libexec $out
       makeWrapper $out/libexec/index.js $out/bin/prefetch-yarn-deps \
-        --prefix PATH : ${lib.makeBinPath [ coreutils nix-prefetch-git ]}
+        --prefix PATH : ${lib.makeBinPath [ coreutils nix-prefetch-git nix ]}
 
       runHook postInstall
     '';


### PR DESCRIPTION
fixes "Error: spawn nix-hash ENOENT"

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
