### PR TITLE
vector and oniguruma update

### DIFF
--- a/pkgs/development/libraries/oniguruma/default.nix
+++ b/pkgs/development/libraries/oniguruma/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "onig";
-  version = "6.9.6";
+  version = "6.9.7.1";
 
   src = fetchFromGitHub {
     owner = "kkos";
     repo = "oniguruma";
     rev = "v${version}";
-    sha256 = "0y0dv6axvjjzi9367xc4q2nvvx58919iyzy25d5022lpz9z569kj";
+    sha256 = "sha256-IBWxmzmVdKTkHbfy7V8ejpeIdfOU/adGwpUTCMdLU3w=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -26,18 +26,21 @@
     ++ (lib.optional stdenv.targetPlatform.isUnix "unix"))
 }:
 
-rustPlatform.buildRustPackage rec {
+let
   pname = "vector";
-  version = "0.16.1";
+  version = "0.17.3";
+in
+rustPlatform.buildRustPackage {
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "timberio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-10e0cWt6XW8msNR/RXbaOpdwTAlRLm6jVvDed905rho=";
+    sha256 = "sha256-1Z2GtzWkS7cxzCs+RBKMtWbzIIt4aeS1Iy9kMBEeDMw=";
   };
 
-  cargoSha256 = "sha256-ezQ/tX/uKzJprLQt2xIUZwGuUOmuRmTO+gPsf3MLEv8=";
+  cargoSha256 = "sha256-UEGdvyRPPh5Kb9+0qFyv8UBFslOKn5/R/ineawFA91w=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]
     ++ lib.optionals stdenv.isDarwin [ Security libiconv coreutils CoreServices ];
@@ -63,7 +66,8 @@ rustPlatform.buildRustPackage rec {
       -- --test-threads 1 \
       --skip=sinks::loki::tests::healthcheck_grafana_cloud \
       --skip=kubernetes::api_watcher::tests::test_stream_errors \
-      --skip=sources::socket::test::tcp_with_tls_intermediate_ca
+      --skip=sources::socket::test::tcp_with_tls_intermediate_ca \
+      --skip=sources::host_metrics::cgroups::tests::generates_cgroups_metrics
   '';
 
   # recent overhauls of DNS support in 0.9 mean that we try to resolve


### PR DESCRIPTION
###### Motivation for this change

this is just an upstream update, but it tripped me since it required an update of oniguruma.
It took me a while to find that that was the problem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
