### PR TITLE
stb: 20180211 -> unstable-2021-09-10

### DIFF
--- a/pkgs/development/libraries/stb/default.nix
+++ b/pkgs/development/libraries/stb/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "stb";
-  version = "20180211";
+  version = "unstable-2021-09-10";
 
   src = fetchFromGitHub {
     owner = "nothings";
     repo = "stb";
-    rev = "e6afb9cbae4064da8c3e69af3ff5c4629579c1d2";
-    sha256 = "079nsn9bnb8c0vfq26g5l53q6gzx19a5x9q2nb55mpcljxsgxnmf";
+    rev = "af1a5bc352164740c1cc1354942b1c6b72eacb8a";
+    sha256 = "0qq35cd747lll4s7bmnxb3pqvyp2hgcr9kyf758fax9lx76iwjhr";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2021-42715
https://nvd.nist.gov/vuln/detail/CVE-2021-42716

`nixpkgs-review` happy on macos 10.15 & nixos x86_64 apart from existing failure `curaLulzbot`.

No doubt there are vendored versions of this sitting throughout nixpkgs which we'll never find.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
