### PR TITLE
flameshot: fix desktop Exec path and autostart directory location

### DIFF
--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , lib
 , fetchFromGitHub
+, fetchpatch
 , qtbase
 , cmake
 , qttools
@@ -19,6 +20,21 @@ mkDerivation rec {
     sha256 = "1ncknjayl6am740f49g0lc28z1zsifbicxz1j1kwps3ksj15nl7a";
   };
 
+  patches = [
+    # Support for USE_LAUNCHER_ABSOLUTE_PATH.
+    # Should be removed when the next release comes out.
+    (fetchpatch {
+      url = "https://github.com/flameshot-org/flameshot/commit/1031980ed1e62d24d7f719998b7951d48801e3fa.patch";
+      sha256 = "sha256-o8Zz/bBvitXMDFt5rAfubiUPOx+EQ+ITgrfnFM3dFjE=";
+    })
+    # Fix autostart write path.
+    # Should be removed when the next release comes out.
+    (fetchpatch {
+      url = "https://github.com/flameshot-org/flameshot/commit/7977cbb52c2d785abd0d85d9df5991e8f7cae441.patch";
+      sha256 = "sha256-wWa9Y+4flBiggOMuX7KQyL+q3f2cALGeQBGusX2x6sk=";
+    })
+  ];
+
   passthru = {
     updateScript = nix-update-script {
       attrPath = pname;
@@ -28,10 +44,13 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake qttools qtsvg ];
   buildInputs = [ qtbase ];
 
+  # Use relative path for the .desktop file.
+  cmakeFlags = [ "-DUSE_LAUNCHER_ABSOLUTE_PATH=OFF" ];
+
   meta = with lib; {
     description = "Powerful yet simple to use screenshot software";
     homepage = "https://github.com/flameshot-org/flameshot";
-    maintainers = with maintainers; [ scode ];
+    maintainers = with maintainers; [ scode oxalica ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #141873 without upgrading to unstable git version, since it's not required and we need to port this to stable.

Override #141976 

cc @rycee @YizhePKU 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
1 package updated:
flameshot

1 package built:
flameshot
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
