### PR TITLE
plantuml-server: 1.2021.7 -> 1.2021.12

### DIFF
--- a/nixos/modules/services/web-apps/plantuml-server.nix
+++ b/nixos/modules/services/web-apps/plantuml-server.nix
@@ -58,8 +58,8 @@ in
 
       graphvizPackage = mkOption {
         type = types.package;
-        default = pkgs.graphviz_2_32;
-        defaultText = literalExpression "pkgs.graphviz_2_32";
+        default = pkgs.graphviz;
+        defaultText = literalExpression "pkgs.graphviz";
         description = "Package containing the dot executable.";
       };
 

--- a/pkgs/tools/misc/plantuml-server/default.nix
+++ b/pkgs/tools/misc/plantuml-server/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchFromGitHub, maven, jdk8_headless }:
 
 let
-  version = "1.2021.7";
+  version = "1.2021.12";
 
   src = fetchFromGitHub {
     owner = "plantuml";
     repo = "plantuml-server";
     rev = "v${version}";
-    sha256 = "sha256-kY7b3ocm1zudGIf72MNMZDUG2t2FFqucRr3kRaFv7mo=";
+    sha256 = "sha256:016mrs4djbaid1ma5922dvq372pphbzzmjzsjalj2dqp60538xll";
   };
 
   # perform fake build to make a fixed-output derivation out of the files downloaded from maven central
@@ -28,7 +28,7 @@ let
     installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-HzT5rBycrd48KskWKAGtkMKdCDQ8NPYADVWZh8K0ll4=";
+    outputHash = "sha256:12w1iw9c5j7y9hhaip07j3aszjiiakkww1v3zszlj15fj8jgqyf2";
   };
 in
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://plantuml.com/changes

The `plantuml` package moved from `graphviz_2_32` to `graphviz` https://github.com/NixOS/nixpkgs/commit/e785e1b24be254cc4cd9efe7717b6d248691faed. As far I can tell `plantuml-server` was the only remaining dependent on `graphviz_2_32` so it can be removed now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
