### PR TITLE
storrent: init at 2021-10-10

### DIFF
--- a/pkgs/applications/networking/p2p/storrent/default.nix
+++ b/pkgs/applications/networking/p2p/storrent/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "storrent-unstable";
+  version = "2021-10-10";
+
+  src = fetchFromGitHub {
+    owner = "jech";
+    repo = "storrent";
+    rev = "681733cf74de08bea251ada672ea8c666eb1b679";
+    sha256 = "0grrqgawswb44fahf40060jl691rlyccwlqkljvgy8mzzw1kjzj4";
+  };
+
+  vendorSha256 = "0sz2fz7bqgwd5i7sacyxs7bmb8ly6xrxrakqi9c446vzlkh898hj";
+
+  meta = with lib; {
+    homepage = "https://github.com/jech/storrent";
+    description = "An implementation of the BitTorrent protocol that is optimised for streaming media";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26822,6 +26822,8 @@ with pkgs;
 
   songrec = callPackage ../applications/audio/songrec {};
 
+  storrent = callPackage ../applications/networking/p2p/storrent { };
+
   spacegun = callPackage ../applications/networking/cluster/spacegun {};
 
   stride = callPackage ../applications/networking/instant-messengers/stride { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add https://github.com/jech/storrent

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
