### PR TITLE
opendkim: fix darwin

### DIFF
--- a/pkgs/development/libraries/opendkim/default.nix
+++ b/pkgs/development/libraries/opendkim/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, libbsd, openssl, libmilter
-, autoreconfHook, perl, makeWrapper }:
+, autoreconfHook, perl, makeWrapper, unbound }:
 
 stdenv.mkDerivation rec {
   pname = "opendkim";
@@ -16,11 +16,11 @@ stdenv.mkDerivation rec {
     "--with-milter=${libmilter}"
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
-  ];
+  ] ++ lib.optional stdenv.isDarwin "--with-unbound=${unbound}";
 
   nativeBuildInputs = [ autoreconfHook pkg-config makeWrapper ];
 
-  buildInputs = [ libbsd openssl libmilter perl ];
+  buildInputs = [ libbsd openssl libmilter perl ] ++ lib.optional stdenv.isDarwin unbound;
 
   postInstall = ''
     wrapProgram $out/sbin/opendkim-genkey \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
* fixes: `configure: error: "unbound required on Darwin"`

###### Things done
* Add `unbound` to `buildInputs` for Darwin
* Add `--with-unbound` flag to the build

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
