### PR TITLE
perlPackages.CompressRawLzma: init at 2.101

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3518,6 +3518,27 @@ let
     };
   };
 
+  CompressRawLzma = buildPerlPackage {
+    pname = "Compress-Raw-Lzma";
+    version = "2.101";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Lzma-2.101.tar.gz";
+      sha256 = "bb267fd31981eda11f444038f8a0fca4b94a51ae61b2db71246abf6a4d322a36";
+    };
+    buildInputs = [ pkgs.xz ];
+    preConfigure = ''
+      cat > config.in <<EOF
+        INCLUDE      = ${pkgs.xz.dev}/include
+        LIB          = ${pkgs.xz.out}/lib
+      EOF
+    '';
+    meta = {
+      homepage = "https://github.com/pmqs/Compress-Raw-Lzma";
+      description = "Low-Level Interface to lzma compression library";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   CompressRawZlib = buildPerlPackage {
     pname = "Compress-Raw-Zlib";
     version = "2.096";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3525,7 +3525,6 @@ let
       url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Lzma-2.101.tar.gz";
       sha256 = "bb267fd31981eda11f444038f8a0fca4b94a51ae61b2db71246abf6a4d322a36";
     };
-    buildInputs = [ pkgs.xz ];
     preConfigure = ''
       cat > config.in <<EOF
         INCLUDE      = ${pkgs.xz.dev}/include


### PR DESCRIPTION
###### Motivation for this change

Dependency of https://github.com/lod/unpack-install-jammer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

##### Notes

- Disclaimer: I have no clue about Perl
- I copied and adapted `preConfigure` from another package to make sure it links `liblzma` during build. Let me know if there's a better way.

Maintainers: @volth @stigtsp @zakame
