### PR TITLE
qgis: 3.16.10 → 3.16.12

### DIFF
--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -57,22 +57,15 @@ let
     six
   ];
 in mkDerivation rec {
-  version = "3.16.10";
+  version = "3.16.12";
   pname = "qgis-unwrapped";
 
   src = fetchFromGitHub {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "sha256-/lsfyTDlkZNIVHg5qgZW7qfOyTC2+1r3ZbsnQmEdy30=";
+    sha256 = "19pr0vby5sy02mhl2gi12mhrjkm8kc8kq7mlnmy41mglf92bwp85";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/qgis/QGIS/commit/fc1ac8bef8dcc3194857ecd32519aca4867b4fa1.patch";
-      sha256 = "106smg3drx8c7yxzfhd1c7xrq757l5cfxx8lklihyvr4a7wc9gpy";
-    })
-  ];
 
   passthru = {
     inherit pythonBuildInputs;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Motivation for this change is to update QGIS to the latest LTS (Long Term Support) version.

###### Things done

* This PR is updating QGIS LTS (Long Term Support) from version 3.16.10 to the latest 3.16.12
* This PR also drops [fc1ac8bef8dcc3194857ecd32519aca4867b4fa1 patch](https://github.com/qgis/QGIS/commit/fc1ac8bef8dcc3194857ecd32519aca4867b4fa1.patch) which is now included in 3.16.12 release. `fetchpatch` code snipped was left in code, commented out as an example in case another patches will be needed in the future. 

I successfully tested built app (`nix-build -A qgis`) on my NixOS 21.05 system with QGIS project test datasets

```
nixpkgs/code git:(qgis-3.16.12) ./result/bin/qgis
```
![screen-imincik-2021-10-23-21_13_20](https://user-images.githubusercontent.com/476346/138568684-1473ab40-e196-4649-8bae-436096f8b768.png)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
