### PR TITLE
scryer-prolog: update dependency lexical-core to fix build

### DIFF
--- a/pkgs/development/compilers/scryer-prolog/cargo.patch
+++ b/pkgs/development/compilers/scryer-prolog/cargo.patch
@@ -26,6 +26,18 @@ index ef25833..d9de212 100644
  dependencies = [
   "libc",
   "winapi 0.3.8",
+@@ -485,9 +487,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "lexical-core"
+-version = "0.4.6"
++version = "0.4.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
++checksum = "34449d00c5d4066537f4dc72320b18e3aa421e8e92669250eecd664c618fefce"
+ dependencies = [
+  "arrayvec 0.4.12",
+  "cfg-if",
 @@ -766,15 +766,6 @@ version = "0.1.2"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"

--- a/pkgs/development/compilers/scryer-prolog/default.nix
+++ b/pkgs/development/compilers/scryer-prolog/default.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
   # Use system openssl, gmp, mpc and mpfr.
   cargoPatches = [ ./cargo.patch ];
 
-  cargoSha256 = "0gb0l2wwf8079jwggn9zxk8pz8pxg3b7pin1d7dsbd4ij52lzyi2";
+  cargoSha256 = "1vf7pfhvpk7ikzibdccw7xgbywv5n4vvshjwsdsf94bhl2knrlg3";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl gmp libmpc mpfr ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix the build of package scryer-prolog. Unfortunately, there is no new release of scryer-prolog itself yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
