### PR TITLE
intel-compute-runtime: 20.34.17727 -> 21.42.21270

### DIFF
--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -2,29 +2,30 @@
 , fetchFromGitHub
 , cmake
 , pkg-config
-
 , lit
-, llvm_8
+, llvm_11
 }:
 
 stdenv.mkDerivation rec {
   pname = "SPIRV-LLVM-Translator";
-  version = "8.0.1-2";
+  version = "unstable-2021-06-13";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-LLVM-Translator";
-    rev = "v${version}";
-    sha256 = "0hxalc3fkliqs61hpr97phbm3qsx4b8vgnlg30aimzr6aas403r5";
+    rev = "c67e6f26a7285aa753598ef792593ac4a545adf9";
+    sha256 = "sha256-1s3lVNTQDl+pUvbzSMsp3cOUSm6I4DzqJxnLMeeE3F4=";
   };
 
-  nativeBuildInputs = [ pkg-config cmake llvm_8.dev ];
+  nativeBuildInputs = [ pkg-config cmake llvm_11.dev ];
 
-  buildInputs = [ llvm_8 ];
+  buildInputs = [ llvm_11 ];
 
   checkInputs = [ lit ];
 
-  cmakeFlags = [ "-DLLVM_INCLUDE_TESTS=ON" ];
+  cmakeFlags = [
+    "-DLLVM_INCLUDE_TESTS=ON"
+  ];
 
   # FIXME: CMake tries to run "/llvm-lit" which of course doesn't exist
   doCheck = false;

--- a/pkgs/development/libraries/opencl-clang/default.nix
+++ b/pkgs/development/libraries/opencl-clang/default.nix
@@ -5,14 +5,14 @@
 , cmake
 , git
 
-, llvmPackages_8
+, llvmPackages_11
 , spirv-llvm-translator
 
 , buildWithPatches ? true
 }:
 
 let
-  llvmPkgs = llvmPackages_8 // {
+  llvmPkgs = llvmPackages_11 // {
     inherit spirv-llvm-translator;
   };
 
@@ -31,7 +31,8 @@ let
     });
 
   passthru = rec {
-
+    spirv-llvm-translator = llvmPkgs.spirv-llvm-translator;
+    llvm = addPatches "llvm" llvmPkgs.llvm;
     libclang = addPatches "clang" llvmPkgs.libclang;
 
     clang-unwrapped = libclang.out;
@@ -43,14 +44,21 @@ let
     patchesOut = stdenv.mkDerivation rec {
       pname = "opencl-clang-patches";
       inherit (library) version src patches;
+      # Clang patches assume the root is the llvm root dir
+      # but clang root in nixpkgs is the clang sub-directory
+      postPatch = ''
+        for filename in patches/clang/*.patch; do
+          substituteInPlace "$filename" \
+            --replace "a/clang/" "a/" \
+            --replace "b/clang/" "b/"
+        done
+      '';
+
       installPhase = ''
         [ -d patches ] && cp -r patches/ $out || mkdir $out
-        mkdir -p $out/clang $out/spirv
+        mkdir -p $out/clang $out/llvm
       '';
     };
-
-    spirv-llvm-translator = addPatches "spirv" llvmPkgs.spirv-llvm-translator;
-
   };
 
   library = let
@@ -59,15 +67,15 @@ let
   in
     stdenv.mkDerivation rec {
       pname = "opencl-clang";
-      version = "unstable-2019-08-16";
+      version = "unstable-2021-06-22";
 
       inherit passthru;
 
       src = fetchFromGitHub {
         owner = "intel";
         repo = "opencl-clang";
-        rev = "94af090661d7c953c516c97a25ed053c744a0737";
-        sha256 = "05cg89m62nqjqm705h7gpdz4jd4hiczg8944dcjsvaybrqv3hcm5";
+        rev = "fd68f64b33e67d58f6c36b9e25c31c1178a1962a";
+        sha256 = "sha256-q1YPBb/LY67iEuQx1fMUQD/I7OsNfobW3yNfJxLXx3E=";
       };
 
       patches = [

--- a/pkgs/os-specific/linux/intel-compute-runtime/default.nix
+++ b/pkgs/os-specific/linux/intel-compute-runtime/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-compute-runtime";
-  version = "20.34.17727";
+  version = "21.42.21270";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "compute-runtime";
     rev = version;
-    sha256 = "19scbbr6jf3yp2v7z8xyzzm01g44jym7xfkf1dz64d5nhvjw6ig5";
+    sha256 = "N9MsDcsL8kBWxfZjhukcxZiSJnXxqMgWF0etOhf2/AE=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];


### PR DESCRIPTION
###### Motivation for this change
`intel-compute-runtime` is quite old. In fact opencl is not working properly on Intel 11th gen integrated GPUs.  This PR updates it to the most recent version. This means a few dependencies also had to be updated. Due to this https://github.com/NixOS/nixpkgs/pull/130127 is kind of obsolete. The packaged version of this PR is not as new as that one because that version is not compatible. Are you fine with this @kvtb?

Fixes https://github.com/NixOS/nixpkgs/issues/142566.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
