### PR TITLE
nerd-font-patcher: init at 2.1.0

### DIFF
--- a/pkgs/applications/misc/nerd-font-patcher/default.nix
+++ b/pkgs/applications/misc/nerd-font-patcher/default.nix
@@ -1,0 +1,41 @@
+{ python3Packages, lib, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "nerd-font-patcher";
+  version = "2.1.0";
+
+  # The size of the nerd fonts repository is bigger than 2GB, because it
+  # contains a lot of fonts and the patcher.
+  # until https://github.com/ryanoasis/nerd-fonts/issues/484 is not fixed,
+  # we download the patcher from an alternative repository
+  src = fetchFromGitHub {
+    owner = "betaboon";
+    repo = "nerd-fonts-patcher";
+    rev = "180684d7a190f75fd2fea7ca1b26c6540db8d3c0";
+    sha256 = "sha256-FAbdLf0XiUXGltAgmq33Wqv6PFo/5qCv62UxXnj3SgI=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ fontforge ];
+
+  format = "other";
+
+  postPatch = ''
+    sed -i font-patcher \
+      -e 's,__dir__ + "/src,"'$out'/share/${pname},'
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/${pname}
+    install -Dm755 font-patcher $out/bin/${pname}
+    cp -ra src/glyphs $out/share/${pname}
+  '';
+
+  meta = with lib; {
+    description = "Font patcher to generate Nerd font";
+    homepage = "https://nerdfonts.com/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ck3d ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26686,6 +26686,8 @@ with pkgs;
 
   neocomp  = callPackage ../applications/window-managers/neocomp { };
 
+  nerd-font-patcher = callPackage ../applications/misc/nerd-font-patcher { };
+
   newsflash = callPackage ../applications/networking/feedreaders/newsflash { };
 
   nicotine-plus = callPackage ../applications/networking/soulseek/nicotine-plus { };


### PR DESCRIPTION
###### Motivation for this change
Package font-patcher from nerd fonts.

see also https://github.com/NixOS/nixpkgs/pull/124042

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
