### PR TITLE
morgen: init at 2.3.2

### DIFF
--- a/pkgs/applications/office/morgen/default.nix
+++ b/pkgs/applications/office/morgen/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, fetchurl, dpkg, autoPatchelfHook, makeWrapper, electron
+, alsa-lib, gtk3, libxshmfence, mesa, nss }:
+
+stdenv.mkDerivation rec {
+  pname = "morgen";
+  version = "2.3.2";
+
+  src = fetchurl {
+    url = "https://download.todesktop.com/210203cqcj00tw1/morgen-${version}.deb";
+    sha256 = "sha256-rlXCZtIw0kkI2rxn41yW1dTAwwDgcqD/FET5fOP4DJg=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [ alsa-lib gtk3 libxshmfence mesa nss ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = ''
+    dpkg-deb -x ${src} ./
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mv usr $out
+    mv opt $out
+
+    substituteInPlace $out/share/applications/morgen.desktop \
+      --replace '/opt/Morgen' $out/bin
+
+    makeWrapper ${electron}/bin/electron $out/bin/morgen \
+      --add-flags $out/opt/Morgen/resources/app.asar
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "All-in-one Calendars, Tasks and Scheduler";
+    homepage = "https://morgen.so/download";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7549,6 +7549,8 @@ with pkgs;
 
   mole = callPackage ../tools/networking/mole { };
 
+  morgen = callPackage ../applications/office/morgen { };
+
   mosh = callPackage ../tools/networking/mosh { };
 
   mpage = callPackage ../tools/text/mpage { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#131496

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
