### PR TITLE
citra: devendor some packages

### DIFF
--- a/pkgs/misc/emulators/citra/default.nix
+++ b/pkgs/misc/emulators/citra/default.nix
@@ -1,26 +1,75 @@
-{ mkDerivation, lib, fetchgit, cmake, SDL2, qtbase, qtmultimedia, boost
-, wrapQtAppsHook }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, wrapQtAppsHook
+, SDL2
+, qtbase
+, qtmultimedia
+, boost17x
+, libpulseaudio
+, pkg-config
+, libusb1
+, zstd
+, libressl
+, alsa-lib
+, rapidjson
+, aacHleDecoding ? true
+, fdk_aac
+, ffmpeg-full
+}:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "citra";
   version = "2021-11-01";
 
-  # Submodules
-  src = fetchgit {
-    url = "https://github.com/citra-emu/citra";
+  src = fetchFromGitHub {
+    owner = "citra-emu";
+    repo = "citra";
     rev = "5a7d80172dd115ad9bc6e8e85cee6ed9511c48d0";
     sha256 = "sha256-vy2JMizBsnRK9NBEZ1dxT7fP/HFhOZSsC+5P+Dzi27s=";
+    fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake wrapQtAppsHook ];
-  buildInputs = [ SDL2 qtbase qtmultimedia boost ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook pkg-config ];
+  buildInputs = [
+    SDL2
+    qtbase
+    qtmultimedia
+    libpulseaudio
+    boost17x
+    libusb1
+    alsa-lib
+    rapidjson # for discord-rpc
+  ] ++ lib.optional aacHleDecoding [ fdk_aac ffmpeg-full ];
 
-  preConfigure = ''
+  cmakeFlags = [
+    "-DUSE_SYSTEM_BOOST=ON"
+    "-DUSE_DISCORD_PRESENCE=ON"
+  ] ++ lib.optionals aacHleDecoding [
+    "-DENABLE_FFMPEG_AUDIO_DECODER=ON"
+    "-DCITRA_USE_BUNDLED_FFMPEG=OFF"
+  ];
+
+  postPatch = ''
+    # we already know the submodules are present
+    substituteInPlace CMakeLists.txt \
+      --replace "check_submodules_present()" ""
+
     # Trick configure system.
     sed -n 's,^ *path = \(.*\),\1,p' .gitmodules | while read path; do
-      mkdir "$path/.git"
+    mkdir "$path/.git"
     done
+
+    rm -rf externals/zstd externals/libressl
+    cp -r ${zstd.src} externals/zstd
+    tar xf ${libressl.src} -C externals/
+    mv externals/${libressl.name} externals/libressl
+    chmod -R a+w externals/zstd
   '';
+
+  # Todo: cubeb audio backend (the default one) doesn't work on the SDL interface.
+  # Note that the two interfaces have two separate configuration files.
 
   meta = with lib; {
     homepage = "https://citra-emu.org";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The package was old and wasn't respecting some Nix formalities (like `wrapQtAppsHook`).

###### Things done
Tested the package on a Wayland session. Ran a game, it seems to run correctly, both audio backends work, but only in the Qt interface: if Citra is launched on the SDL interface then cubeb (the default audio backend) won't work.
Didn't test netplay.
Other than that I think the only thing missing is a Darwin port.

The audio error with the SDL interface and cubeb is:
`Audio.Sink <Critical> audio_core/cubeb_sink.cpp:CubebSink:31: cubeb_init failed`

(Note for those who want to test: the two interfaces have two separate configuration files)
``
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
