### PR TITLE
treewide: rename perlPackages.libintl_perl -> perlPackages.libintl-perl

### DIFF
--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   nativeBuildInputs = [
     autoreconfHook bison cdrkit cpio flex getopt gperf makeWrapper pkg-config qemu
-  ] ++ (with perlPackages; [ perl libintl_perl GetoptLong SysVirt ])
+  ] ++ (with perlPackages; [ perl libintl-perl GetoptLong SysVirt ])
     ++ (with ocamlPackages; [ ocaml findlib ]);
   buildInputs = [
     ncurses jansson

--- a/pkgs/servers/mail/sympa/default.nix
+++ b/pkgs/servers/mail/sympa/default.nix
@@ -24,7 +24,7 @@ let
     IO
     IOStringy
     LWP
-    libintl_perl
+    libintl-perl
 
     MHonArc
     MIMECharset

--- a/pkgs/servers/openxpki/default.nix
+++ b/pkgs/servers/openxpki/default.nix
@@ -15,7 +15,7 @@ perlPackages.buildPerlPackage {
   buildInputs = [ perl openssl gettext python3Packages.sphinx ];
   propagatedBuildInputs = with perlPackages;
     [ # dependencies from Makefile.PL
-      libintl_perl ConfigVersioned LWP ClassAccessorChained IOSocketSSL ClassStd
+      libintl-perl ConfigVersioned LWP ClassAccessorChained IOSocketSSL ClassStd
       CGISession ConfigStd ConfigMerge Connector CryptCBC CryptOpenSSLAES CryptPKCS10
       DBDMock DataPassword DataSerializer DateTimeFormatDateParse IOPrompt
       IPCShareLite JSON LogLog4perl LWPProtocolConnect LWPProtocolHttps MailRFC822Address

--- a/pkgs/tools/misc/fntsample/default.nix
+++ b/pkgs/tools/misc/fntsample/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
         ExporterTiny
         ListMoreUtils
         PDFAPI2
-        libintl_perl
+        libintl-perl
       ];
     in ''
     for cmd in pdfoutline pdf-extract-outline; do

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -852,7 +852,7 @@ let
       sha256 = "ee146cd75d6300837e6ca559bb0bde247d42123c96b2c5d4b2800f38d3e3d1ab";
     };
     buildInputs = [ CaptureTiny TestDeep TestDir TestException TestFile TestFileContents TestMockModule TestMockObject TestNoWarnings TestWarn ];
-    propagatedBuildInputs = [ Clone ConfigGitLike DBI DateTime EncodeLocale HashMerge IOPager IPCRun3 IPCSystemSimple ListMoreUtils PathClass PerlIOutf8_strict PodParser StringFormatter StringShellQuote TemplateTiny Throwable TypeTiny URIdb libintl_perl ];
+    propagatedBuildInputs = [ Clone ConfigGitLike DBI DateTime EncodeLocale HashMerge IOPager IPCRun3 IPCSystemSimple ListMoreUtils PathClass PerlIOutf8_strict PodParser StringFormatter StringShellQuote TemplateTiny Throwable TypeTiny URIdb libintl-perl ];
     doCheck = false;  # Can't find home directory.
     meta = {
       homepage = "https://sqitch.org/";
@@ -11760,7 +11760,7 @@ let
     };
   };
 
-  libintl_perl = buildPerlPackage {
+  libintl-perl = buildPerlPackage {
     pname = "libintl-perl";
     version = "1.32";
     src = fetchurl {
@@ -18612,7 +18612,7 @@ let
       url = "mirror://cpan/authors/id/K/KR/KRYDE/podlinkcheck-15.tar.gz";
       sha256 = "4e3bebec1bf82dbf850a94ae26a253644cf5806ec41afc74e43e1710a37321db";
     };
-    propagatedBuildInputs = [ FileFindIterator FileHomeDir IPCRun PodParser constant-defer libintl_perl ];
+    propagatedBuildInputs = [ FileFindIterator FileHomeDir IPCRun PodParser constant-defer libintl-perl ];
     meta = {
       homepage = "http://user42.tuxfamily.org/podlinkcheck/index.html";
       description = "Check POD L<> link references";
@@ -25222,7 +25222,8 @@ let
   EmailMIMEModifier = self.EmailMIME;
   ExtUtilsCommand = self.ExtUtilsMakeMaker;
   IOstringy = self.IOStringy;
-  libintlperl = self.libintl_perl;
+  libintl_perl = self.libintl-perl;
+  libintlperl = self.libintl-perl;
   LWPProtocolconnect = self.LWPProtocolConnect;
   LWPProtocolhttps = self.LWPProtocolHttps;
   LWPUserAgent = self.LWP;


### PR DESCRIPTION
The other package managers call this package libintl-perl, and it is also the
original name.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
