### PR TITLE
kotlin-native: init at 1.5.31

### DIFF
--- a/pkgs/development/compilers/kotlin/native.nix
+++ b/pkgs/development/compilers/kotlin/native.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchurl
+, jre
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kotlin-native";
+  version = "1.5.31";
+
+  src = let
+    getArch = {
+      "aarch64-darwin" = "macos-aarch64";
+      "x86_64-darwin" = "macos-x86_64";
+      "x86_64-linux" = "linux-x86_64";
+    }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
+
+    getUrl = version: arch:
+      "https://github.com/JetBrains/kotlin/releases/download/v${version}/kotlin-native-${arch}-${version}.tar.gz";
+
+    getHash = arch: {
+      "macos-aarch64" = "sha256-+9AF42AlPn1/8c14t8u+NN8FkoEmdt6tpmIKU9Rp2AM=";
+      "macos-x86_64" = "sha256-/eciSo4Eps2TTsv1XU1Rlm+KBmgQT0MWp2s/OAYtGt4=";
+      "linux-x86_64" = "sha256-Y2t+nlTu+j+h0oRneo7CJx0PmLAkqKYBJ+8go7rargM=";
+    }.${arch};
+  in
+    fetchurl {
+      url = getUrl version getArch;
+      hash = getHash getArch;
+    };
+
+  nativeBuildInputs = [
+    jre
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    mv * $out
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/run_konan --prefix PATH ":" ${lib.makeBinPath [ jre ]}
+  '';
+
+  meta = {
+    homepage = "https://kotlinlang.org/";
+    description = "A modern programming language that makes developers happier";
+    longDescription = ''
+      Kotlin/Native is a technology for compiling Kotlin code to native
+      binaries, which can run without a virtual machine. It is an LLVM based
+      backend for the Kotlin compiler and native implementation of the Kotlin
+      standard library.
+    '';
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+    platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12273,6 +12273,7 @@ with pkgs;
   koka = haskell.lib.justStaticExecutables (haskellPackages.callPackage ../development/compilers/koka { });
 
   kotlin = callPackage ../development/compilers/kotlin { };
+  kotlin-native = callPackage ../development/compilers/kotlin/native.nix { };
 
   lazarus = callPackage ../development/compilers/fpc/lazarus.nix {
     fpc = fpc;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Reopen-redo #138343

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
