### PR TITLE
Update manuskript to 0.12, add desktop file

### DIFF
--- a/pkgs/applications/editors/manuskript/default.nix
+++ b/pkgs/applications/editors/manuskript/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "manuskript";
-  version = "0.11.0";
+  version = "0.12.0";
 
   format = "other";
 
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication rec {
     repo = pname;
     owner = "olivierkes";
     rev = version;
-    sha256 = "1l6l9k6k69yv8xqpll0zv9cwdqqg4zvxy90l6sx5nv2yywh5crla";
+    sha256 = "0gfwwnpjslb0g8y3v9ha4sd8in6bpy6bhi4rn4hmfd2vmq2flpbd";
   };
 
   nativeBuildInputs = [ wrapQtAppsHook ];

--- a/pkgs/applications/editors/manuskript/default.nix
+++ b/pkgs/applications/editors/manuskript/default.nix
@@ -1,4 +1,4 @@
-{ lib, zlib, fetchFromGitHub, python3Packages, wrapQtAppsHook }:
+{ lib, zlib, fetchFromGitHub, python3Packages, wrapQtAppsHook, makeDesktopItem }:
 
 python3Packages.buildPythonApplication rec {
   pname = "manuskript";
@@ -28,11 +28,22 @@ python3Packages.buildPythonApplication rec {
 
   buildPhase = "";
 
-  installPhase = ''
-    mkdir -p $out/share/${pname}
-    cp -av  bin/ i18n/ libs/ manuskript/ resources/ icons/ $out
-    cp -r sample-projects/ $out/share/${pname}
-  '';
+  installPhase = (
+    let
+      desktopItem = makeDesktopItem {
+        name = "Manuskript";
+        exec = "manuskript";
+        desktopName = "Manuskript";
+        genericName = "Manuskript";
+        categories = "Office;";
+      };
+    in
+      ''
+        mkdir -p $out/share/${pname}
+        cp -av  bin/ i18n/ libs/ manuskript/ resources/ icons/ $out
+        cp -a ${desktopItem}/share/applications $out/share
+        cp -r sample-projects/ $out/share/${pname}
+      '');
 
   postFixup = ''
     wrapQtApp $out/bin/manuskript


### PR DESCRIPTION
###### Motivation for this change

- Update to latest version
- Add desktop file for Linux desktops
- 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
