### PR TITLE
soupault: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/tools/typesetting/soupault/default.nix
+++ b/pkgs/tools/typesetting/soupault/default.nix
@@ -2,7 +2,7 @@
 
 ocamlPackages.buildDunePackage rec {
   pname = "soupault";
-  version = "3.1.0";
+  version = "3.2.0";
 
   useDune2 = true;
 
@@ -10,7 +10,7 @@ ocamlPackages.buildDunePackage rec {
     owner = "dmbaturin";
     repo = pname;
     rev = version;
-    sha256 = "sha256-SVNC2DbdciunSKTCmmX0SqaEXMe1DkVX4VJTqriI8Y4=";
+    sha256 = "sha256-T1K/ntCK19LfPmMtaAa9c1JjSL+5dax2SNhM4yUFln4=";
   };
 
   buildInputs = with ocamlPackages; [
@@ -23,6 +23,7 @@ ocamlPackages.buildDunePackage rec {
     lambdasoup
     lua-ml
     logs
+    markup
     odate
     otoml
     re


### PR DESCRIPTION
###### Motivation for this change

https://github.com/dmbaturin/soupault/releases/tag/3.2.0

~~Currently this appears to be blocked by [lambdasoup](https://github.com/NixOS/nixpkgs/blob/a0dbe47318bbab7559ffbfa7c4872a517833409f/pkgs/development/ocaml-modules/lambdasoup/default.nix) upgrading to `0.7.3` ([this](https://github.com/dmbaturin/soupault/commit/9a60b5aa22b562f721ba151dbcff918eb383bb7b#diff-efdd5172f3ea4161150198b9ae6eeb6034285f937a4b8e6a02c46ca8adbc7869) commit) though. @vbgl what does upgrading that library entail? I can only assume this could possibly break things downstream and I'm not well-versed in the OCaml community.~~

Depends on: #142720

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
