### PR TITLE
fclones: 0.16.1 -> 0.17.0

### DIFF
--- a/pkgs/tools/misc/fclones/default.nix
+++ b/pkgs/tools/misc/fclones/default.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "fclones";
-  version = "0.16.1";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "pkolaczk";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-7rwiqjjXB1+R+/kauGjiJOX/UtMmQW3U3xGL/rsSiQ0=";
+    sha256 = "sha256-JygW1Ri9BA4Qssu6MlQCCjnAok9OD2pcGdavOyHxbIo=";
   };
 
-  cargoSha256 = "sha256-g4z+05jiVaH3KCPVwJmvQbi0OCYtuafyZyVZDRRyPRA=";
+  cargoSha256 = "sha256-sDHsj0qxKW5JJCI9H0WytgugtEmLaLU2EIgCcXdfQH0=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     AppKit


### PR DESCRIPTION
###### Motivation for this change

Upgrades fclones to the v0.17.0 release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
