### PR TITLE
ocamlPackages.lambdasoup: 0.7.2 → 0.7.3

### DIFF
--- a/pkgs/development/ocaml-modules/lambdasoup/default.nix
+++ b/pkgs/development/ocaml-modules/lambdasoup/default.nix
@@ -2,9 +2,9 @@
 
 buildDunePackage rec {
   pname = "lambdasoup";
-  version = "0.7.2";
+  version = "0.7.3";
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
   useDune2 = true;
 
@@ -12,7 +12,7 @@ buildDunePackage rec {
     owner = "aantron";
     repo = pname;
     rev = version;
-    sha256 = "0php51lyz3ll0psazjd59yw02xb9w84150gkyiwmn3fa0iq8nf7m";
+    sha256 = "sha256:1wclkn1pl0d150dw0xswb29jc7y1q9mhipff1pnsc1hli3pyvvb7";
   };
 
   propagatedBuildInputs = [ markup ];


### PR DESCRIPTION
###### Motivation for this change

#142711
cc @toastal 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
