### PR TITLE
[21.05] nixos/bookstack: fix error message output

### DIFF
--- a/nixos/modules/services/web-apps/bookstack.nix
+++ b/nixos/modules/services/web-apps/bookstack.nix
@@ -219,7 +219,7 @@ in {
 
     assertions = [
       { assertion = db.createLocally -> db.user == user;
-        message = "services.bookstack.database.user must be set to ${user} if services.mediawiki.database.createLocally is set true.";
+        message = "services.bookstack.database.user must be set to ${user} if services.bookstack.database.createLocally is set true.";
       }
       { assertion = db.createLocally -> db.passwordFile == null;
         message = "services.bookstack.database.passwordFile cannot be specified if services.bookstack.database.createLocally is set to true.";


### PR DESCRIPTION
###### Motivation for this change

There was a wrong massage output for errors on setup "mediawiki" instead of "bookstack" thats a bit confusing.

###### Things done

I only change the output massage and nothing else so the package will work like before! No new tests are needed.
