### PR TITLE
ocaml: enable parallel building

### DIFF
--- a/pkgs/development/compilers/ocaml/Makefile.nixpkgs
+++ b/pkgs/development/compilers/ocaml/Makefile.nixpkgs
@@ -1,0 +1,16 @@
+# ocaml build system does not allow for parallel building of some
+# top-level targets like 'world', 'bootstrap', 'world.opt' as
+# then spawn '$(MAKE) all' subprocesses that conflict among each
+# other. But we would still like to run each target in parallel
+# individually. This file defines such entry points.
+
+# Re-export all existing phases to make 'make install' work as is.
+include Makefile
+
+nixpkgs_world:
+	$(MAKE) world
+
+nixpkgs_world_bootstrap_world_opt:
+	$(MAKE) world
+	$(MAKE) bootstrap
+	$(MAKE) world.opt


### PR DESCRIPTION
Enable parallel building for ocaml-4.06 and above. tested as:

    $ nix build -f. ocaml-ng.ocamlPackages_{4_{00_1,01_0,02,03,04,05,06,07,08,09,10,11,12,13},latest}.ocaml --keep-going --rebuild

ocaml build system supports parallel building, but but for multiple
top-level targets at the same time as it usually spawns subprocess
$(MAKE) that occasionally conflict with one another. To work it around
we use tiny Makefile with a single rule that calls top-level targets
sequentially as makefile calls:

    nixpkgs_world_bootstrap_world_opt:
       $(MAKE) world
       $(MAKE) bootstrap
       $(MAKE) world.opt

On a 16-core machine ocaml-4.12 build speeds up from 6m55s to 1m35s.

Releases 4_00_1, 4_01_0, 4_04 and 4_05 still have some race in them.
Thus this change enables parallel builds only for ocaml-4.06 and above.