### PR TITLE
python3Packages.python_magic: pull upstream fix for file-5.41

### DIFF
--- a/pkgs/development/python-modules/python-magic/default.nix
+++ b/pkgs/development/python-modules/python-magic/default.nix
@@ -3,6 +3,7 @@
 , python
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , substituteAll
 , file
 , glibcLocales
@@ -20,6 +21,13 @@ buildPythonPackage rec {
   };
 
   patches = [
+    # pull upstream patch to support file-5.41
+    (fetchpatch {
+      name = "file-5.41-compat.patch";
+      url = "https://github.com/ahupp/python-magic/commit/0ae7e7ceac0e80e03adc75c858bb378c0427331a.patch";
+      sha256 = "0vclaamb56nza1mcy88wjbkh81hnish2gzvl8visa2cknhgdmk50";
+    })
+
     (substituteAll {
       src = ./libmagic-path.patch;
       libmagic = "${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}";


### PR DESCRIPTION
Fixes build failure of form:

    $ nix build -f. python3Packages.python_magic
    ...
    python3.9-python-magic> FAIL: test_mime_types (__main__.MagicTest)
    ...
    python3.9-python-magic> AssertionError: 'application/x-bytecode.python' not found in ('application/octet-stream', 'text/x-bytecode.python')