### PR TITLE
Shells autoenable

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2111.section.xml
@@ -520,6 +520,14 @@ Superuser created successfully.
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="options.html#opt-users.users._name_.shell">users.users.&lt;name&gt;.shell</link>
+          now implies the corresponding enable option of the shell, if
+          one exists. If this is undesired, you can override it by
+          manually setting the option to false.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>services.geoip-updater</literal> was broken and has
           been replaced by
           <link xlink:href="options.html#opt-services.geoipupdate.enable">services.geoipupdate</link>.

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -193,6 +193,7 @@ In addition to numerous new and upgraded packages, this release has the followin
     users.groups.foo = {};
   }
   ```
+- [users.users.&lt;name&gt;.shell](options.html#opt-users.users._name_.shell) now implies the corresponding enable option of the shell, if one exists. If this is undesired, you can override it by manually setting the option to false.
 
 - `services.geoip-updater` was broken and has been replaced by [services.geoipupdate](options.html#opt-services.geoipupdate.enable).
 

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -54,6 +54,11 @@ rec {
     else
       shell;
 
+  # Check if the shellName appears as pname of a shell set in users.users of the given config
+  usedAsShell = shellName: config:
+    any (s: shellName == (s.pname or null))
+      (mapAttrsToList (_: getAttr "shell") config.users.users);
+
   /* Recurse into a list or an attrset, searching for attrs named like
      the value of the "attr" parameter, and return an attrset where the
      names are the corresponding jq path where the attrs were found and

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -169,10 +169,8 @@ let
         example = literalExpression "pkgs.bashInteractive";
         description = ''
           The path to the user's shell. Can use shell derivations,
-          like <literal>pkgs.bashInteractive</literal>. Don’t
-          forget to enable your shell in
-          <literal>programs</literal> if necessary,
-          like <code>programs.zsh.enable = true;</code>.
+          like <literal>pkgs.bashInteractive</literal>. Will automatically
+          enable your shell in <literal>programs</literal> if necessary.
         '';
       };
 

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, utils, ... }:
 
 with lib;
 
@@ -48,7 +48,7 @@ in
     programs.fish = {
 
       enable = mkOption {
-        default = false;
+        default = utils.usedAsShell "fish" config;
         description = ''
           Whether to configure fish as an interactive shell.
         '';

--- a/nixos/modules/programs/xonsh.nix
+++ b/nixos/modules/programs/xonsh.nix
@@ -1,6 +1,6 @@
 # This module defines global configuration for the xonsh.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, utils, ... }:
 
 with lib;
 
@@ -17,7 +17,7 @@ in
     programs.xonsh = {
 
       enable = mkOption {
-        default = false;
+        default = utils.usedAsShell "xonsh" config;
         description = ''
           Whether to configure xonsh as an interactive shell.
         '';

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -1,6 +1,6 @@
 # This module defines global configuration for the zshell.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, utils, ... }:
 
 with lib;
 
@@ -42,7 +42,7 @@ in
     programs.zsh = {
 
       enable = mkOption {
-        default = false;
+        default = utils.usedAsShell "zsh" config;
         description = ''
           Whether to configure zsh as an interactive shell. To enable zsh for
           a particular user, use the <option>users.users.&lt;name?&gt;.shell</option>


### PR DESCRIPTION
###### Motivation for this change
fix #127924 and generally improve user experience in this regard 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
