### PR TITLE
duckstation: 2021-10-01 -> 2021-10-19

### DIFF
--- a/pkgs/misc/emulators/duckstation/default.nix
+++ b/pkgs/misc/emulators/duckstation/default.nix
@@ -12,19 +12,21 @@
 , gtk3
 , libevdev
 , curl
-, libpulseaudio
+, libpulseaudio ? null
 , sndio
 , mesa
+, vulkan-loader ? null
+, wayland
 }:
 mkDerivation rec {
   pname = "duckstation";
-  version = "unstable-2021-10-01";
+  version = "unstable-2021-10-19";
 
   src = fetchFromGitHub {
     owner = "stenzek";
     repo = pname;
-    rev = "a7096f033ecca48827fa55825fc0d0221265f1c2";
-    sha256 = "sha256-e/Y1TJBuY76q3/0MCAqu9AJzLxIoJ8FJUV5vc/AgcjA=";
+    rev = "96f4fdf8d88ff3a120f3bc409a6a6487cdcbd55f";
+    sha256 = "sha256-WWsi7kmFEYES2BoNKIFF1+lKHJGP3hbTZ9o3eWp+EcE=";
   };
 
   nativeBuildInputs = [ cmake ninja pkg-config extra-cmake-modules wrapQtAppsHook qttools ];
@@ -38,11 +40,13 @@ mkDerivation rec {
     mesa
     curl
     libpulseaudio
+    wayland
+    vulkan-loader
   ];
 
   cmakeFlags = [
-    "-DUSE_DRMKMS=ON"
-    "-DUSE_EGL=ON"
+    #"-DUSE_DRMKMS=ON" # Broken in combination with Wayland, https://github.com/stenzek/duckstation/issues/2630
+    "-DUSE_WAYLAND=ON"
   ];
 
   postPatch = ''
@@ -76,9 +80,13 @@ mkDerivation rec {
     runHook postCheck
   '';
 
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib"
+  ];
+
   # TODO:
-  # - vulkan graphics backend (OpenGL works).
-  # - default sound backend (cubeb) does not work, but SDL does.
+  # - default sound backend (cubeb) does not work, but SDL does. Strangely, switching to cubeb while a game is running makes it work.
+
   meta = with lib; {
     description = "PlayStation 1 emulator focusing on playability, speed and long-term maintainability";
     homepage = "https://github.com/stenzek/duckstation";

--- a/pkgs/misc/emulators/duckstation/default.nix
+++ b/pkgs/misc/emulators/duckstation/default.nix
@@ -12,10 +12,10 @@
 , gtk3
 , libevdev
 , curl
-, libpulseaudio ? null
+, libpulseaudio
 , sndio
 , mesa
-, vulkan-loader ? null
+, vulkan-loader
 , wayland
 }:
 mkDerivation rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Updating the package is more of an excuse for the following improvements:
- Vulkan now works;
- Games can be launched in the Qt interface on a Wayland session;

However the latter, due to a bug on Duckstation side, required me to disable DRMKMS from Cmake's flags (I didn't remove the `mesa` dependency though). Whether to accept the regression or to wait for them to fix the issue is your choice. https://github.com/stenzek/duckstation/issues/2630

###### Things done
I also found out that the cubeb audio backend, previously thought broken, actually does work... if you switch to it while a game is running. Considering that there are weird problems with cubeb on Citra too (#142700), maybe it's an issue with `libpulseaudio`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
