### PR TITLE
unison-ucm: M2g -> M2j

### DIFF
--- a/pkgs/development/compilers/unison/default.nix
+++ b/pkgs/development/compilers/unison/default.nix
@@ -32,7 +32,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     mv ucm $out/bin
     mv ui $out/ui
-    wrapProgram $out/bin/ucm --prefix PATH ":" "${lib.makeBinPath [ less ]}" --set UCM_WEB_UI "$out/ui";
+    wrapProgram $out/bin/ucm \
+    	 --prefix PATH ":" "${lib.makeBinPath [ less ]}" \
+    	 --set UCM_WEB_UI "$out/ui"
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/unison/default.nix
+++ b/pkgs/development/compilers/unison/default.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation rec {
     mv ucm $out/bin
     mv ui $out/ui
     wrapProgram $out/bin/ucm \
-    	 --prefix PATH ":" "${lib.makeBinPath [ less ]}" \
-    	 --set UCM_WEB_UI "$out/ui"
+      --prefix PATH ":" "${lib.makeBinPath [ less ]}" \
+      --set UCM_WEB_UI "$out/ui"
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/unison/default.nix
+++ b/pkgs/development/compilers/unison/default.nix
@@ -6,18 +6,18 @@
 
 stdenv.mkDerivation rec {
   pname = "unison-code-manager";
-  milestone_id = "M2g";
+  milestone_id = "M2j";
   version = "1.0.${milestone_id}-alpha";
 
   src = if (stdenv.isDarwin) then
     fetchurl {
       url = "https://github.com/unisonweb/unison/releases/download/release/${milestone_id}/ucm-macos.tar.gz";
-      sha256 = "1ib9pdzrfpzbi35fpwm9ym621nlydplvzgbhnyd86dbwbv3i9sga";
+      sha256 = "0lrj37mfqzwg9n757ymjb440jx51kj1s8g6qv9vis9pxckmy0m08";
     }
   else
     fetchurl {
       url = "https://github.com/unisonweb/unison/releases/download/release/${milestone_id}/ucm-linux.tar.gz";
-      sha256 = "004jx7q657mkcrvilk4lfkp8xcpl2bjflpn9m2p7jzlrlk97v9nj";
+      sha256 = "0qvin1rlkjwijchsijq3vbnn4injawchh2w97kyq7i3idh8ccl59";
     };
 
   # The tarball is just the prebuilt binary, in the archive root.
@@ -31,7 +31,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     mv ucm $out/bin
-    wrapProgram $out/bin/ucm --prefix PATH ":" "${lib.makeBinPath [ less ]}";
+    mv ui $out/ui
+    wrapProgram $out/bin/ucm --prefix PATH ":" "${lib.makeBinPath [ less ]}" --set UCM_WEB_UI "$out/ui";
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Version update and small changes to make included documentation explorer work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
