### PR TITLE
yabridge: 3.5.2 -> 3.6.0 and fix for wine 6.20

### DIFF
--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -1,6 +1,7 @@
 { lib
 , multiStdenv
 , fetchFromGitHub
+, fetchpatch
 , substituteAll
 , meson
 , ninja
@@ -85,6 +86,12 @@ in multiStdenv.mkDerivation rec {
       src = ./hardcode-wine.patch;
       inherit wine;
     })
+    # Remove with next yabridge update
+    (fetchpatch {
+      name = "fix-for-wine-6.20.patch";
+      url = "https://github.com/robbert-vdh/yabridge/commit/5be149cb525a638f7fc3adf84918c8239ee50ecf.patch";
+      sha256 = "sha256-x/gfn4mKZIGQ4M0o/0LlZF8i8wZDx/bkwf8wp0BGDBo=";
+    })
   ];
 
   postPatch = ''
@@ -121,8 +128,8 @@ in multiStdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    sed -i "214s|xcb.*|xcb_32bit_dep = winegcc.find_library('xcb', dirs: [ '${lib.getLib pkgsi686Linux.xorg.libxcb}/lib', ])|" meson.build
-    sed -i "192 i '${lib.getLib pkgsi686Linux.boost}/lib'," meson.build
+    sed -i "221s|xcb.*|xcb_32bit_dep = winegcc.find_library('xcb', dirs: [ '${lib.getLib pkgsi686Linux.xorg.libxcb}/lib', ])|" meson.build
+    sed -i "199 i '${lib.getLib pkgsi686Linux.boost}/lib'," meson.build
   '';
 
   installPhase = ''

--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -47,25 +47,25 @@ let
 
   # Derived from vst3.wrap
   vst3 = rec {
-    version = "3.7.2_build_28-patched";
+    version = "3.7.3_build_20-patched";
     src = fetchFromGitHub {
       owner = "robbert-vdh";
       repo = "vst3sdk";
       rev = "v${version}";
       fetchSubmodules = true;
-      sha256 = "sha256-39pvfcg4fvf7DAbAPzEHA1ja1LFL6r88nEwNYwaDC8w=";
+      sha256 = "sha256-m2y7No7BNbIjLNgdAqIAEr6UuAZZ/wwM2+iPWKK17gQ=";
     };
   };
 in multiStdenv.mkDerivation rec {
   pname = "yabridge";
-  version = "3.5.2";
+  version = "3.6.0";
 
   # NOTE: Also update yabridgectl's cargoHash when this is updated
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = pname;
     rev = version;
-    hash = "sha256-SLiksc8lQo2A5sefKbcaJyhi8vPdp2p2Jbc7bvM0sDw=";
+    hash = "sha256-lgSkZ0i2DojP6HXJP3cC5FUtfv7R/nsSiHT60bPSyLc=";
   };
 
   # Unpack subproject sources

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   src = yabridge.src;
   sourceRoot = "source/tools/yabridgectl";
-  cargoHash = "sha256-2x3qB0LbCBUZ4zqKIXPtYdWis+4QANTaJdFvoFbccGE=";
+  cargoHash = "sha256-20sh9yovZHqoUk+3aVs/D8SWY29FdPjX+NeJt35KfWM=";
 
   patches = [
     # By default, yabridgectl locates libyabridge.so by using


### PR DESCRIPTION
###### Motivation for this change

The recent wine update to 6.20 #142694 broke this package. Upstream has a patch already, so this PR includes both a version bump and the necessary patch. Line numbers in `meson.build` are changed by that patch, so the `sed` insertions also need to move down.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
