### PR TITLE
android-tools: 31.0.2 -> 31.0.3

### DIFF
--- a/pkgs/tools/misc/android-tools/default.nix
+++ b/pkgs/tools/misc/android-tools/default.nix
@@ -9,11 +9,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "android-tools";
-  version = "31.0.2";
+  version = "31.0.3";
 
   src = fetchurl {
     url = "https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz";
-    sha256 = "sha256-YbO/bCQMsLTQzP72lsVZhuBmV4Q2J9+VD9z2iBrw+NQ=";
+    sha256 = "0adhws565ny90vzh5jpkbcai8sfs3b9acs0bgl6bm9z1nr2xklnp";
   };
 
   patches = [
@@ -27,10 +27,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch = ''
-    sed -i -E "0,/import api_pb2/ s//from google.protobuf import api_pb2/" vendor/avb/aftltool.py
-  '';
-
   nativeBuildInputs = [ cmake perl go ];
   buildInputs = [ protobuf zlib gtest brotli lz4 zstd libusb1 pcre2 fmt_7 ];
   propagatedBuildInputs = [ pythonEnv ];
@@ -43,7 +39,6 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    install -Dm755 ../vendor/avb/aftltool.py -t $out/bin
     install -Dm755 ../vendor/avb/avbtool.py -t $out/bin
     install -Dm755 ../vendor/mkbootimg/mkbootimg.py $out/bin/mkbootimg
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

@musfay: It looks like upstream dropped `aftltool.py` but I didn't have a closer look. Feel free to investigate if you still need that tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
