### PR TITLE
zfp: init at 0.5.5

### DIFF
--- a/pkgs/tools/compression/zfp/default.nix
+++ b/pkgs/tools/compression/zfp/default.nix
@@ -1,0 +1,59 @@
+{ cmake, cudatoolkit, fetchFromGitHub, gfortran, lib, llvmPackages, pythonPackages, stdenv, targetPlatform
+, enableCfp ? true
+, enableCuda ? false
+, enableExamples ? true
+, enableFortran ? builtins.elem targetPlatform.system gfortran.meta.platforms
+, enableOpenMP ? true
+, enablePython ? true
+, enableUtilities ? true }:
+
+stdenv.mkDerivation rec {
+  pname = "zfp";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "LLNL";
+    repo = "zfp";
+    rev = version;
+    sha256 = "19ycflz35qsrzfcvxdyy0mgbykfghfi9y5v684jb4awjp7nf562c";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = lib.optional enableCuda cudatoolkit
+    ++ lib.optional enableFortran gfortran
+    ++ lib.optional enableOpenMP llvmPackages.openmp
+    ++ lib.optionals enablePython [ pythonPackages.cython pythonPackages.numpy pythonPackages.python ];
+
+  cmakeFlags = [
+    # More tests not enabled by default
+    ''-DZFP_BINARY_DIR=${placeholder "out"}''
+    ''-DZFP_BUILD_TESTING_LARGE=ON''
+  ]
+    ++ lib.optionals targetPlatform.isDarwin [
+      "-DCMAKE_INSTALL_BINDIR=bin"
+      "-DCMAKE_INSTALL_LIBDIR=lib"
+    ]
+    ++ lib.optional enableCfp "-DBUILD_CFP=ON"
+    ++ lib.optional enableCuda "-DZFP_WITH_CUDA=ON"
+    ++ lib.optional enableExamples "-DBUILD_EXAMPLES=ON"
+    ++ lib.optional enableFortran "-DBUILD_ZFORP=ON"
+    ++ lib.optional enableOpenMP "-DZFP_WITH_OPENMP=ON"
+    ++ lib.optional enablePython "-DBUILD_ZFPY=ON"
+    ++ ([ "-DBUILD_UTILITIES=${if enableUtilities then "ON" else "OFF"}" ]);
+
+  preCheck = lib.optional targetPlatform.isDarwin ''
+    export DYLD_LIBRARY_PATH="$out/lib:$DYLD_LIBRARY_PATH"
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://computing.llnl.gov/projects/zfp";
+    description = "Library for random-access compression of floating-point arrays";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.spease ];
+    # 64-bit only
+    platforms = platforms.aarch64 ++ platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11072,6 +11072,8 @@ with pkgs;
 
   zerofree = callPackage ../tools/filesystems/zerofree { };
 
+  zfp = callPackage ../tools/compression/zfp {};
+
   zfs-autobackup = callPackage ../tools/backup/zfs-autobackup { };
 
   zfsbackup = callPackage ../tools/backup/zfsbackup { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
