### PR TITLE
stig: 0.11.2a0 -> 0.12.2a0

### DIFF
--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -7,24 +7,14 @@ python3Packages.buildPythonApplication rec {
   pname = "stig";
   # This project has a different concept for pre release / alpha,
   # Read the project's README for details: https://github.com/rndusr/stig#stig
-  version = "0.11.2a0";
+  version = "0.12.2a0";
 
   src = fetchFromGitHub {
     owner = "rndusr";
     repo = "stig";
     rev = "v${version}";
-    sha256 = "05dn6mr86ly65gdqarl16a2jk1bwiw5xa6r4kyag3s6lqsv66iw8";
+    sha256 = "0sk4vgj3cn75nyrng2d6q0pj1h968kcmbpr9sv1lj1g8fc7g0n4f";
   };
-
-  # urwidtrees 1.0.3 is requested by the developer because 1.0.2 (which is packaged
-  # in nixpkgs) is not uploaded to pypi and 1.0.1 has a problematic `setup.py`.
-  # As long as we don't have any problems installing it, no special features / specific bugs
-  # were fixed in 1.0.3 that aren't available in 1.0.2 are used by stig.
-  # See https://github.com/rndusr/stig/issues/120
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "urwidtrees>=1.0.3dev0" "urwidtrees"
-  '';
 
   propagatedBuildInputs = with python3Packages; [
     urwid
@@ -62,7 +52,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "TUI and CLI for the BitTorrent client Transmission";
     homepage = "https://github.com/rndusr/stig";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ doronbehar ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
