### PR TITLE
m17n_lib: explicitly disable parallel building

### DIFF
--- a/pkgs/tools/inputmethods/m17n-lib/default.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ m17n_db ];
 
+  # Fails parallel build due to missing intra-package depends:
+  #   https://savannah.nongnu.org/bugs/index.php?61377
+  #     make[2]: *** No rule to make target '../src/libm17n-core.la', needed by 'libm17n.la'.  Stop.
+  enableParallelBuilding = false;
+
   meta = {
     homepage = "https://www.nongnu.org/m17n/";
     description = "Multilingual text processing library (runtime)";


### PR DESCRIPTION
Parallel build fails due to incomplete dependencies between libraries
within package. Let's fix it upstream first and meanwhile disable
parallel builds.