### PR TITLE
NixOS: Document impurity issues with boot.binfmt.emulatedSystems

### DIFF
--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -249,7 +249,6 @@ in {
           List of systems to emulate. Will also configure Nix to
           support your new systems.
           Warning: the builder can execute all emulated systems within the same build, which introduces impurities in the case of cross compilation.
-          In case of cross compilation this introduces impurity.
         '';
         type = types.listOf types.str;
       };

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -249,7 +249,7 @@ in {
           List of systems to emulate. Will also configure Nix to
           support your new systems.
           Be careful nix build can execute all emulated systems at the same time.
-          In case of cross compilation this can introduces impurity issues.
+          In case of cross compilation this introduces impurity.
         '';
         type = types.listOf types.str;
       };

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -248,7 +248,7 @@ in {
         description = ''
           List of systems to emulate. Will also configure Nix to
           support your new systems.
-          Be careful nix build can execute all emulated systems at the same time.
+          Be careful as a build can execute all emulated systems at the same time.
           In case of cross compilation this introduces impurity.
         '';
         type = types.listOf types.str;

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -248,7 +248,7 @@ in {
         description = ''
           List of systems to emulate. Will also configure Nix to
           support your new systems.
-          Be careful as a build can execute all emulated systems at the same time.
+          Warning: the builder can execute all emulated systems within the same build, which introduces impurities in the case of cross compilation.
           In case of cross compilation this introduces impurity.
         '';
         type = types.listOf types.str;

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -248,8 +248,8 @@ in {
         description = ''
           List of systems to emulate. Will also configure Nix to
           support your new systems.
-          But be careful, Nix build can execute all emulated systems.
-          In case of cross compilation this option introduces impurity issues.
+          Be careful nix build can execute all emulated systems at the same time.
+          In case of cross compilation this can introduces impurity issues.
         '';
         type = types.listOf types.str;
       };

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -248,6 +248,8 @@ in {
         description = ''
           List of systems to emulate. Will also configure Nix to
           support your new systems.
+          But be careful, Nix build can execute all emulated systems.
+          In case of cross compilation this option introduces impurity issues.
         '';
         type = types.listOf types.str;
       };


### PR DESCRIPTION
###### Motivation for this change
For cross compiled packages, we have to take care boot.binfmt.emulatedSystems is not set. This PR adds more some note to the NixOS option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
