### PR TITLE
xalanc: explicitly disable parallel building

### DIFF
--- a/pkgs/development/libraries/xalanc/default.nix
+++ b/pkgs/development/libraries/xalanc/default.nix
@@ -22,6 +22,15 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ xercesc getopt ];
 
+  # Parallel build fails as:
+  #   c++ ... -c ... ExecutionContext.cpp
+  #   ProblemListenerBase.hpp:28:10: fatal error: LocalMsgIndex.hpp: No such file or directory
+  # The build failure happens due to missing intra-project dependencies
+  # against generated headers. Future 1.12 version dropped
+  # autotools-based build system. Let's disable parallel builds until
+  # next release.
+  enableParallelBuilding = false;
+
   meta = {
     homepage = "http://xalan.apache.org/";
     description = "A XSLT processor for transforming XML documents";


### PR DESCRIPTION
Parallel build fails due to incomplete dependencies between libraries
and headers within package. Let's disable parallel builds and try it on
in next release (it switched to cmake from autotools).