### PR TITLE
sqlitebrowser: enable support for encrypted databases

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchFromGitHub, cmake
-, qtbase, qttools, sqlite, wrapGAppsHook }:
+, qtbase, qttools, sqlcipher, wrapGAppsHook }:
 
 mkDerivation rec {
   pname = "sqlitebrowser";
@@ -16,9 +16,13 @@ mkDerivation rec {
   # but qscintilla is currently in a bit of a mess as some consumers expect a
   # -qt4 or -qt5 prefix while others do not.
   # We *really* should get that cleaned up.
-  buildInputs = [ qtbase sqlite ];
+  buildInputs = [ qtbase sqlcipher ];
 
   nativeBuildInputs = [ cmake qttools wrapGAppsHook ];
+
+  cmakeFlags = [
+    "-Dsqlcipher=1"
+  ];
 
   meta = with lib; {
     description = "DB Browser for SQLite";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
