### PR TITLE
pythia: 8.305 -> 8.306

### DIFF
--- a/pkgs/development/libraries/physics/pythia/default.nix
+++ b/pkgs/development/libraries/physics/pythia/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pythia";
-  version = "8.305";
+  version = "8.306";
 
   src = fetchurl {
-    url = "http://home.thep.lu.se/~torbjorn/pythia8/pythia${builtins.replaceStrings ["."] [""] version}.tgz";
-    sha256 = "03rpy2bmx67217fh1spfn36x9xrk0igcj56byki77lgj0y5mz21a";
+    url = "https://pythia.org/download/pythia83/pythia${builtins.replaceStrings ["."] [""] version}.tgz";
+    sha256 = "sha256-c0gDtyKxwbU8jPLw08MHR8gPwt3l4LoUG8k5fa03qPY=";
   };
 
   nativeBuildInputs = [ rsync ];
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A program for the generation of high-energy physics events";
     license = licenses.gpl2Only;
-    homepage = "http://home.thep.lu.se/~torbjorn/Pythia.html";
+    homepage = "https://pythia.org";
     platforms = platforms.unix;
     maintainers = with maintainers; [ veprbl ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Fixed the incorrect scale being set when applying the POWHEG veto, i.e. main31.cc. Note that the number of emissions is correct in 8.303, but is incorrect in 8.304 and 8.305. Thanks to Mikhail Kirsanov.
* Fixed repeated initialization causing an ever expanding physics pointer list in the main Pythia class.
* Fixed issue for HepMC output from Vincia, which would previously issue warnings about inconsistent mother/daughter relationships, caused by Vincia's antenna-style bookkeeping by which emitted partons have two mothers instead of one. For status codes 43, 51, and 53, the HepMC interface now ignores the second parent, always using just the first one to define the vertex structure. Minor modifications to Vincia's QCD shower to ensure that the first mother is the one that changed colour and hence would be identified with the "radiator" in a collinear context. Analogous modifications in the QED module so the most collinear parent is the first mother.
* Removed assert statements from Angantyr.
* Shortened Pythia constructor header.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
