### PR TITLE
mtrace: init at 2.33-50

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -198,7 +198,7 @@ stdenv.mkDerivation ({
   BASH_SHELL = "/bin/sh";
 
   # Used by libgcc, elf-header, and others to determine ABI
-  passthru = { inherit version; };
+  passthru = { inherit version; minorRelease = version; };
 }
 
 // (removeAttrs args [ "withLinuxHeaders" "withGd" ]) //

--- a/pkgs/development/libraries/glibc/mtrace.nix
+++ b/pkgs/development/libraries/glibc/mtrace.nix
@@ -1,0 +1,38 @@
+{ glibc, perl }:
+
+# Small wrapper which only exposes `mtrace(3)` from `glibc`. This can't be placed
+# into `glibc` itself because it depends on Perl which would mean that the final
+# `glibc` inside a stdenv bootstrap has a dependency `glibc -> perl -> bootstrap tools`,
+# so this is now in its own package that isn't used for bootstrapping.
+#
+# `glibc` needs to be overridden here because it's still needed to `./configure` the source in order
+# to have a build environment where we can call the needed make target.
+
+glibc.overrideAttrs ({ meta ? {}, ... }: {
+  pname = "glibc-mtrace";
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir malloc
+    make -C ../glibc-${glibc.minorRelease}/malloc objdir=`pwd` `pwd`/malloc/mtrace;
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv malloc/mtrace $out/bin/
+  '';
+
+  # Perl interpreter used for `mtrace`.
+  buildInputs = [ perl ];
+
+  # Reset a few things declared by `pkgs.glibc`.
+  outputs = [ "out" ];
+  separateDebugInfo = false;
+
+  meta = meta // {
+    description = "Perl script used to interpret and provide human readable output of the trace log contained in the file mtracedata, whose contents were produced by mtrace(3).";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16248,6 +16248,8 @@ with pkgs;
     stdenv = gccStdenv; # doesn't compile without gcc
   };
 
+  mtrace = callPackage ../development/libraries/glibc/mtrace.nix { };
+
   # Provided by libc on Operating Systems that use the Extensible Linker Format.
   elf-header =
     if stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf"


### PR DESCRIPTION

###### Motivation for this change
`mtrace(1)` is a small Perl script that interprets and provides
human-readable output for `malloc(3)` traces.

Even though this is actually part of `glibc` itself I decided to place
this into its own package. The main reason for this is that this script
has a runtime dependency on Perl which would complicate `stdenv`
bootstrapping since we'd have to compile another Perl that doesn't depend on
the bootstrap tools that is used as runtime dependency for the
stage2 glibc.

Since this is only a dev/debugging tool, splitting this up seemed like a
reasonable choice to me.

On a leaking C program, this can be used like this:

    $ env MALLOC_TRACE=$(pwd)/trace ./a.out
    $ ./result/bin/mtrace ./trace

    Memory not freed:
    -----------------
               Address     Size     Caller
    0x0000000001875690      0x4  at 0x401151

Closes #141924


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
