### PR TITLE
buttercup-desktop: init at 2.13.0

### DIFF
--- a/pkgs/tools/security/buttercup-desktop/default.nix
+++ b/pkgs/tools/security/buttercup-desktop/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchurl, appimageTools }:
+
+let
+  pname = "buttercup-desktop";
+  version = "2.13.0";
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "https://github.com/buttercup/buttercup-desktop/releases/download/v${version}/Buttercup-linux-x86_64.AppImage";
+    sha256 = "sha256-JXXJZyd/fp2463WyxIB+pKcNzGUFfCouPE6iTx2lhME=";
+  };
+  appimageContents = appimageTools.extractType2 { inherit name src; };
+
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.libsecret ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/buttercup-desktop
+    install -m 444 -D ${appimageContents}/buttercup.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/buttercup.desktop \
+      --replace 'Exec=AppRun' 'Exec=buttercup-desktop'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = with lib; {
+    description = "Cross-Platform Passwords & Secrets Vault";
+    homepage = "https://buttercup.pw";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2108,6 +2108,8 @@ with pkgs;
 
   butane = callPackage ../development/tools/butane { };
 
+  buttercup-desktop = callPackage ../tools/security/buttercup-desktop { };
+
   charles = charles4;
   inherit (callPackage ../applications/networking/charles {})
     charles3


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

closes #129523

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
