### PR TITLE
python3Packages.pyatv: 0.8.2 -> 0.9.5

### DIFF
--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -6,6 +6,7 @@
 , cryptography
 , deepdiff
 , fetchFromGitHub
+, mediafile
 , miniaudio
 , netifaces
 , protobuf
@@ -13,19 +14,23 @@
 , pytest-asyncio
 , pytest-timeout
 , pytestCheckHook
+, pythonOlder
 , srptools
 , zeroconf
 }:
 
 buildPythonPackage rec {
   pname = "pyatv";
-  version = "0.8.2";
+  version = "0.9.5";
+
+  format = "setuptools";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "postlund";
     repo = pname;
     rev = "v${version}";
-    sha256 = "035cjm78xakvfi7k8zahjk0xr23p9my67d8jvq5bqrd506awrl0f";
+    sha256 = "sha256-7aeXTR0ecrm5+KHRCdW3+HLjU3U7Ja/J6JTU5QscCto=";
   };
 
   postPatch = ''
@@ -38,6 +43,7 @@ buildPythonPackage rec {
     audio-metadata
     bitarray
     cryptography
+    mediafile
     miniaudio
     netifaces
     protobuf
@@ -55,7 +61,9 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  pythonImportsCheck = [ "pyatv" ];
+  pythonImportsCheck = [
+    "pyatv"
+  ];
 
   meta = with lib; {
     description = "Python client library for the Apple TV";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.9.5

Change log: https://github.com/postlund/pyatv/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
