### PR TITLE
dhallPackages.buildDhallUrl: add function for easily building dhall remote imports

### DIFF
--- a/doc/languages-frameworks/dhall.section.md
+++ b/doc/languages-frameworks/dhall.section.md
@@ -50,7 +50,7 @@ expression does not protect the Prelude import with a semantic integrity
 check, so the first step is to freeze the expression using `dhall freeze`,
 like this:
 
-```bash
+```ShellSession
 $ dhall freeze --inplace ./true.dhall
 ```
 
@@ -113,7 +113,7 @@ in
 
 … which we can then build using this command:
 
-```bash
+```ShellSession
 $ nix build --file ./example.nix dhallPackages.true
 ```
 
@@ -121,7 +121,7 @@ $ nix build --file ./example.nix dhallPackages.true
 
 The above package produces the following directory tree:
 
-```bash
+```ShellSession
 $ tree -a ./result
 result
 ├── .cache
@@ -135,7 +135,7 @@ result
 
 * `source.dhall` contains the result of interpreting our Dhall package:
 
-  ```bash
+  ```ShellSession
   $ cat ./result/source.dhall
   True
   ```
@@ -143,7 +143,7 @@ result
 * The `.cache` subdirectory contains one binary cache product encoding the
   same result as `source.dhall`:
 
-  ```bash
+  ```ShellSession
   $ dhall decode < ./result/.cache/dhall/122027abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
   True
   ```
@@ -151,7 +151,7 @@ result
 * `binary.dhall` contains a Dhall expression which handles fetching and decoding
   the same cache product:
 
-  ```bash
+  ```ShellSession
   $ cat ./result/binary.dhall
   missing sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
   $ cp -r ./result/.cache .cache
@@ -168,7 +168,7 @@ to conserve disk space when they are used exclusively as dependencies.  For
 example, if we build the Prelude package it will only contain the binary
 encoding of the expression:
 
-```bash
+```ShellSession
 $ nix build --file ./example.nix dhallPackages.Prelude
 
 $ tree -a result
@@ -199,7 +199,7 @@ Dhall overlay like this:
 … and now the Prelude will contain the fully decoded result of interpreting
 the Prelude:
 
-```bash
+```ShellSession
 $ nix build --file ./example.nix dhallPackages.Prelude
 
 $ tree -a result
@@ -302,7 +302,7 @@ Additionally, `buildDhallGitHubPackage` accepts the same arguments as
 You can use the `dhall-to-nixpkgs` command-line utility to automate
 packaging Dhall code.  For example:
 
-```bash
+```ShellSession
 $ nix-env --install --attr haskellPackages.dhall-nixpkgs
 
 $ nix-env --install --attr nix-prefetch-git  # Used by dhall-to-nixpkgs
@@ -329,7 +329,7 @@ The utility takes care of automatically detecting remote imports and converting
 them to package dependencies.  You can also use the utility on local
 Dhall directories, too:
 
-```bash
+```ShellSession
 $ dhall-to-nixpkgs directory ~/proj/dhall-semver
 { buildDhallDirectoryPackage, Prelude }:
   buildDhallDirectoryPackage {
@@ -350,7 +350,7 @@ sometimes easier than manually packaging all remote imports.
 
 This can be used like the following:
 
-```bash
+```ShellSession
 $ dhall-to-nixpkgs directory --fixed-output-derivations ~/proj/dhall-semver
 { buildDhallDirectoryPackage, buildDhallUrl }:
   buildDhallDirectoryPackage {
@@ -390,7 +390,7 @@ in  Prelude.Bool.not False
 
 If we try to rebuild that expression the build will fail:
 
-```
+```ShellSession
 $ nix build --file ./example.nix dhallPackages.true
 builder for '/nix/store/0f1hla7ff1wiaqyk1r2ky4wnhnw114fi-true.drv' failed with exit code 1; last 10 log lines:
 
@@ -416,7 +416,7 @@ importing the URL.
 However, we can override the default Prelude version by using `dhall-to-nixpkgs`
 to create a Dhall package for our desired Prelude:
 
-```bash
+```ShellSession
 $ dhall-to-nixpkgs github https://github.com/dhall-lang/dhall-lang.git \
     --name Prelude \
     --directory Prelude \
@@ -427,7 +427,7 @@ $ dhall-to-nixpkgs github https://github.com/dhall-lang/dhall-lang.git \
 … and then referencing that package in our Dhall overlay, by either overriding
 the Prelude globally for all packages, like this:
 
-```bash
+```nix
   dhallOverrides = self: super: {
     true = self.callPackage ./true.nix { };
 
@@ -438,7 +438,7 @@ the Prelude globally for all packages, like this:
 … or selectively overriding the Prelude dependency for just the `true` package,
 like this:
 
-```bash
+```nix
   dhallOverrides = self: super: {
     true = self.callPackage ./true.nix {
       Prelude = self.callPackage ./Prelude.nix { };

--- a/doc/languages-frameworks/dhall.section.md
+++ b/doc/languages-frameworks/dhall.section.md
@@ -334,7 +334,7 @@ $ dhall-to-nixpkgs directory ~/proj/dhall-semver
 { buildDhallDirectoryPackage, Prelude }:
   buildDhallDirectoryPackage {
     name = "proj";
-    src = /Users/gabriel/proj/dhall-semver;
+    src = ~/proj/dhall-semver;
     file = "package.dhall";
     source = false;
     document = false;
@@ -355,7 +355,7 @@ $ dhall-to-nixpkgs directory --fixed-output-derivations ~/proj/dhall-semver
 { buildDhallDirectoryPackage, buildDhallUrl }:
   buildDhallDirectoryPackage {
     name = "proj";
-    src = /Users/gabriel/proj/dhall-semver;
+    src = ~/proj/dhall-semver;
     file = "package.dhall";
     source = false;
     document = false;

--- a/doc/languages-frameworks/dhall.section.md
+++ b/doc/languages-frameworks/dhall.section.md
@@ -363,7 +363,7 @@ $ dhall-to-nixpkgs directory --fixed-output-derivations ~/proj/dhall-semver
       (buildDhallUrl {
         url = "https://prelude.dhall-lang.org/v17.0.0/package.dhall";
         hash = "sha256-ENs8kZwl6QRoM9+Jeo/+JwHcOQ+giT2VjDQwUkvlpD4=";
-        dhall-hash = "sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e";
+        dhallHash = "sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e";
         })
       ];
     }

--- a/doc/languages-frameworks/dhall.section.md
+++ b/doc/languages-frameworks/dhall.section.md
@@ -342,6 +342,37 @@ $ dhall-to-nixpkgs directory ~/proj/dhall-semver
     }
 ```
 
+### Remote imports as fixed-output derivations {#ssec-dhall-remote-imports-as-fod}
+
+`dhall-to-nixpkgs` has the ability to fetch and build remote imports as
+fixed-output derivations by using their Dhall integrity check.  This is
+sometimes easier than manually packaging all remote imports.
+
+This can be used like the following:
+
+```bash
+$ dhall-to-nixpkgs directory --fixed-output-derivations ~/proj/dhall-semver
+{ buildDhallDirectoryPackage, buildDhallUrl }:
+  buildDhallDirectoryPackage {
+    name = "proj";
+    src = /Users/gabriel/proj/dhall-semver;
+    file = "package.dhall";
+    source = false;
+    document = false;
+    dependencies = [
+      (buildDhallUrl {
+        url = "https://prelude.dhall-lang.org/v17.0.0/package.dhall";
+        hash = "sha256-ENs8kZwl6QRoM9+Jeo/+JwHcOQ+giT2VjDQwUkvlpD4=";
+        dhall-hash = "sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e";
+        })
+      ];
+    }
+```
+
+Here, `dhall-semver`'s `Prelude` dependency is fetched and built with the
+`buildDhallUrl` helper function, instead of being passed in as a function
+argument.
+
 ## Overriding dependency versions {#ssec-dhall-overriding-dependency-versions}
 
 Suppose that we change our `true.dhall` example expression to depend on an older

--- a/doc/languages-frameworks/dhall.section.md
+++ b/doc/languages-frameworks/dhall.section.md
@@ -345,7 +345,7 @@ $ dhall-to-nixpkgs directory ~/proj/dhall-semver
 ### Remote imports as fixed-output derivations {#ssec-dhall-remote-imports-as-fod}
 
 `dhall-to-nixpkgs` has the ability to fetch and build remote imports as
-fixed-output derivations by using their Dhall integrity check.  This is
+fixed-output derivations by using their Dhall integrity check. This is
 sometimes easier than manually packaging all remote imports.
 
 This can be used like the following:

--- a/pkgs/development/interpreters/dhall/build-dhall-url.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-url.nix
@@ -22,7 +22,7 @@
 
   # Dhall hash of the input Dhall file.
   # example: "sha256:6534a24145e93db3df3ef4bc39e2ba743404ea3e8d6cfdbb868d5c83d61f10d2"
-, dhall-hash
+, dhallHash
 
   # Name for this derivation.
 , name ? (baseNameOf url + "-cache")
@@ -61,7 +61,7 @@ let
         nativeBuildInputs = [ cacert ];
       }
       ''
-        echo "${url} ${dhall-hash}" > in-dhall-file
+        echo "${url} ${dhallHash}" > in-dhall-file
         ${dhall}/bin/dhall --alpha --plain --file in-dhall-file | ${dhallNoHTTP}/bin/dhall encode > $out
       '';
 
@@ -83,7 +83,7 @@ in
 
     export XDG_CACHE_HOME=$PWD/${cache}
 
-    SHA_HASH="${dhall-hash}"
+    SHA_HASH="${dhallHash}"
 
     HASH_FILE="''${SHA_HASH/sha256:/1220}"
 

--- a/pkgs/development/interpreters/dhall/build-dhall-url.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-url.nix
@@ -1,0 +1,98 @@
+{ cacert, dhall, dhall-docs, haskell, lib, runCommand }:
+
+# `buildDhallUrl` is similar to `buildDhallDirectoryPackage` or
+# `buildDhallGitHubPackage`, but instead builds a Nixpkgs Dhall package
+# based on a hashed URL.  This will generally be a URL that has an integrity
+# check in a Dhall file.
+#
+# Similar to `buildDhallDirectoryPackage` and `buildDhallGitHubPackage`, the output
+# of this function is a derivation that has a `binary.dhall` file, along with
+# a `.cache/` directory with the actual contents of the Dhall file from the
+# suppiled URL.
+#
+# This function is primarily used by `dhall-to-nixpkgs directory --fixed-output-derivations`.
+
+{ # URL of the input Dhall file.
+  # example: "https://raw.githubusercontent.com/cdepillabout/example-dhall-repo/c1b0d0327146648dcf8de997b2aa32758f2ed735/example1.dhall"
+  url
+
+  # Nix hash of the input Dhall file.
+  # example: "sha256-ZTSiQUXpPbPfPvS8OeK6dDQE6j6NbP27ho1cg9YfENI="
+, hash
+
+  # Dhall hash of the input Dhall file.
+  # example: "sha256:6534a24145e93db3df3ef4bc39e2ba743404ea3e8d6cfdbb868d5c83d61f10d2"
+, dhall-hash
+
+  # Name for this derivation.
+, name ? (baseNameOf url + "-cache")
+
+  # `buildDhallUrl` can include both a "source distribution" in
+  # `source.dhall` and a "binary distribution" in `binary.dhall`:
+  #
+  # * `source.dhall` is a dependency-free αβ-normalized Dhall expression
+  #
+  # * `binary.dhall` is an expression of the form: `missing sha256:${HASH}`
+  #
+  #   This expression requires you to install the cache product located at
+  #   `.cache/dhall/1220${HASH}` to successfully resolve
+  #
+  # By default, `buildDhallUrl` only includes "binary.dhall" to conserve
+  # space within the Nix store, but if you set the following `source` option to
+  # `true` then the package will also include `source.dhall`.
+, source ? false
+}:
+
+let
+  # HTTP support is disabled in order to force that HTTP dependencies are built
+  # using Nix instead of using Dhall's support for HTTP imports.
+  dhallNoHTTP = haskell.lib.appendConfigureFlag dhall "-f-with-http";
+
+  # This uses Dhall's remote importing capabilities for downloading a Dhall file.
+  # The output Dhall file has all imports resolved, and then is
+  # alpha-normalized and binary-encoded.
+  downloadedEncodedFile =
+    runCommand
+      (baseNameOf url)
+      {
+        outputHashAlgo = null;
+        outputHash = hash;
+        name = baseNameOf url;
+        nativeBuildInputs = [ cacert ];
+      }
+      ''
+        echo "${url} ${dhall-hash}" > in-dhall-file
+        ${dhall}/bin/dhall --alpha --plain --file in-dhall-file | ${dhallNoHTTP}/bin/dhall encode > $out
+      '';
+
+   cache = ".cache";
+
+   data = ".local/share";
+
+   cacheDhall = "${cache}/dhall";
+
+   dataDhall = "${data}/dhall";
+
+   sourceFile = "source.dhall";
+
+in
+  runCommand name { } (''
+    set -eu
+
+    mkdir -p ${cacheDhall}
+
+    export XDG_CACHE_HOME=$PWD/${cache}
+
+    mkdir -p $out/${cacheDhall}
+
+    SHA_HASH="${dhall-hash}"
+
+    HASH_FILE="''${SHA_HASH/sha256:/1220}"
+
+    cp ${downloadedEncodedFile} $out/${cacheDhall}/$HASH_FILE
+
+    echo "missing $SHA_HASH" > $out/binary.dhall
+  '' +
+  lib.optionalString source ''
+    ${dhallNoHTTP}/bin/dhall decode --file ${downloadedEncodedFile} > $out/${sourceFile}
+  '')

--- a/pkgs/development/interpreters/dhall/build-dhall-url.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-url.nix
@@ -79,11 +79,9 @@ in
   runCommand name { } (''
     set -eu
 
-    mkdir -p ${cacheDhall}
+    mkdir -p ${cacheDhall} $out/${cacheDhall}
 
     export XDG_CACHE_HOME=$PWD/${cache}
-
-    mkdir -p $out/${cacheDhall}
 
     SHA_HASH="${dhall-hash}"
 

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -55,4 +55,6 @@ with pkgs;
   trivial-overriding = callPackage ../build-support/trivial-builders/test-overriding.nix {};
 
   writers = callPackage ../build-support/writers/test.nix {};
+
+  dhall = callPackage ./dhall { };
 }

--- a/pkgs/test/dhall/buildDhallUrl/default.nix
+++ b/pkgs/test/dhall/buildDhallUrl/default.nix
@@ -9,6 +9,6 @@
 dhallPackages.buildDhallUrl {
   url = "https://raw.githubusercontent.com/cdepillabout/example-dhall-nix/e6a675c72ecd4dd23d254a02aea8181fe875747f/mydhallfile.dhall";
   hash = "sha256-434x+QjHRzuprBdw0h6wmwB1Zj6yZqQb533me8XdO4c=";
-  dhall-hash = "sha256:e37e31f908c7473ba9ac1770d21eb09b0075663eb266a41be77de67bc5dd3b87";
+  dhallHash = "sha256:e37e31f908c7473ba9ac1770d21eb09b0075663eb266a41be77de67bc5dd3b87";
   source = true;
 }

--- a/pkgs/test/dhall/buildDhallUrl/default.nix
+++ b/pkgs/test/dhall/buildDhallUrl/default.nix
@@ -1,0 +1,14 @@
+{ dhallPackages, lib }:
+
+# This file tests that dhallPackages.buildDhallUrl is able to successfully
+# build a Nix Dhall package for a given remote Dhall import.
+#
+# TODO: It would be nice to extend this test to make sure that the resulting
+# Nix Dhall package is has the expected contents.
+
+dhallPackages.buildDhallUrl {
+  url = "https://raw.githubusercontent.com/cdepillabout/example-dhall-nix/e6a675c72ecd4dd23d254a02aea8181fe875747f/mydhallfile.dhall";
+  hash = "sha256-434x+QjHRzuprBdw0h6wmwB1Zj6yZqQb533me8XdO4c=";
+  dhall-hash = "sha256:e37e31f908c7473ba9ac1770d21eb09b0075663eb266a41be77de67bc5dd3b87";
+  source = true;
+}

--- a/pkgs/test/dhall/default.nix
+++ b/pkgs/test/dhall/default.nix
@@ -3,4 +3,3 @@
 lib.recurseIntoAttrs {
   buildDhallUrl = callPackage ./buildDhallUrl { };
 }
-

--- a/pkgs/test/dhall/default.nix
+++ b/pkgs/test/dhall/default.nix
@@ -1,0 +1,6 @@
+{ lib, callPackage }:
+
+lib.recurseIntoAttrs {
+  buildDhallUrl = callPackage ./buildDhallUrl { };
+}
+

--- a/pkgs/top-level/dhall-packages.nix
+++ b/pkgs/top-level/dhall-packages.nix
@@ -17,12 +17,16 @@ let
       buildDhallDirectoryPackage =
         callPackage ../development/interpreters/dhall/build-dhall-directory-package.nix { };
 
+      buildDhallUrl =
+        callPackage ../development/interpreters/dhall/build-dhall-url.nix { };
+
     in
       { inherit
           callPackage
           buildDhallPackage
           buildDhallGitHubPackage
           buildDhallDirectoryPackage
+          buildDhallUrl
         ;
 
         lib = import ../development/dhall-modules/lib.nix { inherit lib; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds the `buildDhallUrl` function as discussed in https://github.com/dhall-lang/dhall-haskell/pull/2318.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
