### PR TITLE
grab-site: 2.2.0 -> 2.2.2; pythonPackages.ludios_wpull: 3.0.7 -> 3.0.9

### DIFF
--- a/pkgs/development/python-modules/ludios_wpull/default.nix
+++ b/pkgs/development/python-modules/ludios_wpull/default.nix
@@ -21,8 +21,8 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     rev = version;
-    owner = "ludios";
-    repo = "wpull";
+    owner = "ArchiveTeam";
+    repo = "ludios_wpull";
     sha256 = "0j4dir0dgg8pkf4d1znicz6wyyi1wzij50r21z838cycsdr54j4c";
   };
 
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Web crawler; fork of wpull used by grab-site";
-    homepage = "https://github.com/ludios/wpull";
+    homepage = "https://github.com/ArchiveTeam/ludios_wpull";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ ivan ];
     broken = lib.versions.major tornado.version != "4";

--- a/pkgs/development/python-modules/ludios_wpull/default.nix
+++ b/pkgs/development/python-modules/ludios_wpull/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy3k
 , chardet
 , dnspython
 , html5-parser
@@ -15,15 +14,16 @@
 
 buildPythonPackage rec {
   pname = "ludios_wpull";
-  version = "3.0.7";
+  version = "3.0.9";
 
-  disabled = (!isPy3k) || (pythonAtLeast "3.8");
+  # https://github.com/ArchiveTeam/ludios_wpull/issues/20
+  disabled = pythonAtLeast "3.9";
 
   src = fetchFromGitHub {
     rev = version;
     owner = "ludios";
     repo = "wpull";
-    sha256 = "1j96avm0ynbazypzp766wh26n4qc73y7wgsiqfrdfl6x7rx20wgf";
+    sha256 = "0j4dir0dgg8pkf4d1znicz6wyyi1wzij50r21z838cycsdr54j4c";
   };
 
   propagatedBuildInputs = [ chardet dnspython html5-parser lxml namedlist sqlalchemy tornado Yapsy ];

--- a/pkgs/tools/backup/grab-site/default.nix
+++ b/pkgs/tools/backup/grab-site/default.nix
@@ -1,8 +1,15 @@
-{ lib, python37, fetchFromGitHub }:
+{ lib, python38, fetchFromGitHub }:
 let
-  python = python37.override {
+  python = python38.override {
     self = python;
     packageOverrides = self: super: {
+      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
+        version = "1.3.24";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "ebbb777cbf9312359b897bf81ba00dae0f5cb69fba2a18265dcc18a6f5ef7519";
+        };
+      });
       tornado = super.tornado_4;
     };
   };
@@ -10,18 +17,18 @@ let
 in
 with python.pkgs; buildPythonApplication rec {
   pname = "grab-site";
-  version = "2.2.0";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     rev = version;
     owner = "ArchiveTeam";
     repo = "grab-site";
-    sha256 = "1jxcv9dral6h7vfpfqkp1yif6plj0vspzakymkj8hfl75nh0wpv8";
+    sha256 = "0af53g703kqpxa6bn72mb2l5l0qrjknq5wqwl4wryyscdp4xabx4";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"wpull @ https://github.com/ArchiveTeam/ludios_wpull/tarball/master#egg=wpull-3.0.7"' '"wpull"'
+      --replace '"wpull @ https://github.com/ArchiveTeam/ludios_wpull/tarball/master#egg=wpull-${ludios_wpull.version}"' '"wpull"'
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

This updates grab-site, broken at runtime since 9974c90a1597a7b2b009e798374615899d57db7d when `python3Packages.sqlalchemy` was upgraded to 1.4 in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
