### PR TITLE
imagej: fix crash with opening dialogs

### DIFF
--- a/pkgs/applications/graphics/imagej/default.nix
+++ b/pkgs/applications/graphics/imagej/default.nix
@@ -59,7 +59,7 @@ in stdenv.mkDerivation rec {
   postFixup = lib.optionalString stdenv.isLinux ''
     makeWrapper ${jre}/bin/java $out/bin/imagej \
       ''${gappsWrapperArgs[@]} \
-      --add-flags "-jar $out/share/java/ij.jar -ijpath $out/share" 
+      --add-flags "-jar $out/share/java/ij.jar -ijpath $out/share"
 
     install -Dm644 ${icon} $out/share/icons/hicolor/128x128/apps/imagej.png
     substituteInPlace $out/share/applications/ImageJ.desktop \

--- a/pkgs/applications/graphics/imagej/default.nix
+++ b/pkgs/applications/graphics/imagej/default.nix
@@ -1,11 +1,13 @@
 { lib
 , stdenv
 , fetchurl
+, glib
 , jre
 , unzip
 , makeWrapper
 , makeDesktopItem
 , copyDesktopItems
+, wrapGAppsHook
 }:
 
 let
@@ -21,7 +23,7 @@ in stdenv.mkDerivation rec {
     url = "https://wsr.imagej.net/distros/cross-platform/ij${version}.zip";
     sha256 = "sha256-MGuUdUDuW3s/yGC68rHr6xxzmYScUjdXRawDpc1UQqw=";
   };
-  nativeBuildInputs = [ copyDesktopItems makeWrapper unzip ];
+  nativeBuildInputs = [ copyDesktopItems makeWrapper unzip glib wrapGAppsHook ];
   desktopItems = lib.optionals stdenv.isLinux [
     (makeDesktopItem {
       name = "ImageJ";

--- a/pkgs/applications/graphics/imagej/default.nix
+++ b/pkgs/applications/graphics/imagej/default.nix
@@ -24,6 +24,8 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-MGuUdUDuW3s/yGC68rHr6xxzmYScUjdXRawDpc1UQqw=";
   };
   nativeBuildInputs = [ copyDesktopItems makeWrapper unzip glib wrapGAppsHook ];
+  dontWrapGApps = true;
+
   desktopItems = lib.optionals stdenv.isLinux [
     (makeDesktopItem {
       name = "ImageJ";
@@ -49,13 +51,15 @@ in stdenv.mkDerivation rec {
     # Simple cp shall clear suid bits, if any.
     cp ij.jar $out/share/java
     cp -dR luts macros plugins $out/share
-    makeWrapper ${jre}/bin/java $out/bin/imagej \
-      --add-flags "-jar $out/share/java/ij.jar -ijpath $out/share"
 
     runHook postInstall
   '';
 
   postFixup = lib.optionalString stdenv.isLinux ''
+    makeWrapper ${jre}/bin/java $out/bin/imagej \
+      ''${gappsWrapperArgs[@]} \
+      --add-flags "-jar $out/share/java/ij.jar -ijpath $out/share" 
+
     install -Dm644 ${icon} $out/share/icons/hicolor/128x128/apps/imagej.png
     substituteInPlace $out/share/applications/ImageJ.desktop \
       --replace Exec=imagej Exec=$out/bin/imagej

--- a/pkgs/applications/graphics/imagej/default.nix
+++ b/pkgs/applications/graphics/imagej/default.nix
@@ -23,7 +23,8 @@ in stdenv.mkDerivation rec {
     url = "https://wsr.imagej.net/distros/cross-platform/ij${version}.zip";
     sha256 = "sha256-MGuUdUDuW3s/yGC68rHr6xxzmYScUjdXRawDpc1UQqw=";
   };
-  nativeBuildInputs = [ copyDesktopItems makeWrapper unzip glib wrapGAppsHook ];
+  nativeBuildInputs = [ copyDesktopItems makeWrapper unzip wrapGAppsHook ];
+  buildInputs = [ glib ];
   dontWrapGApps = true;
 
   desktopItems = lib.optionals stdenv.isLinux [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Standard build of imagej crashes with an error like:
`(java:20665): GLib-GIO-ERROR **: 11:44:24.105: No GSettings schemas are
installed on the system` when opening any dialog (e.g. open file menu).

This fixes that. Hat tip to @raboof for the idea from their solution to
the same problem in a different package
(https://github.com/NixOS/nixpkgs/pull/108216/commits/e0a2307c866818668badf3661e57f35d19f9dca8)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
