### PR TITLE
source-han-serif: 1.001R -> 2.000R

### DIFF
--- a/pkgs/data/fonts/source-han/default.nix
+++ b/pkgs/data/fonts/source-han/default.nix
@@ -48,8 +48,13 @@ in
   serif = makePackage {
     family = "serif";
     description = "serif";
-    rev = "1.001R";
-    sha256 = "0nnsb2w140ih0cnp1fh7s4csvzp9y0cavz9df2ryhv215mh9z4m0";
+    rev = "2.000R";
+    sha256 = "0x3n6s4khdd6l0crwd7g9sjaqp8lkvksglhc7kj3cv80hldab9wp";
+    postFetch = ''
+      mkdir -p $out/share/fonts/opentype/source-han-serif
+      unzip $downloadedFile -d $out/share/fonts/opentype/source-han-serif
+    '';
+    zip = ".zip";
   };
 
   mono = makePackage {


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
