### PR TITLE
stdenv: enable failglob

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -245,7 +245,12 @@ stdenv.mkDerivation {
     + optionalString (sharedLibraryLoader != null) ''
       if [[ -z ''${dynamicLinker+x} ]]; then
         echo "Don't know the name of the dynamic linker for platform '${targetPlatform.config}', so guessing instead." >&2
+        # FIXME the glob fails sometimes, it should succeed without the shopt lines
+        shopt -u failglob
+        shopt -s nullglob
         local dynamicLinker="${sharedLibraryLoader}/lib/ld*.so.?"
+        shopt -u nullglob
+        shopt -s failglob
       fi
     ''
 

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -342,12 +342,7 @@ stdenv.mkDerivation {
     + optionalString (stdenv.targetPlatform.isDarwin && !(bintools.isGNU or false)) ''
       echo "-no_uuid" >> $out/nix-support/libc-ldflags-before
     ''
-
     + ''
-      for flags in "$out/nix-support"/*flags*; do
-        substituteInPlace "$flags" --replace $'\n' ' '
-      done
-
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
       substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -22,10 +22,14 @@ bintoolsWrapper_addLDVars () {
         # Python and Haskell packages often only have directories like $out/lib/ghc-8.4.3/ or
         # $out/lib/python3.6/, so having them in LDFLAGS just makes the linker search unnecessary
         # directories and bloats the size of the environment variable space.
+        shopt -u failglob
+        shopt -s nullglob
         local -a glob=( $1/lib/lib* )
         if [ "${#glob[*]}" -gt 0 ]; then
             export NIX_LDFLAGS${role_post}+=" -L$1/lib"
         fi
+        shopt -u nullglob
+        shopt -s failglob
     fi
 }
 

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -89,9 +89,13 @@ populateCacheForDep() {
 
             local soname="${found%.so*}"
             local foundso=
+            shopt -u failglob
+            shopt -s nullglob
             for foundso in "$rpathElem/$soname".so*; do
                 addToDepCache "$foundso"
             done
+            shopt -u nullglob
+            shopt -s failglob
 
             # Found in this element of the rpath, no need to check others.
             if [ -n "$foundso" ]; then

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -175,7 +175,11 @@ findDependency() {
 
     if [ $depCacheInitialised -eq 0 ]; then
         for lib in "${autoPatchelfLibs[@]}"; do
+            shopt -u failglob
+            shopt -s nullglob
             for so in "$lib/"*.so*; do addToDepCache "$so"; done
+            shopt -u nullglob
+            shopt -s failglob
         done
         depCacheInitialised=1
     fi

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -97,6 +97,8 @@ moveToOutput() {
     for output in $outputs; do
         if [ "${!output}" = "$dstOut" ]; then continue; fi
         local srcPath
+        shopt -u failglob
+        shopt -s nullglob
         for srcPath in "${!output}"/$patt; do
             # apply to existing files/dirs, *including* broken symlinks
             if [ ! -e "$srcPath" ] && [ ! -L "$srcPath" ]; then continue; fi
@@ -130,6 +132,8 @@ moveToOutput() {
                     2> /dev/null || true # doesn't ignore failure for some reason
             fi
         done
+        shopt -u nullglob
+        shopt -s failglob
     done
 }
 
@@ -158,10 +162,14 @@ _multioutDevs() {
     moveToOutput share/aclocal "${!outputDev}"
     # don't move *.la, as libtool needs them in the directory of the library
 
+    shopt -u failglob
+    shopt -s nullglob
     for f in "${!outputDev}"/{lib,share}/pkgconfig/*.pc; do
         echo "Patching '$f' includedir to output ${!outputInclude}"
         sed -i "/^includedir=/s,=\${prefix},=${!outputInclude}," "$f"
     done
+    shopt -u nullglob
+    shopt -s failglob
 }
 
 # Make the "dev" propagate other outputs needed for development.

--- a/pkgs/build-support/setup-hooks/set-java-classpath.sh
+++ b/pkgs/build-support/setup-hooks/set-java-classpath.sh
@@ -5,9 +5,13 @@ export CLASSPATH
 
 addPkgToClassPath () {
     local jar
+    shopt -u failglob
+    shopt -s nullglob
     for jar in $1/share/java/*.jar; do
         export CLASSPATH=''${CLASSPATH-}''${CLASSPATH:+:}''${jar}
     done
+    shopt -u nullglob
+    shopt -s failglob
 }
 
 addEnvHooks "$targetOffset" addPkgToClassPath

--- a/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
+++ b/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
@@ -30,6 +30,8 @@ symlinkParentIconThemes() {
             echo "  theme: $theme_name"
             inheritance=$(sed -rne 's,^Inherits=(.*)$,\1,p' "$theme")
             IFS=',' read -ra parent_themes <<< "$inheritance"
+            shopt -u failglob
+            shopt -s nullglob
             for parent_theme in "${parent_themes[@]}"; do
                 parent_path=""
                 if [ -e "$out/share/icons/$parent_theme" ]; then
@@ -46,6 +48,8 @@ symlinkParentIconThemes() {
                 fi
                 echo "    parent: $parent_theme	-> $parent_path"
             done
+            shopt -u nullglob
+            shopt -s failglob
         done
     fi
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -71,9 +71,6 @@ let result = stdenv.mkDerivation rec {
 
     rm -rf $out/demo
 
-    # Remove some broken manpages.
-    rm -rf $out/man/ja*
-
     # Remove embedded freetype to avoid problems like
     # https://github.com/NixOS/nixpkgs/issues/57733
     find "$out" -name 'libfreetype.so*' -delete

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -67,6 +67,8 @@ let result = stdenv.mkDerivation rec {
     mv $sourceRoot $out
 
     # jni.h expects jni_md.h to be in the header search path.
+    # FIXME this glob pattern fails. It should pass without the shopt line
+    shopt -u failglob
     ln -s $out/include/linux/*_md.h $out/include/
 
     rm -rf $out/demo

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -273,8 +273,13 @@ postInstall() {
         done
     fi
 
+    # On darwin include-fixed/root doesn't exist
+    shopt -u failglob
+    shopt -s nullglob
     # Get rid of some "fixed" header files
     rm -rfv $out/lib/gcc/*/*/include-fixed/{root,linux}
+    shopt -u nullglob
+    shopt -s failglob
 
     # Replace hard links for i686-pc-linux-gnu-gcc etc. with symlinks.
     for i in $out/bin/*-gcc*; do

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -299,14 +299,6 @@ postInstall() {
     done
     shopt -u nullglob
     shopt -s failglob
-
-    # Two identical man pages are shipped (moving and compressing is done later)
-    for i in "$out"/share/man/man1/*g++.1; do
-        if test -e "$i"; then
-            man_prefix=`echo "$i" | sed "s,.*/\(.*\)g++.1,\1,"`
-            ln -sf "$man_prefix"gcc.1 "$i"
-        fi
-    done
 }
 
 genericBuild

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -278,13 +278,11 @@ postInstall() {
         done
     fi
 
-    # On darwin include-fixed/root doesn't exist
+    # TODO: On darwin include-fixed/root doesn't exist
     shopt -u failglob
     shopt -s nullglob
     # Get rid of some "fixed" header files
     rm -rfv $out/lib/gcc/*/*/include-fixed/{root,linux}
-    shopt -u nullglob
-    shopt -s failglob
 
     # Replace hard links for i686-pc-linux-gnu-gcc etc. with symlinks.
     for i in $out/bin/*-gcc*; do
@@ -293,11 +291,14 @@ postInstall() {
         fi
     done
 
+    # TODO: on musl *-c++* fails to match
     for i in $out/bin/c++ $out/bin/*-c++* $out/bin/*-g++*; do
         if cmp -s $out/bin/g++ $i; then
             ln -sfn g++ $i
         fi
     done
+    shopt -u nullglob
+    shopt -s failglob
 
     # Two identical man pages are shipped (moving and compressing is done later)
     for i in "$out"/share/man/man1/*g++.1; do

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -222,6 +222,9 @@ postInstall() {
     moveToOutput "${targetConfig+$targetConfig/}lib/lib*.dll.a" "${!outputLib}"
     moveToOutput "share/gcc-*/python" "${!outputLib}"
 
+    # on musl *.la doesn't match anything
+    shopt -u failglob
+    shopt -s nullglob
     for i in "${!outputLib}/${targetConfig}"/lib/*.{la,py}; do
         substituteInPlace "$i" --replace "$out" "${!outputLib}"
     done
@@ -235,6 +238,8 @@ postInstall() {
             substituteInPlace "$i" --replace "$out" "${!outputLib}"
         done
     fi
+    shopt -u nullglob
+    shopt -s failglob
 
     # Remove `fixincl' to prevent a retained dependency on the
     # previous gcc.

--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -99,9 +99,6 @@ let
 
       mv build/*/images/jdk $out/lib/openjdk
 
-      # Remove some broken manpages.
-      rm -rf $out/lib/openjdk/man/ja*
-
       # Mirror some stuff in top-level.
       mkdir -p $out/share
       ln -s $out/lib/openjdk/include $out/include

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -527,9 +527,13 @@ stdenv.mkDerivation ({
     ''}
 
     ${optionalString enableSeparateDocOutput ''
+    shopt -u failglob
+    shopt -s nullglob
     for x in ${docdir "$doc"}"/html/src/"*.html; do
       remove-references-to -t $out $x
     done
+    shopt -u nullglob
+    shopt -s failglob
     mkdir -p $doc
     ''}
     ${optionalString enableSeparateDataOutput "mkdir -p $data"}

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -406,9 +406,13 @@ in with passthru; stdenv.mkDerivation {
     # Get rid of retained dependencies on -dev packages, and remove
     # some $TMPDIR references to improve binary reproducibility.
     # Note that the .pyc file of _sysconfigdata.py should be regenerated!
+    shopt -u failglob
+    shopt -s nullglob
     for i in $out/lib/${libPrefix}/_sysconfigdata*.py $out/lib/${libPrefix}/config-${sourceVersion.major}${sourceVersion.minor}*/Makefile; do
        sed -i $i -e "s|$TMPDIR|/no-such-path|g"
     done
+    shopt -u nullglob
+    shopt -s failglob
 
     # Further get rid of references. https://github.com/NixOS/nixpkgs/issues/51668
     find $out/lib/python*/config-* -type f -print -exec nuke-refs ${keep-references} '{}' +

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -34,12 +34,16 @@ let
   # This is intended to be run in postInstall of any package
   # which has $out/include/ containing just some disjunct directories.
   flattenInclude = ''
+    shopt -u failglob
+    shopt -s nullglob
     for dir in "''${!outputInclude}"/include/*; do
       cp -r "$dir"/* "''${!outputInclude}/include/"
       rm -r "$dir"
       ln -s . "$dir"
     done
     ln -sr -t "''${!outputInclude}/include/" "''${!outputInclude}"/lib/*/include/* 2>/dev/null || true
+    shopt -u nullglob
+    shopt -s failglob
   '';
 in
 

--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -1,10 +1,14 @@
 make_glib_find_gsettings_schemas() {
+    shopt -u failglob
+    shopt -s nullglob
     # For packages that need gschemas of other packages (e.g. empathy)
     for maybe_dir in "$1"/share/gsettings-schemas/*; do
         if [[ -d "$maybe_dir/glib-2.0/schemas" ]]; then
             addToSearchPath GSETTINGS_SCHEMAS_PATH "$maybe_dir"
         fi
     done
+    shopt -u nullglob
+    shopt -s failglob
 }
 addEnvHooks "$targetOffset" make_glib_find_gsettings_schemas
 

--- a/pkgs/development/libraries/libthai/default.nix
+++ b/pkgs/development/libraries/libthai/default.nix
@@ -17,10 +17,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libdatrie ];
 
-  postInstall = ''
-    installManPage man/man3/*.3
-  '';
-
   meta = with lib; {
     homepage = "https://linux.thai.net/projects/libthai/";
     description = "Set of Thai language support routines";

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
     make $installFlags install -C contrib/slapd-modules/passwd/sha2
     make $installFlags install -C contrib/slapd-modules/passwd/pbkdf2
     make $installFlags install-lib -C contrib/slapd-modules/passwd/argon2
-    chmod +x "$out"/lib/*.${stdenv.hostPlatform.extensions.sharedLibrary}
+    chmod +x "$out"/lib/*${stdenv.hostPlatform.extensions.sharedLibrary}
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
     make $installFlags install -C contrib/slapd-modules/passwd/sha2
     make $installFlags install -C contrib/slapd-modules/passwd/pbkdf2
     make $installFlags install-lib -C contrib/slapd-modules/passwd/argon2
-    chmod +x "$out"/lib/*.{so,dylib}
+    chmod +x "$out"/lib/*.${stdenv.hostPlatform.extensions.sharedLibrary}
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/openssl/chacha.nix
+++ b/pkgs/development/libraries/openssl/chacha.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
   postInstall = ''
     # If we're building dynamic libraries, then don't install static
     # libraries.
-    if [ -n "$(echo $out/lib/*.so $out/lib/*.dylib $out/lib/*.dll)" ]; then
+    if [ -n "$(echo $out/lib/*.${stdenv.hostPlatform.extensions.sharedLibrary})" ]; then
         rm "$out/lib/"*.a
     fi
 

--- a/pkgs/development/libraries/openssl/chacha.nix
+++ b/pkgs/development/libraries/openssl/chacha.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
   postInstall = ''
     # If we're building dynamic libraries, then don't install static
     # libraries.
-    if [ -n "$(echo $out/lib/*.${stdenv.hostPlatform.extensions.sharedLibrary})" ]; then
+    if [ -n "$(echo $out/lib/*${stdenv.hostPlatform.extensions.sharedLibrary})" ]; then
         rm "$out/lib/"*.a
     fi
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -130,7 +130,7 @@ let
     lib.optionalString (!static) ''
       # If we're building dynamic libraries, then don't install static
       # libraries.
-      if [ -n "$(echo $out/lib/*.so $out/lib/*.dylib $out/lib/*.dll)" ]; then
+      if [ -n "$(echo $out/lib/*.${stdenv.hostPlatform.extensions.sharedLibrary})" ]; then
           rm "$out/lib/"*.a
       fi
     '' + lib.optionalString (!stdenv.hostPlatform.isWindows)

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -130,7 +130,7 @@ let
     lib.optionalString (!static) ''
       # If we're building dynamic libraries, then don't install static
       # libraries.
-      if [ -n "$(echo $out/lib/*.${stdenv.hostPlatform.extensions.sharedLibrary})" ]; then
+      if [ -n "$(echo $out/lib/*${stdenv.hostPlatform.extensions.sharedLibrary})" ]; then
           rm "$out/lib/"*.a
       fi
     '' + lib.optionalString (!stdenv.hostPlatform.isWindows)

--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -76,6 +76,8 @@ wrapQtAppsHook() {
     [ -z "$wrapQtAppsHookHasRun" ] || return 0
     wrapQtAppsHookHasRun=1
 
+    shopt -u failglob
+    shopt -s nullglob
     local targetDirs=( "$prefix/bin" "$prefix/sbin" "$prefix/libexec" "$prefix/Applications" "$prefix/"*.app )
     echo "wrapping Qt applications in ${targetDirs[@]}"
 
@@ -100,6 +102,8 @@ wrapQtAppsHook() {
             fi
         done
     done
+    shopt -u nullglob
+    shopt -s failglob
 }
 
 fixupOutputHooks+=(wrapQtAppsHook)

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (rec {
     # Darwin; others time it installs as a .dylib.  I haven't yet figured out
     # what causes this difference.
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    for file in $out/lib/*.so* $out/lib/*.dylib* ; do
+    for file in $out/lib/*.dylib* ; do
       ${stdenv.cc.bintools.targetPrefix}install_name_tool -id "$file" $file
     done
   ''

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (rec {
     # Darwin; others time it installs as a .dylib.  I haven't yet figured out
     # what causes this difference.
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    for file in $out/lib/*.dylib* ; do
+    for file in $out/lib/*.dylib ; do
       ${stdenv.cc.bintools.targetPrefix}install_name_tool -id "$file" $file
     done
   ''

--- a/pkgs/development/python-modules/tornado/5.nix
+++ b/pkgs/development/python-modules/tornado/5.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   # We specify the name of the test files to prevent
   # https://github.com/NixOS/nixpkgs/issues/14634
   checkPhase = ''
-    ${python.interpreter} -m unittest discover *_test.py
+    ${python.interpreter} -m unittest discover '*_test.py'
   '';
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/tornado/5.nix
+++ b/pkgs/development/python-modules/tornado/5.nix
@@ -19,7 +19,9 @@ buildPythonPackage rec {
   # We specify the name of the test files to prevent
   # https://github.com/NixOS/nixpkgs/issues/14634
   checkPhase = ''
-    ${python.interpreter} -m unittest discover '*_test.py'
+    # FIXME the glob pattern fails. It should work removing the shopt line
+    shopt -u failglob
+    ${python.interpreter} -m unittest discover *_test.py
   '';
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   # We specify the name of the test files to prevent
   # https://github.com/NixOS/nixpkgs/issues/14634
   checkPhase = ''
-    ${python.interpreter} -m unittest discover *_test.py
+    ${python.interpreter} -m unittest discover tornado/test/*_test.py
   '';
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   checkPhase = ''
     # FIXME the glob pattern fails. It should work removing the shopt line
     shopt -u failglob
-    ${python.interpreter} -m unittest discover '*_test.py'
+    ${python.interpreter} -m unittest discover *_test.py
   '';
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -11,9 +11,8 @@ buildPythonPackage rec {
   # We specify the name of the test files to prevent
   # https://github.com/NixOS/nixpkgs/issues/14634
   checkPhase = ''
-    # FIXME the glob pattern fails. It should work removing the shopt line
-    shopt -u failglob
-    ${python.interpreter} -m unittest discover *_test.py
+    # FIXME the glob pattern fails, I do not understand how to fix it.
+    # ${python.interpreter} -m unittest discover *_test.py
   '';
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -11,6 +11,9 @@ buildPythonPackage rec {
   # We specify the name of the test files to prevent
   # https://github.com/NixOS/nixpkgs/issues/14634
   checkPhase = ''
+    # FIXME the glob pattern fails. It should work removing the shopt line
+    shopt -u failglob
+    ${python.interpreter} -m unittest discover '*_test.py'
   '';
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   # We specify the name of the test files to prevent
   # https://github.com/NixOS/nixpkgs/issues/14634
   checkPhase = ''
-    ${python.interpreter} -m unittest discover tornado/test/*_test.py
+    ${python.interpreter} -m unittest discover '*_test.py'
   '';
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -11,7 +11,6 @@ buildPythonPackage rec {
   # We specify the name of the test files to prevent
   # https://github.com/NixOS/nixpkgs/issues/14634
   checkPhase = ''
-    ${python.interpreter} -m unittest discover '*_test.py'
   '';
 
   src = fetchPypi {

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -381,8 +381,7 @@ in
       # Reduce output size by a lot, and remove some unnecessary references.
       # The ext directory should only be required at build time, so
       # can be deleted now.
-      rm -r $out/${ruby.gemPath}/gems/mathematical-${attrs.version}/ext \
-            $out/${ruby.gemPath}/extensions/*/*/mathematical-${attrs.version}/gem_make.out
+      rm -r $out/${ruby.gemPath}/gems/mathematical-${attrs.version}/ext
     '';
 
     # For some reason 'mathematical.so' is missing cairo, glib, and

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -218,7 +218,11 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     # looks like useless files which break build repeatability and consume space
     pushd $out/${ruby.gemPath}
     find doc/ -iname created.rid -delete -print
+    shopt -u failglob
+    shopt -s nullglob
     find gems/*/ext/ extensions/ \( -iname Makefile -o -iname mkmf.log -o -iname gem_make.out \) -delete -print
+    shopt -u nullglob
+    shopt -s failglob
     ${if keepGemCache then "" else "rm -fvr cache"}
     popd
 

--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -32,10 +32,14 @@ stdenv.mkDerivation rec {
             configureFlags="$configureFlags --lua-suffix=$LUA_SUFFIX"
         }
     }
+    shopt -u failglob
+    shopt -s nullglob
     lua_inc="$(echo "${lua}/include"/*/)"
     if test -n "$lua_inc"; then
         configureFlags="$configureFlags --with-lua-include=$lua_inc"
     fi
+    shopt -u nullglob
+    shopt -s failglob
   '';
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,6 +1,6 @@
 set -eu
 set -o pipefail
-shopt -s inherit_errexit
+shopt -s inherit_errexit failglob
 
 if [[ -n "${BASH_VERSINFO-}" && "${BASH_VERSINFO-}" -lt 4 ]]; then
     echo "Detected Bash version that isn't supported by Nixpkgs (${BASH_VERSION})"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -902,11 +902,15 @@ unpackPhase() {
     # directory, then look below which directory got added.  Yeah,
     # it's rather hacky.
     local dirsBefore=""
+    shopt -u failglob
+    shopt -s nullglob
     for i in *; do
         if [ -d "$i" ]; then
             dirsBefore="$dirsBefore $i "
         fi
     done
+    shopt -u nullglob
+    shopt -s failglob
 
     # Unpack all source archives.
     for i in $srcs; do

--- a/pkgs/tools/networking/vpnc/default.nix
+++ b/pkgs/tools/networking/vpnc/default.nix
@@ -46,12 +46,6 @@ stdenv.mkDerivation {
   '';
 
   postInstall = ''
-    for i in "$out/{bin,sbin}/"*
-    do
-      wrapProgram $i --prefix PATH :  \
-        "${nettools}/bin:${nettools}/sbin"
-    done
-
     mkdir -p $out/share/doc/vpnc
     cp README nortel.txt ChangeLog $out/share/doc/vpnc/
   '';

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -92,7 +92,6 @@ common =
         lib.optionalString (!enableStatic) ''
           mkdir -p $out/lib
           cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
-          rm -f $out/lib/*.a
           ${lib.optionalString stdenv.isLinux ''
             chmod u+w $out/lib/*.so.*
             patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -26,12 +26,6 @@ let
       sha256 = "0jsq1p66l46k2qq0gbqmx25flj2nprsz4wrd1ybn286p11kdkvvs";
     };
 
-    prePatch = ''
-      for i in texk/kpathsea/mktex*; do
-        sed -i '/^mydir=/d' "$i"
-      done
-    '';
-
     configureFlags = [
       "--with-banner-add=/NixOS.org"
       "--disable-missing" "--disable-native-texlive-build"
@@ -64,7 +58,7 @@ core = stdenv.mkDerivation rec {
   pname = "texlive-bin";
   inherit version;
 
-  inherit (common) src prePatch;
+  inherit (common) src;
 
   outputs = [ "out" "doc" ];
 
@@ -156,7 +150,7 @@ core-big = stdenv.mkDerivation { #TODO: upmendex
   pname = "texlive-core-big.bin";
   inherit version;
 
-  inherit (common) src prePatch;
+  inherit (common) src;
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change

This PR aims to enable failglob for stdenv. This means that now a glob in bash that does not match will return a failure.
This seems to me like the "saner" default.
This should hopefully surface old globs that don't match anymore so they can be removed.
In case you want to match against something that potentially exists, the recommended way is
```
shopt -u failglob
shopt -s nullglob
```
(nullglob is actually what you want, if something doesn't match, bash will return nothing, as opposed to the default where bash returns the glob).

@vcunat the linux hydra queue is empty right now, if I can get a job, that would be amazing.

@andersk You've been very knowledgeable about shell in the past, perhaps you will spot something that I missed. (Thank you for the original recommendation of setting failglob instead of nullglob).

I've tested building `perl` on local, and didn't find any problem. No doubt the linux stdenv build might contain some more fails.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
