### PR TITLE
himalaya: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/himalaya/default.nix
+++ b/pkgs/applications/networking/mailreaders/himalaya/default.nix
@@ -1,33 +1,29 @@
 { lib
-, stdenv
 , rustPlatform
 , fetchFromGitHub
-, openssl
-, pkg-config
-, installShellFiles
+, stdenv
 , enableCompletions ? stdenv.hostPlatform == stdenv.buildPlatform
+, installShellFiles
+, pkg-config
 , Security
 , libiconv
+, openssl
 }:
+
 rustPlatform.buildRustPackage rec {
   pname = "himalaya";
-  version = "0.4.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "soywod";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-6RgT/SxO4vsk8Yx2AbaNIFvnAvgDmeTXvb/v6nUJxhc=";
+    sha256 = "sha256-BmV4kekl0QDbX/ueSrWM5jRvqr6WQeZIs7hiXhiHBSI=";
   };
 
-  cargoSha256 = "sha256-NEuIh7FwIdAWzlChna3+G0VukfV8nYZfVWa+3LxQCIA=";
+  cargoSha256 = "sha256-lu5xVuAw9yTeQr3gpiW5g5bdm7Alf0YXmlbSkPaXhk0=";
 
-  # use --lib flag to avoid test with imap server
-  # https://github.com/soywod/himalaya/issues/145
-  cargoTestFlags = [ "--lib" ];
-
-  nativeBuildInputs = [ ]
-    ++ lib.optionals (enableCompletions) [ installShellFiles ]
+  nativeBuildInputs = lib.optionals enableCompletions [ installShellFiles ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ pkg-config ];
 
   buildInputs =
@@ -49,6 +45,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "CLI email client written in Rust";
     homepage = "https://github.com/soywod/himalaya";
+    changelog = "https://github.com/soywod/himalaya/blob/v${version}/CHANGELOG.md";
     license = licenses.bsd3;
     maintainers = with maintainers; [ yanganto ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

fixes #142846

https://github.com/soywod/himalaya/blob/development/CHANGELOG.md
https://github.com/soywod/himalaya/compare/v0.4.0...v0.5.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
