### PR TITLE
gss: Fix typo in enable/disable-kerberos5 flag

### DIFF
--- a/pkgs/development/libraries/gss/default.nix
+++ b/pkgs/development/libraries/gss/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchurl
-, withShishi ? !stdenv.isDarwin, shishi ? null
+, withShishi ? !stdenv.isDarwin, shishi
 }:
-
-assert withShishi -> shishi != null;
 
 stdenv.mkDerivation rec {
   name = "gss-1.0.3";
@@ -15,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optional withShishi shishi;
 
   configureFlags = [
-    "--${if withShishi != null then "enable" else "disable"}-kerberos5"
+    "--${if withShishi then "enable" else "disable"}-kerberos5"
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/gss/default.nix
+++ b/pkgs/development/libraries/gss/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optional withShishi shishi;
 
   configureFlags = [
-    "--${if withShishi != null then "enable" else "disable"}-kereberos5"
+    "--${if withShishi != null then "enable" else "disable"}-kerberos5"
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/gss/default.nix
+++ b/pkgs/development/libraries/gss/default.nix
@@ -3,10 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gss-1.0.3";
+  pname = "gss";
+  version = "1.0.3";
 
   src = fetchurl {
-    url = "mirror://gnu/gss/${name}.tar.gz";
+    url = "mirror://gnu/gss/${pname}-${version}.tar.gz";
     sha256 = "1syyvh3k659xf1hdv9pilnnhbbhs6vfapayp4xgdcc8mfgf9v4gz";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tried using `gss` as a buildInput and notice the flag typo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
