### PR TITLE
lib: add `removeAll` as alias to `subtractLists`

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -151,6 +151,17 @@ rec {
     # Element to remove from the list
     e: filter (x: x != e);
 
+
+  /* Remove all elements in 'es' from a list. Useful for buildInputs.
+
+     Type: removeAll :: [a] -> [a] -> [a]
+
+     Example:
+       removeAll [ 1 2 ] [ 1 2 3 2 1 ]
+       => [ 3 ]
+  */
+  removeAll = subtractLists;
+
   /* Find the sole element in the list matching the specified
      predicate, returns `default` if no such element exists, or
      `multiple` if there are multiple matching elements.


### PR DESCRIPTION
I constantly find myself looking for a `remove` function that can take a
list of elements to remove, only to not find it and then remember that
`subtractLists` is what I'm looking for.

I figured we could introduce a `removeAll` as an alias to
`subtractLists`, this way users simply grepping for `remove` would hit
the correct function, and also usage when filtering `buildInputs` could
read more naturally.

Alternatively, we could just direct users to `subtractLists` in the
documentation for `remove`.

Not sure what our policy on aliased functions are, hopefuly this is
alright.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
