### PR TITLE
hqplayerd: 4.26.0-67 -> 4.26.2-69

### DIFF
--- a/pkgs/servers/hqplayerd/default.nix
+++ b/pkgs/servers/hqplayerd/default.nix
@@ -8,14 +8,40 @@
 , gcc11
 , gnome
 , gssdp
-, gupnp
 , lib
 , libgmpris
 , llvmPackages_10
 , rpmextract
 , wavpack
-}:
 
+, gupnp
+, gupnp-av
+, meson
+, ninja
+}:
+let
+  # hqplayerd relies on some package versions available for the fc34 release,
+  # which has out-of-date pkgs compared to nixpkgs. The following drvs
+  # can/should be removed when the fc35 hqplayer rpm is made available.
+  gupnp_1_2 = gupnp.overrideAttrs (old: rec {
+    pname = "gupnp";
+    version = "1.2.7";
+    src = fetchurl {
+      url = "mirror://gnome/sources/gupnp/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+      sha256 = "sha256-hEEnbxr9AXbm9ZUCajpQfu0YCav6BAJrrT8hYis1I+w=";
+    };
+  });
+
+  gupnp-av_0_12 = gupnp-av.overrideAttrs (old: rec {
+    pname = "gupnp-av";
+    version = "0.12.11";
+    src = fetchurl {
+      url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+      sha256 = "sha256-aJ3PFJKriZHa6ikTZaMlSKd9GiKU2FszYitVzKnOb9w=";
+    };
+    nativeBuildInputs = lib.subtractLists [ meson ninja ] old.nativeBuildInputs;
+  });
+in
 stdenv.mkDerivation rec {
   pname = "hqplayerd";
   version = "4.26.2-69";
@@ -38,7 +64,8 @@ stdenv.mkDerivation rec {
     gcc11.cc.lib
     gnome.rygel
     gssdp
-    gupnp
+    gupnp_1_2
+    gupnp-av_0_12
     libgmpris
     llvmPackages_10.openmp
     wavpack

--- a/pkgs/servers/hqplayerd/default.nix
+++ b/pkgs/servers/hqplayerd/default.nix
@@ -18,11 +18,11 @@
 
 stdenv.mkDerivation rec {
   pname = "hqplayerd";
-  version = "4.26.0-67";
+  version = "4.26.2-69";
 
   src = fetchurl {
     url = "https://www.signalyst.eu/bins/${pname}/fc34/${pname}-${version}.fc34.x86_64.rpm";
-    sha256 = "sha256-Wbtt1yO/CE2cewOE5RynwEm+fCdOV1cxzR/XiCwj0NU=";
+    sha256 = "sha256-zxUVtOi4fN3EuCbzH/SEse24Qz7/0jozzDX1yW8bhCU=";
   };
 
   unpackPhase = ''


### PR DESCRIPTION
- hqplayerd: 4.26.0-67 -> 4.26.2-69
- hqplayerd: fix gupnp version mismatches with fc34

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
