### PR TITLE
vista-fonts: install cambria.ttc as well

### DIFF
--- a/pkgs/data/fonts/vista-fonts/default.nix
+++ b/pkgs/data/fonts/vista-fonts/default.nix
@@ -14,11 +14,12 @@ stdenvNoCC.mkDerivation {
   unpackPhase = ''
     cabextract --lowercase --filter ppviewer.cab $src
     cabextract --lowercase --filter '*.TTF' ppviewer.cab
+    cabextract --lowercase --filter '*.TTC' ppviewer.cab
   '';
 
   installPhase = ''
     mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
+    cp *.ttf *.ttc $out/share/fonts/truetype
 
     # Set up no-op font configs to override any aliases set up by
     # other packages.


### PR DESCRIPTION
###### Motivation for this change
Before this change, the regular Cambria font was missing and only italic, bold and slanted were available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
