### PR TITLE
entangle: init at 3.0

### DIFF
--- a/pkgs/applications/video/entangle/default.nix
+++ b/pkgs/applications/video/entangle/default.nix
@@ -1,0 +1,125 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, libxml2
+, meson
+, ninja
+, perl
+, python3
+, pkgconf
+, wrapGAppsHook
+, at-spi2-core
+, dbus
+, elfutils
+, epoxy
+, gexiv2
+, glib
+, gobject-introspection
+, gst-plugins-base
+, gstreamer
+, gtk3
+, lcms2
+, libdatrie
+, libgphoto2
+, libgudev
+, libpeas
+, libraw
+, libselinux
+, libsepol
+, libthai
+, libunwind
+, libxkbcommon
+, orc
+, pcre
+, udev
+, util-linux
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "entangle";
+  version = "3.0";
+
+  src = fetchFromGitLab {
+    owner = "entangle";
+    repo = "entangle";
+    rev = "v${version}";
+    sha256 = "hz2WSDOjriQSavFlDT+35x1X5MeInq80ZrSP1WR/td0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    glib.dev
+    libxml2.bin # for xmllint
+    meson
+    ninja
+    perl # for pod2man and build scripts
+    python3 # for build scripts
+    pkgconf
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    at-spi2-core
+    dbus
+    epoxy
+    elfutils
+    gexiv2
+    glib
+    gobject-introspection
+    gst-plugins-base
+    gstreamer
+    gtk3
+    lcms2
+    libdatrie
+    libgphoto2
+    libgudev
+    libpeas
+    libraw
+    libselinux
+    libsepol
+    libthai
+    libunwind
+    libxkbcommon
+    orc
+    pcre
+    udev
+    util-linux
+  ] ++ (with xorg; [
+    libXdmcp
+    libXtst
+  ]);
+
+  dontUseCmakeConfigure = true;
+
+  # Disable building of doc/reference since it requires network connection to render XML to HTML
+  # Patch build script shebangs
+  postPatch = ''
+    sed -i "/subdir('reference')/d" "docs/meson.build"
+    patchShebangs --build build-aux meson_post_install.py
+    sed -i meson_post_install.py \
+      -e "/print('Update icon cache...')/d" \
+      -e "/gtk-update-icon-cache/d"
+  '';
+
+  postInstall = ''
+    substituteInPlace "$out/share/applications/org.entangle_photo.Manager.desktop" \
+      --replace "Exec=entangle" "Exec=$out/bin/entangle"
+  '';
+
+  meta = with lib; {
+    description = "Tethered camera control and capture";
+    longDescription = ''
+      Entangle uses GTK and libgphoto2 to provide a graphical interface
+      for tethered photography with digital cameras.
+      It includes control over camera shooting and configuration settings
+      and 'hands off' shooting directly from the controlling computer.
+      This app can also serve as a camera app for mobile devices.
+    '';
+    homepage = "https://gitlab.com/entangle/entangle";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24505,6 +24505,10 @@ with pkgs;
 
   enhanced-ctorrent = callPackage ../applications/networking/enhanced-ctorrent { };
 
+  entangle = callPackage ../applications/video/entangle {
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  };
+
   eolie = callPackage ../applications/networking/browsers/eolie { };
 
   epdfview = callPackage ../applications/misc/epdfview { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

*Entangle* is a tethered camera controller which enables the photographer to control their camera and take pictures from their computer.

It also runs on mobile Linux phones such as PinePhone and Libriem, according to [LinuxPhoneApps.org](https://linuxphoneapps.org)

It builds and runs. However, it fails to connect to the camera on my laptop, so I'm unable to test the functionality. (Compatibility to different cameras is dependent on `libgphoto2`) It would be great test on Mobile NixOS.

Cc: @samueldr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
