### PR TITLE
python3Packages.pytest-sanic: 1.8.1 -> 1.9.1

### DIFF
--- a/pkgs/development/python-modules/pytest-sanic/default.nix
+++ b/pkgs/development/python-modules/pytest-sanic/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "pytest-sanic";
-  version = "1.8.1";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "yunstanford";
     repo = pname;
     rev = "v${version}";
-    sha256 = "128qxpqilqjhpjzjzzfzsgi4bc0vxwmz0k3xwry6fwhyzcf2bzl5";
+    sha256 = "sha256-82Xq/jyxTXyZVHqn7G+S9K++InDdORCO9oFqgaIgY7s=";
   };
 
   buildInputs = [
@@ -38,33 +38,14 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  postPatch = ''
-    # https://github.com/yunstanford/pytest-sanic/issues/55
-    substituteInPlace setup.py \
-      --replace "websockets>=8.1,<9.0" "websockets>=9.1,<10.0"
-  '';
-
-  disabledTests = [
-    # https://github.com/yunstanford/pytest-sanic/issues/51
-    "test_fixture_sanic_client_get"
-    "test_fixture_sanic_client_post"
-    "test_fixture_sanic_client_put"
-    "test_fixture_sanic_client_delete"
-    "test_fixture_sanic_client_patch"
-    "test_fixture_sanic_client_options"
-    "test_fixture_sanic_client_head"
-    "test_fixture_sanic_client_close"
-    "test_fixture_sanic_client_passing_headers"
-    "test_fixture_sanic_client_context_manager"
-    "test_fixture_test_client_context_manager"
+  pythonImportsCheck = [
+    "pytest_sanic"
   ];
-
-  pythonImportsCheck = [ "pytest_sanic" ];
 
   meta = with lib; {
     description = "A pytest plugin for Sanic";
     homepage = "https://github.com/yunstanford/pytest-sanic/";
     license = licenses.asl20;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.9.1

Change log: https://github.com/yunstanford/pytest-sanic/releases/tag/v1.9.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
