### PR TITLE
libnfc: Fix config file path

### DIFF
--- a/pkgs/development/libraries/libnfc/default.nix
+++ b/pkgs/development/libraries/libnfc/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ libusb-compat-0_1 readline ];
 
+  configureFlags = [ "sysconfdir=/etc" ];
+
   meta = with lib; {
     description = "Open source library libnfc for Near Field Communication";
     license = licenses.gpl3;


### PR DESCRIPTION
###### Motivation for this change

The libnfc was looking for config files in its nix store path. Relevant line from `strace`:

```
openat(AT_FDCWD, "/nix/store/rvmxq2vjj2fp0msq3v3hj12j2fql9qky-libnfc-1.7.1/etc/nfc/libnfc.conf", O_RDONLY) = -1 ENOENT (No such file or directory)
```

Overriding the `sysconfdir` in the derivation fixes the problem. I verified that configuration from `/etc/nfc/libnfc.conf` is loaded correctly when the patch is applied.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of ~~all~~ some binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
