### PR TITLE
your-editor: init at 1203

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11706,6 +11706,13 @@
       fingerprint = "EE59 5E29 BB5B F2B3 5ED2  3F1C D276 FF74 6700 7335";
     }];
   };
+  uniquepointer = {
+    email = "uniquepointer@mailbox.org";
+    matrix = "@uniquepointer:matrix.org";
+    github = "uniquepointer";
+    githubId = 71751817;
+    name = "uniquepointer";
+  };
   unode = {
     email = "alves.rjc@gmail.com";
     matrix = "@renato_alves:matrix.org";

--- a/pkgs/applications/editors/your-editor/default.nix
+++ b/pkgs/applications/editors/your-editor/default.nix
@@ -1,0 +1,36 @@
+{ pkgs, stdenv, fetchFromGitHub, lib, ... }:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "your-editor";
+  version = "1203";
+
+  rev = "608418f2037dc4ef5647e69fcef45302c50f138c";
+  src = fetchFromGitHub {
+    owner = "kammerdienerb";
+    repo = "yed";
+    rev = "608418f";
+    sha256 = "KqK2lcDTn91aCFJIDg+h+QsTrl7745So5aiKCxPkeh4=";
+  };
+
+  buildInputs = [
+  ];
+
+  configurePhase = ''
+    '';
+
+  buildPhase = ''
+    '';
+
+  installPhase = ''
+     patchShebangs install.sh
+    ./install.sh -p $out
+  '';
+
+  meta = with lib; {
+    description = "Your-editor (yed) is a small and simple terminal editor core that is meant to be extended through a powerful plugin architecture.";
+    homepage = "https://your-editor.org/";
+    license = with licenses; [ mit ];
+    platforms = platforms.linux;
+    maintainers = [ uniquepointer ];
+  };
+}

--- a/pkgs/applications/editors/your-editor/default.nix
+++ b/pkgs/applications/editors/your-editor/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Your-editor (yed) is a small and simple terminal editor core that is meant to be extended through a powerful plugin architecture.";
+    description = "Your-editor (yed) is a small and simple terminal editor core that is meant to be extended through a powerful plugin architecture";
     homepage = "https://your-editor.org/";
     license = with licenses; [ mit ];
     platforms = platforms.linux;

--- a/pkgs/applications/editors/your-editor/default.nix
+++ b/pkgs/applications/editors/your-editor/default.nix
@@ -1,29 +1,21 @@
-{ pkgs, stdenv, fetchFromGitHub, lib, ... }:
+{ lib, stdenv, fetchFromGitHub }:
 
-pkgs.stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "your-editor";
   version = "1203";
 
-  rev = "608418f2037dc4ef5647e69fcef45302c50f138c";
   src = fetchFromGitHub {
     owner = "kammerdienerb";
     repo = "yed";
-    rev = "608418f";
+    rev = "608418f2037dc4ef5647e69fcef45302c50f138c";
     sha256 = "KqK2lcDTn91aCFJIDg+h+QsTrl7745So5aiKCxPkeh4=";
   };
 
-  buildInputs = [
-  ];
-
-  configurePhase = ''
-    '';
-
-  buildPhase = ''
-    '';
-
   installPhase = ''
-     patchShebangs install.sh
+    runHook preInstall
+    patchShebangs install.sh
     ./install.sh -p $out
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -31,6 +23,7 @@ pkgs.stdenv.mkDerivation rec {
     homepage = "https://your-editor.org/";
     license = with licenses; [ mit ];
     platforms = platforms.linux;
-    maintainers = [ uniquepointer ];
+    maintainers = with maintainers; [ uniquepointer ];
+    mainProgram = "yed";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29220,6 +29220,8 @@ with pkgs;
 
   yoshimi = callPackage ../applications/audio/yoshimi { };
 
+  your-editor = callPackage ../applications/editors/your-editor { };
+
   youtube-dl = with python3Packages; toPythonApplication youtube-dl;
 
   youtube-dl-light = with python3Packages; toPythonApplication youtube-dl-light;
@@ -33117,8 +33119,6 @@ with pkgs;
   };
 
   yapesdl = callPackage ../misc/emulators/yapesdl { };
-
-  your-editor = callPackage ../applications/editors/your-editor { };
 
   x16-emulator = callPackage ../misc/emulators/commanderx16/emulator.nix { };
   x16-rom = callPackage ../misc/emulators/commanderx16/rom.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33118,6 +33118,8 @@ with pkgs;
 
   yapesdl = callPackage ../misc/emulators/yapesdl { };
 
+  your-editor = callPackage ../applications/editors/your-editor { };
+
   x16-emulator = callPackage ../misc/emulators/commanderx16/emulator.nix { };
   x16-rom = callPackage ../misc/emulators/commanderx16/rom.nix { };
   x16-run = (callPackage ../misc/emulators/commanderx16/run.nix { }) {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding [your-editor(yed)](https://github.com/kammerdienerb/yed) to the nix repos since its mature and has been ready for daily use for a non trivial amount of time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
