### PR TITLE
python3Packages.simple_di: init at 0.1.2

### DIFF
--- a/pkgs/development/python-modules/simple_di/default.nix
+++ b/pkgs/development/python-modules/simple_di/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, setuptools
+, typing-extensions
+, dataclasses
+}:
+
+buildPythonPackage rec {
+  version = "0.1.2";
+  pname = "simple_di";
+  disabled = pythonOlder "3.6.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wqbfbajnwmkzih0jl3mncalr7dslvmwhb5mk11asqvmbp1xhn30";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    typing-extensions
+  ] ++ lib.optional (pythonOlder "3.7") [
+    dataclasses
+  ];
+
+  meta = {
+    description = "Simple dependency injection library";
+    homepage = "https://github.com/bentoml/simple_di";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sauyon ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8450,6 +8450,8 @@ in {
 
   simplekml = callPackage ../development/python-modules/simplekml { };
 
+  simple_di = callPackage ../development/python-modules/simple_di { };
+
   simple-rest-client = callPackage ../development/python-modules/simple-rest-client { };
 
   simple-salesforce = callPackage ../development/python-modules/simple-salesforce { };


### PR DESCRIPTION
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
