### PR TITLE
Revert "calibre: 5.29.0 -> 5.30.0"

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -27,20 +27,19 @@
 
 mkDerivation rec {
   pname = "calibre";
-  version = "5.30.0";
+  version = "5.29.0";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${pname}-${version}.tar.xz";
     sha256 = "sha256-9ymHEpTHDUM3NAGoeSETzKRLKgJLRY4eEli6N5lbZug=";
   };
 
-  # https://sources.debian.org/patches/calibre/5.30.0+dfsg-1
+  # https://sources.debian.org/patches/calibre/5.29.0+dfsg-1
   patches = [
     #  allow for plugin update check, but no calibre version check
     (fetchpatch {
       name = "0001_only_plugin_update.patch";
-      url =
-        "https://sources.debian.org/data/main/c/calibre/${version}%2Bdfsg-1/debian/patches/0001-only-plugin-update.patch";
+      url = "https://sources.debian.org/data/main/c/calibre/5.29.0%2Bdfsg-1/debian/patches/0001-only-plugin-update.patch";
       sha256 = "sha256-aGT8rJ/eQKAkmyHBWdY0ouZuWvDwtLVJU5xY6d3hY3k=";
     })
   ]


### PR DESCRIPTION
Reverts NixOS/nixpkgs#142902

```
error: hash mismatch in fixed-output derivation '/nix/store/jpar1pri8gnig1lvm6qkyfzifz6ay6bn-calibre-5.30.0.tar.xz.drv':
         specified: sha256-9ymHEpTHDUM3NAGoeSETzKRLKgJLRY4eEli6N5lbZug=
            got:    sha256-jvh/JLpMpW2EIlKVFpDJZAL072CWthh0JPQOBjvGDRU=
```

PR didn't update the source hash.