### PR TITLE
sbcl: compile with linkable runtime

### DIFF
--- a/pkgs/development/compilers/sbcl/common.nix
+++ b/pkgs/development/compilers/sbcl/common.nix
@@ -3,6 +3,7 @@
 { lib, stdenv, fetchurl, fetchpatch, writeText, sbclBootstrap
 , sbclBootstrapHost ? "${sbclBootstrap}/bin/sbcl --disable-debugger --no-userinit --no-sysinit"
 , threadSupport ? (stdenv.isi686 || stdenv.isx86_64 || "aarch64-linux" == stdenv.hostPlatform.system || "aarch64-darwin" == stdenv.hostPlatform.system)
+, linkableRuntime ? (stdenv.isi686 || stdenv.isx86_64)
 , disableImmobileSpace ? false
   # Meant for sbcl used for creating binaries portable to non-NixOS via save-lisp-and-die.
   # Note that the created binaries still need `patchelf --set-interpreter ...`
@@ -74,6 +75,7 @@ stdenv.mkDerivation rec {
 
   enableFeatures = with lib;
     optional threadSupport "sb-thread" ++
+    optional linkableRuntime "sb-linkable-runtime" ++
     optional stdenv.isAarch32 "arm";
 
   disableFeatures = with lib;


### PR DESCRIPTION
###### Motivation for this change

Sometimes is useful to have the linkable runtime feature enable, especially when building executable etc. This change should not have any downsides, at least to my knowledge.

Have tested this by building a CLPM application which needed linkable runtime to be enabled. 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
