### PR TITLE
conftest: 0.28.1 -> 0.28.2

### DIFF
--- a/pkgs/development/tools/conftest/default.nix
+++ b/pkgs/development/tools/conftest/default.nix
@@ -1,17 +1,16 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "conftest";
-  version = "0.28.1";
+  version = "0.28.2";
 
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "conftest";
     rev = "v${version}";
-    sha256 = "sha256-o2P14Nsu77AXO+UnMBXthhP3Q7kI7nd/lI6GFE2cs3M=";
+    sha256 = "sha256-lmmk6veBDI51UA/wnFB7Q3DTxZ9J/1qp0OoNgmBrR1Y=";
   };
-
-  vendorSha256 = "sha256-zzckZI/n00BBl166S7uonJFNQ4RJGLCkDyfLRoHZOtA=";
+  vendorSha256 = "sha256-NALyUjFL6OqgCke1QiUxbSNLAoaIMB2zeIWWEfcnCjs=";
 
   ldflags = [
     "-s"
@@ -19,10 +18,22 @@ buildGoModule rec {
     "-X github.com/open-policy-agent/conftest/internal/commands.version=${version}"
   ];
 
-  HOME = "$TMPDIR";
+  nativeBuildInputs = [ installShellFiles ];
+
+  preCheck = ''
+    export HOME="$TMPDIR"
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd conftest \
+      --bash <($out/bin/conftest completion bash) \
+      --fish <($out/bin/conftest completion fish) \
+      --zsh <($out/bin/conftest completion zsh)
+  '';
 
   doInstallCheck = true;
   installCheckPhase = ''
+    export HOME="$TMPDIR"
     $out/bin/conftest --version | grep ${version} > /dev/null
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump conftest to `0.28.2`

Edit: Added completions, resolved removing `HOME = "$TMPDIR"` in favor of doing it within phases (https://github.com/NixOS/nixpkgs/pull/135912)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
