### PR TITLE
lemmy: systemd postgresql setup service cleanup

### DIFF
--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -214,8 +214,6 @@ in
       systemd.services.lemmy-postgresql = mkIf cfg.settings.database.createLocally {
         description = "Lemmy postgresql db";
         after = [ "postgresql.service" ];
-        bindsTo = [ "postgresql.service" ];
-        requiredBy = [ "lemmy.service" ];
         partOf = [ "lemmy.service" ];
         script = with cfg.settings.database; ''
           PSQL() {


### PR DESCRIPTION
###### Motivation for this change

reading more about systemd attributes I realised those 2 don't make sense.
bindstTo is a stronger form of require that will stop the dependent when the upstream service stops.
Since this is just for a database initialisation service that is not continually running, it doesn't make sense here.
requiredBy is usually not specified directly, so just removing it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
