### PR TITLE
Revert "vte: 0.64.2 → 0.66.0"

### DIFF
--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vte";
-  version = "0.66.0";
+  version = "0.64.2";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-0IE6wA+x102IhR52X3VdSWyD4JcJc1jqG6rbOLN7ezM=";
+    sha256 = "sha256-KzyCC2WmZ8HYhZuiBHi+Ym0VGcwxWdrCX3AzMMbQfhg=";
   };
 
   patches = [


### PR DESCRIPTION
This reverts commit 453edd71bfc0a7f56ad6e8969d80945ad1cc3c23.

It refuses to build with gcc9; that's the default on aarch64-linux,
and it would block the nixos-unstable channel.  Discussion:
https://github.com/NixOS/nixpkgs/pull/142731#commitcomment-58711525

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
