### PR TITLE
linuxPackages.rr-zen_workaround: set meta.broken

### DIFF
--- a/pkgs/development/tools/analysis/rr/zen_workaround.nix
+++ b/pkgs/development/tools/analysis/rr/zen_workaround.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.vcunat ];
     platforms = platforms.linux;
+    broken = versionOlder kernel.version "4.19"; # 4.14 breaks and 4.19 works
   };
 }


### PR DESCRIPTION
... on kernels that are too old for the code to build.
I could have thought of this straight away.

###### Things done
(the stuff doesn't really apply here)

https://hydra.nixos.org/eval/1716138?filter=rr-zen_workaround
