### PR TITLE
ocamlPackages.mrmime: init 0.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/coin/default.nix
+++ b/pkgs/development/ocaml-modules/coin/default.nix
@@ -1,0 +1,38 @@
+{ buildDunePackage
+, fetchzip
+, findlib
+, lib
+, menhir
+, ocaml
+, re
+}:
+
+buildDunePackage rec {
+  pname = "coin";
+  version = "0.1.3";
+  minimalOCamlVersion = "4.03";
+
+  src = fetchzip {
+    url = "https://github.com/mirage/coin/releases/download/v${version}/coin-v${version}.tbz";
+    sha256 = "06bfidvglyp9hzvr2xwbdx8wf26is2xrzc31fldzjf5ab0vd076p";
+  };
+
+  postPatch = ''
+    substituteInPlace src/dune --replace 'ocaml} ' \
+      'ocaml} -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib '
+  '';
+
+  useDune2 = true;
+
+  nativeBuildInputs = [ menhir ];
+
+  checkInputs = [ re ];
+  doCheck = true;
+
+  meta = {
+    description = "A library to normalize an KOI8-{U,R} input to Unicode";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/mirage/coin";
+    maintainers = with lib.maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/ocaml-modules/mrmime/default.nix
+++ b/pkgs/development/ocaml-modules/mrmime/default.nix
@@ -1,0 +1,77 @@
+{ afl-persistent
+, alcotest
+, angstrom
+, base64
+, bigarray-compat
+, bigarray-overlap
+, bigstringaf
+, buildDunePackage
+, emile
+, fetchzip
+, fmt
+, fpath
+, hxd
+, ipaddr
+, jsonm
+, ke
+, lib
+, mirage-crypto-rng
+, pecu
+, prettym
+, ptime
+, rosetta
+, rresult
+, unstrctrd
+, uutf
+}:
+
+buildDunePackage rec {
+  pname = "mrmime";
+  version = "0.5.0";
+
+  src = fetchzip {
+    url = "https://github.com/mirage/mrmime/releases/download/v${version}/mrmime-v${version}.tbz";
+    sha256 = "14k67v0b39b8jq3ny2ymi8g8sqx2gd81mlzsjphdzdqnlx6fk716";
+  };
+
+  useDune2 = true;
+
+  buildInputs = [
+    afl-persistent
+    bigarray-compat
+    bigarray-overlap
+    bigstringaf
+    fpath
+    mirage-crypto-rng
+  ];
+
+  propagatedBuildInputs = [
+    angstrom
+    base64
+    emile
+    fmt
+    ipaddr
+    ke
+    pecu
+    prettym
+    ptime
+    rosetta
+    rresult
+    unstrctrd
+    uutf
+  ];
+
+  checkInputs = [
+    alcotest
+    hxd
+    jsonm
+  ];
+  doCheck = true;
+
+  meta = {
+    description = "Parser and generator of mail in OCaml";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/mirage/mrmime";
+    maintainers = with lib.maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/ocaml-modules/prettym/default.nix
+++ b/pkgs/development/ocaml-modules/prettym/default.nix
@@ -1,0 +1,48 @@
+{ alcotest
+, base64
+, bigarray-compat
+, bigarray-overlap
+, bigstringaf
+, buildDunePackage
+, fetchzip
+, fmt
+, jsonm
+, ke
+, lib
+, ptime
+}:
+
+buildDunePackage rec {
+  pname = "prettym";
+  version = "0.0.2";
+
+  src = fetchzip {
+    url = "https://github.com/dinosaure/prettym/releases/download/${version}/prettym-${version}.tbz";
+    sha256 = "03x7jh62mvzc6x2d8xsy456qa6iphw72zm7jmqrakpmsy6zcf2lb";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    bigarray-compat
+    bigarray-overlap
+    bigstringaf
+    fmt
+    ke
+  ];
+
+  checkInputs = [
+    ptime
+    alcotest
+    jsonm
+    base64
+  ];
+  doCheck = true;
+
+  meta = {
+    description = "A simple bounded encoder to serialize human readable values and respect the 80-column constraint";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/dinosaure/prettym";
+    maintainers = with lib.maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/ocaml-modules/rosetta/default.nix
+++ b/pkgs/development/ocaml-modules/rosetta/default.nix
@@ -1,0 +1,34 @@
+{ buildDunePackage
+, coin
+, fetchzip
+, lib
+, yuscii
+, uuuu
+}:
+
+buildDunePackage rec {
+  pname = "rosetta";
+  version = "0.3.0";
+
+  src = fetchzip {
+    url = "https://github.com/mirage/rosetta/releases/download/v${version}/rosetta-v${version}.tbz";
+    sha256 = "1gzp3fbk8qd207cm25dgj9kj7b44ldqpjs63pl6xqvi9hx60m3ij";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    coin
+    uuuu
+    yuscii
+  ];
+
+  doCheck = false; # No tests.
+
+  meta = {
+    description = "Universal decoder of an encoded flow (UTF-7, ISO-8859 and KOI8) to Unicode";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/mirage/rosetta";
+    maintainers = with lib.maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/ocaml-modules/unstrctrd/default.nix
+++ b/pkgs/development/ocaml-modules/unstrctrd/default.nix
@@ -1,0 +1,48 @@
+{ alcotest
+, angstrom
+, bigstringaf
+, buildDunePackage
+, crowbar
+, fetchzip
+, fmt
+, hxd
+, ke
+, lib
+, rresult
+, uutf
+}:
+
+buildDunePackage rec {
+  pname = "unstrctrd";
+  version = "0.3";
+
+  src = fetchzip {
+    url = "https://github.com/dinosaure/unstrctrd/releases/download/v${version}/unstrctrd-v${version}.tbz";
+    sha256 = "0mjm4v7kk75iwwsfnpmxc3bsl8aisz53y7z21sykdp60f4rxnah7";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    angstrom
+    uutf
+  ];
+
+  checkInputs = [
+    alcotest
+    bigstringaf
+    crowbar
+    fmt
+    hxd
+    ke
+    rresult
+  ];
+  doCheck = true;
+
+  meta = {
+    description = "A library for parsing email headers";
+    homepage = "https://github.com/dinosaure/unstrctrd";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/ocaml-modules/uuuu/default.nix
+++ b/pkgs/development/ocaml-modules/uuuu/default.nix
@@ -1,0 +1,40 @@
+{ angstrom
+, buildDunePackage
+, fetchzip
+, findlib
+, lib
+, menhir
+, ocaml
+, re
+}:
+
+buildDunePackage rec {
+  pname = "uuuu";
+  version = "0.2.0";
+
+  src = fetchzip {
+    url = "https://github.com/mirage/uuuu/releases/download/v${version}/uuuu-v${version}.tbz";
+    sha256 = "0457qcxvakbbc56frsh8a5v4y4l0raj9p4zz7jx3brn9255j1mw3";
+  };
+
+  postPatch = ''
+    substituteInPlace src/dune --replace 'ocaml} ' \
+      'ocaml} -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib '
+  '';
+
+  useDune2 = true;
+
+  nativeBuildInputs = [ menhir ];
+
+  buildInputs = [ angstrom ];
+
+  checkInputs = [ re ];
+  doCheck = true;
+
+  meta = {
+    description = "A library to normalize an ISO-8859 input to Unicode code-point";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/mirage/uuuu";
+    maintainers = with lib.maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/development/ocaml-modules/yuscii/default.nix
+++ b/pkgs/development/ocaml-modules/yuscii/default.nix
@@ -1,0 +1,33 @@
+{ alcotest
+, buildDunePackage
+, fetchzip
+, fmt
+, lib
+, uutf
+}:
+
+buildDunePackage rec {
+  pname = "yuscii";
+  version = "0.3.0";
+
+  src = fetchzip {
+    url = "https://github.com/mirage/yuscii/releases/download/v${version}/yuscii-v${version}.tbz";
+    sha256 = "0idywlkw0fbakrxv65swnr5bj7f2vns9kpay7q03gzlv82p670hy";
+  };
+
+  useDune2 = true;
+
+  checkInputs = [
+    alcotest
+    fmt
+    uutf
+  ];
+  doCheck = true;
+
+  meta = {
+    description = "A simple mapper between UTF-7 to Unicode according RFC2152";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/mirage/yuscii";
+    maintainers = with lib.maintainers; [ superherointj ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1178,6 +1178,8 @@ let
 
     ppx_yojson_conv_lib = callPackage ../development/ocaml-modules/ppx_yojson_conv_lib {};
 
+    prettym = callPackage ../development/ocaml-modules/prettym { };
+
     printbox = callPackage ../development/ocaml-modules/printbox { };
 
     process = callPackage ../development/ocaml-modules/process { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1361,6 +1361,8 @@ let
 
     stdint = callPackage ../development/ocaml-modules/stdint { };
 
+    unstrctrd = callPackage ../development/ocaml-modules/unstrctrd { };
+
     uucd = callPackage ../development/ocaml-modules/uucd { };
     uucp = callPackage ../development/ocaml-modules/uucp { };
     uunf = callPackage ../development/ocaml-modules/uunf { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -195,6 +195,8 @@ let
 
     conduit-mirage = callPackage ../development/ocaml-modules/conduit/mirage.nix { };
 
+    coin =  callPackage ../development/ocaml-modules/coin { };
+
     config-file = callPackage ../development/ocaml-modules/config-file { };
 
     containers = callPackage ../development/ocaml-modules/containers { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1416,6 +1416,8 @@ let
 
     yojson = callPackage ../development/ocaml-modules/yojson { };
 
+    yuscii = callPackage ../development/ocaml-modules/yuscii { };
+
     z3 = callPackage ../development/ocaml-modules/z3 {
       inherit (pkgs) z3;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1368,6 +1368,8 @@ let
     uuseg = callPackage ../development/ocaml-modules/uuseg { };
     uutf = callPackage ../development/ocaml-modules/uutf { };
 
+    uuuu = callPackage ../development/ocaml-modules/uuuu { };
+
     variantslib_p4 = callPackage ../development/ocaml-modules/variantslib { };
 
     vchan = callPackage ../development/ocaml-modules/vchan { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -822,6 +822,8 @@ let
 
     mparser-pcre =  callPackage ../development/ocaml-modules/mparser/pcre.nix { };
 
+    mrmime = callPackage ../development/ocaml-modules/mrmime { };
+
     mtime =  callPackage ../development/ocaml-modules/mtime { };
 
     mustache =  callPackage ../development/ocaml-modules/mustache { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1237,6 +1237,8 @@ let
 
     rope = callPackage ../development/ocaml-modules/rope { };
 
+    rosetta = callPackage ../development/ocaml-modules/rosetta { };
+
     routes = callPackage ../development/ocaml-modules/routes { };
 
     rpclib = callPackage ../development/ocaml-modules/rpclib { };


### PR DESCRIPTION
* ocamlPackages.`mrmime`: init 0.5
  * ocamlPackages.`unstrctrd`: init 0.3
  * ocamlPackages.`prettym`: init 0.0.2
  * ocamlPackages.`rosetta`: init 0.3.0
    - ocamlPackages.`yuscii`: init 0.3.0
    - ocamlPackages.`uuuu`: init 0.2.0
    - ocamlPackages.`coin`: init 0.1.3

Pending:
* Package naming:
  IMO package naming should follow `opam` first. I can change it to whatever is decided. But I think we should strive for consistency. And right now we don't have it.
  Affecting:
  - mirage/coin
  - mirage/mrmime
  - mirage/rosetta
  - mirage/uuuu
  - mirage/yuscii

Notes:
* To test package versions:
```
NIX_PATH=$HOME/git/ nix-shell -p  \
    ocaml-ng.ocamlPackages_4_13.findlib \
    ocaml-ng.ocamlPackages_4_13.mrmime \
    ocaml-ng.ocamlPackages_4_13.prettym \
    ocaml-ng.ocamlPackages_4_13.unstrctrd \
    ocaml-ng.ocamlPackages_4_13.rosetta \
    ocaml-ng.ocamlPackages_4_13.coin \
    ocaml-ng.ocamlPackages_4_13.uuuu \
    ocaml-ng.ocamlPackages_4_13.yuscii \
    --run 'ocamlfind list' \
    | grep -e coin -e uuuu -e yuscii -e rosetta -e unstrctrd -e prettym -e mrmime
```
Result:
```
coin                (version: 0.1.3)
mrmime              (version: 0.5.0)
prettym             (version: 0.0.2)
rosetta             (version: 0.3.0)
unstrctrd           (version: 0.3)
unstrctrd.parser    (version: 0.3)
uuuu                (version: 0.2.0)
yuscii              (version: 0.3.0)
``` 

* nixpkgs-review pr 142950
```
7 packages built:
ocamlPackages.coin ocamlPackages.mrmime ocamlPackages.prettym ocamlPackages.rosetta ocamlPackages.unstrctrd ocamlPackages.uuuu ocamlPackages.yuscii
```