### PR TITLE
kubescape: 1.0.126 -> 1.0.127

### DIFF
--- a/pkgs/tools/security/kubescape/default.nix
+++ b/pkgs/tools/security/kubescape/default.nix
@@ -1,28 +1,47 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
-}:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "kubescape";
-  version = "1.0.126";
+  version = "1.0.127";
 
   src = fetchFromGitHub {
     owner = "armosec";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-kx7TgQ+ordlgYfnlt9/KkmTMUwfykGnTOEcTtq7EAYA=";
+    sha256 = "sha256-01k0FJNWrLnwOGa4JgQ/HKSJNgWAzmBUWFhdPi/yPY4=";
   };
+  vendorSha256 = "sha256-cOxjsujlpRbdw4098eMHe2oNAJXWGjKbPeYpKt0DCp8=";
 
-  vendorSha256 = "sha256-u9Jo3/AdW+AhVe/5RwAPfLIjp+H1Omb1SlpctOEQB5Q=";
+  ldflags = [ "-s" "-w" "-X github.com/armosec/kubescape/clihandler/cmd.BuildNumber=v${version}" ];
 
-  # One test is failing, disabling for now
-  doCheck = false;
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    # Running kubescape to generate completions outputs error warnings
+    # but does not crash and completes successfully
+    # https://github.com/armosec/kubescape/issues/200
+    installShellCompletion --cmd kubescape \
+      --bash <($out/bin/kubescape completion bash) \
+      --fish <($out/bin/kubescape completion fish) \
+      --zsh <($out/bin/kubescape completion zsh)
+  '';
 
   meta = with lib; {
     description = "Tool for testing if Kubernetes is deployed securely";
     homepage = "https://github.com/armosec/kubescape";
+    changelog = "https://github.com/armosec/kubescape/releases/tag/v${version}";
+    longDescription = ''
+      Kubescape is the first open-source tool for testing if Kubernetes is
+      deployed securely according to multiple frameworks: regulatory, customized
+      company policies and DevSecOps best practices, such as the NSA-CISA and
+      the MITRE ATT&CK®.
+      Kubescape scans K8s clusters, YAML files, and HELM charts, and detect
+      misconfigurations and software vulnerabilities at early stages of the
+      CI/CD pipeline and provides a risk score instantly and risk trends over
+      time. Kubescape integrates natively with other DevOps tools, including
+      Jenkins, CircleCI and Github workflows.
+    '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; [ fab jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump kubescape to `1.0.127`

Also:

- re-enable now ok tests
- add ldflags for smaller build (`45 MB` -> `40 MB`) and version
- add completions
- add some meta info
- add myself as  a maintainer

@fabaff

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
