### PR TITLE
gnomeExtensions.easyScreenCast: unstable-2020-11-25 -> 1.4.0

### DIFF
--- a/pkgs/desktops/gnome/extensions/EasyScreenCast/default.nix
+++ b/pkgs/desktops/gnome/extensions/EasyScreenCast/default.nix
@@ -2,14 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-EasyScreenCast";
-  version = "unstable-2020-11-25";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
-    # To make it work with gnome 3.38, using effectively: https://github.com/EasyScreenCast/EasyScreenCast/pull/276
-    owner = "Ian2020";
+    owner = "EasyScreenCast";
     repo = "EasyScreenCast";
-    rev = "b1ab4a999bc7110ecbf68b5fe42c37fa67d7cb0d";
-    sha256 = "s9b0ITKUzgG6XOd1bK7i3mGxfc+T+UHrTZhBp0Ff8zQ=";
+    rev = version;
+    sha256 = "sha256-+lh/hqYC9+DUvLE016KuAY4Ybw8KrqEEG7WG4pUbg2k=";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).