### PR TITLE
ckb-next: fix audio by adding libpulseaudio

### DIFF
--- a/pkgs/tools/misc/ckb-next/default.nix
+++ b/pkgs/tools/misc/ckb-next/default.nix
@@ -1,6 +1,6 @@
 { lib, mkDerivation, fetchFromGitHub, substituteAll, udev, stdenv
 , pkg-config, qtbase, cmake, zlib, kmod, libXdmcp, qttools, qtx11extras, libdbusmenu
-, enableLibpulseaudio ? stdenv.isLinux, libpulseaudio
+, withPulseaudio ? stdenv.isLinux, libpulseaudio
 }:
 
 mkDerivation rec {

--- a/pkgs/tools/misc/ckb-next/default.nix
+++ b/pkgs/tools/misc/ckb-next/default.nix
@@ -1,6 +1,7 @@
 { lib, mkDerivation, fetchFromGitHub, substituteAll, udev, stdenv
 , pkg-config, qtbase, cmake, zlib, kmod, libXdmcp, qttools, qtx11extras, libdbusmenu
-, enableLibpulseaudio ? stdenv.isLinux, libpulseaudio ? null }:
+, enableLibpulseaudio ? stdenv.isLinux, libpulseaudio
+}:
 
 mkDerivation rec {
   version = "0.4.4";

--- a/pkgs/tools/misc/ckb-next/default.nix
+++ b/pkgs/tools/misc/ckb-next/default.nix
@@ -22,7 +22,7 @@ mkDerivation rec {
     qttools
     qtx11extras
     libdbusmenu
-  ] ++ lib.optional enableLibpulseaudio libpulseaudio;
+  ] ++ lib.optional withPulseaudio libpulseaudio;
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/misc/ckb-next/default.nix
+++ b/pkgs/tools/misc/ckb-next/default.nix
@@ -1,5 +1,6 @@
-{ lib, mkDerivation, fetchFromGitHub, substituteAll, udev
-, pkg-config, qtbase, cmake, zlib, kmod, libXdmcp, qttools, qtx11extras, libdbusmenu }:
+{ lib, mkDerivation, fetchFromGitHub, substituteAll, udev, stdenv
+, pkg-config, qtbase, cmake, zlib, kmod, libXdmcp, qttools, qtx11extras, libdbusmenu
+, enableLibpulseaudio ? stdenv.isLinux, libpulseaudio ? null }:
 
 mkDerivation rec {
   version = "0.4.4";
@@ -20,7 +21,7 @@ mkDerivation rec {
     qttools
     qtx11extras
     libdbusmenu
-  ];
+  ] ++ lib.optional enableLibpulseaudio libpulseaudio;
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
This fixes audio by adding libpulseaudio.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Without this change, ckb-next doesn't support proper audio detection; e.g. the mute light does not work. This also adds a flag to turn off libpulseaudio inclusion in the package (enableLibpulseaudio).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
