### PR TITLE
python3Packages.pygls: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/pygls/default.nix
+++ b/pkgs/development/python-modules/pygls/default.nix
@@ -36,6 +36,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  # Fixes hanging tests on Darwin
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [ "pygls" ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Fixes the Darwin build for pygls, which indirectly fixes the Darwin build for cmake-language-server.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).