### PR TITLE
notcurses: 2.4.2 -> 2.4.8

### DIFF
--- a/pkgs/development/libraries/notcurses/default.nix
+++ b/pkgs/development/libraries/notcurses/default.nix
@@ -6,7 +6,6 @@
 , ncurses
 , zlib
 , ffmpeg
-, readline
 , fetchFromGitHub
 , lib
 , multimediaSupport ? true
@@ -14,20 +13,20 @@
 
 stdenv.mkDerivation rec {
   pname = "notcurses";
-  version = "2.4.2";
+  version = "2.4.8";
 
   src = fetchFromGitHub {
     owner = "dankamongmen";
     repo = "notcurses";
     rev = "v${version}";
-    sha256 = "sha256-EtHyxnTH2bVoVnWB9wvmF/nCdecvL1TTiVRaajFVC/0=";
+    sha256 = "sha256-d06971005e4cf637cc90a694323c580791d1450a77b1700ae8deb453678d3243";
   };
 
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake pkg-config pandoc ];
 
-  buildInputs = [ libunistring ncurses readline zlib ]
+  buildInputs = [ libunistring ncurses zlib ]
     ++ lib.optional multimediaSupport ffmpeg;
 
   cmakeFlags = [ "-DUSE_QRCODEGEN=OFF" ]

--- a/pkgs/development/libraries/notcurses/default.nix
+++ b/pkgs/development/libraries/notcurses/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "dankamongmen";
     repo = "notcurses";
     rev = "v${version}";
-    sha256 = "sha256-d06971005e4cf637cc90a694323c580791d1450a77b1700ae8deb453678d3243";
+    sha256 = "sha256-mVSToryo7+zW1mow8eJT8GrXYlGe/BeSheJtJDKAgzo=";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18577,9 +18577,7 @@ with pkgs;
 
   notify-sharp = callPackage ../development/libraries/notify-sharp { };
 
-  notcurses = callPackage ../development/libraries/notcurses {
-    readline = readline81;
-  };
+  notcurses = callPackage ../development/libraries/notcurses { };
 
   ncurses5 = ncurses.override {
     abiVersion = "5";


### PR DESCRIPTION
###### Motivation for this change

[Notcurses 2.4.8](https://github.com/dankamongmen/notcurses/releases/tag/v2.4.8) is a solid release, with many new features and bugfixes with respect to 2.4.2. As noted below, readline is no longer used, and has been removed from the specification.

Release notes since 2.4.2 (there was no 2.4.6):
https://github.com/dankamongmen/notcurses/releases/tag/v2.4.8
https://github.com/dankamongmen/notcurses/releases/tag/v2.4.7
https://github.com/dankamongmen/notcurses/releases/tag/v2.4.5
https://github.com/dankamongmen/notcurses/releases/tag/v2.4.4
https://github.com/dankamongmen/notcurses/releases/tag/v2.4.3

Alternative format:

* 2.4.8 (2021-10-23)
  * Added new functions `notcurses_canpixel()` and `notcurses_osversion()`.
  * `notcurses_get()` now evaluates its timeout against `CLOCK_MONOTONIC`
    instead of `CLOCK_REALTIME`.
  * `SIGBUS` is now included among the signals for which a handler is
    by default installed.

* 2.4.7 (2021-10-16)
  * Features 1, 2, and 8 of the Kitty keyboard protocol are now supported. This
    provides much more detailed and fine-grained keyboard reports, including
    key repeat and release events, and modifier events (i.e. pressing Shift by
    itself now generates an event; it is not required to press another key
    along with the modifier). Only Kitty supports this protocol at this time.
  * `XTMODKEYS` is now used where supported. This is essentially a subset of
    the Kitty protocol discussed above.
  * In the absence of any `XTSMGRAPHICS` replies, advertising feature 4 in a
    DA1 response will be considered as claiming support for Sixel with 256
    color registers. If you're a terminal author, please do `XTSMGRAPHICS`.
    Actually, please implement the vastly superior Kitty graphics protocol.
  * `ncvisualplane_create()` now allows for a new pile to be created, by
    passing a `NULL` ancestor `ncplane` in `vopts`. The first argument is
    now a `struct notcurses*` rather than a `struct ncplane*`.
  * `ncvisual_render()` has been deprecated in favor of the new function
    `ncvisual_blit()`. When a `NULL` `vopts->n` is passed to `ncvisual_blit()`,
    a new plane is created (as it was in `ncvisual_render()`), but that plane
    is the root of a new pile, rather than a child of the standard plane.
    The only tricky conversion is if you previously had `vopts.n` as `NULL`,
    and were not using `NCVISUAL_OPTION_CHILDPLANE` (or were passing `NULL`
    as `vopts`). This would result in a new plane bound to the standard plane
    with `ncvisual_render()`, but with `ncvisual_blit()` it will create a new
    pile. To keep the behavior, explicitly pass the standard plane as
    `vopts->n`, and include `NCVISUAL_OPTION_CHILDPLANE` in `vopts->flags`.
    All other cases will continue to work as they did before.

* 2.4.5 (2021-10-06)
  * The poorly-considered function `ncplane_boundlist()`, added in 2.3.17, has
    been removed, having never ought have been born.
  * Added functions `ncplane_move_family_top()`, `ncplane_move_family_bottom()`,
    `ncplane_move_family_above()`, and `ncplane_move_family_below()`.
  * Added functions `ncplane_set_name()` and `ncplane_name()`.

* 2.4.4 (2021-10-03)
  * Notcurses no longer uses libreadline, as it was realized to be incompatible
    with the new input system. `ncdirect_readline()` has been rewritten to
    work without libreadline, which means it's now always available (readline
    was an optional dependency). `NCDIRECT_OPTION_INHIBIT_CBREAK` should *not*
    be used with `ncdirect_readline()`, or else it can't implement line-editing
    keybindings.
  * Helper function `ncwcsrtombs()` is now available for converting a
    `wchar_t *` to a heap-allocated UTF-8 `char *`. 
  * Building without a C++ compiler is now supported using `-DUSE_CPP=off`. See
    the FAQs for restrictions.

* 2.4.3 (2021-09-26)
  * `ncplane_erase_region()` has been made much more general, and can now
    operate relative to the current cursor.
  * Several terminal emulators have recently changed their semantics regarding
    DECSDM. These changes correctly match the real VT340 behavior.
    Unfortunately, this means we always draw Sixels in the upper left corner of
    the screen. Code has been added to deal with XTerm 369, the ayosec/graphics
    branch of Alacritty 15.1, foot 1.8.2, and MinTTY 3.5.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
