### PR TITLE
tree-sitter: update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "52ad1d506debcd4623d641339f8f452e6ea8f10c",
-  "date": "2021-09-23T08:24:24+01:00",
-  "path": "/nix/store/ag2r3d659gj14hgfgdf0nv5dwcihxy3w-tree-sitter-c-sharp",
-  "sha256": "1n8jnw2yp966svkcyh68wwwbqjhrvhykzxilj6k8rn5yx9lpymz5",
+  "rev": "1b01d838cc2c0435eef59bc4ee9d0c77eea458d0",
+  "date": "2021-10-07T21:04:41+01:00",
+  "path": "/nix/store/ghx94r76acsnz4q11nhvfwf4pmslpwz8-tree-sitter-c-sharp",
+  "sha256": "03in0smvj6f12mmc744nk772myhrd5qjswfad1vvmmhd50y35ygx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "a7652fce5943c9d5d9c49dd8e3256a699aa33bf5",
-  "date": "2021-09-24T15:54:22-05:00",
-  "path": "/nix/store/9q4xnklmv1220yjgwdz96qf0l8swx2j6-tree-sitter-cpp",
-  "sha256": "10dbif87axvban83mglvh81gjckbp7qya0rf525s10h8ihy7rbpm",
+  "rev": "f44509141e7e483323d2ec178f2d2e6c0fc041c1",
+  "date": "2021-10-25T11:23:25-07:00",
+  "path": "/nix/store/v6034ry75lfdwsiqydff601zla6xb7a2-tree-sitter-cpp",
+  "sha256": "0hxcpdvyyig8njga1mxp4qcnbbnr1d0aiy27vahijwbh98b081nr",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/rydesun/tree-sitter-dot",
-  "rev": "3a32e207e126a7f1cdd17de2473db1f03e6a3dac",
-  "date": "2021-10-05T10:30:04+08:00",
-  "path": "/nix/store/zz4sj2r6jyl7k4l7g8qggr0gv4wh5nx7-tree-sitter-dot",
-  "sha256": "17j8spga68y40fy2yizpkx7bmxp7h5p9l334w2b0685w2mnvrlgg",
+  "rev": "92877bac7033e409ccfb3f07fe28ef1dfd359457",
+  "date": "2021-10-13T19:28:51+08:00",
+  "path": "/nix/store/h3dyw3kcgw77lma750wjgr1n8pjllxn6-tree-sitter-dot",
+  "sha256": "1l8g348nqqil7lygkhzw1ydwf3q2m5786qddp1f9jg1bdrv9p8rl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "2efe37f92d2e6aeb25186e9da07455bb4a30163c",
-  "date": "2021-05-04T14:05:05-07:00",
-  "path": "/nix/store/bzljwaraqj6zqpq85cz9xb0vwh7c10yj-tree-sitter-java",
-  "sha256": "09v3xg1356ghc2n0yi8iqkp80lbkav0jpfgz8iz2j1sl7ihbvkyw",
+  "rev": "ed3a87f750b1d1d533f15ab93fef3e1f5a46e234",
+  "date": "2021-10-17T09:05:07+02:00",
+  "path": "/nix/store/crd0zzw31hx5jw7m95dvpssr3pi60k5l-tree-sitter-java",
+  "sha256": "14qwmpm7dzqwby59vy1nhyddfz2lpf69ajr65s7qaqh0jcs6rs19",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
@@ -1,9 +1,10 @@
 {
-  "url": "https://github.com/nvim-neorg/tree-sitter-norg.git",
-  "rev": "84949f0c05195907c416cb7d02cf1369b9458b5f",
-  "date": "2021-09-25T17:47:36+00:00",
-  "path": "/nix/store/wa653ml1ajl8923f4am505asxwvsxbzq-tree-sitter-norg",
-  "sha256": "07pzz9acg01r4yyws6savprjn3pccyylx6vq8q9lvrp76pnflks4",
+  "url": "https://github.com/nvim-neorg/tree-sitter-norg",
+  "rev": "ff9ba2caf2c600f327370d516464d3222b9aa1f0",
+  "date": "2021-10-14T12:18:22+02:00",
+  "path": "/nix/store/4142dr4yy1jnbs7lf5kqmsn0rwyr1q7y-tree-sitter-norg",
+  "sha256": "0n74ad636p8q046sw94jxmfd640vabnzqzqjbqypyfw4fx95zwkj",
+  "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "31550c1506b2033c5631cd18886edd600b67861e",
-  "date": "2021-09-27T11:44:23-07:00",
-  "path": "/nix/store/bls6gpbwqacgz7hr900khlfhbal29y27-tree-sitter-php",
-  "sha256": "1qykyziapwmw5qhd5svawzksp4w9hjdql84d7lqs3w0dfa60bjax",
+  "rev": "435fa00006c0d1515c37fbb4dd6a9de284af75ab",
+  "date": "2021-10-17T09:05:36+02:00",
+  "path": "/nix/store/0vgi25jrbc6fks97sxkya80dvwa0gzbk-tree-sitter-php",
+  "sha256": "05k4h58gi616gv41r0qqdb1x4rs8y94vghn2r10yczisgzq4vbad",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "449b6baa6b1cd0c2403636459af1571e075dbaa8",
-  "date": "2021-08-31T13:42:29-07:00",
-  "path": "/nix/store/8m3s0ndhmns8435g2mlbcz9sdbqgmjz7-tree-sitter-scala",
-  "sha256": "1lmiljsd5irzc0pabxdcjgfq98xyqm76fracglq68p106mngia07",
+  "rev": "0a3dd53a7fc4b352a538397d054380aaa28be54c",
+  "date": "2021-10-10T10:34:22-07:00",
+  "path": "/nix/store/mys098cdap3mdp6x4qwlk7b9v84998b0-tree-sitter-scala",
+  "sha256": "1lwyipn5b36fskr8cm60qjblj2chf8336zkqbsifq49z1lj0wvpi",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "ef6ee5b39d6c4660809a61c1c8556fb547283864",
-  "date": "2021-10-04T11:58:33-05:00",
-  "path": "/nix/store/ny8gc7l6hpa4snhccyw3149f7s92071l-tree-sitter-typescript",
-  "sha256": "1gyim8yackz9pq6s62wrywr3gsgwa68jwvd0s6i28xxvln2r7wlb",
+  "rev": "11f8f151327e99361c1ff6764599daeef8633615",
+  "date": "2021-10-21T09:23:26-07:00",
+  "path": "/nix/store/r7vpx7g7d1hdxzqyigmr3v9yp5cmmzsg-tree-sitter-typescript",
+  "sha256": "18gk00glysqapys883hq9v33ca9x6nzgy8lk26wa5pip3spzcsm0",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "fd7bc35927ab44670e02d5ad035e0363f4ffde2b",
-  "date": "2021-09-27T15:41:51+02:00",
-  "path": "/nix/store/q2z07daw81cgn15z79qsfdqc2jc8ib9l-tree-sitter-viml",
-  "sha256": "0s1bp1c8p2ify67x49fv9wh0brn98lix3742zlds892985xl9zrj",
+  "rev": "1d23679256edb241ebed8da1247e340bf9e0c0ad",
+  "date": "2021-10-18T11:21:06+02:00",
+  "path": "/nix/store/5a4kihij5jcdpn73i3m7av82k4pvvzpy-tree-sitter-viml",
+  "sha256": "1660y9n1s76xcv0z27kzbbsr9bdv4c4xakzglzhl7z7qcylxg2rr",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/maxxnino/tree-sitter-zig",
-  "rev": "1f27fd1dfe7f352408f01b4894c7825f3a1d6c47",
-  "date": "2021-09-20T17:51:34+09:00",
-  "path": "/nix/store/c4slv3kpl9dxi2fn6nbhar098ikpfivf-tree-sitter-zig",
-  "sha256": "1sbxvn400wizwwgjw7qcxb0z9gazvzcp3z2986lblff2xw8759vw",
+  "rev": "63e8a11f1858c7351a299223b231c8134ed61612",
+  "date": "2021-10-13T22:25:30+09:00",
+  "path": "/nix/store/2dy3wrmjss5mnmdv6xf50cjj3k9bfpp0-tree-sitter-zig",
+  "sha256": "1izvw3dv5ydklqlh8n4fslyzqdal9n8kark0g4xslcrnji3q71wg",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
