### PR TITLE
[21.05] couchdb3: 3.1.1 -> 3.2.1

### DIFF
--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -1,16 +1,16 @@
 { lib, stdenv, fetchurl, erlang, icu, openssl, spidermonkey_78
-, coreutils, bash, makeWrapper, python3 }:
+, coreutils, bash, makeWrapper, python3, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "couchdb";
-  version = "3.2.0";
+  version = "3.2.1";
 
 
   # when updating this, please consider bumping the erlang/OTP version
   # in all-packages.nix
   src = fetchurl {
     url = "mirror://apache/couchdb/source/${version}/apache-${pname}-${version}.tar.gz";
-    sha256 = "035hy76399yy32rxl536gv7nh8ijihqxhhh5cxn95c3bm97mgslb";
+    sha256 = "1y5cfic88drlr9qiwyj2p8xc9m9hcbvw77j5lwbp0cav78f2vphi";
   };
 
   buildInputs = [ erlang icu openssl spidermonkey_78 (python3.withPackages(ps: with ps; [ requests ]))];
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     cp -r rel/couchdb/* $out
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) couchdb;
+  };
 
   meta = with lib; {
     description = "A database that uses JSON for documents, JavaScript for MapReduce queries, and regular HTTP for an API";

--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -1,26 +1,26 @@
-{ lib, stdenv, fetchurl, erlang, icu, openssl, spidermonkey_68
+{ lib, stdenv, fetchurl, erlang, icu, openssl, spidermonkey_78
 , coreutils, bash, makeWrapper, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "couchdb";
-  version = "3.1.1";
+  version = "3.2.0";
 
 
   # when updating this, please consider bumping the erlang/OTP version
   # in all-packages.nix
   src = fetchurl {
     url = "mirror://apache/couchdb/source/${version}/apache-${pname}-${version}.tar.gz";
-    sha256 = "18wcqxrv2bz88xadkqpqznprrxmcmwr0g6k895xrm8rbp9mpdzlg";
+    sha256 = "035hy76399yy32rxl536gv7nh8ijihqxhhh5cxn95c3bm97mgslb";
   };
 
-  buildInputs = [ erlang icu openssl spidermonkey_68 (python3.withPackages(ps: with ps; [ requests ]))];
+  buildInputs = [ erlang icu openssl spidermonkey_78 (python3.withPackages(ps: with ps; [ requests ]))];
   postPatch = ''
-    substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-68' "${spidermonkey_68.dev}/include/mozjs-68"
+    substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-78' "${spidermonkey_78.dev}/include/mozjs-78"
     patchShebangs bin/rebar
   '';
 
   dontAddPrefix= "True";
-  configureFlags = ["--spidermonkey-version=68"];
+  configureFlags = ["--spidermonkey-version=78"];
   buildFlags = ["release"];
 
   installPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

cherry picked backport to 21.05 for [Vulnerability roundup 107: couchdb-3.1.1: 1 advisory [7.3]](https://github.com/NixOS/nixpkgs/issues/142957)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking 
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
