### PR TITLE
factorio-experimental: 1.1.42 -> 1.1.44

### DIFF
--- a/pkgs/games/factorio/update.py
+++ b/pkgs/games/factorio/update.py
@@ -23,6 +23,8 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string('username', '', 'Factorio username for retrieving binaries.')
 flags.DEFINE_string('token', '', 'Factorio token for retrieving binaries.')
 flags.DEFINE_string('out', '', 'Output path for versions.json.')
+flags.DEFINE_list('release_type', '', 'If non-empty, a comma-separated list of release types to update (e.g. alpha).')
+flags.DEFINE_list('release_channel', '', 'If non-empty, a comma-separated list of release channels to update (e.g. experimental).')
 
 
 @dataclass
@@ -65,7 +67,7 @@ RELEASE_CHANNELS = [
 
 def find_versions_json() -> str:
     if FLAGS.out:
-        return out
+        return FLAGS.out
     try_paths = ["pkgs/games/factorio/versions.json", "versions.json"]
     for path in try_paths:
         if os.path.exists(path):
@@ -118,6 +120,12 @@ def merge_versions(old: OurVersionJSON, new: OurVersionJSON) -> OurVersionJSON:
         old_system = old.get(system_name, {})
         old_release_type = old_system.get(release_type_name, {})
         old_release = old_release_type.get(release_channel_name, {})
+        if FLAGS.release_type and release_type_name not in FLAGS.release_type:
+            logging.info("%s/%s/%s: not in --release_type, not updating", system_name, release_type_name, release_channel_name)
+            return old_release
+        if FLAGS.release_channel and release_channel_name not in FLAGS.release_channel:
+            logging.info("%s/%s/%s: not in --release_channel, not updating", system_name, release_type_name, release_channel_name)
+            return old_release
         if not "sha256" in old_release:
             logging.info("%s/%s/%s: not copying sha256 since it's missing", system_name, release_type_name, release_channel_name)
             return release

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.44.tar.xz",
+        "name": "factorio_alpha_x64-1.1.45.tar.xz",
         "needsAuth": true,
-        "sha256": "1isx5s9bx75zkf1m18spmyvlg037ngagz8fjvf3s1a5sq03a7pl3",
+        "sha256": "1gqf8p253qwlsg66fzh6nb264ckmg2wrrvg7grcxxniki7whd759",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.44/alpha/linux64",
-        "version": "1.1.44"
+        "url": "https://factorio.com/get-download/1.1.45/alpha/linux64",
+        "version": "1.1.45"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.1.42.tar.xz",
@@ -30,12 +30,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.44.tar.xz",
+        "name": "factorio_headless_x64-1.1.45.tar.xz",
         "needsAuth": false,
-        "sha256": "1inw9zxq5gxiwx594ipfg7d6v5b8lfvp4nyix9x2c84mc4hxv5wm",
+        "sha256": "1ga35yricj5k2b00hwyb7jgpa0c4v73q3lj9sn424rjxixy6naxf",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.44/headless/linux64",
-        "version": "1.1.44"
+        "url": "https://factorio.com/get-download/1.1.45/headless/linux64",
+        "version": "1.1.45"
       },
       "stable": {
         "name": "factorio_headless_x64-1.1.42.tar.xz",

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.43.tar.xz",
+        "name": "factorio_alpha_x64-1.1.44.tar.xz",
         "needsAuth": true,
-        "sha256": "1664d4m4pppcgr08av3gg3xmr0wcalm5sym869vcdnfgsgv6jrf2",
+        "sha256": "1isx5s9bx75zkf1m18spmyvlg037ngagz8fjvf3s1a5sq03a7pl3",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.43/alpha/linux64",
-        "version": "1.1.43"
+        "url": "https://factorio.com/get-download/1.1.44/alpha/linux64",
+        "version": "1.1.44"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.1.42.tar.xz",
@@ -30,12 +30,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.43.tar.xz",
+        "name": "factorio_headless_x64-1.1.44.tar.xz",
         "needsAuth": false,
-        "sha256": "1b4q9pr50ckjn86qbwrgcm3kzsjq83pd10110kvwyq8qa6may7cy",
+        "sha256": "1inw9zxq5gxiwx594ipfg7d6v5b8lfvp4nyix9x2c84mc4hxv5wm",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.43/headless/linux64",
-        "version": "1.1.43"
+        "url": "https://factorio.com/get-download/1.1.44/headless/linux64",
+        "version": "1.1.44"
       },
       "stable": {
         "name": "factorio_headless_x64-1.1.42.tar.xz",

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.42.tar.xz",
+        "name": "factorio_alpha_x64-1.1.43.tar.xz",
         "needsAuth": true,
-        "sha256": "08h2pxzsk7sigjqnqm1jxya3i9i5g2mgl378gmbp2jcy2mnn4dvm",
+        "sha256": "1664d4m4pppcgr08av3gg3xmr0wcalm5sym869vcdnfgsgv6jrf2",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.42/alpha/linux64",
-        "version": "1.1.42"
+        "url": "https://factorio.com/get-download/1.1.43/alpha/linux64",
+        "version": "1.1.43"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.1.42.tar.xz",
@@ -30,12 +30,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.42.tar.xz",
+        "name": "factorio_headless_x64-1.1.43.tar.xz",
         "needsAuth": false,
-        "sha256": "1l217fcjcwfi0g5dilsi703cl0wyxsqdqn422hwdbp2ql839k422",
+        "sha256": "1b4q9pr50ckjn86qbwrgcm3kzsjq83pd10110kvwyq8qa6may7cy",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.42/headless/linux64",
-        "version": "1.1.42"
+        "url": "https://factorio.com/get-download/1.1.43/headless/linux64",
+        "version": "1.1.43"
       },
       "stable": {
         "name": "factorio_headless_x64-1.1.42.tar.xz",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://forums.factorio.com/100389

Also pulls in some local changes to update.py that I'd forgotten I had, including one bugfix (oops), and one change to make it easier to script splitting updates into per-attr commits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
