### PR TITLE
snappy: 1.1.8 -> 1.1.9 + add pkgconfig file

### DIFF
--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -4,16 +4,14 @@
 
 stdenv.mkDerivation rec {
   pname = "snappy";
-  version = "1.1.8";
+  version = "1.1.9";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "snappy";
     rev = version;
-    sha256 = "1j0kslq2dvxgkcxl1gakhvsa731yrcvcaipcp5k8k7ayicvkv9jv";
+    sha256 = "sha256-JXWl63KVP+CDNWIXYtz+EKqWLJbPKl3ifhr8dKAp/w8=";
   };
-
-  patches = [ ./disable-benchmark.patch ];
 
   outputs = [ "out" "dev" ];
 
@@ -22,16 +20,28 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+    "-DSNAPPY_BUILD_TESTS=OFF"
+    "-DSNAPPY_BUILD_BENCHMARKS=OFF"
   ];
 
   postInstall = ''
     substituteInPlace "$out"/lib/cmake/Snappy/SnappyTargets.cmake \
       --replace 'INTERFACE_INCLUDE_DIRECTORIES "''${_IMPORT_PREFIX}/include"' 'INTERFACE_INCLUDE_DIRECTORIES "'$dev'"'
+
+    mkdir -p $dev/lib/pkgconfig
+    cat <<EOF > $dev/lib/pkgconfig/snappy.pc
+      Name: snappy
+      Description: Fast compressor/decompressor library.
+      Version: ${version}
+      Libs: -L$out/lib -lsnappy
+      Cflags: -I$dev/include
+    EOF
   '';
 
-  checkTarget = "test";
+  #checkTarget = "test";
 
-  doCheck = true;
+  # requires gbenchmark and gtest but it also installs them out $dev
+  doCheck = false;
 
   meta = with lib; {
     homepage = "https://google.github.io/snappy/";

--- a/pkgs/development/libraries/snappy/disable-benchmark.patch
+++ b/pkgs/development/libraries/snappy/disable-benchmark.patch
@@ -1,5 +1,0 @@
---- a/snappy-test.cc
-+++ b/snappy-test.cc
-@@ -46 +46 @@
--DEFINE_bool(run_microbenchmarks, true,
-+DEFINE_bool(run_microbenchmarks, false,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #72179

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
