### PR TITLE
nixos/binfmt: Add QEMU wrapper to preserve argv[0]

### DIFF
--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -20,16 +20,20 @@ let
                  optionalString fixBinary "F";
   in ":${name}:${type}:${offset'}:${magicOrExtension}:${mask'}:${interpreter}:${flags}";
 
-  activationSnippet = name: { interpreter, ... }: ''
+  activationSnippet = name: { interpreter, wrapInterpreterInShell, ... }: if wrapInterpreterInShell then ''
     rm -f /run/binfmt/${name}
     cat > /run/binfmt/${name} << 'EOF'
     #!${pkgs.bash}/bin/sh
     exec -- ${interpreter} "$@"
     EOF
     chmod +x /run/binfmt/${name}
+  '' else ''
+    rm -f /run/binfmt/${name}
+    ln -s ${interpreter} /run/binfmt/${name}
   '';
 
   getEmulator = system: (lib.systems.elaborate { inherit system; }).emulator pkgs;
+  getQemuArch = system: (lib.systems.elaborate { inherit system; }).qemuArch;
 
   # Mapping of systems to “magicOrExtension” and “mask”. Mostly taken from:
   # - https://github.com/cleverca22/nixos-configs/blob/master/qemu.nix
@@ -238,6 +242,25 @@ in {
               '';
               type = types.bool;
             };
+
+            wrapInterpreterInShell = mkOption {
+              default = true;
+              description = ''
+                Whether to wrap the interpreter in a shell script.
+
+                This allows a shell command to be set as the interpreter.
+              '';
+              type = types.bool;
+            };
+
+            interpreterSandboxPath = mkOption {
+              internal = true;
+              default = null;
+              description = ''
+                Path of the interpreter to expose in the build sandbox.
+              '';
+              type = types.nullOr types.path;
+            };
           };
         }));
       };
@@ -257,16 +280,37 @@ in {
   config = {
     boot.binfmt.registrations = builtins.listToAttrs (map (system: {
       name = system;
-      value = {
+      value = let
         interpreter = getEmulator system;
+        qemuArch = getQemuArch system;
+
+        preserveArgvZero = "qemu-${qemuArch}" == baseNameOf interpreter;
+        interpreterReg = let
+          wrapperName = "qemu-${qemuArch}-binfmt-P";
+          wrapper = pkgs.wrapQemuBinfmtP wrapperName interpreter;
+        in
+          if preserveArgvZero then "${wrapper}/bin/${wrapperName}"
+          else interpreter;
+      in {
+        inherit preserveArgvZero;
+
+        interpreter = interpreterReg;
+        wrapInterpreterInShell = !preserveArgvZero;
+        interpreterSandboxPath = dirOf (dirOf interpreterReg);
       } // (magics.${system} or (throw "Cannot create binfmt registration for system ${system}"));
     }) cfg.emulatedSystems);
     # TODO: add a nix.extraPlatforms option to NixOS!
     nix.extraOptions = lib.mkIf (cfg.emulatedSystems != []) ''
       extra-platforms = ${toString (cfg.emulatedSystems ++ lib.optional pkgs.stdenv.hostPlatform.isx86_64 "i686-linux")}
     '';
-    nix.sandboxPaths = lib.mkIf (cfg.emulatedSystems != [])
-      ([ "/run/binfmt" "${pkgs.bash}" ] ++ (map (system: dirOf (dirOf (getEmulator system))) cfg.emulatedSystems));
+    nix.sandboxPaths = lib.mkIf (cfg.emulatedSystems != []) (
+      let
+        ruleFor = system: cfg.registrations.${system};
+        hasWrappedRule = lib.any (system: (ruleFor system).wrapInterpreterInShell) cfg.emulatedSystems;
+      in [ "/run/binfmt" ]
+        ++ lib.optional hasWrappedRule "${pkgs.bash}"
+        ++ (map (system: (ruleFor system).interpreterSandboxPath) cfg.emulatedSystems)
+      );
 
     environment.etc."binfmt.d/nixos.conf".source = builtins.toFile "binfmt_nixos.conf"
       (lib.concatStringsSep "\n" (lib.mapAttrsToList makeBinfmtLine config.boot.binfmt.registrations));

--- a/nixos/tests/systemd-binfmt.nix
+++ b/nixos/tests/systemd-binfmt.nix
@@ -68,4 +68,23 @@ in {
       machine.succeed("exec -a meow ${testAarch64} meow")
     '';
   };
+
+  ldPreload = makeTest {
+    name = "systemd-binfmt-ld-preload";
+    machine = {
+      boot.binfmt.emulatedSystems = [
+        "aarch64-linux"
+      ];
+    };
+    testScript = let
+      helloAarch64 = pkgs.pkgsCross.aarch64-multiplatform.hello;
+      libredirectAarch64 = pkgs.pkgsCross.aarch64-multiplatform.libredirect;
+    in ''
+      machine.start()
+
+      assert "error" not in machine.succeed(
+          "LD_PRELOAD='${libredirectAarch64}/lib/libredirect.so' ${helloAarch64}/bin/hello 2>&1"
+      ).lower()
+    '';
+  };
 }

--- a/nixos/tests/systemd-binfmt.nix
+++ b/nixos/tests/systemd-binfmt.nix
@@ -1,24 +1,71 @@
 # Teach the kernel how to run armv7l and aarch64-linux binaries,
 # and run GNU Hello for these architectures.
-import ./make-test-python.nix ({ pkgs, ... }: {
-  name = "systemd-binfmt";
-  machine = {
-    boot.binfmt.emulatedSystems = [
-      "armv7l-linux"
-      "aarch64-linux"
-    ];
+
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+
+let
+  expectArgv0 = xpkgs: xpkgs.runCommandCC "expect-argv0" {
+    src = pkgs.writeText "expect-argv0.c" ''
+      #include <stdio.h>
+      #include <string.h>
+
+      int main(int argc, char **argv) {
+        fprintf(stderr, "Our argv[0] is %s\n", argv[0]);
+
+        if (strcmp(argv[0], argv[1])) {
+          fprintf(stderr, "ERROR: argv[0] is %s, should be %s\n", argv[0], argv[1]);
+          return 1;
+        }
+
+        return 0;
+      }
+    '';
+  } ''
+    $CC -o $out $src
+  '';
+in {
+  basic = makeTest {
+    name = "systemd-binfmt";
+    machine = {
+      boot.binfmt.emulatedSystems = [
+        "armv7l-linux"
+        "aarch64-linux"
+      ];
+    };
+
+    testScript = let
+      helloArmv7l = pkgs.pkgsCross.armv7l-hf-multiplatform.hello;
+      helloAarch64 = pkgs.pkgsCross.aarch64-multiplatform.hello;
+    in ''
+      machine.start()
+
+      assert "world" in machine.succeed(
+          "${helloArmv7l}/bin/hello"
+      )
+
+      assert "world" in machine.succeed(
+          "${helloAarch64}/bin/hello"
+      )
+    '';
   };
 
-  testScript = let
-    helloArmv7l = pkgs.pkgsCross.armv7l-hf-multiplatform.hello;
-    helloAarch64 = pkgs.pkgsCross.aarch64-multiplatform.hello;
-  in ''
-    machine.start()
-    assert "world" in machine.succeed(
-        "${helloArmv7l}/bin/hello"
-    )
-    assert "world" in machine.succeed(
-        "${helloAarch64}/bin/hello"
-    )
-  '';
-})
+  preserveArgvZero = makeTest {
+    name = "systemd-binfmt-preserve-argv0";
+    machine = {
+      boot.binfmt.emulatedSystems = [
+        "aarch64-linux"
+      ];
+    };
+    testScript = let
+      testAarch64 = expectArgv0 pkgs.pkgsCross.aarch64-multiplatform;
+    in ''
+      machine.start()
+      machine.succeed("exec -a meow ${testAarch64} meow")
+    '';
+  };
+}

--- a/pkgs/applications/virtualization/qemu/binfmt-p-wrapper.c
+++ b/pkgs/applications/virtualization/qemu/binfmt-p-wrapper.c
@@ -1,0 +1,79 @@
+// This is a tiny wrapper that converts the extra arv[0] argument
+// from binfmt-misc with the P flag enabled to QEMU parameters.
+// It also prevents LD_* environment variables from being applied
+// to QEMU itself.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef TARGET_QEMU
+#error "Define TARGET_QEMU to be the path to the qemu-user binary (e.g., -DTARGET_QEMU=\"/full/path/to/qemu-riscv64\")"
+#endif
+
+extern char **environ;
+
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        fprintf(stderr, "%s: This should be run as the binfmt interpreter with the P flag\n", argv[0]);
+        fprintf(stderr, "%s: My preconfigured qemu-user binary: %s\n", argv[0], TARGET_QEMU);
+        return 1;
+    }
+
+    size_t environ_count = 0;
+    for (char **cur = environ; *cur != NULL; ++cur) {
+        environ_count++;
+    }
+
+    size_t new_argc = 3;
+    size_t new_argv_alloc = argc + 2 * environ_count + 2; // [ "-E", env ] for each LD_* env + [ "-0", argv0 ]
+    char **new_argv = (char**)malloc((new_argv_alloc + 1) * sizeof(char*));
+    if (!new_argv) {
+        fprintf(stderr, "FATAL: Failed to allocate new argv array\n");
+        abort();
+    }
+
+    new_argv[0] = TARGET_QEMU;
+    new_argv[1] = "-0";
+    new_argv[2] = argv[2];
+
+    // Pass all LD_ env variables as -E and strip them in `new_environ`
+    size_t new_environc = 0;
+    char **new_environ = (char**)malloc((environ_count + 1) * sizeof(char*));
+    if (!new_environ) {
+        fprintf(stderr, "FATAL: Failed to allocate new environ array\n");
+        abort();
+    }
+
+    for (char **cur = environ; *cur != NULL; ++cur) {
+        if (strncmp("LD_", *cur, 3) == 0) {
+            new_argv[new_argc++] = "-E";
+            new_argv[new_argc++] = *cur;
+        } else {
+            new_environ[new_environc++] = *cur;
+        }
+    }
+    new_environ[new_environc] = NULL;
+
+    size_t new_arg_start = new_argc;
+    new_argc += argc - 3 + 2; // [ "--", full_binary_path ]
+
+    if (argc > 3) {
+        memcpy(&new_argv[new_arg_start + 2], &argv[3], (argc - 3) * sizeof(char**));
+    }
+
+    new_argv[new_arg_start] = "--";
+    new_argv[new_arg_start + 1] = argv[1];
+    new_argv[new_argc] = NULL;
+
+#ifdef DEBUG
+    for (size_t i = 0; i < new_argc; ++i) {
+        fprintf(stderr, "argv[%zu] = %s\n", i, new_argv[i]);
+    }
+#endif
+
+    return execve(new_argv[0], new_argv, new_environ);
+}
+
+// vim: et:ts=4:sw=4

--- a/pkgs/applications/virtualization/qemu/binfmt-p-wrapper.nix
+++ b/pkgs/applications/virtualization/qemu/binfmt-p-wrapper.nix
@@ -1,0 +1,31 @@
+# binfmt preserve-argv[0] wrapper
+#
+# More details in binfmt-p-wrapper.c
+#
+# The wrapper has to be static so LD_* environment variables
+# cannot affect the execution of the wrapper itself.
+
+{ lib, stdenv, pkgsStatic, enableDebug ? false }:
+
+name: emulator:
+
+pkgsStatic.stdenv.mkDerivation {
+  inherit name;
+
+  src = ./binfmt-p-wrapper.c;
+
+  dontUnpack = true;
+  dontInstall = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p $out/bin
+    $CC -o $out/bin/${name} -static -std=c99 -O2 \
+        -DTARGET_QEMU=\"${emulator}\" \
+        ${lib.optionalString enableDebug "-DDEBUG"} \
+        $src
+
+    runHook postBuild
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27324,6 +27324,8 @@ with pkgs;
 
   qemu-utils = callPackage ../applications/virtualization/qemu/utils.nix {};
 
+  wrapQemuBinfmtP = callPackage ../applications/virtualization/qemu/binfmt-p-wrapper.nix { };
+
   qgis-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/unwrapped.nix {
     withGrass = false;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR enables argv[0] preservation for the QEMU binfmt-misc rules generated by `boot.binfmt.emulatedSystems`. It allows certain packages that rely on argv[0] in their build process (e.g., coreutils for its tests) to correctly build under binfmt.

Traditionally, the emulator invoked by `binfmt-misc` doesn't know what the original argv[0] is when running an executable, because only the absolute path to the foreign executable is passed. Currently, the emulator will simply use the full path as argv[0]. This leads to problems with multi-call executables as well as diff-based test methodologies used in various packages. For example, coreutils relies on output comparison in many test cases:

```
uniq: test 145.p: stderr mismatch, comparing 145.p.3 (expected) and 145.p.E (actual)
*** 145.p.3     Mon Oct 18 07:11:43 2021
--- 145.p.E     Mon Oct 18 07:11:44 2021
***************
*** 1,7 ****
! uniq: invalid argument 'badoption' for '--group'
  Valid arguments are:
    - 'prepend'
    - 'append'
    - 'separate'
    - 'both'
! Try 'uniq --help' for more information.
--- 1,7 ----
! /build/coreutils-8.32/src/uniq: invalid argument 'badoption' for '--group'
  Valid arguments are:
    - 'prepend'
    - 'append'
    - 'separate'
    - 'both'
! Try '/build/coreutils-8.32/src/uniq --help' for more information.
```

`binfmt-misc` now has the "P" flag that, when enabled, will add an extra argument after the absolute path to the foreign binary containing the original argv[0]. However, this also means that CLI compatibility with existing emulator executables is broken. SUSE has been [carrying a patch](https://build.opensuse.org/package/view_file/Virtualization/qemu/linux-user-add-binfmt-wrapper-for-argv-0.patch?expand=1) since 2011 to add `-binfmt` wrappers that translate the new arguments into ones that regular QEMU accepts (`-0` for overriding argv[0]). There have been [attempts](https://lists.gnu.org/archive/html/qemu-devel/2021-02/msg04639.html) to resolve this issue upstream, but so far there seems to be no consensus.

This PR adds a statically-linked wrapper for QEMU that translates the arguments. It's possible to rewrite the arguments in the wrapper script that we use (#118926), but that still leaves [some remaining issues](https://github.com/NixOS/nixpkgs/pull/115406#issuecomment-952610803) (e.g., extraneous output when setting LD_PRELOAD).

Tested by building coreutils for riscv64-linux on x86_64-linux under binfmt ([before](https://github.com/NixOS/nixpkgs/files/7422012/without-fix.log), [after](https://github.com/NixOS/nixpkgs/files/7432774/with-c-wrapper.log)).

<!-- Old Solution

In our case, this is much easier since we already wrap the emulators under a shell script. With this PR we simply generate a different wrapper script that rewrites the arguments passed to the emulator when we detect that QEMU is in use.

We only perform the rewrite when the emulator name is in the form of `qemu-{arch}`. It's unlikely that QEMU will change the arguments of the regular binary to support the P flag, breaking compatibily with all existing usages. Even in the aforementioned proposal, QEMU will only enable P argument parsing when its own argv[0] ends with `-binfmt-P`.

A couple of NixOS test cases have been added to check both the old and new behaviors. The test suite of coreutils (logs for riscv64-linux build on x86_64-linux host: [without this PR](https://github.com/NixOS/nixpkgs/files/7422012/without-fix.log) -> [with this PR](https://github.com/NixOS/nixpkgs/files/7422010/with-fix-1.log)) still doesn't complete, but all argv[0]-related failures are fixed.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested on platform(s)
  - [x] riscv64-linux on x86_64-linux
  - [x] aarch64-linux on x86_64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
