### PR TITLE
statix: init at 0.3.1; vimPlugins.statix: init at 0.1.0

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -30,6 +30,7 @@
 , nodePackages
 , skim
 , sqlite
+, statix
 , stylish-haskell
 , tabnine
 , vim
@@ -526,6 +527,17 @@ self: super: {
         --replace "path = vim.g.sqlite_clib_path" "path = vim.g.sqlite_clib_path or ${lib.escapeShellArg libsqlite}"
     '';
   });
+
+  statix = buildVimPluginFrom2Nix {
+    inherit (statix) pname src meta;
+    version = "0.1.0";
+    dependencies = with self; [ statix ];
+    postPatch = ''
+      cd vim-plugin
+      substituteInPlace ftplugin/nix.vim --replace statix ${statix}/bin/statix
+      substituteInPlace plugin/statix.vim --replace statix ${statix}/bin/statix
+    '';
+  };
 
   sved =
     let

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -528,11 +528,15 @@ self: super: {
     '';
   });
 
-  statix = buildVimPluginFrom2Nix {
+  statix = buildVimPluginFrom2Nix rec {
     inherit (statix) pname src meta;
     version = "0.1.0";
     dependencies = with self; [ statix ];
     postPatch = ''
+      # check that version is up to date
+      grep 'pname = "statix-vim"' -A 1 flake.nix \
+        | grep -F 'version = "${version}"' flake.nix
+
       cd vim-plugin
       substituteInPlace ftplugin/nix.vim --replace statix ${statix}/bin/statix
       substituteInPlace plugin/statix.vim --replace statix ${statix}/bin/statix

--- a/pkgs/tools/nix/statix/default.nix
+++ b/pkgs/tools/nix/statix/default.nix
@@ -2,6 +2,8 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "statix";
+  # also update version of the vim plugin in pkgs/misc/vim-plugins/overrides.nix
+  # the version can be found in flake.nix of the source code
   version = "0.3.1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/nix/statix/default.nix
+++ b/pkgs/tools/nix/statix/default.nix
@@ -1,0 +1,26 @@
+{ lib, rustPlatform, fetchFromGitHub, withJson ? true }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "statix";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "nerdypepper";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Jh3ErzK8vqEdDtZP7O/PAmHQznUTB18nCQwfckFxyLA=";
+  };
+
+  cargoSha256 = "sha256-y+vBHAHTe++tYOWWQ5ioFlprRfDximZE8KSGNNBSPAk=";
+
+  cargoBuildFlags = lib.optionals withJson [ "--features" "json" ];
+
+  cargoCheckFlags = cargoBuildFlags;
+
+  meta = with lib; {
+    description = "Lints and suggestions for the nix programming language";
+    homepage = "https://github.com/nerdypepper/statix";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda nerdypepper ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15167,6 +15167,8 @@ with pkgs;
 
   sselp = callPackage ../tools/X11/sselp{ };
 
+  statix = callPackage ../tools/nix/statix { };
+
   stm32cubemx = callPackage ../development/embedded/stm32/stm32cubemx { };
 
   stm32flash = callPackage ../development/embedded/stm32/stm32flash { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

statix gives lints and suggestions for the nix programming language

https://github.com/nerdypepper/statix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
