### PR TITLE
[staging] rustPlatform: add support for features

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -186,6 +186,33 @@ added. To find the correct hash, you can first use `lib.fakeSha256` or
 `lib.fakeHash` as a stub hash. Building the package (and thus the
 vendored dependencies) will then inform you of the correct hash.
 
+### Cargo features {#cargo-features}
+
+You can disable default features using `buildNoDefaultFeatures`, and
+extra features can be added with `buildFeatures`.
+
+If you want to use different features for check phase, you can use
+`checkNoDefaultFeatures` and `checkFeatures`. They are only passed to
+`cargo test` and not `cargo build`. If left unset, they default to
+`buildNoDefaultFeatures` and `buildFeatures`.
+
+For example:
+
+```nix
+rustPlatform.buildRustPackage rec {
+  pname = "myproject";
+  version = "1.0.0";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "color" "net" ];
+
+  # disable network features in tests
+  checkFeatures = [ "color" ];
+
+  # ...
+}
+```
+
 ### Cross compilation {#cross-compilation}
 
 By default, Rust packages are compiled for the host platform, just like any
@@ -261,7 +288,7 @@ rustPlatform.buildRustPackage {
 Please note that the code will be compiled twice here: once in `release` mode
 for the `buildPhase`, and again in `debug` mode for the `checkPhase`.
 
-Test flags, e.g., `--features xxx/yyy`, can be passed to `cargo test` via the
+Test flags, e.g., `--package foo`, can be passed to `cargo test` via the
 `cargoTestFlags` attribute.
 
 Another attribute, called `checkFlags`, is used to pass arguments to the test
@@ -421,18 +448,20 @@ you of the correct hash.
 * `cargoBuildHook`: use Cargo to build a crate. If the crate to be
   built is a crate in e.g. a Cargo workspace, the relative path to the
   crate to build can be set through the optional `buildAndTestSubdir`
-  environment variable. Additional Cargo build flags can be passed
-  through `cargoBuildFlags`.
+  environment variable. Features can be specified with
+  `cargoBuildNoDefaultFeatures` and `cargoBuildFeatures`. Additional
+  Cargo build flags can be passed through `cargoBuildFlags`.
 * `maturinBuildHook`: use [Maturin](https://github.com/PyO3/maturin)
   to build a Python wheel. Similar to `cargoBuildHook`, the optional
   variable `buildAndTestSubdir` can be used to build a crate in a
   Cargo workspace. Additional maturin flags can be passed through
   `maturinBuildFlags`.
 * `cargoCheckHook`: run tests using Cargo. The build type for checks
-  can be set using `cargoCheckType`. Additional flags can be passed to
-  the tests using `checkFlags` and `checkFlagsArray`. By default,
-  tests are run in parallel. This can be disabled by setting
-  `dontUseCargoParallelTests`.
+  can be set using `cargoCheckType`. Features can be specified with
+  `cargoCheckNoDefaultFeaatures` and `cargoCheckFeatures`. Additional
+  flags can be passed to the tests using `checkFlags` and
+  `checkFlagsArray`. By default, tests are run in parallel. This can
+  be disabled by setting `dontUseCargoParallelTests`.
 * `cargoInstallHook`: install binaries and static/shared libraries
   that were built using `cargoBuildHook`.
 

--- a/pkgs/applications/audio/ncspot/default.nix
+++ b/pkgs/applications/audio/ncspot/default.nix
@@ -5,13 +5,6 @@
 , withMPRIS ? false, dbus ? null
 }:
 
-let
-  features = [ "cursive/pancurses-backend" ]
-    ++ lib.optional withALSA "alsa_backend"
-    ++ lib.optional withPulseAudio "pulseaudio_backend"
-    ++ lib.optional withPortAudio "portaudio_backend"
-    ++ lib.optional withMPRIS "mpris";
-in
 rustPlatform.buildRustPackage rec {
   pname = "ncspot";
   version = "0.9.0";
@@ -25,8 +18,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0sdbba32f56z2q7kha5fxw2f00hikbz9sf4zl4wfl2i9b13j7mj0";
 
-  cargoBuildFlags = [ "--no-default-features" "--features" "${lib.concatStringsSep "," features}" ];
-
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ ncurses openssl ]
@@ -35,6 +26,13 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optional withPulseAudio libpulseaudio
     ++ lib.optional withPortAudio portaudio
     ++ lib.optional withMPRIS dbus;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "cursive/pancurses-backend" ]
+    ++ lib.optional withALSA "alsa_backend"
+    ++ lib.optional withPulseAudio "pulseaudio_backend"
+    ++ lib.optional withPortAudio "portaudio_backend"
+    ++ lib.optional withMPRIS "mpris";
 
   doCheck = false;
 

--- a/pkgs/applications/version-management/git-and-tools/lucky-commit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lucky-commit/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = lib.optional (!withOpenCL) "--no-default-features";
 
   # disable tests that require gpu
-  cargoTestFlags = [ "--no-default-features" ];
+  checkNoDefaultFeatures = true;
 
   meta = with lib; {
     description = "Change the start of your git commit hashes to whatever you want";

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -36,6 +36,10 @@
 , cargoLock ? null
 , cargoVendorDir ? null
 , checkType ? buildType
+, buildNoDefaultFeatures ? false
+, checkNoDefaultFeatures ? buildNoDefaultFeatures
+, buildFeatures ? [ ]
+, checkFeatures ? buildFeatures
 , depsExtraArgs ? {}
 
 # Toggles whether a custom sysroot is created when the target is a .json file.
@@ -102,6 +106,14 @@ stdenv.mkDerivation ((removeAttrs args [ "depsExtraArgs" "cargoLock" ]) // lib.o
   cargoBuildType = buildType;
 
   cargoCheckType = checkType;
+
+  cargoBuildNoDefaultFeatures = buildNoDefaultFeatures;
+
+  cargoCheckNoDefaultFeatures = checkNoDefaultFeatures;
+
+  cargoBuildFeatures = buildFeatures;
+
+  cargoCheckFeatures = checkFeatures;
 
   patchRegistryDeps = ./patch-registry-deps;
 

--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -13,6 +13,14 @@ cargoBuildHook() {
         cargoBuildProfileFlag="--${cargoBuildType}"
     fi
 
+    if [ -n "${cargoBuildNoDefaultFeatures-}" ]; then
+        cargoBuildNoDefaultFeaturesFlag=--no-default-features
+    fi
+
+    if [ -n "${cargoBuildFeatures-}" ]; then
+        cargoBuildFeaturesFlag="--features=${cargoBuildFeatures// /,}"
+    fi
+
     (
     set -x
     env \
@@ -24,6 +32,8 @@ cargoBuildHook() {
         --target @rustTargetPlatformSpec@ \
         --frozen \
         ${cargoBuildProfileFlag} \
+        ${cargoBuildNoDefaultFeaturesFlag} \
+        ${cargoBuildFeaturesFlag} \
         ${cargoBuildFlags}
     )
 

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -20,7 +20,16 @@ cargoCheckHook() {
         cargoCheckProfileFlag="--${cargoCheckType}"
     fi
 
-    argstr="${cargoCheckProfileFlag} --target @rustTargetPlatformSpec@ --frozen ${cargoTestFlags}";
+    if [ -n "${cargoCheckNoDefaultFeatures-}" ]; then
+        cargoCheckNoDefaultFeaturesFlag=--no-default-features
+    fi
+
+    if [ -n "${cargoCheckFeatures-}" ]; then
+        cargoCheckFeaturesFlag="--features=${cargoCheckFeatures// /,}"
+    fi
+
+    argstr="${cargoCheckProfileFlag} ${cargoCheckNoDefaultFeaturesFlag} ${cargoCheckFeaturesFlag}
+        --target @rustTargetPlatformSpec@ --frozen ${cargoTestFlags}"
 
     (
         set -x


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

adds `cargoBuild{NoDefault,}Features` to `cargoBuildHook`
adds `cargoCheck{NoDefault,}Features` to `cargoCheckHook`

adds `{build,check}{NoDefault,}Features` to `buildRustPackage`

changes ncspot and lucky-commit to use the new feature options

If this gets merged, I will make a follow up to adopt this treewide

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
