### PR TITLE
pocket-casts: set electron version on top-level

### DIFF
--- a/pkgs/applications/audio/pocket-casts/default.nix
+++ b/pkgs/applications/audio/pocket-casts/default.nix
@@ -1,11 +1,7 @@
-{ lib, stdenv, fetchurl, dpkg, autoPatchelfHook, makeWrapper, electron_12,
-alsa-lib, gtk3, libXScrnSaver, libXtst, mesa, nss }:
+{ lib, stdenv, fetchurl, dpkg, autoPatchelfHook, makeWrapper, electron
+, alsa-lib, gtk3, libXScrnSaver, libXtst, mesa, nss }:
 
-let
-  # Using Electron 12 to solve errors regarding threading
-  electron = electron_12;
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "pocket-casts";
   version = "0.5.0";
 
@@ -41,8 +37,9 @@ in stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    substituteInPlace $out/share/applications/pocket-casts.desktop --replace '"/opt/Pocket Casts/pocket-casts"' $out/bin/pocket-casts
-    substituteInPlace $out/share/applications/pocket-casts.desktop --replace '/usr/share/icons/hicolor/0x0/apps/pocket-casts.png' "pocket-casts"
+    substituteInPlace $out/share/applications/pocket-casts.desktop \
+      --replace '"/opt/Pocket Casts/pocket-casts"' $out/bin/pocket-casts \
+      --replace '/usr/share/icons/hicolor/0x0/apps/pocket-casts.png' "pocket-casts"
     makeWrapper ${electron}/bin/electron \
       $out/bin/pocket-casts \
       --add-flags $out/opt/pocket-casts/resources/app.asar

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3404,7 +3404,9 @@ with pkgs;
 
   pn = callPackage ../tools/text/pn { };
 
-  pocket-casts = callPackage ../applications/audio/pocket-casts { };
+  pocket-casts = callPackage ../applications/audio/pocket-casts {
+    electron = electron_12;
+  };
 
   poweralertd = callPackage ../tools/misc/poweralertd { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Addressing concerns post-merge of #142670

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
