### PR TITLE
ocserv: 0.12.6 -> 1.1.2

### DIFF
--- a/pkgs/tools/networking/ocserv/default.nix
+++ b/pkgs/tools/networking/ocserv/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ocserv";
-  version = "0.12.6";
+  version = "1.1.2";
 
   src = fetchFromGitLab {
     owner = "openconnect";
     repo = "ocserv";
-    rev = "ocserv_${lib.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "0k7sx9sg8akxwfdl51cvdqkdrx9qganqddgri2yhcgznc3f3pz5b";
+    rev = version;
+    sha256 = "gXolG4zTnJpgI32SuudhvlP9snI0k4Oa1mqE7eGbdE0=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/openconnect/ocserv";
     license = licenses.gpl2;
     description = "This program is openconnect VPN server (ocserv), a server for the openconnect VPN client";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ neverbehave ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The ocserv repo seems to update their rev and here is the correct version, alone with a major version update (especially for new kernel and IPv6).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
