### PR TITLE
makeRustPlatform: allow to easily override stdenv

### DIFF
--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -1,6 +1,6 @@
-{ buildPackages, callPackage }:
+{ buildPackages, callPackage, stdenv }@prev:
 
-{ rustc, cargo, ... }:
+{ rustc, cargo, stdenv ? prev.stdenv, ... }:
 
 rec {
   rust = {
@@ -9,27 +9,27 @@ rec {
 
   fetchCargoTarball = buildPackages.callPackage ../../../build-support/rust/fetchCargoTarball.nix {
     git = buildPackages.gitMinimal;
-    inherit cargo;
+    inherit stdenv cargo;
   };
 
   buildRustPackage = callPackage ../../../build-support/rust {
     git = buildPackages.gitMinimal;
-    inherit cargoBuildHook cargoCheckHook cargoInstallHook cargoSetupHook
+    inherit stdenv cargoBuildHook cargoCheckHook cargoInstallHook cargoSetupHook
       fetchCargoTarball importCargoLock rustc;
   };
 
   importCargoLock = buildPackages.callPackage ../../../build-support/rust/import-cargo-lock.nix {};
 
   rustcSrc = callPackage ./rust-src.nix {
-    inherit rustc;
+    inherit stdenv rustc;
   };
 
   rustLibSrc = callPackage ./rust-lib-src.nix {
-    inherit rustc;
+    inherit stdenv rustc;
   };
 
   # Hooks
   inherit (callPackage ../../../build-support/rust/hooks {
-    inherit cargo rustc;
+    inherit stdenv cargo rustc;
   }) cargoBuildHook cargoCheckHook cargoInstallHook cargoSetupHook maturinBuildHook;
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This allows users to easily override the stdenv of their entire rust platform by
passing in the `stdenv` attr when calling `makeRustPlatform`.

This hopefully makes things less brittle when trying to build Rust packages with
clang and lld.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
