### PR TITLE
[staging-next] coreutils: Disable SEEK_HOLE due to corruption

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -29,8 +29,11 @@ stdenv.mkDerivation (rec {
     sha256 = "sha256-zjCs30pBvFuzDdlV6eqnX6IWtOPesIiJ7TJDPHs7l84=";
   };
 
-  patches = [ ./fix-chmod-exit-code.patch ]
-    ++ optional stdenv.hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch
+  patches = [
+    ./fix-chmod-exit-code.patch
+    # Workaround for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51433
+    ./disable-seek-hole.patch
+  ] ++ optional stdenv.hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch
     # fix gnulib tests on 32-bit ARM. Included on coreutils master.
     # https://lists.gnu.org/r/bug-gnulib/2020-08/msg00225.html
     ++ optional stdenv.hostPlatform.isAarch32 ./fix-gnulib-tests-arm.patch;

--- a/pkgs/tools/misc/coreutils/disable-seek-hole.patch
+++ b/pkgs/tools/misc/coreutils/disable-seek-hole.patch
@@ -1,0 +1,43 @@
+diff --git a/src/copy.c b/src/copy.c
+index cb9018f93..2a4ccc061 100644
+--- a/src/copy.c
++++ b/src/copy.c
+@@ -502,7 +502,7 @@ write_zeros (int fd, off_t n_bytes)
+   return true;
+ }
+
+-#ifdef SEEK_HOLE
++#if 0
+ /* Perform an efficient extent copy, if possible.  This avoids
+    the overhead of detecting holes in hole-introducing/preserving
+    copy, and thus makes copying sparse files much more efficient.
+@@ -1095,7 +1095,7 @@ infer_scantype (int fd, struct stat const *sb,
+          && ST_NBLOCKS (*sb) < sb->st_size / ST_NBLOCKSIZE))
+     return PLAIN_SCANTYPE;
+
+-#ifdef SEEK_HOLE
++#if 0
+   scan_inference->ext_start = lseek (fd, 0, SEEK_DATA);
+   if (0 <= scan_inference->ext_start)
+     return LSEEK_SCANTYPE;
+@@ -1377,7 +1377,7 @@ copy_reg (char const *src_name, char const *dst_name,
+       off_t n_read;
+       bool wrote_hole_at_eof = false;
+       if (! (
+-#ifdef SEEK_HOLE
++#if 0
+              scantype == LSEEK_SCANTYPE
+              ? lseek_copy (source_desc, dest_desc, buf, buf_size, hole_size,
+                            scan_inference.ext_start, src_open_sb.st_size,
+diff --git a/tests/seek-data-capable b/tests/seek-data-capable
+index cc6372214..6e7a9ec1e 100644
+--- a/tests/seek-data-capable
++++ b/tests/seek-data-capable
+@@ -1,5 +1,7 @@
+ import sys, os, errno, platform
+
++sys.exit(1)
++
+ # Pass an _empty_ file
+ if len(sys.argv) != 2:
+     sys.exit(1)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

    coreutils: Disable SEEK_HOLE due to corruption

    See https://github.com/openzfs/zfs/issues/11900 as an example. This only
    happens on Coreutils 9.0. Reported here:
    https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51433


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
