### PR TITLE
searx: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -59,7 +59,7 @@ toPythonModule (buildPythonApplication rec {
   pythonImportsCheck = [ "searx" ];
 
   postInstall = ''
-    # change default password (otherwise it wont run)
+    # change default secret key (otherwise it wont run)
     sed -i 's/ultrasecretkey/'$RANDOM'/g' $out/lib/python*/site-packages/searx/settings.yml
     # Create a symlink for easier access to static data
     mkdir -p $out/share

--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -4,7 +4,7 @@ with python3Packages;
 
 toPythonModule (buildPythonApplication rec {
   pname = "searx";
-  version = "1.0.0";
+  version = "1.0.1";
 
   # pypi doesn't receive updates
   src = fetchFromGitHub {
@@ -59,6 +59,8 @@ toPythonModule (buildPythonApplication rec {
   pythonImportsCheck = [ "searx" ];
 
   postInstall = ''
+    # change default password (otherwise it wont run)
+    sed -i 's/ultrasecretkey/'$RANDOM'/g' $out/lib/python*/site-packages/searx/settings.yml
     # Create a symlink for easier access to static data
     mkdir -p $out/share
     ln -s ../${python3.sitePackages}/searx/static $out/share/


### PR DESCRIPTION
default secretkey is changed to random one (otherwise app does not start)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`searx-run` didn't start (errmsg: `please change default `ultrasecretkey` to something else)

###### Things done

Updated the default `ultrasecretkey` to a random number in `settings.yml` (using `sed` in `default.nix` postInstall-section).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
