### PR TITLE
[21.05] pidgin: use system certificates to fix letsencrypt

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -9,6 +9,7 @@
 , gnutls ? null
 , libgcrypt ? null
 , plugins, symlinkJoin
+, cacert
 }:
 
 # FIXME: clean the mess around choosing the SSL library (nss by default)
@@ -59,6 +60,7 @@ let unwrapped = stdenv.mkDerivation rec {
     "--with-nss-includes=${nss.dev}/include/nss"
     "--with-nss-libs=${nss.out}/lib"
     "--with-ncurses-headers=${ncurses.dev}/include"
+    "--with-system-ssl-certs=${cacert}/etc/ssl/certs"
     "--disable-meanwhile"
     "--disable-nm"
     "--disable-tcl"


### PR DESCRIPTION
###### Motivation for this change
Manual backport of https://github.com/NixOS/nixpkgs/pull/143125
It seems important, automatic backport won't work.
cc @vcunat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
