### PR TITLE
ocamlPackages.piaf: init 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/gluten/default.nix
+++ b/pkgs/development/ocaml-modules/gluten/default.nix
@@ -1,0 +1,34 @@
+{ buildDunePackage
+, bigstringaf
+, faraday
+, fetchurl
+, lib
+}:
+
+buildDunePackage rec {
+  pname = "gluten";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://github.com/anmonteiro/gluten/releases/download/${version}/gluten-${version}.tbz";
+    sha256 = "1pl0mpcprz8hmaiv28p7w51qfcx7s76zdkak0vm5cazbjl38nc46";
+  };
+
+  minimalOCamlVersion = "4.06";
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    bigstringaf
+    faraday
+  ];
+
+  doCheck = false; # No tests
+
+  meta = {
+    description = "An implementation of a platform specific runtime code for driving network libraries based on state machines, such as http/af, h2 and websocketaf";
+    license = lib.licenses.bsd3;
+    homepage = "https://github.com/anmonteiro/gluten";
+    maintainers = with lib.maintainers; [ anmonteiro superherointj ];
+  };
+}

--- a/pkgs/development/ocaml-modules/gluten/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/gluten/lwt-unix.nix
@@ -1,0 +1,17 @@
+{ buildDunePackage
+, faraday-lwt-unix
+, gluten
+, gluten-lwt
+, lwt_ssl
+}:
+
+buildDunePackage rec {
+  pname = "gluten-lwt-unix";
+  inherit (gluten) doCheck meta src useDune2 version;
+
+  propagatedBuildInputs = [
+    faraday-lwt-unix
+    gluten-lwt
+    lwt_ssl
+  ];
+}

--- a/pkgs/development/ocaml-modules/gluten/lwt.nix
+++ b/pkgs/development/ocaml-modules/gluten/lwt.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage
+, gluten
+, lwt
+}:
+
+buildDunePackage rec {
+  pname = "gluten-lwt";
+  inherit (gluten) doCheck meta src useDune2 version;
+
+  propagatedBuildInputs = [
+    gluten
+    lwt
+  ];
+}

--- a/pkgs/development/ocaml-modules/piaf/default.nix
+++ b/pkgs/development/ocaml-modules/piaf/default.nix
@@ -1,0 +1,54 @@
+{ alcotest-lwt
+, buildDunePackage
+, dune-site
+, fetchzip
+, gluten-lwt-unix
+, lib
+, logs
+, lwt_ssl
+, magic-mime
+, mrmime
+, openssl
+, pecu
+, psq
+, ssl
+, uri
+}:
+
+buildDunePackage rec {
+  pname = "piaf";
+  version = "0.1.0";
+
+  src = fetchzip {
+    url = "https://github.com/anmonteiro/piaf/releases/download/${version}/piaf-${version}.tbz";
+    sha256 = "0d431kz3bkwlgdamvsv94mzd9631ppcjpv516ii91glzlfdzh5hz";
+  };
+
+  postPatch = ''
+    substituteInPlace ./vendor/dune --replace "mrmime.prettym" "prettym"
+  '';
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    logs
+    magic-mime
+    mrmime
+    psq
+    uri
+    gluten-lwt-unix
+  ];
+
+  checkInputs = [
+    alcotest-lwt
+    dune-site
+  ];
+  doCheck = true;
+
+  meta = {
+    description = "An HTTP library with HTTP/2 support written entirely in OCaml";
+    homepage = "https://github.com/anmonteiro/piaf";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ anmonteiro superherointj ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -421,6 +421,7 @@ let
 
     gluten = callPackage ../development/ocaml-modules/gluten { };
     gluten-lwt = callPackage ../development/ocaml-modules/gluten/lwt.nix { };
+    gluten-lwt-unix = callPackage ../development/ocaml-modules/gluten/lwt-unix.nix { };
 
     gmap = callPackage ../development/ocaml-modules/gmap { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1038,6 +1038,8 @@ let
 
     phylogenetics = callPackage ../development/ocaml-modules/phylogenetics { };
 
+    piaf = callPackage ../development/ocaml-modules/piaf { };
+
     piqi = callPackage ../development/ocaml-modules/piqi { };
 
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -420,6 +420,7 @@ let
     getopt = callPackage ../development/ocaml-modules/getopt { };
 
     gluten = callPackage ../development/ocaml-modules/gluten { };
+    gluten-lwt = callPackage ../development/ocaml-modules/gluten/lwt.nix { };
 
     gmap = callPackage ../development/ocaml-modules/gmap { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -419,6 +419,8 @@ let
 
     getopt = callPackage ../development/ocaml-modules/getopt { };
 
+    gluten = callPackage ../development/ocaml-modules/gluten { };
+
     gmap = callPackage ../development/ocaml-modules/gmap { };
 
     gnuplot = callPackage ../development/ocaml-modules/gnuplot {


### PR DESCRIPTION
* ocamlPackages.gluten: init 0.2.1
* ocamlPackages.gluten-lwt: init 0.2.1
* ocamlPackages.gluten-lwt-unix: init 0.2.1
* ocamlPackages.piaf: init 0.1.0

## Notes

`gluten-mirage` and `gluten-async` is not included because it is broken in this release. ~~On a next working release I may include it.~~

To test versions:
```
NIX_PATH=$HOME/git/ nix-shell -p  \
    ocaml-ng.ocamlPackages_4_13.findlib \
    ocaml-ng.ocamlPackages_4_13.gluten \
    ocaml-ng.ocamlPackages_4_13.gluten-lwt \
    ocaml-ng.ocamlPackages_4_13.gluten-lwt-unix \
    ocaml-ng.ocamlPackages_4_13.piaf \
    --run 'ocamlfind list' \
    | grep -e gluten -e gluten-lwt -e gluten-lwt-unix -e piaf
```