### PR TITLE
qbe: 2021-06-17 → 2021-10-26, fix on darwin

### DIFF
--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -6,12 +6,12 @@
 
 stdenv.mkDerivation rec {
   pname = "qbe";
-  version = "unstable-2021-06-17";
+  version = "unstable-2021-10-26";
 
   src = fetchgit {
     url = "git://c9x.me/qbe.git";
-    rev = "6d9ee1389572ae985f6a39bb99dbd10cdf42c123";
-    sha256 = "NaURS5Eu8NBd92wGQcyFEXCALU9Z93nNQeZ8afq4KMw=";
+    rev = "900805a8fe5cfa799966c4ef221524e967c44ca5";
+    sha256 = "sha256-ahUpG2JH3Ee6FUGfTYZZ2TLk5tF6ovvMxbsjZjVug2o=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];


### PR DESCRIPTION
###### Motivation for this change
Fix check on darwin:
```
...
double.ssa...                                /tmp/qbe.zzzz.s:28:19: error: unexpected token in '.section' directive
.section .note.GNU-stack,"",@progbits
                  ^
[cc fail]
...
mandel.ssa...                                /tmp/qbe.zzzz.s:101:19: error: unexpected token in '.section' directive
.section .note.GNU-stack,"",@progbits
                  ^
[cc fail]
...
2 test(s) failed!
make: *** [Makefile:70: check] Error 2
```

Test passed on linux and darwin:
```
$ nix build --print-build-logs .#qbe.tests.can-run-hello-world
qbe-test-can-run-hello-world> One and one make 2!
```

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
