### PR TITLE
types.submoduleWith: Add evalModules function

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -274,6 +274,17 @@ checkConfigError 'A definition for option .fun.\[function body\]. is not of type
 checkConfigOutput "b a" config.result ./functionTo/list-order.nix
 checkConfigOutput "a c" config.result ./functionTo/merging-attrs.nix
 
+## types.submoduleWith.evalModules {}
+# This tests another entrypoint, so it doesn't use the normal test utilities.
+if nix-instantiate --expr 'import ./eval-via-type.nix {}' --eval-only --show-trace --json --strict -A config.foo.enable 2>/dev/null | grep --silent true
+then
+    pass=$((pass + 1))
+else
+    echo 2>&1 "eval-via-type failed"
+    fail=$((fail + 1))
+fi
+
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/eval-via-type.nix
+++ b/lib/tests/modules/eval-via-type.nix
@@ -1,0 +1,10 @@
+{ lib ? import ../.. }:
+
+{
+  inherit ((lib.types.submoduleWith {
+    modules = [ { options.foo.enable = lib.mkEnableOption "foo"; } ];
+    specialArgs.modulesPath = ./.;
+  }).evalModules {
+    modules = [ { config.foo.enable = true; } ];
+  }) config options;
+}


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This makes it easier to write configuration systems that can be
reused as submodules, by writing the configuration system as a
type, exposing the type (e.g. in a flake lib attribute), and
using the type's evalModules function in the configuration
system's own wiring.

The alternative, the status quo, is for the configuration system to duplicate its invocation logic when providing both a type and an `evalModules`-based function. This is error prone. Here's a best case example of the status quo:

```nix
let
  type = lib.types.submoduleWith {
    modules = myBuiltInModules;
    inherit specialArgs;
  };
  # Avoidable boilerplate:
  evalConfig = configuration: lib.evalModules {
    modules = [ configuration ] ++ myBuiltInModules;
    inherit specialArgs;
  };
  # With this pr
  evalConfig = configuration: type.evalModules { modules = [ configuration ]; };
```

Also note that because `modules` and `specialArgs` are now referenced only once, we don't need to rely on `let` bindings as much.

It also turns out the the internal `evalTypeModules` is a decent abstraction. Wasn't expecting that :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
