### PR TITLE
dunst: patch to fix double free / avoid core dump

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper
+{ stdenv, lib, fetchFromGitHub, makeWrapper, fetchpatch
 , pkg-config, which, perl, libXrandr
 , cairo, dbus, systemd, gdk-pixbuf, glib, libX11, libXScrnSaver
 , wayland, wayland-protocols
@@ -15,6 +15,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-BWbvGetXXCXbfPRY+u6gEfzBmX8PLSnI6a5vfCByiC0=";
   };
+
+  patches = [
+    (fetchpatch {
+      # fixes double free (https://github.com/dunst-project/dunst/issues/957)
+      url = "https://github.com/dunst-project/dunst/commit/dc8efbbaff0e9ba881fa187a01bfe5c033fbdcf9.patch";
+      sha256 = "sha256-xuODOFDP9Eqr3g8OtNnaMmTihhurfj2NLeZPr0TF4vY=";
+    })
+  ];
 
   nativeBuildInputs = [ perl pkg-config which systemd makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change
fix https://github.com/NixOS/nixpkgs/issues/143043

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
