### PR TITLE
gradle: add 7.3-rc-3, 6.8 -> 6.9.1

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -63,35 +63,23 @@ rec {
     };
   };
 
-  gradle_7_3 = gradleGen (gradleSpec {
-    version = "7.3-rc-2";
-    nativeVersion = "0.22-milestone-21";
-    sha256 = "0ydg26i376bjax5lval9n79v8afng467vkx3zdga0bzxl8dbi9z6";
-  });
-
   gradle_latest = gradle_7;
 
   # NOTE: 7.3 is a candidate.
   gradle_7 = gradle_7_2;
 
-  gradle_7_2 = gradleGen (gradleSpec {
-    version = "7.2";
-    nativeVersion = "0.22-milestone-21";
-    sha256 = "1pg6w5czysywsgdvmll5bwd2p6y99cn5sn3gw69cps9mkjd710gm";
-  });
+  gradle_7_3 = gradleGen (gradleSpec (import ./gradle-7.3-rc-3-spec.nix));
+  gradle_7_2 = gradleGen (gradleSpec (import ./gradle-7.2-spec.nix));
+  gradle_6_9 = gradleGen (gradleSpec (import ./gradle-6.9.1-spec.nix));
 
-  gradle_6_9 = gradleGen (gradleSpec {
-    version = "6.9.1";
-    nativeVersion = "0.22-milestone-20";
-    sha256 = "1zmjfwlh34b65rdx9izgavw3qwqqwm39h5siyj2bf0m55111a4lc";
-  });
-
+  # NOTE: No GitHub Release for this release, so update.sh does not work.
   gradle_5_6 = gradleGen (gradleSpec {
     version = "5.6.4";
     nativeVersion = "0.18";
     sha256 = "03d86bbqd19h9xlanffcjcy3vg1k5905vzhf9mal9g21603nfc0z";
   });
 
+  # NOTE: No GitHub Release for this release, so update.sh does not work.
   gradle_4_10 = gradleGen (gradleSpec {
     version = "4.10.3";
     nativeVersion = "0.14";

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -63,24 +63,33 @@ rec {
     };
   };
 
+  gradle_7_3 = gradleGen (gradleSpec {
+    version = "7.3-rc-2";
+    nativeVersion = "0.22-milestone-21";
+    sha256 = "0ydg26i376bjax5lval9n79v8afng467vkx3zdga0bzxl8dbi9z6";
+  });
+
   gradle_latest = gradle_7;
 
-  gradle_7 = gradleGen (gradleSpec {
+  # NOTE: 7.3 is a candidate.
+  gradle_7 = gradle_7_2;
+
+  gradle_7_2 = gradleGen (gradleSpec {
     version = "7.2";
     nativeVersion = "0.22-milestone-21";
     sha256 = "1pg6w5czysywsgdvmll5bwd2p6y99cn5sn3gw69cps9mkjd710gm";
   });
 
-  gradle_6_8 = gradleGen (gradleSpec {
-    version = "6.8.3";
-    nativeVersion = "0.22-milestone-9";
-    sha256 = "01fjrk5nfdp6mldyblfmnkq2gv1rz1818kzgr0k2i1wzfsc73akz";
+  gradle_6_9 = gradleGen (gradleSpec {
+    version = "6.9.1";
+    nativeVersion = "0.22-milestone-20";
+    sha256 = "1zmjfwlh34b65rdx9izgavw3qwqqwm39h5siyj2bf0m55111a4lc";
   });
 
   gradle_5_6 = gradleGen (gradleSpec {
     version = "5.6.4";
     nativeVersion = "0.18";
-    sha256 = "1f3067073041bc44554d0efe5d402a33bc3d3c93cc39ab684f308586d732a80d";
+    sha256 = "03d86bbqd19h9xlanffcjcy3vg1k5905vzhf9mal9g21603nfc0z";
   });
 
   gradle_4_10 = gradleGen (gradleSpec {

--- a/pkgs/development/tools/build-managers/gradle/gradle-6.9.1-spec.nix
+++ b/pkgs/development/tools/build-managers/gradle/gradle-6.9.1-spec.nix
@@ -1,0 +1,5 @@
+{
+  version = "6.9.1";
+  nativeVersion = "0.22-milestone-20";
+  sha256 = "1zmjfwlh34b65rdx9izgavw3qwqqwm39h5siyj2bf0m55111a4lc";
+}

--- a/pkgs/development/tools/build-managers/gradle/gradle-7.2-spec.nix
+++ b/pkgs/development/tools/build-managers/gradle/gradle-7.2-spec.nix
@@ -1,0 +1,5 @@
+{
+  version = "7.2";
+  nativeVersion = "0.22-milestone-21";
+  sha256 = "1pg6w5czysywsgdvmll5bwd2p6y99cn5sn3gw69cps9mkjd710gm";
+}

--- a/pkgs/development/tools/build-managers/gradle/gradle-7.3-rc-3-spec.nix
+++ b/pkgs/development/tools/build-managers/gradle/gradle-7.3-rc-3-spec.nix
@@ -1,0 +1,5 @@
+{
+  version = "7.3-rc-3";
+  nativeVersion = "0.22-milestone-21";
+  sha256 = "0401q4qpl36a2vnlrlsblflfiiy3b95gyj2wj62hzc1x00hbfznm";
+}

--- a/pkgs/development/tools/build-managers/gradle/update.sh
+++ b/pkgs/development/tools/build-managers/gradle/update.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-prefetch curl jq
+
+# Generates Gradle release specs from GitHub Releases.
+#
+# As of 2021-11, this script has very poor error handling,
+# it is expected to be run by maintainers as one-off job
+# only.
+#
+# NOTE: The earliest Gradle release that has a
+# corresponding entry as GitHub Release is 6.8-rc-1.
+
+for v in $(curl -s "https://api.github.com/repos/gradle/gradle/releases" | jq -r '.[].tag_name' | sort -n -r)
+do
+    # Tag names and download filenames are not the same,
+    # we modify the tag name slightly to translate it
+    # to the naming scheme of download filenames.
+    # This translation assumes a tag naming scheme.
+    # As of 2021-11 it works from 6.8-rc-1 to 7.3-rc-3.
+
+    # Remove first letter (assumed to be "v").
+    v=${v:1}
+
+    # To lower case.
+    v=${v,,}
+
+    # Add dash after "rc".
+    v=${v/-rc/-rc-}
+
+    # Remove trailing ".0"
+    v=${v%.0}
+
+    # Remove trailing ".0" for release candidates.
+    v=${v/.0-rc/-rc}
+
+    f="gradle-${v}-spec.nix"
+
+    if [ -f "$f" ]
+    then
+        echo "$v SKIP"
+        continue
+    fi
+
+    url="https://services.gradle.org/distributions/gradle-${v}-bin.zip"
+    read -d "\n" gradle_hash gradle_path < <(nix-prefetch-url --print-path $url)
+
+    # Prefix and suffix for "native-platform" dependency.
+    gradle_native_prefix="gradle-$v/lib/native-native-"
+    gradle_native_suffix=".jar"
+    gradle_native=$(zipinfo -1 "$gradle_path" "$gradle_native_prefix*$gradle_native_suffix" | head -n1)
+    gradle_native=${gradle_native#"$gradle_native_prefix"}
+    gradle_native=${gradle_native%"$gradle_native_suffix"}
+
+    echo -e "{\\n  version = \"$v\";\\n  nativeVersion = \"$gradle_native\";\\n  sha256 = \"$gradle_hash\";\\n}" > $f
+
+    echo "$v DONE"
+done

--- a/pkgs/development/tools/scenebuilder/default.nix
+++ b/pkgs/development/tools/scenebuilder/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, jdk11, gradleGen, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell, makeWrapper, glib, wrapGAppsHook }:
 let
-  gradle = (gradleGen.override (old: { java = jdk11; })).gradle_6_8;
+  gradle = (gradleGen.override (old: { java = jdk11; })).gradle_6_9;
 
   pname = "scenebuilder";
   version = "15.0.1";

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -88,7 +88,7 @@ let
   '';
 
   # The default one still uses jdk8 (#89731)
-  gradle_6 = (gradleGen.override (old: { java = jdk; })).gradle_6_8;
+  gradle_6 = (gradleGen.override (old: { java = jdk; })).gradle_6_9;
 
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14567,7 +14567,7 @@ with pkgs;
   gradle_4_10 = res.gradleGen.gradle_4_10;
   gradle_4 = gradle_4_10;
   gradle_5 = res.gradleGen.gradle_5_6;
-  gradle_6 = res.gradleGen.gradle_6_8;
+  gradle_6 = res.gradleGen.gradle_6_9;
   gradle_7 = res.gradleGen.gradle_7;
 
   gperf = callPackage ../development/tools/misc/gperf { };


### PR DESCRIPTION
Added the most recent release candidate, while keeping `gradle_latest` pointing at the latest (non-candidate) release.

Bumped 6.8 to 6.9.1.

Standing by for Gradle 7.3

```sh
nix-prefetch-url "https://services.gradle.org/distributions/gradle-7.3-bin.zip"
```