### PR TITLE
zoom-us: Update updater script for new Zoom version syntax

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/update.sh
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/update.sh
@@ -5,6 +5,6 @@ set -eu -o pipefail
 
 version="$(curl -Ls https://zoom.us/download\?os\=linux | \
   pup '.linux-ver-text text{}' | \
-  awk -F'[ ().]' '{printf $2"."$3"."$6"."$7"\n"}')"
+  awk -F'[ ().]' '{printf $2"."$3"."$4"."$6"\n"}')"
 
 update-source-version zoom-us "$version"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Since version 5.8.0 (16), the zoom.us version naming scheme has changed. Instead of `x.y.z (a.b)`, new zoom versions use the scheme `x.y.z (a)`.

This commit adapts the awk script to extract versions from the new naming scheme.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
