### PR TITLE
auto-multiple-choice: init at 1.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11200,6 +11200,17 @@
     githubId = 1141680;
     name = "Thane Gill";
   };
+  thblt = {
+    name = "Thibault Polge";
+    email = "thibault@thb.lt";
+    matrix = "@thbltp:matrix.org";
+    github = "thblt";
+    githubId = 2453136;
+    keys = [{
+      longkeyid = "rsa4096/0x63A44817A52EAB7B";
+      fingerprint = "D2A2 F0A1 E7A8 5E6F B711  DEE5 63A4 4817 A52E AB7B";
+    }];
+  };
   TheBrainScrambler = {
     email = "esthromeris@riseup.net";
     github = "TheBrainScrambler";

--- a/pkgs/applications/misc/auto-multiple-choice/default.nix
+++ b/pkgs/applications/misc/auto-multiple-choice/default.nix
@@ -1,0 +1,163 @@
+{ lib
+, stdenv
+, fetchurl
+, perlPackages
+, makeWrapper
+, wrapGAppsHook
+, cairo
+, dblatex
+, gnumake
+, gobject-introspection
+, graphicsmagick
+, gsettings-desktop-schemas
+, gtk3
+, libnotify
+, librsvg
+, libxslt
+, netpbm
+, opencv
+, pango
+, perl
+, pkg-config
+, poppler
+, auto-multiple-choice
+}:
+stdenv.mkDerivation rec {
+  pname = "auto-multiple-choice";
+  version = "1.5.1";
+  src = fetchurl {
+    url = "https://download.auto-multiple-choice.net/${pname}_${version}_precomp.tar.gz";
+    sha256 = "71831122f7b43245d3289617064e0b561817c0130ee1773c1b957841b28b854c";
+  };
+  tlType = "run";
+
+  # There's only the Makefile
+  dontConfigure = true;
+
+  makeFlags = [
+    "PERLPATH=${perl}/bin/perl"
+    # We *need* to pass DESTDIR, as the Makefile ignores PREFIX.
+    "DESTDIR=$(out)"
+    # Relative paths.
+    "BINDIR=/bin"
+    "PERLDIR=/share/perl5"
+    "MODSDIR=/lib/"
+    "TEXDIR=/tex/latex/" # what texlive.combine expects
+    "TEXDOCDIR=/share/doc/texmf/" # TODO where to put this?
+    "MAN1DIR=/share/man/man1"
+    "DESKTOPDIR=/share/applications"
+    "METAINFODIR=/share/metainfo"
+    "ICONSDIR=/share/auto-multiple-choice/icons"
+    "APPICONDIR=/share/icons/hicolor"
+    "LOCALEDIR=/share/locale"
+    "MODELSDIR=/share/auto-multiple-choice/models"
+    "DOCDIR=/share/doc/auto-multiple-choice"
+    "SHARED_MIMEINFO_DIR=/share/mime/packages"
+    "LANG_GTKSOURCEVIEW_DIR=/share/gtksourceview-4/language-specs"
+    # Pretend to be redhat so `install` doesn't try to chown/chgrp.
+    "SYSTEM_TYPE=rpm"
+  ];
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/auto-multiple-choice \
+    ''${makeWrapperArgs[@]} \
+    --prefix PERL5LIB : "${with perlPackages; makePerlPath [
+      ArchiveZip
+      DBDSQLite
+      Cairo
+      CairoGObject
+      DBI
+      Glib
+      GlibObjectIntrospection
+      Gtk3
+      LocaleGettext
+      PerlMagick
+      TextCSV
+      XMLParser
+      XMLSimple
+      XMLWriter
+    ]}:"$out/share/perl5 \
+    --prefix XDG_DATA_DIRS : "$out/share" \
+    --set TEXINPUTS ":.:$out/share/texmf/tex/latex/AMC"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    cairo
+    cairo.dev
+    dblatex
+    gnumake
+    gobject-introspection
+    graphicsmagick
+    gsettings-desktop-schemas
+    gtk3
+    libnotify
+    librsvg
+    libxslt
+    netpbm
+    opencv
+    pango
+    poppler
+  ] ++ (with perlPackages; [
+    perl
+    ArchiveZip
+    Cairo
+    CairoGObject
+    DBDSQLite
+    DBI
+    Glib
+    GlibObjectIntrospection
+    Gtk3
+    LocaleGettext
+    PerlMagick
+    TextCSV
+    XMLParser
+    XMLSimple
+    XMLWriter
+  ]);
+
+  meta = with lib; {
+    description = "Create and manage multiple choice questionnaires with automated marking.";
+    longDescription = ''
+      Create, manage and mark multiple-choice questionnaires.
+      auto-multiple-choice features automated or manual formatting with
+      LaTeX, shuffling of questions and answers and automated marking using
+      Optical Mark Recognition.
+
+      Questionnaires can be created using either a very simple text syntax,
+      AMC-TXT, or LaTeX. In the latter case, your TeXLive installation must
+      be combined with this package.  This can be done in configuration.nix
+      as follows:
+
+      <screen>
+      …
+      environment.systemPackages = with pkgs; [
+        auto-multiple-choice
+        (texlive.combine {
+          inherit (pkgs.texlive) scheme-full;
+          extra =
+            {
+              pkgs = [ auto-multiple-choice ];
+            };
+        })
+      ];
+      </screen>
+
+      For usage instructions, see documentation at the project's homepage.
+    '';
+    homepage = "https://www.auto-multiple-choice.net/";
+    changelog = "https://gitlab.com/jojo_boulix/auto-multiple-choice/-/blob/master/ChangeLog";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.thblt ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23692,6 +23692,8 @@ with pkgs;
 
   audio-recorder = callPackage ../applications/audio/audio-recorder { };
 
+  auto-multiple-choice = callPackage ../applications/misc/auto-multiple-choice { };
+
   autokey = callPackage ../applications/office/autokey { };
 
   autotalent = callPackage ../applications/audio/autotalent { };


### PR DESCRIPTION
###### Motivation for this change

There are two commits in this PR:

 - One to create the auto-multiple-choice package.
 - The other to add myself to the maintainers list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (Ran this, there was none)
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking 
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
