### PR TITLE
default-crate-overrides: some more crates

### DIFF
--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -12,6 +12,7 @@
 , dbus-glib
 , gdk-pixbuf
 , cairo
+, python2
 , python3
 , libsodium
 , postgresql
@@ -22,7 +23,11 @@
 , clang
 , llvmPackages
 , linux-pam
+, cmake
+, glib
+, freetype
 , rdkafka
+, udev
 , ...
 }:
 
@@ -61,6 +66,10 @@ in
     buildInputs = [ dbus ];
   };
 
+  expat-sys = attrs: {
+    nativeBuildInputs = [ cmake ];
+  };
+
   foundationdb-sys = attrs: {
     buildInputs = [ foundationdb ];
     # needed for 0.4+ release, when the FFI bindings are auto-generated
@@ -73,6 +82,16 @@ in
 
   foundationdb = attrs: {
     buildInputs = [ foundationdb ];
+  };
+
+  freetype-sys = attrs: {
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ freetype ];
+  };
+
+  glib-sys = attrs: {
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ glib ];
   };
 
   gobject-sys = attrs: {
@@ -112,6 +131,11 @@ in
     buildInputs = [ dbus ];
   };
 
+  libudev-sys = attrs: {
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ udev ];
+  };
+
   nettle-sys = attrs: {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ nettle clang ];
@@ -144,6 +168,10 @@ in
   rink = attrs: {
     buildInputs = [ gmp ];
     crateBin = [{ name = "rink"; path = "src/bin/rink.rs"; }];
+  };
+
+  sdl2-sys = attr: {
+    nativeBuildInputs = [ curl ];
   };
 
   security-framework-sys = attr: {
@@ -182,6 +210,15 @@ in
 
   serde_derive = attrs: {
     buildInputs = lib.optional stdenv.isDarwin Security;
+  };
+
+  servo-fontconfig-sys = attrs: {
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ freetype ];
+  };
+
+  skia-bindings = attrs: {
+    nativeBuildInputs = [ python2 ];
   };
 
   thrussh-libsodium = attrs: {


### PR DESCRIPTION
###### Motivation for this change

Necessary crate overrides for
- `expat-sys`
- `glib-sys`
- `libudev-sys`
- `sdl2-sys`
- `servo-fontconfig`
- `skia-bindings`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
