### PR TITLE
clpm: 0.3.6 -> 0.4.1

### DIFF
--- a/pkgs/development/tools/clpm/default.nix
+++ b/pkgs/development/tools/clpm/default.nix
@@ -2,32 +2,45 @@
 , stdenv
 , fetchgit
 , wrapLisp
-, sbcl_2_0_9
+, sbcl
 , openssl
 }:
 
 stdenv.mkDerivation rec {
   pname = "clpm";
-  version = "0.3.6";
+  version = "0.4.1";
 
   src = fetchgit {
     url = "https://gitlab.common-lisp.net/clpm/clpm";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "04w46yhv31p4cfb84b6qvyfw7x5nx6lzyd4yzhd9x6qvb7p5kmfh";
+    sha256 = "sha256-UhaLmbdsIPj6O+s262HUMxuz/5t43JR+TlOjq8Y2CDs=";
   };
 
   buildInputs = [
-    (wrapLisp sbcl_2_0_9)
+    (wrapLisp sbcl)
+  ];
+
+  propagatedBuildInputs = [
     openssl
   ];
+
+  patchPhase = ''
+    # patch cl-plus-ssl to ensure that it finds libssl and libcrypto
+    sed 's|libssl.so|${openssl.out}/lib/libssl.so|' -i ext/cl-plus-ssl/src/reload.lisp
+    sed 's|libcrypto.so|${openssl.out}/lib/libcrypto.so|' -i ext/cl-plus-ssl/src/reload.lisp
+    # patch dexador to avoid error due to dexador being loaded multiple times
+    sed -i 's/defpackage/uiop:define-package/g' ext/dexador/src/dexador.lisp
+  '';
 
   buildPhase = ''
     runHook preBuild
 
-    ln -s ${openssl.out}/lib/libcrypto*${stdenv.hostPlatform.extensions.sharedLibrary}* .
-    ln -s ${openssl.out}/lib/libssl*${stdenv.hostPlatform.extensions.sharedLibrary}* .
-    common-lisp.sh --script scripts/build.lisp
+    # exporting home to avoid using /homeless-shelter/.cache/ as this will cause
+    # ld to complaing about `impure path used in link`.
+    export HOME=$TMP
+
+    common-lisp.sh --script scripts/build-release.lisp
 
     runHook postBuild
   '';
@@ -35,7 +48,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    INSTALL_ROOT=$out sh install.sh
+    cd build/release-staging/dynamic/clpm-${version}*/
+    INSTALL_ROOT=$out/ sh install.sh
 
     runHook postInstall
   '';
@@ -48,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.clpm.dev/";
     license = licenses.bsd2;
     maintainers = [ maintainers.petterstorvik ];
-    platforms = platforms.all;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/tools/clpm/default.nix
+++ b/pkgs/development/tools/clpm/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.clpm.dev/";
     license = licenses.bsd2;
     maintainers = [ maintainers.petterstorvik ];
-    platforms = platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/development/tools/clpm/default.nix
+++ b/pkgs/development/tools/clpm/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     openssl
   ];
 
-  patchPhase = ''
+  postPatch = ''
     # patch cl-plus-ssl to ensure that it finds libssl and libcrypto
     sed 's|libssl.so|${openssl.out}/lib/libssl.so|' -i ext/cl-plus-ssl/src/reload.lisp
     sed 's|libcrypto.so|${openssl.out}/lib/libcrypto.so|' -i ext/cl-plus-ssl/src/reload.lisp
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     cd build/release-staging/dynamic/clpm-${version}*/
-    INSTALL_ROOT=$out/ sh install.sh
+    INSTALL_ROOT=$out/ bash install.sh
 
     runHook postInstall
   '';
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.clpm.dev/";
     license = licenses.bsd2;
     maintainers = [ maintainers.petterstorvik ];
-    platforms = lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update CLPM to version 0.4.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
