### PR TITLE
factorio: set pname

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -134,7 +134,6 @@ let
 
   base = with actual; {
     pname = "factorio-${releaseType}";
-
     inherit version src;
 
     preferLocalBuild = true;

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -133,9 +133,9 @@ let
   modDir = factorio-utils.mkModDirDrv mods;
 
   base = with actual; {
-    name = "factorio-${releaseType}-${version}";
+    pname = "factorio-${releaseType}";
 
-    inherit src;
+    inherit version src;
 
     preferLocalBuild = true;
     dontBuild = true;


### PR DESCRIPTION


###### Motivation for this change

This is recommended in https://nixos.org/manual/nixpkgs/unstable/#sec-using-stdenv. Also this allows me to use `allowUnfreePredicate` with a function filtering for `pname`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
