### PR TITLE
corefonts: set pname

### DIFF
--- a/pkgs/data/fonts/corefonts/default.nix
+++ b/pkgs/data/fonts/corefonts/default.nix
@@ -25,7 +25,8 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "corefonts-1";
+  pname = "corefonts";
+  version = "1";
 
   exes = map ({name, sha256}: fetchurl {
     url = "mirror://sourceforge/corefonts/${name}32.exe";


### PR DESCRIPTION

###### Motivation for this change

This is recommended in https://nixos.org/manual/nixpkgs/unstable/#sec-using-stdenv. Also this allows me to use allowUnfreePredicate with a function filtering for `pname`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
