### PR TITLE
cloudcompare: Cleanup/fix comments

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -1,7 +1,6 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , dxflib
 , eigen
@@ -20,9 +19,7 @@
 
 mkDerivation rec {
   pname = "cloudcompare";
-  # Released version doesn't work with packaged PCL
-  # because it's too new. Considering that a release
-  # is a year ago it's unreasonable to wait for it.
+  # Released version(v2.11.3) doesn't work with packaged PCL.
   version = "unstable-2021-10-14";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change
Handle the comments from @SuperSandro2000 for  https://github.com/NixOS/nixpkgs/pull/141569 that was already merged:

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
