### PR TITLE
ffsend: 0.2.72 -> 0.2.74

### DIFF
--- a/pkgs/tools/misc/ffsend/default.nix
+++ b/pkgs/tools/misc/ffsend/default.nix
@@ -17,16 +17,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   pname = "ffsend";
-  version = "0.2.72";
+  version = "0.2.74";
 
   src = fetchFromGitLab {
     owner = "timvisee";
     repo = "ffsend";
     rev = "v${version}";
-    sha256 = "sha256-YEmEaf0ob2ulmQghwDYi0RtGuTdRHCoLdPnuVjxvlxE=";
+    sha256 = "0ia9agh0h9hp06ijmlgnw63n3xz2jajjw1maz27sawqp342x9vn5";
   };
 
-  cargoSha256 = "sha256-mcWQzfMc2cJjp0EFcfG7SAM70ItwEC/N13UDiRiI3ys=";
+  cargoSha256 = "0dl671sw3amny52a81bx7imh94dvi91dprwhcm1b0g40mjic45pw";
 
   nativeBuildInputs = [ cmake pkg-config installShellFiles ];
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change
https://github.com/timvisee/ffsend/compare/v0.2.72...v0.2.74

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files: upload works
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).