### PR TITLE
ponysay: 3.0.3 -> unstable-2021-03-27

### DIFF
--- a/pkgs/tools/misc/ponysay/default.nix
+++ b/pkgs/tools/misc/ponysay/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "ponysay";
-  version = "3.0.3";
+  version = "unstable-2021-03-27";
 
   src = fetchFromGitHub {
     owner = "erkin";
     repo = "ponysay";
-    rev = version;
-    sha256 = "sha256-R2B0TU3ZSEncGsijKgvhaHIbcZa5Dx/jVPxrILBaoVw=";
+    rev = "8a2c71416e70e4e7b0931917ebfd6479f51ddf9a";
+    sha256 = "sha256-LNc83E+7NFYYILORElNlYC7arQKGUJHv6phu+vM5xpQ=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Ponysay hasn't had a stable release since 2017 I think and there have been important fixes committed to master since then such as removal of ugly warnings printed in its output due to changes since python 3.8 (https://github.com/erkin/ponysay/issues/295)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
