### PR TITLE
threema-desktop: init at 1.0.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/threema-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/threema-desktop/default.nix
@@ -1,0 +1,55 @@
+{ lib, stdenv, fetchurl, dpkg, autoPatchelfHook, makeWrapper, electron
+, alsa-lib, glibc, gtk3, libxshmfence, mesa, nss }:
+
+stdenv.mkDerivation rec {
+  pname = "threema-desktop";
+  version = "1.0.3";
+
+  src = fetchurl {
+    # As Threema only offers a Latest Release url, the plan is to upload each
+    # new release url to web.archive.org until their Github releases page gets populated.
+    url = "https://web.archive.org/web/20211027194646/https://releases.threema.ch/web-electron/v1/release/Threema-Latest.deb";
+    sha256 = "sha256-qiFv52nnyfHxCWTePmyxW/MgzFy3EUxmW6n+UIkw7tk=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [ alsa-lib glibc gtk3 libxshmfence mesa nss ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = ''
+    # Can't unpack with the common dpkg-deb -x method
+    dpkg --fsys-tarfile $src | tar --extract
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # This will cause confusion, not needed
+    rm -r usr/bin
+    mv usr $out
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    mv $out/share/applications/threema.desktop $out/share/applications/threema-desktop.desktop
+    makeWrapper ${electron}/bin/electron \
+      $out/bin/threema \
+      --add-flags $out/lib/threema/resources/app.asar
+  '';
+
+  meta = with lib; {
+    description = "Desktop client for Threema, a privacy-focused end-to-end encrypted mobile messenger";
+    homepage = "https://threema.ch";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/threema-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/threema-desktop/default.nix
@@ -40,8 +40,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     mv $out/share/applications/threema.desktop $out/share/applications/threema-desktop.desktop
-    makeWrapper ${electron}/bin/electron \
-      $out/bin/threema \
+    makeWrapper ${electron}/bin/electron $out/bin/threema \
       --add-flags $out/lib/threema/resources/app.asar
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9876,6 +9876,8 @@ with pkgs;
 
   thinkpad-scripts = python3.pkgs.callPackage ../tools/misc/thinkpad-scripts { };
 
+  threema-desktop = callPackage ../applications/networking/instant-messengers/threema-desktop { };
+
   tidy-viewer = callPackage ../tools/text/tidy-viewer { };
 
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

closes #143169

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
