### PR TITLE
markmind: init at 1.3.1

### DIFF
--- a/pkgs/applications/misc/markmind/default.nix
+++ b/pkgs/applications/misc/markmind/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, fetchurl, appimageTools, makeWrapper, electron }:
+
+stdenv.mkDerivation rec {
+  pname = "markmind";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "https://github.com/MarkMindCkm/Mark-Mind/releases/download/v${version}/Mark.Mind-${version}.AppImage";
+    sha256 = "sha256-iOJ0IOIzleA69rv94Qd35rMbHc+XSi8OPatf2V6sYrI=";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    name = "markmind-${version}";
+    inherit src;
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/markmind $out/share/applications
+    cp -a ${appimageContents}/{locales,resources} $out/share/markmind
+    cp -a ${appimageContents}/mind.desktop $out/share/applications/markmind.desktop
+    cp -a ${appimageContents}/usr/share/icons $out/share
+    substituteInPlace $out/share/applications/markmind.desktop \
+      --replace 'Exec=AppRun' 'Exec=markmind'
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${electron}/bin/electron $out/bin/markmind \
+      --add-flags $out/share/markmind/resources/app.asar
+  '';
+
+  meta = with lib; {
+    description = "Mind map and outliner editor";
+    homepage = "https://github.com/MarkMindCkm/Mark-Mind";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26351,6 +26351,10 @@ with pkgs;
 
   markets = callPackage ../applications/misc/markets { };
 
+  markmind = callPackage ../applications/misc/markmind {
+    electron = electron_9;
+  };
+
   marp = callPackage ../applications/office/marp { };
 
   magnetico = callPackage ../applications/networking/p2p/magnetico { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#142870

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Observation: Requires Electron 9, which is EOL.