### PR TITLE
argyllcms: make reproducible

### DIFF
--- a/pkgs/tools/graphics/argyllcms/default.nix
+++ b/pkgs/tools/graphics/argyllcms/default.nix
@@ -13,83 +13,88 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-umY3wQfG26Okqnw+MCUnlwWTAyJ6MR/FHe5oe61KBh0=";
   };
 
-  # The contents of this file comes from the Jamtop file from the
-  # root of the ArgyllCMS distribution, rewritten to pick up Nixpkgs
-  # library paths. When ArgyllCMS is updated, make sure that changes
-  # in that file is reflected here.
-  jamTop = writeText "argyllcms_jamtop" ''
-    DESTDIR = "/" ;
-    REFSUBDIR = "share/argyllcms" ;
-
-    # Keep this DESTDIR anchored to Jamtop. PREFIX is used literally
-    ANCHORED_PATH_VARS = DESTDIR ;
-
-    # Tell standalone libraries that they are part of Argyll:
-    DEFINES += ARGYLLCMS ;
-
-    # enable serial instruments & support
-    USE_SERIAL = true ;
-
-    # enable fast serial instruments & support
-    USE_FAST_SERIAL = true ;                # (Implicit in USE_SERIAL too)
-
-    # enable USB instruments & support
-    USE_USB = true ;
-
-    # enable dummy Demo Instrument (only if code is available)
-    USE_DEMOINST = true ;
-
-    # enable Video Test Patch Generator and 3DLUT device support
-    # (V2.0.0 and above)
-    USE_VTPGLUT = false ;
-
-    # enable Printer device support
-    USE_PRINTER = false ;
-
-    # enable CMF Measurement device and accessory support (if present)
-    USE_CMFM = false ;
-
-    # Use ArgyllCMS version of libusb (deprecated - don't use)
-    USE_LIBUSB = false ;
-
-    # Compile in graph plotting code (Not fully implemented)
-    USE_PLOT = true ;		# [true]
-
-    JPEGLIB = ;
-    JPEGINC = ;
-    HAVE_JPEG = true ;
-
-    TIFFLIB = ;
-    TIFFINC = ;
-    HAVE_TIFF = true ;
-
-    PNGLIB = ;
-    PNGINC = ;
-    HAVE_PNG = true ;
-
-    ZLIB = ;
-    ZINC = ;
-    HAVE_Z = true ;
-
-    SSLLIB = ;
-    SSLINC = ;
-    HAVE_SSL = true ;
-
-    LINKFLAGS +=
-      ${lib.concatStringsSep " " (map (x: "-L${x}/lib") buildInputs)}
-      -ldl -lrt -lX11 -lXext -lXxf86vm -lXinerama -lXrandr -lXau -lXdmcp -lXss
-      -ljpeg -ltiff -lpng -lssl ;
-  '';
-
   nativeBuildInputs = [ jam unzip ];
 
-  preConfigure = ''
+  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    substituteInPlace Jambase \
+      --replace "-m64" ""
+  '';
+
+  preConfigure = let
+    # The contents of this file comes from the Jamtop file from the
+    # root of the ArgyllCMS distribution, rewritten to pick up Nixpkgs
+    # library paths. When ArgyllCMS is updated, make sure that changes
+    # in that file is reflected here.
+    jamTop = writeText "argyllcms_jamtop" ''
+      DESTDIR = "/" ;
+      REFSUBDIR = "share/argyllcms" ;
+
+      # Keep this DESTDIR anchored to Jamtop. PREFIX is used literally
+      ANCHORED_PATH_VARS = DESTDIR ;
+
+      # Tell standalone libraries that they are part of Argyll:
+      DEFINES += ARGYLLCMS ;
+
+      # enable serial instruments & support
+      USE_SERIAL = true ;
+
+      # enable fast serial instruments & support
+      USE_FAST_SERIAL = true ;                # (Implicit in USE_SERIAL too)
+
+      # enable USB instruments & support
+      USE_USB = true ;
+
+      # enable dummy Demo Instrument (only if code is available)
+      USE_DEMOINST = true ;
+
+      # enable Video Test Patch Generator and 3DLUT device support
+      # (V2.0.0 and above)
+      USE_VTPGLUT = false ;
+
+      # enable Printer device support
+      USE_PRINTER = false ;
+
+      # enable CMF Measurement device and accessory support (if present)
+      USE_CMFM = false ;
+
+      # Use ArgyllCMS version of libusb (deprecated - don't use)
+      USE_LIBUSB = false ;
+
+      # Compile in graph plotting code (Not fully implemented)
+      USE_PLOT = true ;		# [true]
+
+      JPEGLIB = ;
+      JPEGINC = ;
+      HAVE_JPEG = true ;
+
+      TIFFLIB = ;
+      TIFFINC = ;
+      HAVE_TIFF = true ;
+
+      PNGLIB = ;
+      PNGINC = ;
+      HAVE_PNG = true ;
+
+      ZLIB = ;
+      ZINC = ;
+      HAVE_Z = true ;
+
+      SSLLIB = ;
+      SSLINC = ;
+      HAVE_SSL = true ;
+
+      LINKFLAGS +=
+        ${lib.concatStringsSep " " (map (x: "-L${x}/lib") buildInputs)}
+        -ldl -lrt -lX11 -lXext -lXxf86vm -lXinerama -lXrandr -lXau -lXdmcp -lXss
+        -ljpeg -ltiff -lpng -lssl ;
+    '';
+  in ''
     cp ${jamTop} Jamtop
     substituteInPlace Makefile --replace "-j 3" "-j $NIX_BUILD_CORES"
     # Remove tiff, jpg and png to be sure the nixpkgs-provided ones are used
     rm -rf tiff jpg png
 
-    unset AR
+    export AR="$AR rusc"
   '';
 
   buildInputs = [
@@ -110,6 +115,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/etc/udev/rules.d
     sed -i '/udev-acl/d' usb/55-Argyll.rules
     cp -v usb/55-Argyll.rules $out/etc/udev/rules.d/
+
+    sed -i -e 's/^CREATED .*/CREATED "'"$(date -d @$SOURCE_DATE_EPOCH)"'"/g' $out/share/argyllcms/RefMediumGamut.gam
+
   '';
 
   meta = with lib; {


### PR DESCRIPTION
and make binfmt cross-compilable

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
closes #93507

###### Things done
without binfmt enabled the build fails with `/bin/sh: imdi/imdi_make: not found`
```
argyllcms-aarch64-unknown-linux-gnu> unpacking sources
argyllcms-aarch64-unknown-linux-gnu> unpacking source archive /nix/store/agk6sn75qc3hv7fyzg76jva1bhfzbmhb-source
argyllcms-aarch64-unknown-linux-gnu> source root is source
argyllcms-aarch64-unknown-linux-gnu> patching sources
argyllcms-aarch64-unknown-linux-gnu> updateAutotoolsGnuConfigScriptsPhase
argyllcms-aarch64-unknown-linux-gnu> Updating Autotools / GNU config script to a newer upstream version: ./tiff/config/config.sub
argyllcms-aarch64-unknown-linux-gnu> Updating Autotools / GNU config script to a newer upstream version: ./jpeg/config.sub
argyllcms-aarch64-unknown-linux-gnu> Updating Autotools / GNU config script to a newer upstream version: ./tiff/config/config.guess
argyllcms-aarch64-unknown-linux-gnu> Updating Autotools / GNU config script to a newer upstream version: ./jpeg/config.guess
argyllcms-aarch64-unknown-linux-gnu> configuring
argyllcms-aarch64-unknown-linux-gnu> fixing libtool script ./jpeg/ltmain.sh
argyllcms-aarch64-unknown-linux-gnu> no configure script, doing nothing
argyllcms-aarch64-unknown-linux-gnu> building
argyllcms-aarch64-unknown-linux-gnu> build flags: SHELL=/nix/store/wadmyilr414n7bimxysbny876i2vlm5r-bash-5.1-p8/bin/bash PREFIX=/nix/store/62ab0zglrvw8hangplcs7fmxfwsbh9lw-argyllcms-aarch64-unknown-linux-gnu-2.2.1 all
argyllcms-aarch64-unknown-linux-gnu> jam -q -fJambase -j 22
argyllcms-aarch64-unknown-linux-gnu> We're on a 64 bit host
argyllcms-aarch64-unknown-linux-gnu> HOME =  /homeless-shelter
argyllcms-aarch64-unknown-linux-gnu> PWD =  /build/source
argyllcms-aarch64-unknown-linux-gnu> ...patience...
argyllcms-aarch64-unknown-linux-gnu> ...found 1127 target(s)...
argyllcms-aarch64-unknown-linux-gnu> ...updating 442 target(s)...
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/numsup.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/dnsq.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/powell.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/dhsx.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/varmet.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/ludecomp.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/svd.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/zbrent.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/rand.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/sobol.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/aatree.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/quadprog.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/gnewt.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/roots.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ numlib/ui.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ plot/plot.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ plot/vrml.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ icc/icc.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ cgats/pars.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ cgats/cgats.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-attr.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-entity.o
argyllcms-aarch64-unknown-linux-gnu> Archive numlib/libui.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib numlib/libui.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-file.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-get.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-index.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-node.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-private.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-search.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-set.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xml/mxml-string.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ yajl/yajl.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ yajl/yajl_alloc.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ yajl/yajl_buf.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ yajl/yajl_encode.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ yajl/yajl_gen.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ yajl/yajl_lex.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ yajl/yajl_parser.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ yajl/yajl_tree.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ yajl/yajl_version.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ rspl/rspl.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ rspl/scat.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ rspl/rev.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ rspl/gam.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ rspl/spline.o
argyllcms-aarch64-unknown-linux-gnu> yajl/yajl_gen.c: In function 'yajl_gen_integer':
argyllcms-aarch64-unknown-linux-gnu> yajl/yajl_gen.c:269:16: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'longlong' {aka 'long int'} [-Wformat=]
argyllcms-aarch64-unknown-linux-gnu>   269 |     sprintf(i, "%" PF64PREC "d", number);
argyllcms-aarch64-unknown-linux-gnu>       |                ^~~               ~~~~~~
argyllcms-aarch64-unknown-linux-gnu>       |                                  |
argyllcms-aarch64-unknown-linux-gnu>       |                                  longlong {aka long int}
argyllcms-aarch64-unknown-linux-gnu> yajl/yajl_gen.c:269:30: note: format string is defined here
argyllcms-aarch64-unknown-linux-gnu>   269 |     sprintf(i, "%" PF64PREC "d", number);
argyllcms-aarch64-unknown-linux-gnu>       |                 ~~~~~~~~~~~~~^
argyllcms-aarch64-unknown-linux-gnu>       |                              |
argyllcms-aarch64-unknown-linux-gnu>       |                              long long int
argyllcms-aarch64-unknown-linux-gnu> Cc_ rspl/opt.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ gamut/gamut.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ gamut/gammap.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ gamut/nearsmth.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xicc.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xlutfix.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xspect.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xcolorants.o
argyllcms-aarch64-unknown-linux-gnu> Archive plot/libplot.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib plot/libplot.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xutils.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/iccjpeg.o
argyllcms-aarch64-unknown-linux-gnu> Archive yajl/libyajl.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib yajl/libyajl.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xdevlin.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xcam.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/cam97s3.o
argyllcms-aarch64-unknown-linux-gnu> Archive xml/libmxml.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib xml/libmxml.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/cam02.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/mpp.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/ccmx.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/ccss.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xfit.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xdgb.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/moncurve.o
argyllcms-aarch64-unknown-linux-gnu> Archive cgats/libcgats.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib cgats/libcgats.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xcal.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/bt1886.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/tm3015.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xcolorants2.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/xutils2.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ xicc/iccjpeg2.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ imdi/imdi_make.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ imdi/imdi_gen.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ imdi/cgen.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ imdi/imdi_tab.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/inst.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/insttypes.o
argyllcms-aarch64-unknown-linux-gnu> In file included from imdi/imdi.h:20,
argyllcms-aarch64-unknown-linux-gnu>                  from imdi/imdi_make.c:31:
argyllcms-aarch64-unknown-linux-gnu> imdi/imdi_utl.h:38:9: note: #pragma message: Using 64 bit integer color kernel
argyllcms-aarch64-unknown-linux-gnu>    38 | #pragma message("Using 64 bit integer color kernel")
argyllcms-aarch64-unknown-linux-gnu>       |         ^~~~~~~
argyllcms-aarch64-unknown-linux-gnu> In file included from imdi/imdi_gen.c:99:
argyllcms-aarch64-unknown-linux-gnu> imdi/imdi_utl.h:38:9: note: #pragma message: Using 64 bit integer color kernel
argyllcms-aarch64-unknown-linux-gnu>    38 | #pragma message("Using 64 bit integer color kernel")
argyllcms-aarch64-unknown-linux-gnu>       |         ^~~~~~~
argyllcms-aarch64-unknown-linux-gnu> Archive xicc/libxutils.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib xicc/libxutils.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/icoms.o
argyllcms-aarch64-unknown-linux-gnu> In file included from imdi/imdi.h:20,
argyllcms-aarch64-unknown-linux-gnu>                  from imdi/cgen.c:29:
argyllcms-aarch64-unknown-linux-gnu> imdi/imdi_utl.h:38:9: note: #pragma message: Using 64 bit integer color kernel
argyllcms-aarch64-unknown-linux-gnu>    38 | #pragma message("Using 64 bit integer color kernel")
argyllcms-aarch64-unknown-linux-gnu>       |         ^~~~~~~
argyllcms-aarch64-unknown-linux-gnu> In file included from imdi/imdi.h:20,
argyllcms-aarch64-unknown-linux-gnu>                  from imdi/imdi_tab.c:26:
argyllcms-aarch64-unknown-linux-gnu> imdi/imdi_utl.h:38:9: note: #pragma message: Using 64 bit integer color kernel
argyllcms-aarch64-unknown-linux-gnu>    38 | #pragma message("Using 64 bit integer color kernel")
argyllcms-aarch64-unknown-linux-gnu>       |         ^~~~~~~
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/disptechs.o
argyllcms-aarch64-unknown-linux-gnu> imdi/imdi_make.c: In function 'main':
argyllcms-aarch64-unknown-linux-gnu> imdi/imdi_make.c:264:24: warning: '.c' directive writing 2 bytes into a region of size between 1 and 1125 [-Wformat-overflow=]
argyllcms-aarch64-unknown-linux-gnu>   264 |     sprintf(temp, "%s%s.c",dirname,ofname);
argyllcms-aarch64-unknown-linux-gnu>       |                        ^~
argyllcms-aarch64-unknown-linux-gnu> In file included from /nix/store/s7q476yng3bi68my2853ilgx1qhs34jg-aarch64-unknown-linux-gnu-stage-final-gcc-debug-9.3.0/aarch64-unknown-linux-gnu/sys-include/stdio.h:866,
argyllcms-aarch64-unknown-linux-gnu>                  from imdi/imdi_make.c:24:
argyllcms-aarch64-unknown-linux-gnu> /nix/store/s7q476yng3bi68my2853ilgx1qhs34jg-aarch64-unknown-linux-gnu-stage-final-gcc-debug-9.3.0/aarch64-unknown-linux-gnu/sys-include/bits/stdio2.h:38:10: note: '__builtin___sprintf_chk' output between 3 and 1127 bytes into a destination of size 1125
argyllcms-aarch64-unknown-linux-gnu>    38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
argyllcms-aarch64-unknown-linux-gnu>       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>    39 |       __glibc_objsize (__s), __fmt,
argyllcms-aarch64-unknown-linux-gnu>       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>    40 |       __va_arg_pack ());
argyllcms-aarch64-unknown-linux-gnu>       |       ~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/rspec.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/xrga.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/dtp22.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/dtp41.o
argyllcms-aarch64-unknown-linux-gnu> Archive xicc/libxcolorants.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib xicc/libxcolorants.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/dtp51.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/ss.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/ss_imp.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/dtp20.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/i1disp.o
argyllcms-aarch64-unknown-linux-gnu> Archive numlib/libnum.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib numlib/libnum.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/i1d3.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/i1pro.o
argyllcms-aarch64-unknown-linux-gnu> Archive gamut/libgammap.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib gamut/libgammap.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/i1pro_imp.o
argyllcms-aarch64-unknown-linux-gnu> ...on 100th target...
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/munki.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/munki_imp.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/hcfr.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/spyd2.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/spydX.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/huey.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/colorhug.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/ex1.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/usbio.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/hidio.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ imdi/cgen.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/i1pro3.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/i1pro3_imp.o
argyllcms-aarch64-unknown-linux-gnu> Archive gamut/libgamut.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib gamut/libgamut.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/specbos.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/kleink10.o
argyllcms-aarch64-unknown-linux-gnu> In file included from imdi/imdi.h:20,
argyllcms-aarch64-unknown-linux-gnu>                  from imdi/cgen.c:29:
argyllcms-aarch64-unknown-linux-gnu> imdi/imdi_utl.h:38:9: note: #pragma message: Using 64 bit integer color kernel
argyllcms-aarch64-unknown-linux-gnu>    38 | #pragma message("Using 64 bit integer color kernel")
argyllcms-aarch64-unknown-linux-gnu>       |         ^~~~~~~
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/smcube.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/dtp92.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/dispsup.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/dispwin.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/webwin.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/ccwin.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/dummywin.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/mongoose.o
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c: In function 'get_displays':
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:742:22: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'XID' {aka 'long unsigned int'} [-Wformat=]
argyllcms-aarch64-unknown-linux-gnu>   742 |     debugrr2((errout,"XRRGetOutputPrimary returned XID %x\n",primary));
argyllcms-aarch64-unknown-linux-gnu>       |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>       |                                                              |
argyllcms-aarch64-unknown-linux-gnu>       |                                                              XID {aka long unsigned int}
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:187:52: note: in definition of macro 'debugrr2'
argyllcms-aarch64-unknown-linux-gnu>   187 | # define debugrr2(xx) if (callback_ddebug) fprintf xx
argyllcms-aarch64-unknown-linux-gnu>       |                                                    ^~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:742:57: note: format string is defined here
argyllcms-aarch64-unknown-linux-gnu>   742 |     debugrr2((errout,"XRRGetOutputPrimary returned XID %x\n",primary));
argyllcms-aarch64-unknown-linux-gnu>       |                                                        ~^
argyllcms-aarch64-unknown-linux-gnu>       |                                                         |
argyllcms-aarch64-unknown-linux-gnu>       |                                                         unsigned int
argyllcms-aarch64-unknown-linux-gnu>       |                                                        %lx
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:797:23: warning: too many arguments for format [-Wformat-extra-args]
argyllcms-aarch64-unknown-linux-gnu>   797 |      debugrr2((errout,"CRTC skipped as it has no mode or no outputs\n",i,xj,crtci->noutput));
argyllcms-aarch64-unknown-linux-gnu>       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:187:52: note: in definition of macro 'debugrr2'
argyllcms-aarch64-unknown-linux-gnu>   187 | # define debugrr2(xx) if (callback_ddebug) fprintf xx
argyllcms-aarch64-unknown-linux-gnu>       |                                                    ^~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c: In function 'dispwin_get_ramdac':
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:1505:20: warning: too many arguments for format [-Wformat-extra-args]
argyllcms-aarch64-unknown-linux-gnu>  1505 |    debugr2((errout,"XRRGetCrtcGammaSize number of entries %d inconsistent with previous value\n",nent,p->nent));
argyllcms-aarch64-unknown-linux-gnu>       |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:185:45: note: in definition of macro 'debugr2'
argyllcms-aarch64-unknown-linux-gnu>   185 | # define debugr2(xx) if (p->ddebug) fprintf xx
argyllcms-aarch64-unknown-linux-gnu>       |                                             ^~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:1556:20: warning: too many arguments for format [-Wformat-extra-args]
argyllcms-aarch64-unknown-linux-gnu>  1556 |    debugr2((errout,"XF86VidModeGetGammaRampSize number of entries %d inconsistent with previous value\n",nent,p->nent));
argyllcms-aarch64-unknown-linux-gnu>       |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:185:45: note: in definition of macro 'debugr2'
argyllcms-aarch64-unknown-linux-gnu>   185 | # define debugr2(xx) if (p->ddebug) fprintf xx
argyllcms-aarch64-unknown-linux-gnu>       |                                             ^~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c: In function 'new_dispwin':
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5404:21: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
argyllcms-aarch64-unknown-linux-gnu>  5404 |     debugr2((errout,"new_dispwin: Default Visual red mask 0x%x is not %d bits\n",vinfo->red_mask,p->fdepth));
argyllcms-aarch64-unknown-linux-gnu>       |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>       |                                                                                       |
argyllcms-aarch64-unknown-linux-gnu>       |                                                                                       long unsigned int
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:185:45: note: in definition of macro 'debugr2'
argyllcms-aarch64-unknown-linux-gnu>   185 | # define debugr2(xx) if (p->ddebug) fprintf xx
argyllcms-aarch64-unknown-linux-gnu>       |                                             ^~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5404:62: note: format string is defined here
argyllcms-aarch64-unknown-linux-gnu>  5404 |     debugr2((errout,"new_dispwin: Default Visual red mask 0x%x is not %d bits\n",vinfo->red_mask,p->fdepth));
argyllcms-aarch64-unknown-linux-gnu>       |                                                             ~^
argyllcms-aarch64-unknown-linux-gnu>       |                                                              |
argyllcms-aarch64-unknown-linux-gnu>       |                                                              unsigned int
argyllcms-aarch64-unknown-linux-gnu>       |                                                             %lx
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5417:21: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
argyllcms-aarch64-unknown-linux-gnu>  5417 |     debugr2((errout,"new_dispwin: Default Visual green mask 0x%x is not %d bits\n",vinfo->red_mask,p->fdepth));
argyllcms-aarch64-unknown-linux-gnu>       |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>       |                                                                                         |
argyllcms-aarch64-unknown-linux-gnu>       |                                                                                         long unsigned int
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:185:45: note: in definition of macro 'debugr2'
argyllcms-aarch64-unknown-linux-gnu>   185 | # define debugr2(xx) if (p->ddebug) fprintf xx
argyllcms-aarch64-unknown-linux-gnu>       |                                             ^~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5417:64: note: format string is defined here
argyllcms-aarch64-unknown-linux-gnu>  5417 |     debugr2((errout,"new_dispwin: Default Visual green mask 0x%x is not %d bits\n",vinfo->red_mask,p->fdepth));
argyllcms-aarch64-unknown-linux-gnu>       |                                                               ~^
argyllcms-aarch64-unknown-linux-gnu>       |                                                                |
argyllcms-aarch64-unknown-linux-gnu>       |                                                                unsigned int
argyllcms-aarch64-unknown-linux-gnu>       |                                                               %lx
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5430:21: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'long unsigned int' [-Wformat=]
argyllcms-aarch64-unknown-linux-gnu>  5430 |     debugr2((errout,"new_dispwin: Default Visual blue mask 0x%x is not %d bits\n",vinfo->red_mask,p->fdepth));
argyllcms-aarch64-unknown-linux-gnu>       |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>       |                                                                                        |
argyllcms-aarch64-unknown-linux-gnu>       |                                                                                        long unsigned int
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:185:45: note: in definition of macro 'debugr2'
argyllcms-aarch64-unknown-linux-gnu>   185 | # define debugr2(xx) if (p->ddebug) fprintf xx
argyllcms-aarch64-unknown-linux-gnu>       |                                             ^~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5430:63: note: format string is defined here
argyllcms-aarch64-unknown-linux-gnu>  5430 |     debugr2((errout,"new_dispwin: Default Visual blue mask 0x%x is not %d bits\n",vinfo->red_mask,p->fdepth));
argyllcms-aarch64-unknown-linux-gnu>       |                                                              ~^
argyllcms-aarch64-unknown-linux-gnu>       |                                                               |
argyllcms-aarch64-unknown-linux-gnu>       |                                                               unsigned int
argyllcms-aarch64-unknown-linux-gnu>       |                                                              %lx
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c: In function 'dispwin_uninstall_profile':
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:3156:4: warning: ignoring return value of 'setegid', declared with attribute warn_unused_result [-Wunused-result]
argyllcms-aarch64-unknown-linux-gnu>  3156 |    setegid(getgid());
argyllcms-aarch64-unknown-linux-gnu>       |    ^~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:3157:4: warning: ignoring return value of 'seteuid', declared with attribute warn_unused_result [-Wunused-result]
argyllcms-aarch64-unknown-linux-gnu>  3157 |    seteuid(getuid());
argyllcms-aarch64-unknown-linux-gnu>       |    ^~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c: In function 'restore_display':
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:3652:3: warning: ignoring return value of 'system', declared with attribute warn_unused_result [-Wunused-result]
argyllcms-aarch64-unknown-linux-gnu>  3652 |   system("xscreensaver -nosplash 2>/dev/null >/dev/null&");
argyllcms-aarch64-unknown-linux-gnu>       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:3661:3: warning: ignoring return value of 'system', declared with attribute warn_unused_result [-Wunused-result]
argyllcms-aarch64-unknown-linux-gnu>  3661 |   system("dcop kdesktop KScreensaverIface enable true 2>&1 >/dev/null");
argyllcms-aarch64-unknown-linux-gnu>       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c: In function 'new_dispwin':
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5746:6: warning: ignoring return value of 'system', declared with attribute warn_unused_result [-Wunused-result]
argyllcms-aarch64-unknown-linux-gnu>  5746 |      system("xscreensaver-command -exit 2>/dev/null >/dev/null");
argyllcms-aarch64-unknown-linux-gnu>       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5763:7: warning: ignoring return value of 'freopen', declared with attribute warn_unused_result [-Wunused-result]
argyllcms-aarch64-unknown-linux-gnu>  5763 |       freopen("/dev/null", "r", stdin);
argyllcms-aarch64-unknown-linux-gnu>       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5764:7: warning: ignoring return value of 'freopen', declared with attribute warn_unused_result [-Wunused-result]
argyllcms-aarch64-unknown-linux-gnu>  5764 |       freopen("/dev/null", "a", stdout);  /* Hide output */
argyllcms-aarch64-unknown-linux-gnu>       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5765:7: warning: ignoring return value of 'freopen', declared with attribute warn_unused_result [-Wunused-result]
argyllcms-aarch64-unknown-linux-gnu>  5765 |       freopen("/dev/null", "a", stderr);
argyllcms-aarch64-unknown-linux-gnu>       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> spectro/dispwin.c:5784:6: warning: ignoring return value of 'system', declared with attribute warn_unused_result [-Wunused-result]
argyllcms-aarch64-unknown-linux-gnu>  5784 |      system("dcop kdesktop KScreensaverIface enable false 2>&1 >/dev/null");
argyllcms-aarch64-unknown-linux-gnu>       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/insttypes2.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/xrga2.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/disptechs2.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/xdg_bds.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/aglob.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/conv.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/base64.o
argyllcms-aarch64-unknown-linux-gnu> Archive spectro/libinsttypes.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib spectro/libinsttypes.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/pollem.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ spectro/instappsup.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ scanin/scanrd.o
argyllcms-aarch64-unknown-linux-gnu> Archive spectro/libdisptechs.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib spectro/libdisptechs.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ profile/profin.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ profile/profout.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ render/render.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ render/thscreen.o
argyllcms-aarch64-unknown-linux-gnu> Archive plot/libvrml.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib plot/libvrml.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ namedc/namedc.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ ccast/ccmdns.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ ccast/ccpacket.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ ccast/ccmes.o
argyllcms-aarch64-unknown-linux-gnu> Archive spectro/libconv.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib spectro/libconv.a
argyllcms-aarch64-unknown-linux-gnu> render/render.c: In function 'render2d_write':
argyllcms-aarch64-unknown-linux-gnu> render/render.c:319:2: warning: 'uint16' is deprecated [-Wdeprecated-declarations]
argyllcms-aarch64-unknown-linux-gnu>   319 |  uint16 samplesperpixel = 0, bitspersample = 0;
argyllcms-aarch64-unknown-linux-gnu>       |  ^~~~~~
argyllcms-aarch64-unknown-linux-gnu> render/render.c:319:2: warning: 'uint16' is deprecated [-Wdeprecated-declarations]
argyllcms-aarch64-unknown-linux-gnu> render/render.c:320:2: warning: 'uint16' is deprecated [-Wdeprecated-declarations]
argyllcms-aarch64-unknown-linux-gnu>   320 |  uint16 extrasamples = 0; /* Extra "alpha" samples */
argyllcms-aarch64-unknown-linux-gnu>       |  ^~~~~~
argyllcms-aarch64-unknown-linux-gnu> render/render.c:321:2: warning: 'uint16' is deprecated [-Wdeprecated-declarations]
argyllcms-aarch64-unknown-linux-gnu>   321 |  uint16 extrainfo[MXCH2D]; /* Info about extra samples */
argyllcms-aarch64-unknown-linux-gnu>       |  ^~~~~~
argyllcms-aarch64-unknown-linux-gnu> render/render.c:322:2: warning: 'uint16' is deprecated [-Wdeprecated-declarations]
argyllcms-aarch64-unknown-linux-gnu>   322 |  uint16 photometric = 0;
argyllcms-aarch64-unknown-linux-gnu>       |  ^~~~~~
argyllcms-aarch64-unknown-linux-gnu> render/render.c:323:2: warning: 'uint16' is deprecated [-Wdeprecated-declarations]
argyllcms-aarch64-unknown-linux-gnu>   323 |  uint16 inkset = 0xffff;
argyllcms-aarch64-unknown-linux-gnu>       |  ^~~~~~
argyllcms-aarch64-unknown-linux-gnu> Cc_ ccast/ccast.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ ccast/chan/cast_channel.pb-c.o
argyllcms-aarch64-unknown-linux-gnu> Link_ imdi/imdi_make
argyllcms-aarch64-unknown-linux-gnu> Archive spectro/libinstapp.a
argyllcms-aarch64-unknown-linux-gnu> aarch64-unknown-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
argyllcms-aarch64-unknown-linux-gnu> Ranlib spectro/libinstapp.a
argyllcms-aarch64-unknown-linux-gnu> Cc_ ccast/chan/protobuf-c.o
argyllcms-aarch64-unknown-linux-gnu> Cc_ ccast/dpat.o
argyllcms-aarch64-unknown-linux-gnu> Chmod1 imdi/imdi_make
argyllcms-aarch64-unknown-linux-gnu> GenFileND1 imdi/imdi_k.h
argyllcms-aarch64-unknown-linux-gnu> /bin/sh: imdi/imdi_make: not found
argyllcms-aarch64-unknown-linux-gnu>    imdi/imdi_make -d imdi
argyllcms-aarch64-unknown-linux-gnu> ...failed GenFileND1 imdi/imdi_k.h ...
argyllcms-aarch64-unknown-linux-gnu> scanin/scanrd.c: In function 'read_relists':
argyllcms-aarch64-unknown-linux-gnu> scanin/scanrd.c:2116:36: warning: '%s' directive writing up to 19 bytes into a region of size between 1 and 20 [-Wformat-overflow=]
argyllcms-aarch64-unknown-linux-gnu>  2116 |       sprintf(s->sboxes[i].name,"%s%s",xf,yfix1);
argyllcms-aarch64-unknown-linux-gnu>       |                                    ^~     ~~~~~
argyllcms-aarch64-unknown-linux-gnu> In file included from /nix/store/s7q476yng3bi68my2853ilgx1qhs34jg-aarch64-unknown-linux-gnu-stage-final-gcc-debug-9.3.0/aarch64-unknown-linux-gnu/sys-include/stdio.h:866,
argyllcms-aarch64-unknown-linux-gnu>                  from scanin/scanrd.c:42:
argyllcms-aarch64-unknown-linux-gnu> /nix/store/s7q476yng3bi68my2853ilgx1qhs34jg-aarch64-unknown-linux-gnu-stage-final-gcc-debug-9.3.0/aarch64-unknown-linux-gnu/sys-include/bits/stdio2.h:38:10: note: '__builtin___sprintf_chk' output between 1 and 39 bytes into a destination of size 20
argyllcms-aarch64-unknown-linux-gnu>    38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
argyllcms-aarch64-unknown-linux-gnu>       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>    39 |       __glibc_objsize (__s), __fmt,
argyllcms-aarch64-unknown-linux-gnu>       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>    40 |       __va_arg_pack ());
argyllcms-aarch64-unknown-linux-gnu>       |       ~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> scanin/scanrd.c:2114:36: warning: '%s' directive writing up to 19 bytes into a region of size between 1 and 20 [-Wformat-overflow=]
argyllcms-aarch64-unknown-linux-gnu>  2114 |       sprintf(s->sboxes[i].name,"%s%s",yfix1,xf);
argyllcms-aarch64-unknown-linux-gnu>       |                                    ^~        ~~
argyllcms-aarch64-unknown-linux-gnu> In file included from /nix/store/s7q476yng3bi68my2853ilgx1qhs34jg-aarch64-unknown-linux-gnu-stage-final-gcc-debug-9.3.0/aarch64-unknown-linux-gnu/sys-include/stdio.h:866,
argyllcms-aarch64-unknown-linux-gnu>                  from scanin/scanrd.c:42:
argyllcms-aarch64-unknown-linux-gnu> /nix/store/s7q476yng3bi68my2853ilgx1qhs34jg-aarch64-unknown-linux-gnu-stage-final-gcc-debug-9.3.0/aarch64-unknown-linux-gnu/sys-include/bits/stdio2.h:38:10: note: '__builtin___sprintf_chk' output between 1 and 39 bytes into a destination of size 20
argyllcms-aarch64-unknown-linux-gnu>    38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
argyllcms-aarch64-unknown-linux-gnu>       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>    39 |       __glibc_objsize (__s), __fmt,
argyllcms-aarch64-unknown-linux-gnu>       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu>    40 |       __va_arg_pack ());
argyllcms-aarch64-unknown-linux-gnu>       |       ~~~~~~~~~~~~~~~~~
argyllcms-aarch64-unknown-linux-gnu> ...failed updating 1 target(s)...
argyllcms-aarch64-unknown-linux-gnu> ...updated 150 target(s)...
argyllcms-aarch64-unknown-linux-gnu> make: *** [Makefile:4: all] Error 1
error: builder for '/nix/store/zc8wf77gi15mpshzr9z65piazilak43j-argyllcms-aarch64-unknown-linux-gnu-2.2.1.drv' failed with exit code 2;
       last 10 log lines:
       > /nix/store/s7q476yng3bi68my2853ilgx1qhs34jg-aarch64-unknown-linux-gnu-stage-final-gcc-debug-9.3.0/aarch64-unknown-linux-gnu/sys-include/bits/stdio2.h:38:10: note: '__builtin___sprintf_chk' output between 1 and 39 bytes into a destination of size 20
       >    38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
       >       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       >    39 |       __glibc_objsize (__s), __fmt,
       >       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       >    40 |       __va_arg_pack ());
       >       |       ~~~~~~~~~~~~~~~~~
       > ...failed updating 1 target(s)...
       > ...updated 150 target(s)...
       > make: *** [Makefile:4: all] Error 1
       For full logs, run 'nix log /nix/store/zc8wf77gi15mpshzr9z65piazilak43j-argyllcms-aarch64-unknown-linux-gnu-2.2.1.drv'.
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
