### PR TITLE
zld: init at 1.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9535,6 +9535,12 @@
     githubId = 165283;
     name = "Alexey Kutepov";
   };
+  rgnns = {
+    email = "gl@gabriellievano.com";
+    github = "rgnns";
+    githubId = 811827;
+    name = "Gabriel Lievano";
+  };
   rgrunbla = {
     email = "remy@grunblatt.org";
     github = "rgrunbla";

--- a/pkgs/development/tools/zld/default.nix
+++ b/pkgs/development/tools/zld/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchzip }:
+
+stdenv.mkDerivation rec {
+  pname = "zld";
+  version = "1.3.3";
+  src = fetchzip {
+    url = "https://github.com/michaeleisel/zld/releases/download/${version}/zld.zip";
+    sha256 = "0qb4l7a4vhpnzkgzhw0jivz40jr5gdhqfyynhbkhn7ryh5s52d1p";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp zld $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "A faster version of Apple's linker";
+    homepage = "https://github.com/michaeleisel/zld";
+    license = licenses.mit;
+    maintainers = [ maintainers.rgnns ];
+    platforms = platforms.darwin;
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10935,6 +10935,8 @@ with pkgs;
 
   zimwriterfs = callPackage ../tools/text/zimwriterfs { };
 
+  zld = callPackage ../development/tools/zld { };
+
   par = callPackage ../tools/text/par { };
 
   zip = callPackage ../tools/archivers/zip { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`zld` is a faster linker than Apple's linker.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
