### PR TITLE
nextcloud-desktop: make autostart entry start client from path

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/0001-When-creating-the-autostart-entry-do-not-use-an-abso.patch
+++ b/pkgs/applications/networking/nextcloud-client/0001-When-creating-the-autostart-entry-do-not-use-an-abso.patch
@@ -1,0 +1,26 @@
+From bade623bb98c957d9a274df75b58296beb8ae6a7 Mon Sep 17 00:00:00 2001
+From: Marvin Dostal <maffinmaffinmaffinmaffin@gmail.com>
+Date: Sun, 17 Oct 2021 21:26:51 +0200
+Subject: [PATCH] When creating the autostart entry, do not use an absolute
+ path
+
+---
+ src/common/utility_unix.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/common/utility_unix.cpp b/src/common/utility_unix.cpp
+index 010408395..16964c64f 100644
+--- a/src/common/utility_unix.cpp
++++ b/src/common/utility_unix.cpp
+@@ -83,7 +83,7 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName,
+         ts << QLatin1String("[Desktop Entry]") << endl
+            << QLatin1String("Name=") << guiName << endl
+            << QLatin1String("GenericName=") << QLatin1String("File Synchronizer") << endl
+-           << QLatin1String("Exec=\"") << executablePath << "\" --background" << endl
++           << QLatin1String("Exec=") << "nextcloud --background" << endl
+            << QLatin1String("Terminal=") << "false" << endl
+            << QLatin1String("Icon=") << APPLICATION_ICON_NAME << endl
+            << QLatin1String("Categories=") << QLatin1String("Network") << endl
+-- 
+2.31.1
+

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -33,6 +33,7 @@ mkDerivation rec {
   patches = [
     # Explicitly move dbus configuration files to the store path rather than `/etc/dbus-1/services`.
     ./0001-Explicitly-copy-dbus-files-into-the-store-dir.patch
+    ./0001-When-creating-the-autostart-entry-do-not-use-an-abso.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix the autostart entry that the nextcloud-client creates. 
See  #141816


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
