### PR TITLE
default-crate-overrides: fixup

### DIFF
--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -12,7 +12,6 @@
 , dbus-glib
 , gdk-pixbuf
 , cairo
-, python2
 , python3
 , libsodium
 , postgresql
@@ -170,10 +169,6 @@ in
     crateBin = [{ name = "rink"; path = "src/bin/rink.rs"; }];
   };
 
-  sdl2-sys = attr: {
-    nativeBuildInputs = [ curl ];
-  };
-
   security-framework-sys = attr: {
     propagatedBuildInputs = [ Security ];
   };
@@ -215,10 +210,6 @@ in
   servo-fontconfig-sys = attrs: {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ freetype ];
-  };
-
-  skia-bindings = attrs: {
-    nativeBuildInputs = [ python2 ];
   };
 
   thrussh-libsodium = attrs: {


### PR DESCRIPTION


###### Motivation for this change

Fixup of https://github.com/NixOS/nixpkgs/pull/143162.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
