### PR TITLE
hypnotix: init at 2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6588,6 +6588,12 @@
       fingerprint = "5B93 9CFA E8FC 4D8F E07A  3AEA DFE1 D4A0 1733 7E2A";
     }];
   };
+  loxley = {
+    name = "loxley";
+    email = "linuxsysop+nix@gmail.com";
+    github = "loxley";
+    githubId = 837283;
+  };
   luis = {
     email = "luis.nixos@gmail.com";
     github = "Luis-Hebendanz";

--- a/pkgs/applications/video/hypnotix/default.nix
+++ b/pkgs/applications/video/hypnotix/default.nix
@@ -1,0 +1,101 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  dconf,
+  gettext,
+  glib,
+  gsettings-desktop-schemas,
+  gtk3,
+  hicolor-icon-theme,
+  mpv,
+  python3,
+  python3Packages,
+  wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hypnotix";
+  version = "2.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "hypnotix";
+    rev = version;
+    sha256 = "1silrdyi1i6dghcxs91vhqw76srmxjqbrqcyzsjmddsv8a0nzaim";
+
+  };
+
+  buildInputs = [
+    dconf
+    gettext
+    glib
+    gsettings-desktop-schemas
+    gtk3
+    hicolor-icon-theme
+    mpv
+    python3
+    python3Packages.wrapPython
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    imdbpy
+    mpv
+    pycairo
+    pygobject3
+    requests
+    setproctitle
+    unidecode
+    xapp
+  ];
+
+  dontConfigure = true;
+
+  pythonPath = propagatedBuildInputs;
+
+  libPath = lib.makeLibraryPath buildInputs;
+
+  postPatch = ''
+    substituteInPlace usr/bin/hypnotix --replace "/usr/lib/hypnotix" "$out/lib/hypnotix"
+    substituteInPlace usr/lib/hypnotix/hypnotix.py --replace "/usr/share/hypnotix" "$out/share/hypnotix"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+	  install -D     -t "$out"/bin usr/bin/hypnotix
+	  install -D     -t "$out"/lib/hypnotix usr/lib/hypnotix/{common,hypnotix}.py
+	  install -Dm644 -t "$out"/lib/hypnotix usr/lib/hypnotix/mpv.py
+	  install -Dm644 -t "$out"/share/applications usr/share/applications/hypnotix.desktop
+	  install -Dm644 -t "$out"/share/glib-2.0/schemas usr/share/glib-2.0/schemas/org.x.hypnotix.gschema.xml
+	  install -Dm644 -t "$out"/share/hypnotix usr/share/hypnotix/*.{css,png,ui}
+	  install -Dm644 -t "$out"/share/hypnotix/pictures usr/share/hypnotix/pictures/*.svg
+	  install -Dm644 -t "$out"/share/hypnotix/pictures/badges usr/share/hypnotix/pictures/badges/*
+    install -Dm644 -t "$out"/share/icons/hicolor/scalable/apps usr/share/icons/hicolor/scalable/apps/hypnotix.svg
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    ${glib.dev}/bin/glib-compile-schemas "$out"/share/glib-2.0/schemas
+  '';
+
+  preFixup = ''
+    buildPythonPath "$out $pythonPath"
+    gappsWrapperArgs+=(
+      --prefix PYTHONPATH : "$program_PYTHONPATH"
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/:$out/share"
+      --prefix LD_LIBRARY_PATH : ${libPath}
+    )
+  '';
+
+  meta = with lib; {
+    description = "Hypnotix is an IPTV streaming application with support for live TV, movies and series.";
+    homepage = "https://github.com/linuxmint/hypnotix";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.loxley ];
+    platforms = [ "x86_64-linux"];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33413,4 +33413,6 @@ with pkgs;
   zthrottle = callPackage ../tools/misc/zthrottle { };
 
   zktree = callPackage ../applications/misc/zktree {};
+
+  hypnotix = callPackage ../applications/video/hypnotix {};
 }


### PR DESCRIPTION
###### Motivation for this change

Hypnotix is an IPTV streaming application with support for live TV, movies and series.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
