### PR TITLE
losslessaudiochecker: init at 2.0.5

### DIFF
--- a/pkgs/applications/audio/losslessaudiochecker/default.nix
+++ b/pkgs/applications/audio/losslessaudiochecker/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchurl, autoPatchelfHook }:
+
+stdenv.mkDerivation {
+  pname = "losslessaudiochecker";
+  version = "2.0.5";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20211119122205/https://losslessaudiochecker.com/dl/LAC-Linux-64bit.tar.gz";
+    sha256 = "1i1zbl7sqwxwmhw89lgz922l5k85in3y76zb06h8j3zd0lb20wkq";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  setSourceRoot = "sourceRoot=$PWD";
+
+  dontBuild = true;
+
+  installPhase = ''
+    install LAC -D -t $out/bin
+  '';
+
+  meta = {
+    description = "Utility to check whether audio is truly lossless or not";
+    homepage = "https://losslessaudiochecker.com";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.x86_64;
+    maintainers = with lib.maintainers; [ p-h ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25237,6 +25237,8 @@ with pkgs;
 
   lollypop = callPackage ../applications/audio/lollypop { };
 
+  losslessaudiochecker = callPackage ../applications/audio/losslessaudiochecker { };
+
   m32edit = callPackage ../applications/audio/midas/m32edit.nix {};
 
   manim = python3Packages.callPackage ../applications/video/manim {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add losslessaudiochecker

###### Things done
losslessaudiochecker build file

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
