### PR TITLE
Nixos manual: nixos-rebuild switch to clear boot entries

### DIFF
--- a/nixos/doc/manual/administration/cleaning-store.chapter.md
+++ b/nixos/doc/manual/administration/cleaning-store.chapter.md
@@ -58,5 +58,5 @@ a while to finish.
 ## NixOS Boot Entries {#sect-nixos-gc-boot-entries}
 
 If your `/boot` partition runs out of space, after clearing old profiles
-you must rebuild your system with `nixos-rebuild` to update the `/boot`
-partition and clear space.
+you must rebuild your system with `nixos-rebuild boot` or `nixos-rebuild
+switch` to update the `/boot` partition and clear space.

--- a/nixos/doc/manual/from_md/administration/cleaning-store.chapter.xml
+++ b/nixos/doc/manual/from_md/administration/cleaning-store.chapter.xml
@@ -64,7 +64,8 @@ $ nix-store --optimise
     <para>
       If your <literal>/boot</literal> partition runs out of space,
       after clearing old profiles you must rebuild your system with
-      <literal>nixos-rebuild</literal> to update the
+      <literal>nixos-rebuild boot</literal> or
+      <literal>nixos-rebuild switch</literal> to update the
       <literal>/boot</literal> partition and clear space.
     </para>
   </section>


### PR DESCRIPTION
the `nixos-rebuild` command has multiple subcommands, and not each of
them would fix the problem of a large `/boot` partition, so let’s be
more precise here.