### PR TITLE
vmTools: Fix missing backing format in runInLinuxImage

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -390,7 +390,7 @@ rec {
       diskImage=$(pwd)/disk-image.qcow2
       origImage=${attrs.diskImage}
       if test -d "$origImage"; then origImage="$origImage/disk-image.qcow2"; fi
-      ${qemu}/bin/qemu-img create -b "$origImage" -f qcow2 $diskImage
+      ${qemu}/bin/qemu-img create -F ${attrs.diskImageFormat} -b "$origImage" -f qcow2 $diskImage
     '';
 
     /* Inside the VM, run the stdenv setup script normally, but at the

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -28,10 +28,9 @@ with vmTools;
   buildInDebian = runInLinuxImage (stdenv.mkDerivation {
     name = "deb-compile";
     src = patchelf.src;
-    diskImage = diskImages.ubuntu1204i386;
+    diskImage = diskImages.ubuntu1804i386;
     memSize = 512;
-    prePhases = [ sysInfoPhase ];
-    sysInfoPhase = ''
+    postHook = ''
       dpkg-query --list
     '';
   });

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -29,6 +29,7 @@ with vmTools;
     name = "deb-compile";
     src = patchelf.src;
     diskImage = diskImages.ubuntu1804i386;
+    diskImageFormat = "qcow2";
     memSize = 512;
     postHook = ''
       dpkg-query --list


### PR DESCRIPTION
###### Motivation for this change
With updating qemu to version 6.1.0 the derivation runInLinuxImage is broken.
I updated the test buildInDebian to demonstrate the error:

```
$ nix-build ./pkgs/build-support/vm/test.nix -A buildInDebian
...
running post-install script...
[   28.263737] reboot: Power down
building '/nix/store/8mfxdn4x7yh59ws458c9ppb8jb8ajpcw-deb-compile.drv'...
qemu-img: /build/disk-image.qcow2: Backing file specified without backing format
Detected format of qcow2.
```

Qemu 6.1.0 make the argument backing format mandatory, see https://listman.redhat.com/archives/libvir-list/2021-May/msg00054.html

I added an additional attribute diskImageFormat to runInLinuxImage to fix the problem.

###### Things done
The test buildInDebian is built without error.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
