### PR TITLE
zsh: fix `git stash drop` completions

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ncurses, pcre, buildPackages }:
+{ lib, stdenv, fetchurl, fetchpatch, ncurses, pcre, buildPackages }:
 
 let
   version = "5.8";
@@ -21,6 +21,13 @@ stdenv.mkDerivation {
   patches = [
     # fix location of timezone data for TZ= completion
     ./tz_completion.patch
+    # This commit will be released with the next version of zsh
+    (fetchpatch {
+      name = "fix-git-stash-drop-completions.patch";
+      url = "https://github.com/zsh-users/zsh/commit/754658aff38e1bdf487c58bec6174cbecd019d11.patch";
+      sha256 = "sha256-ud/rLD+SqvyTzT6vwOr+MWH+LY5o5KACrU1TpmL15Lo=";
+      excludes = [ "ChangeLog" ];
+    })
   ];
 
   buildInputs = [ ncurses pcre ];


### PR DESCRIPTION
###### Motivation for this change

Cherry pick the unreleased fix for `git stash drop` completions: https://github.com/zsh-users/zsh/commit/754658aff38e1bdf487c58bec6174cbecd019d11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
