### PR TITLE
coreboot-toolchain: Rework and update to latest release

### DIFF
--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -1,16 +1,24 @@
-{ callPackage, fetchgit, lib, stdenvNoCC
-, bison, curl, git, perl
-, flex, gnat11, zlib
+{ bison
+, callPackage
+, curl
+, fetchgit
+, flex
+, git
+, gnat11
+, lib
+, perl
+, stdenvNoCC
+, zlib
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "coreboot-toolchain";
-  version = "4.14";
+  version = "4.15";
 
   src = fetchgit {
     url = "https://review.coreboot.org/coreboot";
     rev = version;
-    sha256 = "00xr74yc0kj9rrqa1a8b7bih865qlp9i4zs67ysavkfrjrwwssxm";
+    sha256 = "0y137dhfi0zf9nmyq49ksrad69yspbnsmzc4wjkw3hjwvzgi8j27";
     fetchSubmodules = false;
   };
 

--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -3,6 +3,7 @@
 , curl
 , fetchgit
 , flex
+, getopt
 , git
 , gnat11
 , lib
@@ -18,8 +19,14 @@ stdenvNoCC.mkDerivation rec {
   src = fetchgit {
     url = "https://review.coreboot.org/coreboot";
     rev = version;
-    sha256 = "0y137dhfi0zf9nmyq49ksrad69yspbnsmzc4wjkw3hjwvzgi8j27";
+    sha256 = "1qsb2ca22h5f0iwc254qsfm7qcn8967ir8aybdxa1pakgmnfsyp9";
     fetchSubmodules = false;
+    leaveDotGit = true;
+    postFetch = ''
+      patchShebangs $out/util/crossgcc/buildgcc
+      PATH=${lib.makeBinPath [ getopt ]}:$PATH $out/util/crossgcc/buildgcc -W > $out/.crossgcc_version
+      rm -rf $out/.git
+    '';
   };
 
   nativeBuildInputs = [ bison curl git perl ];
@@ -37,10 +44,11 @@ stdenvNoCC.mkDerivation rec {
       ) (callPackage ./stable.nix { })
     }
 
-    patchShebangs util/genbuild_h/genbuild_h.sh util/crossgcc/buildgcc
+    patchShebangs util/genbuild_h/genbuild_h.sh
   '';
 
   buildPhase = ''
+    export CROSSGCC_VERSION=$(cat .crossgcc_version)
     make crossgcc-i386 CPUS=$NIX_BUILD_CORES DEST=$out
   '';
 

--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -11,6 +11,7 @@ stdenvNoCC.mkDerivation rec {
     url = "https://review.coreboot.org/coreboot";
     rev = version;
     sha256 = "00xr74yc0kj9rrqa1a8b7bih865qlp9i4zs67ysavkfrjrwwssxm";
+    fetchSubmodules = false;
   };
 
   nativeBuildInputs = [ bison curl git perl ];

--- a/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
@@ -1,9 +1,9 @@
 { fetchurl }: [
   {
-    name = "gmp-6.2.0.tar.xz";
+    name = "gmp-6.2.1.tar.xz";
     archive = fetchurl {
-      sha256 = "09hmg8k63mbfrx1x3yy6y1yzbbq85kw5avbibhcgrg9z3ganr3i5";
-      url = "mirror://gnu/gmp/gmp-6.2.0.tar.xz";
+      sha256 = "1wml97fdmpcynsbw9yl77rj29qibfp652d0w3222zlfx5j8jjj7x";
+      url = "mirror://gnu/gmp/gmp-6.2.1.tar.xz";
     };
   }
   {
@@ -14,31 +14,31 @@
     };
   }
   {
-    name = "mpc-1.2.0.tar.gz";
+    name = "mpc-1.2.1.tar.gz";
     archive = fetchurl {
-      sha256 = "19pxx3gwhwl588v496g3aylhcw91z1dk1d5x3a8ik71sancjs3z9";
-      url = "mirror://gnu/mpc/mpc-1.2.0.tar.gz";
+      sha256 = "0n846hqfqvmsmim7qdlms0qr86f1hck19p12nq3g3z2x74n3sl0p";
+      url = "mirror://gnu/mpc/mpc-1.2.1.tar.gz";
     };
   }
   {
-    name = "gcc-8.3.0.tar.xz";
+    name = "gcc-11.2.0.tar.xz";
     archive = fetchurl {
-      sha256 = "0b3xv411xhlnjmin2979nxcbnidgvzqdf4nbhix99x60dkzavfk4";
-      url = "mirror://gnu/gcc/gcc-8.3.0/gcc-8.3.0.tar.xz";
+      sha256 = "12zs6vd2rapp42x154m479hg3h3lsafn3xhg06hp5hsldd9xr3nh";
+      url = "mirror://gnu/gcc/gcc-11.2.0/gcc-11.2.0.tar.xz";
     };
   }
   {
-    name = "binutils-2.35.1.tar.xz";
+    name = "binutils-2.37.tar.xz";
     archive = fetchurl {
-      sha256 = "01w6xvfy7sjpw8j08k111bnkl27j760bdsi0wjvq44ghkgdr3v9w";
-      url = "mirror://gnu/binutils/binutils-2.35.1.tar.xz";
+      sha256 = "0b53hhgfnafw27y0c3nbmlfidny2cc5km29pnfffd8r0y0j9f3c2";
+      url = "mirror://gnu/binutils/binutils-2.37.tar.xz";
     };
   }
   {
-    name = "acpica-unix2-20200925.tar.gz";
+    name = "acpica-unix2-20210331.tar.gz";
     archive = fetchurl {
-      sha256 = "18n6129fkgj85piid7v4zxxksv3h0amqp4p977vcl9xg3bq0zd2w";
-      url = "https://acpica.org/sites/acpica/files/acpica-unix2-20200925.tar.gz";
+      sha256 = "1h98pvc9iy1c49cid0ppjwk5zsy2m1xbvfqb72pkwkrd4rn35arx";
+      url = "https://acpica.org/sites/acpica/files/acpica-unix2-20210331.tar.gz";
     };
   }
   {

--- a/pkgs/development/tools/misc/coreboot-toolchain/update.sh
+++ b/pkgs/development/tools/misc/coreboot-toolchain/update.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env nix-shell
 #!nix-shell --pure -i bash -p nix cacert git getopt
 
-rootdir="../../../../../"
+if [ ! -d .git ]; then
+  echo "This script needs to be run from the root directory of nixpkgs. Exiting."
+  exit 1
+fi
 
-src="$(nix-build $rootdir --no-out-link -A coreboot-toolchain.src)"
+pkg_dir="$(dirname "$0")"
+
+src="$(nix-build . --no-out-link -A coreboot-toolchain.src)"
 urls=$($src/util/crossgcc/buildgcc -u)
 
 tmp=$(mktemp)
@@ -28,4 +33,4 @@ echo ']' >> $tmp
 
 sed -ie 's/https\:\/\/ftpmirror\.gnu\.org/mirror\:\/\/gnu/g' $tmp
 
-mv $tmp sources.nix
+mv $tmp $pkg_dir/sources.nix


### PR DESCRIPTION
###### Motivation for this change
* Disable fetching of the submodules
* Rework update script
* Update to latest release
* Improve reproducibility

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
