### PR TITLE
arcan.arcan: fix static openal issues

### DIFF
--- a/pkgs/desktops/arcan/arcan/000-openal.patch
+++ b/pkgs/desktops/arcan/arcan/000-openal.patch
@@ -1,0 +1,15 @@
+diff -Naur source-old/src/CMakeLists.txt source-new/src/CMakeLists.txt
+--- source-old/src/CMakeLists.txt	1969-12-31 21:00:01.000000000 -0300
++++ source-new/src/CMakeLists.txt	2021-10-29 12:03:06.461399341 -0300
+@@ -362,10 +360,8 @@
+ 	if (EXISTS ${EXTERNAL_SRC_DIR}/git/openal AND STATIC_OPENAL)
+ 		amsg("${CL_YEL}Building OpenAL static from external/git mirror${CL_RST}")
+ 		ExternalProject_Add(OpenAL
+-			SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/openal
++			SOURCE_DIR "${EXTERNAL_SRC_DIR}/git/openal"
+ 			BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/openal_static
+-			UPDATE_COMMAND ""
+-			GIT_REPOSITORY "${EXTERNAL_SRC_DIR}/git/openal"
+ 			${EXTERNAL_DEFS}
+ 			${CMAKE_EXTERNAL_DEFS}
+ 			-DALSOFT_BACKEND_DSOUND=OFF

--- a/pkgs/desktops/arcan/arcan/001-luajit.patch
+++ b/pkgs/desktops/arcan/arcan/001-luajit.patch
@@ -1,0 +1,17 @@
+diff -Naur source-old/src/CMakeLists.txt source-new/src/CMakeLists.txt
+--- source-old/src/CMakeLists.txt	1969-12-31 21:00:01.000000000 -0300
++++ source-new/src/CMakeLists.txt	2021-10-29 12:03:06.461399341 -0300
+@@ -419,12 +415,7 @@
+ 		set(LUA_TAG "luajit51")
+ 		if (EXISTS ${EXTERNAL_SRC_DIR}/git/luajit)
+ 			ExternalProject_Add(luajit
+-				SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/luajit
+-				GIT_REPOSITORY "${EXTERNAL_SRC_DIR}/git/luajit"
+-				CONFIGURE_COMMAND ""
+-				GIT_TAG "v2.1.0-beta3"
+-				UPDATE_COMMAND ""
+-				INSTALL_COMMAND ""
++				SOURCE_DIR "${EXTERNAL_SRC_DIR}/git/luajit"
+ 				BUILD_IN_SOURCE 1
+ 				BUILD_COMMAND "${EXTMAKE_CMD}"
+ 				DEFAULT_CC=${CMAKE_C_COMPILER}

--- a/pkgs/desktops/arcan/arcan/002-libuvc.patch
+++ b/pkgs/desktops/arcan/arcan/002-libuvc.patch
@@ -1,0 +1,15 @@
+diff -Naur source-old/src/frameserver/decode/default/CMakeLists.txt source-new/src/frameserver/decode/default/CMakeLists.txt
+--- source-old/src/frameserver/decode/default/CMakeLists.txt	1969-12-31 21:00:01.000000000 -0300
++++ source-new/src/frameserver/decode/default/CMakeLists.txt	2021-10-29 12:01:31.989933725 -0300
+@@ -62,10 +62,8 @@
+ 		if (STATIC_LIBUVC)
+ 			pkg_check_modules(LIBUSB_1 REQUIRED libusb-1.0)
+ 			ExternalProject_Add(libuvc
+-				SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/frameserver/decode/libuvc"
++				SOURCE_DIR "${EXTERNAL_SRC_DIR}/git/libuvc"
+ 				BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/libuvc_static"
+-				UPDATE_COMMAND ""
+-				GIT_REPOSITORY "${EXTERNAL_SRC_DIR}/git/libuvc"
+ 				${EXTERNAL_DEFS}
+ 				${CMAKE_EXTERNAL_DEFS}
+ 				-DBUILD_UVC_STATIC=ON

--- a/pkgs/desktops/arcan/arcan/003-freetype.patch
+++ b/pkgs/desktops/arcan/arcan/003-freetype.patch
@@ -1,0 +1,14 @@
+diff -Naur source-old/src/CMakeLists.txt source-new/src/CMakeLists.txt
+--- source-old/src/CMakeLists.txt	1969-12-31 21:00:01.000000000 -0300
++++ source-new/src/CMakeLists.txt	2021-10-29 12:03:06.461399341 -0300
+@@ -317,9 +317,7 @@
+ 		find_package(BZip2 REQUIRED QUIET)
+ 		pkg_check_modules(HARFBUZZ REQUIRED QUIET harfbuzz)
+ 		ExternalProject_Add(Freetype
+-			SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/freetype"
+-			UPDATE_COMMAND ""
+-			GIT_REPOSITORY "${EXTERNAL_SRC_DIR}/git/freetype"
++			SOURCE_DIR "${EXTERNAL_SRC_DIR}/git/freetype"
+ 			${EXTERNAL_DEFS}
+ 			${CMAKE_EXTERNAL_DEFS}
+ 			-DWITH_ZLIB=OFF

--- a/pkgs/desktops/arcan/arcan/clone-sources.nix
+++ b/pkgs/desktops/arcan/arcan/clone-sources.nix
@@ -1,0 +1,25 @@
+{ fetchgit, fetchFromGitHub }:
+{
+  letoram-openal-src = fetchFromGitHub {
+    owner = "letoram";
+    repo = "openal";
+    rev = "1c7302c580964fee9ee9e1d89ff56d24f934bdef";
+    hash = "sha256-InqU59J0zvwJ20a7KU54xTM7d76VoOlFbtj7KbFlnTU=";
+  };
+  freetype-src = fetchgit {
+    url = "git://git.sv.nongnu.org/freetype/freetype2.git";
+    rev = "94cb3a2eb96b3f17a1a3bd0e6f7da97c0e1d8f57";
+    sha256 = "sha256-LzjqunX/T8khF2UjPlPYiQOwMGem8MqPYneR2LdZ5Fg=";
+  };
+  libuvc-src = fetchgit {
+    owner = "libuvc";
+    repo = "libuvc";
+    rev = "b2b01ae6a2875d05c99eb256bb15815018d6e837";
+    sha256 = "sha256-2zCTjyodRARkHM/Q0r4bdEH9LO1Z9xPCnY2xE4KZddA=";
+  };
+  luajit-src = fetchgit {
+    url = "https://luajit.org/git/luajit-2.0.git";
+    rev = "d3294fa63b344173db68dd612c6d3801631e28d4";
+    sha256 = "sha256-1iHBXcbYhWN4M8g5oH09S1j1WrjYzI6qcRbHsdfpRkk=";
+  };
+}


### PR DESCRIPTION
Arcan has some interesting idiosyncrasies. One of them is using cmake. The other
is using cmake to vendoring some low-level, custom-patched dependencies.

In order to work around them, I have created ... a custom patch!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
