### PR TITLE
[21.05] qemu: fix CVE-2021-3527, CVE-2021-3682, CVE-2021-3713

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -96,6 +96,26 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/qemu-project/qemu/-/commit/9f22893adcb02580aee5968f32baa2cd109b3ec2.patch";
       sha256 = "1vkhm9vl671y4cra60b6704339qk1h5dyyb3dfvmvpsvfyh2pm7n";
     })
+    (fetchpatch {
+      name = "CVE-2021-3527-patch1.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/05a40b172e4d691371534828078be47e7fff524c.patch";
+      sha256 = "19hwwyb3vh7pli921dx74i4bgpnlc7s43jma5mqzfp6wc158g5zl";
+    })
+    (fetchpatch {
+      name = "CVE-2021-3527-patch2.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/7ec54f9eb62b5d177e30eb8b1cad795a5f8d8986.patch";
+      sha256 = "1qakkb7i4gx3x4rrp7500yxqrcnvc2h6a8g916csynscbprlvl97";
+    })
+    (fetchpatch {
+      name = "CVE-2021-3682.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/5e796671e6b8d5de4b0b423dce1b3eba144a92c9.patch";
+      sha256 = "0g87arqvjff1vzgzb87h67ws51y033slhzlqx1yy4fw9dzkszj9k";
+    })
+    (fetchpatch {
+      name = "CVE-2021-3713.patch";
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/13b250b12ad3c59114a6a17d59caf073ce45b33a.patch";
+      sha256 = "0lkzfc7gdlvj4rz9wk07fskidaqysmx8911g914ds1jnczgk71mf";
+    })
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {


### PR DESCRIPTION
Backport patches for 6.0.0

https://nvd.nist.gov/vuln/detail/CVE-2021-3527
https://nvd.nist.gov/vuln/detail/CVE-2021-3682
https://nvd.nist.gov/vuln/detail/CVE-2021-3713

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

For https://github.com/NixOS/nixpkgs/issues/143003
Includes https://github.com/NixOS/nixpkgs/pull/143296
Closes https://github.com/NixOS/nixpkgs/issues/138694

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
