### PR TITLE
python3Packages.flake8-length: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/flake8-length/default.nix
+++ b/pkgs/development/python-modules/flake8-length/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, flake8
+, pytestCheckHook
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "flake8-length";
+  version = "0.2.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15frvccm1qx783jlx8fw811ks9jszln3agbb58lg4dhbmjaf2cxw";
+  };
+
+  propagatedBuildInputs = [
+    flake8
+  ];
+
+  pythonImportsCheck = [
+    "flake8_length"
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "tests/" ];
+
+  meta = {
+    description = "Flake8 plugin for a smart line length validation";
+    homepage = "https://github.com/orsinium-labs/flake8-length";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sauyon ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2685,6 +2685,8 @@ in {
 
   flake8 = callPackage ../development/python-modules/flake8 { };
 
+  flake8-length = callPackage ../development/python-modules/flake8-length { };
+
   flake8-debugger = callPackage ../development/python-modules/flake8-debugger { };
 
   flake8-future-import = callPackage ../development/python-modules/flake8-future-import { };


### PR DESCRIPTION
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
