### PR TITLE
gtk-theme-framework: init at 0.2.3

### DIFF
--- a/pkgs/data/themes/gtk-theme-framework/default.nix
+++ b/pkgs/data/themes/gtk-theme-framework/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, theme, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "gtk-theme-framework";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "jaxwilko";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1z5s5rsgiypanf2z0avaisbflnvwrc8aiy5qskrsvbbaja63jy3s";
+  };
+
+  postPatch = ''
+    substituteInPlace main.sh \
+      --replace "#!/usr/bin/env bash" "#!/bin/sh"
+
+    substituteInPlace scripts/install.sh \
+      --replace "#!/usr/bin/env bash" "#!/bin/sh"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/themes
+    ./main.sh -i -t ${theme} -d $out/share/themes
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/jaxwilko/gtk-theme-framework";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ flexagoon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22729,6 +22729,16 @@ with pkgs;
 
   gruvbox-dark-gtk = callPackage ../data/themes/gruvbox-dark-gtk { };
 
+  palenight-theme = callPackage ../data/themes/gtk-theme-framework { theme = "palenight"; };
+
+  amarena-theme = callPackage ../data/themes/gtk-theme-framework { theme = "amarena"; };
+
+  gruvterial-theme = callPackage ../data/themes/gtk-theme-framework { theme = "gruvterial"; };
+
+  oceanic-theme = callPackage ../data/themes/gtk-theme-framework { theme = "oceanic"; };
+
+  spacx-gtk-theme = callPackage ../data/themes/gtk-theme-framework { theme = "spacx"; };
+
   gruvbox-dark-icons-gtk = callPackage ../data/icons/gruvbox-dark-icons-gtk {
     inherit (plasma5Packages) breeze-icons;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds 5 new gtk themes built with gtk-theme-framework
https://github.com/jaxwilko/gtk-theme-framework

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
