### PR TITLE
python3Packages.gvm-tools: 21.6.1 -> 21.10.0

### DIFF
--- a/pkgs/development/python-modules/gvm-tools/default.nix
+++ b/pkgs/development/python-modules/gvm-tools/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , poetry-core
 , pytestCheckHook
 , python-gvm
@@ -10,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "gvm-tools";
-  version = "21.6.1";
+  version = "21.10.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +18,7 @@ buildPythonPackage rec {
     owner = "greenbone";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1n9alryf52xkwxwagmq8bdn3a8scnmgh3qfdjwj6jybcyk36rv6n";
+    sha256 = "sha256-LGdbqkIKdmtUOGSoCme6oVG1aCbtASSxi9K9f3khafA=";
   };
 
   nativeBuildInputs = [
@@ -32,15 +31,6 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-  ];
-
-  patches = [
-    # Switch to poetry-core, https://github.com/greenbone/gvm-tools/pull/520
-    (fetchpatch {
-      name = "switch-to-poetry-core.patch";
-      url = "https://github.com/greenbone/gvm-tools/commit/db65495181ca339610b1007a33cc13285a470242.patch";
-      sha256 = "069rg742pxjd36vap0xp6367rd69pji4yfxbycc7z0b8gvf80w5z";
-    })
   ];
 
   disabledTests = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 21.10.0

Change log: https://github.com/greenbone/gvm-tools/releases/tag/v21.10.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
