### PR TITLE
dump1090: 5.0 → 6.1

### DIFF
--- a/pkgs/applications/radio/dump1090/default.nix
+++ b/pkgs/applications/radio/dump1090/default.nix
@@ -5,17 +5,19 @@
 , libusb1
 , ncurses
 , rtl-sdr
+, hackrf
+, limesuite
 }:
 
 stdenv.mkDerivation rec {
   pname = "dump1090";
-  version = "5.0";
+  version = "6.1";
 
   src = fetchFromGitHub {
     owner = "flightaware";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1fckfcgypmplzl1lidd04jxiabczlfx9mv21d6rbsfknghsjpn03";
+    sha256 = "sha256-OLXnT5TD6ZBNJUk4qXOMbr+NWdw3j1rv1xkFPZi4Wo8=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -25,7 +27,15 @@ stdenv.mkDerivation rec {
     libusb1
     ncurses
     rtl-sdr
-  ];
+    hackrf
+  ] ++ lib.optional stdenv.isLinux limesuite;
+
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang
+    "-Wno-implicit-function-declaration -Wno-int-conversion";
+
+  buildFlags = [ "dump1090" "view1090" ];
+
+  doCheck = true;
 
   installPhase = ''
     runHook preInstall
@@ -41,7 +51,7 @@ stdenv.mkDerivation rec {
     description = "A simple Mode S decoder for RTLSDR devices";
     homepage = "https://github.com/flightaware/dump1090";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ earldouglas ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
* [changelog](https://github.com/flightaware/dump1090/compare/v5.0...v6.1)
* enable on darwin
* enable HackRF support
* enable LimeSDR support (linux only)
* enable tests

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
