### PR TITLE
ikiwiki: Various fixes

### DIFF
--- a/pkgs/applications/misc/ikiwiki/default.nix
+++ b/pkgs/applications/misc/ikiwiki/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, perlPackages, gettext, makeWrapper, ImageMagick, which, highlight
+{ lib, stdenv, fetchurl, fetchpatch, perlPackages, gettext, makeWrapper, ImageMagick, which, highlight
 , gitSupport ? false, git
 , docutilsSupport ? false, python, docutils
 , monotoneSupport ? false, monotone
@@ -31,9 +31,17 @@ stdenv.mkDerivation rec {
     ++ lib.optionals subversionSupport [subversion]
     ++ lib.optionals mercurialSupport [mercurial];
 
-  # A few markdown tests fail, but this is expected when using Text::Markdown
-  # instead of Text::Markdown::Discount.
-  patches = [ ./remove-markdown-tests.patch ];
+  patches = [
+    # A few markdown tests fail, but this is expected when using Text::Markdown
+    # instead of Text::Markdown::Discount.
+    ./remove-markdown-tests.patch
+
+    (fetchpatch {
+      name = "Catch-up-to-highlight-4.0-API-change";
+      url = "http://source.ikiwiki.branchable.com/?p=source.git;a=patch;h=9ea3f9dfe7c0341f4e002b48728b8139293e19d0";
+      sha256 = "16s4wvsfclx0a5cm2awr69dvw2vsi8lpm0d7kyl5w0kjlmzfc7h9";
+    })
+  ];
 
   postPatch = ''
     sed -i s@/usr/bin/perl@${perlPackages.perl}/bin/perl@ pm_filter mdwn2man

--- a/pkgs/applications/misc/ikiwiki/default.nix
+++ b/pkgs/applications/misc/ikiwiki/default.nix
@@ -74,5 +74,6 @@ stdenv.mkDerivation rec {
     homepage = "http://ikiwiki.info/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
+    maintainers = [ maintainers.wentasah ];
   };
 }

--- a/pkgs/applications/misc/ikiwiki/default.nix
+++ b/pkgs/applications/misc/ikiwiki/default.nix
@@ -23,7 +23,10 @@ stdenv.mkDerivation rec {
       TimeDate gettext makeWrapper DBFile CGISession CGIFormBuilder LocaleGettext
       RpcXML XMLSimple ImageMagick YAML YAMLLibYAML HTMLTree AuthenPassphrase
       NetOpenIDConsumer LWPxParanoidAgent CryptSSLeay ])
-    ++ lib.optionals docutilsSupport [python docutils]
+    ++ lib.optionals docutilsSupport [
+         (python.withPackages (pp: with pp; [ pygments ]))
+         docutils
+       ]
     ++ lib.optionals gitSupport [git]
     ++ lib.optionals monotoneSupport [monotone]
     ++ lib.optionals bazaarSupport [breezy]

--- a/pkgs/applications/misc/ikiwiki/default.nix
+++ b/pkgs/applications/misc/ikiwiki/default.nix
@@ -50,6 +50,9 @@ stdenv.mkDerivation rec {
     # State the gcc dependency, and make the cgi use our wrapper
     sed -i -e 's@$0@"'$out/bin/ikiwiki'"@' \
         -e "s@'cc'@'${stdenv.cc}/bin/gcc'@" IkiWiki/Wrapper.pm
+    # Without patched plugin shebangs, some tests like t/rst.t fail
+    # (with docutilsSupport enabled)
+    patchShebangs plugins/*
   '';
 
   configurePhase = "perl Makefile.PL PREFIX=$out";


### PR DESCRIPTION
###### Motivation for this change

Ikiwiki doesn't work well with current nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
