### PR TITLE
nixosTests.qt-wayland: init

### DIFF
--- a/nixos/modules/services/wayland/cage.nix
+++ b/nixos/modules/services/wayland/cage.nix
@@ -5,33 +5,43 @@ with lib;
 let
   cfg = config.services.cage;
 in {
-  options.services.cage.enable = mkEnableOption "cage kiosk service";
+  options.services.cage = {
+    enable = mkEnableOption "cage kiosk service";
 
-  options.services.cage.user = mkOption {
-    type = types.str;
-    default = "demo";
-    description = ''
-      User to log-in as.
-    '';
+    user = mkOption {
+      type = types.str;
+      default = "demo";
+      description = ''
+        User to log-in as.
+      '';
+    };
+
+    extraArguments = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      defaultText = literalExpression "[]";
+      description = "Additional command line arguments to pass to Cage.";
+      example = ["-d"];
+    };
+
+    program = mkOption {
+      type = types.path;
+      default = "${pkgs.xterm}/bin/xterm";
+      defaultText = literalExpression ''"''${pkgs.xterm}/bin/xterm"'';
+      description = ''
+        Program to run in cage.
+      '';
+    };
+
+    package = mkOption {
+        type = types.package;
+        default = pkgs.cage;
+        defaultText = "pkgs.cage";
+        description = ''
+          This option specifies the cage package.
+        '';
+      };
   };
-
-  options.services.cage.extraArguments = mkOption {
-    type = types.listOf types.str;
-    default = [];
-    defaultText = literalExpression "[]";
-    description = "Additional command line arguments to pass to Cage.";
-    example = ["-d"];
-  };
-
-  options.services.cage.program = mkOption {
-    type = types.path;
-    default = "${pkgs.xterm}/bin/xterm";
-    defaultText = literalExpression ''"''${pkgs.xterm}/bin/xterm"'';
-    description = ''
-      Program to run in cage.
-    '';
-  };
-
   config = mkIf cfg.enable {
 
     # The service is partially based off of the one provided in the
@@ -55,7 +65,7 @@ in {
       unitConfig.ConditionPathExists = "/dev/tty1";
       serviceConfig = {
         ExecStart = ''
-          ${pkgs.cage}/bin/cage \
+          ${cfg.package}/bin/cage \
             ${escapeShellArgs cfg.extraArguments} \
             -- ${cfg.program}
         '';

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -383,6 +383,7 @@ in
   prowlarr = handleTest ./prowlarr.nix {};
   pt2-clone = handleTest ./pt2-clone.nix {};
   qboot = handleTestOn ["x86_64-linux" "i686-linux"] ./qboot.nix {};
+  qt-wayland = handleTest ./qt-wayland.nix {};
   quorum = handleTest ./quorum.nix {};
   rabbitmq = handleTest ./rabbitmq.nix {};
   radarr = handleTest ./radarr.nix {};

--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -9,17 +9,9 @@ import ./make-test-python.nix ({ pkgs, ...} :
   machine = { ... }:
 
   {
-    imports = [ ./common/user-account.nix ];
-    services.cage = {
-      enable = true;
-      user = "alice";
-      # Disable color and bold and use a larger font to make OCR easier:
-      program = "${pkgs.xterm}/bin/xterm -cm -pc -fa Monospace -fs 24";
-    };
-
-    virtualisation.memorySize = 1024;
-    # Need to switch to a different GPU driver than the default one (-vga std) so that Cage can launch:
-    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+    imports = [ ./common/wayland-cage.nix ];
+    # Disable color and bold and use a larger font to make OCR easier:
+    services.cage.program = "${pkgs.xterm}/bin/xterm -cm -pc -fa Monospace -fs 24";
   };
 
   enableOCR = true;

--- a/nixos/tests/common/wayland-cage.nix
+++ b/nixos/tests/common/wayland-cage.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }: {
+  imports = [ ./user-account.nix ];
+  services.cage = {
+    enable = true;
+    user = "alice";
+  };
+
+  virtualisation.memorySize = 1024;
+  # Need to switch to a different GPU driver than the default one (-vga std) so that Cage can launch:
+  virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+}

--- a/nixos/tests/qt-wayland.nix
+++ b/nixos/tests/qt-wayland.nix
@@ -1,0 +1,31 @@
+import ./make-test-python.nix ({ pkgs, ...} :
+
+{
+  name = "qt-wayland";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ synthetica ];
+  };
+
+  machine = { ... }:
+
+  {
+    imports = [ ./common/wayland-cage.nix ];
+    services.cage = {
+      program = "${pkgs.lxqt.qterminal}/bin/qterminal";
+      package = pkgs.cage.override { xwayland = null; };
+    };
+  };
+
+  enableOCR = true;
+
+  testScript = { nodes, ... }: let
+    user = nodes.machine.config.users.users.alice;
+  in ''
+    with subtest("Wait for cage to boot up"):
+        start_all()
+        machine.wait_for_file("/run/user/${toString user.uid}/wayland-0.lock")
+        machine.wait_until_succeeds("pgrep qterminal")
+        machine.wait_for_text("alice@machine")
+        machine.screenshot("screen")
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

QT on wayland has the unfortunate tendency to break. This test verifies that it hasn't

I'm open for suggestions for a different, simpler program to test.

cc @romildo @globin @primeos @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
