### PR TITLE
gromacs: 2020.4 -> 2021.3, cuda, mpi cleanups, performance tunings

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl, cmake, hwloc, fftw, perl, blas, lapack,
+{ lib, stdenv, fetchurl, cmake, hwloc, fftw, perl, blas, lapack, mpi, cudatoolkit,
   singlePrec ? true,
-  mpi ? null,
-  cudatoolkit ? null,
+  enableMpi ? false,
+  enableCuda ? false,
   cpuAcceleration ? null
 }:
 
@@ -34,12 +34,12 @@ in stdenv.mkDerivation rec {
     hwloc
     blas
     lapack
-  ] ++ lib.lists.optional (mpi != null) mpi
-    ++ lib.lists.optional (cudatoolkit != null) cudatoolkit
+  ] ++ lib.lists.optional enableMpi mpi
+    ++ lib.lists.optional enableCuda cudatoolkit
   ;
 
-  propagatedBuildInputs = lib.lists.optional (mpi != null) mpi;
-  propagatedUserEnvPkgs = lib.lists.optional (mpi != null) mpi;
+  propagatedBuildInputs = lib.lists.optional enableMpi mpi;
+  propagatedUserEnvPkgs = lib.lists.optional enableMpi mpi;
 
   cmakeFlags = [
     "-DGMX_SIMD:STRING=${SIMD cpuAcceleration}"
@@ -53,7 +53,7 @@ in stdenv.mkDerivation rec {
       "-DGMX_DEFAULT_SUFFIX=OFF"
     ]
   ) ++ (
-    if (mpi != null)
+    if enableMpi
       then [
         "-DGMX_MPI:BOOL=TRUE"
         "-DGMX_THREAD_MPI:BOOL=FALSE"
@@ -61,7 +61,7 @@ in stdenv.mkDerivation rec {
      else [
        "-DGMX_MPI:BOOL=FALSE"
      ]
-  ) ++ lib.lists.optional (cudatoolkit != null) "-DGMX_GPU=CUDA";
+  ) ++ lib.lists.optional enableCuda "-DGMX_GPU=CUDA";
 
   meta = with lib; {
     homepage = "http://www.gromacs.org";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31197,37 +31197,31 @@ with pkgs;
 
   gromacs = callPackage ../applications/science/molecular-dynamics/gromacs {
     singlePrec = true;
-    mpi = null;
     fftw = fftwSinglePrec;
-    cudatoolkit = null;
   };
 
   gromacsMpi = lowPrio (gromacs.override {
     singlePrec = true;
-    mpi = mpi;
+    enableMpi = true;
     fftw = fftwSinglePrec;
-    cudatoolkit = null;
   });
 
   gromacsDouble = lowPrio (gromacs.override {
     singlePrec = false;
-    mpi = null;
     fftw = fftw;
-    cudatoolkit = null;
   });
 
   gromacsDoubleMpi = lowPrio (gromacs.override {
     singlePrec = false;
-    mpi = mpi;
+    enableMpi = true;
     fftw = fftw;
-    cudatoolkit = null;
   });
 
   gromacsCudaMpi = lowPrio (gromacs.override {
     singlePrec = true;
-    mpi = mpi;
+    enableMpi = true;
+    enableCuda = true;
     fftw = fftwSinglePrec;
-    cudatoolkit = cudatoolkit;
   });
 
   zegrapher = libsForQt5.callPackage ../applications/science/math/zegrapher { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31197,30 +31197,37 @@ with pkgs;
 
   gromacs = callPackage ../applications/science/molecular-dynamics/gromacs {
     singlePrec = true;
-    mpiEnabled = false;
+    mpi = null;
     fftw = fftwSinglePrec;
-    cmake = cmakeCurses;
+    cudatoolkit = null;
   };
 
   gromacsMpi = lowPrio (gromacs.override {
     singlePrec = true;
-    mpiEnabled = true;
+    mpi = mpi;
     fftw = fftwSinglePrec;
-    cmake = cmakeCurses;
+    cudatoolkit = null;
   });
 
   gromacsDouble = lowPrio (gromacs.override {
     singlePrec = false;
-    mpiEnabled = false;
+    mpi = null;
     fftw = fftw;
-    cmake = cmakeCurses;
+    cudatoolkit = null;
   });
 
   gromacsDoubleMpi = lowPrio (gromacs.override {
     singlePrec = false;
-    mpiEnabled = true;
+    mpi = mpi;
     fftw = fftw;
-    cmake = cmakeCurses;
+    cudatoolkit = null;
+  });
+
+  gromacsCudaMpi = lowPrio (gromacs.override {
+    singlePrec = true;
+    mpi = mpi;
+    fftw = fftwSinglePrec;
+    cudatoolkit = cudatoolkit;
   });
 
   zegrapher = libsForQt5.callPackage ../applications/science/math/zegrapher { };


### PR DESCRIPTION
###### Motivation for this change
This updates the GROMACS MD package to the latest version and includes some performance tunings. I've enabled optional CUDA support, BLAS and LAPACK were missing and slow internal routines were used and I've adapted the MPI mechanisms, so that the proper MPI package is always propagated to the environment.
I've also added @markuskowa  and me as maintainers.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
