### PR TITLE
ocamlPackages: editorconfig-checker cleanup

### DIFF
--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
   };
 
   sigs = fetchurl {
-     url = "https://github.com/BinaryAnalysisPlatform/bap/releases/download/v${version}/sigs.zip";
-     sha256 = "0d69jd28z4g64mglq94kj5imhmk5f6sgcsh9q2nij3b0arpcliwk";
+    url = "https://github.com/BinaryAnalysisPlatform/bap/releases/download/v${version}/sigs.zip";
+    sha256 = "0d69jd28z4g64mglq94kj5imhmk5f6sgcsh9q2nij3b0arpcliwk";
   };
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/biniou/default.nix
+++ b/pkgs/development/ocaml-modules/biniou/default.nix
@@ -16,7 +16,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [ easy-format ];
 
   postPatch = ''
-   patchShebangs .
+    patchShebangs .
   '';
 
   meta = {

--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ integers libffi bigarray-compat ];
 
   buildPhase =  ''
-     make XEN=false libffi.config ctypes-base ctypes-stubs
-     make XEN=false ctypes-foreign
+    make XEN=false libffi.config ctypes-base ctypes-stubs
+    make XEN=false ctypes-foreign
   '';
 
   installPhase =  ''

--- a/pkgs/development/ocaml-modules/dose3/default.nix
+++ b/pkgs/development/ocaml-modules/dose3/default.nix
@@ -40,8 +40,8 @@ buildDunePackage rec {
     python39                  # Replaces: conf-python-3
     python39Packages.pyyaml   # Replaces: conf-python3-yaml
   ];
-  doCheck = false; # Tests are failing.
-                   # To enable tests use: lib.versionAtLeast ocaml.version "4.04";
+  doCheck = false;  # Tests are failing.
+                    # To enable tests use: lib.versionAtLeast ocaml.version "4.04";
 
   meta = with lib; {
     description = "Dose library (part of Mancoosi tools)";

--- a/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
@@ -1,6 +1,6 @@
 {lib, buildOcamlJane, async_kernel, bin_prot, core_kernel,
- fieldslib, ppx_assert, ppx_bench, ppx_driver, ppx_expect, ppx_inline_test,
- ppx_jane, sexplib, typerep, variantslib}:
+fieldslib, ppx_assert, ppx_bench, ppx_driver, ppx_expect, ppx_inline_test,
+ppx_jane, sexplib, typerep, variantslib}:
 
 buildOcamlJane {
   name = "async_rpc_kernel";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_compare, ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools, ppx_type_conv, sexplib}:
+ppx_compare, ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools, ppx_type_conv, sexplib}:
 
 buildOcamlJane {
   name = "ppx_assert";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_driver, ppx_inline_test, ppx_tools}:
+ppx_core, ppx_driver, ppx_inline_test, ppx_tools}:
 
 buildOcamlJane {
   name = "ppx_bench";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_tools, ppx_type_conv, bin_prot}:
+ppx_core, ppx_tools, ppx_type_conv, bin_prot}:
 
 buildOcamlJane {
   name = "ppx_bin_prot";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_driver, ppx_tools, ppx_type_conv}:
+ppx_core, ppx_driver, ppx_tools, ppx_type_conv}:
 
 buildOcamlJane {
   name = "ppx_compare";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_driver, ppx_sexp_conv, ppx_tools}:
+ppx_core, ppx_driver, ppx_sexp_conv, ppx_tools}:
 
 buildOcamlJane {
   name = "ppx_custom_printf";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_tools, ppx_type_conv}:
+ppx_core, ppx_tools, ppx_type_conv}:
 
 buildOcamlJane {
   name = "ppx_enumerate";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
@@ -1,7 +1,7 @@
 {lib, buildOcamlJane,
- ppx_assert, ppx_compare, ppx_core, ppx_custom_printf, ppx_driver,
- ppx_fields_conv, ppx_here, ppx_inline_test, ppx_sexp_conv, ppx_tools,
- ppx_variants_conv, re, sexplib, variantslib, fieldslib}:
+ppx_assert, ppx_compare, ppx_core, ppx_custom_printf, ppx_driver,
+ppx_fields_conv, ppx_here, ppx_inline_test, ppx_sexp_conv, ppx_tools,
+ppx_variants_conv, re, sexplib, variantslib, fieldslib}:
 
 buildOcamlJane {
   name = "ppx_expect";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_tools, ppx_type_conv}:
+ppx_core, ppx_tools, ppx_type_conv}:
 
 buildOcamlJane {
   name = "ppx_fields_conv";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_driver}:
+ppx_core, ppx_driver}:
 
 buildOcamlJane {
   name = "ppx_here";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_driver, ppx_tools}:
+ppx_core, ppx_driver, ppx_tools}:
 
 buildOcamlJane {
   name = "ppx_inline_test";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
@@ -1,9 +1,9 @@
 {lib, buildOcamlJane,
- ppx_assert,
- ppx_bench, ppx_bin_prot, ppx_compare, ppx_custom_printf, ppx_driver,
- ppx_enumerate, ppx_expect, ppx_fail, ppx_fields_conv, ppx_here,
- ppx_inline_test, ppx_let, ppx_pipebang, ppx_sexp_conv, ppx_sexp_message,
- ppx_sexp_value, ppx_typerep_conv, ppx_variants_conv}:
+ppx_assert,
+ppx_bench, ppx_bin_prot, ppx_compare, ppx_custom_printf, ppx_driver,
+ppx_enumerate, ppx_expect, ppx_fail, ppx_fields_conv, ppx_here,
+ppx_inline_test, ppx_let, ppx_pipebang, ppx_sexp_conv, ppx_sexp_message,
+ppx_sexp_value, ppx_typerep_conv, ppx_variants_conv}:
 
 buildOcamlJane {
   name = "ppx_jane";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_driver}:
+ppx_core, ppx_driver}:
 
 buildOcamlJane {
   name = "ppx_let";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_tools}:
+ppx_core, ppx_tools}:
 
 buildOcamlJane {
   name = "ppx_optcomp";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_driver, ppx_tools}:
+ppx_core, ppx_driver, ppx_tools}:
 
 buildOcamlJane {
   name = "ppx_pipebang";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_tools, ppx_type_conv, sexplib}:
+ppx_core, ppx_tools, ppx_type_conv, sexplib}:
 
 buildOcamlJane {
   name = "ppx_sexp_conv";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
+ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
 
 buildOcamlJane {
   name = "ppx_sexp_message";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
+ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
 
 buildOcamlJane {
   name = "ppx_sexp_value";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_tools, ppx_type_conv, typerep}:
+ppx_core, ppx_tools, ppx_type_conv, typerep}:
 
 buildOcamlJane {
   name = "ppx_typerep_conv";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
@@ -1,5 +1,5 @@
 {lib, buildOcamlJane,
- ppx_core, ppx_tools, ppx_type_conv, sexplib, variantslib}:
+ppx_core, ppx_tools, ppx_type_conv, sexplib, variantslib}:
 
 buildOcamlJane {
   name = "ppx_variants_conv";

--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -1,15 +1,15 @@
 { stdenv, lib, makeWrapper, fetchzip, ocaml, findlib, tcl, tk }:
 
 let
- params =
-  let mkNewParam = { version, sha256, rev ? version }: {
-    inherit version;
-    src = fetchzip {
-      url = "https://github.com/garrigue/labltk/archive/${rev}.tar.gz";
-      inherit sha256;
-    };
-  }; in
- rec {
+  params =
+    let mkNewParam = { version, sha256, rev ? version }: {
+      inherit version;
+      src = fetchzip {
+        url = "https://github.com/garrigue/labltk/archive/${rev}.tar.gz";
+        inherit sha256;
+      };
+    }; in
+rec {
   "4.06" = mkNewParam {
     version = "8.06.4";
     rev = "labltk-8.06.4";
@@ -42,9 +42,10 @@ let
     version = "8.06.11";
     sha256 = "1zjpg9jvs6i9jvbgn6zgispwqiv8rxvaszxcx9ha9fax3wzhv9qy";
   };
- };
- param = params . ${lib.versions.majorMinor ocaml.version}
-   or (throw "labltk is not available for OCaml ${ocaml.version}");
+};
+
+param = params . ${lib.versions.majorMinor ocaml.version}
+  or (throw "labltk is not available for OCaml ${ocaml.version}");
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -19,8 +19,8 @@ buildDunePackage rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ cppo dune-configurator ]
-   ++ optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims
-   ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
+    ++ optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims
+    ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
   propagatedBuildInputs = [ libev mmap ocplib-endian seq result ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/mlgmp/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmp/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   propagatedbuildInputs = [gmp mpfr ncurses];
 
   postInstall  = ''
-     cp ${./META} $out/lib/ocaml/${ocaml.version}/site-lib/gmp/META
+    cp ${./META} $out/lib/ocaml/${ocaml.version}/site-lib/gmp/META
   '';
 
   meta = {

--- a/pkgs/development/ocaml-modules/mysql/default.nix
+++ b/pkgs/development/ocaml-modules/mysql/default.nix
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = [
-     "--prefix=$out"
-     "--libdir=$out/lib/ocaml/${ocaml.version}/site-lib/mysql"
+    "--prefix=$out"
+    "--libdir=$out/lib/ocaml/${ocaml.version}/site-lib/mysql"
   ];
 
   buildInputs = [ ocaml findlib ];

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -25,13 +25,13 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
- preConfigure = ''
-   aclocal -I support
-   autoconf
-   export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE `pkg-config --cflags cairo gdk-pixbuf glib gtk+ pango`"
-   export LABLGTKDIR=${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2
-   cp ${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2/pango.ml ./src
-   cp ${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2/gaux.ml ./src
+  preConfigure = ''
+    aclocal -I support
+    autoconf
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE `pkg-config --cflags cairo gdk-pixbuf glib gtk+ pango`"
+    export LABLGTKDIR=${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2
+    cp ${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2/pango.ml ./src
+    cp ${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2/gaux.ml ./src
   '';
 
   postInstall = ''

--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/1.8.x.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/1.8.x.nix
@@ -1,24 +1,24 @@
 { lib, fetchFromGitHub, buildDunePackage, ocaml, result, ppx_derivers }:
 
 buildDunePackage rec {
-   pname = "ocaml-migrate-parsetree";
-   version = "1.8.0";
+  pname = "ocaml-migrate-parsetree";
+  version = "1.8.0";
 
-   useDune2 = lib.versionAtLeast ocaml.version "4.08";
+  useDune2 = lib.versionAtLeast ocaml.version "4.08";
 
-   src = fetchFromGitHub {
-     owner = "ocaml-ppx";
-     repo = pname;
-     rev = "v${version}";
-     sha256 = "16x8sxc4ygxrr1868qpzfqyrvjf3hfxvjzmxmf6ibgglq7ixa2nq";
-   };
+  src = fetchFromGitHub {
+    owner = "ocaml-ppx";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "16x8sxc4ygxrr1868qpzfqyrvjf3hfxvjzmxmf6ibgglq7ixa2nq";
+  };
 
-   propagatedBuildInputs = [ ppx_derivers result ];
+  propagatedBuildInputs = [ ppx_derivers result ];
 
-   meta = {
-     description = "Convert OCaml parsetrees between different major versions";
-     license = lib.licenses.lgpl21;
-     maintainers = [ lib.maintainers.vbgl ];
-     inherit (src.meta) homepage;
-   };
+  meta = {
+    description = "Convert OCaml parsetrees between different major versions";
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+  };
 }

--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/2.x.nix
@@ -1,22 +1,22 @@
 { lib, fetchurl, buildDunePackage }:
 
 buildDunePackage rec {
-   pname = "ocaml-migrate-parsetree";
-   version = "2.2.0";
+  pname = "ocaml-migrate-parsetree";
+  version = "2.2.0";
 
-   useDune2 = true;
+  useDune2 = true;
 
-   minimalOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
-   src = fetchurl {
-     url = "https://github.com/ocaml-ppx/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-     sha256 = "188v3z09bg4gyv80c138fa3a3j2w54w5gc4r1ajw7klr70yqz9mj";
-   };
+  src = fetchurl {
+    url = "https://github.com/ocaml-ppx/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
+    sha256 = "188v3z09bg4gyv80c138fa3a3j2w54w5gc4r1ajw7klr70yqz9mj";
+  };
 
-   meta = {
-     description = "Convert OCaml parsetrees between different major versions";
-     license = lib.licenses.lgpl21;
-     maintainers = with lib.maintainers; [ vbgl sternenseemann ];
-     homepage = "https://github.com/ocaml-ppx/ocaml-migrate-parsetree";
-   };
+  meta = {
+    description = "Convert OCaml parsetrees between different major versions";
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ vbgl sternenseemann ];
+    homepage = "https://github.com/ocaml-ppx/ocaml-migrate-parsetree";
+  };
 }

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -27,12 +27,11 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://ocsigen.org/ocsigen-start";
     description = "Eliom application skeleton";
-    longDescription =''
-     An Eliom application skeleton, ready to use to build your own application with users, (pre)registration, notifications, etc.
-      '';
+    longDescription = ''
+      An Eliom application skeleton, ready to use to build your own application with users, (pre)registration, notifications, etc.
+    '';
     license = lib.licenses.lgpl21Only;
     inherit (ocaml.meta) platforms;
     maintainers = [ lib.maintainers.gal_bolle ];
   };
-
 }

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
- pname = "ocsigen-toolkit";
- name = "ocaml${ocaml.version}-${pname}-${version}";
- version = "3.0.1";
+  pname = "ocsigen-toolkit";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+  version = "3.0.1";
 
- propagatedBuildInputs = [ calendar js_of_ocaml-ppx_deriving_json eliom ];
- buildInputs = [ ocaml findlib opaline ];
+  propagatedBuildInputs = [ calendar js_of_ocaml-ppx_deriving_json eliom ];
+  buildInputs = [ ocaml findlib opaline ];
 
- installPhase = ''
+  installPhase = ''
     runHook preInstall
     mkdir -p $OCAMLFIND_DESTDIR
     export OCAMLPATH=$out/lib/ocaml/${ocaml.version}/site-lib/:$OCAMLPATH
@@ -33,6 +33,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.gal_bolle ];
     inherit (ocaml.meta) platforms;
   };
-
-
 }

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -65,8 +65,8 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     ocaml-compiler-libs
     (if param.useOMP2 or true
-     then ocaml-migrate-parsetree-2
-     else ocaml-migrate-parsetree)
+      then ocaml-migrate-parsetree-2
+      else ocaml-migrate-parsetree)
     ppx_derivers
     stdio
     stdlib-shims

--- a/pkgs/development/ocaml-modules/pycaml/default.nix
+++ b/pkgs/development/ocaml-modules/pycaml/default.nix
@@ -32,9 +32,9 @@ stdenv.mkDerivation {
   # the Makefile is not shipped with an install target, hence we do it ourselves.
   installPhase = ''
     ocamlfind install pycaml \
-     dllpycaml_stubs.so libpycaml_stubs.a pycaml.a pycaml.cma \
-     pycaml.cmi pycaml.cmo pycaml.cmx pycaml.cmxa \
-     META
+      dllpycaml_stubs.so libpycaml_stubs.a pycaml.a pycaml.cma \
+      pycaml.cmi pycaml.cmo pycaml.cmx pycaml.cmxa \
+      META
   '';
 
   meta = {


### PR DESCRIPTION
Getting rid of errors for `editorconfig-checker` at ocamlPackages.
(Only indentation & line breaks were affected!)