### PR TITLE
sdrpp: enable on darwin

### DIFF
--- a/pkgs/applications/radio/sdrpp/runtime-prefix.patch
+++ b/pkgs/applications/radio/sdrpp/runtime-prefix.patch
@@ -1,0 +1,60 @@
+From a80a739163d2013ec400223a68a387f4f9297b2a Mon Sep 17 00:00:00 2001
+From: Nikolay Korotkiy <sikmir@gmail.com>
+Date: Fri, 29 Oct 2021 01:38:21 +0300
+Subject: [PATCH] Fix sdrpp breaking every time the package is rebuilt.
+
+On NixOS, the INSTALL_PREFIX changes on every rebuild to the package, but sdrpp
+fills it in as part of the default config and then installs that config
+to the users home folder. Fix this by not substituting @INSTALL_PREFIX@ in the
+default config until runtime.
+---
+ core/src/core.cpp            | 8 ++++++--
+ core/src/gui/main_window.cpp | 6 ++++++
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/core/src/core.cpp b/core/src/core.cpp
+index 9546e60..98d6065 100644
+--- a/core/src/core.cpp
++++ b/core/src/core.cpp
+@@ -242,8 +242,8 @@ int sdrpp_main(int argc, char *argv[]) {
+     defConfig["modulesDirectory"] = "./modules";
+     defConfig["resourcesDirectory"] = "./res";
+ #else
+-    defConfig["modulesDirectory"] = INSTALL_PREFIX "/lib/sdrpp/plugins";
+-    defConfig["resourcesDirectory"] = INSTALL_PREFIX "/share/sdrpp";
++    defConfig["modulesDirectory"] = "@prefix@/lib/sdrpp/plugins";
++    defConfig["resourcesDirectory"] = "@prefix@/share/sdrpp";
+ #endif
+ 
+     // Load config
+@@ -290,6 +290,10 @@ int sdrpp_main(int argc, char *argv[]) {
+     int winHeight = core::configManager.conf["windowSize"]["h"];
+     maximized = core::configManager.conf["maximized"];
+     std::string resDir = core::configManager.conf["resourcesDirectory"];
++    {
++        std::size_t pos = resDir.find("@prefix@");
++        if (pos != std::string::npos) resDir.replace(pos, 8, INSTALL_PREFIX);
++    }
+     json bandColors = core::configManager.conf["bandColors"];
+     core::configManager.release();
+ 
+diff --git a/core/src/gui/main_window.cpp b/core/src/gui/main_window.cpp
+index 954dbd6..52f0eed 100644
+--- a/core/src/gui/main_window.cpp
++++ b/core/src/gui/main_window.cpp
+@@ -44,6 +44,12 @@ void MainWindow::init() {
+     json menuElements = core::configManager.conf["menuElements"];
+     std::string modulesDir = core::configManager.conf["modulesDirectory"];
+     std::string resourcesDir = core::configManager.conf["resourcesDirectory"];
++    {
++        std::size_t pos = modulesDir.find("@prefix@");
++        if (pos != std::string::npos) modulesDir.replace(pos, 8, INSTALL_PREFIX);
++        pos = resourcesDir.find("@prefix@");
++        if (pos != std::string::npos) resourcesDir.replace(pos, 8, INSTALL_PREFIX);
++    }
+     core::configManager.release();
+ 
+     // Load menu elements
+-- 
+2.33.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19315,7 +19315,9 @@ with pkgs;
 
   sdrplay = callPackage ../applications/radio/sdrplay {};
 
-  sdrpp = callPackage ../applications/radio/sdrpp { };
+  sdrpp = callPackage ../applications/radio/sdrpp {
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+  };
 
   sblim-sfcc = callPackage ../development/libraries/sblim-sfcc {};
 


### PR DESCRIPTION
###### Motivation for this change
* Enable on darwin (tested with rtl-sdr device)
* Fix sdrpp breaking every time the package is rebuilt

> On NixOS, the INSTALL_PREFIX changes on every rebuild to the package, but sdrpp
> fills it in as part of the default config and then installs that config
> to the users home folder. Fix this by not substituting @INSTALL_PREFIX@ in the
> default config until runtime.

```
$ cat ~/.config/sdrpp/config.json | jq -r '.modulesDirectory,.resourcesDirectory'
@prefix@/lib/sdrpp/plugins
@prefix@/share/sdrpp
```

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
