### PR TITLE
jackett: 0.18.925 -> 0.19.147

### DIFF
--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -1,30 +1,82 @@
-{ lib, stdenv, fetchurl, mono, makeWrapper, curl, icu60, openssl, zlib }:
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, krb5
+, liburcu
+, lttng-ust
+, zlib
+, openssl
+, makeWrapper
+}:
 
+let
+  liburcu-0-12 = liburcu.overrideAttrs (oldAttrs: rec {
+    version = "0.12.2";
+    src = fetchurl {
+      url = "https://lttng.org/files/urcu/userspace-rcu-${version}.tar.bz2";
+      sha256 = "0yx69kbx9zd6ayjzvwvglilhdnirq4f1x1sdv33jy8bc9wgc3vsf";
+    };
+  });
+
+  lttng-ust-2-10 = (lttng-ust.override {
+    liburcu = liburcu-0-12;
+  }).overrideAttrs (oldAttrs: rec {
+    version = "2.10.5";
+    src = fetchurl {
+      url = "https://lttng.org/files/lttng-ust/lttng-ust-${version}.tar.bz2";
+      sha256 = "0ddwk0nl28bkv2xb78gz16a2bvlpfbjmzwfbgwf5p1cq46dyvy86";
+    };
+  });
+in
 stdenv.mkDerivation rec {
   pname = "jackett";
-  version = "0.18.925";
+  version = "0.19.84";
 
-  src = fetchurl {
-    url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.Mono.tar.gz";
-    sha256 = "1md0iy6sx0agsnvrj9m7bq1lvp5z34x7zv3pvwy4zw8b46w97mnz";
-  };
+  src =
+    if stdenv.isAarch32 then
+      fetchurl
+        {
+          url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxARM32.tar.gz";
+          sha256 = "1iqv8k437rlik83mq019aq157p8bhk8sp2k28lp7mga66vs6wkhb";
+        }
+    else if stdenv.isAarch64 then
+      fetchurl
+        {
+          url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxARM64.tar.gz";
+          sha256 = "1sxp8s09m4gx1xv0cdyxdz5fqg5ihbzrnq9qy54wp34p5v3jknjh";
+        }
+    else if stdenv.isDarwin then
+      fetchurl
+        {
+          url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.macOS.tar.gz";
+          sha256 = "1489pgp1y77crpnnm5mfwvz81400hm3cnv0fq753wfpmgm9g4d4q";
+        }
+    else
+      fetchurl {
+        url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxAMDx64.tar.gz";
+        sha256 = "0dfxnkql7l6dpyqiwd9al8a0nr93s5avb7k7pj0mlq8q38lb8bfk";
+      };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+
+  buildInputs = [ stdenv.cc.cc.lib krb5 lttng-ust-2-10 zlib ];
+
+  libssl = openssl.out;
 
   installPhase = ''
-    mkdir -p $out/{bin,share/${pname}-${version}}
-    cp -r * $out/share/${pname}-${version}
-
-    makeWrapper "${mono}/bin/mono" $out/bin/Jackett \
-      --add-flags "$out/share/${pname}-${version}/JackettConsole.exe" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ curl icu60 openssl zlib ]}
+    mkdir -p $out/{bin,share/jackett}
+    cp -r * $out/share/jackett
+    makeWrapper $out/share/jackett/jackett $out/bin/jackett \
+      --set DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1 \
+      --set LD_LIBRARY_PATH LD_LIBRARY_PATH:$libssl/lib
   '';
 
   meta = with lib; {
     description = "API Support for your favorite torrent trackers";
     homepage = "https://github.com/Jackett/Jackett/";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ edwtjo nyanloutre purcell ];
-    platforms = platforms.all;
+    maintainers = with maintainers; [ edwtjo nyanloutre purcell flexagoon ];
+    platforms = with platforms; [ "x86_64-linux" "aarch64-linux" "armv7a-linux" "armv7l-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -31,25 +31,25 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jackett";
-  version = "0.19.84";
+  version = "0.19.147";
 
   src = rec {
     x86_64-linux = fetchurl {
       url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxAMDx64.tar.gz";
-      sha256 = "0dfxnkql7l6dpyqiwd9al8a0nr93s5avb7k7pj0mlq8q38lb8bfk";
+      sha256 = "1nwsxq3nnm587iirhbsvyj3a5rb6jbd0njca8p557wq4ly99lmgb";
     };
     armv7a-linux = fetchurl {
       url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxARM32.tar.gz";
-      sha256 = "1iqv8k437rlik83mq019aq157p8bhk8sp2k28lp7mga66vs6wkhb";
+      sha256 = "113gmz4hx4narcangq397cgr2s61rgl9kyjf1zx0vcdl8yml0qzr";
     };
     armv7l-linux = armv7a-linux;
     aarch64-linux = fetchurl {
       url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxARM64.tar.gz";
-      sha256 = "1sxp8s09m4gx1xv0cdyxdz5fqg5ihbzrnq9qy54wp34p5v3jknjh";
+      sha256 = "1jb4nd6c058r83ljaq7y8h9a60sbr8kxyi5x1g22sb5m0x1fxv1l";
     };
     x86_64-darwin = fetchurl {
       url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.macOS.tar.gz";
-      sha256 = "1489pgp1y77crpnnm5mfwvz81400hm3cnv0fq753wfpmgm9g4d4q";
+      sha256 = "1dr3hzhjqc9ygizqvrjzk6dxgp5j8kdv4967l2327vn2jy8nlqvg";
     };
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Update Jackett to the latest version
- Use standalone versions of Jackett instead of Mono versions

Closes #143247

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
