### PR TITLE
pomotroid: init at 0.13.0

### DIFF
--- a/pkgs/applications/misc/pomotroid/default.nix
+++ b/pkgs/applications/misc/pomotroid/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, lib, fetchurl, makeWrapper, makeDesktopItem, copyDesktopItems, electron }:
+
+let
+  version = "0.13.0";
+  appIcon = fetchurl {
+    url = "https://raw.githubusercontent.com/Splode/pomotroid/v${version}/static/icon.png";
+    sha256 = "sha256-BEPoOBErw5ZCeK4rtdxdwZZLimbpglu1Cu++4xzuVUs=";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "pomotroid";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/Splode/pomotroid/releases/download/v${version}/${pname}-${version}-linux.tar.gz";
+    sha256 = "sha256-AwpVnvwWQd/cgmZvtr5NprnLyeXz6ym4Fywc808tcSc=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "pomotroid";
+      icon = "pomotroid";
+      comment = meta.description;
+      desktopName = "Pomotroid";
+      genericName = "Pomodoro Application";
+    })
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt/pomotroid $out/share/pomotroid $out/share/pixmaps
+
+    cp -r ./ $out/opt/pomotroid
+    mv $out/opt/pomotroid/{locales,resources} $out/share/pomotroid
+    cp ${appIcon} $out/share/pixmaps/pomotroid.png
+
+    makeWrapper ${electron}/bin/electron $out/bin/pomotroid \
+      --add-flags $out/share/pomotroid/resources/app.asar
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Simple and visually-pleasing Pomodoro timer";
+    homepage = "https://splode.github.io/pomotroid";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27332,6 +27332,10 @@ with pkgs;
 
   polymake = callPackage ../applications/science/math/polymake { };
 
+  pomotroid = callPackage ../applications/misc/pomotroid {
+    electron = electron_9;
+  };
+
   pond = callPackage ../applications/networking/instant-messengers/pond { };
 
   ponymix = callPackage ../applications/audio/ponymix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #131264

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Uses Electron 9, which is EOL.