### PR TITLE
various prefetch-yarn-deps improvements

### DIFF
--- a/pkgs/build-support/node/fetch-yarn-deps/default.nix
+++ b/pkgs/build-support/node/fetch-yarn-deps/default.nix
@@ -49,7 +49,7 @@ in {
       hash_ =
         if hash != "" then { outputHashAlgo = null; outputHash = hash; }
         else if sha256 != "" then { outputHashAlgo = "sha256"; outputHash = sha256; }
-        else throw "fetchYarnDeps requires a hash";
+        else { outputHashAlgo = "sha256"; outputHash = lib.fakeSha256; };
     in stdenv.mkDerivation {
       inherit name;
 

--- a/pkgs/build-support/node/fetch-yarn-deps/index.js
+++ b/pkgs/build-support/node/fetch-yarn-deps/index.js
@@ -18,6 +18,20 @@ const exec = async (...args) => {
 	return res
 }
 
+// This has to match the logic in pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/urlToName.js
+// so that fixup_yarn_lock produces the same paths
+const urlToName = url => {
+  const isCodeloadGitTarballUrl = url.startsWith('https://codeload.github.com/') && url.includes('/tar.gz/')
+
+  if (url.startsWith('git+') || isCodeloadGitTarballUrl) {
+    return path.basename(url)
+  } else {
+    return url
+      .replace(/https:\/\/(.)*(.com)\//g, '') // prevents having long directory names
+      .replace(/[@/%:-]/g, '_') // replace @ and : and - and % characters with underscore
+  }
+}
+
 const downloadFileHttps = (fileName, url, expectedHash) => {
 	return new Promise((resolve, reject) => {
 		https.get(url, (res) => {
@@ -61,18 +75,15 @@ const downloadGit = async (fileName, url, rev) => {
 const downloadPkg = (pkg, verbose) => {
 	const [ url, hash ] = pkg.resolved.split('#')
 	if (verbose) console.log('downloading ' + url)
+	const fileName = urlToName(url)
 	if (url.startsWith('https://codeload.github.com/') && url.includes('/tar.gz/')) {
-		const fileName = path.basename(url)
 		const s = url.split('/')
 		downloadGit(fileName, `https://github.com/${s[3]}/${s[4]}.git`, s[6])
 	} else if (url.startsWith('https://')) {
-		const fileName = url
-			.replace(/https:\/\/(.)*(.com)\//g, '') // prevents having long directory names
-			.replace(/[@/%:-]/g, '_') // replace @ and : and - and % characters with underscore
-
 		return downloadFileHttps(fileName, url, hash)
+	} else if (url.startsWith('git:')) {
+		return downloadGit(fileName, url.replace(/^git\+/, ''), hash)
 	} else if (url.startsWith('git+')) {
-		const fileName = path.basename(url)
 		return downloadGit(fileName, url.replace(/^git\+/, ''), hash)
 	} else {
 		throw new Error('don\'t know how to download "' + url + '"')

--- a/pkgs/build-support/node/fetch-yarn-deps/index.js
+++ b/pkgs/build-support/node/fetch-yarn-deps/index.js
@@ -85,6 +85,8 @@ const downloadPkg = (pkg, verbose) => {
 		return downloadGit(fileName, url.replace(/^git\+/, ''), hash)
 	} else if (url.startsWith('git+')) {
 		return downloadGit(fileName, url.replace(/^git\+/, ''), hash)
+	} else if (url.startsWith('file:')) {
+		console.warn(`ignoring unsupported file:path url "${url}"`)
 	} else {
 		throw new Error('don\'t know how to download "' + url + '"')
 	}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- git:// url encountered when packaging [pleroma-fe](https://git.pleroma.social/pleroma/pleroma-fe/-/blob/develop/yarn.lock#L8101)
- file:path url encountered in https://github.com/NixOS/nixpkgs/pull/143345
- multiple people asked for fetchYarnDeps to use lib.fakeSha256 by default because they want to find out the correct hash that way

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
