### PR TITLE
botamusique: unstable-2021-09-01 -> 7.2.2

### DIFF
--- a/pkgs/tools/audio/botamusique/node-packages.nix
+++ b/pkgs/tools/audio/botamusique/node-packages.nix
@@ -4526,8 +4526,8 @@ let
   args = {
     name = "botamusique";
     packageName = "botamusique";
-    version = "0.0.0";
-    src = ../../../../../../../../../tmp/tmp.IOzfGq3zuo;
+    version = "7.2.2";
+    src = ../../../../../../../../../tmp/tmp.axdirie3HR;
     dependencies = [
       sources."@babel/code-frame-7.10.4"
       sources."@babel/compat-data-7.12.7"

--- a/pkgs/tools/audio/botamusique/src.json
+++ b/pkgs/tools/audio/botamusique/src.json
@@ -1,11 +1,12 @@
 {
   "url": "https://github.com/azlux/botamusique",
-  "rev": "3733353170e1d24b5f3ce2a21643c27ca2a39835",
-  "date": "2021-09-01T12:19:37+02:00",
-  "path": "/nix/store/07vl4lhi6dshh4n7pcyrxvy9m028rrbr-botamusique",
-  "sha256": "0cggan70zymbh9iwggq9a04zkky86k9cncprxb9nnr35gp4l4992",
+  "rev": "9b9b4e40ce7b077ebfa3b9be08d32025d1e43bc3",
+  "date": "2021-10-27T02:29:59+02:00",
+  "path": "/nix/store/9gxn2bw0757yrmx0xhhwq642lixyy88x-botamusique",
+  "sha256": "07n6nyi84ddqp2x8xrds7q83yfqapl5qhkcprzjsmvxhv4a3ar8q",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
-  "leaveDotGit": false
+  "leaveDotGit": false,
+  "version": "7.2.2"
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Swaps out youtube-dl in favor of yt-dlp. Also return to stable versioning.

https://github.com/azlux/botamusique/releases/tag/7.2.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
