### PR TITLE
nodePackages.concurrently: init at 6.3.0

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -79,6 +79,7 @@
 , "code-theme-converter"
 , "coffee-script"
 , "coinmon"
+, "concurrently"
 , "configurable-http-proxy"
 , "conventional-changelog-cli"
 , "cordova"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1467,6 +1467,8 @@ with pkgs;
 
   inherit (nodePackages) bitwarden-cli;
 
+  inherit (nodePackages) concurrently;
+
   inherit (nodePackages) hyperspace-cli;
 
   bklk = callPackage ../applications/misc/bklk { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds the [concurrently](https://www.npmjs.com/package/concurrently) CLI tool to the nodePackages set!

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
