### PR TITLE
nixos/arion: init

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -74,7 +74,7 @@ rec {
     apply ? null,
     # Whether the option is for NixOS developers only.
     internal ? null,
-    # Whether the option shows up in the manual.
+    # Whether the option shows up in the manual. Default: true. Use false to hide the option and any sub-options from submodules. Use "shallow" to hide only sub-options.
     visible ? null,
     # Whether the option can be set only once
     readOnly ? null,
@@ -180,7 +180,10 @@ rec {
           description = opt.description or (lib.warn "Option `${name}' has no description." "This option has no description.");
           declarations = filter (x: x != unknownModule) opt.declarations;
           internal = opt.internal or false;
-          visible = opt.visible or true;
+          visible =
+            if (opt?visible && opt.visible == "shallow")
+            then true
+            else opt.visible or true;
           readOnly = opt.readOnly or false;
           type = opt.type.description or null;
         }
@@ -192,8 +195,9 @@ rec {
         subOptions =
           let ss = opt.type.getSubOptions opt.loc;
           in if ss != {} then optionAttrSetToDocList' opt.loc ss else [];
+        subOptionsVisible = docOption.visible && opt.visible or null != "shallow";
       in
-        [ docOption ] ++ optionals docOption.visible subOptions) (collect isOption options);
+        [ docOption ] ++ optionals subOptionsVisible subOptions) (collect isOption options);
 
 
   /* This function recursively removes all derivation attributes from

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -179,6 +179,13 @@ checkConfigOutput "true" config.submodule.outer ./declare-submoduleWith-modules.
 # which evaluates all the modules defined by the type)
 checkConfigOutput "submodule" options.submodule.type.description ./declare-submoduleWith-modules.nix
 
+## submodules can be declared using (evalModules {...}).type
+checkConfigOutput "true" config.submodule.inner ./declare-submodule-via-evalModules.nix
+checkConfigOutput "true" config.submodule.outer ./declare-submodule-via-evalModules.nix
+# Should also be able to evaluate the type name (which evaluates freeformType,
+# which evaluates all the modules defined by the type)
+checkConfigOutput "submodule" options.submodule.type.description ./declare-submodule-via-evalModules.nix
+
 ## Paths should be allowed as values and work as expected
 checkConfigOutput "true" config.submodule.enable ./declare-submoduleWith-path.nix
 

--- a/lib/tests/modules/declare-submodule-via-evalModules.nix
+++ b/lib/tests/modules/declare-submodule-via-evalModules.nix
@@ -1,6 +1,6 @@
 { lib, ... }: {
   options.submodule = lib.mkOption {
-    inherit (lib.evalModules {
+    type = lib.types.submoduleWith {
       modules = [
         {
           options.inner = lib.mkOption {
@@ -9,7 +9,7 @@
           };
         }
       ];
-    }) type;
+    };
     default = {};
   };
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1155,6 +1155,7 @@
   ./tasks/powertop.nix
   ./testing/service-runner.nix
   ./virtualisation/anbox.nix
+  ./virtualisation/arion.nix
   ./virtualisation/container-config.nix
   ./virtualisation/containerd.nix
   ./virtualisation/containers.nix

--- a/nixos/modules/virtualisation/arion.nix
+++ b/nixos/modules/virtualisation/arion.nix
@@ -44,8 +44,7 @@ let
     };
   };
 
-  arionSettingsType =
-    (cfg.package.eval { modules = [ ]; }).type;
+  arionSettingsType = (cfg.package.eval { modules = [ ]; }).type;
 
 in
 {
@@ -55,7 +54,7 @@ in
       backend = mkOption {
         type = types.enum [ "podman-socket" "docker" ];
         description = ''
-          Which container implementation to use.
+          Which container engine to use.
         '';
       };
       package = mkOption {
@@ -90,9 +89,11 @@ in
       }
       (mkIf (cfg.backend == "podman-socket") {
         virtualisation.docker.enable = false;
-        virtualisation.podman.enable = true;
-        virtualisation.podman.dockerSocket.enable = true;
-        virtualisation.podman.defaultNetwork.dnsname.enable = true;
+        virtualisation.podman = {
+          enable = true;
+          dockerSocket.enable = true;
+          defaultNetwork.dnsname.enable = true;
+        };
 
         virtualisation.arion.docker.client.package = pkgs.docker-client;
       })

--- a/nixos/modules/virtualisation/arion.nix
+++ b/nixos/modules/virtualisation/arion.nix
@@ -1,0 +1,105 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib)
+    attrValues
+    mkIf
+    mkOption
+    mkMerge
+    types
+    ;
+
+  cfg = config.virtualisation.arion;
+
+  projectType = types.submoduleWith {
+    modules = [ projectModule ];
+  };
+
+  projectModule = { config, name, ... }: {
+    options = {
+      settings = mkOption {
+        description = ''
+          Arion project definition, otherwise known as arion-compose.nix contents.
+
+          See <link xlink:href="https://docs.hercules-ci.com/arion/options/">https://docs.hercules-ci.com/arion/options/</link>.
+        '';
+        type = arionSettingsType;
+        visible = "shallow";
+      };
+      _systemd = mkOption { internal = true; };
+    };
+    config = {
+      _systemd.services."arion-${name}" = {
+        wantedBy = [ "multi-user.target" ];
+        after = [ "sockets.target" ];
+
+        path = [
+          cfg.package
+          cfg.docker.client.package
+        ];
+        environment.ARION_PREBUILT = config.settings.out.dockerComposeYaml;
+        script = ''
+          arion --prebuilt-file "$ARION_PREBUILT" up
+        '';
+      };
+    };
+  };
+
+  arionSettingsType =
+    (cfg.package.eval { modules = [ ]; }).type;
+
+in
+{
+
+  options = {
+    virtualisation.arion = {
+      backend = mkOption {
+        type = types.enum [ "podman-socket" "docker" ];
+        description = ''
+          Which container implementation to use.
+        '';
+      };
+      package = mkOption {
+        type = types.package;
+        default = pkgs.arion;
+        description = ''
+          Arion package to use. This will provide <literal>arion</literal>
+          executable that starts the project.
+
+          It also must provide the arion <literal>eval</literal> function as
+          an attribute.
+        '';
+      };
+      docker.client.package = mkOption {
+        type = types.package;
+        internal = true;
+      };
+      projects = mkOption {
+        type = types.attrsOf projectType;
+        default = { };
+        description = ''
+          Arion projects to be run as a service.
+        '';
+      };
+    };
+  };
+
+  config = mkIf (cfg.projects != { }) (
+    mkMerge [
+      {
+        systemd = mkMerge (map (p: p._systemd) (attrValues cfg.projects));
+      }
+      (mkIf (cfg.backend == "podman-socket") {
+        virtualisation.docker.enable = false;
+        virtualisation.podman.enable = true;
+        virtualisation.podman.dockerSocket.enable = true;
+        virtualisation.podman.defaultNetwork.dnsname.enable = true;
+
+        virtualisation.arion.docker.client.package = pkgs.docker-client;
+      })
+      (mkIf (cfg.backend == "docker") {
+        virtualisation.docker.enable = true;
+        virtualisation.arion.docker.client.package = pkgs.docker;
+      })
+    ]
+  );
+}


### PR DESCRIPTION
###### Motivation for this change

1. Allow arion projects to be deployed as part of a system configuration, immutably, rather than NixOS providing a platform. 
2. Allow use of `nixosTest` for isolated tests.

Note: this includes #143207 and #143453, which can be reviewed independently.

Note: this PR does not remove IFD from `arion.eval`, which could be done by copying the arion modules into Nixpkgs. One step at a time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
