### PR TITLE
[21.05] linux: changes for #140281

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -142,6 +142,16 @@ with lib.maintainers; {
     scope = "Maintain Kodi and related packages.";
   };
 
+  linux-kernel = {
+    members = [
+      TredwellGit
+      ma27
+      nequissimus
+      qyliss
+    ];
+    scope = "Maintain the Linux kernel.";
+  };
+
   matrix = {
     members = [
       ma27

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -1,32 +1,52 @@
 {
     "4.14": {
-        "extra": "-hardened1",
-        "name": "linux-hardened-4.14.251-hardened1.patch",
-        "sha256": "1yv4b10w1psaj4m4r9jicf6c3wkyvb040p7gbdf1455nrcxnxr06",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.251-hardened1/linux-hardened-4.14.251-hardened1.patch"
+        "patch": {
+            "extra": "-hardened1",
+            "name": "linux-hardened-4.14.252-hardened1.patch",
+            "sha256": "1isqlqg4diz0i3f77rigvb07fs2p1v9w2h5165l0rnkb6h26i1gn",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.14.252-hardened1/linux-hardened-4.14.252-hardened1.patch"
+        },
+        "sha256": "022rw51s8fzz6wcxa9xq6h60fglfx0hq7bmqgs5dlrci6plv4fwk",
+        "version": "4.14.252"
     },
     "4.19": {
-        "extra": "-hardened1",
-        "name": "linux-hardened-4.19.212-hardened1.patch",
-        "sha256": "1ildbzxzvkaziqiqlvw92pjmkd64hxdd9sn3fdq88q1pdw5x2jb3",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.212-hardened1/linux-hardened-4.19.212-hardened1.patch"
+        "patch": {
+            "extra": "-hardened1",
+            "name": "linux-hardened-4.19.213-hardened1.patch",
+            "sha256": "03lk4m6sm3545s0xxx0w4sqgrsvrxqm8qg7swn05s36jj20viprm",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/4.19.213-hardened1/linux-hardened-4.19.213-hardened1.patch"
+        },
+        "sha256": "162f5y3jplql3ca5xy889mq6izjinryx2kx16zp582yvsqf8rwiq",
+        "version": "4.19.213"
     },
     "5.10": {
-        "extra": "-hardened1",
-        "name": "linux-hardened-5.10.74-hardened1.patch",
-        "sha256": "0prcrifz1zmjxv492dgd78h8bdsx4bh92dsbnp01nn1wmwbajp8p",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.74-hardened1/linux-hardened-5.10.74-hardened1.patch"
+        "patch": {
+            "extra": "-hardened1",
+            "name": "linux-hardened-5.10.75-hardened1.patch",
+            "sha256": "17gm50aislxihfnmr4vi0p0gpg13m2pbldjpi81clnx93a7rrfw2",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.10.75-hardened1/linux-hardened-5.10.75-hardened1.patch"
+        },
+        "sha256": "0jrhhk89587caw54nhnwms93kq33qdm75x5f18cp61xrxxgjyaqa",
+        "version": "5.10.75"
     },
     "5.14": {
-        "extra": "-hardened1",
-        "name": "linux-hardened-5.14.13-hardened1.patch",
-        "sha256": "01kxjn1sndby3fjfq3g7z0ydrk8nv62bvpvprddqqc3bypk9q7m2",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.14.13-hardened1/linux-hardened-5.14.13-hardened1.patch"
+        "patch": {
+            "extra": "-hardened1",
+            "name": "linux-hardened-5.14.14-hardened1.patch",
+            "sha256": "1hx5yal8jqnxr9c9ikvc6d0xp99kqjarj67720v9d4wvlmgsfabj",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.14.14-hardened1/linux-hardened-5.14.14-hardened1.patch"
+        },
+        "sha256": "0snh17ah49wmfmazy6x42rhvl484h657y0iq4l09a885sjb4xzsd",
+        "version": "5.14.14"
     },
     "5.4": {
-        "extra": "-hardened1",
-        "name": "linux-hardened-5.4.154-hardened1.patch",
-        "sha256": "0d7w27n3wq9jaq0wbf3iv2f0jb1y2v4k0c87rb6sakivwajxn1aw",
-        "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.154-hardened1/linux-hardened-5.4.154-hardened1.patch"
+        "patch": {
+            "extra": "-hardened1",
+            "name": "linux-hardened-5.4.155-hardened1.patch",
+            "sha256": "0l8h9i6asiypgbxl90370kzfsyyc3f4vwl2r191arvrsgw863bid",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.4.155-hardened1/linux-hardened-5.4.155-hardened1.patch"
+        },
+        "sha256": "0f2hfz76rnhmv99zhbh7n1z48316ilxrxrnh4b5m3lj84y80y36c",
+        "version": "5.4.155"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/update.py
+++ b/pkgs/os-specific/linux/kernel/hardened/update.py
@@ -31,7 +31,12 @@ VersionComponent = Union[int, str]
 Version = List[VersionComponent]
 
 
-Patch = TypedDict("Patch", {"name": str, "url": str, "sha256": str, "extra": str})
+PatchData = TypedDict("PatchData", {"name": str, "url": str, "sha256": str, "extra": str})
+Patch = TypedDict("Patch", {
+    "patch": PatchData,
+    "version": str,
+    "sha256": str,
+})
 
 
 @dataclass
@@ -133,7 +138,15 @@ def fetch_patch(*, name: str, release_info: ReleaseInfo) -> Optional[Patch]:
     if not sig_ok:
         return None
 
-    return Patch(name=patch_filename, url=patch_url, sha256=sha256, extra=extra)
+    kernel_ver = release_info.release.tag_name.replace("-hardened1", "")
+    major = kernel_ver.split('.')[0]
+    sha256_kernel, _ = nix_prefetch_url(f"mirror://kernel/linux/kernel/v{major}.x/linux-{kernel_ver}.tar.xz")
+
+    return Patch(
+        patch=PatchData(name=patch_filename, url=patch_url, sha256=sha256, extra=extra),
+        version=kernel_ver,
+        sha256=sha256_kernel
+    )
 
 
 def parse_version(version_str: str) -> Version:
@@ -245,7 +258,7 @@ for kernel_key in sorted(releases.keys()):
     old_version_str: Optional[str] = None
     update: bool
     try:
-        old_filename = patches[kernel_key]["name"]
+        old_filename = patches[kernel_key]["patch"]["name"]
         old_version_str = old_filename.replace("linux-hardened-", "").replace(
             ".patch", ""
         )

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -288,7 +288,7 @@ let
         license = lib.licenses.gpl2Only;
         homepage = "https://www.kernel.org/";
         repositories.git = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git";
-        maintainers = [
+        maintainers = lib.teams.linux-kernel.members ++ [
           maintainers.thoughtpolice
         ];
         platforms = platforms.linux;

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -47,10 +47,11 @@
   cpu-cgroup-v2 = import ./cpu-cgroup-v2-patches;
 
   hardened = let
-    mkPatch = kernelVersion: src: {
+    mkPatch = kernelVersion: { version, sha256, patch }: let src = patch; in {
       name = lib.removeSuffix ".patch" src.name;
       patch = fetchurl (lib.filterAttrs (k: v: k != "extra") src);
       extra = src.extra;
+      inherit version sha256;
     };
     patches = builtins.fromJSON (builtins.readFile ./hardened/patches.json);
   in lib.mapAttrs mkPatch patches;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #142746.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
