### PR TITLE
otel-cli: init at 0.0.19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3360,6 +3360,12 @@
     githubId = 11006031;
     name = "Leo Maroni";
   };
+  emattiza = {
+    email = "nix@mattiza.dev";
+    github = "emattiza";
+    githubId = 11719476;
+    name = "Evan Mattiza";
+  };
   emmanuelrosa = {
     email = "emmanuel_rosa@aol.com";
     matrix = "@emmanuelrosa:matrix.org";

--- a/pkgs/tools/misc/otel-cli/default.nix
+++ b/pkgs/tools/misc/otel-cli/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub, getent }:
+
+buildGoModule rec {
+  inherit getent;
+  pname = "otel-cli";
+  version = "0.0.19";
+  src = fetchFromGitHub {
+    owner = "equinix-labs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-jQKoj55ty68yMDOa7/ulH1xZdI1GUoFyiPWdBHRWDNM=";
+  };
+  checkInputs = [ getent ];
+  vendorSha256 = "sha256-IJ2Gq5z1oNvcpWPh+BMs46VZMN1lHyE+M7kUinTSRr8=";
+  preCheck = ''
+    # This is necessary due to path hard-coding in the E2E Acceptance Test
+    ln -s ${getent}/bin/getent /bin/getent
+    # Must build full binary cli app for test run
+    go build .
+  '';
+  doCheck = false;
+  meta = with lib; {
+    homepage = "https://github.com/equinix-labs/otel-cli";
+    description = "a cli tool for otel instrumenting command line work";
+    platforms = ["x86_64-linux" "i686-linux" "aarch64-linux"];
+    license = with licenses; [asl20];
+    maintainers = with lib.maintainers; [ emattiza ];
+  };
+}

--- a/pkgs/tools/misc/otel-cli/default.nix
+++ b/pkgs/tools/misc/otel-cli/default.nix
@@ -1,29 +1,34 @@
 { lib, buildGoModule, fetchFromGitHub, getent }:
 
 buildGoModule rec {
-  inherit getent;
   pname = "otel-cli";
   version = "0.0.19";
+
   src = fetchFromGitHub {
     owner = "equinix-labs";
     repo = pname;
     rev = "v${version}";
     sha256 = "sha256-jQKoj55ty68yMDOa7/ulH1xZdI1GUoFyiPWdBHRWDNM=";
   };
+
   checkInputs = [ getent ];
+
   vendorSha256 = "sha256-IJ2Gq5z1oNvcpWPh+BMs46VZMN1lHyE+M7kUinTSRr8=";
+
   preCheck = ''
     # This is necessary due to path hard-coding in the E2E Acceptance Test
     ln -s ${getent}/bin/getent /bin/getent
     # Must build full binary cli app for test run
     go build .
   '';
+
   doCheck = false;
+
   meta = with lib; {
     homepage = "https://github.com/equinix-labs/otel-cli";
     description = "a cli tool for otel instrumenting command line work";
     platforms = ["x86_64-linux" "i686-linux" "aarch64-linux"];
-    license = with licenses; [asl20];
+    license = with licenses; [ asl20 ];
     maintainers = with lib.maintainers; [ emattiza ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8249,6 +8249,8 @@ with pkgs;
 
   ostree = callPackage ../tools/misc/ostree { };
 
+  otel-cli = callPackage ../tools/misc/otel-cli {};
+
   otfcc = callPackage ../tools/misc/otfcc { };
 
   otpclient = callPackage ../applications/misc/otpclient { };


### PR DESCRIPTION
Initial package addition of otel-cli, a cli opentelemetry application to
support command-line application instrumentation and observability.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

#143471 