### PR TITLE
Pantheon updates 2021-10-28

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -283,6 +283,7 @@ in
         elementary-music
         elementary-photos
         elementary-screenshot
+        elementary-tasks
         elementary-terminal
         elementary-videos
         epiphany

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
@@ -60,9 +60,8 @@ stdenv.mkDerivation rec {
   '';
 
   preInstall = ''
-    # Install our override for plank dockitems as Appcenter and Tasks is not ready to be preinstalled.
-    # For Appcenter, see: https://github.com/NixOS/nixpkgs/issues/70214.
-    # For Tasks, see: https://github.com/elementary/tasks/issues/243#issuecomment-846259496
+    # Install our override for plank dockitems as Appcenter is not ready to be preinstalled.
+    # See: https://github.com/NixOS/nixpkgs/issues/70214.
     schema_dir=$out/share/glib-2.0/schemas
     install -D ${./overrides/plank-dockitems.gschema.override} $schema_dir/plank-dockitems.gschema.override
 

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/launchers/io.elementary.tasks.dockitem
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/launchers/io.elementary.tasks.dockitem
@@ -1,0 +1,2 @@
+[PlankDockItemPreferences]
+Launcher=file:///run/current-system/sw/share/applications/io.elementary.tasks.desktop

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/overrides/plank-dockitems.gschema.override
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/overrides/plank-dockitems.gschema.override
@@ -1,2 +1,2 @@
 [net.launchpad.plank.dock.settings]
-dock-items=['gala-multitaskingview.dockitem','org.gnome.Epiphany.dockitem','io.elementary.mail.dockitem','io.elementary.calendar.dockitem','io.elementary.music.dockitem','io.elementary.videos.dockitem','io.elementary.photos.dockitem','io.elementary.switchboard.dockitem']
+dock-items=['gala-multitaskingview.dockitem','org.gnome.Epiphany.dockitem','io.elementary.mail.dockitem','io.elementary.tasks.dockitem','io.elementary.calendar.dockitem','io.elementary.music.dockitem','io.elementary.videos.dockitem','io.elementary.photos.dockitem','io.elementary.switchboard.dockitem']

--- a/pkgs/development/libraries/xdg-desktop-portal-pantheon/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-pantheon/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal-pantheon";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "portals";
     rev = version;
-    sha256 = "sha256-uPZUeyyn7HZwcBksY6X5s1bpbIRwqdCNfZKnkynVD+8=";
+    sha256 = "sha256-8gBMjCMEzrFmKHhkXsgcIESC93EOT0ADkRUIJMmerjw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Part of Pantheon 6.0.3 updates (previous one at #143314).

- https://github.com/elementary/portals/pull/34

elementary-tasks is in a better state since 6.0.2 and I am shipping this following upstream.

To test dockitem:

```
$ rm -r ~/.config/plank
$ reboot
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
