### PR TITLE
alsa-firmware: 1.2.1 → 1.2.4

### DIFF
--- a/pkgs/os-specific/linux/alsa-project/alsa-firmware/default.nix
+++ b/pkgs/os-specific/linux/alsa-project/alsa-firmware/default.nix
@@ -1,24 +1,17 @@
-{ lib, stdenv, buildPackages, autoreconfHook, fetchurl, fetchpatch }:
+{ lib, stdenv, buildPackages, autoreconfHook, fetchurl }:
 
 stdenv.mkDerivation rec {
   pname = "alsa-firmware";
-  version = "1.2.1";
+  version = "1.2.4";
 
   src = fetchurl {
     url = "mirror://alsa/firmware/alsa-firmware-${version}.tar.bz2";
-    sha256 = "1aq8z8ajpjvcx7bwhwp36bh5idzximyn77ygk3ifs0my3mbpr8mf";
+    sha256 = "sha256-tnttfQi8/CR+9v8KuIqZwYgwWjz1euLf0LzZpbNs1bs=";
   };
-
-  patches = [ (fetchpatch {
-    url = "https://github.com/alsa-project/alsa-firmware/commit/a8a478485a999ff9e4a8d8098107d3b946b70288.patch";
-    sha256 = "0zd7vrgz00hn02va5bkv7qj2395a1rl6f8jq1mwbryxs7hiysb78";
-  }) ];
 
   nativeBuildInputs = [ autoreconfHook buildPackages.stdenv.cc ];
 
-  configureFlags = [
-    "--with-hotplug-dir=$(out)/lib/firmware"
-  ];
+  configureFlags = [ "--with-hotplug-dir=$(out)/lib/firmware" ];
 
   dontStrip = true;
 


### PR DESCRIPTION
Patch is present on 1.2.4: https://github.com/alsa-project/alsa-firmware/commit/c9e5b369919a956cf56d50a6f0be076e364f7820

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
