### PR TITLE
python3Packages.pytorch-bin: 1.9.1 -> 1.10.0

### DIFF
--- a/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
+++ b/pkgs/development/libraries/science/math/libtorch/binary-hashes.nix
@@ -1,14 +1,19 @@
-version: {
-  x86_64-darwin-cpu = {
-    url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-${version}.zip";
-    hash = "sha256-TOJ+iQpqazta46y4IzIbfEGMjz/fz+pRDV8fKqriB6Q=";
-  };
-  x86_64-linux-cpu = {
-    url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-${version}%2Bcpu.zip";
-    hash = "sha256-gZMNLCzW3j+eplBqWo6lVvuHS5iRqtMD8NL3MoszsVg=";
-  };
-  x86_64-linux-cuda = {
-    url = "https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-${version}%2Bcu111.zip";
-    hash = "sha256-dRu4F8k2SAbtghwrPJNyX0u3tsODCbXfi9EqUdf4xYc=";
+version : builtins.getAttr version {
+  "1.10.0" = {
+    x86_64-darwin-cpu = {
+      name = "libtorch-macos-1.10.0.zip";
+      url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.10.0.zip";
+      hash = "sha256-HSisxHs466c6XwvZEbkV/1kVNBzJOy3uVw9Bh497Vk8=";
+    };
+    x86_64-linux-cpu = {
+      name = "libtorch-cxx11-abi-shared-with-deps-1.10.0-cpu.zip";
+      url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.10.0%2Bcpu.zip";
+      hash = "sha256-wAtA+AZx3HjaFbsrbyfkSXjYM0BP8H5HwCgyHbgJXJ0=";
+    };
+    x86_64-linux-cuda = {
+      name = "libtorch-cxx11-abi-shared-with-deps-1.10.0-cu113.zip";
+      url = "https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.10.0%2Bcu113.zip";
+      hash = "sha256-jPylK4j0V8SEQ8cZU+O22P7kQ28wanIB0GkBzRGyTj8=";
+    };
   };
 }

--- a/pkgs/development/libraries/science/math/libtorch/prefetch.sh
+++ b/pkgs/development/libraries/science/math/libtorch/prefetch.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-prefetch-scripts
+
+set -eou pipefail
+
+version=$1
+
+bucket="https://download.pytorch.org/libtorch"
+CUDA_VERSION=cu113
+
+url_and_key_list=(
+  "x86_64-darwin-cpu $bucket/cpu/libtorch-macos-${version}.zip libtorch-macos-${version}.zip"
+  "x86_64-linux-cpu $bucket/cpu/libtorch-cxx11-abi-shared-with-deps-${version}%2Bcpu.zip libtorch-cxx11-abi-shared-with-deps-${version}-cpu.zip"
+  "x86_64-linux-cuda $bucket/${CUDA_VERSION}/libtorch-cxx11-abi-shared-with-deps-${version}%2B${CUDA_VERSION}.zip libtorch-cxx11-abi-shared-with-deps-${version}-${CUDA_VERSION}.zip"
+)
+
+hashfile="binary-hashes-$version.nix"
+echo "  \"$version\" = {" >> $hashfile
+
+for url_and_key in "${url_and_key_list[@]}"; do
+  key=$(echo "$url_and_key" | cut -d' ' -f1)
+  url=$(echo "$url_and_key" | cut -d' ' -f2)
+  name=$(echo "$url_and_key" | cut -d' ' -f3)
+
+  echo "prefetching ${url}..."
+  hash=$(nix hash to-sri --type sha256 $(nix-prefetch-url --unpack "$url" --name "$name"))
+
+  echo "    $key = {" >> $hashfile
+  echo "      name = \"$name\";" >> $hashfile
+  echo "      url = \"$url\";" >> $hashfile
+  echo "      hash = \"$hash\";" >> $hashfile
+  echo "    };" >> $hashfile
+
+  echo
+done
+
+echo "  };" >> $hashfile
+echo "done."

--- a/pkgs/development/python-modules/pytorch/bin.nix
+++ b/pkgs/development/python-modules/pytorch/bin.nix
@@ -18,7 +18,7 @@ let
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
   unsupported = throw "Unsupported system";
-  version = "1.9.1";
+  version = "1.10.0";
 in buildPythonPackage {
   inherit version;
 
@@ -59,13 +59,19 @@ in buildPythonPackage {
     done
   '';
 
+  # The wheel-binary is not stripped to avoid the error of `ImportError: libtorch_cuda_cpp.so: ELF load command address/offset not properly aligned.`.
+  dontStrip = true;
+
   pythonImportsCheck = [ "torch" ];
 
   meta = with lib; {
     description = "Open source, prototype-to-production deep learning platform";
     homepage = "https://pytorch.org/";
     changelog = "https://github.com/pytorch/pytorch/releases/tag/v${version}";
-    license = licenses.unfree; # Includes CUDA and Intel MKL.
+    # Includes CUDA and Intel MKL, but redistributions of the binary are not limited.
+    # https://docs.nvidia.com/cuda/eula/index.html
+    # https://www.intel.com/content/www/us/en/developer/articles/license/onemkl-license-faq.html
+    license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ junjihashimoto ];
   };

--- a/pkgs/development/python-modules/pytorch/binary-hashes.nix
+++ b/pkgs/development/python-modules/pytorch/binary-hashes.nix
@@ -6,21 +6,21 @@
 # To add a new version, run "prefetch.sh 'new-version'" to paste the generated file as follows.
 
 version : builtins.getAttr version {
-  "1.9.1" = {
+  "1.10.0" = {
     x86_64-linux-37 = {
-      name = "torch-1.9.1-cp37-cp37m-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu111/torch-1.9.1%2Bcu111-cp37-cp37m-linux_x86_64.whl";
-      hash = "sha256-qzXbbpLX+ZlRv41oAyQRk3guU0n/6vuNzWw+nOieL6s=";
+      name = "torch-1.10.0-cp37-cp37m-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torch-1.10.0%2Bcu113-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-KpDbklee2HXSqgrWr1U1nj8EJqUjBWp7SbACw8xtKtg=";
     };
     x86_64-linux-38 = {
-      name = "torch-1.9.1-cp38-cp38-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu111/torch-1.9.1%2Bcu111-cp38-cp38-linux_x86_64.whl";
-      hash = "sha256-JUbcqugax08/iN1LKfXq0ohSpejmbKhbT0by7qMGAzw=";
+      name = "torch-1.10.0-cp38-cp38-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torch-1.10.0%2Bcu113-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-zM3cMriUG9A+3in/ChzOLytRETpe4ju4uXkxasIRQYM=";
     };
     x86_64-linux-39 = {
-      name = "torch-1.9.1-cp39-cp39-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu111/torch-1.9.1%2Bcu111-cp39-cp39-linux_x86_64.whl";
-      hash = "sha256-wNLLtR9ZxKkVOTzwbAikM5H83pXyH+aPHVFyfrO4c1M=";
+      name = "torch-1.10.0-cp39-cp39-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torch-1.10.0%2Bcu113-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-w8UJDh4b5cgDu7ZSvDoKzNH4hiXEyRfvpycNOg+wJOg=";
     };
   };
 }

--- a/pkgs/development/python-modules/pytorch/prefetch.sh
+++ b/pkgs/development/python-modules/pytorch/prefetch.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p nix-prefetch-scripts
 
+set -eou pipefail
+
 version=$1
 
-bucket="https://download.pytorch.org/whl/cu111"
+bucket="https://download.pytorch.org/whl/cu113"
 
 url_and_key_list=(
-"x86_64-linux-37 $bucket/torch-${version}%2Bcu111-cp37-cp37m-linux_x86_64.whl torch-${version}-cp37-cp37m-linux_x86_64.whl"
-"x86_64-linux-38 $bucket/torch-${version}%2Bcu111-cp38-cp38-linux_x86_64.whl torch-${version}-cp38-cp38-linux_x86_64.whl"
-"x86_64-linux-39 $bucket/torch-${version}%2Bcu111-cp39-cp39-linux_x86_64.whl torch-${version}-cp39-cp39-linux_x86_64.whl"
+  "x86_64-linux-37 $bucket/torch-${version}%2Bcu113-cp37-cp37m-linux_x86_64.whl torch-${version}-cp37-cp37m-linux_x86_64.whl"
+  "x86_64-linux-38 $bucket/torch-${version}%2Bcu113-cp38-cp38-linux_x86_64.whl torch-${version}-cp38-cp38-linux_x86_64.whl"
+  "x86_64-linux-39 $bucket/torch-${version}%2Bcu113-cp39-cp39-linux_x86_64.whl torch-${version}-cp39-cp39-linux_x86_64.whl"
 )
 
-hashfile=binary-hashes-"$version".nix
-rm -f $hashfile
+hashfile="binary-hashes-$version.nix"
 echo "  \"$version\" = {" >> $hashfile
 
 for url_and_key in "${url_and_key_list[@]}"; do

--- a/pkgs/development/python-modules/torchaudio/bin.nix
+++ b/pkgs/development/python-modules/torchaudio/bin.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchurl
+, python
+, pytorch-bin
+, pythonOlder
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  pname = "torchaudio";
+  version = "0.10.0";
+  format = "wheel";
+
+  src =
+    let pyVerNoDot = lib.replaceStrings [ "." ] [ "" ] python.pythonVersion;
+        unsupported = throw "Unsupported system";
+        srcs = (import ./binary-hashes.nix version)."${stdenv.system}-${pyVerNoDot}" or unsupported;
+    in fetchurl srcs;
+
+  disabled = ! (pythonAtLeast "3.7" && pythonOlder "3.10");
+
+  propagatedBuildInputs = [
+    pytorch-bin
+  ];
+
+  # The wheel-binary is not stripped to avoid the error of `ImportError: libtorch_cuda_cpp.so: ELF load command address/offset not properly aligned.`.
+  dontStrip = true;
+
+  pythonImportsCheck = [ "torchaudio" ];
+
+  postFixup = ''
+    # Note: after patchelf'ing, libcudart can still not be found. However, this should
+    #       not be an issue, because PyTorch is loaded before torchvision and brings
+    #       in the necessary symbols.
+    patchelf --set-rpath "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}:${pytorch-bin}/${python.sitePackages}/torch/lib:" \
+      "$out/${python.sitePackages}/torchaudio/_torchaudio.so"
+  '';
+
+  meta = with lib; {
+    description = "PyTorch audio library";
+    homepage = "https://pytorch.org/";
+    changelog = "https://github.com/pytorch/audio/releases/tag/v${version}";
+    # Includes CUDA and Intel MKL, but redistributions of the binary are not limited.
+    # https://docs.nvidia.com/cuda/eula/index.html
+    # https://www.intel.com/content/www/us/en/developer/articles/license/onemkl-license-faq.html
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ junjihashimoto ];
+  };
+}

--- a/pkgs/development/python-modules/torchaudio/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchaudio/binary-hashes.nix
@@ -1,0 +1,26 @@
+# Warning: Need to update at the same time as pytorch-bin
+#
+# Precompiled wheels can be found at:
+# https://download.pytorch.org/whl/torch_stable.html
+
+# To add a new version, run "prefetch.sh 'new-version'" to paste the generated file as follows.
+
+version : builtins.getAttr version {
+  "0.10.0" = {
+    x86_64-linux-37 = {
+      name = "torchaudio-0.10.0-cp37-cp37m-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.10.0%2Bcu113-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-FspXTTODdkO0nPUJcJm8+vLIvckUa8gRfBPBT9LcKPw=";
+    };
+    x86_64-linux-38 = {
+      name = "torchaudio-0.10.0-cp38-cp38-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.10.0%2Bcu113-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-Mf7QdXBSIIWRfT7ACthEwFA1V2ieid8legbMnRQnzqI=";
+    };
+    x86_64-linux-39 = {
+      name = "torchaudio-0.10.0-cp39-cp39-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.10.0%2Bcu113-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-LMSGNdmku1iHRy1jCRTTOYcQlRL+Oc9jjZC1nx++skA=";
+    };
+  };
+}

--- a/pkgs/development/python-modules/torchaudio/prefetch.sh
+++ b/pkgs/development/python-modules/torchaudio/prefetch.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-prefetch-scripts
+
+set -eou pipefail
+
+version=$1
+
+bucket="https://download.pytorch.org/whl/cu113"
+
+url_and_key_list=(
+  "x86_64-linux-37 $bucket/torchaudio-${version}%2Bcu113-cp37-cp37m-linux_x86_64.whl torchaudio-${version}-cp37-cp37m-linux_x86_64.whl"
+  "x86_64-linux-38 $bucket/torchaudio-${version}%2Bcu113-cp38-cp38-linux_x86_64.whl torchaudio-${version}-cp38-cp38-linux_x86_64.whl"
+  "x86_64-linux-39 $bucket/torchaudio-${version}%2Bcu113-cp39-cp39-linux_x86_64.whl torchaudio-${version}-cp39-cp39-linux_x86_64.whl"
+)
+
+hashfile=binary-hashes-"$version".nix
+echo "  \"$version\" = {" >> $hashfile
+
+for url_and_key in "${url_and_key_list[@]}"; do
+  key=$(echo "$url_and_key" | cut -d' ' -f1)
+  url=$(echo "$url_and_key" | cut -d' ' -f2)
+  name=$(echo "$url_and_key" | cut -d' ' -f3)
+
+  echo "prefetching ${url}..."
+  hash=$(nix hash to-sri --type sha256 `nix-prefetch-url "$url" --name "$name"`)
+
+  echo "    $key = {" >> $hashfile
+  echo "      name = \"$name\";" >> $hashfile
+  echo "      url = \"$url\";" >> $hashfile
+  echo "      hash = \"$hash\";" >> $hashfile
+  echo "    };" >> $hashfile
+
+  echo
+done
+
+echo "  };" >> $hashfile
+echo "done."

--- a/pkgs/development/python-modules/torchvision/bin.nix
+++ b/pkgs/development/python-modules/torchvision/bin.nix
@@ -15,7 +15,7 @@ let
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
   unsupported = throw "Unsupported system";
-  version = "0.10.1";
+  version = "0.11.1";
 in buildPythonPackage {
   inherit version;
 
@@ -36,6 +36,9 @@ in buildPythonPackage {
     pytorch-bin
   ];
 
+  # The wheel-binary is not stripped to avoid the error of `ImportError: libtorch_cuda_cpp.so: ELF load command address/offset not properly aligned.`.
+  dontStrip = true;
+
   pythonImportsCheck = [ "torchvision" ];
 
   postFixup = let
@@ -52,6 +55,9 @@ in buildPythonPackage {
     description = "PyTorch vision library";
     homepage = "https://pytorch.org/";
     changelog = "https://github.com/pytorch/vision/releases/tag/v${version}";
+    # Includes CUDA and Intel MKL, but redistributions of the binary are not limited.
+    # https://docs.nvidia.com/cuda/eula/index.html
+    # https://www.intel.com/content/www/us/en/developer/articles/license/onemkl-license-faq.html
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ junjihashimoto ];

--- a/pkgs/development/python-modules/torchvision/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchvision/binary-hashes.nix
@@ -6,21 +6,21 @@
 # To add a new version, run "prefetch.sh 'new-version'" to paste the generated file as follows.
 
 version : builtins.getAttr version {
-  "0.10.1" = {
+  "0.11.1" = {
     x86_64-linux-37 = {
-      name = "torchvision-0.10.1-cp37-cp37m-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu111/torchvision-0.10.1%2Bcu111-cp37-cp37m-linux_x86_64.whl";
-      hash = "sha256-1MdsCrOLGkYpfbtv011/b6QG+yKaE+O0jUKeUVj2BJY=";
+      name = "torchvision-0.11.1-cp37-cp37m-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchvision-0.11.1%2Bcu113-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-2xKWqWNKqmOMyVJnPfbtF+B9PQ7z4S66J1T3P8EvM0I=";
     };
     x86_64-linux-38 = {
-      name = "torchvision-0.10.1-cp38-cp38-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu111/torchvision-0.10.1%2Bcu111-cp38-cp38-linux_x86_64.whl";
-      hash = "sha256-LtmsnNSa9g3tCdjW1jhu7AZlGgfyYIVh5/2R+WwcxSo=";
+      name = "torchvision-0.11.1-cp38-cp38-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchvision-0.11.1%2Bcu113-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-bFxvJaNEomytXXANHng+oU8YSLGkuO/TSzkoDskkaIE=";
     };
     x86_64-linux-39 = {
-      name = "torchvision-0.10.1-cp39-cp39-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu111/torchvision-0.10.1%2Bcu111-cp39-cp39-linux_x86_64.whl";
-      hash = "sha256-ZOC/angyiLeOhe+7dAs0W6XlQRKK00T/iI+aBgFNpA0=";
+      name = "torchvision-0.11.1-cp39-cp39-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchvision-0.11.1%2Bcu113-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-ysN3LmSKR+FVKYGnCGQJqa8lVApVT5rPMO+NHmmazAc=";
     };
   };
 }

--- a/pkgs/development/python-modules/torchvision/prefetch.sh
+++ b/pkgs/development/python-modules/torchvision/prefetch.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p nix-prefetch-scripts
 
+set -eou pipefail
+
 version=$1
 
-bucket="https://download.pytorch.org/whl/cu111"
+bucket="https://download.pytorch.org/whl/cu113"
 
 url_and_key_list=(
-"x86_64-linux-37 $bucket/torchvision-${version}%2Bcu111-cp37-cp37m-linux_x86_64.whl torchvision-${version}-cp37-cp37m-linux_x86_64.whl"
-"x86_64-linux-38 $bucket/torchvision-${version}%2Bcu111-cp38-cp38-linux_x86_64.whl torchvision-${version}-cp38-cp38-linux_x86_64.whl"
-"x86_64-linux-39 $bucket/torchvision-${version}%2Bcu111-cp39-cp39-linux_x86_64.whl torchvision-${version}-cp39-cp39-linux_x86_64.whl"
+  "x86_64-linux-37 $bucket/torchvision-${version}%2Bcu113-cp37-cp37m-linux_x86_64.whl torchvision-${version}-cp37-cp37m-linux_x86_64.whl"
+  "x86_64-linux-38 $bucket/torchvision-${version}%2Bcu113-cp38-cp38-linux_x86_64.whl torchvision-${version}-cp38-cp38-linux_x86_64.whl"
+  "x86_64-linux-39 $bucket/torchvision-${version}%2Bcu113-cp39-cp39-linux_x86_64.whl torchvision-${version}-cp39-cp39-linux_x86_64.whl"
 )
 
-hashfile=binary-hashes-"$version".nix
-rm -f $hashfile
+hashfile="binary-hashes-$version.nix"
 echo "  \"$version\" = {" >> $hashfile
 
 for url_and_key in "${url_and_key_list[@]}"; do

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9068,6 +9068,8 @@ in {
 
   toposort = callPackage ../development/python-modules/toposort { };
 
+  torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix { };
+
   torchgpipe = callPackage ../development/python-modules/torchgpipe { };
 
   torchvision = callPackage ../development/python-modules/torchvision { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is an update due to a major release of pytorch.
https://github.com/pytorch/pytorch/releases/tag/v1.10.0

Both torchvision and torchaudio are updated in this pr to depend on a specific pytorch-version.
If we update separately, the dependency will be broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Tests

```shell
$ nix repl
Welcome to Nix version 2.4pre20210908_3c56f62. Type :? for help.

nix-repl> :lf .
warning: Git tree '/home/hashimoto/git/nixpkgs' is dirty
Added 13 variables.

nix-repl> pkgs = outputs.legacyPackages.x86_64-linux

nix-repl> :b pkgs.python3.withPackages (p: with p; [pytorch-bin torchvision-bin torchaudio-bin])

this derivation produced the following outputs:
  out -> /nix/store/gpw4vfswmff4b7n8yczjhclkrvc4x9ih-python3-3.9.6-env

nix-repl> :b pkgs.libtorch-bin.tests.cmake

this derivation produced the following outputs:
  out -> /nix/store/ijsf96zmia0xpa2l85nsgh0cl9cw63yc-libtorch-test-1.10.0

```