### PR TITLE
zfs-kernel: fix strip in cross-compilation

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -144,7 +144,7 @@ let
       # Since zfs compress kernel modules on installation, our strip hooks skip stripping them.
       # Hence we strip modules prior to compression.
       postBuild = optionalString buildKernel ''
-         find . -name "*.ko" -print0 | xargs -0 -P$NIX_BUILD_CORES strip --strip-debug
+         find . -name "*.ko" -print0 | xargs -0 -P$NIX_BUILD_CORES ${stdenv.cc.targetPrefix}strip --strip-debug
       '';
 
       postInstall = optionalString buildKernel ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix https://github.com/NixOS/nixpkgs/pull/141942#issuecomment-954301443

```
$ nix build .#nixosConfigurations.nixos.config.boot.kernelPackages.zfs

$ du -hc $(readlink -e result)/**/*.ko*
5,0K    /nix/store/56ah9x6xr7g9gy8j03b2xwfjxclr640x-zfs-kernel-2.1.1-5.14.14-armv7l-unknown-linux-gnueabihf/lib/modules/5.14.14/extra/avl/zavl.ko.xz
97K     /nix/store/56ah9x6xr7g9gy8j03b2xwfjxclr640x-zfs-kernel-2.1.1-5.14.14-armv7l-unknown-linux-gnueabihf/lib/modules/5.14.14/extra/icp/icp.ko.xz
61K     /nix/store/56ah9x6xr7g9gy8j03b2xwfjxclr640x-zfs-kernel-2.1.1-5.14.14-armv7l-unknown-linux-gnueabihf/lib/modules/5.14.14/extra/lua/zlua.ko.xz
21K     /nix/store/56ah9x6xr7g9gy8j03b2xwfjxclr640x-zfs-kernel-2.1.1-5.14.14-armv7l-unknown-linux-gnueabihf/lib/modules/5.14.14/extra/nvpair/znvpair.ko.xz
37K     /nix/store/56ah9x6xr7g9gy8j03b2xwfjxclr640x-zfs-kernel-2.1.1-5.14.14-armv7l-unknown-linux-gnueabihf/lib/modules/5.14.14/extra/spl/spl.ko.xz
33K     /nix/store/56ah9x6xr7g9gy8j03b2xwfjxclr640x-zfs-kernel-2.1.1-5.14.14-armv7l-unknown-linux-gnueabihf/lib/modules/5.14.14/extra/unicode/zunicode.ko.xz
25K     /nix/store/56ah9x6xr7g9gy8j03b2xwfjxclr640x-zfs-kernel-2.1.1-5.14.14-armv7l-unknown-linux-gnueabihf/lib/modules/5.14.14/extra/zcommon/zcommon.ko.xz
809K    /nix/store/56ah9x6xr7g9gy8j03b2xwfjxclr640x-zfs-kernel-2.1.1-5.14.14-armv7l-unknown-linux-gnueabihf/lib/modules/5.14.14/extra/zfs/zfs.ko.xz
157K    /nix/store/56ah9x6xr7g9gy8j03b2xwfjxclr640x-zfs-kernel-2.1.1-5.14.14-armv7l-unknown-linux-gnueabihf/lib/modules/5.14.14/extra/zstd/zzstd.ko.xz
1,3M    total
```

###### Things done
- [X] Use `${stdenv.cc.targetPrefix}strip` instead of `strip`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
