### PR TITLE
quaternion: 0.0.95.0 -> 0.0.95.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/quaternion/default.nix
+++ b/pkgs/applications/networking/instant-messengers/quaternion/default.nix
@@ -3,7 +3,6 @@
 , lib
 , fetchFromGitHub
 , cmake
-, qtbase
 , qtquickcontrols
 , qtquickcontrols2
 , qtkeychain
@@ -15,19 +14,17 @@
 
 mkDerivation rec {
   pname = "quaternion";
-  version = "0.0.95";
+  version = "0.0.95.1";
 
   src = fetchFromGitHub {
     owner = "QMatrixClient";
     repo = "Quaternion";
     rev = version;
-    sha256 = "sha256-WqhHqo4ySxufulC+TxS2ko2R5hUiORgdNAkp5Awdcw8=";
+    sha256 = "sha256-6FLj/hVY13WO7sMgHCHV57eMJu39cwQHXQX7m0lmv4I=";
   };
 
   buildInputs = [
-    qtbase
     qtmultimedia
-    qtquickcontrols
     qtquickcontrols2
     qtkeychain
     libquotient
@@ -47,11 +44,10 @@ mkDerivation rec {
     '';
 
   meta = with lib; {
-    description =
-      "Cross-platform desktop IM client for the Matrix protocol";
+    description = "Cross-platform desktop IM client for the Matrix protocol";
     homepage = "https://matrix.org/docs/projects/client/quaternion.html";
     license = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
-    inherit (qtbase.meta) platforms;
+    inherit (qtquickcontrols2.meta) platforms;
   };
 }

--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -1,19 +1,24 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, qtbase, qtmultimedia }:
+{ mkDerivation, lib, fetchFromGitHub, cmake, qtmultimedia }:
 
 mkDerivation rec {
   pname = "libquotient";
-  version = "0.6.9";
+  version = "0.6.11";
 
   src = fetchFromGitHub {
     owner = "quotient-im";
     repo = "libQuotient";
     rev = version;
-    sha256 = "sha256-1YiS2b4lYknNSB+8LKB/s6AcF0yQVsakrkp6/Sjkczo=";
+    sha256 = "sha256-FPtxeZOfChIPi4e/h/eZkByH1QL3Fn0OJxe0dnMcTRw=";
   };
 
-  buildInputs = [ qtbase qtmultimedia ];
+  buildInputs = [ qtmultimedia ];
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    # we need libqtolm for this
+    "-DQuotient_ENABLE_E2EE=OFF"
+  ];
 
   meta = with lib; {
     description = "A Qt5 library to write cross-platform clients for Matrix";


### PR DESCRIPTION
###### Motivation for this change

Also includes a very relevant libquotient upgrade.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
