### PR TITLE
power-profiles-daemon: 0.8.1 → 0.10.1

### DIFF
--- a/nixos/modules/services/hardware/power-profiles-daemon.nix
+++ b/nixos/modules/services/hardware/power-profiles-daemon.nix
@@ -42,6 +42,8 @@ in
       }
     ];
 
+    environment.systemPackages = [ package ];
+
     services.dbus.packages = [ package ];
 
     services.udev.packages = [ package ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -371,6 +371,7 @@ in
   postgresql = handleTest ./postgresql.nix {};
   postgresql-wal-receiver = handleTest ./postgresql-wal-receiver.nix {};
   powerdns = handleTest ./powerdns.nix {};
+  power-profiles-daemon = handleTest ./power-profiles-daemon.nix {};
   pppd = handleTest ./pppd.nix {};
   predictable-interface-names = handleTest ./predictable-interface-names.nix {};
   printing = handleTest ./printing.nix {};

--- a/nixos/tests/installed-tests/default.nix
+++ b/nixos/tests/installed-tests/default.nix
@@ -104,5 +104,6 @@ in
   malcontent = callInstalledTest ./malcontent.nix {};
   ostree = callInstalledTest ./ostree.nix {};
   pipewire = callInstalledTest ./pipewire.nix {};
+  power-profiles-daemon = callInstalledTest ./power-profiles-daemon.nix {};
   xdg-desktop-portal = callInstalledTest ./xdg-desktop-portal.nix {};
 }

--- a/nixos/tests/installed-tests/power-profiles-daemon.nix
+++ b/nixos/tests/installed-tests/power-profiles-daemon.nix
@@ -1,0 +1,9 @@
+{ pkgs, lib, makeInstalledTest, ... }:
+
+makeInstalledTest {
+  tested = pkgs.power-profiles-daemon;
+
+  testConfig = {
+    services.power-profiles-daemon.enable = true;
+  };
+}

--- a/pkgs/os-specific/linux/power-profiles-daemon/default.nix
+++ b/pkgs/os-specific/linux/power-profiles-daemon/default.nix
@@ -4,6 +4,7 @@
 , meson
 , ninja
 , fetchFromGitLab
+, fetchpatch
 , libgudev
 , glib
 , polkit
@@ -15,17 +16,26 @@
 , libxml2
 , libxslt
 , upower
+, umockdev
 , systemd
 , python3
 , wrapGAppsNoGuiHook
 , nixosTests
 }:
 
+let
+  testPythonPkgs = ps: with ps; [
+    pygobject3
+    dbus-python
+    python-dbusmock
+  ];
+  testTypelibPath = lib.makeSearchPathOutput "lib" "lib/girepository-1.0" [ umockdev ];
+in
 stdenv.mkDerivation rec {
   pname = "power-profiles-daemon";
   version = "0.10.1";
 
-  outputs = [ "out" "devdoc" ];
+  outputs = [ "out" "devdoc" "installedTests" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -34,6 +44,18 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-sQWiCHc0kEELdmPq9Qdk7OKDUgbM5R44639feC7gjJc=";
   };
+
+  patches = [
+    # Enable installed tests.
+    # https://gitlab.freedesktop.org/hadess/power-profiles-daemon/-/merge_requests/92
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/hadess/power-profiles-daemon/-/commit/3c64d9e1732eb6425e33013c452f1c4aa7a26f7e.patch";
+      sha256 = "din5VuZZwARNDInHtl44yJK8pLmlxr5eoD4iMT4a8HA=";
+    })
+
+    # Install installed tests to separate output.
+    ./installed-tests-path.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -46,9 +68,11 @@ stdenv.mkDerivation rec {
     libxml2 # for xmllint for stripping GResources
     libxslt # for xsltproc for building docs
     gobject-introspection
-    python3
     wrapGAppsNoGuiHook
     python3.pkgs.wrapPython
+
+    # For finding tests.
+    (python3.withPackages testPythonPkgs)
   ];
 
   buildInputs = [
@@ -68,6 +92,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
+    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
     "-Dsystemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     "-Dgtk_doc=true"
   ];
@@ -79,6 +104,18 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs tests/unittest_inspector.py
+  '';
+
+  preConfigure = ''
+    # For finding tests.
+    GI_TYPELIB_PATH_original=$GI_TYPELIB_PATH
+    addToSearchPath GI_TYPELIB_PATH "${testTypelibPath}"
+  '';
+
+  postConfigure = ''
+    # Restore the original value to prevent the program from depending on umockdev.
+    export GI_TYPELIB_PATH=$GI_TYPELIB_PATH_original
+    unset GI_TYPELIB_PATH_original
   '';
 
   preInstall = ''
@@ -96,11 +133,28 @@ stdenv.mkDerivation rec {
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
     # Make Python libraries available
     wrapPythonProgramsIn "$out/bin" "$pythonPath"
+
+    # Make Python libraries available for installed tests
+    makeWrapperArgs+=(
+      --prefix GI_TYPELIB_PATH : "${testTypelibPath}"
+      --prefix PATH : "${lib.makeBinPath [ umockdev ]}"
+      # Vala does not use absolute paths in typelibs
+      # https://github.com/NixOS/nixpkgs/issues/47226
+      # Also umockdev binaries use relative paths for LD_PRELOAD.
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ umockdev ]}"
+      # dbusmock calls its templates using exec so our regular patching of Python scripts
+      # to add package directories to site will not carry over.
+      # https://github.com/martinpitt/python-dbusmock/blob/2254e69279a02fb3027b500ed7288b77c7a80f2a/dbusmock/mockobject.py#L51
+      # https://github.com/martinpitt/python-dbusmock/blob/2254e69279a02fb3027b500ed7288b77c7a80f2a/dbusmock/__main__.py#L60-L62
+      --prefix PYTHONPATH : "${lib.makeSearchPath python3.sitePackages (testPythonPkgs python3.pkgs)}"
+    )
+    wrapPythonProgramsIn "$installedTests/libexec/installed-tests" "$pythonPath ${lib.concatStringsSep " " (testPythonPkgs python3.pkgs)}"
   '';
 
   passthru = {
     tests = {
       nixos = nixosTests.power-profiles-daemon;
+      installed-tests = nixosTests.installed-tests.power-profiles-daemon;
     };
   };
 

--- a/pkgs/os-specific/linux/power-profiles-daemon/default.nix
+++ b/pkgs/os-specific/linux/power-profiles-daemon/default.nix
@@ -6,6 +6,7 @@
 , fetchFromGitLab
 , libgudev
 , glib
+, polkit
 , gobject-introspection
 , gettext
 , gtk-doc
@@ -16,11 +17,12 @@
 , upower
 , systemd
 , python3
+, wrapGAppsNoGuiHook
 }:
 
 stdenv.mkDerivation rec {
   pname = "power-profiles-daemon";
-  version = "0.8.1";
+  version = "0.10.1";
 
   outputs = [ "out" "devdoc" ];
 
@@ -29,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "hadess";
     repo = "power-profiles-daemon";
     rev = version;
-    sha256 = "sha256-OnCUr7KWVPpYGDseBUcJD/PdOobvFnyNA97NhnKbTKY=";
+    sha256 = "sha256-sQWiCHc0kEELdmPq9Qdk7OKDUgbM5R44639feC7gjJc=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +45,9 @@ stdenv.mkDerivation rec {
     libxml2 # for xmllint for stripping GResources
     libxslt # for xsltproc for building docs
     gobject-introspection
+    python3
+    wrapGAppsNoGuiHook
+    python3.pkgs.wrapPython
   ];
 
   buildInputs = [
@@ -50,7 +55,15 @@ stdenv.mkDerivation rec {
     systemd
     upower
     glib
-    (python3.withPackages (ps: with ps; [ ps.pygobject3 ])) # for cli tool
+    polkit
+    python3 # for cli tool
+  ];
+
+  strictDeps = true;
+
+  # for cli tool
+  pythonPath = [
+    python3.pkgs.pygobject3
   ];
 
   mesonFlags = [
@@ -58,11 +71,37 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=true"
   ];
 
+  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
+
+  # Avoid double wrapping
+  dontWrapGApps = true;
+
+  postPatch = ''
+    patchShebangs tests/unittest_inspector.py
+  '';
+
+  preInstall = ''
+    # We have pkexec on PATH so Meson will try to use it when installation fails
+    # due to being unable to write to e.g. /etc.
+    # Let’s pretend we already ran pkexec –
+    # the pkexec on PATH would complain it lacks setuid bit,
+    # obscuring the underlying error.
+    # https://github.com/mesonbuild/meson/blob/492cc9bf95d573e037155b588dc5110ded4d9a35/mesonbuild/minstall.py#L558
+    export PKEXEC_UID=-1
+  '';
+
+  postFixup = ''
+    # Avoid double wrapping
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    # Make Python libraries available
+    wrapPythonProgramsIn "$out/bin" "$pythonPath"
+  '';
+
   meta = with lib; {
     homepage = "https://gitlab.freedesktop.org/hadess/power-profiles-daemon";
     description = "Makes user-selected power profiles handling available over D-Bus";
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ mvnetbiz ];
+    maintainers = with maintainers; [ jtojnar mvnetbiz ];
   };
 }

--- a/pkgs/os-specific/linux/power-profiles-daemon/default.nix
+++ b/pkgs/os-specific/linux/power-profiles-daemon/default.nix
@@ -18,6 +18,7 @@
 , systemd
 , python3
 , wrapGAppsNoGuiHook
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -96,6 +97,12 @@ stdenv.mkDerivation rec {
     # Make Python libraries available
     wrapPythonProgramsIn "$out/bin" "$pythonPath"
   '';
+
+  passthru = {
+    tests = {
+      nixos = nixosTests.power-profiles-daemon;
+    };
+  };
 
   meta = with lib; {
     homepage = "https://gitlab.freedesktop.org/hadess/power-profiles-daemon";

--- a/pkgs/os-specific/linux/power-profiles-daemon/installed-tests-path.patch
+++ b/pkgs/os-specific/linux/power-profiles-daemon/installed-tests-path.patch
@@ -1,0 +1,37 @@
+diff --git a/meson_options.txt b/meson_options.txt
+index 7e89619..76497db 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1,3 +1,4 @@
++option('installed_test_prefix', type: 'string', description: 'Prefix for installed tests')
+ option('systemdsystemunitdir',
+        description: 'systemd unit directory',
+        type: 'string',
+diff --git a/tests/meson.build b/tests/meson.build
+index b306a7f..7670e1b 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -2,8 +2,8 @@ envs = environment()
+ envs.set ('top_builddir', meson.build_root())
+ envs.set ('top_srcdir', meson.source_root())
+ 
+-installed_test_bindir = libexecdir / 'installed-tests' / meson.project_name()
+-installed_test_datadir = datadir / 'installed-tests' / meson.project_name()
++installed_test_bindir = get_option('installed_test_prefix') / 'libexec' / 'installed-tests' / meson.project_name()
++installed_test_datadir = get_option('installed_test_prefix') / 'share' / 'installed-tests' / meson.project_name()
+ 
+ python3 = find_program('python3')
+ unittest_inspector = find_program('unittest_inspector.py')
+diff --git a/tests/integration-test.py b/tests/integration-test.py
+index 22dc42c..0f92b76 100755
+--- a/tests/integration-test.py
++++ b/tests/integration-test.py
+@@ -67,7 +67,7 @@ class Tests(dbusmock.DBusTestCase):
+             print('Testing binaries from JHBuild (%s)' % cls.daemon_path)
+         else:
+             cls.daemon_path = None
+-            with open('/usr/lib/systemd/system/power-profiles-daemon.service') as f:
++            with open('/run/current-system/sw/lib/systemd/system/power-profiles-daemon.service') as f:
+                 for line in f:
+                     if line.startswith('ExecStart='):
+                         cls.daemon_path = line.split('=', 1)[1].strip()


### PR DESCRIPTION
###### Motivation for this change
https://gitlab.freedesktop.org/hadess/power-profiles-daemon/-/blob/0.10.1/NEWS

The new hold functionality might allow to [crash gnome-control-center](https://gitlab.gnome.org/GNOME/gnome-control-center/-/issues/1504) but it is not that concerning.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
