### PR TITLE
sssd: 1.16.5 -> 2.6.0, fix broken build

### DIFF
--- a/nixos/tests/sssd-ldap.nix
+++ b/nixos/tests/sssd-ldap.nix
@@ -1,96 +1,94 @@
-({ pkgs, ... }:
-  let
-    dbDomain = "example.org";
-    dbSuffix = "dc=example,dc=org";
+let
+  dbDomain = "example.org";
+  dbSuffix = "dc=example,dc=org";
 
-    ldapRootUser = "admin";
-    ldapRootPassword = "foobar";
+  ldapRootUser = "admin";
+  ldapRootPassword = "foobar";
 
-    testUser = "alice";
-  in import ./make-test-python.nix {
-    name = "sssd-ldap";
+  testUser = "alice";
+in import ./make-test-python.nix ({pkgs, ...}: {
+  name = "sssd-ldap";
 
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ bbigras ];
-    };
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ bbigras ];
+  };
 
-    machine = { pkgs, ... }: {
-      services.openldap = {
-        enable = true;
-        settings = {
-          children = {
-            "cn=schema".includes = [
-              "${pkgs.openldap}/etc/schema/core.ldif"
-              "${pkgs.openldap}/etc/schema/cosine.ldif"
-              "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
-              "${pkgs.openldap}/etc/schema/nis.ldif"
-            ];
-            "olcDatabase={1}mdb" = {
-              attrs = {
-                objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
-                olcDatabase = "{1}mdb";
-                olcDbDirectory = "/var/db/openldap";
-                olcSuffix = dbSuffix;
-                olcRootDN = "cn=${ldapRootUser},${dbSuffix}";
-                olcRootPW = ldapRootPassword;
-              };
+  machine = { pkgs, ... }: {
+    services.openldap = {
+      enable = true;
+      settings = {
+        children = {
+          "cn=schema".includes = [
+            "${pkgs.openldap}/etc/schema/core.ldif"
+            "${pkgs.openldap}/etc/schema/cosine.ldif"
+            "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
+            "${pkgs.openldap}/etc/schema/nis.ldif"
+          ];
+          "olcDatabase={1}mdb" = {
+            attrs = {
+              objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
+              olcDatabase = "{1}mdb";
+              olcDbDirectory = "/var/db/openldap";
+              olcSuffix = dbSuffix;
+              olcRootDN = "cn=${ldapRootUser},${dbSuffix}";
+              olcRootPW = ldapRootPassword;
             };
           };
         };
-        declarativeContents = {
-          ${dbSuffix} = ''
-            dn: ${dbSuffix}
-            objectClass: top
-            objectClass: dcObject
-            objectClass: organization
-            o: ${dbDomain}
-
-            dn: ou=posix,${dbSuffix}
-            objectClass: top
-            objectClass: organizationalUnit
-
-            dn: ou=accounts,ou=posix,${dbSuffix}
-            objectClass: top
-            objectClass: organizationalUnit
-
-            dn: uid=${testUser},ou=accounts,ou=posix,${dbSuffix}
-            objectClass: person
-            objectClass: posixAccount
-            # userPassword: somePasswordHash
-            homeDirectory: /home/${testUser}
-            uidNumber: 1234
-            gidNumber: 1234
-            cn: ""
-            sn: ""
-          '';
-        };
       };
+      declarativeContents = {
+        ${dbSuffix} = ''
+          dn: ${dbSuffix}
+          objectClass: top
+          objectClass: dcObject
+          objectClass: organization
+          o: ${dbDomain}
 
-      services.sssd = {
-        enable = true;
-        config = ''
-          [sssd]
-          config_file_version = 2
-          services = nss, pam, sudo
-          domains = ${dbDomain}
+          dn: ou=posix,${dbSuffix}
+          objectClass: top
+          objectClass: organizationalUnit
 
-          [domain/${dbDomain}]
-          auth_provider = ldap
-          id_provider = ldap
-          ldap_uri = ldap://127.0.0.1:389
-          ldap_search_base = ${dbSuffix}
-          ldap_default_bind_dn = cn=${ldapRootUser},${dbSuffix}
-          ldap_default_authtok_type = password
-          ldap_default_authtok = ${ldapRootPassword}
+          dn: ou=accounts,ou=posix,${dbSuffix}
+          objectClass: top
+          objectClass: organizationalUnit
+
+          dn: uid=${testUser},ou=accounts,ou=posix,${dbSuffix}
+          objectClass: person
+          objectClass: posixAccount
+          # userPassword: somePasswordHash
+          homeDirectory: /home/${testUser}
+          uidNumber: 1234
+          gidNumber: 1234
+          cn: ""
+          sn: ""
         '';
       };
     };
 
-    testScript = ''
-      machine.start()
-      machine.wait_for_unit("openldap.service")
-      machine.wait_for_unit("sssd.service")
-      machine.succeed("getent passwd ${testUser}")
-    '';
-  }
-)
+    services.sssd = {
+      enable = true;
+      config = ''
+        [sssd]
+        config_file_version = 2
+        services = nss, pam, sudo
+        domains = ${dbDomain}
+
+        [domain/${dbDomain}]
+        auth_provider = ldap
+        id_provider = ldap
+        ldap_uri = ldap://127.0.0.1:389
+        ldap_search_base = ${dbSuffix}
+        ldap_default_bind_dn = cn=${ldapRootUser},${dbSuffix}
+        ldap_default_authtok_type = password
+        ldap_default_authtok = ${ldapRootPassword}
+      '';
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("openldap.service")
+    machine.wait_for_unit("sssd.service")
+    machine.succeed("getent passwd ${testUser}")
+  '';
+})

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -1,12 +1,11 @@
 { config, stdenv, lib, fetchurl, fetchpatch
 , perl, pkg-config
 , libcap, libtool, libxml2, openssl, libuv
-, enablePython ? config.bind.enablePython or false, python3 ? null
-, enableSeccomp ? false, libseccomp ? null, buildPackages, nixosTests
+, enableGSSAPI ? true, libkrb5
+, enablePython ? false, python3
+, enableSeccomp ? false, libseccomp
+, buildPackages, nixosTests
 }:
-
-assert enableSeccomp -> libseccomp != null;
-assert enablePython -> python3 != null;
 
 stdenv.mkDerivation rec {
   pname = "bind";
@@ -28,6 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libtool libxml2 openssl libuv ]
     ++ lib.optional stdenv.isLinux libcap
     ++ lib.optional enableSeccomp libseccomp
+    ++ lib.optional enableGSSAPI libkrb5
     ++ lib.optional enablePython (python3.withPackages (ps: with ps; [ ply ]));
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
     "--without-atf"
     "--without-dlopen"
     "--without-docbook-xsl"
-    "--without-gssapi"
     "--without-idn"
     "--without-idnlib"
     "--without-lmdb"
@@ -53,6 +52,7 @@ stdenv.mkDerivation rec {
     "--with-aes"
   ] ++ lib.optional stdenv.isLinux "--with-libcap=${libcap.dev}"
     ++ lib.optional enableSeccomp "--enable-seccomp"
+    ++ lib.optional enableGSSAPI "--with-gssapi=${libkrb5.dev}"
     ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "BUILD_CC=$(CC_FOR_BUILD)";
 
   postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
SSSD has been broken on unstable for a while:
Build Status for sssd.x86_64-linux on master
✖ (Failed) sssd-1.16.5 from 2021-10-21 - https://hydra.nixos.org/build/155825548

It has been broken since https://github.com/NixOS/nixpkgs/commit/616690dc6439e315da12523f3cc1602939f6364e

###### Things done

- build dnsutils with GSSAPI by default (needed by SSSD)
- bump SSSD to 2.6.0
- clean up sssd-ldap test to make building easier

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
