### PR TITLE
openocd: libgpiod is supported only on linux

### DIFF
--- a/pkgs/development/embedded/openocd/default.nix
+++ b/pkgs/development/embedded/openocd/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ hidapi libftdi1 libusb1 ]
-    ++ lib.optionals stdenv.isLinux [ libgpiod ];
+    ++ lib.optional stdenv.isLinux libgpiod;
 
   configureFlags = [
     "--enable-jtag_vpi"

--- a/pkgs/development/embedded/openocd/default.nix
+++ b/pkgs/development/embedded/openocd/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ hidapi libftdi1 libusb1 libgpiod ];
+  buildInputs = [ hidapi libftdi1 libusb1 ]
+    ++ lib.optionals stdenv.isLinux [ libgpiod ];
 
   configureFlags = [
     "--enable-jtag_vpi"


### PR DESCRIPTION
###### Motivation for this change

`libgpiod` is supported only on linux hence is added in `buildInputs` conditionally.

The following error occurs while trying to install `openocd`:
```
error: Package ‘libgpiod-1.6.3’ in /nix/store/5lvpfhr5q2rqszaz15kmwnxy3491sypn-nixpkgs-21.11pre325602.51acb65b302/nixpkgs/pkgs/development/libraries/libgpiod/default.nix:34 is not supported on ‘x86_64-darwin’, refusing to evaluate.

       a) To temporarily allow packages that are unsupported for this system, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnsupportedSystem = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnsupportedSystem = true; }
       to ~/.config/nixpkgs/config.nix.
(use '--show-trace' to show detailed location information)
```

The following error occurs after enabling `allowUnsupportedSystem`:
```
configure flags: --disable-static --disable-dependency-tracking --prefix=/nix/store/5zj06lpfrizmrck37jjvv2kcgpbfcpmz-libgpiod-1.6.3 --enable-tools=yes --enable-bindings-cxx --prefix=/nix/store/5zj06lpfrizmrck37jjvv2kcgpbfcpmz-libgpiod-1.6.3
...
checking for ppoll... no
configure: error: ppoll() not found (needed to build the library)
error: builder for '/nix/store/gdxva2k9336nj9rp3iys3lazmq53mrk7-libgpiod-1.6.3.drv' failed with exit code 1
error: 1 dependencies of derivation '/nix/store/5clyqc86nc34apjc0bi3vz577s1ildlw-openocd-0.11.0.drv' failed to build
```

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
