### PR TITLE
handbrake: 1.3.3 -> 1.4.2

### DIFF
--- a/nixos/tests/handbrake.nix
+++ b/nixos/tests/handbrake.nix
@@ -1,11 +1,15 @@
 import ./make-test-python.nix ({ pkgs, ... }:
+
 let
   # Download Big Buck Bunny example, licensed under CC Attribution 3.0.
   testMkv = pkgs.fetchurl {
     url = "https://github.com/Matroska-Org/matroska-test-files/blob/cf0792be144ac470c4b8052cfe19bb691993e3a2/test_files/test1.mkv?raw=true";
     sha256 = "1hfxbbgxwfkzv85pvpvx55a72qsd0hxjbm9hkl5r3590zw4s75h9";
+    name = "test1.mkv";
   };
-in {
+
+in
+{
   name = "handbrake";
 
   meta = {
@@ -21,11 +25,9 @@ in {
     # only takes a few seconds.
     start_all()
 
-    machine.succeed(
-        "HandBrakeCLI -i ${testMkv} -o test.mp4 -e x264 -q 20 -B 160"
-    )
-    machine.succeed(
-        "HandBrakeCLI -i ${testMkv} -o test.mkv -e x264 -q 20 -B 160"
-    )
+    machine.succeed("HandBrakeCLI -i ${testMkv} -o test.mp4 -e x264 -q 20 -B 160")
+    machine.succeed("test -e test.mp4")
+    machine.succeed("HandBrakeCLI -i ${testMkv} -o test.mkv -e x264 -q 20 -B 160")
+    machine.succeed("test -e test.mkv")
   '';
 })

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -7,85 +7,119 @@
 # be nice to add the native GUI (and/or the GTK GUI) as an option too, but that
 # requires invoking the Xcode build system, which is non-trivial for now.
 
-{ stdenv, lib, fetchFromGitHub, fetchpatch,
+{ stdenv
+, lib
+, fetchFromGitHub
   # Main build tools
-  pkg-config, autoconf, automake, libtool, m4, xz, python3,
-  numactl,
+, pkg-config
+, autoconf
+, automake
+, libtool
+, m4
+, xz
+, python3
+, numactl
+, writeText
   # Processing, video codecs, containers
-  ffmpeg-full, nv-codec-headers, libogg, x264, x265, libvpx, libtheora, dav1d,
+, ffmpeg-full
+, nv-codec-headers
+, libogg
+, x264
+, x265
+, libvpx
+, libtheora
+, dav1d
+, zimg
   # Codecs, audio
-  libopus, lame, libvorbis, a52dec, speex, libsamplerate,
+, libopus
+, lame
+, libvorbis
+, a52dec
+, speex
+, libsamplerate
   # Text processing
-  libiconv, fribidi, fontconfig, freetype, libass, jansson, libxml2, harfbuzz,
+, libiconv
+, fribidi
+, fontconfig
+, freetype
+, libass
+, jansson
+, libxml2
+, harfbuzz
+, libjpeg_turbo
   # Optical media
-  libdvdread, libdvdnav, libdvdcss, libbluray,
+, libdvdread
+, libdvdnav
+, libdvdcss
+, libbluray
   # Darwin-specific
-  AudioToolbox ? null,
-  Foundation ? null,
-  libobjc ? null,
-  VideoToolbox ? null,
+, AudioToolbox ? null
+, Foundation ? null
+, libobjc ? null
+, VideoToolbox ? null
   # GTK
   # NOTE: 2019-07-19: The gtk3 package has a transitive dependency on dbus,
   # which in turn depends on systemd. systemd is not supported on Darwin, so
   # for now we disable GTK GUI support on Darwin. (It may be possible to remove
   # this restriction later.)
-  useGtk ? !stdenv.isDarwin, wrapGAppsHook ? null,
-  intltool ? null,
-  glib ? null,
-  gtk3 ? null,
-  libappindicator-gtk3 ? null,
-  libnotify ? null,
-  gst_all_1 ? null,
-  dbus-glib ? null,
-  udev ? null,
-  libgudev ? null,
-  hicolor-icon-theme ? null,
+, useGtk ? !stdenv.isDarwin
+, wrapGAppsHook ? null
+, intltool ? null
+, glib ? null
+, gtk3 ? null
+, libappindicator-gtk3 ? null
+, libnotify ? null
+, gst_all_1 ? null
+, dbus-glib ? null
+, udev ? null
+, libgudev ? null
+, hicolor-icon-theme ? null
   # FDK
-  useFdk ? false, fdk_aac ? null
+, useFdk ? false
+, fdk_aac ? null
 }:
 
-stdenv.mkDerivation rec {
-  pname = "handbrake";
-  version = "1.3.3";
+let
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "HandBrake";
     repo = "HandBrake";
     rev = version;
-    sha256 = "0bsmk37543zv3p32a7wxnh2w483am23ha2amj339q3nnb4142krn";
-    extraPostFetch = ''
-      echo "DATE=$(date +"%F %T %z" -r $out/NEWS.markdown)" > $out/version.txt
-    '';
+    sha256 = "sha256-Usz2+U1Wb8yJ5W2HqV0FqBaaE25fuVKk/NwKBHaKzwk=";
   };
 
-  # Remove with a release after 1.3.3
-  patches = [
-    (fetchpatch {
-      name = "audio-fix-ffmpeg-4_4";
-      url = "https://github.com/HandBrake/HandBrake/commit/f28289fb06ab461ea082b4be56d6d1504c0c31c2.patch";
-      sha256 = "sha256:1zcwa4h97d8wjspb8kbd8b1jg0a9vvmv9zaphzry4m9q0bj3h3kz";
-    })
-  ];
+  versionFile = writeText "version.txt" ''
+    BRANCH=${lib.versions.majorMinor version}.x
+    DATE=1970-01-01 00:00:01 +0000
+    HASH=${src.rev}
+    REV=${src.rev}
+    SHORTHASH=${src.rev}
+    TAG=${version}
+    URL=${src.meta.homepage}
+  '';
 
-  # we put as little as possible in src.extraPostFetch as it's much easier to
-  # add to it here without having to fiddle with src.sha256
-  # only DATE and HASH are absolutely necessary
+  inherit (lib) optional optionals optionalString;
+
+in
+stdenv.mkDerivation rec {
+  pname = "handbrake";
+  inherit version src;
+
   postPatch = ''
-    cat >> version.txt <<_EOF
-HASH=${src.rev}
-SHORTHASH=${src.rev}
-TAG=${version}
-URL=${src.meta.homepage}
-_EOF
+    install -Dm444 ${versionFile} ${versionFile.name}
 
     patchShebangs scripts
+
+    substituteInPlace libhb/hb.c \
+      --replace 'return hb_version;' 'return "${version}";'
 
     # Force using nixpkgs dependencies
     sed -i '/MODULES += contrib/d' make/include/main.defs
     sed -e 's/^[[:space:]]*\(meson\|ninja\|nasm\)[[:space:]]*= ToolProbe.*$//g' \
         -e '/    ## Additional library and tool checks/,/    ## MinGW specific library and tool checks/d' \
         -i make/configure.py
-  '' + (lib.optionalString stdenv.isDarwin ''
+  '' + (optionalString stdenv.isDarwin ''
     # Use the Nix-provided libxml2 instead of the patched version available on
     # the Handbrake website.
     substituteInPlace libhb/module.defs \
@@ -95,51 +129,88 @@ _EOF
     # which it isn't in the Nix context. (The actual build goes fine without
     # xcodebuild.)
     sed -e '/xcodebuild = ToolProbe/s/abort=.\+)/abort=False)/' -i make/configure.py
-  '') + (lib.optionalString stdenv.isLinux ''
+  '') + (optionalString stdenv.isLinux ''
     # Use the Nix-provided libxml2 instead of the system-provided one.
     substituteInPlace libhb/module.defs \
       --replace /usr/include/libxml2 ${libxml2.dev}/include/libxml2
   '');
 
   nativeBuildInputs = [
-    pkg-config autoconf automake libtool m4 python3
-  ] ++ lib.optionals useGtk [ intltool wrapGAppsHook ];
+    autoconf
+    automake
+    libtool
+    m4
+    pkg-config
+    python3
+  ]
+  ++ optionals useGtk [ intltool wrapGAppsHook ];
 
   buildInputs = [
-    ffmpeg-full libogg libtheora x264 x265 libvpx dav1d
-    libopus lame libvorbis a52dec speex libsamplerate
-    libiconv fribidi fontconfig freetype libass jansson libxml2 harfbuzz
-    libdvdread libdvdnav libdvdcss libbluray xz
-  ] ++ lib.optional (!stdenv.isDarwin) numactl
-  ++ lib.optionals useGtk [
-    glib gtk3 libappindicator-gtk3 libnotify
-    gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus-glib udev
-    libgudev hicolor-icon-theme
-  ] ++ lib.optional useFdk fdk_aac
-  ++ lib.optionals stdenv.isDarwin [ AudioToolbox Foundation libobjc VideoToolbox ]
+    a52dec
+    dav1d
+    ffmpeg-full
+    fontconfig
+    freetype
+    fribidi
+    harfbuzz
+    jansson
+    lame
+    libass
+    libbluray
+    libdvdcss
+    libdvdnav
+    libdvdread
+    libiconv
+    libjpeg_turbo
+    libogg
+    libopus
+    libsamplerate
+    libtheora
+    libvorbis
+    libvpx
+    libxml2
+    speex
+    x264
+    x265
+    xz
+    zimg
+  ]
+  ++ optional (!stdenv.isDarwin) numactl
+  ++ optionals useGtk [
+    dbus-glib
+    glib
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    gtk3
+    hicolor-icon-theme
+    libappindicator-gtk3
+    libgudev
+    libnotify
+    udev
+  ]
+  ++ optional useFdk fdk_aac
+  ++ optionals stdenv.isDarwin [ AudioToolbox Foundation libobjc VideoToolbox ]
   # NOTE: 2018-12-27: Handbrake supports nv-codec-headers for Linux only,
   # look at ./make/configure.py search "enable_nvenc"
-  ++ lib.optional stdenv.isLinux nv-codec-headers;
+  ++ optional stdenv.isLinux nv-codec-headers;
 
   configureFlags = [
     "--disable-df-fetch"
     "--disable-df-verify"
-    (if useGtk          then "--disable-gtk-update-checks" else "--disable-gtk")
-    (if useFdk          then "--enable-fdk-aac"            else "")
-    (if stdenv.isDarwin then "--disable-xcode"             else "")
-  ] ++ lib.optional (stdenv.isx86_32 || stdenv.isx86_64) "--harden";
+    "--disable-gtk-update-checks"
+  ]
+  ++ optional (!useGtk) "--disable-gtk"
+  ++ optional useFdk "--enable-fdk-aac"
+  ++ optional stdenv.isDarwin "--disable-xcode"
+  ++ optional (stdenv.isx86_32 || stdenv.isx86_64) "--harden";
 
   # NOTE: 2018-12-27: Check NixOS HandBrake test if changing
-  NIX_LDFLAGS = [
-    "-lx265"
-  ];
+  NIX_LDFLAGS = [ "-lx265" ];
 
-  preBuild = ''
-    cd build
-  '';
+  preBuild = "cd build";
 
   meta = with lib; {
-    homepage = "http://handbrake.fr/";
+    homepage = "https://handbrake.fr/";
     description = "A tool for converting video files and ripping DVDs";
     longDescription = ''
       Tool for converting and remuxing video files
@@ -149,7 +220,7 @@ _EOF
       CLI - `HandbrakeCLI`
       GTK GUI - `ghb`
     '';
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ Anton-Latukha wmertens ];
     platforms = with platforms; unix;
   };


### PR DESCRIPTION
###### Motivation for this change

Additional noise from nixpkgs-fmt.

Tested ripping some kids movies - all good.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
