### PR TITLE
mkpasswd: Include support for more hash methods 

### DIFF
--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, whois, libxcrypt, perl, pkg-config }:
 
 stdenv.mkDerivation {
-  name = "mkpasswd-${whois.version}";
-
-  src = whois.src;
+  pname = "mkpasswd";
+  inherit (whois) version;
+  inherit (whois) src;
 
   nativeBuildInputs = [ perl pkg-config ];
   buildInputs = [ libxcrypt ];
 
-  preConfigure = whois.preConfigure;
+  inherit (whois) preConfigure;
   buildPhase = "make mkpasswd";
   installPhase = "make install-mkpasswd";
 

--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, whois, perl, pkg-config }:
+{ lib, stdenv, whois, libxcrypt, perl, pkg-config }:
 
 stdenv.mkDerivation {
   name = "mkpasswd-${whois.version}";
@@ -6,6 +6,7 @@ stdenv.mkDerivation {
   src = whois.src;
 
   nativeBuildInputs = [ perl pkg-config ];
+  buildInputs = [ libxcrypt ];
 
   preConfigure = whois.preConfigure;
   buildPhase = "make mkpasswd";

--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, whois, perl }:
+{ lib, stdenv, whois, perl, pkg-config }:
 
 stdenv.mkDerivation {
   name = "mkpasswd-${whois.version}";
 
   src = whois.src;
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ perl pkg-config ];
 
   preConfigure = whois.preConfigure;
   buildPhase = "make mkpasswd";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

mkpasswd does not include numerous hash methods available in mkpasswd on most other distros (at least Debian & Fedora).

(Before) Available methods:
sha512crypt     SHA-512
sha256crypt     SHA-256
md5crypt        MD5
descrypt        standard 56 bit DES-based crypt(3)

(After) Available methods:
yescrypt        Yescrypt
gost-yescrypt   GOST Yescrypt
scrypt          scrypt
bcrypt          bcrypt
bcrypt-a        bcrypt (obsolete $2a$ version)
sha512crypt     SHA-512
sha256crypt     SHA-256
sunmd5          SunMD5
md5crypt        MD5
bsdicrypt       BSDI extended DES-based crypt(3)
descrypt        standard 56 bit DES-based crypt(3)
nt              NT-Hash

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
