### PR TITLE
arkade: init at 0.8.9

### DIFF
--- a/pkgs/applications/networking/cluster/arkade/default.nix
+++ b/pkgs/applications/networking/cluster/arkade/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+, makeWrapper
+, kubectl
+}:
+
+buildGoModule rec {
+  pname = "arkade";
+  version = "0.8.9";
+
+  src = fetchFromGitHub {
+    owner = "alexellis";
+    repo = "arkade";
+    rev = version;
+    sha256 = "0jv6pip3ywx8bx7m25fby6kl5irnjxvlpss2wkm615gv9ari21aq";
+  };
+
+  CGO_ENABLED = 0;
+
+  vendorSha256 = "05zdd5c2x4k4myxmgj32md8wq08i543l8q81rabqgyd3r9nwv4lx";
+
+  # Exclude pkg/get: tests downloading of binaries which fail when sandbox=true
+  subPackages = [
+    "."
+    "cmd"
+    "pkg/apps"
+    "pkg/archive"
+    "pkg/config"
+    "pkg/env"
+    "pkg/helm"
+    "pkg/k8s"
+    "pkg/types"
+  ];
+
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/alexellis/arkade/cmd.GitCommit=ref/tags/${version}"
+    "-X github.com/alexellis/arkade/cmd.Version=${version}"
+  ];
+
+  buildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/arkade" \
+      --prefix PATH : ${lib.makeBinPath [ kubectl ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/alexellis/arkade";
+    description = "Open Source Kubernetes Marketplace";
+    license = licenses.mit;
+    maintainers = with maintainers; [ welteki ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23815,6 +23815,8 @@ with pkgs;
 
   arion = callPackage ../applications/virtualization/arion { };
 
+  arkade = callPackage ../applications/networking/cluster/arkade { };
+
   asuka = callPackage ../applications/networking/browsers/asuka {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[arkade](https://github.com/alexellis/arkade) is a CLI that provides a portable marketplace for installing helm charts and devops CLIs with a single command.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
