### PR TITLE
plasma5: set default session to plasma X11 and fix sddm

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -200,6 +200,10 @@ in
       ];
 
       services.xserver.displayManager.sessionPackages = [ pkgs.libsForQt5.plasma5.plasma-workspace ];
+      # Default to be `plasma` (X11) instead of `plasmawayland`, since plasma wayland currently has
+      # many tiny bugs.
+      # See: https://github.com/NixOS/nixpkgs/issues/143272
+      services.xserver.displayManager.defaultSession = mkDefault "plasma";
 
       security.wrappers = {
         kcheckpass =

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -280,7 +280,7 @@ in
             null;
         example = "gnome";
         description = ''
-          Graphical session to pre-select in the session chooser (only effective for GDM and LightDM).
+          Graphical session to pre-select in the session chooser (only effective for GDM, LightDM and SDDM).
 
           On GDM, LightDM and SDDM, it will also be used as a session for auto-login.
         '';

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -30,6 +30,9 @@ let
       HaltCommand = "/run/current-system/systemd/bin/systemctl poweroff";
       RebootCommand = "/run/current-system/systemd/bin/systemctl reboot";
       Numlock = if cfg.autoNumlock then "on" else "none"; # on, off none
+
+      # Implementation is done via pkgs/applications/display-managers/sddm/sddm-default-session.patch
+      DefaultSession = optionalString (dmcfg.defaultSession != null) "${dmcfg.defaultSession}.desktop";
     };
 
     Theme = {

--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -19,6 +19,7 @@ in mkDerivation {
 
   patches = [
     ./sddm-ignore-config-mtime.patch
+    ./sddm-default-session.patch
     # Load `/etc/profile` for `environment.variables` with zsh default shell.
     # See: https://github.com/sddm/sddm/pull/1382
     (fetchpatch {

--- a/pkgs/applications/display-managers/sddm/sddm-default-session.patch
+++ b/pkgs/applications/display-managers/sddm/sddm-default-session.patch
@@ -1,0 +1,71 @@
+diff --git a/src/common/Configuration.h b/src/common/Configuration.h
+index cf44a62..7bb9c03 100644
+--- a/src/common/Configuration.h
++++ b/src/common/Configuration.h
+@@ -44,6 +44,7 @@ namespace SDDM {
+                                                                                                    "NOTE: Currently ignored if autologin is enabled."));
+         Entry(InputMethod,         QString,     QStringLiteral("qtvirtualkeyboard"),                   _S("Input method module"));
+         Entry(Namespaces,          QStringList, QStringList(),                                  _S("Comma-separated list of Linux namespaces for user session to enter"));
++        Entry(DefaultSession,      QString,     QString(),                                      _S("System-wide default session"));
+         //  Name   Entries (but it's a regular class again)
+         Section(Theme,
+             Entry(ThemeDir,            QString,     _S(DATA_INSTALL_DIR "/themes"),             _S("Theme directory path"));
+diff --git a/src/greeter/SessionModel.cpp b/src/greeter/SessionModel.cpp
+index 1953c76..54fe2f2 100644
+--- a/src/greeter/SessionModel.cpp
++++ b/src/greeter/SessionModel.cpp
+@@ -43,6 +43,7 @@ namespace SDDM {
+         beginResetModel();
+         populate(Session::WaylandSession, mainConfig.Wayland.SessionDir.get());
+         populate(Session::X11Session, mainConfig.X11.SessionDir.get());
++        selectDefaultSession();
+         endResetModel();
+ 
+         // refresh everytime a file is changed, added or removed
+@@ -52,6 +53,7 @@ namespace SDDM {
+             d->sessions.clear();
+             populate(Session::WaylandSession, mainConfig.Wayland.SessionDir.get());
+             populate(Session::X11Session, mainConfig.X11.SessionDir.get());
++            selectDefaultSession();
+             endResetModel();
+         });
+         watcher->addPath(mainConfig.Wayland.SessionDir.get());
+@@ -149,11 +151,25 @@ namespace SDDM {
+             else
+                 delete si;
+         }
++    }
++
++    void SessionModel::selectDefaultSession() {
++        d->lastIndex = 0;
++
+         // find out index of the last session
+         for (int i = 0; i < d->sessions.size(); ++i) {
+             if (d->sessions.at(i)->fileName() == stateConfig.Last.Session.get()) {
+                 d->lastIndex = i;
+-                break;
++                return;
++            }
++        }
++
++        // Otherwise, fallback to system-wide default session.
++        auto defaultSession = mainConfig.DefaultSession.get();
++        for (int i = 0; i < d->sessions.size(); ++i) {
++            if (QFileInfo(d->sessions.at(i)->fileName()).fileName() == defaultSession) {
++                d->lastIndex = i;
++                return;
+             }
+         }
+     }
+diff --git a/src/greeter/SessionModel.h b/src/greeter/SessionModel.h
+index 2e2efa9..a93315c 100644
+--- a/src/greeter/SessionModel.h
++++ b/src/greeter/SessionModel.h
+@@ -58,6 +58,7 @@ namespace SDDM {
+         SessionModelPrivate *d { nullptr };
+ 
+         void populate(Session::Type type, const QString &path);
++        void selectDefaultSession();
+     };
+ }
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

As suggested by @ttuegel in https://github.com/NixOS/nixpkgs/pull/139657#issuecomment-951393788 and many others in #143272, set the default session to plasma X11 instead of wayland for now.

`sddm` upstream currently doesn't support system-wide default session (https://github.com/sddm/sddm/issues/326), I implemented it in a patch in this PR. I'll maybe upstream it later if time permits.
Note that if you logined non-default session once, it will be selected in the next time. That is, the last logined session still takes precedence over system-wide default session.

Tested in nixos vm.

cc: @abbradar @tobiasBora 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
