### PR TITLE
cni-flannel-plugin: 1.1 -> 1.0.0

### DIFF
--- a/pkgs/tools/networking/flannel/plugin.nix
+++ b/pkgs/tools/networking/flannel/plugin.nix
@@ -2,22 +2,29 @@
 
 buildGoModule rec {
   pname = "cni-plugin-flannel";
-  version = "1.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "flannel-io";
     repo = "cni-plugin";
     rev = "v${version}";
-    sha256 = "sha256-DZC6uJR6TIHdmu8kZcbM+RC7pdejqLCOep0v3PM8/QY=";
+    sha256 = "sha256-zWxw4LZIlkT88yGTnxdupq7cUSacNRxPzzp01O9USDw=";
   };
 
-  vendorSha256 = "sha256-TLAwE3pTnJYOi1AsOQfsG6t3xLKOah/7DvYjsqyltKs=";
+  vendorSha256 = "sha256-zteMlrvRTVxOFlBy+z/qfiSii8+c8PMapwIsdbN+Aig=";
 
   postInstall = ''
     mv $out/bin/cni-plugin $out/bin/flannel
   '';
 
   doCheck = false;
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/flannel 2>&1 | fgrep -q v$version
+    runHook postInstallCheck
+  '';
 
   meta = with lib; {
     description = "flannel CNI plugin";


### PR DESCRIPTION
Update to a properly tagged version. Previously the tag was temporary,
and it was not obvious. See flannel-io/cni-plugin/issues/21.

While here also add install time checking

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

flannel-io/cni-plugin/issues/21

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
