### PR TITLE
Ghc 921 release

### DIFF
--- a/pkgs/development/compilers/ghc/9.2.1.nix
+++ b/pkgs/development/compilers/ghc/9.2.1.nix
@@ -142,23 +142,13 @@ let
 
 in
 stdenv.mkDerivation (rec {
-  version = "9.2.0.20210821";
+  version = "9.2.1";
   pname = "${targetPrefix}ghc${variantSuffix}";
 
   src = fetchurl {
-    url = "https://downloads.haskell.org/ghc/9.2.1-rc1/ghc-${version}-src.tar.xz";
-    sha256 = "1q2pppxv2avhykyxvyq72r5p97rkkiqp19b77yhp85ralbcp4ivw";
+    url = "https://downloads.haskell.org/ghc/9.2.1/ghc-${version}-src.tar.xz";
+    sha256 = "0ippapgw8daddjbfq3zdw9sr93x4zl1zzkbp1yadjdm1jwph2i7l";
   };
-
-  patches = [
-    # picked from release branch, remove with the next release candidate,
-    # see https://gitlab.haskell.org/ghc/ghc/-/issues/19950#note_373726
-    (fetchpatch {
-      name = "fix-darwin-link-failure.patch";
-      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/77456387025ca74299ecc70621cbdb62b1b6ffc9.patch";
-      sha256 = "1g8smrn7hj8cbp9fhrylvmrb15s0xd8lhdgxqnx0asnd4az82gj8";
-    })
-  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

ghc 9.2.1 release

###### Things done

- Version and sha256 bumped
- Now deprecated patch removed

This is still building locally on my machine (I lost my access to a super hot build machine).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

