### PR TITLE
nixos/malloc: fix scudo on non-x86_64 machines

### DIFF
--- a/nixos/modules/config/malloc.nix
+++ b/nixos/modules/config/malloc.nix
@@ -22,8 +22,15 @@ let
       '';
     };
 
-    scudo = {
-      libPath = "${pkgs.llvmPackages_latest.compiler-rt}/lib/linux/libclang_rt.scudo-x86_64.so";
+    scudo = let
+      platformMap = {
+        aarch64-linux = "aarch64";
+        x86_64-linux  = "x86_64";
+      };
+
+      systemPlatform = platformMap.${pkgs.stdenv.hostPlatform.system} or (throw "scudo not supported on ${pkgs.stdenv.hostPlatform.system}");
+    in {
+      libPath = "${pkgs.llvmPackages_latest.compiler-rt}/lib/linux/libclang_rt.scudo-${systemPlatform}.so";
       description = ''
         A user-mode allocator based on LLVM Sanitizer’s CombinedAllocator,
         which aims at providing additional mitigations against heap based


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Came across this enabling the hardened profile on aarch64, cc hardened profile maintainers: @joachifm @emilazy

Fail to use scudo on aarch64 because it's hard linked to copy x86_64 version

```
building '/nix/store/mw65b96bd17qs1gh5305jnnijf1sy5hr-malloc-provider-scudo.drv'...
cp: cannot stat '/nix/store/m0vhs9d1y1jsl0j9hnb6d9vci1yg3rh6-compiler-rt-libc-12.0.1/lib/linux/libclang_rt.scudo-x86_64.so': No such file or directory
error: builder for '/nix/store/mw65b96bd17qs1gh5305jnnijf1sy5hr-malloc-provider-scudo.drv' failed with exit code 1
```

After:

```
building '/nix/store/la55yf80mdjx6qdyrb7gbs79ghvf29ab-malloc-provider-scudo.drv'...
building '/nix/store/5kjy50dmbz16vxx3ygh5c4b0a6mbikg4-nixos-version.drv'...
building '/nix/store/0ygacl0l7fbsaaasrdla9cm7ynjwk8x9-set-environment.drv'...
copying path '/nix/store/w7nzpjq5d4d6lbpzdb9lkdf9bkp7fpg1-aws-crt-cpp-0.17.0' from 'https://cache.nixos.org'...
building '/nix/store/ab9wkbindd5isycpa9r1bhfmwcdms4pn-closure-info.drv'...
building '/nix/store/7spsb894mckqv515rddm8nnfz19605vd-etc-ld-nix.so.preload.drv'...
copying path '/nix/store/lyd9b7cq9vp8x0kaz1bmh5gfygspjl5c-aws-sdk-cpp-1.9.121' from 'https://cache.nixos.org'...
building '/nix/store/ms9f4yimway8q9m77zyhlnhx7j03gnd8-etc-profile.drv'...
building '/nix/store/47dy4vbf3j34x53fghcc45q1az2agrx0-apparmor-closure-rules-mallocLib.drv'...
# ...
created 1645 symlinks in user environment
building '/nix/store/y3xfmykfxsyi5x46gk6sk6j9qyphbldk-dbus-1.drv'...
building '/nix/store/xh1v5vs4wxvhlsi6f110kaj00r3b4kl4-unit-polkit.service.drv'...
building '/nix/store/sich81xf1y1mwiv36xzgrbqa8ahzfg4j-unit-systemd-fsck-.service.drv'...
building '/nix/store/6qz85fy39jx0g9sdjk7rnshzsaj18sbj-unit-dbus.service.drv'...
building '/nix/store/8pv4fgaqcvs9fby3vqkj4yb3plwaphwk-unit-dbus.service.drv'...
building '/nix/store/4bl1xlvjd8gkvl5601al0cf6fl935b4h-system-units.drv'...
building '/nix/store/dibfvqj371rraiiv4558my2cjj21nrk6-user-units.drv'...
building '/nix/store/flhaldbz10cg63zjr74jq74xlvxra9fs-etc.drv'...
building '/nix/store/xz2cljjybp5xadh3wf1cjpqcy7ajlhqb-nixos-system-xyz-21.11.20211029.9ac11c0.drv'...
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
updating GRUB 2 menu...
activating the configuration...
setting up /etc...
reloading user units for root...
setting up tmpfiles
reloading the following units: apparmor.service, dbus.service
restarting the following units: nix-daemon.socket
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
