### PR TITLE
python3Packages.factory_boy: 3.2.0 -> 3.2.1

### DIFF
--- a/pkgs/development/python-modules/factory_boy/default.nix
+++ b/pkgs/development/python-modules/factory_boy/default.nix
@@ -11,15 +11,19 @@
 }:
 
 buildPythonPackage rec {
-  pname = "factory_boy";
-  version = "3.2.0";
+  pname = "factory-boy";
+  version = "3.2.1";
+  format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0nsw2mdjk8sqds3qsix4cf19ws6i0fak79349pw2581ryc7w0720";
+    pname = "factory_boy";
+    inherit version;
+    sha256 = "sha256-qY0newwEfHXrbkq4UIp/gfsD0sshmG9ieRNUbveipV4=";
   };
 
-  propagatedBuildInputs = [ faker ];
+  propagatedBuildInputs = [
+    faker
+  ];
 
   checkInputs = [
     django
@@ -31,8 +35,13 @@ buildPythonPackage rec {
   ];
 
   # Checks for MongoDB requires an a running DB
-  disabledTests = [ "MongoEngineTestCase" ];
-  pythonImportsCheck = [ "factory" ];
+  disabledTests = [
+    "MongoEngineTestCase"
+  ];
+
+  pythonImportsCheck = [
+    "factory"
+  ];
 
   meta = with lib; {
     description = "Python package to create factories for complex objects";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.2.1

Change log: https://github.com/FactoryBoy/factory_boy/blob/master/docs/changelog.rst

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
