### PR TITLE
lib: Expand list of supported platforms

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -33,7 +33,7 @@ rec {
 
      **Warning**: This attribute is considered experimental and is subject to change.
   */
-  flakeExposed = import ./flake-systems.nix { };
+  flakeExposed = import ./flake-systems.nix { inherit lib; };
 
   # Elaborate a `localSystem` or `crossSystem` so that it contains everything
   # necessary.

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -8,6 +8,7 @@ rec {
   platforms = import ./platforms.nix { inherit lib; };
   examples = import ./examples.nix { inherit lib; };
   architectures = import ./architectures.nix { inherit lib; };
+  supported = import ./supported.nix { inherit lib; };
 
   /*
     Elaborated systems contain functions, which means that they don't satisfy

--- a/lib/systems/flake-systems.nix
+++ b/lib/systems/flake-systems.nix
@@ -4,26 +4,32 @@
 # reasonably well are included.
 #
 # [RFC 46]: https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md
-{ }:
+{ lib }:
 
-[
-  # Tier 1
-  "x86_64-linux"
-  # Tier 2
-  "aarch64-linux"
-  "x86_64-darwin"
-  # Tier 3
-  "armv6l-linux"
-  "armv7l-linux"
-  "i686-linux"
-  "mipsel-linux"
+let
+  inherit (builtins) filter;
+  inherit (lib.lists) any;
+  inherit (lib.systems) elaborate;
+  inherit (lib.systems.supported) Tier1 Tier2 Tier3 Tier7;
 
-  # Other platforms with sufficient support in stdenv which is not formally
-  # mandated by their platform tier.
-  "aarch64-darwin"
-  "armv5tel-linux"
-  "powerpc64le-linux"
-  "riscv64-linux"
-
-  # "x86_64-freebsd" is excluded because it is mostly broken
-]
+  anyOf = includes: filter (s: any (include: s == include) includes);
+  getDoubles = map (s: (elaborate s).system);
+in
+getDoubles
+  (  Tier1
+  ++ Tier2
+  )
+++ anyOf [ "armv6l-linux"
+           "armv7l-linux"
+           "i686-linux"
+           "mipsel-linux"
+         ]
+         (getDoubles Tier3)
+# Other platforms with sufficient support in stdenv which is not formally
+# mandated by their platform tier.
+++ anyOf [ "aarch64-darwin"
+           "armv5tel-linux"
+           "powerpc64-linux"
+           "riscv64-linux"
+         ]
+         (getDoubles Tier7)

--- a/lib/systems/supported.nix
+++ b/lib/systems/supported.nix
@@ -1,0 +1,79 @@
+# RFC #46 specified the authoritative source of platform support tiers would be
+# the Nixpkgs manual. Brief discussion in
+# [NixOS/rfcs#113](https://github.com/NixOS/rfcs/pull/113) indicated that code
+# is often a better source of truth than documentation. This file is intented
+# to be exactly that.
+
+{ lib }:
+
+let inherit (lib.systems.examples)
+      aarch64-android
+      aarch64-darwin
+      aarch64-embedded
+      aarch64-multiplatform
+      arm-embedded
+      armv7a-android-prebuilt
+      armv7l-hf-multiplatform
+      avr
+      gnu32
+      gnu64
+      i686-embedded
+      mingw32
+      mingwW64
+      mipsel-linux-gnu
+      musl64
+      powernv
+      ppc-embedded
+      ppc64
+      ppcle-embedded
+      raspberryPi
+      riscv64
+      sheevaplug
+      wasm32
+      x86_64-darwin
+      x86_64-embedded
+      x86_64-freebsd;
+in {
+  tier1 = [ gnu64 ];
+
+  tier2 = [ aarch64-multiplatform x86_64-darwin ];
+
+  # Missing:
+  # armv8*-linux, gcc + glibc
+  # armv{6,7,8}*-linux, gcc + glibc, cross-compilation
+  # aarch64-linux, gcc + glibc, cross-compilation
+  tier3 = [ armv7l-hf-multiplatform gnu32 mipsel-linux-gnu musl64 raspberryPi ];
+
+  # Missing:
+  # x86_64-linux, gcc+musl — static
+  # x86_64-linux, clang+glibc
+  # x86_64-linux, clang+glibc — llvm linker
+  # x86_64-linux — Android
+  # armv8-linux — Android
+  tier4 = [
+    aarch64-android
+    aarch64-embedded
+    arm-embedded
+    armv7a-android-prebuilt # Questionable due to the prebuiltness
+    avr
+    i686-embedded # i686-none?
+    mingw32
+    mingwW64
+    ppc-embedded
+    ppcle-embedded
+    x86_64-embedded # x86_64-none?
+  ];
+
+  # Missing:
+  # x86_64-linux, gcc+glibc — static
+  # x86_64-linux, gcc+glibc — llvm linker
+  tier5 = [];
+
+  tier6 = [ powernv wasm32 ];
+
+  # Missing:
+  # i686-darwin
+  # i686-solaris
+  # x86_64-illumos
+  tier7 = [ aarch64-darwin sheevaplug ppc64 riscv64 x86_64-freebsd ];
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[RFC #112](https://github.com/NixOS/rfcs/pull/112) has raised the question of what the source of truth is about the platforms supported in Nixpkgs. [RFC #46](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md) specified the authoritative source would be the Nixpkgs manual but this hasn't happened yet.

Recently, `lib/systems/supported.nix` was added and this seems like a suitable authoritative source. A Nixpkgs manual section could be auto-generated based on this file. However, this file only lists the platforms that the Hydra CI builds for, so we need to add the other tiers and platforms.

I have added the platforms as they are listed in [RFC #46](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md) almost verbatim because they include the compiler and libc and further properties like which linker or whether the platform uses static libraries. Should this  rather use system triples as in `lib/systems/examples.nix`, e.g., `aarch64-unknown-linux-android`? Or perhaps platforms should be represented as attrsets rather than strings?

The RFC also specifies `x86_64-illumos` while `lib/systems/doubles.nix` has `x86_64-solaris` for illumos. Is either one canonical and are there other platforms with multiple identifiers?

This PR is opened to support NixOS/rfcs#113.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
