### PR TITLE
python3Packages.cirq: 0.12.0 -> 0.13.1, python3Packages.pyquil: 3.0.0 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
+, duet
 , matplotlib
 , networkx
 , numpy
@@ -29,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "cirq-core";
-  version = "0.12.0";
+  version = "0.13.1";
 
   disabled = pythonOlder "3.6";
 
@@ -37,7 +38,7 @@ buildPythonPackage rec {
     owner = "quantumlib";
     repo = "cirq";
     rev = "v${version}";
-    sha256 = "sha256-NPaADiRoPL0KoLugtk0vsnTGuRDK85e4j9kHv9aO/Po=";
+    sha256 = "sha256-MVfJ8iEeW8gFvCNTqrWfYpNNYuDAufHgcjd7Nh3qp8U=";
   };
 
   sourceRoot = "source/${pname}";
@@ -50,6 +51,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
+    duet
     matplotlib
     networkx
     numpy

--- a/pkgs/development/python-modules/cirq-rigetti/default.nix
+++ b/pkgs/development/python-modules/cirq-rigetti/default.nix
@@ -39,7 +39,8 @@ buildPythonPackage rec {
       --replace "httpx~=0.15.5" "httpx" \
       --replace "idna~=2.10" "idna" \
       --replace "requests~=2.18" "requests" \
-      --replace "pyjwt~=1.7.1" "pyjwt"
+      --replace "pyjwt~=1.7.1" "pyjwt" \
+      --replace "qcs-api-client~=0.8.0" "qcs-api-client"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/cirq/default.nix
+++ b/pkgs/development/python-modules/cirq/default.nix
@@ -1,7 +1,12 @@
 { lib
 , buildPythonPackage
+, cirq-aqt
 , cirq-core
 , cirq-google
+, cirq-ionq
+, cirq-pasqal
+, cirq-rigetti
+, cirq-web
   # test inputs
 , pytestCheckHook
 }:
@@ -11,8 +16,13 @@ buildPythonPackage rec {
   inherit (cirq-core) version src meta;
 
   propagatedBuildInputs = [
+    cirq-aqt
     cirq-core
+    cirq-ionq
     cirq-google
+    cirq-rigetti
+    cirq-pasqal
+    cirq-web
   ];
 
   # pythonImportsCheck = [ "cirq" "cirq.Circuit" ];  # cirq's importlib hook doesn't work here
@@ -20,8 +30,13 @@ buildPythonPackage rec {
 
   # Don't run submodule or development tool tests
   disabledTestPaths = [
-    "cirq-google"
+    "cirq-aqt"
     "cirq-core"
+    "cirq-google"
+    "cirq-ionq"
+    "cirq-pasqal"
+    "cirq-rigetti"
+    "cirq-web"
     "dev_tools"
   ];
 

--- a/pkgs/development/python-modules/duet/default.nix
+++ b/pkgs/development/python-modules/duet/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "duet";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "duet";
+    rev = "v${version}";
+    sha256 = "sha256-hK2Cx7dSm1mGM2z9oCoRogfa2aIsjyJcdpSSfdHhPmw=";
+  };
+
+  propagatedBuildInputs = [ typing-extensions ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "A simple future-based async library for python";
+    homepage = "https://github.com/google/duet";
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/development/python-modules/pyquil/default.nix
+++ b/pkgs/development/python-modules/pyquil/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , importlib-metadata
 , ipython
 , lark-parser
@@ -15,13 +16,14 @@
 , pythonOlder
 , qcs-api-client
 , retry
+, respx
 , rpcq
 , scipy
 }:
 
 buildPythonPackage rec {
   pname = "pyquil";
-  version = "3.0.0";
+  version = "3.0.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -30,8 +32,16 @@ buildPythonPackage rec {
     owner = "rigetti";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0070pslz6vvyavm5pm27q2bng2mfmkb41v5czzckz7m8db3b1r2x";
+    sha256 = "sha256-OU7/LjcpCxvqlcfdlm5ll4f0DYXf0yxNprM8Muu2wyg=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "pyquil-pr-1404-unpin-qcs-api-client-version-pyproject.patch";
+      url = "https://github.com/rigetti/pyquil/commit/2e35a4fdf65262fdf39c5091aeddfa3f3564925a.patch";
+      sha256 = "sha256-KGDNU2wpzsuifQSbbkoMwaFXspHW6zyIJ5GRZbw+lUY=";
+    })
+  ];
 
   nativeBuildInputs = [
     poetry-core
@@ -55,6 +65,7 @@ buildPythonPackage rec {
     pytest-httpx
     pytest-mock
     pytestCheckHook
+    respx
     ipython
   ];
 
@@ -67,6 +78,7 @@ buildPythonPackage rec {
     # Tests require network access
     "test/e2e/"
     "test/unit/test_api.py"
+    "test/unit/test_engagement_manager.py"
     "test/unit/test_operator_estimation.py"
     "test/unit/test_wavefunction_simulator.py"
     "test/unit/test_compatibility_v2_operator_estimation.py"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2313,6 +2313,8 @@ in {
 
   duecredit = callPackage ../development/python-modules/duecredit { };
 
+  duet = callPackage ../development/python-modules/duet { };
+
   dufte = callPackage ../development/python-modules/dufte { };
 
   dugong = callPackage ../development/python-modules/dugong { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- python3Packages.duet: init at 0.2.1 (dependency of cirq)
- python3Packages.cirq-core: 0.12.0 -> 0.13.1
- python3Packages.pyquil: 3.0.0 -> 3.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
