### PR TITLE
pcsx2: unstable-2020-11-13 -> unstable-2021-10-28

### DIFF
--- a/pkgs/misc/emulators/pcsx2/default.nix
+++ b/pkgs/misc/emulators/pcsx2/default.nix
@@ -2,7 +2,6 @@
 , cmake
 , fetchFromGitHub
 , fmt
-, gcc-unwrapped
 , gettext
 , glib
 , gtk3
@@ -13,7 +12,6 @@
 , libpulseaudio
 , libsamplerate
 , libxml2
-, makeWrapper
 , perl
 , pkg-config
 , portaudio
@@ -28,47 +26,24 @@
 
 stdenv.mkDerivation {
   pname = "pcsx2";
-  version = "unstable-2020-11-13";
+  version = "unstable-2021-10-28";
 
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
     fetchSubmodules = true;
-    rev = "319287dbe552c8405720b25dfdf5fa518deeee0b";
-    sha256 = "1kswc8vw9hbv2nigp8cxrgf2s0ik7p4i203cbqci8zjmnkaqpsai";
+    rev = "52eab493591137d830b45337e04c75ff525a31f9";
+    sha256 = "RhAo5Fob8G16jzb9MOAS43vwTkFzf5XupymN0dzeGJU=";
   };
 
   cmakeFlags = [
-    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
     "-DDISABLE_ADVANCE_SIMD=TRUE"
     "-DDISABLE_PCSX2_WRAPPER=TRUE"
-    "-DDOC_DIR=${placeholder "out"}/share/doc/pcsx2"
-    "-DGAMEINDEX_DIR=${placeholder "out"}/share/pcsx2"
-    "-DGLSL_SHADER_DIR=${placeholder "out"}/share/pcsx2"
-    "-DGTK3_API=TRUE"
     "-DPACKAGE_MODE=TRUE"
-    "-DPLUGIN_DIR=${placeholder "out"}/lib/pcsx2"
-    "-DREBUILD_SHADER=TRUE"
-    "-DUSE_LTO=TRUE"
-    "-DwxWidgets_CONFIG_EXECUTABLE=${wxGTK}/bin/wx-config"
-    "-DwxWidgets_INCLUDE_DIRS=${wxGTK}/include"
-    "-DwxWidgets_LIBRARIES=${wxGTK}/lib"
     "-DXDG_STD=TRUE"
   ];
 
-  postPatch = ''
-    substituteInPlace cmake/BuildParameters.cmake \
-      --replace /usr/bin/gcc-ar ${gcc-unwrapped}/bin/gcc-ar \
-      --replace /usr/bin/gcc-nm ${gcc-unwrapped}/bin/gcc-nm \
-      --replace /usr/bin/gcc-ranlib ${gcc-unwrapped}/bin/gcc-ranlib
-  '';
-
-  postFixup = ''
-    wrapProgram $out/bin/PCSX2 \
-      --set __GL_THREADED_OPTIMIZATIONS 1
-  '';
-
-  nativeBuildInputs = [ cmake makeWrapper perl pkg-config wrapGAppsHook ];
+  nativeBuildInputs = [ cmake perl pkg-config wrapGAppsHook ];
 
   buildInputs = [
     alsa-lib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

Bumped the version and tested a game.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
