### PR TITLE
z & nixos/programs.z: init at 1622481819

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13001,4 +13001,10 @@
     githubId = 88109321;
   };
 
+  ursi =
+    { name = "Mason Mackaman";
+      email = "masondeanm@aol.com";
+      github = "ursi";
+      githubId = 17836748;
+    };
 }

--- a/nixos/modules/programs/z.nix
+++ b/nixos/modules/programs/z.nix
@@ -1,0 +1,109 @@
+with builtins;
+{ config, lib, pkgs, ... }:
+  let
+    l = lib; p = pkgs; t = l.types;
+
+    make-bool-options =
+      mapAttrs
+        (_: description:
+           l.mkOption
+             { type = t.bool;
+               inherit description;
+               default = true;
+             }
+        );
+
+    make-str-options =
+      mapAttrs
+        (_: description:
+           l.mkOption
+             { type = t.nullOr t.str;
+               inherit description;
+               default = null;
+             }
+        );
+
+    bool-options =
+      { resolve-symlinks = "resolve symlinks";
+
+        prompt-command =
+          ''
+          Automatically have z handle the PROMPT_COMMAND/precmd.
+
+          Note: if you override your PROMPT_COMMAND after z does, it will override the changes z makes, and z will not work. You can do something like
+
+          export PROMPT_COMMAND="my-prompt-command $PROMPT_COMMAND"
+
+          to fix this.
+          '';
+      };
+
+    str-options =
+      { cmd = "Set the name of the command (defaults: z).";
+        data = "Change the datafile (default: $HOME/.z).";
+        owner = "To allow usage when in 'sudo -s' mode";
+      };
+  in
+  { options.programs.z =
+      { enable = l.mkEnableOption "z";
+
+        max-score =
+          l.mkOption
+            { type = t.nullOr t.int;
+              description = "Lower to age entries out faster (default: 9000)";
+              default = null;
+            };
+
+        exclude-dirs =
+          l.mkOption
+            { type = t.listOf t.path;
+              description = "An array of directories to exclude";
+              default = [];
+            };
+      }
+      // make-bool-options bool-options
+      // make-str-options str-options;
+
+    config =
+      let cfg = config.programs.z; in
+      { environment =
+          { interactiveShellInit =
+              l.optionalString (cfg.exclude-dirs != [])
+                ''
+                export _Z_EXCLUDE_DIRS=(${
+                concatStringsSep " "
+                  (map (v: ''"${v}"'') cfg.exclude-dirs)
+                })
+                ''
+              + l.optionalString cfg.enable ". ${p.z}/z.sh";
+
+            systemPackages = l.optional cfg.enable p.z;
+
+            variables =
+              let
+                z-var = str: "_Z_${l.toUpper (replaceStrings [ "-" ] [ "_" ] str)}";
+                z-var-no = str: z-var "no-${str}";
+                foldOnto = f: xs: init: foldl' f init xs;
+              in
+              l.pipe
+                (l.optionalAttrs (cfg.max-score != null)
+                   { ${z-var "max-score"} = toString cfg.max-score; }
+                )
+                [ (foldOnto
+                     (acc: n:
+                        if cfg.${n} then acc else acc // { ${z-var-no n} = "1"; }
+                     )
+                     (attrNames bool-options)
+                  )
+
+                  (foldOnto
+                     (acc: n:
+                        let value = cfg.${n}; in
+                        if value == null then acc else acc // { ${z-var n} = value; }
+                     )
+                     (attrNames str-options)
+                  )
+                ];
+          };
+      };
+  }

--- a/pkgs/tools/misc/z/default.nix
+++ b/pkgs/tools/misc/z/default.nix
@@ -1,0 +1,45 @@
+{ fetchFromGitHub, lib, stdenv }:
+  stdenv.mkDerivation
+    { pname = "z";
+      version = "1622481819";
+      # ^ there isn't a version, so the UNIX time of the commit is used
+
+      src =
+        fetchFromGitHub
+          { owner = "rupa";
+            repo = "z";
+            rev = "b82ac78a2d4457d2ca09973332638f123f065fd1";
+            sha256 = "0phk9lswwxsypchb11qsnxy1pv5xg1zkrqj8im6x2icma63hfcz2";
+          };
+
+      phases = [ "unpackPhase" "installPhase" ];
+
+      installPhase =
+        ''
+        mkdir -p $out/share/man/man1
+        cp z.1 $out/share/man/man1
+        cp z.sh $out
+        # ^ for use in the module
+        '';
+
+      meta =
+        let l = lib; in
+        { description = "A simple cd-like command that makes it very easy to go to any location you've cd'd to in the past";
+
+          longDescription =
+            ''
+            Tracks your most used directories, based on 'frecency'.
+
+            After  a  short  learning  phase, z will take you to the most 'frecent'
+            directory that matches ALL of the regexes given on the command line, in
+            order.
+
+            For example, z foo bar would match /foo/bar but not /bar/foo.
+            '';
+
+          homepage = "https://github.com/rupa/z";
+          license = l.licenses.wtfpl;
+          platforms = l.platforms.all;
+          maintainers = [ l.maintainers.ursi ];
+        };
+    }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33533,6 +33533,8 @@ with pkgs;
 
   xcfun = callPackage ../development/libraries/science/chemistry/xcfun { };
 
+  z = callPackage ../tools/misc/z {};
+
   zesarux = callPackage ../misc/emulators/zesarux { };
 
   zk = callPackage ../applications/office/zk {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Make it easy to declaratively use this tool on NixOS
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [n/a] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).