### PR TITLE
duckstation: unstable-2021-10-19 -> unstable-2021-10-29

### DIFF
--- a/pkgs/misc/emulators/duckstation/default.nix
+++ b/pkgs/misc/emulators/duckstation/default.nix
@@ -20,13 +20,13 @@
 }:
 mkDerivation rec {
   pname = "duckstation";
-  version = "unstable-2021-10-19";
+  version = "unstable-2021-10-29";
 
   src = fetchFromGitHub {
     owner = "stenzek";
     repo = pname;
-    rev = "96f4fdf8d88ff3a120f3bc409a6a6487cdcbd55f";
-    sha256 = "sha256-WWsi7kmFEYES2BoNKIFF1+lKHJGP3hbTZ9o3eWp+EcE=";
+    rev = "287b1e1abc98ef3f01d8530e0b428b58d8e77e96";
+    sha256 = "sha256-1s7oBdOOkK6a3DKCZ70dAilFzlzrURwhx+MRTmOPWJE=";
   };
 
   nativeBuildInputs = [ cmake ninja pkg-config extra-cmake-modules wrapQtAppsHook qttools ];
@@ -45,7 +45,7 @@ mkDerivation rec {
   ];
 
   cmakeFlags = [
-    #"-DUSE_DRMKMS=ON" # Broken in combination with Wayland, https://github.com/stenzek/duckstation/issues/2630
+    "-DUSE_DRMKMS=ON" # Broken in combination with Wayland, https://github.com/stenzek/duckstation/issues/2630
     "-DUSE_WAYLAND=ON"
   ];
 


### PR DESCRIPTION
###### Motivation for this change
The regression I talked about in the last pull request https://github.com/NixOS/nixpkgs/pull/142741 has been fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
