### PR TITLE
gfbgraph: 0.2.4 → 0.2.5

### DIFF
--- a/pkgs/development/libraries/gfbgraph/default.nix
+++ b/pkgs/development/libraries/gfbgraph/default.nix
@@ -1,36 +1,52 @@
-{ lib, stdenv, fetchurl, pkg-config, glib, librest, gnome-online-accounts
-, gnome, libsoup, json-glib, gobject-introspection
-, gtk-doc, pkgs, docbook-xsl-nons, autoconf, automake, libtool }:
+{ stdenv
+, lib
+, fetchurl
+, pkg-config
+, glib
+, librest
+, gnome-online-accounts
+, gnome
+, libsoup
+, json-glib
+, gobject-introspection
+, gtk-doc
+, pkgs
+, docbook-xsl-nons
+}:
 
 stdenv.mkDerivation rec {
   pname = "gfbgraph";
-  version = "0.2.4";
+  version = "0.2.5";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0yck7dwvjk16a52nafjpi0a39rxwmg0w833brj45acz76lgkjrb0";
+    sha256 = "nLOBs/eLoRNt+Xrz8G47EdzCqzOawI907aD4BX1mA+M=";
   };
 
   nativeBuildInputs = [
-    pkg-config gobject-introspection gtk-doc
-    docbook-xsl-nons autoconf automake libtool
+    pkg-config
+    gobject-introspection
+    gtk-doc
+    docbook-xsl-nons
   ];
-  buildInputs = [ glib gnome-online-accounts ];
-  propagatedBuildInputs = [ libsoup json-glib librest ];
 
-  configureFlags = [ "--enable-introspection" "--enable-gtk-doc" ];
+  buildInputs = [
+    glib
+    gnome-online-accounts
+  ];
 
-  prePatch = ''
-    patchShebangs autogen.sh
-    substituteInPlace autogen.sh \
-      --replace "which" "${pkgs.which}/bin/which"
-  '';
+  propagatedBuildInputs = [
+    libsoup
+    json-glib
+    librest
+  ];
 
-  preConfigure = ''
-    NOCONFIGURE=1 ./autogen.sh
-  '';
+  configureFlags = [
+    "--enable-introspection"
+    "--enable-gtk-doc"
+  ];
 
   enableParallelBuilding = true;
 
@@ -45,7 +61,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.gnome.org/Projects/GFBGraph";
     description = "GLib/GObject wrapper for the Facebook Graph API";
     maintainers = teams.gnome.members;
-    license = licenses.lgpl2;
+    license = licenses.lgpl21Plus;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://gitlab.gnome.org/GNOME/libgfbgraph/-/commits/v_0_2_5

Fixes CVE-2021-39358



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
