### PR TITLE
python3Packages.httplib2: drop upstreamed patch (fails to apply)

### DIFF
--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , isPy27
 , mock
 , pyparsing
@@ -24,14 +23,6 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "sha256-1zqs3YRVtm5DwewETLtRg5XhMJPJsMi0QLfeGirOURs=";
   };
-
-  patches = [
-    # fix test_inject_space
-    (fetchpatch {
-      url = "https://github.com/httplib2/httplib2/commit/08d6993b69256fbc6c0b1c615c24910803c4d610.patch";
-      sha256 = "0kbd1skn58m20kfkh4qzd66g9bvj31xlkbhsg435dkk4qz6l3yn3";
-    })
-  ];
 
   postPatch = ''
     sed -i "/--cov/d" setup.cfg


### PR DESCRIPTION
```
$ nix build -f.  python3Packages.httplib2 -L
...
python3.9-httplib2> patching sources
python3.9-httplib2> applying patch /nix/store/gbpay7j261cbshpnkfgvp3lbnwa41p89-08d6993b69256fbc6c0b1c615c24910803c4d610.patch
python3.9-httplib2> patching file tests/test_http.py
python3.9-httplib2> Reversed (or previously applied) patch detected!  Assume -R? [n]
python3.9-httplib2> Apply anyway? [n]
python3.9-httplib2> Skipping patch.
python3.9-httplib2> 1 out of 1 hunk ignored -- saving rejects to file tests/test_http.py.rej
```