### PR TITLE
ocamlPackages.awa: 0.0.3 -> 0.0.4

### DIFF
--- a/pkgs/development/ocaml-modules/awa/default.nix
+++ b/pkgs/development/ocaml-modules/awa/default.nix
@@ -8,21 +8,21 @@
 
 buildDunePackage rec {
   pname = "awa";
-  version = "0.0.3";
+  version = "0.0.4";
 
   minimumOCamlVersion = "4.07";
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/awa-ssh/releases/download/v${version}/awa-v${version}.tbz";
-    sha256 = "5a7927363ffe672cccf12d5425386e84f6f553a17ffec2b01ae5dc28180c831a";
+    sha256 = "1l7nsd8jifxjq78xyzcc0z9igc02m2qlvv4cxzsgdim6n1jfzxj2";
   };
 
   nativeBuildInputs = [ ppx_sexp_conv ppx_cstruct ];
 
   propagatedBuildInputs = [
     mirage-crypto mirage-crypto-rng mirage-crypto-pk x509
-    cstruct cstruct-sexp sexplib rresult mtime
+    cstruct cstruct-sexp sexplib mtime
     logs base64 hacl_x25519 zarith
   ];
 
@@ -33,6 +33,7 @@ buildDunePackage rec {
     description = "SSH implementation in OCaml";
     license = licenses.isc;
     homepage = "https://github.com/mirage/awa-ssh";
+    changelog = "https://github.com/mirage/awa-ssh/raw/v${version}/CHANGES.md";
     maintainers = [ maintainers.sternenseemann ];
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/mirage/awa-ssh/releases/tag/v0.0.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
